### PR TITLE
feat(editors): align highlight coverage for import block syntax

### DIFF
--- a/editors/README.md
+++ b/editors/README.md
@@ -53,9 +53,10 @@ The TextMate grammar (`editors/fcstm.tmLanguage.json`) provides syntax highlight
 
 ## Supported Syntax
 
-Both implementations support the complete FCSTM syntax. The Pygments lexer is
-already updated for import-related syntax added in PR79, while the TextMate /
-VSCode side is tracked separately in the later editor-support phase.
+Both implementations support the complete FCSTM syntax, including the import
+statement, block-form import mappings, wildcard selectors, and target templates.
+The Pygments lexer and the TextMate / VSCode grammar are kept aligned and share
+the same validation checkpoints in `editors/validate.py`.
 
 **Keywords:** `state`, `pseudo`, `import`, `as`, `named`, `def`, `event`, `enter`, `during`, `exit`, `before`, `after`, `abstract`, `ref`, `effect`, `if`, `else`, `and`, `or`, `not`
 

--- a/editors/fcstm.tmLanguage.json
+++ b/editors/fcstm.tmLanguage.json
@@ -94,6 +94,44 @@
           }
         },
         {
+          "name": "meta.definition.import.block.fcstm",
+          "begin": "\\b(import)\\s+((?:\"[^\"]*\"|'[^']*'))\\s+(as)\\s+([a-zA-Z_][a-zA-Z0-9_]*)(?:\\s+(named)\\s+((?:\"[^\"]*\"|'[^']*')))?\\s*(\\{)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.control.fcstm"
+            },
+            "2": {
+              "name": "string.quoted.double.fcstm"
+            },
+            "3": {
+              "name": "keyword.control.fcstm"
+            },
+            "4": {
+              "name": "entity.name.type.state.fcstm"
+            },
+            "5": {
+              "name": "keyword.control.fcstm"
+            },
+            "6": {
+              "name": "string.quoted.double.fcstm"
+            },
+            "7": {
+              "name": "punctuation.section.mapping.fcstm"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.mapping.fcstm"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#import-body"
+            }
+          ]
+        },
+        {
           "name": "meta.definition.import.fcstm",
           "match": "\\b(import)\\s+((?:\"[^\"]*\"|'[^']*'))\\s+(as)\\s+([a-zA-Z_][a-zA-Z0-9_]*)\\b(?:\\s+(named)\\s+((?:\"[^\"]*\"|'[^']*')))?",
           "captures": {
@@ -270,6 +308,87 @@
         {
           "name": "variable.other.fcstm",
           "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+        }
+      ]
+    },
+    "import-body": {
+      "patterns": [
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#strings"
+        },
+        {
+          "name": "keyword.control.fcstm",
+          "match": "\\b(def|event|named)\\b"
+        },
+        {
+          "name": "keyword.operator.transition.fcstm",
+          "match": "->"
+        },
+        {
+          "name": "variable.parameter.fcstm",
+          "match": "\\$\\{[0-9]+\\}|\\$[0-9]+"
+        },
+        {
+          "name": "variable.parameter.fcstm",
+          "match": "\\b[A-Za-z_][A-Za-z0-9_]*(?:\\$\\{[0-9]+\\}|\\$[0-9]+|\\*)[A-Za-z0-9_*${}]*"
+        },
+        {
+          "name": "variable.parameter.fcstm",
+          "match": "\\*[A-Za-z0-9_${}][A-Za-z0-9_*${}]*"
+        },
+        {
+          "name": "keyword.operator.wildcard.fcstm",
+          "match": "\\*"
+        },
+        {
+          "name": "keyword.operator.path.fcstm",
+          "match": "/"
+        },
+        {
+          "name": "punctuation.separator.mapping.fcstm",
+          "match": ","
+        },
+        {
+          "include": "#import-selector-set"
+        },
+        {
+          "name": "variable.other.fcstm",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+        }
+      ]
+    },
+    "import-selector-set": {
+      "patterns": [
+        {
+          "name": "meta.import.selector-set.fcstm",
+          "begin": "\\{",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.section.mapping.fcstm"
+            }
+          },
+          "end": "\\}",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.section.mapping.fcstm"
+            }
+          },
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "name": "punctuation.separator.mapping.fcstm",
+              "match": ","
+            },
+            {
+              "name": "variable.other.fcstm",
+              "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+            }
+          ]
         }
       ]
     }

--- a/editors/validate.py
+++ b/editors/validate.py
@@ -279,6 +279,30 @@ state System named "System State Machine" {
     }
 
     // ========================================================================
