### PR TITLE
feat(model): 把 model.py 的 SyntaxError raise 全部改造成结构化 ModelDiagnostic 发射（PR-2 for #103）

### DIFF
--- a/docs/source/api_doc/diagnostics/codes.rst
+++ b/docs/source/api_doc/diagnostics/codes.rst
@@ -1,0 +1,40 @@
+pyfcstm.diagnostics.codes
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.codes
+
+.. automodule:: pyfcstm.diagnostics.codes
+
+
+CODE\_REGISTRY
+-----------------------------------------------------
+
+.. autodata:: CODE_REGISTRY
+
+
+CodesSchemaError
+-----------------------------------------------------
+
+.. autoclass:: CodesSchemaError
+
+
+CodeFieldSpec
+-----------------------------------------------------
+
+.. autoclass:: CodeFieldSpec
+    :members: name,type,required,description
+
+
+CodeSpec
+-----------------------------------------------------
+
+.. autoclass:: CodeSpec
+    :members: required_fields,code,severity,description,refs_schema,example_dsl
+
+
+load\_codes
+-----------------------------------------------------
+
+.. autofunction:: load_codes
+
+

--- a/docs/source/api_doc/diagnostics/codes.rst
+++ b/docs/source/api_doc/diagnostics/codes.rst
@@ -22,7 +22,7 @@ CodeFieldSpec
 -----------------------------------------------------
 
 .. autoclass:: CodeFieldSpec
-    :members: name,type,required,description
+    :members: name,type,required,description,enum
 
 
 CodeSpec

--- a/docs/source/api_doc/diagnostics/index.rst
+++ b/docs/source/api_doc/diagnostics/index.rst
@@ -1,20 +1,16 @@
-pyfcstm.model
+pyfcstm.diagnostics
 ========================================================
 
-.. currentmodule:: pyfcstm.model
+.. currentmodule:: pyfcstm.diagnostics
 
-.. automodule:: pyfcstm.model
+.. automodule:: pyfcstm.diagnostics
 
 
 .. toctree::
     :maxdepth: 3
 
-    base
-    expr
-    imports
-    load
-    model
-    plantuml
+    codes
+    sink
 
 \_\_all\_\_
 -----------------------------------------------------

--- a/docs/source/api_doc/diagnostics/sink.rst
+++ b/docs/source/api_doc/diagnostics/sink.rst
@@ -1,0 +1,15 @@
+pyfcstm.diagnostics.sink
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.sink
+
+.. automodule:: pyfcstm.diagnostics.sink
+
+
+DiagnosticSink
+-----------------------------------------------------
+
+.. autoclass:: DiagnosticSink
+    :members: __init__,collect,diagnostics,has_errors,emit,finalize_or_raise
+
+

--- a/docs/source/api_doc/index.rst
+++ b/docs/source/api_doc/index.rst
@@ -10,6 +10,7 @@ pyfcstm
     :maxdepth: 3
 
     config/index
+    diagnostics/index
     dsl/index
     entry/index
     highlight/index

--- a/docs/source/api_doc/utils/validate.rst
+++ b/docs/source/api_doc/utils/validate.rst
@@ -6,6 +6,20 @@ pyfcstm.utils.validate
 .. automodule:: pyfcstm.utils.validate
 
 
+Span
+-----------------------------------------------------
+
+.. autoclass:: Span
+    :members: line,column,end_line,end_column
+
+
+ModelDiagnostic
+-----------------------------------------------------
+
+.. autoclass:: ModelDiagnostic
+    :members: __post_init__,is_error,format_line,code,severity,message,span,refs
+
+
 ValidationError
 -----------------------------------------------------
 

--- a/docs/source/api_doc_en.rst
+++ b/docs/source/api_doc_en.rst
@@ -7,6 +7,7 @@ API Documentation
     :hidden:
 
     api_doc/config/index
+    api_doc/diagnostics/index
     api_doc/dsl/index
     api_doc/entry/index
     api_doc/highlight/index
@@ -18,6 +19,7 @@ API Documentation
     api_doc/utils/index
 
 * :doc:`api_doc/config/index`
+* :doc:`api_doc/diagnostics/index`
 * :doc:`api_doc/dsl/index`
 * :doc:`api_doc/entry/index`
 * :doc:`api_doc/highlight/index`

--- a/docs/source/api_doc_zh.rst
+++ b/docs/source/api_doc_zh.rst
@@ -7,6 +7,7 @@ API 文档
     :hidden:
 
     api_doc/config/index
+    api_doc/diagnostics/index
     api_doc/dsl/index
     api_doc/entry/index
     api_doc/highlight/index
@@ -18,6 +19,7 @@ API 文档
     api_doc/utils/index
 
 * :doc:`api_doc/config/index`
+* :doc:`api_doc/diagnostics/index`
 * :doc:`api_doc/dsl/index`
 * :doc:`api_doc/entry/index`
 * :doc:`api_doc/highlight/index`

--- a/pyfcstm/diagnostics/__init__.py
+++ b/pyfcstm/diagnostics/__init__.py
@@ -31,11 +31,13 @@ from .codes import (
     CodesSchemaError,
     load_codes,
 )
+from .sink import DiagnosticSink
 
 __all__ = [
     'CODE_REGISTRY',
     'CodeFieldSpec',
     'CodeSpec',
     'CodesSchemaError',
+    'DiagnosticSink',
     'load_codes',
 ]

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -44,7 +44,7 @@ import os
 import sys
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import yaml
 
@@ -99,12 +99,18 @@ class CodeFieldSpec:
     :type required: bool
     :param description: Human-readable explanation of the field.
     :type description: str
+    :param enum: Optional tuple of allowed string values for the field.
+        When present, downstream emit-test infrastructure (and any future
+        runtime validator) checks that ``refs[field]`` is a member of the
+        tuple. ``None`` means the field has no enumeration constraint.
+    :type enum: Optional[Tuple[str, ...]]
     """
 
     name: str
     type: str
     required: bool
     description: str
+    enum: Optional[Tuple[str, ...]] = None
 
 
 @dataclass(frozen=True)
@@ -178,11 +184,38 @@ def _validate_field(path: str, code: str, field_name: str, raw: Any) -> CodeFiel
             f"got {type(raw_required).__name__}: {raw_required!r}",
         ))
     description = str(raw.get('description', ''))
+
+    raw_enum = raw.get('enum')
+    field_enum: Optional[Tuple[str, ...]] = None
+    if raw_enum is not None:
+        if not isinstance(raw_enum, list):
+            raise CodesSchemaError(_ctx(
+                path,
+                f"code {code!r} field {field_name!r} 'enum' must be a list "
+                f"when present,",
+                f"got {type(raw_enum).__name__}",
+            ))
+        if not raw_enum:
+            raise CodesSchemaError(_ctx(
+                path,
+                f"code {code!r} field {field_name!r} 'enum' must be non-empty "
+                f"when present.",
+            ))
+        for value in raw_enum:
+            if not isinstance(value, str):
+                raise CodesSchemaError(_ctx(
+                    path,
+                    f"code {code!r} field {field_name!r} 'enum' members must "
+                    f"be strings, got {type(value).__name__}: {value!r}",
+                ))
+        field_enum = tuple(raw_enum)
+
     return CodeFieldSpec(
         name=field_name,
         type=field_type,
         required=raw_required,
         description=description,
+        enum=field_enum,
     )
 
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -239,3 +239,113 @@ E_INITIAL_TRANSITION_INVALID:
         'target_not_child'.
   example_dsl: |
     state Root { state Outer { state Inner; } }
+
+E_DUPLICATE_FUNCTION_NAME:
+  severity: error
+  description: >-
+    Two named lifecycle actions (enter / during / exit / during-aspect) within
+    the same state share the same name. Named actions are referenced via
+    `ref <name>` and must be uniquely identifiable.
+  refs:
+    function_name:
+      type: str
+      required: true
+      description: The duplicated named-action name.
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the state declaring the duplicates.
+    stage:
+      type: str
+      required: true
+      description: >-
+        Lifecycle stage where the duplicate appears. One of: 'enter',
+        'during', 'exit', 'during_aspect'.
+  example_dsl: |
+    state Root {
+        state A {
+            enter Foo { }
+            enter Foo { }
+        }
+    }
+
+E_DURING_ASPECT_INVALID:
+  severity: error
+  description: >-
+    A `during` block is declared inconsistently with the host state's
+    leaf/composite kind. Leaf states must use `during { ... }` without an
+    aspect modifier; composite states must use `during before { ... }` or
+    `during after { ... }` (the aspect is mandatory on composites).
+  refs:
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the offending state.
+    state_kind:
+      type: str
+      required: true
+      description: >-
+        Kind of the host state. One of: 'leaf', 'composite'.
+    aspect:
+      type: str_or_null
+      required: false
+      description: >-
+        The aspect token that was actually used (``'before'``, ``'after'``,
+        or null when the user wrote a bare ``during`` on a composite).
+  example_dsl: |
+    state Root {
+        state A {
+            during before { }
+        }
+    }
+
+E_PSEUDO_NOT_LEAF:
+  severity: error
+  description: >-
+    A state was declared with the `pseudo` keyword but has nested
+    substates. Pseudo states must be leaves: they skip ancestor
+    `>> during` aspects and only make sense without inner structure.
+  refs:
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the offending pseudo state.
+  example_dsl: |
+    state Root {
+        pseudo state Outer {
+            state Inner;
+            [*] -> Inner;
+        }
+    }
+
+E_NAMED_FUNCTION_REF_NOT_FOUND:
+  severity: error
+  description: >-
+    A `ref` lifecycle action could not resolve its target named action.
+    Either the path walks through a state that does not exist, or the final
+    segment is not a named action defined inside the resolved state.
+  refs:
+    ref_path:
+      type: str
+      required: true
+      description: Dotted path of the unresolved reference.
+    reason:
+      type: str
+      required: true
+      description: >-
+        Short tag describing the resolution failure. One of:
+        'state_not_found', 'named_function_not_found'.
+    missing_segment:
+      type: str_or_null
+      required: false
+      description: >-
+        The path segment that failed to resolve. For 'state_not_found' this
+        is the state name that does not exist under the parent path; for
+        'named_function_not_found' this is the action name searched for in
+        the resolved state.
+  example_dsl: |
+    state Root {
+        state A {
+            enter ref NoSuch.NoSuch;
+        }
+    }

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -37,8 +37,8 @@ E_UNDEFINED_VAR:
       type: str
       required: true
       description: >-
-        Which kind of block contained the reference. One of: 'guard',
-        'effect', 'enter', 'during', 'exit', 'init'.
+        Which kind of block contained the reference.
+      enum: ['guard', 'effect', 'enter', 'during', 'exit', 'during_aspect', 'init']
     state_path:
       type: str_or_null
       required: false
@@ -91,8 +91,12 @@ E_MISSING_STATE:
       type: str
       required: false
       description: >-
-        Short tag describing the resolution failure mode. One of:
-        'not_found', 'parent_missing', 'ambiguous'.
+        Short tag describing the resolution failure mode.
+      enum:
+        - 'not_found'
+        - 'parent_missing'
+        - 'ambiguous'
+        - 'event_path_not_found'
   example_dsl: |
     state Root { state A; A -> NoSuch; }
 
@@ -129,9 +133,14 @@ E_EVENT_REF_INVALID:
       type: str
       required: true
       description: >-
-        Short tag describing why the reference is invalid. One of:
-        'empty', 'bare_slash', 'invalid_absolute', 'invalid_relative',
-        'trailing_dots', 'beyond_root'.
+        Short tag describing why the reference is invalid.
+      enum:
+        - 'empty'
+        - 'bare_slash'
+        - 'invalid_absolute'
+        - 'invalid_relative'
+        - 'trailing_dots'
+        - 'beyond_root'
   example_dsl: |
     state Root { state A; state B; A -> B : /; }
 
@@ -149,7 +158,8 @@ E_EVENT_NOT_FOUND:
       type: str
       required: true
       description: >-
-        Resolution scope used. One of: 'local', 'chain', 'absolute'.
+        Resolution scope used.
+      enum: ['local', 'chain', 'absolute']
     searched_from:
       type: str_or_null
       required: false
@@ -174,8 +184,8 @@ E_DANGLING_TRANSITION:
       type: str
       required: true
       description: >-
-        Short tag describing the dangling reason. One of: 'src_not_found',
-        'tgt_not_found', 'both_not_found'.
+        Short tag describing the dangling reason.
+      enum: ['src_not_found', 'tgt_not_found', 'both_not_found']
   example_dsl: |
     state Root { state A; NoSuch -> A; }
 
@@ -216,8 +226,12 @@ E_FORCED_TRANSITION_EXPANSION:
       type: str
       required: true
       description: >-
-        Short tag describing why expansion failed. One of: 'src_not_found',
-        'tgt_not_found', 'src_is_root', 'wildcard_no_descendants'.
+        Short tag describing why expansion failed.
+      enum:
+        - 'src_not_found'
+        - 'tgt_not_found'
+        - 'src_is_root'
+        - 'wildcard_no_descendants'
   example_dsl: |
     state Root { state A; !NoSuch -> A; }
 
@@ -235,8 +249,8 @@ E_INITIAL_TRANSITION_INVALID:
       type: str
       required: true
       description: >-
-        Short tag describing the failure. One of: 'missing_entry',
-        'target_not_child'.
+        Short tag describing the failure.
+      enum: ['missing_entry', 'target_not_child']
   example_dsl: |
     state Root { state Outer { state Inner; } }
 
@@ -258,9 +272,8 @@ E_DUPLICATE_FUNCTION_NAME:
     stage:
       type: str
       required: true
-      description: >-
-        Lifecycle stage where the duplicate appears. One of: 'enter',
-        'during', 'exit', 'during_aspect'.
+      description: Lifecycle stage where the duplicate appears.
+      enum: ['enter', 'during', 'exit', 'during_aspect']
   example_dsl: |
     state Root {
         state A {
@@ -284,14 +297,15 @@ E_DURING_ASPECT_INVALID:
     state_kind:
       type: str
       required: true
-      description: >-
-        Kind of the host state. One of: 'leaf', 'composite'.
+      description: Kind of the host state.
+      enum: ['leaf', 'composite']
     aspect:
       type: str_or_null
       required: false
       description: >-
         The aspect token that was actually used (``'before'``, ``'after'``,
         or null when the user wrote a bare ``during`` on a composite).
+      enum: ['before', 'after']
   example_dsl: |
     state Root {
         state A {
@@ -332,9 +346,8 @@ E_NAMED_FUNCTION_REF_NOT_FOUND:
     reason:
       type: str
       required: true
-      description: >-
-        Short tag describing the resolution failure. One of:
-        'state_not_found', 'named_function_not_found'.
+      description: Short tag describing the resolution failure.
+      enum: ['state_not_found', 'named_function_not_found']
     missing_segment:
       type: str_or_null
       required: false

--- a/pyfcstm/diagnostics/sink.py
+++ b/pyfcstm/diagnostics/sink.py
@@ -107,6 +107,7 @@ class DiagnosticSink:
 def _emit(
         sink: Optional[DiagnosticSink],
         diagnostic: ModelDiagnostic,
+        prior_diagnostics: Optional[List[ModelDiagnostic]] = None,
 ) -> None:
     """
     Convenience helper: route ``diagnostic`` through ``sink`` if one is
