### PR TITLE
fix(ci): align macOS Cairo runtime setup across workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,16 @@ jobs:
         if: ${{ env.OS_NAME == 'MacOS' }}
         shell: bash
         run: |
-          brew install tree cloc wget curl make zip cairo pkg-config
+          brew install tree cloc wget curl make zip
+      - name: Set up Cairo runtime on MacOS
+        if: ${{ env.OS_NAME == 'MacOS' }}
+        shell: bash
+        run: |
+          brew install cairo pkg-config
+      - name: Expose Cairo runtime on MacOS
+        if: ${{ env.OS_NAME == 'MacOS' }}
+        shell: bash
+        run: |
           BREW_PREFIX="$(brew --prefix)"
           echo "PKG_CONFIG_PATH=${BREW_PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" >> $GITHUB_ENV
           echo "DYLD_FALLBACK_LIBRARY_PATH=${BREW_PREFIX}/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}" >> $GITHUB_ENV
@@ -149,8 +158,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-build.txt
-      - name: Verify Cairo runtime on Windows
-        if: ${{ env.OS_NAME == 'Windows' }}
+      - name: Verify Cairo runtime on Windows and MacOS
+        if: ${{ env.OS_NAME == 'Windows' || env.OS_NAME == 'MacOS' }}
         shell: bash
         run: |
           python - <<'PY'
@@ -162,7 +171,7 @@ jobs:
                   b'</svg>'
               )
           )
-          print('CairoSVG runtime is available on Windows.')
+          print('CairoSVG runtime is available on', "${{ env.OS_NAME }}")
           PY
       - name: Test the basic environment
         shell: bash

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -129,7 +129,16 @@ jobs:
         if: ${{ env.OS_NAME == 'MacOS' }}
         shell: bash
         run: |
-          brew install tree cloc wget curl make zip cairo pkg-config
+          brew install tree cloc wget curl make zip
+      - name: Set up Cairo runtime on MacOS
+        if: ${{ env.OS_NAME == 'MacOS' }}
+        shell: bash
+        run: |
+          brew install cairo pkg-config
+      - name: Expose Cairo runtime on MacOS
+        if: ${{ env.OS_NAME == 'MacOS' }}
+        shell: bash
+        run: |
           BREW_PREFIX="$(brew --prefix)"
           echo "PKG_CONFIG_PATH=${BREW_PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" >> $GITHUB_ENV
           echo "DYLD_FALLBACK_LIBRARY_PATH=${BREW_PREFIX}/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}" >> $GITHUB_ENV
@@ -143,8 +152,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-build.txt
-      - name: Verify Cairo runtime on Windows
-        if: ${{ env.OS_NAME == 'Windows' }}
+      - name: Verify Cairo runtime on Windows and MacOS
+        if: ${{ env.OS_NAME == 'Windows' || env.OS_NAME == 'MacOS' }}
         shell: bash
         run: |
           python - <<'PY'
@@ -156,7 +165,7 @@ jobs:
                   b'</svg>'
               )
           )
-          print('CairoSVG runtime is available on Windows.')
+          print('CairoSVG runtime is available on', "${{ env.OS_NAME }}")
           PY
       - name: Test the basic environment
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,8 +211,21 @@ jobs:
           echo "${{ steps.msys2.outputs.msys2-location }}\\mingw64\\bin" >> "$GITHUB_PATH"
       - name: Set up system dependencies on MacOS
         if: ${{ env.OS_NAME == 'MacOS' }}
+        shell: bash
         run: |
           brew install tree cloc wget curl make zip
+      - name: Set up Cairo runtime on MacOS
+        if: ${{ env.OS_NAME == 'MacOS' }}
+        shell: bash
+        run: |
+          brew install cairo pkg-config
+      - name: Expose Cairo runtime on MacOS
+        if: ${{ env.OS_NAME == 'MacOS' }}
+        shell: bash
+        run: |
+          BREW_PREFIX="$(brew --prefix)"
+          echo "PKG_CONFIG_PATH=${BREW_PREFIX}/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" >> $GITHUB_ENV
+          echo "DYLD_FALLBACK_LIBRARY_PATH=${BREW_PREFIX}/lib${DYLD_FALLBACK_LIBRARY_PATH:+:${DYLD_FALLBACK_LIBRARY_PATH}}" >> $GITHUB_ENV
       - name: Set up python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
         with:
@@ -223,8 +236,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install -r requirements-build.txt
-      - name: Verify Cairo runtime on Windows
-        if: ${{ env.OS_NAME == 'Windows' }}
+      - name: Verify Cairo runtime on Windows and MacOS
+        if: ${{ env.OS_NAME == 'Windows' || env.OS_NAME == 'MacOS' }}
         shell: bash
         run: |
           python - <<'PY'
@@ -236,7 +249,7 @@ jobs:
                   b'</svg>'
               )
           )
-          print('CairoSVG runtime is available on Windows.')
+          print('CairoSVG runtime is available on', "${{ env.OS_NAME }}")
           PY
       - name: Test the basic environment
         shell: bash


### PR DESCRIPTION
## Summary
- split macOS Cairo handling into dedicated setup and exposure stages in all three CLI/build workflows
- add macOS Cairo runtime setup to `test.yml` build_cli to match the Windows path
- enable the Python-based CairoSVG probe on both Windows and macOS across all three workflows

## Testing
- git diff --check
- python YAML parse for `.github/workflows/test.yml`, `.github/workflows/release.yml`, and `.github/workflows/release_test.yml`