+    // Import statements (import_statement)
+    // ========================================================================
+
+    state ImportHost named "Import Host" {
+        state Bus;
+
+        // Simple import without block
+        import "./modules/simple.fcstm" as Simple;
+
+        // Import with block and every mapping form the grammar accepts
+        import "./modules/worker.fcstm" as Worker named "Worker Module" {
+            def counter -> shared_counter;
+            def {status_flag, a, b, c} -> set_*;
+            def sensor_* -> sensor_$1;
+            def a_*_b_* -> pair_${1}_${2}_${0};
+            def * -> fallback_$0;
+            event /Start -> Bus.Start named "Mapped Start";
+            event /Alarm -> /Bus.Alarm;
+        }
+
+        [*] -> Bus;
+    }
+
+    // ========================================================================
     // Forced transitions (transition_force_definition)
     // ========================================================================
 
@@ -368,6 +392,14 @@ SHARED_CHECKPOINT_SPECS: List[Dict[str, Any]] = [
             SharedExpectation('named', Token.Keyword.Declaration, 'keywords', 'keyword.control.fcstm'),
             SharedExpectation('def', Token.Keyword.Declaration, 'keywords', 'keyword.control.fcstm'),
             SharedExpectation('event', Token.Keyword.Declaration, 'keywords', 'keyword.control.fcstm'),
+        ],
+    },
+    {
+        'name': 'Keywords - Import',
+        'description': 'import, as keywords used by import statements',
+        'items': [
+            SharedExpectation('import', Token.Keyword.Declaration, 'keywords', 'keyword.control.fcstm'),
+            SharedExpectation('as', Token.Keyword.Declaration, 'keywords', 'keyword.control.fcstm'),
         ],
     },
     {
@@ -574,6 +606,18 @@ SHARED_CHECKPOINT_SPECS: List[Dict[str, Any]] = [
             SharedExpectation('"Stop Event"', Token.String.Double, 'strings', 'string.quoted.double.fcstm'),
         ],
     },