@@ -116,13 +117,27 @@ def _emit(
     "callers expect classic raise behavior" without conditional plumbing at
     every call site.
 
+    When ``sink`` is ``None`` and ``prior_diagnostics`` is provided, the
+    raised :class:`ModelValidationError` carries those prior entries before
+    the new ``diagnostic`` — matching the strict-mode
+    :meth:`DiagnosticSink.emit` semantics where accumulated context (e.g.
+    earlier warnings) is preserved into the raise.
+
     :param sink: Active sink, or ``None`` to raise immediately.
     :type sink: pyfcstm.diagnostics.sink.DiagnosticSink, optional
     :param diagnostic: The structured diagnostic to route.
     :type diagnostic: pyfcstm.utils.validate.ModelDiagnostic
+    :param prior_diagnostics: Optional list of diagnostics already
+        accumulated by the caller; included in the raise on the
+        ``sink is None`` path. Defaults to ``None``.
+    :type prior_diagnostics: List[ModelDiagnostic], optional
     :raises pyfcstm.utils.validate.ModelValidationError: When ``sink`` is
         ``None`` or when the sink is in strict mode.
     """
     if sink is None:
-        raise ModelValidationError(diagnostics=[diagnostic])
+        all_diagnostics: List[ModelDiagnostic] = (
+            list(prior_diagnostics) if prior_diagnostics else []
+        )
+        all_diagnostics.append(diagnostic)
+        raise ModelValidationError(diagnostics=all_diagnostics)
     sink.emit(diagnostic)

--- a/pyfcstm/diagnostics/sink.py
+++ b/pyfcstm/diagnostics/sink.py
@@ -1,0 +1,128 @@
+"""
+Runtime sink for emitting :class:`pyfcstm.utils.validate.ModelDiagnostic`.
+
+The sink lets a single pass of model construction (or, later, design-health
+inspection) operate in two modes through one code path:
+
+* **strict** (the default) — each ``emit()`` raises a
+  :class:`pyfcstm.utils.validate.ModelValidationError` immediately, carrying
+  the diagnostic just produced plus any earlier ones. This preserves the
+  pre-PR-2 behavior where the very first semantic error aborts the build.
+
+* **collect** — ``emit()`` appends to an internal list and returns; the
+  caller is expected to call :meth:`finalize` (or read :attr:`diagnostics`
+  directly) at the end of the pass to inspect / surface every diagnostic
+  found, even though the resulting model may be partial.
+
+Downstream consumers (LLM agent loops, IDE integrations, the future
+``jsfcstm`` visualization layer) dispatch on
+:attr:`ModelDiagnostic.code`. The sink is purely a runtime helper — the
+contract surface is the diagnostic objects themselves, not this class.
+"""
+
+from typing import List, Optional
+
+from ..utils.validate import ModelDiagnostic, ModelValidationError
+
+
+class DiagnosticSink:
+    """
+    Collects :class:`ModelDiagnostic` objects emitted during a pass.
+
+    :param collect: When ``False`` (the default), every ``emit()`` call
+        raises :class:`ModelValidationError` immediately, carrying the
+        accumulated diagnostics. When ``True``, errors are accumulated and
+        the caller decides when to surface them.
+    :type collect: bool
+
+    Example::
+
+        >>> from pyfcstm.diagnostics.sink import DiagnosticSink
+        >>> from pyfcstm.utils import ModelDiagnostic
+        >>> sink = DiagnosticSink(collect=True)
+        >>> sink.emit(ModelDiagnostic(code='E_X', severity='error', message='x'))
+        >>> sink.emit(ModelDiagnostic(code='E_Y', severity='error', message='y'))
+        >>> [d.code for d in sink.diagnostics]
+        ['E_X', 'E_Y']
+        >>> sink.has_errors()
+        True
+    """
+
+    def __init__(self, collect: bool = False) -> None:
+        self._collect = bool(collect)
+        self._diagnostics: List[ModelDiagnostic] = []
+
+    @property
+    def collect(self) -> bool:
+        """
+        :return: ``True`` if the sink accumulates diagnostics, ``False`` if
+            it raises immediately.
+        :rtype: bool
+        """
+        return self._collect
+
+    @property
+    def diagnostics(self) -> List[ModelDiagnostic]:
+        """
+        :return: A snapshot copy of the diagnostics accumulated so far.
+        :rtype: List[ModelDiagnostic]
+        """
+        return list(self._diagnostics)
+
+    def has_errors(self) -> bool:
+        """
+        :return: ``True`` if at least one accumulated diagnostic has
+            ``severity == 'error'``.
+        :rtype: bool
+        """
+        return any(d.is_error() for d in self._diagnostics)
+
+    def emit(self, diagnostic: ModelDiagnostic) -> None:
+        """
+        Record a diagnostic. In strict mode, raise immediately.
+
+        :param diagnostic: The structured diagnostic to record.
+        :type diagnostic: pyfcstm.utils.validate.ModelDiagnostic
+        :raises pyfcstm.utils.validate.ModelValidationError: When the sink
+            is in strict mode (the default) and the diagnostic has error
+            severity.
+        """
+        self._diagnostics.append(diagnostic)
+        if not self._collect and diagnostic.is_error():
+            raise ModelValidationError(diagnostics=list(self._diagnostics))
+
+    def finalize_or_raise(self) -> None:
+        """
+        In collect mode, raise a single :class:`ModelValidationError`
+        carrying all accumulated error diagnostics if any are present.
+        In strict mode this is a no-op (errors already raised at emit time).
+
+        :raises pyfcstm.utils.validate.ModelValidationError: When collect
+            mode accumulated at least one error-severity diagnostic.
+        """
+        if self._collect and self.has_errors():
+            raise ModelValidationError(diagnostics=list(self._diagnostics))
+
+
+def _emit(
+        sink: Optional[DiagnosticSink],
+        diagnostic: ModelDiagnostic,
+) -> None:
+    """
+    Convenience helper: route ``diagnostic`` through ``sink`` if one is
+    provided; otherwise raise immediately as :class:`ModelValidationError`.
+
+    Used by code paths that want to support both "callers pass a sink" and
+    "callers expect classic raise behavior" without conditional plumbing at
+    every call site.
+
+    :param sink: Active sink, or ``None`` to raise immediately.
+    :type sink: pyfcstm.diagnostics.sink.DiagnosticSink, optional
+    :param diagnostic: The structured diagnostic to route.
+    :type diagnostic: pyfcstm.utils.validate.ModelDiagnostic
+    :raises pyfcstm.utils.validate.ModelValidationError: When ``sink`` is
+        ``None`` or when the sink is in strict mode.
+    """
+    if sink is None:
+        raise ModelValidationError(diagnostics=[diagnostic])
+    sink.emit(diagnostic)

--- a/pyfcstm/dsl/listener.py
+++ b/pyfcstm/dsl/listener.py
@@ -58,13 +58,24 @@ def _ctx_span(ctx) -> Span:
     ANTLR exposes ``token.column`` (0-based start) and ``len(token.text)``;
     we translate that into a 1-based half-open range so downstream tooling
     can highlight the matching source slice with simple substring math.
+
+    M3 from PR-110 review: when ``stop.text`` is empty (synthetic / EOF
+    tokens during ANTLR error recovery), the naive
+    ``stop.column + len(stop.text) + 1`` formula would produce a
+    zero-width span on a single line (``end_column == column``). Editor
+    squiggles refuse to render zero-width spans, so we widen single-line
+    spans by at least one column. Multi-line spans are always
+    positive-width by construction.
     """
     start = ctx.start
     stop = ctx.stop if ctx.stop is not None else start
+    column = start.column + 1
     end_column = stop.column + len(stop.text) + 1
+    if stop.line == start.line and end_column <= column:
+        end_column = column + 1
     return Span(
         line=start.line,
-        column=start.column + 1,
+        column=column,
         end_line=stop.line,
         end_column=end_column,
     )

--- a/pyfcstm/dsl/listener.py
+++ b/pyfcstm/dsl/listener.py
@@ -39,6 +39,35 @@ from typing import Any, Dict
 from .grammar import GrammarListener, GrammarParser
 from .node import *
 from ..utils import format_multiline_comment
+from ..utils.validate import Span
+
+
+def _ctx_span(ctx) -> Span:
+    """
+    Build a 1-based :class:`Span` covering an ANTLR4 parse context.
+
+    Semantics follow common editor / LSP conventions:
+
+    * ``line`` / ``column`` —  the 1-based start position (column points at
+      the **first character** of the first token).
+    * ``end_line`` / ``end_column`` — the 1-based exclusive end position
+      (``end_column`` points one column **past** the last character of the
+      last token, so a span covering ``[col, end_col)`` exactly contains
+      the token range).
+
+    ANTLR exposes ``token.column`` (0-based start) and ``len(token.text)``;
+    we translate that into a 1-based half-open range so downstream tooling
+    can highlight the matching source slice with simple substring math.
+    """
+    start = ctx.start
+    stop = ctx.stop if ctx.stop is not None else start
+    end_column = stop.column + len(stop.text) + 1
+    return Span(
+        line=start.line,
+        column=start.column + 1,
+        end_line=stop.line,
+        end_column=end_column,
+    )
 
 
 def _parse_string_literal(raw_text: str) -> str:
@@ -494,11 +523,13 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.Def_assignmentContext
         """
         super().exitDef_assignment(ctx)
-        self.nodes[ctx] = DefAssignment(
+        node = DefAssignment(
             name=str(ctx.ID()),
             type=ctx.deftype.text,
             expr=self.nodes[ctx.init_expression()],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitState_machine_dsl(
         self, ctx: GrammarParser.State_machine_dslContext
@@ -525,7 +556,7 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.LeafStateDefinitionContext
         """
         super().exitLeafStateDefinition(ctx)
-        self.nodes[ctx] = StateDefinition(
+        node = StateDefinition(
             name=str(ctx.ID()),
             extra_name=_parse_string_literal(ctx.extra_name.text)
             if ctx.extra_name
@@ -537,6 +568,8 @@ class GrammarParseListener(GrammarListener):
             exits=[],
             is_pseudo=bool(ctx.pseudo),
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitCompositeStateDefinition(
         self, ctx: GrammarParser.CompositeStateDefinitionContext
@@ -548,7 +581,7 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.CompositeStateDefinitionContext
         """
         super().exitCompositeStateDefinition(ctx)
-        self.nodes[ctx] = StateDefinition(
+        node = StateDefinition(
             name=str(ctx.ID()),
             extra_name=_parse_string_literal(ctx.extra_name.text)
             if ctx.extra_name
@@ -603,6 +636,8 @@ class GrammarParseListener(GrammarListener):
             ],
             is_pseudo=bool(ctx.pseudo),
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitEntryTransitionDefinition(
         self, ctx: GrammarParser.EntryTransitionDefinitionContext
@@ -614,7 +649,7 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.EntryTransitionDefinitionContext
         """
         super().exitEntryTransitionDefinition(ctx)
-        self.nodes[ctx] = TransitionDefinition(
+        node = TransitionDefinition(
             from_state=INIT_STATE,
             to_state=ctx.to_state.text,
             event_id=self.nodes[ctx.chain_id()] if ctx.chain_id() else None,
@@ -625,6 +660,8 @@ class GrammarParseListener(GrammarListener):
             if ctx.operational_statement_set()
             else [],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitNormalTransitionDefinition(
         self, ctx: GrammarParser.NormalTransitionDefinitionContext
@@ -641,7 +678,7 @@ class GrammarParseListener(GrammarListener):
             event_id = self.nodes[ctx.chain_id()]
         elif ctx.from_id:
             event_id = ChainID([ctx.from_state.text, ctx.from_id.text])
-        self.nodes[ctx] = TransitionDefinition(
+        node = TransitionDefinition(
             from_state=ctx.from_state.text,
             to_state=ctx.to_state.text,
             event_id=event_id,
@@ -652,6 +689,8 @@ class GrammarParseListener(GrammarListener):
             if ctx.operational_statement_set()
             else [],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitExitTransitionDefinition(
         self, ctx: GrammarParser.ExitTransitionDefinitionContext
@@ -668,7 +707,7 @@ class GrammarParseListener(GrammarListener):
             event_id = self.nodes[ctx.chain_id()]
         elif ctx.from_id:
             event_id = ChainID([ctx.from_state.text, ctx.from_id.text])
-        self.nodes[ctx] = TransitionDefinition(
+        node = TransitionDefinition(
             from_state=ctx.from_state.text,
             to_state=EXIT_STATE,
             event_id=event_id,
@@ -679,6 +718,8 @@ class GrammarParseListener(GrammarListener):
             if ctx.operational_statement_set()
             else [],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitChain_id(self, ctx: GrammarParser.Chain_idContext) -> None:
         """
@@ -1016,7 +1057,7 @@ class GrammarParseListener(GrammarListener):
             event_id = self.nodes[ctx.chain_id()]
         elif ctx.from_id:
             event_id = ChainID([ctx.from_state.text, ctx.from_id.text])
-        self.nodes[ctx] = ForceTransitionDefinition(
+        node = ForceTransitionDefinition(
             from_state=ctx.from_state.text,
             to_state=ctx.to_state.text,
             event_id=event_id,
@@ -1024,6 +1065,8 @@ class GrammarParseListener(GrammarListener):
             if ctx.cond_expression()
             else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitExitForceTransitionDefinition(
         self, ctx: GrammarParser.ExitForceTransitionDefinitionContext
@@ -1040,7 +1083,7 @@ class GrammarParseListener(GrammarListener):
             event_id = self.nodes[ctx.chain_id()]
         elif ctx.from_id:
             event_id = ChainID([ctx.from_state.text, ctx.from_id.text])
-        self.nodes[ctx] = ForceTransitionDefinition(
+        node = ForceTransitionDefinition(
             from_state=ctx.from_state.text,
             to_state=EXIT_STATE,
             event_id=event_id,
@@ -1048,6 +1091,8 @@ class GrammarParseListener(GrammarListener):
             if ctx.cond_expression()
             else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitNormalAllForceTransitionDefinition(
         self, ctx: GrammarParser.NormalAllForceTransitionDefinitionContext
@@ -1059,7 +1104,7 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.NormalAllForceTransitionDefinitionContext
         """
         super().exitNormalAllForceTransitionDefinition(ctx)
-        self.nodes[ctx] = ForceTransitionDefinition(
+        node = ForceTransitionDefinition(
             from_state=ALL,
             to_state=ctx.to_state.text,
             event_id=self.nodes[ctx.chain_id()] if ctx.chain_id() else None,
@@ -1067,6 +1112,8 @@ class GrammarParseListener(GrammarListener):
             if ctx.cond_expression()
             else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitExitAllForceTransitionDefinition(
         self, ctx: GrammarParser.ExitAllForceTransitionDefinitionContext
@@ -1078,8 +1125,7 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.ExitAllForceTransitionDefinitionContext
         """
         super().exitExitAllForceTransitionDefinition(ctx)
-        # print(self.nodes[ctx.chain_id()] if ctx.chain_id() else None)
-        self.nodes[ctx] = ForceTransitionDefinition(
+        node = ForceTransitionDefinition(
             from_state=ALL,
             to_state=EXIT_STATE,
             event_id=self.nodes[ctx.chain_id()] if ctx.chain_id() else None,
@@ -1087,6 +1133,8 @@ class GrammarParseListener(GrammarListener):
             if ctx.cond_expression()
             else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitEvent_definition(self, ctx: GrammarParser.Event_definitionContext) -> None:
         """

--- a/pyfcstm/dsl/node.py
+++ b/pyfcstm/dsl/node.py
@@ -46,11 +46,13 @@ import json
 import math
 import os
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from textwrap import indent
 from typing import List, Union, Optional, Any
 
 from hbutils.design import SingletonMark
+
+from ..utils.validate import Span
 
 __all__ = [
     "ASTNode",
@@ -785,6 +787,7 @@ class DefAssignment(Statement):
     name: str
     type: str
     expr: Expr
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1272,6 +1275,7 @@ class TransitionDefinition(ASTNode):
     event_id: Optional[ChainID]
     condition_expr: Optional[Expr]
     post_operations: List["OperationalStatement"]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1350,6 +1354,7 @@ class ForceTransitionDefinition(ASTNode):
     to_state: Union[str, _StateSingletonMark]
     event_id: Optional[ChainID]
     condition_expr: Optional[Expr]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1444,6 +1449,7 @@ class StateDefinition(ASTNode):
     during_aspects: List["DuringAspectStatement"] = None
     force_transitions: List["ForceTransitionDefinition"] = None
     is_pseudo: bool = False
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         """

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -51,7 +51,9 @@ from .base import AstExportable, PlantUMLExportable
 from .expr import Expr, parse_expr_node_to_expr
 from .imports import assemble_state_machine_imports
 from .plantuml import PlantUMLOptions, PlantUMLOptionsInput, format_state_name
+from ..diagnostics import DiagnosticSink
 from ..dsl import node as dsl_nodes, INIT_STATE, EXIT_STATE
+from ..utils.validate import ModelDiagnostic, ModelValidationError, Span
 
 __all__ = [
     "OperationStatement",
@@ -2030,13 +2032,31 @@ class StateMachine(AstExportable, PlantUMLExportable):
 def parse_dsl_node_to_state_machine(
     dnode: dsl_nodes.StateMachineDSLProgram,
     path: Optional[str] = None,
-) -> StateMachine:
+    *,
+    collect: bool = False,
+) -> Union[
+    StateMachine,
+    Tuple[Optional[StateMachine], List[ModelDiagnostic]],
+]:
     """
     Parse a state machine DSL program AST node into a StateMachine object.
 
     This function validates the state machine structure and builds a complete
     StateMachine object with all states, transitions, events, and variable
     definitions.
+
+    The implementation routes every semantic error through a
+    :class:`pyfcstm.diagnostics.DiagnosticSink`. In the default **strict**
+    mode (``collect=False``), the first error raises
+    :class:`pyfcstm.utils.validate.ModelValidationError` carrying a
+    :class:`pyfcstm.utils.validate.ModelDiagnostic` list. In **collect**
+    mode (``collect=True``), all detected errors are accumulated and
+    returned alongside the partially-built model (which may be ``None`` if
+    construction could not progress past a fatal point).
+
+    The ``ModelValidationError`` exception multi-inherits from
+    :class:`SyntaxError`, so callers using ``except SyntaxError:`` continue
+    to work after this refactor.
 
     :param dnode: The state machine DSL program AST node to parse
     :type dnode: dsl_nodes.StateMachineDSLProgram
@@ -2046,14 +2066,17 @@ def parse_dsl_node_to_state_machine(
         Existing directories are treated as import base directories directly,
         while file paths use their parent directory as the import base.
     :type path: Optional[str]
+    :param collect: When ``True``, return ``(model_or_None, diagnostics)``
+        instead of raising on the first error. Defaults to ``False``.
+    :type collect: bool
 
-    :return: The parsed state machine
-    :rtype: StateMachine
+    :return: The parsed state machine, or a ``(model, diagnostics)`` tuple
+        when ``collect=True``.
+    :rtype: Union[StateMachine, Tuple[Optional[StateMachine], List[ModelDiagnostic]]]
 
-    :raises SyntaxError: If there are syntax errors in the state machine definition,
-        such as duplicate variable definitions, unknown states in transitions,
-        missing entry transitions, invalid references, or import statements
-        that have not yet been assembled.
+    :raises pyfcstm.utils.validate.ModelValidationError: When ``collect=False``
+        and the DSL contains a semantic error. Multi-inherits from
+        :class:`SyntaxError` for backwards compatibility.
 
     Example::
 
@@ -2067,8 +2090,12 @@ def parse_dsl_node_to_state_machine(
     """
 
     dnode = assemble_state_machine_imports(dnode, path=path)
+    sink = DiagnosticSink(collect=collect)
 
-    d_defines = {}
+    d_defines: Dict[str, VarDefine] = {}
+    # Track first-declaration spans so duplicate diagnostics can point at
+    # the previous definition.
+    d_define_spans: Dict[str, Optional[Span]] = {}
     for def_item in dnode.definitions:
         if def_item.name not in d_defines:
             d_defines[def_item.name] = VarDefine(
@@ -2076,12 +2103,23 @@ def parse_dsl_node_to_state_machine(
                 type=def_item.type,
                 init=parse_expr_node_to_expr(def_item.expr),
             )
+            d_define_spans[def_item.name] = getattr(def_item, '_span', None)
         else:
-            raise SyntaxError(f"Duplicated variable definition - {def_item}.")
+            sink.emit(ModelDiagnostic(
+                code='E_DUPLICATE_VAR',
+                severity='error',
+                message=f"Duplicated variable definition - {def_item}.",
+                span=getattr(def_item, '_span', None),
+                refs={
+                    'var_name': def_item.name,
+                    'previous_span': d_define_spans.get(def_item.name),
+                },
+            ))
 
     def _parse_operation_block(
         op_nodes: List[dsl_nodes.OperationalStatement],
         unknown_var_message: str,
+        referenced_in: str,
         owner_node,
         available_vars: Optional[Set[str]] = None,
     ) -> List[OperationStatement]:
@@ -2092,6 +2130,7 @@ def parse_dsl_node_to_state_machine(
                 _parse_operation_statement(
                     op_item=op_item,
                     unknown_var_message=unknown_var_message,
+                    referenced_in=referenced_in,
                     owner_node=owner_node,
                     available_vars=available_vars,
                 )
@@ -2102,6 +2141,7 @@ def parse_dsl_node_to_state_machine(
     def _parse_operation_statement(
         op_item: dsl_nodes.OperationalStatement,
         unknown_var_message: str,
+        referenced_in: str,
         owner_node,
         available_vars: Set[str],
     ) -> OperationStatement:
@@ -2113,9 +2153,20 @@ def parse_dsl_node_to_state_machine(
                     unknown_vars.append(var.name)
 
             if unknown_vars:
-                raise SyntaxError(
-                    f"{unknown_var_message} {', '.join(unknown_vars)} in transition:\n{owner_node}"
-                )
+                sink.emit(ModelDiagnostic(
+                    code='E_UNDEFINED_VAR',
+                    severity='error',
+                    message=(
+                        f"{unknown_var_message} {', '.join(unknown_vars)} "
+                        f"in transition:\n{owner_node}"
+                    ),
+                    span=getattr(owner_node, '_span', None),
+                    refs={
+                        'var_name': unknown_vars,
+                        'referenced_in': referenced_in,
+                        'expr_text': str(op_item.expr),
+                    },
+                ))
 
             operation = Operation(var_name=op_item.name, expr=operation_val)
             available_vars.add(op_item.name)
@@ -2124,6 +2175,7 @@ def parse_dsl_node_to_state_machine(
             return _parse_if_block(
                 if_node=op_item,
                 unknown_var_message=unknown_var_message,
+                referenced_in=referenced_in,
                 owner_node=owner_node,
                 available_vars=available_vars,
             )
@@ -2133,6 +2185,7 @@ def parse_dsl_node_to_state_machine(
     def _parse_if_block(
         if_node: dsl_nodes.OperationIf,
         unknown_var_message: str,
+        referenced_in: str,
         owner_node,
         available_vars: Set[str],
     ) -> IfBlock:
@@ -2150,14 +2203,26 @@ def parse_dsl_node_to_state_machine(
                     ):
                         unknown_vars.append(var.name)
                 if unknown_vars:
-                    raise SyntaxError(
-                        f"{unknown_var_message} {', '.join(unknown_vars)} in transition:\n{owner_node}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_UNDEFINED_VAR',
+                        severity='error',
+                        message=(
+                            f"{unknown_var_message} {', '.join(unknown_vars)} "
+                            f"in transition:\n{owner_node}"
+                        ),
+                        span=getattr(owner_node, '_span', None),
+                        refs={
+                            'var_name': unknown_vars,
+                            'referenced_in': referenced_in,
+                            'expr_text': str(branch.condition),
+                        },
+                    ))
 
             branch_available_vars = set(base_available_vars)
             branch_statements = _parse_operation_block(
                 op_nodes=branch.statements,
                 unknown_var_message=unknown_var_message,
+                referenced_in=referenced_in,
                 owner_node=owner_node,
                 available_vars=branch_available_vars,
             )
@@ -2173,15 +2238,28 @@ def parse_dsl_node_to_state_machine(
         current_path = tuple((*current_path, node.name))
         d_substates = {}
 
+        substate_first_spans: Dict[str, Optional[Span]] = {}
         for subnode in node.substates:
             if subnode.name not in d_substates:
                 d_substates[subnode.name] = _recursive_build_states(
                     subnode, current_path=current_path
                 )
+                substate_first_spans[subnode.name] = getattr(subnode, '_span', None)
             else:
-                raise SyntaxError(
-                    f"Duplicate state name in namespace {'.'.join(current_path)!r}:\n{subnode}"
-                )
+                sink.emit(ModelDiagnostic(
+                    code='E_DUPLICATE_STATE',
+                    severity='error',
+                    message=(
+                        f"Duplicate state name in namespace "
+                        f"{'.'.join(current_path)!r}:\n{subnode}"
+                    ),
+                    span=getattr(subnode, '_span', None),
+                    refs={
+                        'state_name': subnode.name,
+                        'parent_path': '.'.join(current_path),
+                        'previous_span': substate_first_spans.get(subnode.name),
+                    },
+                ))
 
         named_functions = {}
         on_enters = []
@@ -2191,6 +2269,7 @@ def parse_dsl_node_to_state_machine(
                 enter_operations = _parse_operation_block(
                     enter_item.operations,
                     "Unknown enter operation variable",
+                    "enter",
                     enter_item,
                 )
                 on_stage = OnStage(
@@ -2239,28 +2318,63 @@ def parse_dsl_node_to_state_machine(
             if on_stage is not None:
                 if on_stage.name:
                     if on_stage.name in named_functions:
-                        raise SyntaxError(
-                            f"Duplicate function name {on_stage.name!r} in state:\n{node}"
-                        )
+                        sink.emit(ModelDiagnostic(
+                            code='E_DUPLICATE_FUNCTION_NAME',
+                            severity='error',
+                            message=(
+                                f"Duplicate function name {on_stage.name!r} "
+                                f"in state:\n{node}"
+                            ),
+                            span=getattr(enter_item, '_span', None),
+                            refs={
+                                'function_name': on_stage.name,
+                                'state_path': '.'.join(current_path),
+                                'stage': 'enter',
+                            },
+                        ))
                     named_functions[on_stage.name] = on_stage
                 on_enters.append(on_stage)
 
         on_durings = []
         for during_item in node.durings:
             if not d_substates and during_item.aspect is not None:
-                raise SyntaxError(
-                    f"For leaf state {node.name!r}, during cannot assign aspect {during_item.aspect!r}:\n{during_item}"
-                )
+                sink.emit(ModelDiagnostic(
+                    code='E_DURING_ASPECT_INVALID',
+                    severity='error',
+                    message=(
+                        f"For leaf state {node.name!r}, during cannot assign "
+                        f"aspect {during_item.aspect!r}:\n{during_item}"
+                    ),
+                    span=getattr(during_item, '_span', None),
+                    refs={
+                        'state_path': '.'.join(current_path),
+                        'state_kind': 'leaf',
+                        'aspect': during_item.aspect,
+                    },
+                ))
             if d_substates and during_item.aspect is None:
-                raise SyntaxError(
-                    f"For composite state {node.name!r}, during must assign aspect to either 'before' or 'after':\n{during_item}"
-                )
+                sink.emit(ModelDiagnostic(
+                    code='E_DURING_ASPECT_INVALID',
+                    severity='error',
+                    message=(
+                        f"For composite state {node.name!r}, during must "
+                        f"assign aspect to either 'before' or 'after':\n"
+                        f"{during_item}"
+                    ),
+                    span=getattr(during_item, '_span', None),
+                    refs={
+                        'state_path': '.'.join(current_path),
+                        'state_kind': 'composite',
+                        'aspect': None,
+                    },
+                ))
 
             on_stage = None
             if isinstance(during_item, dsl_nodes.DuringOperations):
                 during_operations = _parse_operation_block(
                     during_item.operations,
                     "Unknown during operation variable",
+                    "during",
                     during_item,
                 )
                 on_stage = OnStage(
@@ -2309,9 +2423,20 @@ def parse_dsl_node_to_state_machine(
             if on_stage is not None:
                 if on_stage.name:
                     if on_stage.name in named_functions:
-                        raise SyntaxError(
-                            f"Duplicate function name {on_stage.name!r} in state:\n{node}"
-                        )
+                        sink.emit(ModelDiagnostic(
+                            code='E_DUPLICATE_FUNCTION_NAME',
+                            severity='error',
+                            message=(
+                                f"Duplicate function name {on_stage.name!r} "
+                                f"in state:\n{node}"
+                            ),
+                            span=getattr(during_item, '_span', None),
+                            refs={
+                                'function_name': on_stage.name,
+                                'state_path': '.'.join(current_path),
+                                'stage': 'during',
+                            },
+                        ))
                     named_functions[on_stage.name] = on_stage
                 on_durings.append(on_stage)
 
@@ -2322,6 +2447,7 @@ def parse_dsl_node_to_state_machine(
                 exit_operations = _parse_operation_block(
                     exit_item.operations,
                     "Unknown exit operation variable",
+                    "exit",
                     exit_item,
                 )
                 on_stage = OnStage(
@@ -2370,9 +2496,20 @@ def parse_dsl_node_to_state_machine(
             if on_stage is not None:
                 if on_stage.name:
                     if on_stage.name in named_functions:
-                        raise SyntaxError(
-                            f"Duplicate function name {on_stage.name!r} in state:\n{node}"
-                        )
+                        sink.emit(ModelDiagnostic(
+                            code='E_DUPLICATE_FUNCTION_NAME',
+                            severity='error',
+                            message=(
+                                f"Duplicate function name {on_stage.name!r} "
+                                f"in state:\n{node}"
+                            ),
+                            span=getattr(exit_item, '_span', None),
+                            refs={
+                                'function_name': on_stage.name,
+                                'state_path': '.'.join(current_path),
+                                'stage': 'exit',
+                            },
+                        ))
                     named_functions[on_stage.name] = on_stage
                 on_exits.append(on_stage)
 
@@ -2383,6 +2520,7 @@ def parse_dsl_node_to_state_machine(
                 during_operations = _parse_operation_block(
                     during_aspect_item.operations,
                     "Unknown during aspect variable",
+                    "during_aspect",
                     during_aspect_item,
                 )
                 on_aspect = OnAspect(
@@ -2431,9 +2569,20 @@ def parse_dsl_node_to_state_machine(
             if on_aspect is not None:
                 if on_aspect.name:
                     if on_aspect.name in named_functions:
-                        raise SyntaxError(
-                            f"Duplicate function name {on_aspect.name!r} in state:\n{node}"
-                        )
+                        sink.emit(ModelDiagnostic(
+                            code='E_DUPLICATE_FUNCTION_NAME',
+                            severity='error',
+                            message=(
+                                f"Duplicate function name {on_aspect.name!r} "
+                                f"in state:\n{node}"
+                            ),
+                            span=getattr(during_aspect_item, '_span', None),
+                            refs={
+                                'function_name': on_aspect.name,
+                                'state_path': '.'.join(current_path),
+                                'stage': 'during_aspect',
+                            },
+                        ))
                     named_functions[on_aspect.name] = on_aspect
                 on_during_aspects.append(on_aspect)
 
@@ -2459,9 +2608,18 @@ def parse_dsl_node_to_state_machine(
             named_functions=named_functions,
         )
         if my_state.is_pseudo and not my_state.is_leaf_state:
-            raise SyntaxError(
-                f"Pseudo state {'.'.join(current_path)} must be a leaf state:\n{node}"
-            )
+            sink.emit(ModelDiagnostic(
+                code='E_PSEUDO_NOT_LEAF',
+                severity='error',
+                message=(
+                    f"Pseudo state {'.'.join(current_path)} must be a leaf "
+                    f"state:\n{node}"
+                ),
+                span=getattr(node, '_span', None),
+                refs={
+                    'state_path': '.'.join(current_path),
+                },
+            ))
         for func_item in [
             *my_state.on_enters,
             *my_state.on_durings,
@@ -2491,18 +2649,38 @@ def parse_dsl_node_to_state_machine(
             else:
                 from_state = f_transnode.from_state
                 if from_state not in current_state.substates:
-                    raise SyntaxError(
-                        f"Unknown from state {from_state!r} of force transition:\n{f_transnode}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_FORCED_TRANSITION_EXPANSION',
+                        severity='error',
+                        message=(
+                            f"Unknown from state {from_state!r} of force "
+                            f"transition:\n{f_transnode}"
+                        ),
+                        span=getattr(f_transnode, '_span', None),
+                        refs={
+                            'original_raw': str(f_transnode),
+                            'reason': 'src_not_found',
+                        },
+                    ))
 
             if f_transnode.to_state is dsl_nodes.EXIT_STATE:
                 to_state = dsl_nodes.EXIT_STATE
             else:
                 to_state = f_transnode.to_state
                 if to_state not in current_state.substates:
-                    raise SyntaxError(
-                        f"Unknown to state {to_state!r} of force transition:\n{f_transnode}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_FORCED_TRANSITION_EXPANSION',
+                        severity='error',
+                        message=(
+                            f"Unknown to state {to_state!r} of force "
+                            f"transition:\n{f_transnode}"
+                        ),
+                        span=getattr(f_transnode, '_span', None),
+                        refs={
+                            'original_raw': str(f_transnode),
+                            'reason': 'tgt_not_found',
+                        },
+                    ))
 
             my_event_id, trans_event = None, None
             if f_transnode.event_id is not None:
@@ -2518,9 +2696,24 @@ def parse_dsl_node_to_state_machine(
                     if seg in start_state.substates:
                         start_state = start_state.substates[seg]
                     else:
-                        raise SyntaxError(
-                            f"Cannot find state {'.'.join((*base_path, *my_event_id.path[:-1]))} for transition:\n{f_transnode}"
-                        )
+                        sink.emit(ModelDiagnostic(
+                            code='E_MISSING_STATE',
+                            severity='error',
+                            message=(
+                                f"Cannot find state "
+                                f"{'.'.join((*base_path, *my_event_id.path[:-1]))} "
+                                f"for transition:\n{f_transnode}"
+                            ),
+                            span=getattr(f_transnode, '_span', None),
+                            refs={
+                                'state_path': '.'.join(
+                                    (*base_path, *my_event_id.path[:-1])
+                                ),
+                                'referenced_from': '.'.join(current_path),
+                                'reason': 'event_path_not_found',
+                            },
+                        ))
+                        break
 
                 suffix_name = my_event_id.path[-1]
                 if suffix_name not in start_state.events:
@@ -2538,9 +2731,21 @@ def parse_dsl_node_to_state_machine(
                     if var.name not in d_defines:
                         unknown_vars.append(var.name)
                 if unknown_vars:
-                    raise SyntaxError(
-                        f"Unknown guard variable {', '.join(unknown_vars)} in force transition:\n{f_transnode}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_UNDEFINED_VAR',
+                        severity='error',
+                        message=(
+                            f"Unknown guard variable "
+                            f"{', '.join(unknown_vars)} in force "
+                            f"transition:\n{f_transnode}"
+                        ),
+                        span=getattr(f_transnode, '_span', None),
+                        refs={
+                            'var_name': unknown_vars,
+                            'referenced_in': 'guard',
+                            'expr_text': str(f_transnode.condition_expr),
+                        },
+                    ))
 
             force_transition_tuples_to_inherit.append(
                 (from_state, to_state, my_event_id, trans_event, condition_expr, guard)
@@ -2591,18 +2796,46 @@ def parse_dsl_node_to_state_machine(
             else:
                 from_state = transnode.from_state
                 if from_state not in current_state.substates:
-                    raise SyntaxError(
-                        f"Unknown from state {from_state!r} of transition:\n{transnode}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_DANGLING_TRANSITION',
+                        severity='error',
+                        message=(
+                            f"Unknown from state {from_state!r} of "
+                            f"transition:\n{transnode}"
+                        ),
+                        span=getattr(transnode, '_span', None),
+                        refs={
+                            'src': str(transnode.from_state),
+                            'tgt': (
+                                None if transnode.to_state is dsl_nodes.EXIT_STATE
+                                else str(transnode.to_state)
+                            ),
+                            'reason': 'src_not_found',
+                        },
+                    ))
 
             if transnode.to_state is dsl_nodes.EXIT_STATE:
                 to_state = dsl_nodes.EXIT_STATE
             else:
                 to_state = transnode.to_state
                 if to_state not in current_state.substates:
-                    raise SyntaxError(
-                        f"Unknown to state {to_state!r} of transition:\n{transnode}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_DANGLING_TRANSITION',
+                        severity='error',
+                        message=(
+                            f"Unknown to state {to_state!r} of "
+                            f"transition:\n{transnode}"
+                        ),
+                        span=getattr(transnode, '_span', None),
+                        refs={
+                            'src': (
+                                None if transnode.from_state is dsl_nodes.INIT_STATE
+                                else str(transnode.from_state)
+                            ),
+                            'tgt': str(transnode.to_state),
+                            'reason': 'tgt_not_found',
+                        },
+                    ))
 
             trans_event, guard = None, None
             if transnode.event_id is not None:
@@ -2616,9 +2849,24 @@ def parse_dsl_node_to_state_machine(
                     if seg in start_state.substates:
                         start_state = start_state.substates[seg]
                     else:
-                        raise SyntaxError(
-                            f"Cannot find state {'.'.join((*base_path, *transnode.event_id.path[:-1]))} for transition:\n{transnode}"
-                        )
+                        sink.emit(ModelDiagnostic(
+                            code='E_MISSING_STATE',
+                            severity='error',
+                            message=(
+                                f"Cannot find state "
+                                f"{'.'.join((*base_path, *transnode.event_id.path[:-1]))} "
+                                f"for transition:\n{transnode}"
+                            ),
+                            span=getattr(transnode, '_span', None),
+                            refs={
+                                'state_path': '.'.join(
+                                    (*base_path, *transnode.event_id.path[:-1])
+                                ),
+                                'referenced_from': '.'.join(current_path),
+                                'reason': 'event_path_not_found',
+                            },
+                        ))
+                        break
 
                 suffix_name = transnode.event_id.path[-1]
                 if suffix_name not in start_state.events:
@@ -2635,13 +2883,26 @@ def parse_dsl_node_to_state_machine(
                     if var.name not in d_defines:
                         unknown_vars.append(var.name)
                 if unknown_vars:
-                    raise SyntaxError(
-                        f"Unknown guard variable {', '.join(unknown_vars)} in transition:\n{transnode}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_UNDEFINED_VAR',
+                        severity='error',
+                        message=(
+                            f"Unknown guard variable "
+                            f"{', '.join(unknown_vars)} in "
+                            f"transition:\n{transnode}"
+                        ),
+                        span=getattr(transnode, '_span', None),
+                        refs={
+                            'var_name': unknown_vars,
+                            'referenced_in': 'guard',
+                            'expr_text': str(transnode.condition_expr),
+                        },
+                    ))
 
             post_operations = _parse_operation_block(
                 transnode.post_operations,
                 "Unknown transition operation variable",
+                "effect",
                 transnode,
             )
 
@@ -2655,9 +2916,19 @@ def parse_dsl_node_to_state_machine(
             transitions.append(transition)
 
         if current_state.substates and not has_entry_trans:
-            raise SyntaxError(
-                f"At least 1 entry transition should be assigned in non-leaf state {node.name!r}:\n{node}"
-            )
+            sink.emit(ModelDiagnostic(
+                code='E_INITIAL_TRANSITION_INVALID',
+                severity='error',
+                message=(
+                    f"At least 1 entry transition should be assigned in "
+                    f"non-leaf state {node.name!r}:\n{node}"
+                ),
+                span=getattr(node, '_span', None),
+                refs={
+                    'composite_path': '.'.join(current_path),
+                    'reason': 'missing_entry',
+                },
+            ))
 
         for func_item in [
             *current_state.on_enters,
@@ -2667,20 +2938,50 @@ def parse_dsl_node_to_state_machine(
         ]:
             if func_item.ref_state_path is not None:
                 state = root_state
+                walk_failed = False
                 for i, segment in enumerate(func_item.ref_state_path[1:-1], start=1):
                     if segment not in state.substates:
-                        raise SyntaxError(
-                            f"Cannot find state {'.'.join(func_item.ref_state_path[: i + 1])} "
-                            f"under state {'.'.join(func_item.ref_state_path[:i])}, "
-                            f"so cannot resolve reference {'.'.join(func_item.ref_state_path)!r}."
-                        )
+                        sink.emit(ModelDiagnostic(
+                            code='E_NAMED_FUNCTION_REF_NOT_FOUND',
+                            severity='error',
+                            message=(
+                                f"Cannot find state "
+                                f"{'.'.join(func_item.ref_state_path[: i + 1])} "
+                                f"under state "
+                                f"{'.'.join(func_item.ref_state_path[:i])}, "
+                                f"so cannot resolve reference "
+                                f"{'.'.join(func_item.ref_state_path)!r}."
+                            ),
+                            span=None,
+                            refs={
+                                'ref_path': '.'.join(func_item.ref_state_path),
+                                'reason': 'state_not_found',
+                                'missing_segment': segment,
+                            },
+                        ))
+                        walk_failed = True
+                        break
                     state = state.substates[segment]
+                if walk_failed:
+                    continue
 
                 segment = func_item.ref_state_path[-1]
                 if segment not in state.named_functions:
-                    raise SyntaxError(
-                        f"Cannot find named function {segment!r} under state:\n{state.to_ast_node()}"
-                    )
+                    sink.emit(ModelDiagnostic(
+                        code='E_NAMED_FUNCTION_REF_NOT_FOUND',
+                        severity='error',
+                        message=(
+                            f"Cannot find named function {segment!r} under "
+                            f"state:\n{state.to_ast_node()}"
+                        ),
+                        span=None,
+                        refs={
+                            'ref_path': '.'.join(func_item.ref_state_path),
+                            'reason': 'named_function_not_found',
+                            'missing_segment': segment,
+                        },
+                    ))
+                    continue
                 func_item.ref = state.named_functions[segment]
                 assert func_item.ref.state_path == func_item.ref_state_path
 
@@ -2690,7 +2991,20 @@ def parse_dsl_node_to_state_machine(
     _recursive_finish_states(
         dnode.root_state, current_state=root_state, current_path=()
     )
-    return StateMachine(
+    machine = StateMachine(
         defines=d_defines,
         root_state=root_state,
     )
+
+    if collect:
+        # In collect mode we always return the tuple. ``machine`` is the
+        # best-effort build even when diagnostics were emitted; downstream
+        # callers should consult ``has_errors()`` (or the diagnostics list)
+        # before treating it as valid.
+        return machine, sink.diagnostics
+
+    # Strict mode: sink already raised on any error diagnostic at emit
+    # time, so reaching here means the build is clean. ``finalize_or_raise``
+    # is a no-op for strict mode but kept for symmetry / future-proofing.
+    sink.finalize_or_raise()
+    return machine

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -3020,6 +3020,10 @@ def parse_dsl_node_to_state_machine(
                 walk_failed = False
                 for i, segment in enumerate(func_item.ref_state_path[1:-1], start=1):
                     if segment not in state.substates:
+                        # M1 from PR-110 review: the named-function ref AST
+                        # nodes don't carry their own spans yet, so fall back
+                        # to the owning state's span. State-level anchoring
+                        # is imprecise but vastly better than line 1.
                         sink.emit(ModelDiagnostic(
                             code='E_NAMED_FUNCTION_REF_NOT_FOUND',
                             severity='error',
@@ -3031,7 +3035,7 @@ def parse_dsl_node_to_state_machine(
                                 f"so cannot resolve reference "
                                 f"{'.'.join(func_item.ref_state_path)!r}."
                             ),
-                            span=None,
+                            span=getattr(node, '_span', None),
                             refs={
                                 'ref_path': '.'.join(func_item.ref_state_path),
                                 'reason': 'state_not_found',
@@ -3053,7 +3057,7 @@ def parse_dsl_node_to_state_machine(
                             f"Cannot find named function {segment!r} under "
                             f"state:\n{state.to_ast_node()}"
                         ),
-                        span=None,
+                        span=getattr(node, '_span', None),
                         refs={
                             'ref_path': '.'.join(func_item.ref_state_path),
                             'reason': 'named_function_not_found',

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -2692,6 +2692,12 @@ def parse_dsl_node_to_state_machine(
                     )
                 start_state = root_state
                 base_path = (root_state.name,)
+                # Walk the event-id state segments. On a missing segment
+                # we emit the diagnostic and skip the suffix resolution —
+                # without this guard, collect mode would silently fabricate
+                # an Event in whatever partial state ``start_state`` landed
+                # on (C1 from PR-110 review).
+                path_resolved = True
                 for seg in my_event_id.path[:-1]:
                     if seg in start_state.substates:
                         start_state = start_state.substates[seg]
@@ -2713,15 +2719,17 @@ def parse_dsl_node_to_state_machine(
                                 'reason': 'event_path_not_found',
                             },
                         ))
+                        path_resolved = False
                         break
 
-                suffix_name = my_event_id.path[-1]
-                if suffix_name not in start_state.events:
-                    start_state.events[suffix_name] = Event(
-                        name=suffix_name,
-                        state_path=start_state.path,
-                    )
-                trans_event = start_state.events[suffix_name]
+                if path_resolved:
+                    suffix_name = my_event_id.path[-1]
+                    if suffix_name not in start_state.events:
+                        start_state.events[suffix_name] = Event(
+                            name=suffix_name,
+                            state_path=start_state.path,
+                        )
+                    trans_event = start_state.events[suffix_name]
 
             condition_expr, guard = f_transnode.condition_expr, None
             if f_transnode.condition_expr is not None:
@@ -2845,6 +2853,10 @@ def parse_dsl_node_to_state_machine(
                 else:
                     start_state = current_state
                     base_path = current_state.path
+                # See C1 in PR-110 review: collect mode must not let
+                # suffix resolution mutate ``start_state.events`` after a
+                # failed segment walk.
+                path_resolved = True
                 for seg in transnode.event_id.path[:-1]:
                     if seg in start_state.substates:
                         start_state = start_state.substates[seg]
@@ -2866,15 +2878,17 @@ def parse_dsl_node_to_state_machine(
                                 'reason': 'event_path_not_found',
                             },
                         ))
+                        path_resolved = False
                         break
 
-                suffix_name = transnode.event_id.path[-1]
-                if suffix_name not in start_state.events:
-                    start_state.events[suffix_name] = Event(
-                        name=suffix_name,
-                        state_path=start_state.path,
-                    )
-                trans_event = start_state.events[suffix_name]
+                if path_resolved:
+                    suffix_name = transnode.event_id.path[-1]
+                    if suffix_name not in start_state.events:
+                        start_state.events[suffix_name] = Event(
+                            name=suffix_name,
+                            state_path=start_state.path,
+                        )
+                    trans_event = start_state.events[suffix_name]
 
             if transnode.condition_expr is not None:
                 guard = parse_expr_node_to_expr(transnode.condition_expr)

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -2122,6 +2122,7 @@ def parse_dsl_node_to_state_machine(
         referenced_in: str,
         owner_node,
         available_vars: Optional[Set[str]] = None,
+        state_path: Optional[str] = None,
     ) -> List[OperationStatement]:
         available_vars = set(available_vars or d_defines)
         operations = []
@@ -2133,6 +2134,7 @@ def parse_dsl_node_to_state_machine(
                     referenced_in=referenced_in,
                     owner_node=owner_node,
                     available_vars=available_vars,
+                    state_path=state_path,
                 )
             )
 
@@ -2144,6 +2146,7 @@ def parse_dsl_node_to_state_machine(
         referenced_in: str,
         owner_node,
         available_vars: Set[str],
+        state_path: Optional[str] = None,
     ) -> OperationStatement:
         if isinstance(op_item, dsl_nodes.OperationAssignment):
             operation_val = parse_expr_node_to_expr(op_item.expr)
@@ -2164,6 +2167,7 @@ def parse_dsl_node_to_state_machine(
                     refs={
                         'var_name': unknown_vars,
                         'referenced_in': referenced_in,
+                        'state_path': state_path,
                         'expr_text': str(op_item.expr),
                     },
                 ))
@@ -2178,6 +2182,7 @@ def parse_dsl_node_to_state_machine(
                 referenced_in=referenced_in,
                 owner_node=owner_node,
                 available_vars=available_vars,
+                state_path=state_path,
             )
         else:
             raise TypeError(f"Unknown operation statement node - {op_item!r}.")
@@ -2188,6 +2193,7 @@ def parse_dsl_node_to_state_machine(
         referenced_in: str,
         owner_node,
         available_vars: Set[str],
+        state_path: Optional[str] = None,
     ) -> IfBlock:
         base_available_vars = set(available_vars)
         branches = []
@@ -2214,6 +2220,7 @@ def parse_dsl_node_to_state_machine(
                         refs={
                             'var_name': unknown_vars,
                             'referenced_in': referenced_in,
+                            'state_path': state_path,
                             'expr_text': str(branch.condition),
                         },
                     ))
@@ -2225,6 +2232,7 @@ def parse_dsl_node_to_state_machine(
                 referenced_in=referenced_in,
                 owner_node=owner_node,
                 available_vars=branch_available_vars,
+                state_path=state_path,
             )
             branches.append(
                 IfBlockBranch(condition=condition, statements=branch_statements)
@@ -2271,6 +2279,7 @@ def parse_dsl_node_to_state_machine(
                     "Unknown enter operation variable",
                     "enter",
                     enter_item,
+                    state_path='.'.join(current_path),
                 )
                 on_stage = OnStage(
                     stage="enter",
@@ -2318,6 +2327,10 @@ def parse_dsl_node_to_state_machine(
             if on_stage is not None:
                 if on_stage.name:
                     if on_stage.name in named_functions:
+                        # I1 from PR-110: first-wins tiebreaker — keep the
+                        # initial declaration so collect/strict modes resolve
+                        # ``ref X`` identically (strict raises before the
+                        # overwrite would have happened).
                         sink.emit(ModelDiagnostic(
                             code='E_DUPLICATE_FUNCTION_NAME',
                             severity='error',
@@ -2332,7 +2345,8 @@ def parse_dsl_node_to_state_machine(
                                 'stage': 'enter',
                             },
                         ))
-                    named_functions[on_stage.name] = on_stage
+                    else:
+                        named_functions[on_stage.name] = on_stage
                 on_enters.append(on_stage)
 
         on_durings = []
@@ -2376,6 +2390,7 @@ def parse_dsl_node_to_state_machine(
                     "Unknown during operation variable",
                     "during",
                     during_item,
+                    state_path='.'.join(current_path),
                 )
                 on_stage = OnStage(
                     stage="during",
@@ -2437,7 +2452,8 @@ def parse_dsl_node_to_state_machine(
                                 'stage': 'during',
                             },
                         ))
-                    named_functions[on_stage.name] = on_stage
+                    else:
+                        named_functions[on_stage.name] = on_stage
                 on_durings.append(on_stage)
 
         on_exits = []
@@ -2449,6 +2465,7 @@ def parse_dsl_node_to_state_machine(
                     "Unknown exit operation variable",
                     "exit",
                     exit_item,
+                    state_path='.'.join(current_path),
                 )
                 on_stage = OnStage(
                     stage="exit",
@@ -2510,7 +2527,8 @@ def parse_dsl_node_to_state_machine(
                                 'stage': 'exit',
                             },
                         ))
-                    named_functions[on_stage.name] = on_stage
+                    else:
+                        named_functions[on_stage.name] = on_stage
                 on_exits.append(on_stage)
 
         on_during_aspects = []
@@ -2522,6 +2540,7 @@ def parse_dsl_node_to_state_machine(
                     "Unknown during aspect variable",
                     "during_aspect",
                     during_aspect_item,
+                    state_path='.'.join(current_path),
                 )
                 on_aspect = OnAspect(
                     stage="during",
@@ -2583,7 +2602,8 @@ def parse_dsl_node_to_state_machine(
                                 'stage': 'during_aspect',
                             },
                         ))
-                    named_functions[on_aspect.name] = on_aspect
+                    else:
+                        named_functions[on_aspect.name] = on_aspect
                 on_during_aspects.append(on_aspect)
 
         d_events = {}
@@ -2644,6 +2664,13 @@ def parse_dsl_node_to_state_machine(
 
         force_transition_tuples_to_inherit = []
         for f_transnode in [*force_transitions, *node.force_transitions]:
+            # I3 from PR-110: if either side of a forced transition is
+            # unresolved, skip the rest of the per-transition processing
+            # AND the inherit-tuple append. Otherwise collect mode keeps a
+            # bad ``(from_state, to_state, ...)`` tuple that quietly
+            # corrupts the inheritance phase (bad to_state being attached
+            # to a real substate's transitions).
+            unresolved = False
             if f_transnode.from_state == dsl_nodes.ALL:
                 from_state = dsl_nodes.ALL
             else:
@@ -2662,6 +2689,7 @@ def parse_dsl_node_to_state_machine(
                             'reason': 'src_not_found',
                         },
                     ))
+                    unresolved = True
 
             if f_transnode.to_state is dsl_nodes.EXIT_STATE:
                 to_state = dsl_nodes.EXIT_STATE
@@ -2681,6 +2709,10 @@ def parse_dsl_node_to_state_machine(
                             'reason': 'tgt_not_found',
                         },
                     ))
+                    unresolved = True
+
+            if unresolved:
+                continue
 
             my_event_id, trans_event = None, None
             if f_transnode.event_id is not None:
@@ -2751,6 +2783,7 @@ def parse_dsl_node_to_state_machine(
                         refs={
                             'var_name': unknown_vars,
                             'referenced_in': 'guard',
+                            'state_path': '.'.join(current_path),
                             'expr_text': str(f_transnode.condition_expr),
                         },
                     ))
@@ -2798,52 +2831,82 @@ def parse_dsl_node_to_state_machine(
 
         has_entry_trans = False
         for transnode in node.transitions:
+            # I2 from PR-110: when both sides of a transition are unresolved,
+            # codes.yaml's ``reason='both_not_found'`` should fire as a
+            # single combined diagnostic rather than two unrelated ones
+            # against the same source location.
+            src_unknown = (
+                transnode.from_state is not dsl_nodes.INIT_STATE
+                and transnode.from_state not in current_state.substates
+            )
+            tgt_unknown = (
+                transnode.to_state is not dsl_nodes.EXIT_STATE
+                and transnode.to_state not in current_state.substates
+            )
+
             if transnode.from_state is dsl_nodes.INIT_STATE:
                 from_state = dsl_nodes.INIT_STATE
                 has_entry_trans = True
             else:
                 from_state = transnode.from_state
-                if from_state not in current_state.substates:
-                    sink.emit(ModelDiagnostic(
-                        code='E_DANGLING_TRANSITION',
-                        severity='error',
-                        message=(
-                            f"Unknown from state {from_state!r} of "
-                            f"transition:\n{transnode}"
-                        ),
-                        span=getattr(transnode, '_span', None),
-                        refs={
-                            'src': str(transnode.from_state),
-                            'tgt': (
-                                None if transnode.to_state is dsl_nodes.EXIT_STATE
-                                else str(transnode.to_state)
-                            ),
-                            'reason': 'src_not_found',
-                        },
-                    ))
 
             if transnode.to_state is dsl_nodes.EXIT_STATE:
                 to_state = dsl_nodes.EXIT_STATE
             else:
                 to_state = transnode.to_state
-                if to_state not in current_state.substates:
-                    sink.emit(ModelDiagnostic(
-                        code='E_DANGLING_TRANSITION',
-                        severity='error',
-                        message=(
-                            f"Unknown to state {to_state!r} of "
-                            f"transition:\n{transnode}"
+
+            if src_unknown and tgt_unknown:
+                sink.emit(ModelDiagnostic(
+                    code='E_DANGLING_TRANSITION',
+                    severity='error',
+                    message=(
+                        f"Unknown from state {from_state!r} and "
+                        f"unknown to state {to_state!r} of "
+                        f"transition:\n{transnode}"
+                    ),
+                    span=getattr(transnode, '_span', None),
+                    refs={
+                        'src': str(transnode.from_state),
+                        'tgt': str(transnode.to_state),
+                        'reason': 'both_not_found',
+                    },
+                ))
+            elif src_unknown:
+                sink.emit(ModelDiagnostic(
+                    code='E_DANGLING_TRANSITION',
+                    severity='error',
+                    message=(
+                        f"Unknown from state {from_state!r} of "
+                        f"transition:\n{transnode}"
+                    ),
+                    span=getattr(transnode, '_span', None),
+                    refs={
+                        'src': str(transnode.from_state),
+                        'tgt': (
+                            None if transnode.to_state is dsl_nodes.EXIT_STATE
+                            else str(transnode.to_state)
                         ),
-                        span=getattr(transnode, '_span', None),
-                        refs={
-                            'src': (
-                                None if transnode.from_state is dsl_nodes.INIT_STATE
-                                else str(transnode.from_state)
-                            ),
-                            'tgt': str(transnode.to_state),
-                            'reason': 'tgt_not_found',
-                        },
-                    ))
+                        'reason': 'src_not_found',
+                    },
+                ))
+            elif tgt_unknown:
+                sink.emit(ModelDiagnostic(
+                    code='E_DANGLING_TRANSITION',
+                    severity='error',
+                    message=(
+                        f"Unknown to state {to_state!r} of "
+                        f"transition:\n{transnode}"
+                    ),
+                    span=getattr(transnode, '_span', None),
+                    refs={
+                        'src': (
+                            None if transnode.from_state is dsl_nodes.INIT_STATE
+                            else str(transnode.from_state)
+                        ),
+                        'tgt': str(transnode.to_state),
+                        'reason': 'tgt_not_found',
+                    },
+                ))
 
             trans_event, guard = None, None
             if transnode.event_id is not None:
@@ -2909,6 +2972,7 @@ def parse_dsl_node_to_state_machine(
                         refs={
                             'var_name': unknown_vars,
                             'referenced_in': 'guard',
+                            'state_path': '.'.join(current_path),
                             'expr_text': str(transnode.condition_expr),
                         },
                     ))
@@ -2918,6 +2982,7 @@ def parse_dsl_node_to_state_machine(
                 "Unknown transition operation variable",
                 "effect",
                 transnode,
+                state_path='.'.join(current_path),
             )
 
             transition = Transition(

--- a/pyfcstm/utils/validate.py
+++ b/pyfcstm/utils/validate.py
@@ -269,6 +269,19 @@ class ModelValidationError(SyntaxError):
             super().__init__(message)
 
     def _build_summary_message(self) -> str:
+        # Single-entry path: emit the underlying message verbatim so that
+        # downstream consumers (and existing tests) that match the raw
+        # ``SyntaxError`` message text continue to work after PR-2's
+        # ``raise SyntaxError(...)`` -> ``raise ModelValidationError(...)``
+        # migration. The "Model diagnostics, N items in total:" wrapper
+        # only adds value when there is more than one entry to enumerate.
+        single_error = len(self.errors) == 1 and not self.diagnostics
+        single_diag = len(self.diagnostics) == 1 and not self.errors
+        if single_error:
+            return str(self.errors[0])
+        if single_diag:
+            return self.diagnostics[0].message
+
         parts: List[str] = []
         if self.errors:
             error_lines = [

--- a/pyfcstm/utils/validate.py
+++ b/pyfcstm/utils/validate.py
@@ -275,6 +275,14 @@ class ModelValidationError(SyntaxError):
         # ``raise SyntaxError(...)`` -> ``raise ModelValidationError(...)``
         # migration. The "Model diagnostics, N items in total:" wrapper
         # only adds value when there is more than one entry to enumerate.
+        #
+        # Threshold semantics (M2 from PR-110 review): the fast path only
+        # fires when one of ``errors`` / ``diagnostics`` is empty and the
+        # other has exactly one entry. The mixed 1+1 case still routes to
+        # the enumerated multi-item format on purpose — that case carries
+        # two semantically distinct entries (one legacy validation error
+        # plus one structured diagnostic) that deserve enumeration. PR-3
+        # may revisit this if a new aggregated raise type emerges.
         single_error = len(self.errors) == 1 and not self.diagnostics
         single_diag = len(self.diagnostics) == 1 and not self.errors
         if single_error:

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -287,6 +287,81 @@ class TestLoaderValidation:
         with pytest.raises(CodesSchemaError, match='must be a mapping'):
             load_codes(path)
 
+    def test_rejects_enum_as_non_list(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: Bad enum shape.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+                  enum: "not_a_list"
+        """)
+        with pytest.raises(CodesSchemaError, match='enum'):
+            load_codes(path)
+
+    def test_rejects_enum_as_empty_list(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: Empty enum.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+                  enum: []
+        """)
+        with pytest.raises(CodesSchemaError, match='non-empty'):
+            load_codes(path)
+
+    def test_rejects_enum_with_non_string_member(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: Mixed enum.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+                  enum: ['ok', 42, 'still_ok']
+        """)
+        with pytest.raises(CodesSchemaError, match='strings'):
+            load_codes(path)
+
+    def test_accepts_field_without_enum(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: No-enum field is fine.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+        """)
+        reg = load_codes(path)
+        assert reg['E_FOO'].refs_schema['bar'].enum is None
+
+    def test_loads_enum_into_code_field_spec(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            E_FOO:
+              severity: error
+              description: With enum.
+              refs:
+                bar:
+                  type: str
+                  required: true
+                  description: A bar.
+                  enum: ['a', 'b', 'c']
+        """)
+        reg = load_codes(path)
+        spec = reg['E_FOO'].refs_schema['bar']
+        assert spec.enum == ('a', 'b', 'c')
+
     def test_rejects_example_dsl_as_non_string(self, tmp_path):
         path = self._write_yaml(tmp_path, """
             E_FOO:

--- a/test/diagnostics/test_sink.py
+++ b/test/diagnostics/test_sink.py
@@ -1,0 +1,134 @@
+"""
+Unit tests for :class:`pyfcstm.diagnostics.DiagnosticSink`.
+
+PR-2 of the Layer 1 structured-diagnostic refactor (see issue #103) routes
+every semantic error in ``model.py`` through this sink. These tests pin
+down the two-mode contract:
+
+* **strict** (default) — each ``emit()`` of an error-severity diagnostic
+  raises :class:`pyfcstm.utils.validate.ModelValidationError` immediately.
+* **collect** — errors accumulate, the caller decides when to surface them.
+"""
+
+import pytest
+
+from pyfcstm.diagnostics import DiagnosticSink
+from pyfcstm.diagnostics.sink import _emit
+from pyfcstm.utils import ModelDiagnostic, ModelValidationError
+
+
+def _err(code: str = 'E_X', message: str = 'm') -> ModelDiagnostic:
+    return ModelDiagnostic(code=code, severity='error', message=message)
+
+
+def _warn(code: str = 'W_X', message: str = 'm') -> ModelDiagnostic:
+    return ModelDiagnostic(code=code, severity='warning', message=message)
+
+
+@pytest.mark.unittest
+class TestDiagnosticSinkStrict:
+    def test_default_is_strict(self):
+        sink = DiagnosticSink()
+        assert sink.collect is False
+
+    def test_strict_emit_raises_immediately(self):
+        sink = DiagnosticSink()
+        with pytest.raises(ModelValidationError) as info:
+            sink.emit(_err('E_UNDEFINED_VAR', 'oops'))
+        assert info.value.diagnostics[0].code == 'E_UNDEFINED_VAR'
+
+    def test_strict_emit_carries_previous_diagnostics(self):
+        # If a sink had a warning queued before an error, the raise must
+        # include the warning too (downstream tooling wants the full
+        # picture, not just the line that aborted).
+        sink = DiagnosticSink()
+        sink.emit(_warn('W_DEADLOCK', 'd1'))
+        with pytest.raises(ModelValidationError) as info:
+            sink.emit(_err('E_X', 'oops'))
+        codes = [d.code for d in info.value.diagnostics]
+        assert codes == ['W_DEADLOCK', 'E_X']
+
+    def test_strict_warning_does_not_raise(self):
+        sink = DiagnosticSink()
+        # Warnings are recorded but never abort the build.
+        sink.emit(_warn('W_DEADLOCK', 'd'))
+        assert not sink.has_errors()
+        assert sink.diagnostics[0].code == 'W_DEADLOCK'
+
+
+@pytest.mark.unittest
+class TestDiagnosticSinkCollect:
+    def test_collect_emit_does_not_raise(self):
+        sink = DiagnosticSink(collect=True)
+        sink.emit(_err('E_X', 'a'))
+        sink.emit(_err('E_Y', 'b'))
+        sink.emit(_warn('W_Z', 'c'))
+        codes = [d.code for d in sink.diagnostics]
+        assert codes == ['E_X', 'E_Y', 'W_Z']
+
+    def test_collect_has_errors_reflects_severity(self):
+        sink = DiagnosticSink(collect=True)
+        sink.emit(_warn('W_Z', 'c'))
+        assert not sink.has_errors()
+        sink.emit(_err('E_X', 'a'))
+        assert sink.has_errors()
+
+    def test_finalize_or_raise_raises_on_errors(self):
+        sink = DiagnosticSink(collect=True)
+        sink.emit(_err('E_X', 'a'))
+        sink.emit(_err('E_Y', 'b'))
+        with pytest.raises(ModelValidationError) as info:
+            sink.finalize_or_raise()
+        assert len(info.value.diagnostics) == 2
+
+    def test_finalize_or_raise_is_noop_without_errors(self):
+        sink = DiagnosticSink(collect=True)
+        sink.emit(_warn('W_Z', 'c'))
+        # No error severity present — must NOT raise.
+        sink.finalize_or_raise()
+        # Warnings still recorded after no-op.
+        assert sink.diagnostics[0].code == 'W_Z'
+
+    def test_finalize_or_raise_is_noop_in_strict_mode(self):
+        sink = DiagnosticSink(collect=False)
+        # Strict mode would have raised at emit time; in this fixture we
+        # never emit, so finalize is just a no-op for symmetry.
+        sink.finalize_or_raise()
+
+
+@pytest.mark.unittest
+class TestDiagnosticsSnapshot:
+    def test_diagnostics_property_returns_copy(self):
+        sink = DiagnosticSink(collect=True)
+        sink.emit(_err('E_X', 'a'))
+        snap = sink.diagnostics
+        snap.append(_err('E_FAKE', 'fake'))  # mutate snapshot
+        # Original sink unchanged.
+        assert len(sink.diagnostics) == 1
+        assert sink.diagnostics[0].code == 'E_X'
+
+    def test_collect_property(self):
+        assert DiagnosticSink(collect=True).collect is True
+        assert DiagnosticSink(collect=False).collect is False
+
+
+@pytest.mark.unittest
+class TestEmitHelper:
+    """``_emit`` is a convenience wrapper that supports both sink-routed
+    and direct-raise call sites without conditional plumbing."""
+
+    def test_emit_with_none_sink_raises_immediately(self):
+        with pytest.raises(ModelValidationError) as info:
+            _emit(None, _err('E_X', 'oops'))
+        assert info.value.diagnostics[0].code == 'E_X'
+
+    def test_emit_with_strict_sink_raises(self):
+        sink = DiagnosticSink()
+        with pytest.raises(ModelValidationError):
+            _emit(sink, _err('E_X', 'oops'))
+
+    def test_emit_with_collect_sink_accumulates(self):
+        sink = DiagnosticSink(collect=True)
+        _emit(sink, _err('E_X', 'a'))
+        _emit(sink, _err('E_Y', 'b'))
+        assert [d.code for d in sink.diagnostics] == ['E_X', 'E_Y']

--- a/test/dsl/test_listener_spans.py
+++ b/test/dsl/test_listener_spans.py
@@ -379,6 +379,71 @@ class TestSpanInvariants:
                 f"child={child_span}, parent={root._span}"
             )
 
+    def test_ctx_span_handles_empty_stop_text(self):
+        """
+        M3 from PR-110 review: when an ANTLR ``stop`` token has empty
+        text (e.g. synthetic / EOF tokens during error recovery),
+        ``_ctx_span`` previously computed
+        ``end_column = stop.column + len(stop.text) + 1`` which becomes
+        ``stop.column + 1`` — i.e. ``end_column == column`` on the same
+        line, a zero-width span that downstream editor squiggles refuse
+        to render.
+
+        The fix must guarantee at least one column of width on a single-
+        line span. We drive ``_ctx_span`` directly with a stub context.
+        """
+        from pyfcstm.dsl.listener import _ctx_span
+
+        class _StubToken:
+            def __init__(self, line, column, text):
+                self.line = line
+                self.column = column
+                self.text = text
+
+        class _StubCtx:
+            def __init__(self, start, stop):
+                self.start = start
+                self.stop = stop
+
+        # Same start/stop with empty text — the worst case.
+        tok = _StubToken(line=4, column=10, text='')
+        ctx = _StubCtx(start=tok, stop=tok)
+        span = _ctx_span(ctx)
+        assert span.line == 4
+        assert span.column == 11  # 0-based -> 1-based
+        # Zero-width would be end_column == 11 — must NOT happen.
+        assert span.end_column > span.column, (
+            f"_ctx_span produced zero-width single-line span: {span}"
+        )
+
+    def test_single_line_span_is_never_zero_width(self, parsed):
+        """For real parsed fixtures, every single-line span must cover
+        at least one character. Sister to the empty-token unit test."""
+        src, ast = parsed
+
+        def _walk(node):
+            yield node
+            for attr in ('definitions', 'root_state', 'substates',
+                         'transitions', 'force_transitions'):
+                child = getattr(node, attr, None)
+                if child is None:
+                    continue
+                if isinstance(child, list):
+                    for c in child:
+                        yield from _walk(c)
+                else:
+                    yield from _walk(child)
+
+        for node in _walk(ast):
+            span = getattr(node, '_span', None)
+            if span is None:
+                continue
+            if span.end_line == span.line:
+                assert span.end_column > span.column, (
+                    f"{type(node).__name__} has zero-width single-line span: "
+                    f"{span}"
+                )
+
     def test_slice_via_span_equals_original_for_full_root(self, parsed):
         src, ast = parsed
         root_span = ast.root_state._span

--- a/test/dsl/test_listener_spans.py
+++ b/test/dsl/test_listener_spans.py
@@ -1,0 +1,388 @@
+"""
+Precision tests for AST-node :class:`pyfcstm.utils.validate.Span` propagation.
+
+PR-2 of the Layer 1 structured-diagnostic refactor (see issue #103) requires
+the diagnostic-emit pipeline in :mod:`pyfcstm.model.model` to anchor each
+:class:`pyfcstm.utils.validate.ModelDiagnostic` to a precise source
+location. The anchor data comes from
+:func:`pyfcstm.dsl.listener._ctx_span`, which the listener attaches to
+``DefAssignment`` / ``StateDefinition`` / ``TransitionDefinition`` /
+``ForceTransitionDefinition`` instances as a ``_span`` attribute.
+
+This file pins down the precision contract by, for every spanning node
+kind:
+
+1. Constructing a DSL snippet with the relevant construct on a known line
+   and column.
+2. Parsing and locating the AST node.
+3. Slicing the source text using the node's ``_span`` ``[column, end_column)``
+   half-open range on the ``[line, end_line]`` line set.
+4. Asserting the slice equals the expected source substring of the
+   construct, character-for-character.
+
+If any of the asserts fail, ``_ctx_span`` is reporting an imprecise
+location that downstream tooling (IDE, jsfcstm visualization, LLM agent
+loop) would visualize incorrectly.
+"""
+
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.utils.validate import Span
+
+
+def _slice_by_span(source: str, span: Span) -> str:
+    """
+    Slice ``source`` using ``[column, end_column)`` half-open columns over
+    ``[line, end_line]`` lines. Both line and column indexing are 1-based,
+    matching the :class:`Span` contract.
+    """
+    assert span is not None, "span must not be None"
+    lines = source.split('\n')
+    if span.end_line is None or span.end_line == span.line:
+        line_text = lines[span.line - 1]
+        return line_text[span.column - 1:(span.end_column or span.column + 1) - 1]
+    # Multi-line slice: head line tail + intermediate full lines + last
+    # line up to end_column (exclusive).
+    pieces = [lines[span.line - 1][span.column - 1:]]
+    for i in range(span.line, span.end_line - 1):
+        pieces.append(lines[i])
+    pieces.append(lines[span.end_line - 1][:span.end_column - 1])
+    return '\n'.join(pieces)
+
+
+@pytest.mark.unittest
+class TestDefAssignmentSpan:
+    def test_simple_def_int(self):
+        src = "def int counter = 0;\nstate Root { state A; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        span = ast.definitions[0]._span
+        assert _slice_by_span(src, span) == "def int counter = 0;"
+        assert span.line == 1
+        assert span.column == 1
+        assert span.end_line == 1
+        assert span.end_column == 21  # exclusive end after ';'
+
+    def test_def_float(self):
+        src = "def float temp = 25.5;\nstate Root { state A; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        assert _slice_by_span(src, ast.definitions[0]._span) == "def float temp = 25.5;"
+
+    def test_def_with_leading_blank_lines(self):
+        src = "\n\n  def int x = 0xFF;\nstate Root { state A; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        span = ast.definitions[0]._span
+        assert span.line == 3
+        assert span.column == 3
+        assert _slice_by_span(src, span) == "def int x = 0xFF;"
+
+    def test_def_with_hex_literal(self):
+        src = "def int mask = 0xCAFE;\nstate Root { state A; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        assert _slice_by_span(src, ast.definitions[0]._span) == "def int mask = 0xCAFE;"
+
+    def test_def_with_arithmetic_init(self):
+        src = "def int flags = 0xFF & 0x0F;\nstate Root { state A; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        assert _slice_by_span(src, ast.definitions[0]._span) == "def int flags = 0xFF & 0x0F;"
+
+    def test_multiple_defs_each_span_correct(self):
+        src = "def int x = 0;\ndef float y = 1.5;\ndef int z = 7;\nstate Root { state A; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        assert _slice_by_span(src, ast.definitions[0]._span) == "def int x = 0;"
+        assert _slice_by_span(src, ast.definitions[1]._span) == "def float y = 1.5;"
+        assert _slice_by_span(src, ast.definitions[2]._span) == "def int z = 7;"
+        assert ast.definitions[0]._span.line == 1
+        assert ast.definitions[1]._span.line == 2
+        assert ast.definitions[2]._span.line == 3
+
+
+@pytest.mark.unittest
+class TestStateDefinitionSpan:
+    def test_leaf_state_simple(self):
+        src = "state Root { state Idle; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        # Root state span covers the full composite block
+        root_span = ast.root_state._span
+        assert _slice_by_span(src, root_span) == "state Root { state Idle; }"
+        # Leaf state span covers just "state Idle;"
+        leaf_span = ast.root_state.substates[0]._span
+        assert _slice_by_span(src, leaf_span) == "state Idle;"
+
+    def test_pseudo_state_span_includes_pseudo_keyword(self):
+        src = "state Root { pseudo state Special; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        leaf_span = ast.root_state.substates[0]._span
+        assert _slice_by_span(src, leaf_span) == "pseudo state Special;"
+
+    def test_named_leaf_state(self):
+        src = 'state Root { state Running named "System Running"; }'
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        leaf_span = ast.root_state.substates[0]._span
+        assert _slice_by_span(src, leaf_span) == 'state Running named "System Running";'
+
+    def test_composite_state_multiline(self):
+        src = "state Outer {\n    state A;\n    state B;\n}"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        span = ast.root_state._span
+        assert span.line == 1
+        assert span.column == 1
+        assert span.end_line == 4
+        # End column points one past the closing brace on line 4
+        assert span.end_column == 2
+        assert _slice_by_span(src, span) == src
+
+    def test_nested_composite_each_substate_correct(self):
+        src = "state Root {\n    state Mid {\n        state Leaf;\n    }\n}"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        root = ast.root_state
+        assert root._span.line == 1
+        assert root._span.column == 1
+
+        mid = root.substates[0]
+        assert mid._span.line == 2
+        assert mid._span.column == 5
+        assert _slice_by_span(src, mid._span) == (
+            "state Mid {\n        state Leaf;\n    }"
+        )
+
+        leaf = mid.substates[0]
+        assert leaf._span.line == 3
+        assert leaf._span.column == 9
+        assert _slice_by_span(src, leaf._span) == "state Leaf;"
+
+    def test_leaf_with_column_offset(self):
+        src = "state Root {     state Inner;     }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        leaf = ast.root_state.substates[0]
+        # Find the "state Inner;" text and verify span maps to it.
+        start_idx = src.index("state Inner;")
+        # ANTLR's column is 0-based; our span.column is 1-based.
+        assert leaf._span.column == start_idx + 1
+        assert _slice_by_span(src, leaf._span) == "state Inner;"
+
+
+@pytest.mark.unittest
+class TestTransitionDefinitionSpan:
+    def test_normal_transition_simple(self):
+        src = "state Root { state A; state B; A -> B; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        trans = ast.root_state.transitions[0]
+        assert _slice_by_span(src, trans._span) == "A -> B;"
+
+    def test_normal_transition_with_event(self):
+        src = "state Root { state A; state B; A -> B :: Done; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        trans = ast.root_state.transitions[0]
+        assert _slice_by_span(src, trans._span) == "A -> B :: Done;"
+
+    def test_normal_transition_with_guard(self):
+        src = "def int x = 0;\nstate Root { state A; state B; A -> B : if [x > 0]; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        trans = ast.root_state.transitions[0]
+        assert _slice_by_span(src, trans._span) == "A -> B : if [x > 0];"
+
+    def test_normal_transition_with_effect(self):
+        # The transition rule does not include the trailing ';' as part of
+        # the parse context; the span covers from the source-state token
+        # through the closing '}' of the effect block.
+        src = "def int x = 0;\nstate Root { state A; state B; A -> B effect { x = 1; }; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        trans = ast.root_state.transitions[0]
+        assert _slice_by_span(src, trans._span) == "A -> B effect { x = 1; }"
+
+    def test_entry_transition(self):
+        src = "state Root { state A; [*] -> A; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        trans = ast.root_state.transitions[0]
+        # Entry transitions start with `[`; span includes the trailing ';'.
+        assert _slice_by_span(src, trans._span) == "[*] -> A;"
+
+    def test_exit_transition(self):
+        src = "state Root { state A; A -> [*]; }"
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        trans = ast.root_state.transitions[0]
+        assert _slice_by_span(src, trans._span) == "A -> [*];"
+
+    def test_transition_multiline(self):
+        src = (
+            "state Root {\n"
+            "    state A;\n"
+            "    state B;\n"
+            "    A -> B :: Done;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        trans = ast.root_state.transitions[0]
+        assert trans._span.line == 4
+        assert trans._span.column == 5
+        assert trans._span.end_line == 4
+        assert _slice_by_span(src, trans._span) == "A -> B :: Done;"
+
+
+@pytest.mark.unittest
+class TestForceTransitionDefinitionSpan:
+    def test_force_transition_normal_named_source(self):
+        # `!State -> Target :: Event;`
+        src = (
+            "state Root {\n"
+            "    state A;\n"
+            "    state B;\n"
+            "    event Go;\n"
+            "    !A -> B :: Go;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        ft = ast.root_state.force_transitions[0]
+        assert ft._span.line == 5
+        # Force-transition grammar includes the trailing ';' in the parse ctx.
+        assert _slice_by_span(src, ft._span) == "!A -> B :: Go;"
+
+    def test_force_transition_exit_form(self):
+        src = (
+            "state Root {\n"
+            "    state A;\n"
+            "    event Fatal;\n"
+            "    !A -> [*] :: Fatal;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        ft = ast.root_state.force_transitions[0]
+        assert _slice_by_span(src, ft._span) == "!A -> [*] :: Fatal;"
+
+    def test_force_transition_all_wildcard(self):
+        src = (
+            "state Root {\n"
+            "    state A;\n"
+            "    state ErrorHandler;\n"
+            "    event GlobalErr;\n"
+            "    !* -> ErrorHandler :: GlobalErr;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        ft = ast.root_state.force_transitions[0]
+        assert _slice_by_span(src, ft._span) == "!* -> ErrorHandler :: GlobalErr;"
+
+    def test_force_transition_all_to_exit(self):
+        src = (
+            "state Root {\n"
+            "    state A;\n"
+            "    event GlobalErr;\n"
+            "    !* -> [*] :: GlobalErr;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        ft = ast.root_state.force_transitions[0]
+        assert _slice_by_span(src, ft._span) == "!* -> [*] :: GlobalErr;"
+
+
+@pytest.mark.unittest
+class TestSpanInvariants:
+    """Cross-cutting properties that every spanned node must obey."""
+
+    @pytest.fixture
+    def parsed(self):
+        src = (
+            "def int x = 0;\n"
+            "def float y = 1.5;\n"
+            "state Root {\n"
+            "    state Idle;\n"
+            "    state Active {\n"
+            "        state Sub;\n"
+            "        [*] -> Sub;\n"
+            "    }\n"
+            "    event Go;\n"
+            "    !Idle -> Active :: Go;\n"
+            "    Active -> Idle :: Go;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        return src, ast
+
+    def test_every_spanned_node_has_span_attribute(self, parsed):
+        src, ast = parsed
+        targets = [
+            ast.definitions[0],
+            ast.definitions[1],
+            ast.root_state,
+            ast.root_state.substates[0],
+            ast.root_state.substates[1],
+            ast.root_state.substates[1].substates[0],
+            ast.root_state.substates[1].transitions[0],
+            ast.root_state.transitions[0],
+            ast.root_state.force_transitions[0],
+        ]
+        for node in targets:
+            span = getattr(node, '_span', None)
+            assert span is not None, f"node missing _span: {node!r}"
+            assert span.line >= 1
+            assert span.column >= 1
+
+    def test_spans_are_well_formed(self, parsed):
+        src, ast = parsed
+
+        def _walk(node, results):
+            span = getattr(node, '_span', None)
+            if span is not None:
+                # end_line >= line; if same line, end_column > column.
+                assert span.end_line is not None
+                assert span.end_column is not None
+                assert span.end_line >= span.line
+                if span.end_line == span.line:
+                    assert span.end_column > span.column, (
+                        f"degenerate single-line span on {type(node).__name__}: "
+                        f"col={span.column}, end_col={span.end_column}"
+                    )
+                results.append((type(node).__name__, span))
+            # Walk children
+            for attr in ('definitions', 'root_state', 'substates',
+                         'transitions', 'force_transitions'):
+                child = getattr(node, attr, None)
+                if child is None:
+                    continue
+                if isinstance(child, list):
+                    for c in child:
+                        _walk(c, results)
+                else:
+                    _walk(child, results)
+
+        results = []
+        _walk(ast, results)
+        # We should have collected spans for definitions + states + transitions
+        assert len(results) >= 8
+
+    def test_parent_span_contains_children_spans(self, parsed):
+        """For nested constructs, the parent's span fully encloses each child's span."""
+        src, ast = parsed
+        root = ast.root_state
+        for child in root.substates + root.transitions + root.force_transitions:
+            child_span = getattr(child, '_span', None)
+            if child_span is None:
+                continue
+            # Either child starts on a later line, or starts on same line with greater column
+            ok_start = (
+                child_span.line > root._span.line
+                or (child_span.line == root._span.line
+                    and child_span.column >= root._span.column)
+            )
+            ok_end = (
+                child_span.end_line < root._span.end_line
+                or (child_span.end_line == root._span.end_line
+                    and child_span.end_column <= root._span.end_column)
+            )
+            assert ok_start, (
+                f"child {type(child).__name__} starts before parent: "
+                f"child={child_span}, parent={root._span}"
+            )
+            assert ok_end, (
+                f"child {type(child).__name__} ends after parent: "
+                f"child={child_span}, parent={root._span}"
+            )
+
+    def test_slice_via_span_equals_original_for_full_root(self, parsed):
+        src, ast = parsed
+        root_span = ast.root_state._span
+        sliced = _slice_by_span(src, root_span)
+        # Slice should start with "state Root" and end with "}"
+        assert sliced.startswith("state Root")
+        assert sliced.endswith("}")

--- a/test/model/test_diagnostic_emit.py
+++ b/test/model/test_diagnostic_emit.py
@@ -384,6 +384,279 @@ state Root { state A; }
 
 
 @pytest.mark.unittest
+class TestI1FirstWinsNamedFunction:
+    """
+    I1 from PR-110 review: in strict mode the duplicate-named-function
+    raise prevents the subsequent overwrite of ``named_functions[name]``;
+    in collect mode the overwrite still happens, so "last wins" silently
+    flips. Pin "first wins" as the canonical tiebreaker across both modes.
+    """
+
+    def test_collect_mode_named_function_first_wins_enter(self):
+        machine, diags = _collect("""
+state Root {
+    state A {
+        enter F1 { }
+        enter F1 { }
+    }
+    [*] -> A;
+}
+""")
+        # Both stages emit the duplicate-function diagnostic.
+        dup = [d for d in diags if d.code == 'E_DUPLICATE_FUNCTION_NAME']
+        assert len(dup) >= 1
+
+        # The named_functions map under state A must point at the FIRST
+        # declaration (first wins), so a `ref F1` resolves consistently
+        # with strict mode's "abort on duplicate before overwrite".
+        a = machine.root_state.substates['A']
+        first_decl = a.on_enters[0]
+        assert a.named_functions['F1'] is first_decl
+
+    def test_collect_mode_named_function_first_wins_during(self):
+        machine, diags = _collect("""
+state Root {
+    state Outer {
+        during before { }
+        state Inner {
+            during D1 { }
+            during D1 { }
+        }
+        [*] -> Inner;
+    }
+    [*] -> Outer;
+}
+""")
+        inner = machine.root_state.substates['Outer'].substates['Inner']
+        first_decl = inner.on_durings[0]
+        assert inner.named_functions['D1'] is first_decl
+
+
+@pytest.mark.unittest
+class TestI2DanglingTransitionBothNotFound:
+    """
+    I2 from PR-110 review: when both ``from_state`` and ``to_state`` of a
+    transition are unresolved, codes.yaml declares ``reason='both_not_found'``
+    but the emit logic produces two separate diagnostics (one
+    ``src_not_found`` + one ``tgt_not_found``). Collapse to a single
+    diagnostic carrying ``reason='both_not_found'`` so downstream
+    consumers don't double-count one broken transition.
+    """
+
+    def test_both_sides_unknown_emits_single_both_not_found(self):
+        machine, diags = _collect("""
+state Root {
+    state A;
+    NoSrc -> NoTgt;
+}
+""")
+        dangling = [d for d in diags if d.code == 'E_DANGLING_TRANSITION']
+        assert len(dangling) == 1, (
+            f"expected 1 E_DANGLING_TRANSITION, got {len(dangling)}: "
+            f"{[d.refs for d in dangling]}"
+        )
+        d = dangling[0]
+        assert d.refs['reason'] == 'both_not_found'
+        assert d.refs['src'] == 'NoSrc'
+        assert d.refs['tgt'] == 'NoTgt'
+
+    def test_only_src_unknown_still_emits_src_not_found(self):
+        diag = _strict_diag("""
+state Root {
+    state Target;
+    NoSrc -> Target;
+}
+""")
+        assert diag.code == 'E_DANGLING_TRANSITION'
+        assert diag.refs['reason'] == 'src_not_found'
+
+    def test_only_tgt_unknown_still_emits_tgt_not_found(self):
+        diag = _strict_diag("""
+state Root {
+    state Source;
+    Source -> NoTgt;
+}
+""")
+        assert diag.code == 'E_DANGLING_TRANSITION'
+        assert diag.refs['reason'] == 'tgt_not_found'
+
+
+@pytest.mark.unittest
+class TestI3ForceTransitionFailureContinues:
+    """
+    I3 from PR-110 review: failed src/tgt resolution still appends the
+    broken tuple to ``force_transition_tuples_to_inherit``. The bad
+    string later mismatches ``ALL`` and any real substate name, so the
+    inheritance phase silently drops the transition — on top of the
+    diagnostic — but the bad string also lingers in the tuple list and
+    risks downstream defensive-validation logic getting confused.
+
+    After the fix, a failed force-transition must not appear in any form
+    in the partial model (apart from the diagnostic itself).
+    """
+
+    def _walk_states(self, machine):
+        if machine is None:
+            return
+        def _go(s):
+            yield s
+            for c in s.substates.values():
+                yield from _go(c)
+        yield from _go(machine.root_state)
+
+    def test_force_transition_with_bad_src_does_not_pollute_transitions(self):
+        machine, diags = _collect("""
+state Root {
+    state A;
+    state B;
+    !NoSrc -> A;
+    [*] -> A;
+}
+""")
+        ftd = [d for d in diags if d.code == 'E_FORCED_TRANSITION_EXPANSION']
+        assert ftd, "missing E_FORCED_TRANSITION_EXPANSION"
+        # No state in the machine should carry a transition whose
+        # from_state matches the bad source.
+        for state in self._walk_states(machine):
+            for trans in state.transitions:
+                assert getattr(trans, 'from_state', None) != 'NoSrc', (
+                    f"phantom transition with from_state='NoSrc' leaked "
+                    f"into state {'.'.join(state.path)!r}"
+                )
+
+    def test_force_transition_with_bad_tgt_does_not_pollute_transitions(self):
+        machine, diags = _collect("""
+state Root {
+    state A;
+    state B;
+    !A -> NoTgt;
+    [*] -> A;
+}
+""")
+        ftd = [d for d in diags if d.code == 'E_FORCED_TRANSITION_EXPANSION']
+        assert ftd, "missing E_FORCED_TRANSITION_EXPANSION"
+        # Bad to_state must not propagate as a real Transition in any
+        # state's transitions list.
+        for state in self._walk_states(machine):
+            for trans in state.transitions:
+                assert trans.to_state != 'NoTgt', (
+                    f"phantom transition with to_state='NoTgt' leaked "
+                    f"into state {'.'.join(state.path)!r}"
+                )
+
+
+@pytest.mark.unittest
+class TestI4UndefinedVarStatePath:
+    """
+    I4 from PR-110 review: E_UNDEFINED_VAR.refs.state_path is the
+    downstream-required field that tells LLM repair agents "which state
+    owns this block". For block-bound contexts (enter/during/exit/
+    during_aspect), the parser has ``current_path`` available locally
+    and must populate it.
+
+    Guard sites on transitions stay None since the offending block is
+    not state-owned per se.
+    """
+
+    def test_undefined_in_enter_block_carries_state_path(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A {
+        enter { x = unknown + 1; }
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs.get('state_path') == 'Root.A'
+
+    def test_undefined_in_during_block_carries_state_path(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A {
+        during { x = unknown + 1; }
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs.get('state_path') == 'Root.A'
+
+    def test_undefined_in_exit_block_carries_state_path(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A {
+        exit { x = unknown + 1; }
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs.get('state_path') == 'Root.A'
+
+    def test_undefined_in_during_aspect_block_carries_state_path(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state Outer {
+        during before { x = unknown + 1; }
+        state Inner;
+        [*] -> Inner;
+    }
+    [*] -> Outer;
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs.get('state_path') == 'Root.Outer'
+
+
+@pytest.mark.unittest
+class TestI5EmitHelperPreservesContext:
+    """
+    I5 from PR-110 review: ``_emit(None, ...)`` raises with
+    ``diagnostics=[diagnostic]`` only, losing any previously accumulated
+    warnings or earlier diagnostics. The semantically equivalent
+    ``DiagnosticSink.emit`` (in strict mode) raises with the full
+    accumulated list. Callers shouldn't have to track which path is
+    "context-preserving".
+
+    The fix is to make ``_emit`` accept an optional ``prior`` list (or
+    drop the helper entirely as unused). This test pins the API:
+    ``_emit`` either preserves a prior list passed alongside, or
+    ``None``-sink raise carries the single diagnostic but documents the
+    asymmetry by accepting a ``prior_diagnostics`` kwarg.
+    """
+
+    def test_emit_with_none_sink_accepts_prior_diagnostics(self):
+        from pyfcstm.diagnostics.sink import _emit
+        from pyfcstm.utils import ModelDiagnostic
+        prior = [
+            ModelDiagnostic(code='W_X', severity='warning', message='early'),
+        ]
+        with pytest.raises(ModelValidationError) as info:
+            _emit(None, ModelDiagnostic(
+                code='E_X', severity='error', message='boom',
+            ), prior_diagnostics=prior)
+        codes = [d.code for d in info.value.diagnostics]
+        assert codes == ['W_X', 'E_X']
+
+    def test_emit_with_none_sink_default_no_prior(self):
+        # Backwards-compat: existing callers that don't pass prior just
+        # raise with the single diagnostic.
+        from pyfcstm.diagnostics.sink import _emit
+        from pyfcstm.utils import ModelDiagnostic
+        with pytest.raises(ModelValidationError) as info:
+            _emit(None, ModelDiagnostic(
+                code='E_X', severity='error', message='boom',
+            ))
+        codes = [d.code for d in info.value.diagnostics]
+        assert codes == ['E_X']
+
+
+@pytest.mark.unittest
 class TestEmitMatchesEnum:
     """
     C2 from PR-110 review: every ``refs[field]`` value emitted from a real

--- a/test/model/test_diagnostic_emit.py
+++ b/test/model/test_diagnostic_emit.py
@@ -384,6 +384,86 @@ state Root { state A; }
 
 
 @pytest.mark.unittest
+class TestCollectModeNoPhantomMutation:
+    """
+    C1 from PR-110 review: in collect mode, ``sink.emit(E_MISSING_STATE)``
+    no longer raises — but the code immediately below the segment-walk
+    falls through and inserts a fabricated ``Event`` into whatever state
+    the walk got stuck on (usually root or the last good parent).
+
+    The "best-effort partial model" returned by collect mode must not be
+    silently polluted with events the user never wrote. These tests assert
+    no phantom events appear in any state's ``events`` dict after a bad
+    event-id path triggers ``E_MISSING_STATE``.
+    """
+
+    def _walk_states(self, machine):
+        # Recursive walker that yields every State in the model.
+        def _go(s):
+            yield s
+            for child in s.substates.values():
+                yield from _go(child)
+        if machine is None:
+            return
+        yield from _go(machine.root_state)
+
+    def test_normal_transition_bad_event_path_no_phantom_event(self):
+        machine, diags = _collect("""
+state Root {
+    state A; state B;
+    [*] -> A;
+    A -> B : /NoSuch.GhostEvent;
+}
+""")
+        codes = [d.code for d in diags]
+        assert 'E_MISSING_STATE' in codes
+        # No state in the partial model should carry a phantom 'GhostEvent'.
+        for state in self._walk_states(machine):
+            assert 'GhostEvent' not in state.events, (
+                f"phantom event 'GhostEvent' leaked into state "
+                f"{'.'.join(state.path)!r} after E_MISSING_STATE in collect mode"
+            )
+
+    def test_force_transition_bad_event_path_no_phantom_event(self):
+        machine, diags = _collect("""
+state Root {
+    state A; state B;
+    [*] -> A;
+    !A -> B : /NoSuch.GhostEvent;
+}
+""")
+        codes = [d.code for d in diags]
+        assert 'E_MISSING_STATE' in codes
+        for state in self._walk_states(machine):
+            assert 'GhostEvent' not in state.events, (
+                f"phantom event 'GhostEvent' leaked into state "
+                f"{'.'.join(state.path)!r} after E_MISSING_STATE in force "
+                f"transition collect mode"
+            )
+
+    def test_phantom_does_not_create_follow_on_diagnostics(self):
+        """A phantom event under the wrong parent would let downstream
+        transitions in the same pass match it and skip further error
+        reporting — assert the diagnostic list stays minimal."""
+        machine, diags = _collect("""
+state Root {
+    state A; state B;
+    [*] -> A;
+    A -> B : /NoSuch.GhostEvent;
+    A -> B : /AlsoNoSuch.OtherEvent;
+}
+""")
+        # Both bad transitions must each surface their own diagnostic; if
+        # the first one polluted state.events, the second's resolution
+        # logic might find a phantom and silently succeed.
+        missing_diags = [d for d in diags if d.code == 'E_MISSING_STATE']
+        assert len(missing_diags) >= 2, (
+            f"expected 2 distinct E_MISSING_STATE, got "
+            f"{[d.refs.get('state_path') for d in missing_diags]}"
+        )
+
+
+@pytest.mark.unittest
 class TestSpanPropagation:
     def test_duplicate_var_carries_span(self):
         diag = _strict_diag("""

--- a/test/model/test_diagnostic_emit.py
+++ b/test/model/test_diagnostic_emit.py
@@ -1,0 +1,495 @@
+"""
+Fixture-driven tests that verify
+:func:`pyfcstm.model.parse_dsl_node_to_state_machine` emits the right
+structured :class:`pyfcstm.utils.validate.ModelDiagnostic` for each of the
+14 ``E_*`` codes registered in ``pyfcstm/diagnostics/codes.yaml``.
+
+PR-2 of the Layer 1 structured-diagnostic refactor (see issue #103)
+guarantees:
+
+1. Every legacy ``raise SyntaxError`` site in ``model.py`` is replaced by
+   ``sink.emit(ModelDiagnostic(code=..., severity='error', message=...,
+   refs=...))``.
+2. Strict-mode callers (the default, ``collect=False``) still get
+   :class:`pyfcstm.utils.validate.ModelValidationError`, which multi-
+   inherits from :class:`SyntaxError` for backwards compatibility. The
+   PR-0 baseline (``test/model/test_error_baseline.py``) checks the
+   substring contract.
+3. ``collect=True`` returns ``(model_or_None, diagnostics)`` so callers
+   that want every error in one pass (IDE, LLM agent loop) can have them.
+
+Each test below pairs a minimal DSL snippet with assertions on
+``diag.code`` / ``diag.refs`` keys to lock the structured payload contract
+that downstream consumers (``research_ideas`` ``SemanticFeedback``
+schema) read.
+"""
+
+import pytest
+
+from pyfcstm.diagnostics import CODE_REGISTRY
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.utils import ModelDiagnostic, ModelValidationError, Span
+
+
+def _collect(dsl_text: str):
+    ast = parse_with_grammar_entry(dsl_text, entry_name='state_machine_dsl')
+    return parse_dsl_node_to_state_machine(ast, collect=True)
+
+
+def _strict_diag(dsl_text: str) -> ModelDiagnostic:
+    """Run in strict mode, expect raise, return the first diagnostic."""
+    ast = parse_with_grammar_entry(dsl_text, entry_name='state_machine_dsl')
+    with pytest.raises(ModelValidationError) as info:
+        parse_dsl_node_to_state_machine(ast)
+    assert info.value.diagnostics, "expected at least one diagnostic"
+    return info.value.diagnostics[0]
+
+
+def _assert_refs_match_schema(diag: ModelDiagnostic) -> None:
+    """The diagnostic's ``refs`` must only carry keys declared in the
+    ``codes.yaml`` schema, and every required key must be present."""
+    spec = CODE_REGISTRY.get(diag.code)
+    assert spec is not None, f"unknown code {diag.code!r}"
+    declared = set(spec.refs_schema.keys())
+    actual = set(diag.refs.keys())
+    extra = actual - declared
+    assert not extra, (
+        f"{diag.code} refs has extra keys {extra} not in codes.yaml schema"
+    )
+    required = set(spec.required_fields())
+    missing = required - actual
+    assert not missing, (
+        f"{diag.code} refs missing required keys {missing}"
+    )
+
+
+@pytest.mark.unittest
+class TestEUndefinedVar:
+    def test_undefined_in_guard(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A; state B;
+    A -> B : if [unknown > 0];
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs['var_name'] == ['unknown']
+        assert diag.refs['referenced_in'] == 'guard'
+        _assert_refs_match_schema(diag)
+
+    def test_undefined_in_force_transition_guard(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A; state B;
+    !A -> B : if [unknown > 0];
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs['referenced_in'] == 'guard'
+
+    def test_undefined_in_effect(self):
+        # ``x = unknown + 1`` references ``unknown`` on the RHS, which must
+        # already exist. ``x = 1`` style is *not* used because the DSL
+        # treats LHS-only undeclared names as block-local temporaries.
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A; state B;
+    [*] -> A;
+    A -> B effect { x = unknown + 1; };
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs['referenced_in'] == 'effect'
+
+    def test_undefined_in_enter(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A {
+        enter { x = unknown + 1; }
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs['referenced_in'] == 'enter'
+
+    def test_undefined_in_exit(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A {
+        exit { x = unknown + 1; }
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs['referenced_in'] == 'exit'
+
+    def test_undefined_in_during_leaf(self):
+        diag = _strict_diag("""
+def int x = 0;
+state Root {
+    state A {
+        during { x = unknown + 1; }
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_UNDEFINED_VAR'
+        assert diag.refs['referenced_in'] == 'during'
+
+
+@pytest.mark.unittest
+class TestEDuplicateVar:
+    def test_two_defs_same_name(self):
+        diag = _strict_diag("""
+def int x = 0;
+def int x = 1;
+state Root { state A; }
+""")
+        assert diag.code == 'E_DUPLICATE_VAR'
+        assert diag.refs['var_name'] == 'x'
+        # previous_span should anchor at the first declaration
+        assert diag.refs['previous_span'] is not None
+        prev = diag.refs['previous_span']
+        assert isinstance(prev, Span)
+        # Diagnostic span anchors at the duplicate, prev_span at line above.
+        assert diag.span is not None
+        assert prev.line < diag.span.line
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestEMissingState:
+    def test_event_path_state_unresolved(self):
+        # Targets a chain-id event referencing a non-existent state.
+        diag = _strict_diag("""
+state Root {
+    state A; state B;
+    A -> B : /NoSuch.GoEvent;
+}
+""")
+        assert diag.code == 'E_MISSING_STATE'
+        assert 'state_path' in diag.refs
+        assert diag.refs['reason'] == 'event_path_not_found'
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestEDuplicateState:
+    def test_two_states_same_name(self):
+        diag = _strict_diag("""
+state Root {
+    state A;
+    state A;
+}
+""")
+        assert diag.code == 'E_DUPLICATE_STATE'
+        assert diag.refs['state_name'] == 'A'
+        assert diag.refs['parent_path'].endswith('Root')
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestEDanglingTransition:
+    def test_unknown_to_state(self):
+        diag = _strict_diag("""
+state Root {
+    state A;
+    A -> NoSuch;
+}
+""")
+        assert diag.code == 'E_DANGLING_TRANSITION'
+        assert diag.refs['tgt'] == 'NoSuch'
+        assert diag.refs['reason'] == 'tgt_not_found'
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestEPseudoNotLeaf:
+    def test_pseudo_with_substates(self):
+        # ``pseudo state X { state Y; ... }`` — pseudo states must be leaves.
+        diag = _strict_diag("""
+state Root {
+    pseudo state Outer {
+        state Inner;
+        [*] -> Inner;
+    }
+    [*] -> Outer;
+}
+""")
+        assert diag.code == 'E_PSEUDO_NOT_LEAF'
+        assert 'state_path' in diag.refs
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestEDuringAspectInvalid:
+    def test_leaf_state_with_aspect(self):
+        # Leaf state must NOT carry a during aspect.
+        diag = _strict_diag("""
+state Root {
+    state A {
+        during before { }
+    }
+}
+""")
+        assert diag.code == 'E_DURING_ASPECT_INVALID'
+        assert diag.refs['state_kind'] == 'leaf'
+        assert diag.refs['aspect'] == 'before'
+        _assert_refs_match_schema(diag)
+
+    def test_composite_without_aspect(self):
+        # Composite state must carry an aspect when it has `during`.
+        diag = _strict_diag("""
+state Root {
+    state Outer {
+        during { }
+        state Inner;
+        [*] -> Inner;
+    }
+    [*] -> Outer;
+}
+""")
+        assert diag.code == 'E_DURING_ASPECT_INVALID'
+        assert diag.refs['state_kind'] == 'composite'
+        assert diag.refs['aspect'] is None
+
+
+@pytest.mark.unittest
+class TestEDuplicateFunctionName:
+    def test_duplicate_enter_name(self):
+        diag = _strict_diag("""
+state Root {
+    state A {
+        enter F1 { }
+        enter F1 { }
+    }
+}
+""")
+        assert diag.code == 'E_DUPLICATE_FUNCTION_NAME'
+        assert diag.refs['function_name'] == 'F1'
+        assert diag.refs['stage'] == 'enter'
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestEInitialTransitionInvalid:
+    def test_composite_missing_entry(self):
+        diag = _strict_diag("""
+state Root {
+    state Outer {
+        state Inner;
+    }
+}
+""")
+        assert diag.code == 'E_INITIAL_TRANSITION_INVALID'
+        assert diag.refs['reason'] == 'missing_entry'
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestEForcedTransitionExpansion:
+    def test_force_unknown_from_state(self):
+        diag = _strict_diag("""
+state Root {
+    state A;
+    !NoSuch -> A;
+}
+""")
+        assert diag.code == 'E_FORCED_TRANSITION_EXPANSION'
+        assert diag.refs['reason'] == 'src_not_found'
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestENamedFunctionRefNotFound:
+    def test_named_ref_state_not_found(self):
+        diag = _strict_diag("""
+state Root {
+    state A {
+        enter ref NoSuch.NoSuch;
+    }
+}
+""")
+        assert diag.code == 'E_NAMED_FUNCTION_REF_NOT_FOUND'
+        assert diag.refs['reason'] == 'state_not_found'
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestCollectMode:
+    def test_collect_returns_tuple(self):
+        machine, diags = _collect("""
+state Root {
+    state A;
+    state A;
+}
+""")
+        # `machine` may or may not be None depending on how far parsing got;
+        # diagnostics list must carry the duplicate-state error.
+        codes = [d.code for d in diags]
+        assert 'E_DUPLICATE_STATE' in codes
+
+    def test_collect_gathers_multiple_distinct_errors(self):
+        # Two completely independent errors in one DSL — collect mode must
+        # surface both, strict mode raises on the first.
+        machine, diags = _collect("""
+def int x = 0;
+def int x = 1;
+state Root {
+    state A;
+    state A;
+}
+""")
+        codes = [d.code for d in diags]
+        assert 'E_DUPLICATE_VAR' in codes
+        assert 'E_DUPLICATE_STATE' in codes
+
+    def test_strict_mode_raises_on_first(self):
+        # Same DSL as above, strict mode aborts at the first issue. The
+        # raised exception still carries the first diagnostic in its
+        # `diagnostics` list.
+        ast = parse_with_grammar_entry("""
+def int x = 0;
+def int x = 1;
+state Root {
+    state A;
+    state A;
+}
+""", entry_name='state_machine_dsl')
+        with pytest.raises(ModelValidationError) as info:
+            parse_dsl_node_to_state_machine(ast)
+        assert len(info.value.diagnostics) == 1
+        assert info.value.diagnostics[0].code == 'E_DUPLICATE_VAR'
+
+    def test_strict_caught_via_syntax_error(self):
+        # Backwards-compat: `ModelValidationError` multi-inherits
+        # `SyntaxError`, so downstream code catching the plain
+        # `SyntaxError` keeps working after PR-2.
+        ast = parse_with_grammar_entry("""
+def int x = 0;
+def int x = 1;
+state Root { state A; }
+""", entry_name='state_machine_dsl')
+        with pytest.raises(SyntaxError) as info:
+            parse_dsl_node_to_state_machine(ast)
+        assert info.value.diagnostics[0].code == 'E_DUPLICATE_VAR'
+
+
+@pytest.mark.unittest
+class TestSpanPropagation:
+    def test_duplicate_var_carries_span(self):
+        diag = _strict_diag("""
+def int x = 0;
+def int x = 1;
+state Root { state A; }
+""")
+        assert diag.span is not None
+        # The duplicate is on line 3 of the DSL (after the leading blank).
+        assert diag.span.line == 3
+
+    def test_duplicate_state_carries_span(self):
+        diag = _strict_diag("""
+state Root {
+    state A;
+    state A;
+}
+""")
+        assert diag.span is not None
+        # The duplicate state line is the 4th line.
+        assert diag.span.line == 4
+
+    def test_collect_mode_continues_past_event_path_failure(self):
+        # In collect mode, the sink doesn't raise — the loop hits ``break``
+        # to skip the rest of the bad event chain and keep walking the
+        # rest of the model. Exercises the safety ``break`` after the
+        # ``E_MISSING_STATE`` emit in the transition event-id walk.
+        machine, diags = _collect("""
+def int x = 0;
+state Root {
+    state A; state B;
+    [*] -> A;
+    A -> B : /NoSuch.Event;
+    A -> B : if [unknown > 0];
+}
+""")
+        codes = {d.code for d in diags}
+        assert 'E_MISSING_STATE' in codes
+        # The guard's E_UNDEFINED_VAR must still surface, proving the
+        # event-id failure didn't short-circuit the whole pass.
+        assert 'E_UNDEFINED_VAR' in codes
+
+    def test_collect_mode_continues_past_force_transition_event_path_failure(self):
+        machine, diags = _collect("""
+def int x = 0;
+state Root {
+    state A; state B;
+    [*] -> A;
+    !A -> B : /NoSuch.Evt;
+    A -> B : if [unknown > 0];
+}
+""")
+        codes = {d.code for d in diags}
+        assert 'E_MISSING_STATE' in codes
+        assert 'E_UNDEFINED_VAR' in codes
+
+    def test_collect_mode_continues_past_named_ref_state_not_found(self):
+        # ``walk_failed = True; break; if walk_failed: continue`` — exercise
+        # the named-function ref walk that needs to skip a broken ref
+        # without crashing the whole pass.
+        machine, diags = _collect("""
+state Root {
+    state A {
+        enter ref NoSuch.Other.Foo;
+    }
+    state B {
+        enter ref MoreMissing.Bar;
+    }
+    [*] -> A;
+}
+""")
+        codes = [d.code for d in diags]
+        # Both refs are unresolved — collect mode must surface both.
+        assert codes.count('E_NAMED_FUNCTION_REF_NOT_FOUND') >= 2
+
+    def test_collect_mode_named_function_not_found_continues(self):
+        # The terminal ``continue`` after ``E_NAMED_FUNCTION_REF_NOT_FOUND``
+        # with reason 'named_function_not_found' — ref walks past the state
+        # tree successfully but the leaf name isn't a named action. A
+        # bare-name relative ref resolves through the state tree and only
+        # fails on the leaf segment.
+        machine, diags = _collect("""
+state Root {
+    state A {
+        enter ref Missing1;
+    }
+    state B {
+        enter ref Missing2;
+    }
+    [*] -> A;
+}
+""")
+        nf_diags = [d for d in diags if d.code == 'E_NAMED_FUNCTION_REF_NOT_FOUND']
+        assert len(nf_diags) >= 2
+        for d in nf_diags:
+            assert d.refs['reason'] == 'named_function_not_found'
+
+    def test_e_lineno_via_syntax_error_interface(self):
+        # The SyntaxError 4-tuple maps (line, column) from the first
+        # diagnostic with a span. Downstream `except SyntaxError as e:
+        # e.lineno` keeps working.
+        ast = parse_with_grammar_entry("""
+def int x = 0;
+def int x = 1;
+state Root { state A; }
+""", entry_name='state_machine_dsl')
+        with pytest.raises(SyntaxError) as info:
+            parse_dsl_node_to_state_machine(ast)
+        assert info.value.lineno == 3

--- a/test/model/test_diagnostic_emit.py
+++ b/test/model/test_diagnostic_emit.py
@@ -384,6 +384,47 @@ state Root { state A; }
 
 
 @pytest.mark.unittest
+class TestM1NamedFunctionRefSpan:
+    """
+    M1 from PR-110 review: E_NAMED_FUNCTION_REF_NOT_FOUND emit sites
+    hard-coded ``span=None``. The containing StateDefinition has _span
+    available — use it as a fallback so ``e.lineno`` and IDE annotations
+    can anchor somewhere meaningful instead of falling back to line 1.
+    """
+
+    def test_named_ref_state_not_found_carries_state_span(self):
+        diag = _strict_diag("""
+state Root {
+    state A {
+        enter ref NoSuch.NoSuch;
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_NAMED_FUNCTION_REF_NOT_FOUND'
+        assert diag.refs['reason'] == 'state_not_found'
+        assert diag.span is not None, (
+            "M1: state-level fallback span must replace the previously "
+            "hard-coded None"
+        )
+        # The owning state A is on line 3 (after the leading blank line).
+        assert diag.span.line >= 3
+
+    def test_named_ref_function_not_found_carries_state_span(self):
+        diag = _strict_diag("""
+state Root {
+    state A {
+        enter ref MissingFunc;
+    }
+    [*] -> A;
+}
+""")
+        assert diag.code == 'E_NAMED_FUNCTION_REF_NOT_FOUND'
+        assert diag.refs['reason'] == 'named_function_not_found'
+        assert diag.span is not None
+
+
+@pytest.mark.unittest
 class TestI1FirstWinsNamedFunction:
     """
     I1 from PR-110 review: in strict mode the duplicate-named-function

--- a/test/model/test_diagnostic_emit.py
+++ b/test/model/test_diagnostic_emit.py
@@ -384,6 +384,148 @@ state Root { state A; }
 
 
 @pytest.mark.unittest
+class TestEmitMatchesEnum:
+    """
+    C2 from PR-110 review: every ``refs[field]`` value emitted from a real
+    DSL fixture must be a member of the ``enum`` declared for that field
+    in codes.yaml. Schema documentation is documentation-only; the only
+    way to keep emitters honest is to drive them through fixtures and
+    assert membership.
+
+    These tests would catch the original drift where ``E_MISSING_STATE``
+    was emitting ``reason='event_path_not_found'`` against an enum that
+    only allowed ``'not_found' | 'parent_missing' | 'ambiguous'``.
+    """
+
+    # (fixture_dsl, expected_code, refs_assertions)
+    # refs_assertions is a list of (field_name, expected_value_or_None)
+    # where None means "just assert the field is present".
+    ENUM_FIXTURES = [
+        # E_MISSING_STATE — normal transition through bad event path
+        (
+            """
+state Root {
+    state A; state B;
+    [*] -> A;
+    A -> B : /NoSuch.GhostEvt;
+}
+""",
+            'E_MISSING_STATE',
+            [('reason', None)],  # whatever reason it emits must be in enum
+        ),
+        # E_DANGLING_TRANSITION — unknown to-state
+        (
+            """
+state Root {
+    state A;
+    A -> NoSuch;
+}
+""",
+            'E_DANGLING_TRANSITION',
+            [('reason', None)],
+        ),
+        # E_FORCED_TRANSITION_EXPANSION — unknown src
+        (
+            """
+state Root {
+    state A;
+    !NoSuch -> A;
+}
+""",
+            'E_FORCED_TRANSITION_EXPANSION',
+            [('reason', None)],
+        ),
+        # E_INITIAL_TRANSITION_INVALID — composite missing entry
+        (
+            """
+state Root {
+    state Outer {
+        state Inner;
+    }
+}
+""",
+            'E_INITIAL_TRANSITION_INVALID',
+            [('reason', None)],
+        ),
+        # E_NAMED_FUNCTION_REF_NOT_FOUND — bare-name unresolved
+        (
+            """
+state Root {
+    state A {
+        enter ref MissingFunc;
+    }
+    [*] -> A;
+}
+""",
+            'E_NAMED_FUNCTION_REF_NOT_FOUND',
+            [('reason', None)],
+        ),
+        # E_DURING_ASPECT_INVALID — leaf state with aspect
+        (
+            """
+state Root {
+    state A {
+        during before { }
+    }
+}
+""",
+            'E_DURING_ASPECT_INVALID',
+            [('state_kind', None)],
+        ),
+        # E_UNDEFINED_VAR — referenced_in tag
+        (
+            """
+def int x = 0;
+state Root {
+    state A; state B;
+    [*] -> A;
+    A -> B : if [unknown > 0];
+}
+""",
+            'E_UNDEFINED_VAR',
+            [('referenced_in', None)],
+        ),
+        # E_DUPLICATE_FUNCTION_NAME — stage tag
+        (
+            """
+state Root {
+    state A {
+        enter F1 { }
+        enter F1 { }
+    }
+    [*] -> A;
+}
+""",
+            'E_DUPLICATE_FUNCTION_NAME',
+            [('stage', None)],
+        ),
+    ]
+
+    @pytest.mark.parametrize(
+        'dsl,expected_code,refs_assertions',
+        ENUM_FIXTURES,
+        ids=[f[1] + '_' + str(i) for i, f in enumerate(ENUM_FIXTURES)],
+    )
+    def test_emitted_refs_values_are_in_declared_enum(
+            self, dsl, expected_code, refs_assertions):
+        """For every enumerated field the emitter populates, the value
+        must be a member of the schema's declared enum (if any)."""
+        diag = _strict_diag(dsl)
+        assert diag.code == expected_code
+        spec = CODE_REGISTRY[diag.code]
+        for field_name, _ in refs_assertions:
+            field_spec = spec.refs_schema[field_name]
+            declared_enum = field_spec.enum
+            if declared_enum is None:
+                continue  # no enum constraint for this field
+            actual = diag.refs.get(field_name)
+            assert actual in declared_enum, (
+                f"code {diag.code} field {field_name!r}: emitted value "
+                f"{actual!r} is not in declared enum {declared_enum}"
+            )
+
+
+@pytest.mark.unittest
 class TestCollectModeNoPhantomMutation:
     """
     C1 from PR-110 review: in collect mode, ``sink.emit(E_MISSING_STATE)``

--- a/test/utils/test_diagnostics.py
+++ b/test/utils/test_diagnostics.py
@@ -154,6 +154,29 @@ class TestModelValidationError:
         assert 'unknown var' in str(err)
         assert err.diagnostics[0].code == 'E_UNDEFINED_VAR'
 
+    def test_one_plus_one_mixed_still_uses_list_format(self):
+        """
+        M2 from PR-110 review: a ``ModelValidationError(errors=[e],
+        diagnostics=[d])`` carries one entry on each side. Even though the
+        total is 2, the bare-message fast path is intentionally NOT used —
+        the two entries deserve enumeration. This test pins the threshold
+        semantics so the boundary isn't changed accidentally during PR-3.
+
+        If a future PR genuinely wants 1+1 to render bare, this test
+        guarantees we make that decision explicitly rather than via drift.
+        """
+        diag = ModelDiagnostic(code='E_X', severity='error', message='mixed_diag')
+        e = ModelValidationError(
+            errors=[ValidationError('mixed_err')],
+            diagnostics=[diag],
+        )
+        s = str(e)
+        # Multi-item enumeration kicks in: both prefixes appear, and the
+        # "in total" wrapper is present (current canonical format).
+        assert '[error/VALIDATION] mixed_err' in s
+        assert '[error/E_X] mixed_diag' in s
+        assert 'in total' in s
+
     def test_multiple_diagnostics_construction_uses_list_format(self):
         diags = [
             ModelDiagnostic(code='E_UNDEFINED_VAR', severity='error', message='m1'),

--- a/test/utils/test_diagnostics.py
+++ b/test/utils/test_diagnostics.py
@@ -147,7 +147,26 @@ class TestModelValidationError:
         assert err.errors == []
         assert len(err.diagnostics) == 1
         assert err.diagnostics[0] is diag
-        assert 'E_UNDEFINED_VAR' in str(err)
+        # Single-diagnostic case emits the bare message verbatim — this is
+        # how the PR-0 baseline ``"foo" in err.msg`` substring asserts stay
+        # green after PR-2's raise migration. Structured downstream
+        # consumers dispatch on ``err.diagnostics[0].code`` instead.
+        assert 'unknown var' in str(err)
+        assert err.diagnostics[0].code == 'E_UNDEFINED_VAR'
+
+    def test_multiple_diagnostics_construction_uses_list_format(self):
+        diags = [
+            ModelDiagnostic(code='E_UNDEFINED_VAR', severity='error', message='m1'),
+            ModelDiagnostic(code='E_MISSING_STATE', severity='error', message='m2'),
+        ]
+        err = ModelValidationError(diagnostics=diags)
+        s = str(err)
+        # Multi-entry path uses the "Model diagnostics, N items in total:"
+        # wrapper to enumerate every line.
+        assert 'Model diagnostics' in s
+        assert '2 items in total' in s
+        assert '[error/E_UNDEFINED_VAR]' in s
+        assert '[error/E_MISSING_STATE]' in s
 
     def test_mixed_errors_and_diagnostics(self):
         diag = ModelDiagnostic(code='E_X', severity='error', message='mx')


### PR DESCRIPTION
## 概述

#103 跟踪的 Layer 1 结构化诊断改造的 **PR-2 / 第三个 PR**。把 `pyfcstm/model/model.py` 里所有 22 处 `raise SyntaxError(f"...")` 改造成 `sink.emit(ModelDiagnostic(...))`，**下游 `research_ideas` 现在 22 行 regex 反解可以一次性替换成结构化字段读取**。

PR-1（#109）给的契约骨架（`Span` / `ModelDiagnostic` / `ModelValidationError` / `CODE_REGISTRY`）和 PR-0（#105）的错误基线在本 PR 都被严格遵守 —— PR-0 baseline 全绿是机械替换正确性的硬证据。

> ⚠️ 本 PR 暂时挂上等 claude -p superpower code review，我自审 + 修完后再请你 review。

## 关键改动

### `pyfcstm.diagnostics.sink`（新模块）

`DiagnosticSink` 是发射诊断的运行时枢纽，两种模式：

- **strict**（默认）—— 每个 error severity 的 `emit()` 立刻 raise `ModelValidationError`，携带累积过的所有诊断（包括之前 emit 的 warning）。保持 PR-0 之前"第一个错就 abort"的语义不变。
- **collect** —— 全部累积，调用方决定何时结算。配套 `finalize_or_raise()` 在 collect 模式下有 error 时一次性 raise。

外加 `_emit(sink, diag)` helper：sink=None 时直接 raise，等价于"内联 raise"调用方写法。

### `pyfcstm.diagnostics.codes.yaml` —— 新增 4 个 E_* code

PR-1 只覆盖了 10 个最临界的 code（对齐下游 `SemanticFeedback` schema）。PR-2 把 `model.py` 剩下的 raise 点全部覆盖：

| 新 code | 触发 |
|---|---|
| `E_DUPLICATE_FUNCTION_NAME` | 同名 named action (enter/during/exit/aspect 4 处) |
| `E_DURING_ASPECT_INVALID` | leaf state `during` 带 aspect、composite state `during` 不带 aspect |
| `E_PSEUDO_NOT_LEAF` | `pseudo state` 写成 composite |
| `E_NAMED_FUNCTION_REF_NOT_FOUND` | `ref` 解析失败（state walk 中断 / leaf segment 不是 named action） |

注册表当前 **14 个 code**，全部对应到具体的 raise 点 + 至少一个 fixture 测试。

### `pyfcstm.dsl.node` —— 加 `_span` dataclass field

按 #107 review 反馈，从 setattr 方案改成正经的 dataclass field：

```python
_span: Optional[Span] = field(default=None, repr=False, compare=False)
```

`repr=False` 让 `repr()` 不显示 span，`compare=False` 让 `==` 忽略 span。覆盖：
- `DefAssignment`
- `StateDefinition`
- `TransitionDefinition`
- `ForceTransitionDefinition`

实测：positional 构造、关键字构造、equality、`repr` 输出 —— **全部和改造前 byte-identical**。

### `pyfcstm.dsl.listener` —— 精确 span 生成

新增 `_ctx_span(ctx) -> Span`，把 ANTLR4 的 0-based `(start.line, start.column)` + `(stop.column, len(stop.text))` 转成 LSP 风格的 **1-based half-open** Span（`column` 指首字符位置、`end_column` 指最后一个字符之后的位置）。

8 个 listener `exit*Definition` 方法构造完 AST 节点后立刻挂上 `_span`：
- `exitDef_assignment`
- `exitLeafStateDefinition` / `exitCompositeStateDefinition`
- `exitEntryTransitionDefinition` / `exitNormalTransitionDefinition` / `exitExitTransitionDefinition`
- `exitNormalForceTransitionDefinition` / `exitExitForceTransitionDefinition`
- `exitNormalAllForceTransitionDefinition` / `exitExitAllForceTransitionDefinition`

**精度严格验证**（见 `test/dsl/test_listener_spans.py`）：对每种 spanning 节点，**用 span 切片源代码后等于期望子串**，字符级精确。

### `pyfcstm.model.model` —— 22 处 raise 全替换

`parse_dsl_node_to_state_machine(dnode, path=None, *, collect=False)`：

- 默认 `collect=False` —— 行为完全等同 PR-2 之前（第一个错就抛 `ModelValidationError`，由于多重继承也是 `SyntaxError`）
- `collect=True` —— 返回 `(model_or_None, diagnostics)`，让 IDE / LLM agent loop 一次拿到所有错误

每个 emit 点都带：

1. **原始 f-string 作为 `message`** —— PR-0 baseline 的 `"foo" in err.msg` 子串断言全部仍绿
2. **上游 AST 节点的 `_span`** 作为 anchor —— 配合 PR-1 的 `SyntaxError` 4-tuple 映射，`e.lineno` / `e.offset` 有真值
3. **跟 codes.yaml schema 严格对齐的 `refs`** —— 字段名、必填字段、enum 值都对齐，下游可以直接 dispatch

`_parse_operation_block` 函数签名加 `referenced_in: str` 参数（`'guard'` / `'effect'` / `'enter'` / `'during'` / `'exit'` / `'during_aspect'`），让 `E_UNDEFINED_VAR` 的 `refs.referenced_in` 能携带准确的上下文。原 `unknown_var_message` 文本完全保留。

collect 模式新增 break / continue 安全路径，避免一次错误后后续遍历崩（例如 event_id 路径段找不到时 break 跳出循环、`walk_failed` 标记跳过 ref 解析的尾段）。

### `pyfcstm.utils.validate` —— summary message 简化

按 PR-0 / dlc6_f* / dlc1 / dlc2 / dlc5 等做 `err.args[0]` 精确比较的旧测试要求，`_build_summary_message` 单 diagnostic / 单 error 情况下**直接发 bare message**，多个时才走 "Model diagnostics, N items in total:" 列表格式。

## 测试 / 覆盖率

新增 ~110 个断言：

| 文件 | case 数 | 用途 |
|---|---:|---|
| `test/dsl/test_listener_spans.py` | 27 | 每种 spanning 节点的 span 切片精度验证 + invariants |
| `test/diagnostics/test_sink.py` | 16 | DiagnosticSink 两模式 + `_emit` helper 全覆盖 |
| `test/model/test_diagnostic_emit.py` | 22 | 14 个 E_* code 至少一个 fixture + collect 模式 + SyntaxError 兼容 |
| `test/utils/test_diagnostics.py` 扩 | +6 | 多 diagnostic 列表格式 + 单 diagnostic bare message |

覆盖率（`SKIP_SLOW_TESTS=1` fast 路径）：

| 模块 | Stmts | Miss | Cover |
|---|---:|---:|---:|
| `pyfcstm/diagnostics/__init__.py` | 3 | 0 | **100%** |
| `pyfcstm/diagnostics/codes.py` | 91 | 0 | **100%** |
| `pyfcstm/diagnostics/sink.py` | 25 | 0 | **100%** |
| `pyfcstm/dsl/listener.py` | 318 | 0 | **100%** |
| `pyfcstm/model/model.py` | 871 | 1 | **99%** (剩 1 行是 pre-existing `raise TypeError` dead code) |
| `pyfcstm/utils/validate.py` | 72 | 2 | **97%** (剩 Py3.7 `typing_extensions` fallback 不可达) |

**Fast 路径 total：8396 passed / 164 skipped / 24 秒**（vs full 174 秒，~7× 加速）。

## 向后兼容

- 现有调用 `parse_dsl_node_to_state_machine(ast)` 不带 `collect` 参数 —— 行为零变化
- `ModelValidationError` 多重继承 `SyntaxError`：所有 `except SyntaxError:` 都仍 catch，`e.lineno` / `e.offset` 现在有真值
- 现有测试里 `assert "..." in err.msg` 子串匹配 —— **全部仍绿**，因为 diagnostic.message 保留原 f-string 文本，且单 diag 时 `_build_summary_message` 直接发 bare message
- `test/model/test_sample_neg_dlc6_f{1..6}.py` 这种严格 `text_aligner.assert_equal` 精确消息匹配 —— **全部仍绿**
- AST node 加 `_span` dataclass field：`repr=False` + `compare=False`，equality 和 repr 两套都不受影响；positional / kwarg 构造也不受影响（新字段有默认值）

## Test plan

- [x] PR-0 baseline（13 case）全绿
- [x] dlc6_f1..f6 / dlc1 / dlc2 / dlc5 精确消息匹配全绿
- [x] 14 个 E_* code 每个至少 1 个 fixture，断言 code / refs schema match
- [x] collect 模式收齐多个独立错误
- [x] strict 模式 catch via `except SyntaxError` 仍工作
- [x] `e.lineno` 映射自首个带 span 的 diagnostic
- [x] AST span 切片源代码后字符级精确
- [x] `make rst_auto` 已运行（含新增 `pyfcstm.diagnostics.sink` API doc）
- [ ] CI 跨 OS × Python 矩阵全绿（fast 路径，commit 带 `[skip-slow]`）

## Cross-link

- 跟踪 issue：#103
- 前置：#105（PR-0 baseline）/ #106（CI 触发子串文档）/ #109（PR-1 契约骨架）
- Layer 2 配套：#104
- 下游目标：`HansBug/research_ideas#12`（22 行 regex 反解可以替换为结构化字段读取）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
