### PR TITLE
fix(jsfcstm): bump serialize-javascript override to ^7.0.5 (GHSA-5c6j-r48x-rmvq, GHSA-qj8w-gfj5-8c6v)

### DIFF
--- a/editors/jsfcstm/package-lock.json
+++ b/editors/jsfcstm/package-lock.json
@@ -1152,16 +1152,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-3.6.0.tgz",
@@ -1185,27 +1175,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.8.1",
       "resolved": "https://registry.npmmirror.com/semver/-/semver-7.8.1.tgz",
@@ -1220,13 +1189,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmmirror.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmmirror.com/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {

--- a/editors/jsfcstm/package.json
+++ b/editors/jsfcstm/package.json
@@ -156,6 +156,6 @@
   },
   "overrides": {
     "glob": "^11.0.0",
-    "serialize-javascript": "^6.0.2"
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Resolves two Dependabot alerts on `editors/jsfcstm/package-lock.json`:

| GHSA | Severity | Vulnerable range | First patched |
|---|---|---|---|
| [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) (RCE via `RegExp.flags` / `Date.prototype.toISOString`) | high | `<= 7.0.2` | 7.0.3 |
| [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) (CPU DoS via crafted array-likes) | medium | `>= 5.0.0, < 7.0.5` | 7.0.5 |

`serialize-javascript` reaches `jsfcstm` only through `mocha` (a `devDependency`). The existing override pinned it to `^6.0.2`, which is still within the vulnerable range for both advisories. Bump the override to `^7.0.5` so the lockfile resolves a patched release.

## Compatibility analysis

- **Not in published artifact.** `serialize-javascript` is not imported by any file under `editors/jsfcstm/src/`, so it never lands in `dist/`. Confirmed by `grep -rl "serialize-javascript" dist/` returning empty after `npm run build`.
- **ES2015 output preserved.** `dist/**/*.js` contains no ES2017+ syntax (no `async`/`await`, optional chaining, nullish coalescing). TypeScript still targets ES2015 per `tsconfig.json`.
- **`engines.node` unaffected.** `engines.node: ">=16"` describes the runtime envelope for consumers of the published package. `serialize-javascript@7` only runs in dev (`mocha` worker), so its higher Node requirement does not regress the published artifact.
- **CI matrix already satisfies serialize-javascript@7.** `.github/workflows/test.yml` runs `jsfcstm_unit` on Node `20` and `22`, both >= 18.

## Local verification

```
npm install               # serialize-javascript resolves to 7.0.5
npm run build             # OK
npm run test:unit         # 399 passing, 0 failing
```

`[skip-slow]` is included in the commit message so the C/C++ template tests are skipped in CI for this docs-irrelevant, jsfcstm-only change.

## Test plan

- [x] Local build succeeds
- [x] Local unit tests pass (399/399)
- [x] `dist/` contains no `serialize-javascript` references
- [x] `dist/` contains no ES2017+ syntax (ES2015 target preserved)
- [ ] CI `jsfcstm unit tests` green on Node 20 + 22
- [ ] CI Python unittest matrix green with `SKIP_SLOW_TESTS=1`
- [ ] Dependabot alerts #18 and #22 auto-close after merge