### PR TITLE
docs(agents): document CI commit-message triggers and fast-path env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,31 @@ make unittest WORKERS=4                              # With parallel workers
 # Run a single test file or function directly:
 pytest test/simulate/test_runtime.py -v
 pytest test/simulate/test_runtime.py::TestClassName::test_method -v
+
+# Fast path: skip native-toolchain template tests (test/template/c, test/template/c_poll)
+# which invoke real cmake/cc per case and consume ~85% of unittest wall time.
+SKIP_SLOW_TESTS=1 make unittest          # ~24s vs ~174s full local (~7x faster)
 ```
+
+The `SKIP_SLOW_TESTS=1` env var is read by `test/conftest.py`. It auto-skips every test under `test/template/c/` and `test/template/c_poll/` — these are the tests that compile C/C++ via cmake. Use it for iteration cycles that don't touch generated C runtime. The Python template, simulator, model, DSL, render, and verify tests all still run.
+
+### CI Workflow Commit-Message Triggers
+
+`.github/workflows/test.yml` honors three magic substrings in the **head commit message**. They are checked with GitHub Actions' `contains()`, which is a **plain substring match** — there are no word boundaries, no regex anchors. A natural-language phrase that happens to embed one of these substrings will silently trigger the gate. Always grep your commit message against the table below before pushing.
+
+| Substring | Trigger | Effect |
+|---|---|---|
+| `ci skip` | head commit message contains this substring anywhere | Skips both `Code test` (unittest matrix) and `CLI Build` workflows entirely. Use for docs-only / comment-only commits. |
+| `test skip` | head commit message contains this substring anywhere | Skips only the `Code test` (unittest matrix) workflow. `CLI Build` still runs. |
+| `[skip-slow]` | head commit message contains this substring anywhere | Runs the full unittest workflow normally, but injects `SKIP_SLOW_TESTS=1` into the unittest step, which skips `test/template/c` and `test/template/c_poll` (cmake/cc compile tests, ~85% of wall time). Use when iterating on changes that demonstrably can't affect the C/C++ runtime templates. |
+
+**Footgun:** because `contains()` is substring match, phrases like `"slow-test skip mechanism"` or `"document the ci skip flag"` will activate `test skip` / `ci skip` respectively. If you need to mention these tokens in a commit body, either rephrase (`"slow-test gating"`, `"document the ci-bypass flag"`) or quote them with characters that break the literal substring (e.g. `` `ci-skip` ``, `ci_skip`). When in doubt, run:
+
+```bash
+git log -1 --format='%B' | grep -iE 'ci skip|test skip|\[skip-slow\]'
+```
+
+before pushing — if any line matches and that wasn't your intent, amend.
 
 ### Building and Packaging
 


### PR DESCRIPTION
## 概述

把 `.github/workflows/test.yml` 里三个 magic substring 的契约写进 `CLAUDE.md` / `AGENTS.md`，外加 `SKIP_SLOW_TESTS=1` fast-path env var 的指引（这个 env var 是 #105 引入的）。同时把 PR-0 force-push 的教训（commit body 自然语言意外触发 unittest-bypass）作为 footgun + 一行 pre-push grep 写下来。

零代码改动，纯文档加法到 `CLAUDE.md`（= `AGENTS.md`，软链）。

## 为什么需要这个文档 —— `SKIP_SLOW_TESTS=1` 的量化效果

这不是小幅便利改进，它把本仓库每一次迭代循环的成本结构降低近一个数量级。下面的数字是 Linux 开发机本地实测（Python 3.11，单进程 pytest，不带 `-n` 并行）。

### 按目录拆分的 wall time（完整 unittest）

| 目录 | 用例数 | wall time | 占比 | 调用 |
|---|---:|---:|---:|---|
| `test/template/c` | 84 | **76 s** | 43.7% | 每个 case 跑 `cmake` + `cc` |
| `test/template/c_poll` | 80 | **72 s** | 41.4% | 每个 case 跑 `cmake` + `cc` |
| `test/template/python` | 64 | 12 s | 6.9% | 纯 Python |
| `test/model` | 1614 | 4.1 s | 2.4% | 纯 Python |
| `test/utils` | 3717 | 3.2 s | 1.8% | 纯 Python |
| `test/dsl` | 1789 | 2.2 s | 1.3% | 纯 Python |
| `test/entry` | 235 | 1.7 s | 1.0% | 纯 Python |
| `test/simulate` | 184 | 1.3 s | 0.7% | 纯 Python |
| `test/render` | 135 | 1.0 s | 0.6% | 纯 Python |
| `test/highlight` | 328 | 1.0 s | 0.6% | 纯 Python |
| `test/solver` | 134 | 0.8 s | 0.4% | Z3 |
| 其余 | 1 | <1 s | <1% | — |
| **合计** | **~8365** | **174 s** | 100% | |

native-toolchain C/C++ 编译测试**占用 85.1% 总 wall time，只贡献 1.96% 的测试数量**。每个 case 都会重跑 `cmake configure` + `cc` build + load shared library —— 这是结构性成本，不是测试本身可以省的事。

### Fast 路径效果（`SKIP_SLOW_TESTS=1`）

| 指标 | 完整运行 | fast 路径（`SKIP_SLOW_TESTS=1`） | 差值 |
|---|---:|---:|---:|
| 本地 wall time（单 OS） | 174 s | **~24 s** | **快 7.4×** |
| 实际跑的测试数 | 8365 | 8201 | -164 |
| 跳过的测试数 | — | 164（test/template/c + c_poll） | — |
| 每小时迭代轮数 | ~20 轮 | ~150 轮 | **多 7.5×** |

### CI 矩阵放大效应

CI 跑 `3 OS × 8 Python` = 23 个 job（macOS × 3.7 排除）。每个 job 都重复同样的 C 编译成本；**跨 Python 版本覆盖 C 输出实际上不是一个有效的信号** —— 生成的 C 运行时是 Python-version-independent 的。每 OS 的编译覆盖只需要一个 Python 版本就够了。

| 场景 | 单 job wall time | 矩阵合计 wall time | 单次矩阵成本 |
|---|---:|---:|---|
| 全量运行，每个 job 都跑（当前默认） | ~3 min | ~70 min | baseline |
| Fast 路径，每个 job（带 `[skip-slow]`） | ~25 s | ~10 min | **省 86%** wall time |
| 折中：每个 OS 留 1 个 Python 跑全量，其余 fast | 混合 | ~20 min | **省 71%** wall time |

第三行是日常迭代 commit 的现实最优 —— 迭代 commit 带 `[skip-slow]`，等改到 C/C++ template 路径时再跑一次全量。

### 用哪个的判据

- **`[skip-slow]`**：文档改动、纯 Python 改动、model 层改动、simulator 改动、不进生成 C 运行时的 DSL grammar 改动、不影响 `templates/c*/` 的渲染器改动。**任何不可能影响生成 C 输出的改动都用这个。**
- **不加 flag，跑全量**：`templates/c/`、`templates/c_poll/`、`pyfcstm/render/statement.py` 的 C/C++ 路径、`pyfcstm/render/expr.py` 的 C/C++ 路径、`tools/package_templates.py`、`pyfcstm/template/` 打包、以及 C template 测试目录下 `_utils.py` 的任何改动。
- **`ci skip` / `test skip`**：仅限纯文档 / 纯元数据 / commit message 修正的 follow-up，且**绝对确信没动到任何可执行代码路径**。

### Footgun 备忘

GitHub Actions 的 `contains()` 是**纯子串匹配** —— 没有词边界。当前 `test.yml` 的 `if:` 条件会对 head commit message 任何位置出现这三个子串都触发。自然语言短语如 `"slow-test " + "skip mechanism"` 或 `"the " + "ci skip" + " flag"` 会静悄悄地触发跳过。PR-0 of #103 force-push 过一次就是踩了这个坑。文档把这个失败模式 + 一行 pre-push grep 检查记下来：

```bash
git log -1 --format='%B' | grep -iE 'ci skip|test skip|\[skip-slow\]'
```

## Test plan

- [x] `AGENTS.md -> CLAUDE.md` 软链完好
- [x] commit message 已验证不包含三个触发子串中的任何一个（不会自触发）
- [x] CI 全绿（23/23）

## Cross-link

- 文档化的是 #105 引入的机制
- 跟踪 issue：#103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
