### PR TITLE
feat(model): PR-3 — event_resolve 结构化诊断 + sink 注入 + ModelValueError/ModelLookupError

### DIFF
--- a/docs/source/api_doc/utils/validate.rst
+++ b/docs/source/api_doc/utils/validate.rst
@@ -33,6 +33,18 @@ ModelValidationError
     :members: __init__
 
 
+ModelValueError
+-----------------------------------------------------
+
+.. autoclass:: ModelValueError
+
+
+ModelLookupError
+-----------------------------------------------------
+
+.. autoclass:: ModelLookupError
+
+
 IValidatable
 -----------------------------------------------------
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -163,7 +163,13 @@ E_EVENT_NOT_FOUND:
     searched_from:
       type: str_or_null
       required: false
-      description: Dotted state path where the search originated.
+      description: >-
+        Dotted state path of the **caller** that initiated the lookup
+        (i.e. the state on which `.resolve_event()` was invoked, or, for
+        `StateMachine.resolve_event`, the state machine's root). This is
+        the originating location of the bad reference in source — not
+        the effective search root, which is always the model root for
+        absolute references.
   example_dsl: |
     state Root { state A; state B; A -> B :: NoEvent; }
 

--- a/pyfcstm/diagnostics/sink.py
+++ b/pyfcstm/diagnostics/sink.py
@@ -20,7 +20,7 @@ Downstream consumers (LLM agent loops, IDE integrations, the future
 contract surface is the diagnostic objects themselves, not this class.
 """
 
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from ..utils.validate import ModelDiagnostic, ModelValidationError
 
@@ -107,37 +107,88 @@ class DiagnosticSink:
 def _emit(
         sink: Optional[DiagnosticSink],
         diagnostic: ModelDiagnostic,
+        *,
+        exc_cls: Type[ModelValidationError] = ModelValidationError,
         prior_diagnostics: Optional[List[ModelDiagnostic]] = None,
 ) -> None:
     """
     Convenience helper: route ``diagnostic`` through ``sink`` if one is
-    provided; otherwise raise immediately as :class:`ModelValidationError`.
+    provided in collect mode; otherwise raise the typed ``exc_cls``.
 
-    Used by code paths that want to support both "callers pass a sink" and
-    "callers expect classic raise behavior" without conditional plumbing at
-    every call site.
+    Used by code paths that want to support all three sink dispositions
+    without writing the ``if sink is None: raise; elif sink.collect: emit;
+    else: raise typed`` ladder at every call site:
 
-    When ``sink`` is ``None`` and ``prior_diagnostics`` is provided, the
-    raised :class:`ModelValidationError` carries those prior entries before
-    the new ``diagnostic`` — matching the strict-mode
-    :meth:`DiagnosticSink.emit` semantics where accumulated context (e.g.
-    earlier warnings) is preserved into the raise.
+    * ``sink=None`` (no sink) — raise ``exc_cls`` carrying ``[diagnostic]``
+      plus any optional ``prior_diagnostics`` already accumulated by the
+      caller.
+    * ``sink`` provided AND ``sink.collect=True`` — append the diagnostic
+      to the sink and return; the caller is responsible for surfacing the
+      collected list later.
+    * ``sink`` provided AND ``sink.collect=False`` (strict) — also raise
+      ``exc_cls``, but include the sink's previously accumulated entries
+      (e.g. earlier warnings) in the raise. The diagnostic is also
+      appended to the sink so post-raise inspection sees a consistent
+      history.
+
+    The strict-sink path is what makes ``ModelValueError`` /
+    ``ModelLookupError`` reachable when a caller layers a sink onto an
+    existing API that historically raised ``ValueError`` / ``LookupError``.
+    Without ``exc_cls``, strict-sink mode would silently downgrade those
+    raises to plain :class:`ModelValidationError`, breaking
+    ``except ValueError:`` / ``except LookupError:`` catch handlers.
 
     :param sink: Active sink, or ``None`` to raise immediately.
     :type sink: pyfcstm.diagnostics.sink.DiagnosticSink, optional
     :param diagnostic: The structured diagnostic to route.
     :type diagnostic: pyfcstm.utils.validate.ModelDiagnostic
+    :param exc_cls: Exception class to raise when ``sink`` is ``None`` or
+        strict. Must inherit :class:`ModelValidationError`; defaults to
+        :class:`ModelValidationError` itself. Callers that want
+        ``except ValueError:`` / ``except LookupError:`` catch
+        compatibility should pass :class:`ModelValueError` or
+        :class:`ModelLookupError`.
+    :type exc_cls: Type[ModelValidationError], optional
     :param prior_diagnostics: Optional list of diagnostics already
-        accumulated by the caller; included in the raise on the
-        ``sink is None`` path. Defaults to ``None``.
+        accumulated by the caller; prepended to the raise's diagnostics
+        list. Defaults to ``None``.
     :type prior_diagnostics: List[ModelDiagnostic], optional
-    :raises pyfcstm.utils.validate.ModelValidationError: When ``sink`` is
-        ``None`` or when the sink is in strict mode.
+    :raises pyfcstm.utils.validate.ModelValidationError: Of type
+        ``exc_cls``. Only raised when ``sink`` is ``None`` or
+        ``sink.collect`` is ``False``.
+
+    Example::
+
+        >>> from pyfcstm.diagnostics import DiagnosticSink
+        >>> from pyfcstm.diagnostics.sink import _emit
+        >>> from pyfcstm.utils import ModelDiagnostic
+        >>> from pyfcstm.utils.validate import ModelValueError
+        >>> sink = DiagnosticSink(collect=True)
+        >>> _emit(sink, ModelDiagnostic(
+        ...     code='E_EVENT_REF_INVALID', severity='error', message='m',
+        ... ), exc_cls=ModelValueError)
+        >>> [d.code for d in sink.diagnostics]
+        ['E_EVENT_REF_INVALID']
     """
+    accumulated: List[ModelDiagnostic] = (
+        list(prior_diagnostics) if prior_diagnostics else []
+    )
+
     if sink is None:
-        all_diagnostics: List[ModelDiagnostic] = (
-            list(prior_diagnostics) if prior_diagnostics else []
-        )
-        all_diagnostics.append(diagnostic)
-        raise ModelValidationError(diagnostics=all_diagnostics)
-    sink.emit(diagnostic)
+        accumulated.append(diagnostic)
+        raise exc_cls(diagnostics=accumulated)
+
+    if sink.collect:
+        sink.emit(diagnostic)
+        return
+
+    # Strict sink (collect=False): emit raises ``ModelValidationError``
+    # internally with all prior sink entries + the new one. We catch and
+    # translate to ``exc_cls`` so legacy ``except ValueError:`` /
+    # ``except LookupError:`` handlers stay alive.
+    try:
+        sink.emit(diagnostic)
+    except ModelValidationError as err:
+        raise exc_cls(
+            diagnostics=accumulated + list(err.diagnostics),
+        ) from err

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -52,6 +52,7 @@ from .expr import Expr, parse_expr_node_to_expr
 from .imports import assemble_state_machine_imports
 from .plantuml import PlantUMLOptions, PlantUMLOptionsInput, format_state_name
 from ..diagnostics import DiagnosticSink
+from ..diagnostics.sink import _emit as _emit_or_raise
 from ..dsl import node as dsl_nodes, INIT_STATE, EXIT_STATE
 from ..utils.validate import (
     ModelDiagnostic,
@@ -1659,26 +1660,38 @@ class State(AstExportable, PlantUMLExportable):
 
         :param event_ref: The event reference string to resolve
         :type event_ref: str
-        :param collect_into: Optional structured-diagnostic sink. When provided, any
-            failure is recorded as a :class:`pyfcstm.utils.validate.ModelDiagnostic`
-            on the sink and the method returns ``None`` instead of raising — letting
-            callers accumulate multiple diagnostics in one pass. When omitted
-            (the default), the method raises :class:`ModelValueError` or
-            :class:`ModelLookupError` directly, both of which multi-inherit
-            ``ValueError`` / ``LookupError`` for backwards compatibility with
-            existing ``except ValueError:`` / ``except LookupError:`` callers.
+        :param collect_into: Optional structured-diagnostic sink. Behavior
+            depends on which sink mode the caller picked:
+
+            * ``None`` (the default) — raise :class:`ModelValueError` or
+              :class:`ModelLookupError` immediately on failure. Both
+              multi-inherit ``ValueError`` / ``LookupError`` for backwards
+              compatibility with existing ``except ValueError:`` /
+              ``except LookupError:`` callers.
+            * ``DiagnosticSink(collect=True)`` — record the failure as a
+              :class:`pyfcstm.utils.validate.ModelDiagnostic` on the sink
+              and return ``None`` instead of raising. Lets callers
+              accumulate multiple diagnostics across many invocations in
+              a single pass (IDE / agent loop usage).
+            * ``DiagnosticSink(collect=False)`` (strict sink) — also
+              raise, but route the diagnostic through the sink first so
+              any previously accumulated entries (e.g. warnings) are
+              carried into the raise. The raise still uses the typed
+              :class:`ModelValueError` / :class:`ModelLookupError`
+              subclass, preserving the legacy catch surface.
         :type collect_into: pyfcstm.diagnostics.DiagnosticSink, optional
         :return: The resolved Event object from the state hierarchy, or
-            ``None`` when ``collect_into`` is provided and resolution failed.
+            ``None`` when ``collect_into`` is a ``collect=True`` sink and
+            resolution failed.
         :rtype: Optional[Event]
-        :raises pyfcstm.utils.validate.ModelValueError: If the event reference
-            is syntactically invalid (empty, malformed, exceeds root). Multi-
-            inherits :class:`ValueError`. Only raised when ``collect_into`` is
-            ``None``.
-        :raises pyfcstm.utils.validate.ModelLookupError: If the event reference
-            parses but the targeted state or event does not exist. Multi-
-            inherits :class:`LookupError`. Only raised when ``collect_into`` is
-            ``None``.
+        :raises pyfcstm.utils.validate.ModelValueError: If the event
+            reference is syntactically invalid (empty, malformed, exceeds
+            root). Multi-inherits :class:`ValueError`. Raised when
+            ``collect_into`` is ``None`` or a strict sink.
+        :raises pyfcstm.utils.validate.ModelLookupError: If the event
+            reference parses but the targeted state or event does not
+            exist. Multi-inherits :class:`LookupError`. Raised when
+            ``collect_into`` is ``None`` or a strict sink.
 
         Example::
 
@@ -1709,35 +1722,32 @@ class State(AstExportable, PlantUMLExportable):
             scope = 'local'
 
         def _fail_invalid(reason: str, message: str) -> None:
-            diag = ModelDiagnostic(
-                code='E_EVENT_REF_INVALID',
-                severity='error',
-                message=message,
-                refs={
-                    'event_ref': event_ref,
-                    'reason': reason,
-                },
+            _emit_or_raise(
+                collect_into,
+                ModelDiagnostic(
+                    code='E_EVENT_REF_INVALID',
+                    severity='error',
+                    message=message,
+                    refs={'event_ref': event_ref, 'reason': reason},
+                ),
+                exc_cls=ModelValueError,
             )
-            if collect_into is not None:
-                collect_into.emit(diag)
-                return
-            raise ModelValueError(diagnostics=[diag])
 
         def _fail_not_found(message: str, searched_from: Optional[str] = None) -> None:
-            diag = ModelDiagnostic(
-                code='E_EVENT_NOT_FOUND',
-                severity='error',
-                message=message,
-                refs={
-                    'event_ref': event_ref,
-                    'scope': scope,
-                    'searched_from': searched_from,
-                },
+            _emit_or_raise(
+                collect_into,
+                ModelDiagnostic(
+                    code='E_EVENT_NOT_FOUND',
+                    severity='error',
+                    message=message,
+                    refs={
+                        'event_ref': event_ref,
+                        'scope': scope,
+                        'searched_from': searched_from,
+                    },
+                ),
+                exc_cls=ModelLookupError,
             )
-            if collect_into is not None:
-                collect_into.emit(diag)
-                return
-            raise ModelLookupError(diagnostics=[diag])
 
         if not event_ref:
             _fail_invalid('empty', "Event reference cannot be empty")
@@ -1791,7 +1801,23 @@ class State(AstExportable, PlantUMLExportable):
                 )
                 return None
 
-            # Move up the hierarchy
+            # I2 from PR-112 review: validate the remaining dotted path
+            # BEFORE walking up the hierarchy. Otherwise a malformed tail
+            # like ``.foo..bar`` reports ``reason='beyond_root'`` when
+            # called from the root (walk exhausts first) but
+            # ``reason='invalid_relative'`` from a deeper state (walk
+            # succeeds, then split fails). ``reason`` is a schema-backed
+            # enum contract field — the same syntax error must produce
+            # the same reason regardless of caller depth.
+            path_parts = remaining_path.split(".")
+            if not all(path_parts):
+                _fail_invalid(
+                    'invalid_relative',
+                    f"Invalid parent-relative event reference: {event_ref!r}",
+                )
+                return None
+
+            # Move up the hierarchy (now safe — syntax already validated)
             current_state = self
             for _ in range(dot_count):
                 if current_state.parent is None:
@@ -1802,15 +1828,6 @@ class State(AstExportable, PlantUMLExportable):
                     )
                     return None
                 current_state = current_state.parent
-
-            # Split the remaining path
-            path_parts = remaining_path.split(".")
-            if not all(path_parts):
-                _fail_invalid(
-                    'invalid_relative',
-                    f"Invalid parent-relative event reference: {event_ref!r}",
-                )
-                return None
 
             event_name = path_parts[-1]
             target_state_path = current_state.path + tuple(path_parts[:-1])
@@ -2063,24 +2080,29 @@ class StateMachine(AstExportable, PlantUMLExportable):
 
         :param event_path: The complete event path (e.g., ``"Root.System.Active.error"``)
         :type event_path: str
-        :param collect_into: Optional structured-diagnostic sink. When provided, any
-            failure is recorded as a :class:`pyfcstm.utils.validate.ModelDiagnostic`
-            on the sink and the method returns ``None`` instead of raising — letting
-            callers accumulate multiple diagnostics in one pass. When omitted
-            (the default), the method raises :class:`ModelValueError` or
-            :class:`ModelLookupError` directly, both of which multi-inherit
-            ``ValueError`` / ``LookupError`` for backwards compatibility.
+        :param collect_into: Optional structured-diagnostic sink. Behavior
+            depends on the sink mode (see :meth:`State.resolve_event` for
+            the full matrix):
+
+            * ``None`` — raise :class:`ModelValueError` /
+              :class:`ModelLookupError` immediately.
+            * ``DiagnosticSink(collect=True)`` — accumulate on the sink
+              and return ``None``.
+            * ``DiagnosticSink(collect=False)`` (strict) — also raise the
+              typed subclass, but route through the sink first so any
+              previously accumulated entries are preserved into the raise.
         :type collect_into: pyfcstm.diagnostics.DiagnosticSink, optional
-        :return: The resolved Event object, or ``None`` when ``collect_into``
-            is provided and resolution failed.
+        :return: The resolved Event object, or ``None`` when
+            ``collect_into`` is a ``collect=True`` sink and resolution
+            failed.
         :rtype: Optional[Event]
-        :raises pyfcstm.utils.validate.ModelValueError: If the event path is
-            invalid or empty (multi-inherits :class:`ValueError`). Only raised
-            when ``collect_into`` is ``None``.
-        :raises pyfcstm.utils.validate.ModelLookupError: If any state in the
-            path or the event does not exist (multi-inherits
-            :class:`LookupError`). Only raised when ``collect_into`` is
-            ``None``.
+        :raises pyfcstm.utils.validate.ModelValueError: If the event path
+            is invalid or empty (multi-inherits :class:`ValueError`).
+            Raised when ``collect_into`` is ``None`` or strict.
+        :raises pyfcstm.utils.validate.ModelLookupError: If any state in
+            the path or the event does not exist (multi-inherits
+            :class:`LookupError`). Raised when ``collect_into`` is
+            ``None`` or strict.
 
         Example::
 
@@ -2091,35 +2113,32 @@ class StateMachine(AstExportable, PlantUMLExportable):
             'error'
         """
         def _fail_invalid(reason: str, message: str) -> None:
-            diag = ModelDiagnostic(
-                code='E_EVENT_REF_INVALID',
-                severity='error',
-                message=message,
-                refs={
-                    'event_ref': event_path,
-                    'reason': reason,
-                },
+            _emit_or_raise(
+                collect_into,
+                ModelDiagnostic(
+                    code='E_EVENT_REF_INVALID',
+                    severity='error',
+                    message=message,
+                    refs={'event_ref': event_path, 'reason': reason},
+                ),
+                exc_cls=ModelValueError,
             )
-            if collect_into is not None:
-                collect_into.emit(diag)
-                return
-            raise ModelValueError(diagnostics=[diag])
 
         def _fail_not_found(message: str, searched_from: Optional[str] = None) -> None:
-            diag = ModelDiagnostic(
-                code='E_EVENT_NOT_FOUND',
-                severity='error',
-                message=message,
-                refs={
-                    'event_ref': event_path,
-                    'scope': 'absolute',
-                    'searched_from': searched_from,
-                },
+            _emit_or_raise(
+                collect_into,
+                ModelDiagnostic(
+                    code='E_EVENT_NOT_FOUND',
+                    severity='error',
+                    message=message,
+                    refs={
+                        'event_ref': event_path,
+                        'scope': 'absolute',
+                        'searched_from': searched_from,
+                    },
+                ),
+                exc_cls=ModelLookupError,
             )
-            if collect_into is not None:
-                collect_into.emit(diag)
-                return
-            raise ModelLookupError(diagnostics=[diag])
 
         if not event_path:
             _fail_invalid('empty', "Event path cannot be empty")

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -53,7 +53,13 @@ from .imports import assemble_state_machine_imports
 from .plantuml import PlantUMLOptions, PlantUMLOptionsInput, format_state_name
 from ..diagnostics import DiagnosticSink
 from ..dsl import node as dsl_nodes, INIT_STATE, EXIT_STATE
-from ..utils.validate import ModelDiagnostic, ModelValidationError, Span
+from ..utils.validate import (
+    ModelDiagnostic,
+    ModelLookupError,
+    ModelValidationError,
+    ModelValueError,
+    Span,
+)
 
 __all__ = [
     "OperationStatement",
@@ -1630,7 +1636,12 @@ class State(AstExportable, PlantUMLExportable):
         for _, substate in self.substates.items():
             yield from substate.walk_states()
 
-    def resolve_event(self, event_ref: str) -> Event:
+    def resolve_event(
+            self,
+            event_ref: str,
+            *,
+            collect_into: Optional[DiagnosticSink] = None,
+    ) -> Optional[Event]:
         """
         Resolve an event reference string to an existing Event object in the state hierarchy.
 
@@ -1648,11 +1659,26 @@ class State(AstExportable, PlantUMLExportable):
 
         :param event_ref: The event reference string to resolve
         :type event_ref: str
-        :return: The resolved Event object from the state hierarchy
-        :rtype: Event
-        :raises ValueError: If the event reference is invalid or cannot be resolved
-        :raises ValueError: If parent-relative reference goes beyond the root state
-        :raises LookupError: If the event does not exist in the state hierarchy
+        :param collect_into: Optional structured-diagnostic sink. When provided, any
+            failure is recorded as a :class:`pyfcstm.utils.validate.ModelDiagnostic`
+            on the sink and the method returns ``None`` instead of raising — letting
+            callers accumulate multiple diagnostics in one pass. When omitted
+            (the default), the method raises :class:`ModelValueError` or
+            :class:`ModelLookupError` directly, both of which multi-inherit
+            ``ValueError`` / ``LookupError`` for backwards compatibility with
+            existing ``except ValueError:`` / ``except LookupError:`` callers.
+        :type collect_into: pyfcstm.diagnostics.DiagnosticSink, optional
+        :return: The resolved Event object from the state hierarchy, or
+            ``None`` when ``collect_into`` is provided and resolution failed.
+        :rtype: Optional[Event]
+        :raises pyfcstm.utils.validate.ModelValueError: If the event reference
+            is syntactically invalid (empty, malformed, exceeds root). Multi-
+            inherits :class:`ValueError`. Only raised when ``collect_into`` is
+            ``None``.
+        :raises pyfcstm.utils.validate.ModelLookupError: If the event reference
+            parses but the targeted state or event does not exist. Multi-
+            inherits :class:`LookupError`. Only raised when ``collect_into`` is
+            ``None``.
 
         Example::
 
@@ -1667,8 +1693,55 @@ class State(AstExportable, PlantUMLExportable):
             >>> state.resolve_event("/global.shutdown")
             Event(name="shutdown", state_path=("Root", "global"))
         """
+        # Determine the resolution scope from the lexical form of the reference.
+        # This is used both for the structured ``refs.scope`` field on
+        # ``E_EVENT_NOT_FOUND`` and to keep the legacy error message text
+        # accurate for the parent-relative branch ("chain") versus the bare
+        # relative form ("local"). The empty-ref case has no meaningful
+        # scope yet — we default to ``'local'`` for refs purposes.
         if not event_ref:
-            raise ValueError("Event reference cannot be empty")
+            scope = 'local'
+        elif event_ref.startswith('/'):
+            scope = 'absolute'
+        elif event_ref.startswith('.'):
+            scope = 'chain'
+        else:
+            scope = 'local'
+
+        def _fail_invalid(reason: str, message: str) -> None:
+            diag = ModelDiagnostic(
+                code='E_EVENT_REF_INVALID',
+                severity='error',
+                message=message,
+                refs={
+                    'event_ref': event_ref,
+                    'reason': reason,
+                },
+            )
+            if collect_into is not None:
+                collect_into.emit(diag)
+                return
+            raise ModelValueError(diagnostics=[diag])
+
+        def _fail_not_found(message: str, searched_from: Optional[str] = None) -> None:
+            diag = ModelDiagnostic(
+                code='E_EVENT_NOT_FOUND',
+                severity='error',
+                message=message,
+                refs={
+                    'event_ref': event_ref,
+                    'scope': scope,
+                    'searched_from': searched_from,
+                },
+            )
+            if collect_into is not None:
+                collect_into.emit(diag)
+                return
+            raise ModelLookupError(diagnostics=[diag])
+
+        if not event_ref:
+            _fail_invalid('empty', "Event reference cannot be empty")
+            return None
 
         # Determine the target state path and event name based on reference type
         target_state_path = None
@@ -1679,7 +1752,8 @@ class State(AstExportable, PlantUMLExportable):
             # Remove leading '/' and resolve from root
             relative_path = event_ref[1:]
             if not relative_path:
-                raise ValueError("Absolute event reference cannot be just '/'")
+                _fail_invalid('bare_slash', "Absolute event reference cannot be just '/'")
+                return None
 
             # Find root state
             root_state = self
@@ -1689,7 +1763,11 @@ class State(AstExportable, PlantUMLExportable):
             # Split the path
             path_parts = relative_path.split(".")
             if not all(path_parts):
-                raise ValueError(f"Invalid absolute event reference: {event_ref!r}")
+                _fail_invalid(
+                    'invalid_absolute',
+                    f"Invalid absolute event reference: {event_ref!r}",
+                )
+                return None
 
             event_name = path_parts[-1]
             target_state_path = root_state.path + tuple(path_parts[:-1])
@@ -1707,26 +1785,32 @@ class State(AstExportable, PlantUMLExportable):
             # Get the remaining path after dots
             remaining_path = event_ref[dot_count:]
             if not remaining_path:
-                raise ValueError(
-                    f"Parent-relative event reference cannot end with dots: {event_ref!r}"
+                _fail_invalid(
+                    'trailing_dots',
+                    f"Parent-relative event reference cannot end with dots: {event_ref!r}",
                 )
+                return None
 
             # Move up the hierarchy
             current_state = self
             for _ in range(dot_count):
                 if current_state.parent is None:
-                    raise ValueError(
+                    _fail_invalid(
+                        'beyond_root',
                         f"Parent-relative event reference {event_ref!r} goes beyond root state "
-                        f"(current state: {'.'.join(self.path)}, tried to go up {dot_count} levels)"
+                        f"(current state: {'.'.join(self.path)}, tried to go up {dot_count} levels)",
                     )
+                    return None
                 current_state = current_state.parent
 
             # Split the remaining path
             path_parts = remaining_path.split(".")
             if not all(path_parts):
-                raise ValueError(
-                    f"Invalid parent-relative event reference: {event_ref!r}"
+                _fail_invalid(
+                    'invalid_relative',
+                    f"Invalid parent-relative event reference: {event_ref!r}",
                 )
+                return None
 
             event_name = path_parts[-1]
             target_state_path = current_state.path + tuple(path_parts[:-1])
@@ -1735,7 +1819,11 @@ class State(AstExportable, PlantUMLExportable):
         else:
             path_parts = event_ref.split(".")
             if not all(path_parts):
-                raise ValueError(f"Invalid relative event reference: {event_ref!r}")
+                _fail_invalid(
+                    'invalid_relative',
+                    f"Invalid relative event reference: {event_ref!r}",
+                )
+                return None
 
             event_name = path_parts[-1]
             target_state_path = self.path + tuple(path_parts[:-1])
@@ -1750,18 +1838,22 @@ class State(AstExportable, PlantUMLExportable):
         current_state = root_state
         for i, state_name in enumerate(target_state_path[1:], 1):  # Skip root name
             if state_name not in current_state.substates:
-                raise LookupError(
+                _fail_not_found(
                     f"State {'.'.join(target_state_path[: i + 1])!r} not found in hierarchy "
-                    f"while resolving event reference {event_ref!r}"
+                    f"while resolving event reference {event_ref!r}",
+                    searched_from='.'.join(self.path),
                 )
+                return None
             current_state = current_state.substates[state_name]
 
         # Look for the event in the target state
         if event_name not in current_state.events:
-            raise LookupError(
+            _fail_not_found(
                 f"Event {event_name!r} not found in state {'.'.join(target_state_path)!r} "
-                f"while resolving event reference {event_ref!r}"
+                f"while resolving event reference {event_ref!r}",
+                searched_from='.'.join(self.path),
             )
+            return None
 
         return current_state.events[event_name]
 
@@ -1955,7 +2047,12 @@ class StateMachine(AstExportable, PlantUMLExportable):
         """
         yield from self.root_state.walk_states()
 
-    def resolve_event(self, event_path: str) -> Event:
+    def resolve_event(
+            self,
+            event_path: str,
+            *,
+            collect_into: Optional[DiagnosticSink] = None,
+    ) -> Optional[Event]:
         """
         Resolve a full event path to an existing Event object in the state machine.
 
@@ -1966,10 +2063,24 @@ class StateMachine(AstExportable, PlantUMLExportable):
 
         :param event_path: The complete event path (e.g., ``"Root.System.Active.error"``)
         :type event_path: str
-        :return: The resolved Event object from the state hierarchy
-        :rtype: Event
-        :raises ValueError: If the event path is invalid or empty
-        :raises LookupError: If any state in the path or the event does not exist
+        :param collect_into: Optional structured-diagnostic sink. When provided, any
+            failure is recorded as a :class:`pyfcstm.utils.validate.ModelDiagnostic`
+            on the sink and the method returns ``None`` instead of raising — letting
+            callers accumulate multiple diagnostics in one pass. When omitted
+            (the default), the method raises :class:`ModelValueError` or
+            :class:`ModelLookupError` directly, both of which multi-inherit
+            ``ValueError`` / ``LookupError`` for backwards compatibility.
+        :type collect_into: pyfcstm.diagnostics.DiagnosticSink, optional
+        :return: The resolved Event object, or ``None`` when ``collect_into``
+            is provided and resolution failed.
+        :rtype: Optional[Event]
+        :raises pyfcstm.utils.validate.ModelValueError: If the event path is
+            invalid or empty (multi-inherits :class:`ValueError`). Only raised
+            when ``collect_into`` is ``None``.
+        :raises pyfcstm.utils.validate.ModelLookupError: If any state in the
+            path or the event does not exist (multi-inherits
+            :class:`LookupError`). Only raised when ``collect_into`` is
+            ``None``.
 
         Example::
 
@@ -1979,21 +2090,57 @@ class StateMachine(AstExportable, PlantUMLExportable):
             >>> event.name
             'error'
         """
+        def _fail_invalid(reason: str, message: str) -> None:
+            diag = ModelDiagnostic(
+                code='E_EVENT_REF_INVALID',
+                severity='error',
+                message=message,
+                refs={
+                    'event_ref': event_path,
+                    'reason': reason,
+                },
+            )
+            if collect_into is not None:
+                collect_into.emit(diag)
+                return
+            raise ModelValueError(diagnostics=[diag])
+
+        def _fail_not_found(message: str, searched_from: Optional[str] = None) -> None:
+            diag = ModelDiagnostic(
+                code='E_EVENT_NOT_FOUND',
+                severity='error',
+                message=message,
+                refs={
+                    'event_ref': event_path,
+                    'scope': 'absolute',
+                    'searched_from': searched_from,
+                },
+            )
+            if collect_into is not None:
+                collect_into.emit(diag)
+                return
+            raise ModelLookupError(diagnostics=[diag])
+
         if not event_path:
-            raise ValueError("Event path cannot be empty")
+            _fail_invalid('empty', "Event path cannot be empty")
+            return None
 
         # Split the path into components
         path_parts = event_path.split(".")
         if not all(path_parts):
-            raise ValueError(
-                f"Invalid event path: {event_path!r} (contains empty parts)"
+            _fail_invalid(
+                'invalid_absolute',
+                f"Invalid event path: {event_path!r} (contains empty parts)",
             )
+            return None
 
         if len(path_parts) < 2:
-            raise ValueError(
+            _fail_invalid(
+                'invalid_absolute',
                 f"Invalid event path: {event_path!r} "
-                f"(must contain at least state name and event name)"
+                f"(must contain at least state name and event name)",
             )
+            return None
 
         # The last part is the event name, everything before is the state path
         event_name = path_parts[-1]
@@ -2004,27 +2151,35 @@ class StateMachine(AstExportable, PlantUMLExportable):
 
         # Verify the first part matches the root state name
         if state_path_parts[0] != current_state.name:
-            raise LookupError(
+            _fail_not_found(
                 f"Event path root '{state_path_parts[0]}' does not match "
                 f"state machine root '{current_state.name}' "
-                f"while resolving event path {event_path!r}"
+                f"while resolving event path {event_path!r}",
+                searched_from=current_state.name,
             )
+            return None
 
         # Navigate through the remaining state path
         for i, state_name in enumerate(state_path_parts[1:], 1):
             if state_name not in current_state.substates:
-                raise LookupError(
-                    f"State '{state_name}' not found in state '{'.'.join(state_path_parts[:i])}' "
-                    f"while resolving event path {event_path!r}"
+                _fail_not_found(
+                    f"State '{state_name}' not found in state "
+                    f"'{'.'.join(state_path_parts[:i])}' "
+                    f"while resolving event path {event_path!r}",
+                    searched_from='.'.join(state_path_parts[:i]),
                 )
+                return None
             current_state = current_state.substates[state_name]
 
         # Look for the event in the target state
         if event_name not in current_state.events:
-            raise LookupError(
-                f"Event '{event_name}' not found in state '{'.'.join(state_path_parts)}' "
-                f"while resolving event path {event_path!r}"
+            _fail_not_found(
+                f"Event '{event_name}' not found in state "
+                f"'{'.'.join(state_path_parts)}' "
+                f"while resolving event path {event_path!r}",
+                searched_from='.'.join(state_path_parts),
             )
+            return None
 
         return current_state.events[event_name]
 

--- a/pyfcstm/utils/__init__.py
+++ b/pyfcstm/utils/__init__.py
@@ -72,7 +72,9 @@ from .text import (
 from .validate import (
     IValidatable,
     ModelDiagnostic,
+    ModelLookupError,
     ModelValidationError,
+    ModelValueError,
     Span,
     ValidationError,
 )

--- a/pyfcstm/utils/validate.py
+++ b/pyfcstm/utils/validate.py
@@ -316,6 +316,70 @@ class ModelValidationError(SyntaxError):
         return os.linesep.join(parts)
 
 
+class ModelValueError(ModelValidationError, ValueError):
+    """
+    Raised by model lookup APIs when an input string is syntactically
+    invalid as a value (empty, bad format, dotted path that exceeds the
+    root state, ...).
+
+    Multi-inherits from :class:`ModelValidationError` (which itself
+    multi-inherits :class:`SyntaxError`) and from :class:`ValueError`, so:
+
+    * ``except ValueError:`` continues to catch this — preserving the
+      pre-PR-3 behavior at every call site that already handles
+      ``ValueError`` raised from ``State.resolve_event`` /
+      ``StateMachine.resolve_event``.
+    * ``except SyntaxError:`` continues to catch too (inherited via
+      :class:`ModelValidationError`), keeping the PR-2 multi-inheritance
+      contract consistent.
+    * The new ``except ModelValueError:`` (or ``ModelValidationError``)
+      lets diagnostic-aware consumers dispatch on the typed class.
+
+    All structured diagnostics emitted via this exception carry
+    ``code='E_EVENT_REF_INVALID'`` per the contract in
+    ``pyfcstm/diagnostics/codes.yaml``.
+
+    Example::
+
+        >>> from pyfcstm.utils.validate import ModelValueError
+        >>> try:
+        ...     raise ModelValueError(message="invalid ref")
+        ... except ValueError as e:
+        ...     isinstance(e, ModelValueError)
+        True
+    """
+
+
+class ModelLookupError(ModelValidationError, LookupError):
+    """
+    Raised by model lookup APIs when a state path or event name cannot be
+    found in the live state hierarchy.
+
+    Multi-inherits :class:`ModelValidationError` and :class:`LookupError`,
+    so:
+
+    * ``except LookupError:`` continues to catch this — preserving the
+      pre-PR-3 behavior at every call site that already handles
+      ``LookupError`` raised from ``State.resolve_event`` /
+      ``StateMachine.resolve_event``.
+    * ``except SyntaxError:`` and ``except ModelValidationError:`` both
+      catch as well (inherited path).
+
+    Structured diagnostics emitted via this exception carry
+    ``code='E_EVENT_NOT_FOUND'`` per the contract in
+    ``pyfcstm/diagnostics/codes.yaml``.
+
+    Example::
+
+        >>> from pyfcstm.utils.validate import ModelLookupError
+        >>> try:
+        ...     raise ModelLookupError(message="state not found")
+        ... except LookupError as e:
+        ...     isinstance(e, ModelLookupError)
+        True
+    """
+
+
 class IValidatable:
     """
     Interface class for implementing validatable objects.

--- a/test/model/test_event_resolve_diagnostics.py
+++ b/test/model/test_event_resolve_diagnostics.py
@@ -62,6 +62,14 @@ def _assert_refs_match_schema(diag: ModelDiagnostic) -> None:
     assert not extra, (
         f"{diag.code} refs has extra keys {extra} not in codes.yaml schema"
     )
+    # M2 from PR-112 review: enforce required-field presence. Without
+    # this, a regression that drops a ``required: true`` field (e.g.
+    # ``event_ref`` on E_EVENT_REF_INVALID) slips through silently.
+    for name, field_spec in spec.refs_schema.items():
+        if field_spec.required:
+            assert name in actual, (
+                f"{diag.code} refs missing required field {name!r}"
+            )
     for name, value in diag.refs.items():
         field_spec = spec.refs_schema[name]
         if field_spec.enum is None or value is None:
@@ -280,19 +288,17 @@ class TestSinkInjection:
         machine.root_state.resolve_event('', collect_into=sink)
         machine.resolve_event('Root.NoSuch.Go', collect_into=sink)
 
-    def test_sink_in_strict_mode_still_raises(self, machine):
-        # A strict-mode sink (collect=False) should still let resolve_event
-        # raise — because sink.emit raises on error. This pins the design
-        # contract: collect_into is "give me a sink"; if the sink is strict,
-        # behavior matches no-sink (raise).
+    def test_sink_in_strict_mode_raises_typed_subclass(self, machine):
+        # Post-review fix: a strict-mode sink (collect=False) must raise
+        # the typed subclass (ModelValueError / ModelLookupError), not
+        # plain ModelValidationError — preserving the back-compat catch
+        # surface for ``except ValueError:`` / ``except LookupError:``.
+        # Full MRO matrix is exercised in
+        # TestStrictSinkTypedExceptionMatrix.
         sink = DiagnosticSink(collect=False)
-        with pytest.raises(ModelValidationError) as info:
+        with pytest.raises(ModelValueError) as info:
             machine.root_state.resolve_event('', collect_into=sink)
-        # The strict sink raises plain ModelValidationError (its baseline
-        # raise type), not ModelValueError — because the sink doesn't know
-        # the subclass. Callers that want the typed exception must NOT pass
-        # a strict sink; they either omit collect_into entirely or use a
-        # collect=True sink.
+        assert isinstance(info.value, ValueError)
         assert info.value.diagnostics[0].code == 'E_EVENT_REF_INVALID'
 
     def test_sink_preserves_happy_path(self, machine):
@@ -361,6 +367,200 @@ class TestSinkInjection:
         assert diag.code == expected_code
         key = 'reason' if expected_code == 'E_EVENT_REF_INVALID' else 'scope'
         assert diag.refs[key] == expected_reason_or_scope
+
+
+@pytest.mark.unittest
+class TestStrictSinkTypedExceptionMatrix:
+    """
+    Post-review fix (PR-110/PR-112 review I1 + M5): passing a strict-mode
+    ``DiagnosticSink`` (``collect=False``) to ``resolve_event`` must still
+    raise the typed subclass (``ModelValueError`` / ``ModelLookupError``)
+    so the legacy ``except ValueError:`` / ``except LookupError:`` catch
+    surface keeps working. The earlier implementation routed through
+    ``sink.emit()`` which raised plain ``ModelValidationError``, breaking
+    the back-compat promise.
+
+    These tests pin the full MRO matrix across both resolver methods, both
+    diagnostic codes (E_EVENT_REF_INVALID / E_EVENT_NOT_FOUND), and all
+    four catch handlers (ValueError / LookupError / SyntaxError /
+    ModelValidationError).
+    """
+
+    @pytest.mark.parametrize('event_ref', ['', '/', '/foo..bar', 'foo..bar'])
+    def test_state_resolve_event_strict_sink_keeps_value_error(
+            self, machine, event_ref):
+        sink = DiagnosticSink(collect=False)
+        with pytest.raises(ValueError) as info:
+            machine.root_state.resolve_event(event_ref, collect_into=sink)
+        # All four catch handlers must succeed.
+        assert isinstance(info.value, ModelValueError)
+        assert isinstance(info.value, ValueError)
+        assert isinstance(info.value, SyntaxError)
+        assert isinstance(info.value, ModelValidationError)
+        assert info.value.diagnostics[0].code == 'E_EVENT_REF_INVALID'
+
+    @pytest.mark.parametrize('event_ref', [
+        '/NoSuch.Go',
+        '/Inner.NoEvent',
+        'NoSuch.Go',
+    ])
+    def test_state_resolve_event_strict_sink_keeps_lookup_error(
+            self, machine, event_ref):
+        sink = DiagnosticSink(collect=False)
+        with pytest.raises(LookupError) as info:
+            machine.root_state.resolve_event(event_ref, collect_into=sink)
+        assert isinstance(info.value, ModelLookupError)
+        assert isinstance(info.value, LookupError)
+        assert isinstance(info.value, SyntaxError)
+        assert isinstance(info.value, ModelValidationError)
+        assert info.value.diagnostics[0].code == 'E_EVENT_NOT_FOUND'
+
+    @pytest.mark.parametrize('event_path', ['', 'Root..Go', 'Go'])
+    def test_state_machine_resolve_event_strict_sink_keeps_value_error(
+            self, machine, event_path):
+        sink = DiagnosticSink(collect=False)
+        with pytest.raises(ValueError) as info:
+            machine.resolve_event(event_path, collect_into=sink)
+        assert isinstance(info.value, ModelValueError)
+        assert isinstance(info.value, ValueError)
+        assert isinstance(info.value, SyntaxError)
+
+    @pytest.mark.parametrize('event_path', [
+        'NotRoot.Go',
+        'Root.NoSuch.Go',
+        'Root.Inner.NoEvent',
+    ])
+    def test_state_machine_resolve_event_strict_sink_keeps_lookup_error(
+            self, machine, event_path):
+        sink = DiagnosticSink(collect=False)
+        with pytest.raises(LookupError) as info:
+            machine.resolve_event(event_path, collect_into=sink)
+        assert isinstance(info.value, ModelLookupError)
+        assert isinstance(info.value, LookupError)
+        assert isinstance(info.value, SyntaxError)
+
+
+@pytest.mark.unittest
+class TestParentRelativeReasonDepthIndependence:
+    """
+    Post-review fix (PR-112 review I2): a malformed parent-relative
+    reference like ``.foo..bar`` should report ``reason='invalid_relative'``
+    regardless of the calling state's depth in the hierarchy. The original
+    implementation walked up the hierarchy BEFORE syntax-validating the
+    remaining dotted path, so the same input reported ``beyond_root``
+    when called from a shallow state but ``invalid_relative`` from a
+    deeper one — a contract violation where ``reason`` (a schema-backed
+    enum field) silently changes based on geometry rather than syntax.
+    """
+
+    def test_dotdot_foodotdotbar_from_root_is_invalid_relative(
+            self, machine):
+        # Was previously beyond_root because walk-up exhausts hierarchy
+        # before the syntax check fires. After the fix the syntax check
+        # runs first.
+        with pytest.raises(ModelValueError) as info:
+            machine.root_state.resolve_event('.foo..bar')
+        assert info.value.diagnostics[0].refs['reason'] == 'invalid_relative'
+
+    def test_dotdot_foodotdotbar_from_inner_is_invalid_relative(
+            self, machine):
+        # From Inner (depth 2) the walk-up succeeds, so this already
+        # reported invalid_relative pre-fix. Pin that behavior so the
+        # fix doesn't regress it.
+        inner = machine.root_state.substates['Inner']
+        with pytest.raises(ModelValueError) as info:
+            inner.resolve_event('.foo..bar')
+        assert info.value.diagnostics[0].refs['reason'] == 'invalid_relative'
+
+    def test_dot_foo_from_root_still_beyond_root(self, machine):
+        # Sanity: syntactically valid parent-relative refs that overflow
+        # the root must still report beyond_root.
+        with pytest.raises(ModelValueError) as info:
+            machine.root_state.resolve_event('.foo')
+        assert info.value.diagnostics[0].refs['reason'] == 'beyond_root'
+
+
+@pytest.mark.unittest
+class TestSearchedFromCallerState:
+    """
+    Post-review fix (PR-112 review M3): codes.yaml describes
+    ``E_EVENT_NOT_FOUND.refs.searched_from`` as the originating state
+    path, but the previous tests never asserted the actual value. Pin the
+    contract: ``searched_from`` is the CALLER's state path (not the
+    effective search root, which would always be ``Root`` for absolute
+    refs).
+    """
+
+    def test_local_scope_searched_from_is_caller_state_path(self, machine):
+        inner = machine.root_state.substates['Inner']
+        with pytest.raises(ModelLookupError) as info:
+            inner.resolve_event('NoSuch.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.refs['scope'] == 'local'
+        assert diag.refs['searched_from'] == 'Root.Inner'
+
+    def test_chain_scope_searched_from_is_caller_state_path(self, machine):
+        inner = machine.root_state.substates['Inner']
+        with pytest.raises(ModelLookupError) as info:
+            inner.resolve_event('.NoSuch.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.refs['scope'] == 'chain'
+        assert diag.refs['searched_from'] == 'Root.Inner'
+
+    def test_absolute_scope_searched_from_is_caller_state_path(self, machine):
+        # For absolute refs, the search physically starts at Root, but
+        # the contract says ``searched_from`` carries the caller's state
+        # path so downstream tooling can highlight where the bad ref
+        # textually lives.
+        inner = machine.root_state.substates['Inner']
+        with pytest.raises(ModelLookupError) as info:
+            inner.resolve_event('/NoSuch.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.refs['scope'] == 'absolute'
+        assert diag.refs['searched_from'] == 'Root.Inner'
+
+    def test_state_machine_resolve_event_searched_from_for_root_mismatch(
+            self, machine):
+        # StateMachine.resolve_event isn't tied to a single State, so
+        # ``searched_from`` describes the search root token at the point
+        # of failure. Pin that as ``Root`` (the model's root state name).
+        with pytest.raises(ModelLookupError) as info:
+            machine.resolve_event('NotRoot.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.refs['searched_from'] == 'Root'
+
+
+@pytest.mark.unittest
+class TestAssertRefsMatchSchemaRequiredField:
+    """
+    Post-review fix (PR-112 review M2): the test helper used across this
+    file must enforce required-field presence, not just extra-key absence
+    and enum membership. Without this, a regression that drops a
+    ``required: true`` field (like ``event_ref`` on E_EVENT_REF_INVALID)
+    slips through silently.
+    """
+
+    def test_helper_rejects_missing_required_field(self):
+        # Build a hand-crafted diagnostic that violates the required
+        # contract of E_EVENT_REF_INVALID — missing ``event_ref``.
+        bad_diag = ModelDiagnostic(
+            code='E_EVENT_REF_INVALID',
+            severity='error',
+            message='m',
+            refs={'reason': 'empty'},  # missing event_ref
+        )
+        with pytest.raises(AssertionError, match='missing required field'):
+            _assert_refs_match_schema(bad_diag)
+
+    def test_helper_accepts_all_required_fields_present(self):
+        # Sanity: a well-formed diagnostic must pass.
+        ok_diag = ModelDiagnostic(
+            code='E_EVENT_REF_INVALID',
+            severity='error',
+            message='m',
+            refs={'event_ref': 'x', 'reason': 'empty'},
+        )
+        _assert_refs_match_schema(ok_diag)
 
 
 @pytest.mark.unittest

--- a/test/model/test_event_resolve_diagnostics.py
+++ b/test/model/test_event_resolve_diagnostics.py
@@ -1,0 +1,392 @@
+"""
+PR-3 (issue #103) tests: ``State.resolve_event`` / ``StateMachine.resolve_event``
+now raise structured :class:`pyfcstm.utils.validate.ModelValueError` /
+:class:`pyfcstm.utils.validate.ModelLookupError` carrying
+:class:`pyfcstm.utils.validate.ModelDiagnostic` objects, and accept an
+optional ``collect_into=`` :class:`pyfcstm.diagnostics.DiagnosticSink`
+parameter for accumulator-style resolution.
+
+These tests pin down:
+
+1. Both new exception classes multi-inherit ``ValueError`` / ``LookupError``
+   AND ``SyntaxError`` (via ``ModelValidationError``), preserving the
+   pre-PR-3 catch surface for every existing
+   ``except ValueError:`` / ``except LookupError:`` / ``except SyntaxError:``
+   handler.
+2. The structured diagnostic on every failure path uses the correct
+   ``code`` (``E_EVENT_REF_INVALID`` or ``E_EVENT_NOT_FOUND``) and a
+   ``refs`` payload that conforms to the codes.yaml enum for ``reason``
+   (E_EVENT_REF_INVALID) or ``scope`` (E_EVENT_NOT_FOUND).
+3. The ``collect_into`` sink injection accumulates failures and returns
+   ``None`` instead of raising — letting downstream IDE / agent-loop
+   integrations harvest every diagnostic in one pass.
+"""
+
+import pytest
+
+from pyfcstm.diagnostics import CODE_REGISTRY, DiagnosticSink
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.utils.validate import (
+    ModelDiagnostic,
+    ModelLookupError,
+    ModelValidationError,
+    ModelValueError,
+)
+
+
+@pytest.fixture()
+def machine():
+    src = """
+def int x = 0;
+state Root {
+    state Inner {
+        state Leaf;
+        [*] -> Leaf;
+        event Done;
+    }
+    state Other;
+    event Go;
+    [*] -> Inner;
+}
+"""
+    ast = parse_with_grammar_entry(src, entry_name='state_machine_dsl')
+    return parse_dsl_node_to_state_machine(ast)
+
+
+def _assert_refs_match_schema(diag: ModelDiagnostic) -> None:
+    spec = CODE_REGISTRY[diag.code]
+    declared = set(spec.refs_schema.keys())
+    actual = set(diag.refs.keys())
+    extra = actual - declared
+    assert not extra, (
+        f"{diag.code} refs has extra keys {extra} not in codes.yaml schema"
+    )
+    for name, value in diag.refs.items():
+        field_spec = spec.refs_schema[name]
+        if field_spec.enum is None or value is None:
+            continue
+        assert value in field_spec.enum, (
+            f"{diag.code}.refs[{name}!r] = {value!r} not in enum {field_spec.enum}"
+        )
+
+
+@pytest.mark.unittest
+class TestExceptionHierarchy:
+    """The new typed exceptions must preserve every existing catch."""
+
+    def test_model_value_error_is_value_error(self):
+        e = ModelValueError(diagnostics=[ModelDiagnostic(
+            code='E_EVENT_REF_INVALID', severity='error', message='m',
+            refs={'event_ref': 'x', 'reason': 'empty'},
+        )])
+        assert isinstance(e, ValueError)
+        assert isinstance(e, ModelValidationError)
+        assert isinstance(e, SyntaxError)  # via ModelValidationError -> SyntaxError
+
+    def test_model_lookup_error_is_lookup_error(self):
+        e = ModelLookupError(diagnostics=[ModelDiagnostic(
+            code='E_EVENT_NOT_FOUND', severity='error', message='m',
+            refs={'event_ref': 'x', 'scope': 'absolute'},
+        )])
+        assert isinstance(e, LookupError)
+        assert isinstance(e, ModelValidationError)
+        assert isinstance(e, SyntaxError)
+
+    def test_caught_via_legacy_value_error_handler(self, machine):
+        # Pre-PR-3 code: ``except ValueError as e: ...`` — must still catch.
+        with pytest.raises(ValueError) as info:
+            machine.root_state.resolve_event('')
+        assert isinstance(info.value, ModelValueError)
+        assert info.value.diagnostics[0].code == 'E_EVENT_REF_INVALID'
+
+    def test_caught_via_legacy_lookup_error_handler(self, machine):
+        with pytest.raises(LookupError) as info:
+            machine.root_state.resolve_event('NoSuch.NoEvt')
+        assert isinstance(info.value, ModelLookupError)
+        assert info.value.diagnostics[0].code == 'E_EVENT_NOT_FOUND'
+
+    def test_caught_via_syntax_error_handler(self, machine):
+        # PR-2 multi-inheritance contract: ``except SyntaxError:`` must catch.
+        with pytest.raises(SyntaxError) as info:
+            machine.root_state.resolve_event('')
+        assert isinstance(info.value, ModelValueError)
+
+
+@pytest.mark.unittest
+class TestStateResolveEventRefInvalid:
+    """Each ``reason`` enum value of E_EVENT_REF_INVALID has a fixture."""
+
+    @pytest.mark.parametrize('event_ref,reason', [
+        ('', 'empty'),
+        ('/', 'bare_slash'),
+        ('/foo..bar', 'invalid_absolute'),
+        ('.', 'trailing_dots'),
+        ('foo..bar', 'invalid_relative'),
+    ])
+    def test_invalid_reason_dispatch_from_root(self, machine, event_ref, reason):
+        with pytest.raises(ModelValueError) as info:
+            machine.root_state.resolve_event(event_ref)
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_REF_INVALID'
+        assert diag.refs['reason'] == reason
+        assert diag.refs['event_ref'] == event_ref
+        _assert_refs_match_schema(diag)
+
+    def test_invalid_relative_via_parent_form(self, machine):
+        # The parent-relative form (``.foo..bar``) only reaches the
+        # ``invalid_relative`` branch when ``dot_count`` doesn't exhaust
+        # the root chain. From ``Root.Inner`` one leading dot consumes
+        # the level up to ``Root`` and the remaining ``foo..bar`` splits
+        # to ['foo', '', 'bar'], failing the ``all(parts)`` check.
+        inner = machine.root_state.substates['Inner']
+        with pytest.raises(ModelValueError) as info:
+            inner.resolve_event('.foo..bar')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_REF_INVALID'
+        assert diag.refs['reason'] == 'invalid_relative'
+        _assert_refs_match_schema(diag)
+
+    def test_beyond_root_at_state_inner(self, machine):
+        # Inner is at depth 2 (Root.Inner). Going up 5 levels exceeds root.
+        inner = machine.root_state.substates['Inner']
+        with pytest.raises(ModelValueError) as info:
+            inner.resolve_event('.....Foo')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_REF_INVALID'
+        assert diag.refs['reason'] == 'beyond_root'
+        _assert_refs_match_schema(diag)
+
+
+@pytest.mark.unittest
+class TestStateResolveEventNotFound:
+    """Each ``scope`` enum value of E_EVENT_NOT_FOUND has a fixture."""
+
+    def test_absolute_scope_state_missing(self, machine):
+        with pytest.raises(ModelLookupError) as info:
+            machine.root_state.resolve_event('/NoSuch.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_NOT_FOUND'
+        assert diag.refs['scope'] == 'absolute'
+        _assert_refs_match_schema(diag)
+
+    def test_absolute_scope_event_missing(self, machine):
+        # The state path resolves but the event name doesn't exist.
+        with pytest.raises(ModelLookupError) as info:
+            machine.root_state.resolve_event('/Inner.NoSuchEvent')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_NOT_FOUND'
+        assert diag.refs['scope'] == 'absolute'
+
+    def test_chain_scope_state_missing(self, machine):
+        # ``.`` form (one dot) — chain scope, walks up by 1.
+        inner = machine.root_state.substates['Inner']
+        with pytest.raises(ModelLookupError) as info:
+            inner.resolve_event('.NoSuch.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_NOT_FOUND'
+        assert diag.refs['scope'] == 'chain'
+
+    def test_local_scope_state_missing(self, machine):
+        # Bare relative — local scope.
+        with pytest.raises(ModelLookupError) as info:
+            machine.root_state.resolve_event('NoSuch.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_NOT_FOUND'
+        assert diag.refs['scope'] == 'local'
+
+
+@pytest.mark.unittest
+class TestStateMachineResolveEventPath:
+    def test_empty_path(self, machine):
+        with pytest.raises(ModelValueError) as info:
+            machine.resolve_event('')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_REF_INVALID'
+        assert diag.refs['reason'] == 'empty'
+
+    def test_path_with_empty_parts(self, machine):
+        with pytest.raises(ModelValueError) as info:
+            machine.resolve_event('Root..Go')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_REF_INVALID'
+        assert diag.refs['reason'] == 'invalid_absolute'
+
+    def test_path_with_only_one_part(self, machine):
+        with pytest.raises(ModelValueError) as info:
+            machine.resolve_event('Go')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_REF_INVALID'
+        assert diag.refs['reason'] == 'invalid_absolute'
+
+    def test_root_mismatch(self, machine):
+        with pytest.raises(ModelLookupError) as info:
+            machine.resolve_event('NotRoot.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_NOT_FOUND'
+        assert diag.refs['scope'] == 'absolute'
+
+    def test_middle_state_missing(self, machine):
+        with pytest.raises(ModelLookupError) as info:
+            machine.resolve_event('Root.NoSuch.Go')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_NOT_FOUND'
+
+    def test_leaf_event_missing(self, machine):
+        with pytest.raises(ModelLookupError) as info:
+            machine.resolve_event('Root.Inner.NoEvent')
+        diag = info.value.diagnostics[0]
+        assert diag.code == 'E_EVENT_NOT_FOUND'
+
+    def test_success_path(self, machine):
+        # Sanity: happy path still returns the event.
+        ev = machine.resolve_event('Root.Inner.Done')
+        assert ev.name == 'Done'
+
+
+@pytest.mark.unittest
+class TestSinkInjection:
+    """``collect_into`` accumulates failures and returns ``None``."""
+
+    def test_state_resolve_event_with_sink_returns_none_and_emits(self, machine):
+        sink = DiagnosticSink(collect=True)
+        result = machine.root_state.resolve_event('', collect_into=sink)
+        assert result is None
+        assert len(sink.diagnostics) == 1
+        assert sink.diagnostics[0].code == 'E_EVENT_REF_INVALID'
+
+    def test_state_machine_resolve_event_with_sink_returns_none_and_emits(self, machine):
+        sink = DiagnosticSink(collect=True)
+        result = machine.resolve_event('Root.NoSuch.Go', collect_into=sink)
+        assert result is None
+        assert len(sink.diagnostics) == 1
+        assert sink.diagnostics[0].code == 'E_EVENT_NOT_FOUND'
+
+    def test_sink_accumulates_multiple_failures(self, machine):
+        sink = DiagnosticSink(collect=True)
+        machine.root_state.resolve_event('', collect_into=sink)
+        machine.root_state.resolve_event('/', collect_into=sink)
+        machine.root_state.resolve_event('NoSuch.Go', collect_into=sink)
+        codes = [d.code for d in sink.diagnostics]
+        assert codes == [
+            'E_EVENT_REF_INVALID',
+            'E_EVENT_REF_INVALID',
+            'E_EVENT_NOT_FOUND',
+        ]
+
+    def test_sink_does_not_raise(self, machine):
+        sink = DiagnosticSink(collect=True)
+        # Without sink this would raise — with sink, no raise.
+        machine.root_state.resolve_event('', collect_into=sink)
+        machine.resolve_event('Root.NoSuch.Go', collect_into=sink)
+
+    def test_sink_in_strict_mode_still_raises(self, machine):
+        # A strict-mode sink (collect=False) should still let resolve_event
+        # raise — because sink.emit raises on error. This pins the design
+        # contract: collect_into is "give me a sink"; if the sink is strict,
+        # behavior matches no-sink (raise).
+        sink = DiagnosticSink(collect=False)
+        with pytest.raises(ModelValidationError) as info:
+            machine.root_state.resolve_event('', collect_into=sink)
+        # The strict sink raises plain ModelValidationError (its baseline
+        # raise type), not ModelValueError — because the sink doesn't know
+        # the subclass. Callers that want the typed exception must NOT pass
+        # a strict sink; they either omit collect_into entirely or use a
+        # collect=True sink.
+        assert info.value.diagnostics[0].code == 'E_EVENT_REF_INVALID'
+
+    def test_sink_preserves_happy_path(self, machine):
+        sink = DiagnosticSink(collect=True)
+        ev = machine.resolve_event('Root.Inner.Done', collect_into=sink)
+        assert ev is not None
+        assert ev.name == 'Done'
+        assert sink.diagnostics == []
+
+    # The following parametrize sets cover every ``return None`` branch in
+    # the sink-mode path of both resolve_event methods. Without them the
+    # coverage of model.py lingers around 98% because every error-path is
+    # only exercised by the raise variant.
+
+    @pytest.mark.parametrize('event_ref,expected_code,expected_reason_or_scope', [
+        ('', 'E_EVENT_REF_INVALID', 'empty'),
+        ('/', 'E_EVENT_REF_INVALID', 'bare_slash'),
+        ('/foo..bar', 'E_EVENT_REF_INVALID', 'invalid_absolute'),
+        ('.', 'E_EVENT_REF_INVALID', 'trailing_dots'),
+        ('foo..bar', 'E_EVENT_REF_INVALID', 'invalid_relative'),
+        ('/NoSuch.Go', 'E_EVENT_NOT_FOUND', 'absolute'),
+        ('/Inner.NoEvent', 'E_EVENT_NOT_FOUND', 'absolute'),
+        ('NoSuch.Go', 'E_EVENT_NOT_FOUND', 'local'),
+    ])
+    def test_state_resolve_event_all_failure_branches_via_sink(
+            self, machine, event_ref, expected_code, expected_reason_or_scope):
+        sink = DiagnosticSink(collect=True)
+        result = machine.root_state.resolve_event(event_ref, collect_into=sink)
+        assert result is None
+        assert sink.diagnostics, f"no diagnostic for ref {event_ref!r}"
+        diag = sink.diagnostics[0]
+        assert diag.code == expected_code
+        key = 'reason' if expected_code == 'E_EVENT_REF_INVALID' else 'scope'
+        assert diag.refs[key] == expected_reason_or_scope
+
+    @pytest.mark.parametrize('inner_ref,expected_reason', [
+        ('.....TooDeep', 'beyond_root'),
+        ('.foo..bar', 'invalid_relative'),
+    ])
+    def test_state_resolve_event_parent_relative_via_sink(
+            self, machine, inner_ref, expected_reason):
+        # Drive the parent-relative branches from ``Inner`` so neither of
+        # them collapses into ``beyond_root`` prematurely.
+        sink = DiagnosticSink(collect=True)
+        inner = machine.root_state.substates['Inner']
+        result = inner.resolve_event(inner_ref, collect_into=sink)
+        assert result is None
+        assert sink.diagnostics
+        assert sink.diagnostics[0].refs['reason'] == expected_reason
+
+    @pytest.mark.parametrize('event_path,expected_code,expected_reason_or_scope', [
+        ('', 'E_EVENT_REF_INVALID', 'empty'),
+        ('Root..Go', 'E_EVENT_REF_INVALID', 'invalid_absolute'),
+        ('Go', 'E_EVENT_REF_INVALID', 'invalid_absolute'),
+        ('NotRoot.Go', 'E_EVENT_NOT_FOUND', 'absolute'),
+        ('Root.NoSuch.Go', 'E_EVENT_NOT_FOUND', 'absolute'),
+        ('Root.Inner.NoEvent', 'E_EVENT_NOT_FOUND', 'absolute'),
+    ])
+    def test_state_machine_resolve_event_all_failure_branches_via_sink(
+            self, machine, event_path, expected_code, expected_reason_or_scope):
+        sink = DiagnosticSink(collect=True)
+        result = machine.resolve_event(event_path, collect_into=sink)
+        assert result is None
+        assert sink.diagnostics
+        diag = sink.diagnostics[0]
+        assert diag.code == expected_code
+        key = 'reason' if expected_code == 'E_EVENT_REF_INVALID' else 'scope'
+        assert diag.refs[key] == expected_reason_or_scope
+
+
+@pytest.mark.unittest
+class TestBackwardsCompatMessage:
+    """The original error messages stay intact so existing
+    ``pytest.raises(ValueError, match=...)`` test fixtures continue to
+    work without modification."""
+
+    @pytest.mark.parametrize('event_ref,expected_substring', [
+        ('', 'Event reference cannot be empty'),
+        ('/', "cannot be just '/'"),
+        ('/foo..bar', 'Invalid absolute event reference'),
+        ('.', 'cannot end with dots'),
+        ('foo..bar', 'Invalid relative event reference'),
+    ])
+    def test_state_resolve_event_message_preserved(
+            self, machine, event_ref, expected_substring):
+        with pytest.raises(ValueError) as info:
+            machine.root_state.resolve_event(event_ref)
+        assert expected_substring in str(info.value)
+
+    def test_state_machine_resolve_event_message_preserved(self, machine):
+        with pytest.raises(ValueError) as info:
+            machine.resolve_event('')
+        assert 'Event path cannot be empty' in str(info.value)
+
+        with pytest.raises(LookupError) as info:
+            machine.resolve_event('NotRoot.Go')
+        assert 'does not match' in str(info.value)


### PR DESCRIPTION
## 概述

#103 跟踪的 Layer 1 结构化诊断改造的 **PR-3（收官）**。把 `State.resolve_event` / `StateMachine.resolve_event` 里 17 处 `raise ValueError` / `raise LookupError` 全部转成结构化 `ModelDiagnostic` 发射，新增两个分类异常 + 收口的 sink 注入路径。

> ⚠️ 已挂等 claude -p + codex 双 superpower code review，自审 + 修完再请你 review，**不要 auto-merge**。

## 关键改动

### `pyfcstm.utils.validate` —— 两个新分类异常

```python
class ModelValueError(ModelValidationError, ValueError):
    """raise from event_resolve when input is syntactically invalid"""

class ModelLookupError(ModelValidationError, LookupError):
    """raise from event_resolve when state/event name is not found"""
```

**三重继承保住所有现存 catch 路径**：
- `except ValueError:` / `except LookupError:` —— 仓内 0 处（PR-3-precheck 已确认）+ 下游全 `except Exception:` 兜底，但**测试侧 25+ 个 `pytest.raises(ValueError|LookupError, match=...)` 必须不破** ✓
- `except SyntaxError:` —— 通过 `ModelValidationError` 继承链 ✓
- `except ModelValidationError:` —— 新加的 typed dispatch 入口 ✓

### `pyfcstm.model.model` —— sink 注入 + 结构化 emit

两个 `resolve_event` 方法都加 keyword-only 参数：

```python
def resolve_event(self, event_ref, *, collect_into: Optional[DiagnosticSink] = None) -> Optional[Event]:
    ...
```

- `collect_into=None`（默认）—— **行为完全等同 PR-3 之前**，直接 raise `ModelValueError` / `ModelLookupError`
- `collect_into=DiagnosticSink(collect=True)` —— emit 到 sink，返回 None，**不 raise**，让 IDE / agent loop 一次拿到全部错误

每个 emit 都带：
1. **原始 f-string 作为 message** —— `test_model_resolve_event.py` 25+ 个 `match=...` 子串断言全部仍绿
2. **跟 codes.yaml schema 严格对齐的 refs** —— `event_ref` / `reason` (enum: `'empty' | 'bare_slash' | 'invalid_absolute' | 'invalid_relative' | 'trailing_dots' | 'beyond_root'`) / `scope` (enum: `'local' | 'chain' | 'absolute'`，根据 ref 前缀自动 derive) / `searched_from`

### codes.yaml —— **零新增 code**

PR-3-precheck 已确认：17 处 raise 站点全部映射到 PR-1/PR-2 已有的 `E_EVENT_REF_INVALID` + `E_EVENT_NOT_FOUND` 两个 code，**新增 code 数 = 0**。所有 reason / scope enum 值都已在 schema 中。

## 测试 / 覆盖率

新增 ~50 个断言：

| 类 | case | 用途 |
|---|---:|---|
| `TestExceptionHierarchy` | 5 | MRO + 3 套 catch handler 全通过 |
| `TestStateResolveEventRefInvalid` | 5+1 | 每个 reason enum 至少一个 fixture |
| `TestStateResolveEventNotFound` | 4 | 每个 scope enum 至少一个 fixture |
| `TestStateMachineResolveEventPath` | 7 | 全 6 个 raise 站点 + 1 happy path |
| `TestSinkInjection` | 6 | sink 累积 / 不 raise / 多个失败 / happy / strict-mode |
| `TestBackwardsCompatMessage` | 6 参数化 | `pytest.raises(match=...)` 兼容回归 |
| Sink 模式参数化 (per-branch) | ~14 | 把每个 `return None` 分支全打到 |

覆盖率（`SKIP_SLOW_TESTS=1` fast 路径）：

| 模块 | Stmts | Miss | Cover |
|---|---:|---:|---:|
| `pyfcstm/diagnostics/__init__.py` | 3 | 0 | **100%** |
| `pyfcstm/diagnostics/codes.py` | 103 | 0 | **100%** |
| `pyfcstm/diagnostics/sink.py` | 27 | 0 | **100%** |
| `pyfcstm/dsl/listener.py` | 321 | 0 | **100%** |
| `pyfcstm/model/model.py` | 932 | 1 | **99%** (剩 1 行 pre-existing dead-code TypeError) |
| `pyfcstm/utils/validate.py` | 74 | 2 | **97%** (剩 Py3.7 `typing_extensions` fallback 不可达) |

**Fast 路径 total：8481 passed / 164 skipped / 24 秒**（vs full 174 秒，~7× 加速）。

## 向后兼容矩阵

| catch 模式 | 仍工作 | 备注 |
|---|---|---|
| `except ValueError:` | ✅ | `ModelValueError IS-A ValueError` |
| `except LookupError:` | ✅ | `ModelLookupError IS-A LookupError` |
| `except SyntaxError:` | ✅ | 两个新类都 inherit `SyntaxError` via `ModelValidationError` |
| `except ModelValidationError:` | ✅ | 新加 dispatch 入口 |
| `assert "..." in str(e)` | ✅ | message 保留原文 |
| `pytest.raises(ValueError, match='...')` | ✅ | 子串断言不变 |

## Test plan

- [x] PR-0 / PR-1 / PR-2 fixture 全绿
- [x] `test_model_resolve_event.py` 25+ 个 `match=...` 全过（**零修改**）
- [x] 每个 reason / scope enum 都有至少 1 个 emit fixture
- [x] Sink 注入：collect 模式累积 + happy path 不污染
- [x] `make rst_auto` 运行
- [ ] CI 跨 OS × Python 矩阵全绿（fast 路径，commit 带 `[skip-slow]`）
- [ ] **等 claude -p + codex 双 review** 跑完处理反馈再 merge

## Cross-link

- 跟踪 issue：#103
- 前置：#105（PR-0）/ #106（CI 文档）/ #109（PR-1）/ #110（PR-2）
- PR-3-precheck 调研：[issue #103 comment](https://github.com/HansBug/pyfcstm/issues/103#issuecomment-4563003233)
- 下游目标：`HansBug/research_ideas#12`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
