### PR TITLE
feat(verify): structured-diagnostic contract skeleton (PR-1 for #103)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1214,6 +1214,7 @@ fabric.properties
 /pyfcstm/**/*.json
 /pyfcstm/**/*.yaml
 /pyfcstm/**/*.yml
+!/pyfcstm/verify/codes.yaml
 !/test/testfile/**/*
 !/zoo/testfile/**/*
 /test/testfile/dataset

--- a/pyfcstm/utils/__init__.py
+++ b/pyfcstm/utils/__init__.py
@@ -69,4 +69,10 @@ from .text import (
     to_rust_identifier,
     to_go_identifier,
 )
-from .validate import ValidationError, ModelValidationError, IValidatable
+from .validate import (
+    IValidatable,
+    ModelDiagnostic,
+    ModelValidationError,
+    Span,
+    ValidationError,
+)

--- a/pyfcstm/utils/validate.py
+++ b/pyfcstm/utils/validate.py
@@ -37,9 +37,115 @@ Example::
 """
 
 import os
-from typing import Callable, List
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+try:
+    from typing import Literal
+except ImportError:  # Python < 3.8
+    from typing_extensions import Literal
 
 from hbutils.string import plural_word
+
+
+@dataclass(frozen=True)
+class Span:
+    """
+    Source-code location used as the anchor for a :class:`ModelDiagnostic`.
+
+    All coordinates are 1-based. ``end_line`` / ``end_column`` are optional;
+    when omitted the span is treated as pointing at a single source position.
+
+    :param line: 1-based source line where the diagnostic anchor begins.
+    :type line: int
+    :param column: 1-based source column where the diagnostic anchor begins.
+    :type column: int
+    :param end_line: 1-based source line where the diagnostic anchor ends,
+        defaults to ``None``.
+    :type end_line: int, optional
+    :param end_column: 1-based source column where the diagnostic anchor ends,
+        defaults to ``None``.
+    :type end_column: int, optional
+
+    Example::
+
+        >>> from pyfcstm.utils.validate import Span
+        >>> span = Span(line=3, column=12)
+        >>> span.line, span.column
+        (3, 12)
+        >>> Span(line=3, column=12, end_line=3, end_column=20).end_column
+        20
+    """
+
+    line: int
+    column: int
+    end_line: Optional[int] = None
+    end_column: Optional[int] = None
+
+
+@dataclass
+class ModelDiagnostic:
+    """
+    Structured semantic or design-health diagnostic produced by the model layer.
+
+    Designed as the **stable contract** between :mod:`pyfcstm.model` and
+    downstream consumers such as IDE integrations, LLM agent loops, and
+    evaluation scripts. Consumers should dispatch on :attr:`code` only and
+    treat :attr:`message` as human-facing text that may change between
+    releases.
+
+    The full set of valid :attr:`code` values together with their
+    :attr:`refs` payload schema lives in
+    :mod:`pyfcstm.verify.codes` (loaded from ``pyfcstm/verify/codes.yaml``);
+    this dataclass intentionally does not validate ``code`` at construction
+    time so that experimental codes can be emitted in tests.
+
+    :param code: Stable diagnostic code, e.g. ``'E_UNDEFINED_VAR'``,
+        ``'W_DEADLOCK_LEAF'``. Always treated as the public contract.
+    :type code: str
+    :param severity: Either ``'error'`` or ``'warning'``.
+    :type severity: str
+    :param message: Human-readable rendering of the diagnostic. **Not** part
+        of the contract — downstream tools must not regex-match against it.
+    :type message: str
+    :param span: Optional source position, defaults to ``None``.
+    :type span: pyfcstm.utils.validate.Span, optional
+    :param refs: Structured payload keyed by field names defined in
+        ``codes.yaml`` for this code. Defaults to an empty dict.
+    :type refs: Dict[str, Any]
+
+    Example::
+
+        >>> from pyfcstm.utils.validate import ModelDiagnostic, Span
+        >>> diag = ModelDiagnostic(
+        ...     code='E_UNDEFINED_VAR',
+        ...     severity='error',
+        ...     message="Unknown guard variable 'unknown_var' in transition",
+        ...     span=Span(line=5, column=21),
+        ...     refs={'var_name': 'unknown_var', 'referenced_in': 'guard'},
+        ... )
+        >>> diag.code
+        'E_UNDEFINED_VAR'
+        >>> diag.is_error()
+        True
+        >>> diag.refs['var_name']
+        'unknown_var'
+    """
+
+    code: str
+    severity: Literal['error', 'warning']
+    message: str
+    span: Optional[Span] = None
+    refs: Dict[str, Any] = field(default_factory=dict)
+
+    def is_error(self) -> bool:
+        """
+        Return ``True`` if this diagnostic has error severity.
+
+        :return: ``True`` for ``severity == 'error'``, ``False`` otherwise.
+        :rtype: bool
+        """
+        return self.severity == 'error'
 
 
 class ValidationError(Exception):
@@ -59,32 +165,81 @@ class ValidationError(Exception):
     pass
 
 
-class ModelValidationError(Exception):
+class ModelValidationError(SyntaxError):
     """
     Exception class for aggregating multiple validation errors.
 
     This exception contains a list of :class:`ValidationError` instances and
     formats them into a readable error message.
 
-    :param errors: List of validation errors that occurred
-    :type errors: List[ValidationError]
+    It multi-inherits from :class:`SyntaxError` for backwards compatibility:
+    callers that previously caught ``SyntaxError`` raised from
+    :mod:`pyfcstm.model` continue to work after later PRs in the Layer 1
+    refactor switch raise sites to this class.
 
-    :ivar errors: Stored validation errors
+    In addition to the legacy :attr:`errors` list, instances may also carry
+    a :attr:`diagnostics` list of structured :class:`ModelDiagnostic`
+    objects when raised from the new collect-mode pipeline. Existing
+    callers that do not read :attr:`diagnostics` continue to work as before.
+
+    :param errors: List of validation errors that occurred, defaults to ``None``.
+    :type errors: List[ValidationError], optional
+    :param diagnostics: List of structured diagnostics, defaults to ``None``.
+    :type diagnostics: List[ModelDiagnostic], optional
+    :param message: Pre-formatted summary message, defaults to ``None``.
+        When omitted, a summary is built from :attr:`errors` /
+        :attr:`diagnostics`.
+    :type message: str, optional
+
+    :ivar errors: Stored validation errors.
     :vartype errors: List[ValidationError]
+    :ivar diagnostics: Stored structured diagnostics.
+    :vartype diagnostics: List[ModelDiagnostic]
 
     Example::
 
         >>> err = ModelValidationError([ValidationError("A"), ValidationError("B")])
         >>> "2 errors" in str(err)
         True
+        >>> isinstance(err, SyntaxError)
+        True
+        >>> err.diagnostics
+        []
     """
 
-    def __init__(self, errors: List[ValidationError]) -> None:
-        super().__init__(
-            f"Model validation error, {plural_word(len(errors), 'error')} in total:{os.linesep}"
-            f"{os.linesep.join(map(lambda x: f'{x[0]}. {x[1]}', enumerate(map(repr, errors), start=1)))}",
-        )
-        self.errors = errors
+    def __init__(
+            self,
+            errors: Optional[List[ValidationError]] = None,
+            diagnostics: Optional[List[ModelDiagnostic]] = None,
+            message: Optional[str] = None,
+    ) -> None:
+        self.errors: List[ValidationError] = list(errors) if errors else []
+        self.diagnostics: List[ModelDiagnostic] = list(diagnostics) if diagnostics else []
+        if message is None:
+            message = self._build_summary_message()
+        super().__init__(message)
+
+    def _build_summary_message(self) -> str:
+        parts: List[str] = []
+        if self.errors:
+            parts.append(
+                f"Model validation error, {plural_word(len(self.errors), 'error')} in total:"
+                f"{os.linesep}"
+                f"{os.linesep.join(f'{i}. {repr(e)}' for i, e in enumerate(self.errors, start=1))}"
+            )
+        if self.diagnostics:
+            diag_lines = [
+                f"{i}. [{d.severity}/{d.code}] {d.message}"
+                for i, d in enumerate(self.diagnostics, start=1)
+            ]
+            parts.append(
+                f"Model diagnostics, {plural_word(len(self.diagnostics), 'item')} in total:"
+                f"{os.linesep}"
+                f"{os.linesep.join(diag_lines)}"
+            )
+        if not parts:
+            return "Model validation error."
+        return os.linesep.join(parts)
 
 
 class IValidatable:

--- a/pyfcstm/verify/__init__.py
+++ b/pyfcstm/verify/__init__.py
@@ -1,0 +1,26 @@
+"""
+Structural verification and design-health diagnostics for pyfcstm state machines.
+
+This package hosts:
+
+* :mod:`pyfcstm.verify.codes` — the single source of truth for structured
+  diagnostic codes (``codes.yaml`` + the :data:`CODE_REGISTRY` loader).
+
+Future PRs in the Layer 1 / Layer 2 work add:
+
+* a static model inspector that produces design-health warnings,
+* a static simulation auditor that dry-runs speculative validation across
+  the model.
+
+See ``HansBug/pyfcstm`` issue #103 for the migration plan and ``codes.yaml``
+for the authoritative code catalog.
+"""
+
+from .codes import CODE_REGISTRY, CodeFieldSpec, CodeSpec, load_codes
+
+__all__ = [
+    'CODE_REGISTRY',
+    'CodeFieldSpec',
+    'CodeSpec',
+    'load_codes',
+]

--- a/pyfcstm/verify/codes.py
+++ b/pyfcstm/verify/codes.py
@@ -1,0 +1,233 @@
+"""
+Loader for the structured diagnostic code registry.
+
+This module loads ``codes.yaml`` (the single source of truth for diagnostic
+codes emitted by :mod:`pyfcstm.model`) at import time and exposes the parsed
+table as :data:`CODE_REGISTRY`. Downstream consumers — including the
+``research_ideas`` LLM agent loop, IDE integrations, and the future
+``jsfcstm`` visualization layer — can mirror this registry to drive their
+own dispatch logic without depending on exception message text.
+
+The loader performs structural validation on import so that schema drift
+in ``codes.yaml`` fails fast.
+
+The module contains:
+
+* :class:`CodeFieldSpec` - Per-field schema describing a ``refs`` payload key.
+* :class:`CodeSpec` - Full specification for one diagnostic code.
+* :data:`CODE_REGISTRY` - Mapping ``code -> CodeSpec`` loaded at import time.
+* :func:`load_codes` - Parse a YAML file path and return the registry.
+
+.. note::
+   The codes.yaml file is intentionally kept lightweight: it does not
+   enforce ``refs`` runtime types on every emitted diagnostic. The schema
+   serves as documentation and as the contract surface for downstream
+   tools and tests.
+
+Example::
+
+    >>> from pyfcstm.verify.codes import CODE_REGISTRY
+    >>> spec = CODE_REGISTRY['E_UNDEFINED_VAR']
+    >>> spec.severity
+    'error'
+    >>> 'var_name' in spec.refs_schema
+    True
+"""
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional
+
+import yaml
+
+_ALLOWED_SEVERITIES = ('error', 'warning')
+_ALLOWED_REF_TYPES = (
+    'str',
+    'str_or_null',
+    'int',
+    'int_or_null',
+    'bool',
+    'Span',
+    'list[str]',
+)
+
+
+@dataclass(frozen=True)
+class CodeFieldSpec:
+    """
+    Schema for a single field inside :attr:`CodeSpec.refs_schema`.
+
+    :param name: Field name as it will appear in :attr:`ModelDiagnostic.refs`.
+    :type name: str
+    :param type: Field type token. Must be one of the allowed type tokens
+        documented at the top of ``codes.yaml``.
+    :type type: str
+    :param required: Whether this field must be present when the diagnostic
+        is emitted.
+    :type required: bool
+    :param description: Human-readable explanation of the field.
+    :type description: str
+    """
+
+    name: str
+    type: str
+    required: bool
+    description: str
+
+
+@dataclass(frozen=True)
+class CodeSpec:
+    """
+    Full specification for a single diagnostic code.
+
+    :param code: Stable code identifier (e.g. ``'E_UNDEFINED_VAR'``).
+    :type code: str
+    :param severity: ``'error'`` or ``'warning'``.
+    :type severity: str
+    :param description: Human-readable description of when the code fires.
+    :type description: str
+    :param refs_schema: Mapping ``field_name -> CodeFieldSpec`` describing
+        the structured payload for diagnostics with this code.
+    :type refs_schema: Dict[str, CodeFieldSpec]
+    :param example_dsl: Minimal DSL snippet that triggers the code,
+        defaults to ``None``.
+    :type example_dsl: str, optional
+    """
+
+    code: str
+    severity: str
+    description: str
+    refs_schema: Mapping[str, CodeFieldSpec]
+    example_dsl: Optional[str] = None
+
+    def required_fields(self) -> List[str]:
+        """
+        Return the names of fields that must be present in ``refs``.
+
+        :return: List of required field names in declaration order.
+        :rtype: List[str]
+        """
+        return [name for name, spec in self.refs_schema.items() if spec.required]
+
+
+def _validate_field(code: str, field_name: str, raw: Any) -> CodeFieldSpec:
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"codes.yaml: code {code!r} field {field_name!r} must be a mapping, got {type(raw).__name__}."
+        )
+    if 'type' not in raw:
+        raise ValueError(
+            f"codes.yaml: code {code!r} field {field_name!r} is missing required key 'type'."
+        )
+    field_type = raw['type']
+    if field_type not in _ALLOWED_REF_TYPES:
+        raise ValueError(
+            f"codes.yaml: code {code!r} field {field_name!r} has unsupported type {field_type!r}. "
+            f"Allowed: {_ALLOWED_REF_TYPES}."
+        )
+    required = bool(raw.get('required', False))
+    description = str(raw.get('description', ''))
+    return CodeFieldSpec(
+        name=field_name,
+        type=field_type,
+        required=required,
+        description=description,
+    )
+
+
+def _validate_code(code: str, raw: Any) -> CodeSpec:
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"codes.yaml: code {code!r} must be a mapping, got {type(raw).__name__}."
+        )
+    severity = raw.get('severity')
+    if severity not in _ALLOWED_SEVERITIES:
+        raise ValueError(
+            f"codes.yaml: code {code!r} has invalid severity {severity!r}. "
+            f"Allowed: {_ALLOWED_SEVERITIES}."
+        )
+    description = str(raw.get('description', '')).strip()
+    if not description:
+        raise ValueError(
+            f"codes.yaml: code {code!r} must have a non-empty 'description'."
+        )
+
+    raw_refs = raw.get('refs') or {}
+    if not isinstance(raw_refs, dict):
+        raise ValueError(
+            f"codes.yaml: code {code!r} 'refs' must be a mapping when present, "
+            f"got {type(raw_refs).__name__}."
+        )
+    refs_schema: Dict[str, CodeFieldSpec] = {}
+    for field_name, field_raw in raw_refs.items():
+        refs_schema[field_name] = _validate_field(code, field_name, field_raw)
+
+    example_dsl = raw.get('example_dsl')
+    if example_dsl is not None and not isinstance(example_dsl, str):
+        raise ValueError(
+            f"codes.yaml: code {code!r} 'example_dsl' must be a string when present, "
+            f"got {type(example_dsl).__name__}."
+        )
+
+    # Codes follow a 1-letter severity prefix convention: E_* for errors,
+    # W_* for warnings. Enforce so that severity and code stay in sync.
+    expected_prefix = 'E_' if severity == 'error' else 'W_'
+    if not code.startswith(expected_prefix):
+        raise ValueError(
+            f"codes.yaml: code {code!r} has severity {severity!r} but does not start "
+            f"with the expected prefix {expected_prefix!r}."
+        )
+
+    return CodeSpec(
+        code=code,
+        severity=severity,
+        description=description,
+        refs_schema=refs_schema,
+        example_dsl=example_dsl,
+    )
+
+
+def load_codes(path: str) -> Dict[str, CodeSpec]:
+    """
+    Load and validate a ``codes.yaml`` file from disk.
+
+    :param path: Filesystem path to the YAML file.
+    :type path: str
+    :return: Mapping ``code -> CodeSpec`` parsed from the file.
+    :rtype: Dict[str, CodeSpec]
+    :raises FileNotFoundError: If ``path`` does not exist.
+    :raises ValueError: If the YAML structure does not match the expected
+        schema, or if a code uses an unknown severity / type token.
+
+    Example::
+
+        >>> import os
+        >>> from pyfcstm.verify.codes import load_codes
+        >>> path = os.path.join(os.path.dirname(__file__), 'codes.yaml')
+
+    """
+    with open(path, 'r', encoding='utf-8') as f:
+        raw = yaml.safe_load(f)
+    if raw is None:
+        raise ValueError(f"codes.yaml at {path!r} is empty.")
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"codes.yaml at {path!r} must contain a top-level mapping, "
+            f"got {type(raw).__name__}."
+        )
+    registry: Dict[str, CodeSpec] = {}
+    for code, entry in raw.items():
+        if not isinstance(code, str):
+            raise ValueError(
+                f"codes.yaml at {path!r}: top-level key {code!r} must be a string."
+            )
+        registry[code] = _validate_code(code, entry)
+    if not registry:
+        raise ValueError(f"codes.yaml at {path!r} contains no code definitions.")
+    return registry
+
+
+_CODES_YAML_PATH = os.path.join(os.path.dirname(__file__), 'codes.yaml')
+
+#: Mapping ``code -> CodeSpec`` loaded from ``codes.yaml`` at import time.
+CODE_REGISTRY: Dict[str, CodeSpec] = load_codes(_CODES_YAML_PATH)

--- a/pyfcstm/verify/codes.yaml
+++ b/pyfcstm/verify/codes.yaml
@@ -1,0 +1,239 @@
+# Single source of truth for structured diagnostic codes emitted by
+# `pyfcstm.model` and consumed by downstream tools (LLM agent loops, IDE
+# integrations, evaluation scripts, and the jsfcstm visualization layer).
+#
+# Each entry documents:
+#   - `severity`       — 'error' or 'warning'
+#   - `description`    — human-readable explanation of when this code fires
+#   - `refs`           — payload schema for `ModelDiagnostic.refs`. Each
+#                        field declares its type, whether it is required,
+#                        and a short description. Field names are part of
+#                        the public contract; downstream consumers should
+#                        rely on these names verbatim.
+#   - `example_dsl`    — minimal DSL snippet that triggers the code (used
+#                        by unit tests and by downstream tooling to
+#                        validate their dispatch paths).
+#
+# Allowed `refs.*.type` tokens:
+#   str | str_or_null | int | int_or_null | bool | Span | list[str]
+#
+# Adding a new code: append a new top-level entry here AND add a fixture
+# test that triggers it from a real DSL snippet. The loader in `codes.py`
+# verifies the schema at import time.
+
+E_UNDEFINED_VAR:
+  severity: error
+  description: >-
+    A guard, effect, or lifecycle-action block references a name that was
+    never declared with a top-level `def` statement.
+  refs:
+    var_name:
+      type: str
+      required: true
+      description: The undeclared identifier as it appeared in the source.
+    referenced_in:
+      type: str
+      required: true
+      description: >-
+        Which kind of block contained the reference. One of: 'guard',
+        'effect', 'enter', 'during', 'exit', 'init'.
+    state_path:
+      type: str_or_null
+      required: false
+      description: >-
+        Dotted path of the state that owns the offending block, when the
+        reference is inside a state body (not a guard/effect on a
+        transition).
+    expr_text:
+      type: str_or_null
+      required: false
+      description: Original expression text containing the reference.
+  example_dsl: |
+    def int x = 0;
+    state Root { state A; state B; A -> B : if [unknown_var > 0]; }
+
+E_DUPLICATE_VAR:
+  severity: error
+  description: >-
+    A top-level `def` statement re-declares an identifier that was already
+    defined earlier in the file.
+  refs:
+    var_name:
+      type: str
+      required: true
+      description: The duplicated identifier.
+    previous_span:
+      type: Span
+      required: false
+      description: Source position of the first declaration.
+  example_dsl: |
+    def int x = 0;
+    def int x = 1;
+    state Root { state A; }
+
+E_MISSING_STATE:
+  severity: error
+  description: >-
+    A transition target references a state path that cannot be resolved
+    in the surrounding hierarchy.
+  refs:
+    state_path:
+      type: str
+      required: true
+      description: The unresolved dotted state path.
+    referenced_from:
+      type: str_or_null
+      required: false
+      description: Dotted path of the state from which the reference was made.
+    reason:
+      type: str
+      required: false
+      description: >-
+        Short tag describing the resolution failure mode. One of:
+        'not_found', 'parent_missing', 'ambiguous'.
+  example_dsl: |
+    state Root { state A; A -> NoSuch; }
+
+E_DUPLICATE_STATE:
+  severity: error
+  description: Two states share the same name within the same parent scope.
+  refs:
+    state_name:
+      type: str
+      required: true
+      description: The duplicated state name.
+    parent_path:
+      type: str
+      required: true
+      description: Dotted path of the parent that contains both states.
+    previous_span:
+      type: Span
+      required: false
+      description: Source position of the first declaration.
+  example_dsl: |
+    state Root { state A; state A; }
+
+E_EVENT_REF_INVALID:
+  severity: error
+  description: >-
+    The textual form of an event reference is syntactically invalid (e.g.
+    bare '/', trailing dots, going beyond the root state).
+  refs:
+    event_ref:
+      type: str
+      required: true
+      description: The raw event reference text.
+    reason:
+      type: str
+      required: true
+      description: >-
+        Short tag describing why the reference is invalid. One of:
+        'empty', 'bare_slash', 'invalid_absolute', 'invalid_relative',
+        'trailing_dots', 'beyond_root'.
+  example_dsl: |
+    state Root { state A; state B; A -> B : /; }
+
+E_EVENT_NOT_FOUND:
+  severity: error
+  description: >-
+    An event reference parses correctly but does not resolve to any event
+    defined in the targeted scope.
+  refs:
+    event_ref:
+      type: str
+      required: true
+      description: The raw event reference text.
+    scope:
+      type: str
+      required: true
+      description: >-
+        Resolution scope used. One of: 'local', 'chain', 'absolute'.
+    searched_from:
+      type: str_or_null
+      required: false
+      description: Dotted state path where the search originated.
+  example_dsl: |
+    state Root { state A; state B; A -> B :: NoEvent; }
+
+E_DANGLING_TRANSITION:
+  severity: error
+  description: >-
+    A transition cannot resolve either its source or its target.
+  refs:
+    src:
+      type: str_or_null
+      required: false
+      description: Raw source state expression as written in the DSL.
+    tgt:
+      type: str_or_null
+      required: false
+      description: Raw target state expression as written in the DSL.
+    reason:
+      type: str
+      required: true
+      description: >-
+        Short tag describing the dangling reason. One of: 'src_not_found',
+        'tgt_not_found', 'both_not_found'.
+  example_dsl: |
+    state Root { state A; NoSuch -> A; }
+
+E_TYPE_MISMATCH:
+  severity: error
+  description: >-
+    A guard, effect, or assignment uses an expression whose type does not
+    match the expected category (arithmetic vs boolean).
+  refs:
+    expected:
+      type: str
+      required: true
+      description: >-
+        Expected category. One of: 'numeric', 'boolean'.
+    actual:
+      type: str
+      required: true
+      description: Actual category produced by the expression.
+    expr_text:
+      type: str
+      required: true
+      description: Original expression text.
+  example_dsl: |
+    def int x = 0;
+    state Root { state A; state B; A -> B : if [x]; }
+
+E_FORCED_TRANSITION_EXPANSION:
+  severity: error
+  description: >-
+    A forced transition (`!State -> ...` or `!*`) cannot be expanded
+    because the source or target reference is invalid.
+  refs:
+    original_raw:
+      type: str
+      required: true
+      description: Raw forced-transition text as written.
+    reason:
+      type: str
+      required: true
+      description: >-
+        Short tag describing why expansion failed. One of: 'src_not_found',
+        'tgt_not_found', 'src_is_root', 'wildcard_no_descendants'.
+  example_dsl: |
+    state Root { state A; !NoSuch -> A; }
+
+E_INITIAL_TRANSITION_INVALID:
+  severity: error
+  description: >-
+    A composite state either lacks an entry transition (`[*] -> child`) or
+    declares one whose target is not a direct child of the composite.
+  refs:
+    composite_path:
+      type: str
+      required: true
+      description: Dotted path of the offending composite state.
+    reason:
+      type: str
+      required: true
+      description: >-
+        Short tag describing the failure. One of: 'missing_entry',
+        'target_not_child'.
+  example_dsl: |
+    state Root { state Outer { state Inner; } }

--- a/test/utils/test_diagnostics.py
+++ b/test/utils/test_diagnostics.py
@@ -1,0 +1,167 @@
+"""
+Unit tests for :class:`pyfcstm.utils.validate.Span` and
+:class:`pyfcstm.utils.validate.ModelDiagnostic`, plus the extended
+:class:`pyfcstm.utils.validate.ModelValidationError` introduced in PR-1 of
+the Layer 1 structured-diagnostic refactor (see issue #103).
+
+These tests pin down the public contract of the new dataclasses and
+verify the multi-inheritance backwards-compatibility trick that lets
+PR-2 swap ``raise SyntaxError`` for ``raise ModelValidationError``
+without breaking any caller that catches ``SyntaxError``.
+"""
+
+import pytest
+
+from pyfcstm.utils import (
+    IValidatable,
+    ModelDiagnostic,
+    ModelValidationError,
+    Span,
+    ValidationError,
+)
+
+
+@pytest.mark.unittest
+class TestSpan:
+    def test_basic_construction(self):
+        span = Span(line=3, column=7)
+        assert span.line == 3
+        assert span.column == 7
+        assert span.end_line is None
+        assert span.end_column is None
+
+    def test_construction_with_end_position(self):
+        span = Span(line=3, column=7, end_line=3, end_column=20)
+        assert span.end_line == 3
+        assert span.end_column == 20
+
+    def test_is_frozen(self):
+        span = Span(line=1, column=1)
+        with pytest.raises(Exception):
+            span.line = 2  # noqa
+
+    def test_equality(self):
+        assert Span(line=1, column=1) == Span(line=1, column=1)
+        assert Span(line=1, column=1) != Span(line=1, column=2)
+
+
+@pytest.mark.unittest
+class TestModelDiagnostic:
+    def test_minimal_construction(self):
+        diag = ModelDiagnostic(
+            code='E_UNDEFINED_VAR',
+            severity='error',
+            message="Unknown variable 'x'",
+        )
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.severity == 'error'
+        assert diag.span is None
+        assert diag.refs == {}
+        assert diag.is_error()
+
+    def test_full_construction_with_refs_and_span(self):
+        span = Span(line=5, column=21)
+        diag = ModelDiagnostic(
+            code='E_UNDEFINED_VAR',
+            severity='error',
+            message="Unknown guard variable",
+            span=span,
+            refs={'var_name': 'unknown_var', 'referenced_in': 'guard'},
+        )
+        assert diag.span is span
+        assert diag.refs['var_name'] == 'unknown_var'
+        assert diag.refs['referenced_in'] == 'guard'
+
+    def test_warning_severity_is_not_error(self):
+        diag = ModelDiagnostic(
+            code='W_DEADLOCK_LEAF',
+            severity='warning',
+            message="Deadlock leaf",
+        )
+        assert not diag.is_error()
+
+    def test_refs_default_is_independent_per_instance(self):
+        """Guard against the classic dataclass-mutable-default trap."""
+        a = ModelDiagnostic(code='E_X', severity='error', message='m')
+        b = ModelDiagnostic(code='E_Y', severity='error', message='m')
+        a.refs['k'] = 1
+        assert 'k' not in b.refs
+
+
+@pytest.mark.unittest
+class TestModelValidationError:
+    def test_inherits_from_syntax_error(self):
+        """
+        Backwards-compatibility trick: PR-2 will replace
+        ``raise SyntaxError(...)`` in model.py with
+        ``raise ModelValidationError(...)``. All ``except SyntaxError:``
+        callers must continue to work.
+        """
+        err = ModelValidationError([ValidationError('A')])
+        assert isinstance(err, SyntaxError)
+        assert isinstance(err, Exception)
+
+    def test_legacy_errors_only_construction(self):
+        err = ModelValidationError([ValidationError('A'), ValidationError('B')])
+        assert len(err.errors) == 2
+        assert err.diagnostics == []
+        assert '2 errors' in str(err)
+
+    def test_diagnostics_only_construction(self):
+        diag = ModelDiagnostic(
+            code='E_UNDEFINED_VAR',
+            severity='error',
+            message='unknown var',
+        )
+        err = ModelValidationError(diagnostics=[diag])
+        assert err.errors == []
+        assert len(err.diagnostics) == 1
+        assert err.diagnostics[0] is diag
+        assert 'E_UNDEFINED_VAR' in str(err)
+
+    def test_mixed_errors_and_diagnostics(self):
+        diag = ModelDiagnostic(code='E_X', severity='error', message='mx')
+        err = ModelValidationError(
+            errors=[ValidationError('A')],
+            diagnostics=[diag],
+        )
+        assert len(err.errors) == 1
+        assert len(err.diagnostics) == 1
+
+    def test_caught_via_syntax_error_handler(self):
+        """The whole point of the multi-inheritance trick."""
+        try:
+            raise ModelValidationError(
+                diagnostics=[ModelDiagnostic(code='E_X', severity='error', message='m')]
+            )
+        except SyntaxError as e:
+            assert isinstance(e, ModelValidationError)
+            assert e.diagnostics[0].code == 'E_X'
+        else:
+            pytest.fail("ModelValidationError should be catchable as SyntaxError")
+
+    def test_default_construction_is_empty(self):
+        err = ModelValidationError()
+        assert err.errors == []
+        assert err.diagnostics == []
+        assert str(err)  # non-empty fallback message
+
+    def test_custom_message_overrides_summary(self):
+        err = ModelValidationError(
+            diagnostics=[ModelDiagnostic(code='E_X', severity='error', message='m')],
+            message="custom top-level message",
+        )
+        assert 'custom top-level message' in str(err)
+
+    def test_ivalidatable_still_raises_model_validation_error(self):
+        """The IValidatable mixin must continue to work after the refactor."""
+
+        class _BadModel(IValidatable):
+            def _v(self) -> None:
+                raise ValidationError("bad")
+
+            __validators__ = [_v]
+
+        with pytest.raises(ModelValidationError) as info:
+            _BadModel().validate()
+        assert len(info.value.errors) == 1

--- a/test/verify/test_codes_yaml.py
+++ b/test/verify/test_codes_yaml.py
@@ -1,0 +1,210 @@
+"""
+Unit tests for :mod:`pyfcstm.verify.codes` — the loader that parses
+``codes.yaml`` and exposes :data:`pyfcstm.verify.codes.CODE_REGISTRY` as
+the single source of truth for diagnostic codes.
+
+These tests pin down the schema contract that downstream consumers
+(``research_ideas`` LLM agent loop, future jsfcstm visualization, IDE
+integrations) rely on, and verify the loader's structural validation
+fails fast when the YAML is malformed.
+"""
+
+import os
+import textwrap
+
+import pytest
+
+from pyfcstm.verify import CODE_REGISTRY, CodeFieldSpec, CodeSpec, load_codes
+from pyfcstm.verify.codes import _ALLOWED_REF_TYPES, _ALLOWED_SEVERITIES
+
+
+@pytest.mark.unittest
+class TestCodeRegistryShape:
+    def test_registry_is_non_empty(self):
+        assert len(CODE_REGISTRY) >= 10, (
+            "PR-1 introduces 10 error codes; the registry should never shrink "
+            "below that floor without explicit removal in a follow-up PR."
+        )
+
+    def test_all_entries_are_code_specs(self):
+        for code, spec in CODE_REGISTRY.items():
+            assert isinstance(spec, CodeSpec)
+            assert spec.code == code
+
+    @pytest.mark.parametrize('code', sorted(CODE_REGISTRY.keys()))
+    def test_each_code_has_valid_severity(self, code):
+        assert CODE_REGISTRY[code].severity in _ALLOWED_SEVERITIES
+
+    @pytest.mark.parametrize('code', sorted(CODE_REGISTRY.keys()))
+    def test_each_code_has_non_empty_description(self, code):
+        assert CODE_REGISTRY[code].description.strip()
+
+    @pytest.mark.parametrize('code', sorted(CODE_REGISTRY.keys()))
+    def test_each_code_has_at_least_one_ref_field(self, code):
+        assert len(CODE_REGISTRY[code].refs_schema) >= 1, (
+            f"code {code} has no refs schema; a diagnostic without any "
+            f"structured payload is rarely useful to downstream tooling."
+        )
+
+    @pytest.mark.parametrize('code', sorted(CODE_REGISTRY.keys()))
+    def test_each_ref_field_uses_allowed_type(self, code):
+        for field_name, field_spec in CODE_REGISTRY[code].refs_schema.items():
+            assert isinstance(field_spec, CodeFieldSpec)
+            assert field_spec.type in _ALLOWED_REF_TYPES, (
+                f"code {code} field {field_name} uses unsupported type "
+                f"{field_spec.type!r}"
+            )
+
+    def test_error_codes_use_E_prefix(self):
+        for code, spec in CODE_REGISTRY.items():
+            if spec.severity == 'error':
+                assert code.startswith('E_'), (
+                    f"error code {code} must start with 'E_'"
+                )
+
+    def test_warning_codes_use_W_prefix(self):
+        for code, spec in CODE_REGISTRY.items():
+            if spec.severity == 'warning':
+                assert code.startswith('W_'), (
+                    f"warning code {code} must start with 'W_'"
+                )
+
+
+@pytest.mark.unittest
+class TestPR1CodesPresence:
+    """
+    Lock in the exact set of error codes introduced by PR-1 so that future
+    refactors removing or renaming any of them surface as an obvious test
+    failure (downstream contract guard).
+    """
+
+    PR1_CODES = {
+        'E_UNDEFINED_VAR',
+        'E_DUPLICATE_VAR',
+        'E_MISSING_STATE',
+        'E_DUPLICATE_STATE',
+        'E_EVENT_REF_INVALID',
+        'E_EVENT_NOT_FOUND',
+        'E_DANGLING_TRANSITION',
+        'E_TYPE_MISMATCH',
+        'E_FORCED_TRANSITION_EXPANSION',
+        'E_INITIAL_TRANSITION_INVALID',
+    }
+
+    def test_all_pr1_codes_present(self):
+        missing = self.PR1_CODES - set(CODE_REGISTRY)
+        assert not missing, f"PR-1 codes missing from registry: {missing}"
+
+    def test_e_undefined_var_required_fields(self):
+        spec = CODE_REGISTRY['E_UNDEFINED_VAR']
+        required = set(spec.required_fields())
+        assert 'var_name' in required
+        assert 'referenced_in' in required
+
+    def test_e_missing_state_required_fields(self):
+        spec = CODE_REGISTRY['E_MISSING_STATE']
+        assert 'state_path' in spec.required_fields()
+
+    def test_e_dangling_transition_reason_required(self):
+        spec = CODE_REGISTRY['E_DANGLING_TRANSITION']
+        assert 'reason' in spec.required_fields()
+
+
+@pytest.mark.unittest
+class TestLoaderValidation:
+    def _write_yaml(self, tmp_path, body: str) -> str:
+        target = tmp_path / 'codes.yaml'
+        target.write_text(textwrap.dedent(body), encoding='utf-8')
+        return str(target)
+
+    def test_loads_minimal_valid_file(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: A test code.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+        """)
+        reg = load_codes(path)
+        assert 'E_FOO' in reg
+        assert reg['E_FOO'].refs_schema['bar'].type == 'str'
+
+    def test_rejects_unknown_severity(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: critical
+              description: Bad severity.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+        """)
+        with pytest.raises(ValueError, match='severity'):
+            load_codes(path)
+
+    def test_rejects_unknown_ref_type(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: Bad ref type.
+              refs:
+                bar:
+                  type: complex_thing
+                  required: true
+                  description: A bar.
+        """)
+        with pytest.raises(ValueError, match='unsupported type'):
+            load_codes(path)
+
+    def test_rejects_missing_description(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: ""
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+        """)
+        with pytest.raises(ValueError, match='description'):
+            load_codes(path)
+
+    def test_rejects_severity_prefix_mismatch(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            W_FOO:
+              severity: error
+              description: Prefix and severity disagree.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+        """)
+        with pytest.raises(ValueError, match='prefix'):
+            load_codes(path)
+
+    def test_rejects_empty_file(self, tmp_path):
+        target = tmp_path / 'codes.yaml'
+        target.write_text('', encoding='utf-8')
+        with pytest.raises(ValueError, match='empty'):
+            load_codes(str(target))
+
+    def test_rejects_non_mapping_root(self, tmp_path):
+        target = tmp_path / 'codes.yaml'
+        target.write_text('- E_FOO\n', encoding='utf-8')
+        with pytest.raises(ValueError, match='top-level mapping'):
+            load_codes(str(target))
+
+    def test_real_codes_yaml_path_resolves(self):
+        path = os.path.join(
+            os.path.dirname(__file__), '..', '..',
+            'pyfcstm', 'verify', 'codes.yaml',
+        )
+        assert os.path.isfile(path)
+        reg = load_codes(path)
+        assert set(reg.keys()) == set(CODE_REGISTRY.keys())


### PR DESCRIPTION
> ⚠️ 本 PR 之前被 auto-merge 进 main，因为 review 流程被跳过，已通过 `git revert -m 1`（commit `a2719eb8`）回退。新的 review PR 见 **#109**。本 PR body 已翻译成中文，仅作历史归档。

---

## 概述

#103 跟踪的 Layer 1 结构化诊断改造的第二个 PR，在 PR-0（#105）之上递进。**纯加法，`pyfcstm.model` 行为零变动** —— PR-0 基线测试保持全绿。PR-2 之后会基于本 PR 定义的契约，把 `model.py` 的 raise 点改造成发射 `ModelDiagnostic`。

## 改动内容

### `pyfcstm.utils.validate`（扩展）

- 新增 **`Span`** dataclass —— frozen，1-based `line` / `column`，可选 `end_line` / `end_column`
- 新增 **`ModelDiagnostic`** dataclass —— `code` / `severity` / `message` / `span` / `refs`
- **`ModelValidationError` 现在多重继承 `SyntaxError`**，并在原有 `errors` 列表之外携带可选的 `diagnostics` 列表。多重继承是个向后兼容的"小聪明"：PR-2 把 `raise SyntaxError` 替换成 `raise ModelValidationError` 之后，**仓内**和**下游 `research_ideas` agent loop** 里所有 `except SyntaxError:` 的捕获代码都不需要改动

### `pyfcstm.verify`（新包）

- **`codes.yaml`** —— 诊断 code 的单一来源。PR-1 落地 10 个 `E_*` code：
  - `E_UNDEFINED_VAR`、`E_DUPLICATE_VAR`、`E_MISSING_STATE`、`E_DUPLICATE_STATE`
  - `E_EVENT_REF_INVALID`、`E_EVENT_NOT_FOUND`、`E_DANGLING_TRANSITION`
  - `E_TYPE_MISMATCH`、`E_FORCED_TRANSITION_EXPANSION`、`E_INITIAL_TRANSITION_INVALID`

  每条 code 都记录 severity、description、`refs` schema（按字段拆开写 type/required/description）和触发用的最小 `example_dsl` 片段。**`refs` 字段名跟下游 `research_ideas` 的 `SemanticFeedback` schema 严格对齐**。

- **`codes.py`** —— `load_codes()` 加载器，import 时就做结构化校验。暴露 `CODE_REGISTRY`。

- **`.gitignore`** —— 在 `pyfcstm/**/*.yaml` 黑名单下面给 `pyfcstm/verify/codes.yaml` 单独 allowlist。

### 测试（89 个新断言）

- `test/utils/test_diagnostics.py` —— 17 个断言
- `test/verify/test_codes_yaml.py` —— 72 个断言

## Cross-link

- 跟踪 issue：#103
- 前置：#105（PR-0）
- 重开的 review PR：#109
- 回退 commit：`a2719eb8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
