### PR TITLE
test(infra): slow-test skip + error baseline snapshot (PR-0 for #103)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,6 +112,17 @@ jobs:
           tree .
           cloc pyfcstm
           cloc test
+      - name: Detect skip-slow flag in commit message
+        id: skipslow
+        shell: bash
+        run: |
+          MSG="${{ github.event.head_commit.message }}"
+          if echo "$MSG" | grep -q '\[skip-slow\]'; then
+            echo "SKIP_SLOW_TESTS=1" >> $GITHUB_ENV
+            echo "Detected [skip-slow] — native-toolchain template tests will be skipped."
+          else
+            echo "SKIP_SLOW_TESTS=" >> $GITHUB_ENV
+          fi
       - name: Run unittest
         env:
           CI: 'true'

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ markers =
     unittest
     benchmark
     ignore
+    slow: tests that invoke native toolchains (cmake / cc) and take significantly longer

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,41 @@
+import os
+
 import pytest
 from hbutils.testing import TextAligner
+
+
+_SLOW_TEST_PATH_PREFIXES = (
+    os.path.join('test', 'template', 'c', ''),
+    os.path.join('test', 'template', 'c_poll', ''),
+)
+
+
+def _is_slow_path(nodeid: str) -> bool:
+    norm = nodeid.replace('\\', '/').replace('/', os.sep)
+    for prefix in _SLOW_TEST_PATH_PREFIXES:
+        if norm.startswith(prefix) or norm.startswith(prefix.replace(os.sep, '/')):
+            return True
+    if any(prefix.replace(os.sep, '/') in nodeid.replace('\\', '/') for prefix in _SLOW_TEST_PATH_PREFIXES):
+        return True
+    return False
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-mark native-toolchain template tests as ``slow`` and optionally skip them.
+
+    When ``SKIP_SLOW_TESTS=1`` is set (e.g. CI commit message contains
+    ``[skip-slow]``), tests under ``test/template/c`` and ``test/template/c_poll``
+    are skipped because they invoke real ``cmake`` / ``cc`` compilation per case.
+    """
+    slow_marker = pytest.mark.slow
+    skip_slow = os.environ.get('SKIP_SLOW_TESTS', '').strip().lower() in ('1', 'true', 'yes', 'on')
+    skip_marker = pytest.mark.skip(reason='SKIP_SLOW_TESTS=1 — native-toolchain template tests skipped')
+
+    for item in items:
+        if _is_slow_path(item.nodeid):
+            item.add_marker(slow_marker)
+            if skip_slow:
+                item.add_marker(skip_marker)
 
 
 @pytest.fixture(scope="session")

--- a/test/model/test_error_baseline.py
+++ b/test/model/test_error_baseline.py
@@ -1,0 +1,194 @@
+"""
+Baseline error snapshot for ``pyfcstm.model.parse_dsl_node_to_state_machine``.
+
+This test file is part of **PR-0** of the Layer 1 structured-diagnostic
+refactor (see issue #103). Its purpose is to lock down the **current**
+exception-raising behavior of ``model.py`` so that subsequent PRs (especially
+PR-2, which replaces ``raise SyntaxError`` with structured ``ModelDiagnostic``
+objects) cannot silently regress the existing error-detection surface.
+
+For each baseline case we assert:
+
+1. The DSL snippet still triggers an exception.
+2. The exception type matches what model.py currently raises.
+3. The exception message contains the documented substring contract that the
+   downstream ``research_ideas`` repository (issue ``research_ideas#12``)
+   currently regex-matches.
+
+After PR-2 lands, ``ModelValidationError`` will multi-inherit from
+``SyntaxError`` so all the ``SyntaxError`` baseline assertions remain green.
+The fixture table itself will then be re-used as the source of truth for
+asserting structured ``diagnostic.code`` / ``diagnostic.refs`` in PR-2.
+
+.. note::
+   This file deliberately uses **substring** assertions, not exact equality,
+   because exact message text is *not* part of the public contract. The
+   substring is the minimum stable surface that downstream consumers
+   currently depend on.
+"""
+
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+
+
+def _parse_and_build(dsl_text: str):
+    ast = parse_with_grammar_entry(dsl_text, entry_name='state_machine_dsl')
+    return parse_dsl_node_to_state_machine(ast)
+
+
+_DUPLICATE_VAR = """
+def int x = 0;
+def int x = 1;
+state Root {
+    state A;
+}
+"""
+
+_UNDEFINED_VAR_IN_GUARD = """
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    A -> B : if [unknown_var > 0];
+}
+"""
+
+_UNDEFINED_VAR_IN_EFFECT = """
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    A -> B effect { unknown_var = 1; };
+}
+"""
+
+_UNDEFINED_VAR_IN_ENTER = """
+def int x = 0;
+state Root {
+    state A {
+        enter { unknown_var = 1; }
+    }
+}
+"""
+
+_DUPLICATE_STATE = """
+state Root {
+    state A;
+    state A;
+}
+"""
+
+_DUPLICATE_FUNCTION_NAME = """
+state Root {
+    state A {
+        enter Foo { }
+        enter Foo { }
+    }
+}
+"""
+
+_LEAF_DURING_WITH_ASPECT = """
+state Root {
+    state A {
+        during before { }
+    }
+}
+"""
+
+_COMPOSITE_DURING_WITHOUT_ASPECT = """
+state Root {
+    state Outer {
+        during { }
+        state Inner;
+        [*] -> Inner;
+    }
+    [*] -> Outer;
+}
+"""
+
+_PSEUDO_NOT_LEAF = """
+state Root {
+    pseudo state Outer {
+        state Inner;
+        [*] -> Inner;
+    }
+}
+"""
+
+_UNKNOWN_TO_STATE = """
+state Root {
+    state A;
+    A -> NoSuch;
+}
+"""
+
+_UNKNOWN_FROM_STATE_FORCED = """
+state Root {
+    state A;
+    state B;
+    !NoSuch -> A;
+}
+"""
+
+_MISSING_ENTRY_TRANSITION_IN_COMPOSITE = """
+state Root {
+    state Outer {
+        state Inner;
+    }
+}
+"""
+
+_NAMED_FUNCTION_REF_NOT_FOUND = """
+state Root {
+    state A {
+        enter ref NoSuch.NoSuch;
+    }
+}
+"""
+
+# (case_id, dsl_text, expected_exc_type, expected_message_substring)
+BASELINE_CASES = [
+    ('duplicate_var', _DUPLICATE_VAR, SyntaxError, 'Duplicated variable definition'),
+    ('undefined_var_guard', _UNDEFINED_VAR_IN_GUARD, SyntaxError, 'unknown_var'),
+    ('undefined_var_effect', _UNDEFINED_VAR_IN_EFFECT, SyntaxError, 'unknown_var'),
+    ('undefined_var_enter', _UNDEFINED_VAR_IN_ENTER, SyntaxError, 'unknown_var'),
+    ('duplicate_state', _DUPLICATE_STATE, SyntaxError, 'Duplicate state name'),
+    ('duplicate_function_name', _DUPLICATE_FUNCTION_NAME, SyntaxError, 'Duplicate function name'),
+    ('leaf_during_with_aspect', _LEAF_DURING_WITH_ASPECT, SyntaxError, 'during cannot assign aspect'),
+    ('composite_during_without_aspect', _COMPOSITE_DURING_WITHOUT_ASPECT, SyntaxError,
+     "during must assign aspect"),
+    ('pseudo_not_leaf', _PSEUDO_NOT_LEAF, SyntaxError, 'Pseudo state'),
+    ('unknown_to_state', _UNKNOWN_TO_STATE, SyntaxError, 'Unknown to state'),
+    ('unknown_from_state_forced', _UNKNOWN_FROM_STATE_FORCED, SyntaxError, 'Unknown from state'),
+    ('missing_entry_transition_in_composite', _MISSING_ENTRY_TRANSITION_IN_COMPOSITE, SyntaxError,
+     'entry transition'),
+    ('named_function_ref_not_found', _NAMED_FUNCTION_REF_NOT_FOUND, SyntaxError, 'Cannot find'),
+]
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    'case_id,dsl_text,expected_exc,expected_substr',
+    BASELINE_CASES,
+    ids=[c[0] for c in BASELINE_CASES],
+)
+def test_error_baseline_raises_expected_exception(case_id, dsl_text, expected_exc, expected_substr):
+    """
+    Each baseline DSL snippet must trigger ``expected_exc`` with a message
+    containing ``expected_substr``. This is the contract surface that
+    downstream consumers regex-match today and that PR-2 must preserve.
+    """
+    with pytest.raises(expected_exc) as exc_info:
+        _parse_and_build(dsl_text)
+    assert expected_substr in str(exc_info.value), (
+        f"[{case_id}] expected substring {expected_substr!r} in exception message, "
+        f"got: {str(exc_info.value)!r}"
+    )
+
+
+@pytest.mark.unittest
+def test_error_baseline_table_is_non_empty():
+    """Guard against accidental table truncation."""
+    assert len(BASELINE_CASES) >= 10


### PR DESCRIPTION
## 概述

#103 跟踪的 Layer 1 结构化诊断改造的第一个 PR。纯基础设施 + 测试加法，对 `pyfcstm.model` 零行为变动。

- **慢测试 skip 机制** —— 自动给 `test/template/c` 和 `test/template/c_poll` 打 `slow` mark；commit message 含 `[skip-slow]` 时 CI 注入 `SKIP_SLOW_TESTS=1` 跳过这部分测试。本地实测：native-toolchain template 测试占用 148s / 174s = **~85% 单元测试 wall time**（每个 case 调真 cmake + cc）。Fast 路径实测 ~24s = **~7× 加速**，给所有不动到 C/C++ 运行时的迭代循环用。
- **错误基线快照** —— `test/model/test_error_baseline.py`，表驱动测试锁定 `model.py` 当前的 `SyntaxError` raise surface（13 个 case 覆盖所有不同 message pattern）。断言异常类型 + 下游 `research_ideas` 现在 regex 匹配的 message 子串（见 `research_ideas#12`）。PR-2 会复用这套 fixture 来断言 `ModelDiagnostic.code` / `refs`，**双重收益**。

## 为什么这个 PR 排第一

#103 每个 PR 的显式约束是：**合并后仓库必须端到端可运行**。PR-0 是后续 PR-1/PR-2/PR-3 的回归网 —— 没有这个基线就无法客观证明 `SyntaxError` → `ModelValidationError` 迁移没有破坏下游依赖的现有错误检测面。

## 覆盖范围

| baseline case | 当前抛什么 | 对应下游 regex |
|---|---|---|
| duplicate_var | `SyntaxError` | — |
| undefined_var_guard | `SyntaxError` | `_UNK_VAR_RE` |
| undefined_var_effect | `SyntaxError` | `_UNK_VAR_RE` |
| undefined_var_enter | `SyntaxError` | `_UNK_VAR_RE` |
| duplicate_state | `SyntaxError` | — |
| duplicate_function_name | `SyntaxError` | — |
| leaf_during_with_aspect | `SyntaxError` | — |
| composite_during_without_aspect | `SyntaxError` | — |
| pseudo_not_leaf | `SyntaxError` | — |
| unknown_to_state | `SyntaxError` | `_MISSING_STATE_RE` |
| unknown_from_state_forced | `SyntaxError` | — |
| missing_entry_transition_in_composite | `SyntaxError` | — |
| named_function_ref_not_found | `SyntaxError` | — |

## Test plan

- [x] `pytest test/model/test_error_baseline.py -v` —— 本地 14/14 通过
- [x] `SKIP_SLOW_TESTS=1 pytest test/...` fast 路径 ~24s（对比 full ~174s）
- [x] `pyfcstm/` 本身无改动 —— 已有测试不受影响
- [x] CI 跨 OS × Python 矩阵全绿（23/23）

## Cross-link

- 跟踪 issue：#103
- Layer 2 配套：#104
- 下游 brittle 耦合：`HansBug/research_ideas#12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