+    {
+        'name': 'Import Block - Templates and Selectors',
+        'description': 'wildcard selectors and target templates in import mappings',
+        'items': [
+            SharedExpectation('sensor_*', Token.Name.Variable, 'import-body', 'variable.parameter.fcstm'),
+            SharedExpectation('a_*_b_*', Token.Name.Variable, 'import-body', 'variable.parameter.fcstm'),
+            SharedExpectation('set_*', Token.Name.Variable, 'import-body', 'variable.parameter.fcstm'),
+            SharedExpectation('sensor_$1', Token.Name.Variable, 'import-body', 'variable.parameter.fcstm'),
+            SharedExpectation('fallback_$0', Token.Name.Variable, 'import-body', 'variable.parameter.fcstm'),
+            SharedExpectation('pair_${1}_${2}_${0}', Token.Name.Variable, 'import-body', 'variable.parameter.fcstm'),
+        ],
+    },
 ]
 
 TEXTMATE_STRUCTURE_SPECS: List[Dict[str, Any]] = [
@@ -600,6 +644,10 @@ TEXTMATE_STRUCTURE_SPECS: List[Dict[str, Any]] = [
     {
         'name': 'Unsupported Binary Literals',
         'description': 'binary integer highlighting is not introduced without grammar support',
+    },
+    {
+        'name': 'Import Block Captures',
+        'description': 'block-form import declaration exposes alias and display-name scopes',
     },
 ]
 
@@ -805,7 +853,10 @@ def _validate_textmate_structure(grammar: Dict[str, Any], vscode_copy: Dict[str,
         name='Repository Sections',
         description='expected repository sections are present',
     )
-    expected_sections = ['comments', 'declarations', 'keywords', 'operators', 'constants', 'strings', 'numbers', 'identifiers']
+    expected_sections = [
+        'comments', 'declarations', 'keywords', 'operators', 'constants',
+        'strings', 'numbers', 'identifiers', 'import-body', 'import-selector-set',
+    ]
     repository = grammar.get('repository', {})
     for section in expected_sections:
         if section not in repository:
@@ -820,6 +871,8 @@ def _validate_textmate_structure(grammar: Dict[str, Any], vscode_copy: Dict[str,
     expected_operator_order = [
         '>>',
         '->',
+        ',',
+        '\\{|\\}',
         '\\[\\*\\]',
         '::',
         ':',
@@ -885,6 +938,44 @@ def _validate_textmate_structure(grammar: Dict[str, Any], vscode_copy: Dict[str,
     else:
         binary_checkpoint.passed = True
     checkpoints.append(binary_checkpoint)
+
+    import_block_checkpoint = ValidationCheckpoint(
+        name='Import Block Captures',
+        description='block-form import declaration exposes alias and display-name scopes',
+    )
+    import_block_sample = 'import "./worker.fcstm" as Worker named "Worker Module" {'
+    import_block_expectations = [
+        (1, 'keyword.control.fcstm'),
+        (3, 'keyword.control.fcstm'),
+        (4, 'entity.name.type.state.fcstm'),
+        (5, 'keyword.control.fcstm'),
+        (7, 'punctuation.section.mapping.fcstm'),
+    ]
+    matched_block_pattern = None
+    for pattern in declaration_patterns:
+        begin_regex = pattern.get('begin')
+        if not begin_regex:
+            continue
+        match = _compile_pattern(begin_regex).search(import_block_sample)
+        if not match:
+            continue
+        matched_block_pattern = pattern
+        break
+    if matched_block_pattern is None:
+        import_block_checkpoint.failures.append(
+            f"no declaration pattern with begin captures matched {import_block_sample!r}"
+        )
+    else:
+        begin_captures = matched_block_pattern.get('beginCaptures', {})
+        for capture_group, expected_scope in import_block_expectations:
+            actual_scope = begin_captures.get(str(capture_group), {}).get('name')
+            if actual_scope != expected_scope:
+                import_block_checkpoint.failures.append(
+                    f"block-form import capture {capture_group} expected scope {expected_scope!r}, "
+                    f"got {actual_scope!r}"
+                )
+    import_block_checkpoint.passed = not import_block_checkpoint.failures
+    checkpoints.append(import_block_checkpoint)
 
     return checkpoints
 

--- a/pyfcstm/highlight/pygments_lexer.py
+++ b/pyfcstm/highlight/pygments_lexer.py
@@ -199,7 +199,7 @@ class FcstmLexer(RegexLexer):
 
             # Keywords - state machine structure
             (words((
-                'state', 'pseudo', 'named', 'def', 'event',
+                'state', 'pseudo', 'named', 'def', 'event', 'as',
             ), suffix=r'\b'), Keyword.Declaration),
 
             # Keywords - lifecycle actions
@@ -209,7 +209,7 @@ class FcstmLexer(RegexLexer):
 
             # Keywords - modifiers
             (words((
-                'abstract', 'ref', 'effect', 'as',
+                'abstract', 'ref', 'effect',
             ), suffix=r'\b'), Keyword.Namespace),
 
             # Keywords - types
@@ -304,7 +304,7 @@ class FcstmLexer(RegexLexer):
         'import-header': [
             include('whitespace'),
             include('comments'),
-            (r'\b(?:as)\b', Keyword.Namespace),
+            (r'\b(?:as)\b', Keyword.Declaration),
             (r'\bnamed\b', Keyword.Declaration),
             (r'"([^"\\]|\\[btnfr"\'\\]|\\[0-7]{1,3}|\\u[0-9a-fA-F]{4}|\\x[0-9a-fA-F]{2})*"', String.Double),
             (r"'([^'\\]|\\[btnfr\"'\\]|\\[0-7]{1,3}|\\u[0-9a-fA-F]{4}|\\x[0-9a-fA-F]{2})*'", String.Single),

--- a/test/highlight/test_pygments_lexer.py
+++ b/test/highlight/test_pygments_lexer.py
@@ -554,7 +554,7 @@ class TestImportSyntaxHighlighting:
 
         assert (Keyword.Declaration, 'import') in tokens
         assert (String.Double, '"./worker.fcstm"') in tokens
-        assert (Keyword.Namespace, 'as') in tokens
+        assert (Keyword.Declaration, 'as') in tokens
         assert (Name, 'Worker') in tokens
         assert (Keyword.Declaration, 'named') in tokens
         assert (String.Double, '"Worker Module"') in tokens


### PR DESCRIPTION
## Summary
- Replace the single-line TextMate import declaration with a `begin`/`end`
  region plus new `import-body` / `import-selector-set` repository sections,
  so selectors, target templates (`$0`, `${1}`, compound forms like
  `sensor_$1` or `pair_${1}_${2}_${0}`), set-form selectors, and fallback
  wildcards all get proper scopes inside an import block – matching the
  existing Pygments push modes.
- Move `as` from `Keyword.Namespace` to `Keyword.Declaration` in the Pygments
  lexer so both highlighters group declaration-style keywords the same way.
- Extend `editors/validate.py` with an import sample in the comprehensive
  test corpus, shared checkpoints for `import`/`as` and the new
  template/selector scopes, and a structural check for the block-form
  `beginCaptures`; also update `expected_operator_order` / `expected_sections`
  to match what has been in the committed grammar since PR79.
- Refresh `editors/README.md` so it no longer describes TextMate/VSCode as
  lagging behind Pygments on import syntax.

## Test plan
- [x] `python editors/validate.py` → Pygments 25/25, TextMate 30/30
- [x] `pytest test/highlight/ test/entry/ test/dsl/` (2415 passed)
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)