### PR TITLE
Layer 2 PR-A fix: schema↔emit parity (issue #104)

### DIFF
--- a/editors/jsfcstm/scripts/sync-runtime-assets.js
+++ b/editors/jsfcstm/scripts/sync-runtime-assets.js
@@ -72,16 +72,33 @@ function syncSharedSchemaDist() {
     copyFile(sharedSchemaSource, sharedSchemaDistTarget);
 }
 
-function syncSharedCodesSrc() {
+function ensureSharedCodesExists() {
     if (!fs.existsSync(sharedCodesSource)) {
         throw new Error(
             `Shared diagnostic codes registry not found: ${sharedCodesSource}. ` +
             `It must be checked in under pyfcstm/diagnostics/codes.yaml.`
         );
     }
+}
+
+function loadSharedCodesRegistry() {
+    ensureSharedCodesExists();
     const text = fs.readFileSync(sharedCodesSource, 'utf-8');
-    const registry = yaml.load(text);
+    return yaml.load(text);
+}
+
+// I-d: each phase must write only to its own target directory and
+// re-read codes.yaml each time. The previous implementation had
+// ``syncSharedCodesSrc()`` write to both ``src/`` and ``dist/`` which
+// meant ``npm run sync:src && (edit codes.yaml) && npm run sync:dist``
+// left dist/codes.json stale.
+function syncSharedCodesSrc() {
+    const registry = loadSharedCodesRegistry();
     writeJson(sharedCodesSrcTarget, registry);
+}
+
+function syncSharedCodesDist() {
+    const registry = loadSharedCodesRegistry();
     writeJson(sharedCodesDistTarget, registry);
 }
 
@@ -102,6 +119,7 @@ function runDistPhase() {
     fs.rmSync(targetDir, {recursive: true, force: true});
     copyTree(sourceDir, targetDir);
     syncSharedSchemaDist();
+    syncSharedCodesDist();
 }
 
 function main() {

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -800,11 +800,18 @@ function addDuringAspectInvalidDiagnostics(
             continue;
         }
 
+        // I3 lockdown (PR #116 re-review): ``aspect`` may be
+        // ``undefined`` from the live AST or ``null`` after a JSON
+        // round-trip / cross-worker serialization. Treat any value
+        // that is not the literal string ``'before'`` / ``'after'``
+        // as the bare-during case to keep both ends agreeing.
+        const aspectIsBeforeAfter = action.aspect === 'before' || action.aspect === 'after';
+
         // Scenario (a): leaf state with a local ``during before`` /
         // ``during after`` — the aspect-qualified during only makes
         // sense on a composite (it gates on entry/exit of the
         // composite).
-        if (!owner.composite && action.aspect !== undefined) {
+        if (!owner.composite && aspectIsBeforeAfter) {
             diagnostics.push({
                 range: action.range,
                 message: `For leaf state ${JSON.stringify(owner.name)}, during cannot assign aspect ${JSON.stringify(action.aspect)}.`,
@@ -822,7 +829,7 @@ function addDuringAspectInvalidDiagnostics(
 
         // Scenario (b): composite state with a bare ``during`` (no
         // aspect token) — composites must pick ``before`` or ``after``.
-        if (owner.composite && action.aspect === undefined) {
+        if (owner.composite && !aspectIsBeforeAfter) {
             diagnostics.push({
                 range: action.range,
                 message: `For composite state ${JSON.stringify(owner.name)}, during must assign aspect to either 'before' or 'after'.`,

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -814,7 +814,7 @@ function addInitialTransitionInvalidDiagnostics(
                 code: FCSTM_DIAGNOSTIC_CODES.initialTransitionInvalid,
                 data: {
                     composite_path: state.identity.qualifiedName,
-                    reason: 'no_initial_transition',
+                    reason: 'missing_entry',
                 },
             });
         }

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -161,9 +161,11 @@ function addImportMappingDiagnostics(
     for (const importItem of semantic.imports) {
         const seen = new Map<string, FcstmAstImportMapping>();
         for (const mapping of importItem.ast.mappings) {
-            const key = mapping.kind === 'importDefMapping'
-                ? `${mapping.kind}:${mapping.selector.text}->${mapping.targetTemplate}`
-                : `${mapping.kind}:${mapping.sourceEvent.text}->${mapping.targetEvent.text}`;
+            const isVariable = mapping.kind === 'importDefMapping';
+            const mappingKind: 'variable' | 'event' = isVariable ? 'variable' : 'event';
+            const sourceName = isVariable ? mapping.selector.text : mapping.sourceEvent.text;
+            const targetName = isVariable ? mapping.targetTemplate : mapping.targetEvent.text;
+            const key = `${mapping.kind}:${sourceName}->${targetName}`;
             const firstMapping = seen.get(key);
             if (firstMapping) {
                 diagnostics.push({
@@ -175,6 +177,17 @@ function addImportMappingDiagnostics(
                     severity: 'error',
                     source: 'fcstm',
                     code: FCSTM_DIAGNOSTIC_CODES.importDuplicateMapping,
+                    data: {
+                        alias: importItem.alias,
+                        mapping_kind: mappingKind,
+                        // The dedupe key matches when both source AND target
+                        // are identical, so either ``direction`` is technically
+                        // correct. Pick ``source_duplicated`` as the canonical
+                        // form to match pyfcstm's ordering of these checks.
+                        duplicated_name: sourceName,
+                        direction: 'source_duplicated',
+                        host_state_path: importItem.ownerStatePath.join('.'),
+                    },
                     relatedInformation: [{
                         location: {
                             uri: toFileUri(document),

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -768,14 +768,18 @@ function addDuringAspectInvalidDiagnostics(
         stateById.set(state.identity.id, state);
     }
     for (const action of semantic.actions) {
-        if (!action.isGlobalAspect) {
-            continue;
-        }
         const owner = stateById.get(action.ownerStateId);
         if (!owner) {
             continue;
         }
-        if (!owner.composite) {
+        if (action.stage !== 'during') {
+            continue;
+        }
+
+        // Scenario (c): global ``>> during before/after`` aspect on a
+        // leaf state — there is no descendant for the aspect to fan
+        // into.
+        if (action.isGlobalAspect && !owner.composite) {
             diagnostics.push({
                 range: action.range,
                 message: `Aspect '>> during ${action.aspect ?? 'before'}' cannot appear in leaf state ${JSON.stringify(owner.name)}; aspect actions need at least one descendant leaf.`,
@@ -786,6 +790,49 @@ function addDuringAspectInvalidDiagnostics(
                     state_path: action.ownerStatePath.join('.'),
                     state_kind: 'leaf',
                     aspect: action.aspect ?? 'before',
+                },
+            });
+            continue;
+        }
+
+        // I-f scenarios (a) and (b): non-global ``during`` action.
+        if (action.isGlobalAspect) {
+            continue;
+        }
+
+        // Scenario (a): leaf state with a local ``during before`` /
+        // ``during after`` — the aspect-qualified during only makes
+        // sense on a composite (it gates on entry/exit of the
+        // composite).
+        if (!owner.composite && action.aspect !== undefined) {
+            diagnostics.push({
+                range: action.range,
+                message: `For leaf state ${JSON.stringify(owner.name)}, during cannot assign aspect ${JSON.stringify(action.aspect)}.`,
+                severity: 'error',
+                source: 'fcstm',
+                code: FCSTM_DIAGNOSTIC_CODES.duringAspectInvalid,
+                data: {
+                    state_path: action.ownerStatePath.join('.'),
+                    state_kind: 'leaf',
+                    aspect: action.aspect,
+                },
+            });
+            continue;
+        }
+
+        // Scenario (b): composite state with a bare ``during`` (no
+        // aspect token) — composites must pick ``before`` or ``after``.
+        if (owner.composite && action.aspect === undefined) {
+            diagnostics.push({
+                range: action.range,
+                message: `For composite state ${JSON.stringify(owner.name)}, during must assign aspect to either 'before' or 'after'.`,
+                severity: 'error',
+                source: 'fcstm',
+                code: FCSTM_DIAGNOSTIC_CODES.duringAspectInvalid,
+                data: {
+                    state_path: action.ownerStatePath.join('.'),
+                    state_kind: 'composite',
+                    aspect: null,
                 },
             });
         }

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -421,11 +421,26 @@ function pushIdentifierDiagnostic(
  * block-local temporary variables after their first assignment, matching the
  * pyfcstm runtime rule.
  */
+/**
+ * Schema enum for ``E_UNDEFINED_VAR.refs.referenced_in`` (see
+ * ``pyfcstm/diagnostics/codes.yaml``). Threaded from each call site
+ * to keep the emitted payload schema-conformant.
+ */
+export type ReferencedIn =
+    | 'guard'
+    | 'effect'
+    | 'enter'
+    | 'during'
+    | 'exit'
+    | 'during_aspect'
+    | 'init';
+
 function analyzeOperationStatements(
     statements: FcstmAstOperationStatement[] | undefined,
     globals: Set<string>,
     assignedBefore: Set<string>,
-    diagnostics: FcstmDiagnostic[]
+    diagnostics: FcstmDiagnostic[],
+    referencedIn: ReferencedIn
 ): Set<string> {
     const assigned = new Set(assignedBefore);
     if (!statements) {
@@ -451,7 +466,7 @@ function analyzeOperationStatements(
                     `Variable ${JSON.stringify(identifier.name)} is read before it is assigned in this block.`,
                     FCSTM_DIAGNOSTIC_CODES.undefinedVar,
                     'error',
-                    {is_temporary: true, referenced_in: 'operation_block'}
+                    {is_temporary: true, referenced_in: referencedIn}
                 );
             }
             if (assignment.targetName) {
@@ -474,7 +489,7 @@ function analyzeOperationStatements(
                             `Variable ${JSON.stringify(identifier.name)} is read before it is assigned in this block.`,
                             FCSTM_DIAGNOSTIC_CODES.undefinedVar,
                             'error',
-                            {is_temporary: true, referenced_in: 'operation_block'}
+                            {is_temporary: true, referenced_in: referencedIn}
                         );
                     }
                 }
@@ -482,7 +497,8 @@ function analyzeOperationStatements(
                     branch.statements,
                     globals,
                     assigned,
-                    diagnostics
+                    diagnostics,
+                    referencedIn
                 );
                 branchAssigned.push(branchResult);
             }
@@ -509,12 +525,13 @@ function analyzeOperationStatements(
 function analyzeOperationBlock(
     block: FcstmAstOperationBlock | undefined,
     globals: Set<string>,
-    diagnostics: FcstmDiagnostic[]
+    diagnostics: FcstmDiagnostic[],
+    referencedIn: ReferencedIn
 ): void {
     if (!block) {
         return;
     }
-    analyzeOperationStatements(block.statements, globals, new Set(), diagnostics);
+    analyzeOperationStatements(block.statements, globals, new Set(), diagnostics, referencedIn);
 }
 
 function collectTopLevelGlobals(semantic: FcstmSemanticDocument): Set<string> {
@@ -586,7 +603,7 @@ function addEffectBlockDiagnostics(
             effect?: FcstmAstOperationBlock;
         };
         if (ast.effect) {
-            analyzeOperationBlock(ast.effect, globals, diagnostics);
+            analyzeOperationBlock(ast.effect, globals, diagnostics, 'effect');
         }
     }
 }
@@ -602,7 +619,11 @@ function addActionBlockDiagnostics(
         }
         const ast = semanticAction.ast as FcstmAstAction;
         const block = ast.operationBlock || ast.operation_block;
-        analyzeOperationBlock(block, globals, diagnostics);
+        // Map AST stage + aspect onto the schema enum:
+        //   ``>> during before/after`` → ``during_aspect``
+        //   bare ``enter|during|exit`` → same name
+        const referencedIn: ReferencedIn = ast.aspect ? 'during_aspect' : ast.stage;
+        analyzeOperationBlock(block, globals, diagnostics, referencedIn);
     }
 }
 

--- a/editors/jsfcstm/src/workspace/imports.ts
+++ b/editors/jsfcstm/src/workspace/imports.ts
@@ -176,6 +176,10 @@ export class FcstmImportWorkspaceIndex {
                 stateAliasSeen.set(stateKey, aliasMap);
             }
 
+            // Normalize the schema host_state_path: pyfcstm emits '' for
+            // root-hosted imports, not the literal '<root>' sentinel.
+            const hostStatePath = stateKey === '<root>' ? '' : stateKey;
+
             const firstAlias = aliasMap.get(semanticImport.alias);
             if (firstAlias) {
                 diagnostics.push({
@@ -184,6 +188,11 @@ export class FcstmImportWorkspaceIndex {
                     severity: 'error',
                     source: 'fcstm',
                     code: FCSTM_DIAGNOSTIC_CODES.importAliasConflict,
+                    data: {
+                        alias: semanticImport.alias,
+                        host_state_path: hostStatePath,
+                        conflicting_kind: 'previous_import_alias',
+                    },
                     relatedInformation: [{
                         location: {
                             uri: toFileUri(ownerFile),
@@ -207,6 +216,11 @@ export class FcstmImportWorkspaceIndex {
                     severity: 'error',
                     source: 'fcstm',
                     code: FCSTM_DIAGNOSTIC_CODES.importAliasConflict,
+                    data: {
+                        alias: semanticImport.alias,
+                        host_state_path: hostStatePath,
+                        conflicting_kind: 'existing_substate',
+                    },
                     relatedInformation: [{
                         location: {
                             uri: toFileUri(ownerFile),
@@ -224,6 +238,16 @@ export class FcstmImportWorkspaceIndex {
                     severity: 'error',
                     source: 'fcstm',
                     code: FCSTM_DIAGNOSTIC_CODES.importNotFound,
+                    data: {
+                        source_path: semanticImport.sourcePath,
+                        alias: semanticImport.alias,
+                        host_state_path: hostStatePath,
+                        // jsfcstm cannot distinguish read_error / parse_error /
+                        // no_root_state at this layer — the workspace index
+                        // already filtered missing files. ``file_not_found``
+                        // is the only reason that reaches this emit point.
+                        reason: 'file_not_found',
+                    },
                 });
             }
         }
@@ -231,6 +255,7 @@ export class FcstmImportWorkspaceIndex {
         for (const cycle of snapshot.cycles) {
             const firstHop = cycle.files[1];
             const cycleImport = semantic.imports.find(item => item.entryFile && normalizeFile(item.entryFile) === firstHop);
+            const cycleHostPath = cycleImport?.ownerStatePath.join('.') ?? '';
             diagnostics.push({
                 range: cycleImport?.pathRange || fallbackImportRange(),
                 message: `Circular import detected: ${cycle.files.map(item => path.basename(item)).join(' -> ')}.`,
@@ -240,6 +265,12 @@ export class FcstmImportWorkspaceIndex {
                 severity: 'error',
                 source: 'fcstm',
                 code: FCSTM_DIAGNOSTIC_CODES.importCircular,
+                data: {
+                    source_path: cycleImport?.sourcePath ?? cycle.files[1],
+                    alias: cycleImport?.alias ?? '',
+                    host_state_path: cycleHostPath,
+                    cycle_chain: cycle.files,
+                },
             });
         }
 

--- a/editors/jsfcstm/src/workspace/imports.ts
+++ b/editors/jsfcstm/src/workspace/imports.ts
@@ -242,11 +242,34 @@ export class FcstmImportWorkspaceIndex {
                         source_path: semanticImport.sourcePath,
                         alias: semanticImport.alias,
                         host_state_path: hostStatePath,
-                        // jsfcstm cannot distinguish read_error / parse_error /
-                        // no_root_state at this layer — the workspace index
-                        // already filtered missing files. ``file_not_found``
-                        // is the only reason that reaches this emit point.
+                        // I4 (PR #116 re-review): jsfcstm cannot
+                        // distinguish read_error vs parse_error at this
+                        // layer — the workspace index treats both as
+                        // ``missing``. We use ``file_not_found`` for
+                        // the resolution-failed case and emit a
+                        // separate branch below for ``no_root_state``.
                         reason: 'file_not_found',
+                    },
+                });
+            } else if (
+                semanticImport.entryFile &&
+                !semanticImport.targetRootStateName
+            ) {
+                // I4 (PR #116 re-review): file resolved but the parsed
+                // document declares no top-level state — match the
+                // pyfcstm side which emits ``reason: 'no_root_state'``
+                // for the same scenario.
+                diagnostics.push({
+                    range: semanticImport.pathRange,
+                    message: `Import source ${JSON.stringify(semanticImport.sourcePath)} resolved but declares no root state.`,
+                    severity: 'error',
+                    source: 'fcstm',
+                    code: FCSTM_DIAGNOSTIC_CODES.importNotFound,
+                    data: {
+                        source_path: semanticImport.sourcePath,
+                        alias: semanticImport.alias,
+                        host_state_path: hostStatePath,
+                        reason: 'no_root_state',
                     },
                 });
             }

--- a/editors/jsfcstm/src/workspace/model-assembly.ts
+++ b/editors/jsfcstm/src/workspace/model-assembly.ts
@@ -1002,6 +1002,14 @@ function assembleProgramImports(
         }
 
         node.substates = [...importedSubstates, ...node.substates];
+        // I-c from PR #115 review: keep this assignment in lockstep with
+        // ``ast/builder.ts``. By the time we reach this point we have
+        // already merged the import-resolved substates into
+        // ``node.substates``, so ``substates.length > 0`` covers both
+        // the explicit-substate and imported-substate cases — there is
+        // no separate ``imports`` array to check here. The AST builder
+        // computes ``composite`` differently (``substates ∪ imports >
+        // 0``) because it runs BEFORE imports have been resolved.
         node.composite = node.substates.length > 0;
     };
 

--- a/editors/jsfcstm/test/ast.test.ts
+++ b/editors/jsfcstm/test/ast.test.ts
@@ -376,4 +376,46 @@ describe('jsfcstm AST builder', () => {
             'DuringAspectRefFunction',
         ]);
     });
+
+    // I-c from PR #115 review: ``state.composite`` was changed by PR-A
+    // from "has braces" to "substates ∪ imports > 0". This means a
+    // brace-only state that has actions but no substates and no imports
+    // is now a leaf (``composite=false``). Pin that contract here so a
+    // future regression in ``ast/builder.ts`` shows up immediately.
+    it('classifies a brace-only state with actions but no substates/imports as a leaf', async () => {
+        const document = createDocument([
+            'def int x = 0;',
+            'state Root {',
+            '    state Idle {',
+            '        enter { x = x + 1; }',
+            '        exit { x = x - 1; }',
+            '    }',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n'), '/tmp/ast-brace-only-leaf.fcstm');
+
+        const ast = await packageModule.parseAstDocument(document);
+        const idle = ast?.rootState?.substates.find(item => item.name === 'Idle');
+        assert.ok(idle);
+        assert.equal(idle?.composite, false);
+        // ``Root`` is composite because it contains Idle as a substate.
+        assert.equal(ast?.rootState?.composite, true);
+    });
+
+    // I-c sibling test: a state that owns nothing but an ``import``
+    // (no explicit substates) MUST be classified as composite because
+    // the import resolves into a substate during workspace assembly.
+    // The grammar-level ``composite`` flag has to anticipate this.
+    it('classifies an import-only state as composite', async () => {
+        const document = createDocument([
+            'state Root {',
+            '    import "./worker.fcstm" as Worker;',
+            '}',
+        ].join('\n'), '/tmp/ast-import-only-composite.fcstm');
+
+        const ast = await packageModule.parseAstDocument(document);
+        assert.equal(ast?.rootState?.composite, true);
+        assert.equal(ast?.rootState?.substates.length, 0);
+        assert.equal(ast?.rootState?.imports.length, 1);
+    });
 });

--- a/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
+++ b/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
@@ -453,6 +453,34 @@ describe('diagnostics showcase: jsfcstm collectDocumentDiagnostics parity', () =
                     }
                 }
             }
+
+            // 6. E_IMPORT_* required-field payload check. The schema in
+            //    ``codes.yaml`` declares mandatory ``refs.*`` fields for
+            //    every import diagnostic — pyfcstm fills them, jsfcstm
+            //    used to omit them entirely (PR #115 R2.C3). This
+            //    assertion locks the payload parity in place.
+            const IMPORT_REQUIRED_FIELDS: Record<string, string[]> = {
+                'E_IMPORT_NOT_FOUND': ['source_path', 'alias', 'host_state_path', 'reason'],
+                'E_IMPORT_CIRCULAR': ['source_path', 'alias', 'host_state_path', 'cycle_chain'],
+                'E_IMPORT_ALIAS_CONFLICT': ['alias', 'host_state_path', 'conflicting_kind'],
+                'E_IMPORT_DUPLICATE_MAPPING': ['alias', 'mapping_kind', 'duplicated_name', 'direction', 'host_state_path'],
+                'E_IMPORT_MAPPING_INVALID': ['alias', 'mapping_kind', 'host_state_path', 'reason'],
+            };
+            for (const d of diagnostics) {
+                const required = IMPORT_REQUIRED_FIELDS[d.code];
+                if (!required) {
+                    continue;
+                }
+                const data = d.data as Record<string, unknown> | undefined;
+                for (const field of required) {
+                    assert.ok(
+                        data !== undefined
+                            && data[field] !== undefined
+                            && data[field] !== null,
+                        `${fixture.name}: ${d.code} missing required data field "${field}", got data=${JSON.stringify(data)}`,
+                    );
+                }
+            }
         });
     }
 });

--- a/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
+++ b/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
@@ -154,6 +154,40 @@ const SHOWCASE: ShowcaseFixture[] = [
         mustNotFire: ['E_INITIAL_TRANSITION_INVALID'],
     },
     {
+        // I-f scenario (a): leaf state with a *local* ``during after``
+        // (no ``>>``). pyfcstm flags this; jsfcstm now does too.
+        name: '07a-during-aspect-leaf-local-aspect',
+        dsl: [
+            'def int counter = 0;',
+            'state Root {',
+            '    state Idle {',
+            '        during after { counter = counter + 1; }',
+            '    }',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n'),
+        mustFire: ['E_DURING_ASPECT_INVALID'],
+        mustNotFire: ['E_INITIAL_TRANSITION_INVALID'],
+    },
+    {
+        // I-f scenario (b): composite state with a *bare* ``during`` (no
+        // aspect). Composite during must pick before/after — pyfcstm
+        // already enforces this and jsfcstm now matches.
+        name: '07b-during-aspect-composite-bare',
+        dsl: [
+            'def int counter = 0;',
+            'state Root {',
+            '    state Outer {',
+            '        during { counter = counter + 1; }',
+            '        state Inner;',
+            '        [*] -> Inner;',
+            '    }',
+            '    [*] -> Outer;',
+            '}',
+        ].join('\n'),
+        mustFire: ['E_DURING_ASPECT_INVALID'],
+    },
+    {
         name: '08-initial-transition-invalid',
         dsl: [
             'state Root {',

--- a/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
+++ b/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
@@ -419,12 +419,21 @@ describe('diagnostics showcase: jsfcstm collectDocumentDiagnostics parity', () =
 
             // 5. Schema-enum payload checks. These guard against
             //    schema↔emit drift — see ``pyfcstm/diagnostics/codes.yaml``
-            //    for the authoritative ``reason`` enum on each code.
+            //    for the authoritative enums on each code.
             //    Extend this block when adding new codes whose payload
             //    has an enumerated field.
             const VALID_INITIAL_TRANSITION_REASONS = new Set([
                 'missing_entry',
                 'target_not_child',
+            ]);
+            const VALID_REFERENCED_IN = new Set([
+                'guard',
+                'effect',
+                'enter',
+                'during',
+                'exit',
+                'during_aspect',
+                'init',
             ]);
             for (const d of diagnostics) {
                 if (d.code === 'E_INITIAL_TRANSITION_INVALID') {
@@ -433,6 +442,15 @@ describe('diagnostics showcase: jsfcstm collectDocumentDiagnostics parity', () =
                         reason !== undefined && VALID_INITIAL_TRANSITION_REASONS.has(reason),
                         `${fixture.name}: E_INITIAL_TRANSITION_INVALID emitted with reason=${JSON.stringify(reason)}, expected one of [${[...VALID_INITIAL_TRANSITION_REASONS].join(', ')}]`,
                     );
+                }
+                if (d.code === 'E_UNDEFINED_VAR') {
+                    const ri = (d.data as { referenced_in?: string } | undefined)?.referenced_in;
+                    if (ri !== undefined) {
+                        assert.ok(
+                            VALID_REFERENCED_IN.has(ri),
+                            `${fixture.name}: E_UNDEFINED_VAR emitted with referenced_in=${JSON.stringify(ri)}, expected one of [${[...VALID_REFERENCED_IN].join(', ')}]`,
+                        );
+                    }
                 }
             }
         });

--- a/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
+++ b/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
@@ -416,6 +416,25 @@ describe('diagnostics showcase: jsfcstm collectDocumentDiagnostics parity', () =
                     `${fixture.name} produced a diagnostic without a code: ${JSON.stringify(d)}`,
                 );
             }
+
+            // 5. Schema-enum payload checks. These guard against
+            //    schema↔emit drift — see ``pyfcstm/diagnostics/codes.yaml``
+            //    for the authoritative ``reason`` enum on each code.
+            //    Extend this block when adding new codes whose payload
+            //    has an enumerated field.
+            const VALID_INITIAL_TRANSITION_REASONS = new Set([
+                'missing_entry',
+                'target_not_child',
+            ]);
+            for (const d of diagnostics) {
+                if (d.code === 'E_INITIAL_TRANSITION_INVALID') {
+                    const reason = (d.data as { reason?: string } | undefined)?.reason;
+                    assert.ok(
+                        reason !== undefined && VALID_INITIAL_TRANSITION_REASONS.has(reason),
+                        `${fixture.name}: E_INITIAL_TRANSITION_INVALID emitted with reason=${JSON.stringify(reason)}, expected one of [${[...VALID_INITIAL_TRANSITION_REASONS].join(', ')}]`,
+                    );
+                }
+            }
         });
     }
 });

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -153,12 +153,12 @@ class ForLlmSpec:
     Structured guidance attached to a diagnostic code for downstream LLM
     consumers.
 
-    Layer 2 (issue #104) makes this required for new ``W_*`` and ``I_*``
-    codes so that LLM agent loops can read structured fix recommendations
-    instead of regex-ing the human-readable ``message``. Layer 1 ``E_*``
-    codes are grandfathered in without ``for_llm`` for backwards
-    compatibility — when an ``E_*`` code is later updated with one, it
-    will be parsed and validated by the same loader path.
+    Layer 2 (issue #104) requires this for every emitted code — ``E_*``,
+    ``W_*``, and ``I_*`` — so that LLM agent loops can read structured
+    fix recommendations instead of regex-ing the human-readable
+    ``message``. PR-A originally grandfathered the 14 Layer 1 ``E_*``
+    codes; PR-A-fix I-a backfilled them so this field is now expected
+    on every catalogued code.
 
     :param summary: One-line description aimed at LLM consumers.
     :type summary: str
@@ -198,9 +198,10 @@ class CodeSpec:
         declares this required when present; unset means
         ``'pure_static'`` for grandfathered Layer 1 codes.
     :type capability: str, optional
-    :param for_llm: Optional structured guidance for downstream LLM
-        consumers. Required for new Layer 2 ``W_*`` / ``I_*`` codes;
-        absent on grandfathered Layer 1 ``E_*`` codes.
+    :param for_llm: Structured guidance for downstream LLM consumers.
+        Backfilled across all ``E_*`` codes by PR-A-fix I-a; new codes
+        are expected to ship with one. Still typed as ``Optional`` so
+        the loader can tolerate forward-compatibility cases.
     :type for_llm: ForLlmSpec, optional
     """
 

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -80,6 +80,27 @@ _ALLOWED_CAPABILITIES = (
     'requires_simulation',
 )
 
+#: Allowed values for the ``emit_tier`` field on a code. PR-A-fix I-b
+#: lets the schema explicitly declare which emit pipeline produces a
+#: code so downstream dispatchers can register handlers correctly:
+#:
+#: * ``static_pipeline`` — fires during the regular static analysis
+#:   pass (``parse_dsl_node_to_state_machine`` /
+#:   ``collectDocumentDiagnostics``). This is the default for legacy
+#:   codes that omit the field.
+#: * ``lookup_api`` — fires only when a runtime resolver method
+#:   (e.g. ``State.resolve_event``) is invoked explicitly; never seen
+#:   by the static pipeline or the parity tests.
+#: * ``partial_static_pipeline`` — implemented in the static pipeline
+#:   on only one end (typically jsfcstm); the other end intentionally
+#:   does not emit. Downstream LLM consumers should not block waiting
+#:   for the missing end to surface this code.
+_ALLOWED_EMIT_TIERS = (
+    'static_pipeline',
+    'lookup_api',
+    'partial_static_pipeline',
+)
+
 #: Required keys for the ``for_llm`` payload when present on a code.
 #: ``summary`` is a one-line description aimed at downstream LLM consumers;
 #: ``recommended_actions`` is a list of dicts describing concrete fixes;
@@ -203,6 +224,19 @@ class CodeSpec:
         are expected to ship with one. Still typed as ``Optional`` so
         the loader can tolerate forward-compatibility cases.
     :type for_llm: ForLlmSpec, optional
+    :param emit_tier: Which emit pipeline actually fires this code.
+        ``'static_pipeline'`` (default) means the code fires during
+        ``parse_dsl_node_to_state_machine`` / the equivalent jsfcstm
+        ``collectDocumentDiagnostics`` static analysis pass.
+        ``'lookup_api'`` means the code only fires through explicit
+        runtime resolver APIs (e.g. ``State.resolve_event``) and is
+        never produced by the static pipeline. ``'partial_static_pipeline'``
+        marks codes whose static-pipeline emit is implemented on one
+        end only (typically jsfcstm) — downstream LLM consumers should
+        not block waiting for the missing end. PR-A-fix I-b makes the
+        field explicit so dispatchers can register handlers based on
+        the actual emit channel.
+    :type emit_tier: str, optional
     """
 
     code: str
@@ -212,6 +246,7 @@ class CodeSpec:
     example_dsl: Optional[str] = None
     capability: str = 'pure_static'
     for_llm: Optional[ForLlmSpec] = None
+    emit_tier: str = 'static_pipeline'
 
     def required_fields(self) -> List[str]:
         """
@@ -354,6 +389,14 @@ def _validate_code(path: str, code: str, raw: Any) -> CodeSpec:
             f"Allowed: {_ALLOWED_CAPABILITIES}.",
         ))
 
+    emit_tier = raw.get('emit_tier', 'static_pipeline')
+    if emit_tier not in _ALLOWED_EMIT_TIERS:
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} has invalid emit_tier {emit_tier!r}.",
+            f"Allowed: {_ALLOWED_EMIT_TIERS}.",
+        ))
+
     for_llm = _validate_for_llm(path, code, raw.get('for_llm'))
 
     return CodeSpec(
@@ -364,6 +407,7 @@ def _validate_code(path: str, code: str, raw: Any) -> CodeSpec:
         example_dsl=example_dsl,
         capability=capability,
         for_llm=for_llm,
+        emit_tier=emit_tier,
     )
 
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -709,23 +709,54 @@ E_IMPORT_NOT_FOUND:
       enum: ['file_not_found', 'read_error', 'parse_error', 'no_root_state']
   for_llm:
     summary: >-
-      An imported sub-machine file is missing or unreadable. The import
-      statement at host_state_path is dangling — every downstream
-      mapping that depends on it will also be invalid.
+      An import target could not be resolved. Inspect ``refs.reason`` to
+      branch the fix: ``file_not_found`` means the path is wrong or the
+      file does not exist; ``read_error`` means the file exists but the
+      I/O layer rejected it (permissions / encoding); ``parse_error``
+      means the file was loaded but is not valid FCSTM DSL; ``no_root_state``
+      means the file parses but declares no ``state Root { ... }`` block.
+      The four reasons need different fixes — do not collapse them.
     recommended_actions:
       - kind: fix_path
         target: import_statement
+        applies_to_reason: file_not_found
         rationale: >-
-          Adjust the source_path to a real file relative to the host file,
-          or remove the import if the sub-machine is no longer required.
+          For ``file_not_found``, adjust the source_path to a real file
+          relative to the host file, or remove the import if the
+          sub-machine is no longer required.
       - kind: create_file
         target: import_target
+        applies_to_reason: file_not_found
         rationale: >-
-          If the file should exist, create it with at least a top-level
-          ``state Root { ... }`` so its root state can be merged in.
+          For ``file_not_found``, if the file should exist, create it
+          with at least a top-level ``state Root { ... }`` so its root
+          state can be merged in.
+      - kind: fix_permissions
+        target: import_target
+        applies_to_reason: read_error
+        rationale: >-
+          For ``read_error``, the file exists but the I/O layer could not
+          read it. Check file permissions, encoding (FCSTM expects UTF-8
+          or auto-detected text), and that the path is not a directory.
+      - kind: fix_dsl_in_imported_file
+        target: import_target
+        applies_to_reason: parse_error
+        rationale: >-
+          For ``parse_error``, the file was read but contains invalid
+          FCSTM DSL. Open the imported file directly; the underlying
+          grammar parse error is reported with its own line/column when
+          you run ``pyfcstm`` on it standalone.
+      - kind: add_root_state
+        target: import_target
+        applies_to_reason: no_root_state
+        rationale: >-
+          For ``no_root_state``, the file parses but declares no
+          top-level ``state <Name> { ... }``. Add one — the merge needs
+          a root state to inline.
     do_not:
       - "Do not silently rename the alias to dodge the missing file."
       - "Do not add a placeholder state under the alias — the import must resolve to a real file."
+      - "Do not give the same recommended_action regardless of reason — the LLM consumer should branch on ``refs.reason`` and apply only the matching ``applies_to_reason`` actions."
   example_dsl: |
     state System {
         import "missing.fcstm" as Sub;

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -61,6 +61,36 @@ E_UNDEFINED_VAR:
         ``fcstm.readBeforeAssignTemporary`` into this single ``E_*`` code
         plus this flag. Defaults to ``False`` / absent for "real" undefined
         variables that have no matching ``def`` declaration anywhere.
+  for_llm:
+    summary: >-
+      A variable identifier appears in an expression (guard, effect, or
+      action block) but has not been declared with ``def`` at the file
+      top, has not been assigned earlier in the same block (so the
+      block-local temporary path doesn't apply), and is not a known
+      function name. The model refuses to bind unknown identifiers
+      because the generated code would not compile.
+    recommended_actions:
+      - kind: add_definition
+        target: file_top
+        rationale: >-
+          If the variable is genuinely program state, declare it with
+          ``def <type> <name> = <initial>;`` at the file top so the
+          generated runtime allocates storage for it.
+      - kind: assign_first
+        target: same_block
+        rationale: >-
+          If the name was meant to be a block-local temporary, assign
+          to it before reading. Block-local temps only exist after
+          their first assignment in the enclosing concrete block.
+      - kind: fix_typo
+        target: expression
+        rationale: >-
+          If the identifier was meant to be an existing variable,
+          correct the spelling. ``refs.var_name`` carries the exact
+          spelling from the source.
+    do_not:
+      - "Do not declare the variable inside an action block expecting it to leak out — block-local temps are discarded at block exit."
+      - "Do not rely on Python-style implicit None for the missing identifier; the generated runtime will fail to compile."
   example_dsl: |
     def int x = 0;
     state Root { state A; state B; A -> B : if [unknown_var > 0]; }
@@ -79,6 +109,24 @@ E_DUPLICATE_VAR:
       type: Span
       required: false
       description: Source position of the first declaration.
+  for_llm:
+    summary: >-
+      Two ``def`` declarations at the file top use the same variable
+      name. The model allocates one storage slot per name, so a
+      duplicate definition is ambiguous.
+    recommended_actions:
+      - kind: drop_duplicate
+        target: variable_definition
+        rationale: >-
+          If both definitions are meant to declare the same logical
+          variable, keep the first one and delete the second.
+      - kind: rename_one
+        target: variable_definition
+        rationale: >-
+          If both definitions are meant to be separate variables, rename
+          the second to give it its own storage slot.
+    do_not:
+      - "Do not assume the second ``def`` overrides the first — the generated runtime treats this as an error and refuses to compile."
   example_dsl: |
     def int x = 0;
     def int x = 1;
@@ -108,6 +156,24 @@ E_MISSING_STATE:
         - 'parent_missing'
         - 'ambiguous'
         - 'event_path_not_found'
+  for_llm:
+    summary: >-
+      A transition references a state name that does not exist in the
+      machine. The transition target / source must resolve to a state
+      declared in this file or imported.
+    recommended_actions:
+      - kind: fix_typo
+        target: transition
+        rationale: >-
+          If the name was meant to refer to an existing state, correct
+          the spelling. ``refs.state_name`` carries the missing token.
+      - kind: declare_state
+        target: composite_state
+        rationale: >-
+          If the state is genuinely missing, add ``state <name>;`` (or
+          a composite block) under the appropriate composite parent.
+    do_not:
+      - "Do not silently delete the transition; the original intent of the missing state is lost."
   example_dsl: |
     state Root { state A; A -> NoSuch; }
 
@@ -127,6 +193,25 @@ E_DUPLICATE_STATE:
       type: Span
       required: false
       description: Source position of the first declaration.
+  for_llm:
+    summary: >-
+      Two state declarations under the same composite parent use the
+      same name. State names must be unique inside their immediate
+      composite scope.
+    recommended_actions:
+      - kind: drop_duplicate
+        target: state_definition
+        rationale: >-
+          If both declarations describe the same logical state, keep
+          one and remove the other (merge any actions/transitions onto
+          the survivor).
+      - kind: rename_one
+        target: state_definition
+        rationale: >-
+          If the two declarations are meant to be distinct states,
+          rename one to give it its own identity inside the parent.
+    do_not:
+      - "Do not assume the second declaration overrides the first — duplicate state names produce a hard error."
   example_dsl: |
     state Root { state A; state A; }
 
@@ -152,6 +237,27 @@ E_EVENT_REF_INVALID:
         - 'invalid_relative'
         - 'trailing_dots'
         - 'beyond_root'
+  for_llm:
+    summary: >-
+      An event reference (``::``, ``:``, or ``/`` scoped) cannot resolve
+      to a known event under the indicated scope. The grammar accepts
+      the syntactic form, but the resolver cannot bind it to a real
+      event object.
+    recommended_actions:
+      - kind: fix_scope_operator
+        target: transition
+        rationale: >-
+          The three scope operators do not interchange freely. ``::``
+          is source-local, ``:`` is parent-chain, ``/`` is root-absolute.
+          Pick the one that matches where the event is actually
+          declared.
+      - kind: declare_event
+        target: composite_state
+        rationale: >-
+          If the event was supposed to exist, add an
+          ``event <name>;`` declaration in the matching scope.
+    do_not:
+      - "Do not invent a new event by silently aliasing — the dispatcher won't fire on an undeclared name."
   example_dsl: |
     state Root { state A; state B; A -> B : /; }
 
@@ -181,6 +287,24 @@ E_EVENT_NOT_FOUND:
         the originating location of the bad reference in source — not
         the effective search root, which is always the model root for
         absolute references.
+  for_llm:
+    summary: >-
+      A dotted event path could not be resolved against the assembled
+      state hierarchy. The path syntax was valid but no event with
+      that name exists at the resolved state.
+    recommended_actions:
+      - kind: fix_event_path
+        target: transition
+        rationale: >-
+          Confirm the dotted path matches the state hierarchy that
+          actually exists after imports have been merged.
+      - kind: declare_event
+        target: composite_state
+        rationale: >-
+          Add the missing ``event <name>;`` declaration under the
+          intended state.
+    do_not:
+      - "Do not paper over the error by introducing a wildcard alias — events are uniquely bound by their scope."
   example_dsl: |
     state Root { state A; state B; A -> B :: NoEvent; }
 
@@ -203,6 +327,28 @@ E_DANGLING_TRANSITION:
       description: >-
         Short tag describing the dangling reason.
       enum: ['src_not_found', 'tgt_not_found', 'both_not_found']
+  for_llm:
+    summary: >-
+      A transition's source or target points at a state that exists
+      neither in the local composite scope nor in any ancestor scope.
+      The transition cannot be wired into the dispatch graph.
+    recommended_actions:
+      - kind: fix_typo
+        target: transition
+        rationale: >-
+          If the dangling name is misspelled, correct it. ``refs.state_path``
+          carries the location of the offending transition.
+      - kind: declare_target_state
+        target: composite_state
+        rationale: >-
+          Declare the missing state if the transition was intentional.
+      - kind: drop_transition
+        target: transition
+        rationale: >-
+          Remove the transition if it was speculative — leaving a
+          dangling reference blocks the whole file.
+    do_not:
+      - "Do not pretend the transition resolves to ``[*]`` — that has a specific entry/exit semantics."
   example_dsl: |
     state Root { state A; NoSuch -> A; }
 
@@ -225,6 +371,26 @@ E_TYPE_MISMATCH:
       type: str
       required: true
       description: Original expression text.
+  for_llm:
+    summary: >-
+      An expression mixes an arithmetic and a boolean subexpression in
+      a way the grammar does not allow. ``num_expression`` and
+      ``cond_expression`` are strictly separated; comparison operators
+      bridge them, ternary ``? :`` converts boolean → arithmetic.
+    recommended_actions:
+      - kind: wrap_in_ternary
+        target: expression
+        rationale: >-
+          If you wanted to assign a boolean test, wrap it as
+          ``(cond) ? 1 : 0`` so the right-hand side is arithmetic.
+      - kind: add_comparison
+        target: guard
+        rationale: >-
+          If you wanted to gate on a numeric value, compare against a
+          constant (``counter > 0``) instead of using the value
+          directly as a boolean.
+    do_not:
+      - "Do not rely on numeric → boolean implicit coercion; the generated runtimes treat the two domains as distinct."
   example_dsl: |
     def int x = 0;
     state Root { state A; state B; A -> B : if [x]; }
@@ -249,6 +415,26 @@ E_FORCED_TRANSITION_EXPANSION:
         - 'tgt_not_found'
         - 'src_is_root'
         - 'wildcard_no_descendants'
+  for_llm:
+    summary: >-
+      A forced transition (``!Source -> Target`` or ``!* -> Target``)
+      failed to expand cleanly — typically because the source name
+      cannot be found, or because the expansion would create an
+      empty/inconsistent fan-out under the current scope.
+    recommended_actions:
+      - kind: fix_source
+        target: forced_transition
+        rationale: >-
+          Confirm the ``!Name`` source is a real state inside the
+          current composite scope. ``!*`` only matches direct
+          substates; deeper descendants need explicit names.
+      - kind: relocate_forced_transition
+        target: composite_state
+        rationale: >-
+          Move the forced transition into the composite whose substates
+          you actually want to receive the event.
+    do_not:
+      - "Do not add an ``effect { ... }`` block to a forced transition — forced transitions cannot carry effects and the expansion would fail anyway."
   example_dsl: |
     state Root { state A; !NoSuch -> A; }
 
@@ -268,6 +454,25 @@ E_INITIAL_TRANSITION_INVALID:
       description: >-
         Short tag describing the failure.
       enum: ['missing_entry', 'target_not_child']
+  for_llm:
+    summary: >-
+      A composite state lacks a valid ``[*] -> Child`` initial
+      transition, or its declared initial target is not actually a
+      child of this composite. The runtime cannot decide which child
+      to enter when this composite is activated.
+    recommended_actions:
+      - kind: add_initial_transition
+        target: composite_state
+        rationale: >-
+          Add ``[*] -> <ChildName>;`` inside the composite, picking a
+          direct substate as the entry point.
+      - kind: fix_initial_target
+        target: initial_transition
+        rationale: >-
+          If an initial transition already exists, retarget it at a
+          direct child of this composite (not a grandchild).
+    do_not:
+      - "Do not rely on a default ordering of substates; the runtime requires an explicit initial transition."
   example_dsl: |
     state Root { state Outer { state Inner; } }
 
@@ -291,6 +496,24 @@ E_DUPLICATE_FUNCTION_NAME:
       required: true
       description: Lifecycle stage where the duplicate appears.
       enum: ['enter', 'during', 'exit', 'during_aspect']
+  for_llm:
+    summary: >-
+      Two named action / function blocks share the same name within
+      the same scope. Named blocks must be uniquely identifiable so
+      ``ref`` lookups can bind to a single definition.
+    recommended_actions:
+      - kind: rename_one
+        target: named_action
+        rationale: >-
+          Give one of the named blocks a distinct identifier so
+          ``ref <name>`` calls resolve unambiguously.
+      - kind: drop_duplicate
+        target: named_action
+        rationale: >-
+          If the two declarations are meant to be the same logical
+          block, keep one and update its callers to reference it.
+    do_not:
+      - "Do not assume the second declaration shadows the first — the resolver treats this as a hard error."
   example_dsl: |
     state Root {
         state A {
@@ -326,6 +549,26 @@ E_DURING_ASPECT_INVALID:
         The aspect token that was actually used (``'before'``, ``'after'``,
         or null when the user wrote a bare ``during`` on a composite).
       enum: ['before', 'after']
+  for_llm:
+    summary: >-
+      A ``during before`` / ``during after`` or ``>> during ...``
+      aspect declaration was placed on a state that cannot legally
+      receive it (typically a leaf state with no descendant for the
+      aspect to fan out to).
+    recommended_actions:
+      - kind: move_to_composite
+        target: aspect_declaration
+        rationale: >-
+          Aspect actions only make sense on composite states. Move
+          the declaration to a composite ancestor whose descendants
+          should receive the aspect.
+      - kind: drop_aspect
+        target: aspect_declaration
+        rationale: >-
+          If the aspect was speculative and the state is genuinely a
+          leaf, remove the aspect declaration entirely.
+    do_not:
+      - "Do not convert the leaf into a composite just to host the aspect — that changes the runtime entry/exit semantics."
   example_dsl: |
     state Root {
         state A {
@@ -344,6 +587,26 @@ E_PSEUDO_NOT_LEAF:
       type: str
       required: true
       description: Dotted path of the offending pseudo state.
+  for_llm:
+    summary: >-
+      A ``pseudo state`` declaration was given a composite body (or
+      otherwise treated as if it had descendants). Pseudo states must
+      be leaves: they cannot host substates because their semantics
+      explicitly skip ancestor ``>> during`` aspects.
+    recommended_actions:
+      - kind: drop_pseudo_marker
+        target: state_definition
+        rationale: >-
+          If the state genuinely needs substates, remove the
+          ``pseudo`` keyword and treat it as a normal composite.
+      - kind: flatten_pseudo
+        target: state_definition
+        rationale: >-
+          If the state is meant to be a transient pseudo (e.g. an
+          internal junction), remove its substates and turn it back
+          into a leaf.
+    do_not:
+      - "Do not rely on pseudo states for normal hierarchy modeling — they exist solely to bypass ``>> during`` aspect application."
   example_dsl: |
     state Root {
         pseudo state Outer {
@@ -376,6 +639,26 @@ E_NAMED_FUNCTION_REF_NOT_FOUND:
         is the state name that does not exist under the parent path; for
         'named_function_not_found' this is the action name searched for in
         the resolved state.
+  for_llm:
+    summary: >-
+      An ``enter ref ...`` / ``exit ref ...`` / ``during ref ...``
+      clause points at a named action that does not exist. The
+      resolver could not find a matching named block in the indicated
+      scope.
+    recommended_actions:
+      - kind: fix_ref_path
+        target: action_ref
+        rationale: >-
+          Confirm the dotted ref path matches a real named action.
+          Use ``/`` to anchor at the root, or a relative name for the
+          current state.
+      - kind: declare_named_action
+        target: composite_state
+        rationale: >-
+          Add the missing ``enter <Name> { ... }`` / similar block in
+          the resolving scope.
+    do_not:
+      - "Do not silently swap ``ref`` with an inline block — that loses the deduplication that ``ref`` was meant to provide."
   example_dsl: |
     state Root {
         state A {

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -217,6 +217,7 @@ E_DUPLICATE_STATE:
 
 E_EVENT_REF_INVALID:
   severity: error
+  emit_tier: lookup_api
   description: >-
     The textual form of an event reference is syntactically invalid (e.g.
     bare '/', trailing dots, going beyond the root state).
@@ -263,6 +264,7 @@ E_EVENT_REF_INVALID:
 
 E_EVENT_NOT_FOUND:
   severity: error
+  emit_tier: lookup_api
   description: >-
     An event reference parses correctly but does not resolve to any event
     defined in the targeted scope.
@@ -354,6 +356,7 @@ E_DANGLING_TRANSITION:
 
 E_TYPE_MISMATCH:
   severity: error
+  emit_tier: partial_static_pipeline
   description: >-
     A guard, effect, or assignment uses an expression whose type does not
     match the expected category (arithmetic vs boolean).

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -546,9 +546,12 @@ E_DURING_ASPECT_INVALID:
       type: str_or_null
       required: false
       description: >-
-        The aspect token that was actually used (``'before'``, ``'after'``,
-        or null when the user wrote a bare ``during`` on a composite).
-      enum: ['before', 'after']
+        The aspect token that was actually used. ``'before'`` or
+        ``'after'`` for ``during before`` / ``during after`` and
+        ``>> during before/after``; ``null`` when the user wrote a bare
+        ``during`` on a composite state. ``null`` is intentional — the
+        consumer should branch on the bare-during case rather than
+        treat it as an enum value.
   for_llm:
     summary: >-
       A ``during before`` / ``during after`` or ``>> during ...``

--- a/pyfcstm/model/imports.py
+++ b/pyfcstm/model/imports.py
@@ -354,15 +354,16 @@ def _assemble_state(
             for diag in err.diagnostics:
                 sink.emit(diag)
             continue
-        except (AttributeError, KeyError, TypeError, IndexError):
-            # Collect-mode safety net: a previously-collected diagnostic
-            # may have left the imported program in an inconsistent
-            # shape (e.g. a mapping target that points nowhere). Skip
-            # the rest of this import; the original diagnostics that
-            # caused the corruption are already on the sink.
-            if not sink.collect:
-                raise
-            continue
+        # I1 (PR #116 re-review): the structural safety net previously
+        # caught AttributeError/KeyError/TypeError/IndexError to absorb
+        # follow-up exceptions from helpers that had emitted a
+        # diagnostic but kept operating on inconsistent state. Each
+        # such helper now returns an explicit safe fallback after
+        # emit (see ``_resolve_import_event_target_path`` /
+        # ``_ensure_state_path_exists``) so the safety net is removed
+        # — letting any remaining structural exception escape, where
+        # it will surface as a real bug instead of being silently
+        # swallowed.
 
     node.imports = []
 
@@ -611,6 +612,13 @@ def _resolve_import_event_target_path(
     alias: str,
     sink: DiagnosticSink,
 ) -> Tuple[Tuple[str, ...], str, Tuple[str, ...]]:
+    # I1 explicit fallback (PR #116 re-review): if the target path is
+    # empty we emit the schema diagnostic and return a safe sentinel
+    # tuple instead of fall-throughing to ``path[-1]`` (which would
+    # ``IndexError`` and rely on the outer safety net to swallow it).
+    # The sentinel ``('', '', ())`` is intentionally unparseable as a
+    # real event, so downstream consumers can detect-and-skip without
+    # confusing it with valid state machine data.
     if target_event.is_absolute:
         if len(target_event.path) < 1:
             _emit_import_diag(sink,
@@ -622,6 +630,7 @@ def _resolve_import_event_target_path(
                 reason='empty_path',
                 detail='absolute',
             )
+            return ((), '', ())
         target_state_path = tuple((owner_state_path[0], *target_event.path[:-1]))
         return (
             target_state_path,
@@ -639,6 +648,7 @@ def _resolve_import_event_target_path(
                 reason='empty_path',
                 detail='relative',
             )
+            return ((), '', ())
         target_state_path = tuple((*owner_state_path, *target_event.path[:-1]))
         target_event_name = target_event.path[-1]
         target_event_id_path = tuple((*owner_state_path[1:], *target_event.path))
@@ -901,6 +911,9 @@ def _ensure_state_path_exists(
     owner_state_path: Tuple[str, ...],
     sink: DiagnosticSink,
 ) -> dsl_nodes.StateDefinition:
+    # I1 explicit fallback (PR #116 re-review): emit-then-return early
+    # on empty path instead of fall-throughing into ``state_path[0]``
+    # IndexError that the outer safety net would have to swallow.
     if not state_path:
         _emit_import_diag(
             sink,
@@ -912,6 +925,7 @@ def _ensure_state_path_exists(
             reason='empty_path',
             detail='<empty>',
         )
+        return root
     if root.name != state_path[0]:
         _emit_import_diag(
             sink,

--- a/pyfcstm/model/imports.py
+++ b/pyfcstm/model/imports.py
@@ -284,17 +284,21 @@ def _assemble_state(
             sink=sink,
         )
 
-        # The mapping helpers (def / event) keep the legacy always-raise
-        # shape — they have many internal failure modes that we don't
-        # want to thread sink through individually. Instead, wrap the
-        # whole merge pipeline once: in strict mode (collect=False) the
-        # error propagates unchanged; in collect mode, we forward the
-        # diagnostic to the sink and ``continue`` past this import.
+        # The mapping helpers (def / event) are sink-aware: in strict
+        # mode (``DiagnosticSink(collect=False)``) the first emit raises
+        # :class:`ModelValidationError`; in collect mode the diagnostics
+        # accumulate on the sink and each helper continues past
+        # individual errors. We still wrap the call sequence in a safety
+        # net so structural follow-up failures (e.g. ``AttributeError``
+        # / ``TypeError`` triggered by the corrupt state left over from
+        # an accumulated error in collect mode) skip this import
+        # cleanly instead of poisoning the host program.
         try:
             _apply_import_def_mappings(
                 program=imported_program,
                 import_item=import_item,
                 owner_state_path=current_state_path,
+                sink=sink,
             )
             _merge_imported_definitions(
                 host_program=host_program,
@@ -302,6 +306,7 @@ def _assemble_state(
                 host_explicit_def_names=host_explicit_def_names,
                 import_item=import_item,
                 owner_state_path=current_state_path,
+                sink=sink,
             )
 
             imported_root = imported_program.root_state
@@ -309,6 +314,7 @@ def _assemble_state(
                 program=imported_program,
                 import_item=import_item,
                 owner_state_path=current_state_path,
+                sink=sink,
             )
             imported_root.name = import_item.alias
             imported_root.extra_name = (
@@ -320,6 +326,7 @@ def _assemble_state(
                 import_item=import_item,
                 owner_state_path=current_state_path,
                 resolved_event_mappings=event_mappings,
+                sink=sink,
             )
             _rewrite_absolute_paths_for_imported_root(
                 node=imported_root,
@@ -328,12 +335,26 @@ def _assemble_state(
             )
             imported_substates.append(imported_root)
         except ModelValidationError as err:
+            # Strict mode: should not reach here normally because the
+            # helpers raise straight through; keep the re-raise as a
+            # belt-and-braces guard against future helper changes.
             if not sink.collect:
                 raise
+            # Collect mode: forward any straggler diagnostics that
+            # somehow escaped the helper's own sink emit (shouldn't
+            # happen post C-E, but harmless if it does) and skip this
+            # import to avoid further corruption.
             for diag in err.diagnostics:
                 sink.emit(diag)
-            # Skip this import — the partial merge state would corrupt
-            # the host program.
+            continue
+        except (AttributeError, KeyError, TypeError, IndexError):
+            # Collect-mode safety net: a previously-collected diagnostic
+            # may have left the imported program in an inconsistent
+            # shape (e.g. a mapping target that points nowhere). Skip
+            # the rest of this import; the original diagnostics that
+            # caused the corruption are already on the sink.
+            if not sink.collect:
+                raise
             continue
 
     node.imports = []
@@ -504,6 +525,7 @@ def _resolve_import_event_mappings(
     program: dsl_nodes.StateMachineDSLProgram,
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> Dict[Tuple[str, ...], _ResolvedImportEventMapping]:
     event_mappings = [
         item
@@ -515,7 +537,7 @@ def _resolve_import_event_mappings(
 
     for mapping in event_mappings:
         if not mapping.source_event.is_absolute:
-            _emit_import_diag(None, 
+            _emit_import_diag(sink, 
                 'E_IMPORT_MAPPING_INVALID',
                 f"Invalid event mapping in import {import_item.alias!r} under state "
                 f"{'.'.join(owner_state_path)!r}: source event {mapping.source_event} "
@@ -535,9 +557,10 @@ def _resolve_import_event_mappings(
         ) = _resolve_import_event_target_path(
             target_event=mapping.target_event,
             owner_state_path=owner_state_path,
+            sink=sink,
         )
         if source_path in resolved:
-            _emit_import_diag(None, 
+            _emit_import_diag(sink, 
                 'E_IMPORT_DUPLICATE_MAPPING',
                 f"Event mapping conflict: source event "
                 f"{_format_event_path(source_path, is_absolute=True)!r} appears "
@@ -550,7 +573,7 @@ def _resolve_import_event_mappings(
             )
         target_key = (*target_state_path, target_event_name)
         if target_key in target_to_source and target_to_source[target_key] != source_path:
-            _emit_import_diag(None, 
+            _emit_import_diag(sink, 
                 'E_IMPORT_DUPLICATE_MAPPING',
                 f"Event mapping conflict: import {import_item.alias!r} maps multiple "
                 f"module events to the same host event "
@@ -577,10 +600,11 @@ def _resolve_import_event_mappings(
 def _resolve_import_event_target_path(
     target_event: dsl_nodes.ChainID,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> Tuple[Tuple[str, ...], str, Tuple[str, ...]]:
     if target_event.is_absolute:
         if len(target_event.path) < 1:
-            _emit_import_diag(None, 
+            _emit_import_diag(sink, 
                 'E_IMPORT_MAPPING_INVALID',
                 "Invalid empty absolute target event path.",
                 mapping_kind='event',
@@ -596,7 +620,7 @@ def _resolve_import_event_target_path(
         )
     else:
         if len(target_event.path) < 1:
-            _emit_import_diag(None, 
+            _emit_import_diag(sink, 
                 'E_IMPORT_MAPPING_INVALID',
                 "Invalid empty relative target event path.",
                 mapping_kind='event',
@@ -616,6 +640,7 @@ def _apply_import_event_mappings(
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
     resolved_event_mappings: Dict[Tuple[str, ...], _ResolvedImportEventMapping],
+    sink: DiagnosticSink,
 ) -> set:
     source_event_names = {}
     _collect_event_extra_names(program.root_state, current_path=(), output=source_event_names)
@@ -636,10 +661,12 @@ def _apply_import_event_mappings(
         registrations=pending_registrations,
         import_item=import_item,
         owner_state_path=owner_state_path,
+        sink=sink,
     )
     _synthesize_host_events_for_import(
         host_root=host_program.root_state,
         registrations=pending_registrations,
+        sink=sink,
     )
     return {
         tuple(item.target_state_path[1:]) + (item.target_event_name,)
@@ -770,6 +797,7 @@ def _validate_pending_event_registrations(
     registrations: List[_PendingEventRegistration],
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> None:
     by_target = {}
     for item in registrations:
@@ -781,7 +809,7 @@ def _validate_pending_event_registrations(
         existing = by_target[target_key]
         if item.mapping_extra_name is not None and existing.mapping_extra_name is not None:
             if item.mapping_extra_name != existing.mapping_extra_name:
-                _emit_import_diag(None, 
+                _emit_import_diag(sink, 
                     'E_IMPORT_DUPLICATE_MAPPING',
                     f"Event mapping conflict: host event "
                     f"{_format_event_path(target_key, is_absolute=True)!r} "
@@ -800,6 +828,7 @@ def _validate_pending_event_registrations(
 def _synthesize_host_events_for_import(
     host_root: dsl_nodes.StateDefinition,
     registrations: List[_PendingEventRegistration],
+    sink: DiagnosticSink,
 ) -> None:
     if not registrations:
         return
@@ -808,6 +837,7 @@ def _synthesize_host_events_for_import(
         owner_state = _ensure_state_path_exists(
             root=host_root,
             state_path=item.target_state_path,
+            sink=sink,
         )
         event_name = item.target_event_name
         existing_event = None
@@ -831,7 +861,7 @@ def _synthesize_host_events_for_import(
                 and existing_event.extra_name is not None
                 and existing_event.extra_name != item.mapping_extra_name
             ):
-                _emit_import_diag(None, 
+                _emit_import_diag(sink, 
                     'E_IMPORT_DUPLICATE_MAPPING',
                     f"Event mapping conflict: host event "
                     f"{_format_event_path((*item.target_state_path, event_name), is_absolute=True)!r} "
@@ -850,10 +880,11 @@ def _synthesize_host_events_for_import(
 def _ensure_state_path_exists(
     root: dsl_nodes.StateDefinition,
     state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> dsl_nodes.StateDefinition:
     if not state_path:
         _emit_import_diag(
-            None,
+            sink,
             'E_IMPORT_MAPPING_INVALID',
             "Invalid empty host state path for event mapping.",
             mapping_kind='event',
@@ -861,7 +892,7 @@ def _ensure_state_path_exists(
         )
     if root.name != state_path[0]:
         _emit_import_diag(
-            None,
+            sink,
             'E_IMPORT_MAPPING_INVALID',
             f"Invalid host root path for event mapping: expected root {root.name!r}, "
             f"got {state_path[0]!r}.",
@@ -879,7 +910,7 @@ def _ensure_state_path_exists(
                 break
         if next_state is None:
             _emit_import_diag(
-                None,
+                sink,
                 'E_IMPORT_MAPPING_INVALID',
                 f"Event mapping target state "
                 f"{_format_event_path(state_path, is_absolute=True)!r} does not exist "
@@ -901,6 +932,7 @@ def _apply_import_def_mappings(
     program: dsl_nodes.StateMachineDSLProgram,
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> None:
     def_mappings = [
         item
@@ -928,13 +960,14 @@ def _apply_import_def_mappings(
             mappings=def_mappings,
             import_item=import_item,
             owner_state_path=owner_state_path,
+            sink=sink,
         )
         if (
             target_name in target_to_source
             and target_to_source[target_name] != def_item.name
         ):
             _emit_import_diag(
-                None,
+                sink,
                 'E_IMPORT_DUPLICATE_MAPPING',
                 f"Variable mapping conflict: import {import_item.alias!r} maps "
                 f"multiple source variables to the same target variable "
@@ -962,6 +995,7 @@ def _merge_imported_definitions(
     host_explicit_def_names,
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> None:
     existing_definitions = {item.name: item for item in host_program.definitions}
     for def_item in imported_program.definitions:
@@ -974,7 +1008,7 @@ def _merge_imported_definitions(
         if existing_item.type != def_item.type:
             if def_item.name in host_explicit_def_names:
                 _emit_import_diag(
-                    None,
+                    sink,
                     'E_IMPORT_DUPLICATE_MAPPING',
                     f"Variable mapping conflict: target variable {def_item.name!r} "
                     f"already exists in host model as type {existing_item.type!r}, "
@@ -987,7 +1021,7 @@ def _merge_imported_definitions(
                 )
             else:
                 _emit_import_diag(
-                    None,
+                    sink,
                     'E_IMPORT_DUPLICATE_MAPPING',
                     f"Variable mapping conflict: target variable {def_item.name!r} "
                     f"receives incompatible imported types {existing_item.type!r} "
@@ -1004,7 +1038,7 @@ def _merge_imported_definitions(
 
         if existing_item.expr != def_item.expr:
             _emit_import_diag(
-                None,
+                sink,
                 'E_IMPORT_DUPLICATE_MAPPING',
                 f"Variable mapping conflict: target variable {def_item.name!r} has "
                 f"conflicting initial values.",
@@ -1023,6 +1057,7 @@ def _resolve_import_variable_target(
     mappings: List[dsl_nodes.ImportDefMapping],
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> str:
     exact_rules = []
     set_rules = []
@@ -1036,7 +1071,7 @@ def _resolve_import_variable_target(
         if isinstance(selector, dsl_nodes.ImportDefExactSelector):
             if selector.name in seen_exact_names:
                 _emit_import_diag(
-                    None,
+                    sink,
                     'E_IMPORT_DUPLICATE_MAPPING',
                     f"Variable mapping conflict: duplicated exact selector "
                     f"{selector.name!r} in import {import_item.alias!r}.",
@@ -1052,7 +1087,7 @@ def _resolve_import_variable_target(
             for item in selector.names:
                 if item in local_names:
                     _emit_import_diag(
-                        None,
+                        sink,
                         'E_IMPORT_DUPLICATE_MAPPING',
                         f"Variable mapping conflict: duplicated selector name "
                         f"{item!r} inside set rule in import {import_item.alias!r}.",
@@ -1063,7 +1098,7 @@ def _resolve_import_variable_target(
                     )
                 if item in seen_set_names:
                     _emit_import_diag(
-                        None,
+                        sink,
                         'E_IMPORT_DUPLICATE_MAPPING',
                         f"Variable mapping conflict: selector name {item!r} appears "
                         f"in multiple set rules in import {import_item.alias!r}.",
@@ -1084,7 +1119,7 @@ def _resolve_import_variable_target(
 
     if len(fallback_rules) > 1:
         _emit_import_diag(
-            None,
+            sink,
             'E_IMPORT_DUPLICATE_MAPPING',
             f"Variable mapping conflict: multiple fallback rules found in import "
             f"{import_item.alias!r}.",
@@ -1106,6 +1141,7 @@ def _resolve_import_variable_target(
             captures=[],
             import_item=import_item,
             owner_state_path=owner_state_path,
+            sink=sink,
         )
 
     set_matches = [
@@ -1115,7 +1151,7 @@ def _resolve_import_variable_target(
     ]
     if len(set_matches) > 1:
         _emit_import_diag(
-            None,
+            sink,
             'E_IMPORT_DUPLICATE_MAPPING',
             f"Variable mapping conflict: selector name {source_name!r} matches "
             f"multiple set rules in import {import_item.alias!r}.",
@@ -1131,6 +1167,7 @@ def _resolve_import_variable_target(
             captures=[],
             import_item=import_item,
             owner_state_path=owner_state_path,
+            sink=sink,
         )
 
     pattern_matches = []
@@ -1140,7 +1177,7 @@ def _resolve_import_variable_target(
             pattern_matches.append((item, captures))
     if len(pattern_matches) > 1:
         _emit_import_diag(
-            None,
+            sink,
             'E_IMPORT_DUPLICATE_MAPPING',
             f"Variable mapping conflict: source variable {source_name!r} matches "
             f"multiple pattern rules in import {import_item.alias!r}.",
@@ -1157,6 +1194,7 @@ def _resolve_import_variable_target(
             captures=captures,
             import_item=import_item,
             owner_state_path=owner_state_path,
+            sink=sink,
         )
 
     if fallback_rules:
@@ -1166,10 +1204,11 @@ def _resolve_import_variable_target(
             captures=[],
             import_item=import_item,
             owner_state_path=owner_state_path,
+            sink=sink,
         )
 
     _emit_import_diag(
-        None,
+        sink,
         'E_IMPORT_MAPPING_INVALID',
         f"Variable mapping conflict: source variable {source_name!r} in import "
         f"{import_item.alias!r} under state {'.'.join(owner_state_path)!r} is not "
@@ -1197,6 +1236,7 @@ def _render_target_template(
     captures: List[str],
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> str:
     rendered = []
     i = 0
@@ -1206,7 +1246,7 @@ def _render_target_template(
                 end_index = template.find("}", i + 2)
                 if end_index < 0:
                     _emit_import_diag(
-                        None,
+                        sink,
                         'E_IMPORT_MAPPING_INVALID',
                         f"Invalid variable mapping template {template!r} in import "
                         f"{import_item.alias!r}: missing closing '}}'.",
@@ -1218,7 +1258,7 @@ def _render_target_template(
                 raw_index = template[i + 2:end_index]
                 if not raw_index.isdigit():
                     _emit_import_diag(
-                        None,
+                        sink,
                         'E_IMPORT_MAPPING_INVALID',
                         f"Invalid variable mapping template {template!r} in import "
                         f"{import_item.alias!r}: placeholder index {raw_index!r} "
@@ -1236,6 +1276,7 @@ def _render_target_template(
                         template=template,
                         import_item=import_item,
                         owner_state_path=owner_state_path,
+                        sink=sink,
                     )
                 )
                 i = end_index + 1
@@ -1249,6 +1290,7 @@ def _render_target_template(
                         template=template,
                         import_item=import_item,
                         owner_state_path=owner_state_path,
+                        sink=sink,
                     )
                 )
                 i += 2
@@ -1257,7 +1299,7 @@ def _render_target_template(
         if template[i] == "*":
             if len(captures) > 1:
                 _emit_import_diag(
-                    None,
+                    sink,
                     'E_IMPORT_MAPPING_INVALID',
                     f"Invalid variable mapping template {template!r} in import "
                     f"{import_item.alias!r}: bare '*' is ambiguous when the source "
@@ -1284,6 +1326,7 @@ def _mapping_placeholder_value(
     template: str,
     import_item: dsl_nodes.ImportStatement,
     owner_state_path: Tuple[str, ...],
+    sink: DiagnosticSink,
 ) -> str:
     if index == 0:
         return source_name
@@ -1291,7 +1334,7 @@ def _mapping_placeholder_value(
         return captures[index - 1]
     else:
         _emit_import_diag(
-            None,
+            sink,
             'E_IMPORT_MAPPING_INVALID',
             f"Invalid variable mapping template {template!r} in import "
             f"{import_item.alias!r} under state {'.'.join(owner_state_path)!r}: "

--- a/pyfcstm/model/imports.py
+++ b/pyfcstm/model/imports.py
@@ -295,11 +295,13 @@ def _assemble_state(
         # mode (``DiagnosticSink(collect=False)``) the first emit raises
         # :class:`ModelValidationError`; in collect mode the diagnostics
         # accumulate on the sink and each helper continues past
-        # individual errors. We still wrap the call sequence in a safety
-        # net so structural follow-up failures (e.g. ``AttributeError``
-        # / ``TypeError`` triggered by the corrupt state left over from
-        # an accumulated error in collect mode) skip this import
-        # cleanly instead of poisoning the host program.
+        # individual errors via explicit ``return``/``continue`` paths
+        # (see ``_resolve_import_event_target_path`` and
+        # ``_ensure_state_path_exists`` for the sentinel-return form).
+        # Only the ``ModelValidationError`` branch remains below as a
+        # belt-and-braces guard; the previous AttributeError /
+        # TypeError / KeyError / IndexError safety net was removed by
+        # I1 (PR #116 re-review) once every helper became sink-aware.
         try:
             _apply_import_def_mappings(
                 program=imported_program,

--- a/pyfcstm/model/imports.py
+++ b/pyfcstm/model/imports.py
@@ -187,10 +187,17 @@ def _assemble_program(
     sink: DiagnosticSink,
 ) -> None:
     if program.root_state is None:
+        # Top-level entry program has no root state. The user-fed
+        # file is treated as a degenerate import for diagnostic
+        # purposes — there is no enclosing alias/host_state_path.
+        entry_source = import_stack[0] if import_stack else '<entry>'
         _emit_import_diag(
             sink,
             'E_IMPORT_NOT_FOUND',
             "State machine DSL program does not contain a root state.",
+            source_path=entry_source,
+            alias='',
+            host_state_path='',
             reason='no_root_state',
         )
         # In collect mode we cannot proceed without a root state — the
@@ -557,6 +564,7 @@ def _resolve_import_event_mappings(
         ) = _resolve_import_event_target_path(
             target_event=mapping.target_event,
             owner_state_path=owner_state_path,
+            alias=import_item.alias,
             sink=sink,
         )
         if source_path in resolved:
@@ -600,13 +608,15 @@ def _resolve_import_event_mappings(
 def _resolve_import_event_target_path(
     target_event: dsl_nodes.ChainID,
     owner_state_path: Tuple[str, ...],
+    alias: str,
     sink: DiagnosticSink,
 ) -> Tuple[Tuple[str, ...], str, Tuple[str, ...]]:
     if target_event.is_absolute:
         if len(target_event.path) < 1:
-            _emit_import_diag(sink, 
+            _emit_import_diag(sink,
                 'E_IMPORT_MAPPING_INVALID',
                 "Invalid empty absolute target event path.",
+                alias=alias,
                 mapping_kind='event',
                 host_state_path='.'.join(owner_state_path),
                 reason='empty_path',
@@ -620,9 +630,10 @@ def _resolve_import_event_target_path(
         )
     else:
         if len(target_event.path) < 1:
-            _emit_import_diag(sink, 
+            _emit_import_diag(sink,
                 'E_IMPORT_MAPPING_INVALID',
                 "Invalid empty relative target event path.",
+                alias=alias,
                 mapping_kind='event',
                 host_state_path='.'.join(owner_state_path),
                 reason='empty_path',
@@ -666,6 +677,7 @@ def _apply_import_event_mappings(
     _synthesize_host_events_for_import(
         host_root=host_program.root_state,
         registrations=pending_registrations,
+        owner_state_path=owner_state_path,
         sink=sink,
     )
     return {
@@ -828,6 +840,7 @@ def _validate_pending_event_registrations(
 def _synthesize_host_events_for_import(
     host_root: dsl_nodes.StateDefinition,
     registrations: List[_PendingEventRegistration],
+    owner_state_path: Tuple[str, ...],
     sink: DiagnosticSink,
 ) -> None:
     if not registrations:
@@ -837,6 +850,8 @@ def _synthesize_host_events_for_import(
         owner_state = _ensure_state_path_exists(
             root=host_root,
             state_path=item.target_state_path,
+            alias=item.import_alias,
+            owner_state_path=owner_state_path,
             sink=sink,
         )
         event_name = item.target_event_name
@@ -861,17 +876,19 @@ def _synthesize_host_events_for_import(
                 and existing_event.extra_name is not None
                 and existing_event.extra_name != item.mapping_extra_name
             ):
-                _emit_import_diag(sink, 
+                _emit_import_diag(sink,
                     'E_IMPORT_DUPLICATE_MAPPING',
                     f"Event mapping conflict: host event "
                     f"{_format_event_path((*item.target_state_path, event_name), is_absolute=True)!r} "
                     f"receives conflicting display names "
                     f"{existing_event.extra_name!r} and {item.mapping_extra_name!r}.",
+                    alias=item.import_alias,
                     mapping_kind='event',
                     duplicated_name=_format_event_path(
                         (*item.target_state_path, event_name), is_absolute=True
                     ),
                     direction='target_duplicated',
+                    host_state_path='.'.join(owner_state_path),
                 )
             if existing_event.extra_name is None and final_extra_name is not None:
                 existing_event.extra_name = final_extra_name
@@ -880,6 +897,8 @@ def _synthesize_host_events_for_import(
 def _ensure_state_path_exists(
     root: dsl_nodes.StateDefinition,
     state_path: Tuple[str, ...],
+    alias: str,
+    owner_state_path: Tuple[str, ...],
     sink: DiagnosticSink,
 ) -> dsl_nodes.StateDefinition:
     if not state_path:
@@ -887,8 +906,11 @@ def _ensure_state_path_exists(
             sink,
             'E_IMPORT_MAPPING_INVALID',
             "Invalid empty host state path for event mapping.",
+            alias=alias,
             mapping_kind='event',
+            host_state_path='.'.join(owner_state_path),
             reason='empty_path',
+            detail='<empty>',
         )
     if root.name != state_path[0]:
         _emit_import_diag(
@@ -896,7 +918,9 @@ def _ensure_state_path_exists(
             'E_IMPORT_MAPPING_INVALID',
             f"Invalid host root path for event mapping: expected root {root.name!r}, "
             f"got {state_path[0]!r}.",
+            alias=alias,
             mapping_kind='event',
+            host_state_path='.'.join(owner_state_path),
             reason='host_root_mismatch',
             detail=f"expected={root.name!r} got={state_path[0]!r}",
         )
@@ -915,7 +939,9 @@ def _ensure_state_path_exists(
                 f"Event mapping target state "
                 f"{_format_event_path(state_path, is_absolute=True)!r} does not exist "
                 f"in host model.",
+                alias=alias,
                 mapping_kind='event',
+                host_state_path='.'.join(owner_state_path),
                 reason='target_invalid',
                 detail=_format_event_path(state_path, is_absolute=True),
             )
@@ -1079,6 +1105,7 @@ def _resolve_import_variable_target(
                     mapping_kind='variable',
                     duplicated_name=selector.name,
                     direction='source_duplicated',
+                    host_state_path='.'.join(owner_state_path),
                 )
             seen_exact_names[selector.name] = mapping
             exact_rules.append(mapping)
@@ -1095,6 +1122,7 @@ def _resolve_import_variable_target(
                         mapping_kind='variable',
                         duplicated_name=item,
                         direction='source_duplicated',
+                        host_state_path='.'.join(owner_state_path),
                     )
                 if item in seen_set_names:
                     _emit_import_diag(
@@ -1106,6 +1134,7 @@ def _resolve_import_variable_target(
                         mapping_kind='variable',
                         duplicated_name=item,
                         direction='source_duplicated',
+                        host_state_path='.'.join(owner_state_path),
                     )
                 local_names.add(item)
                 seen_set_names[item] = mapping
@@ -1127,6 +1156,7 @@ def _resolve_import_variable_target(
             mapping_kind='variable',
             duplicated_name='<fallback>',
             direction='source_duplicated',
+            host_state_path='.'.join(owner_state_path),
         )
 
     exact_matches = [
@@ -1159,6 +1189,7 @@ def _resolve_import_variable_target(
             mapping_kind='variable',
             duplicated_name=source_name,
             direction='source_duplicated',
+            host_state_path='.'.join(owner_state_path),
         )
     if set_matches:
         return _render_target_template(
@@ -1185,6 +1216,7 @@ def _resolve_import_variable_target(
             mapping_kind='variable',
             duplicated_name=source_name,
             direction='source_duplicated',
+            host_state_path='.'.join(owner_state_path),
         )
     if pattern_matches:
         item, captures = pattern_matches[0]
@@ -1252,6 +1284,7 @@ def _render_target_template(
                         f"{import_item.alias!r}: missing closing '}}'.",
                         alias=import_item.alias,
                         mapping_kind='variable',
+                        host_state_path='.'.join(owner_state_path),
                         reason='template_invalid',
                         detail=template,
                     )
@@ -1265,6 +1298,7 @@ def _render_target_template(
                         f"is not numeric.",
                         alias=import_item.alias,
                         mapping_kind='variable',
+                        host_state_path='.'.join(owner_state_path),
                         reason='template_invalid',
                         detail=template,
                     )
@@ -1306,6 +1340,7 @@ def _render_target_template(
                     f"selector has multiple capture groups.",
                     alias=import_item.alias,
                     mapping_kind='variable',
+                    host_state_path='.'.join(owner_state_path),
                     reason='template_invalid',
                     detail=template,
                 )

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -2290,6 +2290,21 @@ def parse_dsl_node_to_state_machine(
                 },
             ))
 
+    def _collect_block_local_names(
+        op_nodes: List[dsl_nodes.OperationalStatement],
+        accum: Set[str],
+    ) -> None:
+        """Walk an operation block and record every assignment LHS name
+        whose target is NOT a file-top ``def`` — those are exactly the
+        names that look like block-local temporaries (I-i)."""
+        for op_item in op_nodes:
+            if isinstance(op_item, dsl_nodes.OperationAssignment):
+                if op_item.name not in d_defines:
+                    accum.add(op_item.name)
+            elif isinstance(op_item, dsl_nodes.OperationIf):
+                for branch in op_item.branches:
+                    _collect_block_local_names(branch.statements, accum)
+
     def _parse_operation_block(
         op_nodes: List[dsl_nodes.OperationalStatement],
         unknown_var_message: str,
@@ -2297,8 +2312,15 @@ def parse_dsl_node_to_state_machine(
         owner_node,
         available_vars: Optional[Set[str]] = None,
         state_path: Optional[str] = None,
+        block_local_names: Optional[Set[str]] = None,
     ) -> List[OperationStatement]:
         available_vars = set(available_vars or d_defines)
+        # On the outermost call (no block_local_names yet) pre-walk the
+        # block to discover all would-be block-local temps so each emit
+        # can fill the ``is_temporary`` schema flag accurately.
+        if block_local_names is None:
+            block_local_names = set()
+            _collect_block_local_names(op_nodes, block_local_names)
         operations = []
         for op_item in op_nodes:
             operations.append(
@@ -2309,6 +2331,7 @@ def parse_dsl_node_to_state_machine(
                     owner_node=owner_node,
                     available_vars=available_vars,
                     state_path=state_path,
+                    block_local_names=block_local_names,
                 )
             )
 
@@ -2321,7 +2344,9 @@ def parse_dsl_node_to_state_machine(
         owner_node,
         available_vars: Set[str],
         state_path: Optional[str] = None,
+        block_local_names: Optional[Set[str]] = None,
     ) -> OperationStatement:
+        block_local_names = block_local_names if block_local_names is not None else set()
         if isinstance(op_item, dsl_nodes.OperationAssignment):
             operation_val = parse_expr_node_to_expr(op_item.expr)
             unknown_vars = []
@@ -2330,6 +2355,14 @@ def parse_dsl_node_to_state_machine(
                     unknown_vars.append(var.name)
 
             for unknown_var in unknown_vars:
+                # I-i: ``is_temporary`` is True when this name is
+                # assigned somewhere later in the same operation block,
+                # which is the read-before-assign signature of a
+                # would-be block-local temporary. Names that are
+                # neither defined at file top nor assigned anywhere in
+                # this block are "real" undefineds and leave the flag
+                # off per schema default.
+                is_temporary = unknown_var in block_local_names
                 sink.emit(ModelDiagnostic(
                     code='E_UNDEFINED_VAR',
                     severity='error',
@@ -2343,6 +2376,7 @@ def parse_dsl_node_to_state_machine(
                         'referenced_in': referenced_in,
                         'state_path': state_path,
                         'expr_text': str(op_item.expr),
+                        'is_temporary': is_temporary,
                     },
                 ))
 
@@ -2357,6 +2391,7 @@ def parse_dsl_node_to_state_machine(
                 owner_node=owner_node,
                 available_vars=available_vars,
                 state_path=state_path,
+                block_local_names=block_local_names,
             )
         else:
             raise TypeError(f"Unknown operation statement node - {op_item!r}.")
@@ -2368,7 +2403,9 @@ def parse_dsl_node_to_state_machine(
         owner_node,
         available_vars: Set[str],
         state_path: Optional[str] = None,
+        block_local_names: Optional[Set[str]] = None,
     ) -> IfBlock:
+        block_local_names = block_local_names if block_local_names is not None else set()
         base_available_vars = set(available_vars)
         branches = []
         for branch in if_node.branches:
@@ -2383,6 +2420,8 @@ def parse_dsl_node_to_state_machine(
                     ):
                         unknown_vars.append(var.name)
                 for unknown_var in unknown_vars:
+                    # I-i: see _parse_operation_statement.
+                    is_temporary = unknown_var in block_local_names
                     sink.emit(ModelDiagnostic(
                         code='E_UNDEFINED_VAR',
                         severity='error',
@@ -2396,6 +2435,7 @@ def parse_dsl_node_to_state_machine(
                             'referenced_in': referenced_in,
                             'state_path': state_path,
                             'expr_text': str(branch.condition),
+                            'is_temporary': is_temporary,
                         },
                     ))
 
@@ -2407,6 +2447,7 @@ def parse_dsl_node_to_state_machine(
                 owner_node=owner_node,
                 available_vars=branch_available_vars,
                 state_path=state_path,
+                block_local_names=block_local_names,
             )
             branches.append(
                 IfBlockBranch(condition=condition, statements=branch_statements)

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -2329,17 +2329,17 @@ def parse_dsl_node_to_state_machine(
                 if var.name not in available_vars and var.name not in unknown_vars:
                     unknown_vars.append(var.name)
 
-            if unknown_vars:
+            for unknown_var in unknown_vars:
                 sink.emit(ModelDiagnostic(
                     code='E_UNDEFINED_VAR',
                     severity='error',
                     message=(
-                        f"{unknown_var_message} {', '.join(unknown_vars)} "
+                        f"{unknown_var_message} {unknown_var} "
                         f"in transition:\n{owner_node}"
                     ),
                     span=getattr(owner_node, '_span', None),
                     refs={
-                        'var_name': unknown_vars,
+                        'var_name': unknown_var,
                         'referenced_in': referenced_in,
                         'state_path': state_path,
                         'expr_text': str(op_item.expr),
@@ -2382,17 +2382,17 @@ def parse_dsl_node_to_state_machine(
                         and var.name not in unknown_vars
                     ):
                         unknown_vars.append(var.name)
-                if unknown_vars:
+                for unknown_var in unknown_vars:
                     sink.emit(ModelDiagnostic(
                         code='E_UNDEFINED_VAR',
                         severity='error',
                         message=(
-                            f"{unknown_var_message} {', '.join(unknown_vars)} "
+                            f"{unknown_var_message} {unknown_var} "
                             f"in transition:\n{owner_node}"
                         ),
                         span=getattr(owner_node, '_span', None),
                         refs={
-                            'var_name': unknown_vars,
+                            'var_name': unknown_var,
                             'referenced_in': referenced_in,
                             'state_path': state_path,
                             'expr_text': str(branch.condition),
@@ -2965,18 +2965,18 @@ def parse_dsl_node_to_state_machine(
                 for var in guard.list_variables():
                     if var.name not in d_defines:
                         unknown_vars.append(var.name)
-                if unknown_vars:
+                for unknown_var in unknown_vars:
                     sink.emit(ModelDiagnostic(
                         code='E_UNDEFINED_VAR',
                         severity='error',
                         message=(
                             f"Unknown guard variable "
-                            f"{', '.join(unknown_vars)} in force "
+                            f"{unknown_var} in force "
                             f"transition:\n{f_transnode}"
                         ),
                         span=getattr(f_transnode, '_span', None),
                         refs={
-                            'var_name': unknown_vars,
+                            'var_name': unknown_var,
                             'referenced_in': 'guard',
                             'state_path': '.'.join(current_path),
                             'expr_text': str(f_transnode.condition_expr),
@@ -3154,18 +3154,18 @@ def parse_dsl_node_to_state_machine(
                 for var in guard.list_variables():
                     if var.name not in d_defines:
                         unknown_vars.append(var.name)
-                if unknown_vars:
+                for unknown_var in unknown_vars:
                     sink.emit(ModelDiagnostic(
                         code='E_UNDEFINED_VAR',
                         severity='error',
                         message=(
                             f"Unknown guard variable "
-                            f"{', '.join(unknown_vars)} in "
+                            f"{unknown_var} in "
                             f"transition:\n{transnode}"
                         ),
                         span=getattr(transnode, '_span', None),
                         refs={
-                            'var_name': unknown_vars,
+                            'var_name': unknown_var,
                             'referenced_in': 'guard',
                             'state_path': '.'.join(current_path),
                             'expr_text': str(transnode.condition_expr),

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -2296,7 +2296,19 @@ def parse_dsl_node_to_state_machine(
     ) -> None:
         """Walk an operation block and record every assignment LHS name
         whose target is NOT a file-top ``def`` — those are exactly the
-        names that look like block-local temporaries (I-i)."""
+        names that look like block-local temporaries (I-i).
+
+        I5 (PR #116 re-review): this scan deliberately flattens across
+        ``if`` branches — a name assigned in branch A is treated as
+        "could be a temp" even when read in branch B's body. The
+        alternative (branch-aware analysis) would require per-path
+        reachable-assignment tracking and is more precision than the
+        ``is_temporary`` schema flag is meant to carry. Both jsfcstm
+        and pyfcstm agree on this flattened heuristic (jsfcstm's
+        ``analyzeOperationStatements`` always emits ``is_temporary:
+        true`` for operation-block reads), so the flag stays
+        cross-end consistent at the cost of cross-branch precision.
+        """
         for op_item in op_nodes:
             if isinstance(op_item, dsl_nodes.OperationAssignment):
                 if op_item.name not in d_defines:

--- a/test/diagnostics/_schema_check.py
+++ b/test/diagnostics/_schema_check.py
@@ -1,0 +1,109 @@
+"""
+Schema-payload checker for diagnostics emitted by pyfcstm.
+
+I-e from PR #115 review: parity tests historically only compared the
+emitted code set across pyfcstm/jsfcstm, leaving room for schema↔emit
+drift to land silently (C-A/B/C/D were exactly this). This helper is
+the mechanical guard against future drift.
+
+The check is single-source-of-truth driven: it pulls field declarations
+from :data:`pyfcstm.diagnostics.CODE_REGISTRY`, which is loaded from
+``pyfcstm/diagnostics/codes.yaml`` at import time. Every assertion that
+fires here corresponds to a violation of that YAML.
+"""
+
+from typing import Iterable, Optional
+
+from pyfcstm.diagnostics import CODE_REGISTRY
+from pyfcstm.diagnostics.codes import CodeFieldSpec
+from pyfcstm.utils import ModelDiagnostic
+
+
+_TYPE_PREDICATES = {
+    'str': lambda v: isinstance(v, str),
+    'int': lambda v: isinstance(v, int) and not isinstance(v, bool),
+    'float': lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    'bool': lambda v: isinstance(v, bool),
+    'list[str]': lambda v: isinstance(v, list) and all(isinstance(item, str) for item in v),
+    'Span': lambda v: v is None or hasattr(v, 'line'),
+    'str_or_null': lambda v: v is None or isinstance(v, str),
+    'int_or_null': lambda v: v is None or (isinstance(v, int) and not isinstance(v, bool)),
+}
+
+
+def _type_ok(value, type_token: str) -> bool:
+    predicate = _TYPE_PREDICATES.get(type_token)
+    if predicate is None:
+        # Unknown type token — fall back to always-pass so the helper
+        # stays forward-compatible. The yaml-schema test is the place
+        # that catches new type tokens not in this table.
+        return True
+    return predicate(value)
+
+
+def assert_refs_match_schema(diag: ModelDiagnostic, *, context: str = '') -> None:
+    """Assert that ``diag.refs`` conforms to the schema declared for
+    ``diag.code`` in ``codes.yaml``.
+
+    Checks performed:
+
+    1. Every key in ``refs`` is declared in the schema (no extras).
+    2. Every required schema field is present and non-None in ``refs``.
+    3. If the field declares an ``enum``, the actual value is a member.
+    4. The actual value's runtime type matches the schema's ``type``
+       token (``str`` / ``int`` / ``list[str]`` / ``str_or_null`` etc.).
+
+    :param diag: Diagnostic to validate.
+    :type diag: pyfcstm.utils.ModelDiagnostic
+    :param context: Optional context string prefixed onto every failure
+        message — typically the fixture or test name.
+    :type context: str, optional
+    :raises AssertionError: If any of the checks above fails.
+    """
+    prefix = f'{context}: ' if context else ''
+    spec = CODE_REGISTRY.get(diag.code)
+    assert spec is not None, f'{prefix}unknown code {diag.code!r}'
+
+    declared = set(spec.refs_schema.keys())
+    actual = set(diag.refs.keys())
+    extra = actual - declared
+    assert not extra, (
+        f'{prefix}{diag.code} refs has undeclared keys {extra} '
+        f'(declared={sorted(declared)})'
+    )
+
+    for field_name in spec.required_fields():
+        assert field_name in diag.refs, (
+            f'{prefix}{diag.code} refs missing required key {field_name!r}'
+        )
+        assert diag.refs[field_name] is not None, (
+            f'{prefix}{diag.code} refs[{field_name!r}] is required '
+            f'but value is None'
+        )
+
+    for field_name, field_spec in spec.refs_schema.items():
+        if field_name not in diag.refs:
+            continue
+        value = diag.refs[field_name]
+
+        if field_spec.enum:
+            allowed = set(field_spec.enum)
+            assert value in allowed, (
+                f'{prefix}{diag.code} refs[{field_name!r}] = {value!r} '
+                f'not in declared enum {sorted(allowed)}'
+            )
+
+        assert _type_ok(value, field_spec.type), (
+            f'{prefix}{diag.code} refs[{field_name!r}] = {value!r} '
+            f'has runtime type {type(value).__name__}, expected schema '
+            f'type {field_spec.type!r}'
+        )
+
+
+def assert_all_diags_match_schema(
+    diagnostics: Iterable[ModelDiagnostic], *, context: str = '',
+) -> None:
+    """Apply :func:`assert_refs_match_schema` to every diagnostic in
+    ``diagnostics``."""
+    for diag in diagnostics:
+        assert_refs_match_schema(diag, context=context)

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -586,3 +586,58 @@ def test_undefined_var_is_temporary_false_when_no_later_assignment():
             f'real undefined (no later assignment) should have is_temporary=False; '
             f'refs={d.refs}'
         )
+
+
+@pytest.mark.unittest
+def test_lookup_api_codes_never_fire_in_static_pipeline():
+    """I-b from PR #115 review: E_EVENT_REF_INVALID / E_EVENT_NOT_FOUND
+    are marked ``emit_tier: lookup_api`` because they only fire when a
+    caller invokes ``State.resolve_event`` / ``StateMachine.resolve_event``
+    explicitly. The static pipeline (``parse_dsl_node_to_state_machine``)
+    must never produce them. This test pins that contract: even when
+    we exercise every single-file showcase fixture in collect mode,
+    none of the lookup_api codes appear.
+    """
+    from pyfcstm.diagnostics import CODE_REGISTRY
+
+    lookup_api_codes = {
+        code
+        for code, spec in CODE_REGISTRY.items()
+        if spec.emit_tier == 'lookup_api'
+    }
+    assert lookup_api_codes, 'expected at least one lookup_api code in registry'
+
+    for name, dsl, _ in SINGLE_FILE_FIXTURES:
+        codes, _, _ = _collect_codes_from_dsl(dsl)
+        bad = [c for c in codes if c in lookup_api_codes]
+        assert not bad, (
+            f'fixture {name}: static pipeline emitted lookup_api code(s) {bad}; '
+            f'these codes must only surface through ``resolve_event`` API calls.'
+        )
+
+
+@pytest.mark.unittest
+def test_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
+    """I-b sibling: E_TYPE_MISMATCH is currently ``emit_tier:
+    partial_static_pipeline`` — jsfcstm has an analyzer that emits it
+    on type-confused expressions, pyfcstm has no such analyzer. This
+    test pins the "pyfcstm doesn't fire it" half so downstream
+    consumers know not to expect it from the Python side.
+    """
+    from pyfcstm.diagnostics import CODE_REGISTRY
+
+    partial_codes = {
+        code
+        for code, spec in CODE_REGISTRY.items()
+        if spec.emit_tier == 'partial_static_pipeline'
+    }
+    if not partial_codes:
+        pytest.skip('no partial_static_pipeline codes declared')
+
+    for name, dsl, _ in SINGLE_FILE_FIXTURES:
+        codes, _, _ = _collect_codes_from_dsl(dsl)
+        leaked = [c for c in codes if c in partial_codes]
+        assert not leaked, (
+            f'fixture {name}: pyfcstm emitted partial_static_pipeline code(s) {leaked}; '
+            f'these are currently implemented only on jsfcstm.'
+        )

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -33,6 +33,8 @@ from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.utils.validate import ModelDiagnostic
 
+from ._schema_check import assert_all_diags_match_schema
+
 
 def _collect_codes_from_dsl(dsl: str, *, base_dir=None):
     """Parse a DSL string in collect mode and return the emitted code
@@ -50,7 +52,7 @@ def _collect_codes_from_dsl(dsl: str, *, base_dir=None):
     )
     model, diagnostics = result
     codes = [d.code for d in diagnostics]
-    return codes, model
+    return codes, model, diagnostics
 
 
 def _collect_codes_from_file(path: str):
@@ -296,7 +298,7 @@ MULTI_FILE_FIXTURES = [
     item[0] for item in SINGLE_FILE_FIXTURES
 ])
 def test_single_file_fixture_emits_expected_codes(name, dsl, must_fire):
-    codes, _ = _collect_codes_from_dsl(dsl)
+    codes, _, diagnostics = _collect_codes_from_dsl(dsl)
     tally = {}
     for code in codes:
         tally[code] = tally.get(code, 0) + 1
@@ -305,6 +307,11 @@ def test_single_file_fixture_emits_expected_codes(name, dsl, must_fire):
             f'{name}: expected {expected} to fire, got {codes}'
         )
         tally[expected] -= 1
+    # I-e mechanical safeguard: every emitted diagnostic's refs
+    # payload must conform to ``codes.yaml`` (required fields present,
+    # enum values in range, runtime types match). This is the parity
+    # test that would have caught C-A/B/C/D before merge.
+    assert_all_diags_match_schema(diagnostics, context=name)
 
 
 @pytest.mark.unittest
@@ -317,11 +324,12 @@ def test_multi_file_fixture_emits_expected_codes(name, files, entry, must_fire, 
         path.write_text(body, encoding='utf-8')
 
     entry_path = str(tmp_path / entry)
-    codes, _ = _collect_codes_from_file(entry_path)
+    codes, _, diagnostics = _collect_codes_from_file(entry_path)
     for expected in must_fire:
         assert expected in codes, (
             f'{name}: expected {expected} to fire, got {codes}'
         )
+    assert_all_diags_match_schema(diagnostics, context=name)
 
 
 @pytest.mark.unittest
@@ -423,7 +431,7 @@ def test_undefined_var_emits_per_identifier():
         '    A -> B : if [foo > 0 && bar < 10 && baz == 0];',
         '}',
     ])
-    codes, _ = _collect_codes_from_dsl(dsl)
+    codes, _, _ = _collect_codes_from_dsl(dsl)
     assert codes.count('E_UNDEFINED_VAR') == 3, (
         f'expected one E_UNDEFINED_VAR per undefined identifier '
         f'(foo/bar/baz), got {codes}'

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -441,3 +441,57 @@ def test_undefined_var_emits_per_identifier():
             f'refs.var_name must be str per schema, got '
             f'{type(d.refs["var_name"]).__name__}={d.refs["var_name"]!r}'
         )
+
+
+@pytest.mark.unittest
+def test_import_mapping_collect_mode_accumulates_multiple_errors(tmp_path):
+    """C-E from PR #115 R2.C4 / R1.C2: in collect mode, multiple
+    mapping errors inside a *single* import statement must accumulate
+    on the sink, not get truncated to the first one.
+
+    Before the fix, ``imports.py`` wrapped the four mapping helpers in
+    a single ``try/except ModelValidationError`` which forwarded only
+    the FIRST raised diagnostic per import. The mapping pipeline was
+    effectively fail-fast inside an import, contradicting the
+    docstring promise that ``execution continues — the import pipeline
+    is expected to ``continue`` past the offending step``.
+    """
+    worker = tmp_path / 'worker.fcstm'
+    worker.write_text(
+        '\n'.join([
+            'def int sensor_a = 0;',
+            'def int sensor_b = 0;',
+            'def int sensor_c = 0;',
+            'state Worker;',
+        ]),
+        encoding='utf-8',
+    )
+    host = tmp_path / 'host.fcstm'
+    # Three independent duplicate-mapping errors in one import block.
+    host.write_text(
+        '\n'.join([
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '    import "./worker.fcstm" as W {',
+            '        def sensor_a -> io_x;',
+            '        def sensor_a -> io_x;',
+            '        def sensor_b -> io_y;',
+            '        def sensor_b -> io_y;',
+            '        def sensor_c -> io_z;',
+            '        def sensor_c -> io_z;',
+            '    }',
+            '}',
+        ]),
+        encoding='utf-8',
+    )
+    with open(host, 'r', encoding='utf-8') as f:
+        ast = parse_with_grammar_entry(f.read(), 'state_machine_dsl')
+    _, diagnostics = parse_dsl_node_to_state_machine(
+        ast, path=str(host), collect=True,
+    )
+    dup_codes = [d.code for d in diagnostics if d.code == 'E_IMPORT_DUPLICATE_MAPPING']
+    assert len(dup_codes) >= 2, (
+        f'expected at least 2 E_IMPORT_DUPLICATE_MAPPING diagnostics in collect mode, '
+        f'got codes={[d.code for d in diagnostics]}'
+    )

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -206,6 +206,28 @@ SINGLE_FILE_FIXTURES = [
         ]),
         ['E_FORCED_TRANSITION_EXPANSION'],
     ),
+    # I-h: mirror jsfcstm fixture 11-temporary-read-before-assign.
+    # ``tracker`` and ``compute_me`` are not declared at file top, so
+    # the first read of ``compute_me`` (on the right-hand side of the
+    # first assignment) fires E_UNDEFINED_VAR with ``is_temporary=True``
+    # — the schema flag distinguishing read-before-assign of a
+    # would-be block-local temp from a read of a genuinely undefined
+    # identifier.
+    (
+        'temporary-read-before-assign',
+        '\n'.join([
+            'state Root {',
+            '    state Idle {',
+            '        enter {',
+            '            tracker = compute_me + 1;',
+            '            compute_me = tracker * 2;',
+            '        }',
+            '    }',
+            '    [*] -> Idle;',
+            '}',
+        ]),
+        ['E_UNDEFINED_VAR'],
+    ),
 ]
 
 
@@ -503,3 +525,64 @@ def test_import_mapping_collect_mode_accumulates_multiple_errors(tmp_path):
         f'expected at least 2 E_IMPORT_DUPLICATE_MAPPING diagnostics in collect mode, '
         f'got codes={[d.code for d in diagnostics]}'
     )
+
+
+@pytest.mark.unittest
+def test_undefined_var_carries_is_temporary_flag():
+    """I-i from PR #115 review: a read-before-assign of a name that
+    has no file-top ``def`` is semantically a would-be block-local
+    temporary that was never written. ``refs.is_temporary=True``
+    distinguishes this case from a read of a genuinely undefined
+    identifier so downstream LLM consumers can branch on the flag.
+    """
+    dsl = '\n'.join([
+        'state Root {',
+        '    state Idle {',
+        '        enter {',
+        '            tracker = compute_me + 1;',
+        '            compute_me = tracker * 2;',
+        '        }',
+        '    }',
+        '    [*] -> Idle;',
+        '}',
+    ])
+    _, _, diagnostics = _collect_codes_from_dsl(dsl)
+    undef_diags = [d for d in diagnostics if d.code == 'E_UNDEFINED_VAR']
+    assert undef_diags, f'expected E_UNDEFINED_VAR to fire, got {[d.code for d in diagnostics]}'
+    for d in undef_diags:
+        assert d.refs.get('is_temporary') is True, (
+            f'expected is_temporary=True (var has no file-top def), '
+            f'got refs={d.refs}'
+        )
+
+
+@pytest.mark.unittest
+def test_undefined_var_is_temporary_false_when_no_later_assignment():
+    """The complementary half of I-i: a read of a name that is neither
+    a file-top ``def`` nor assigned anywhere later in the same block is
+    a "real" undefined identifier, NOT a would-be temp. The flag must
+    be ``False`` (or absent) so the LLM can give different fix advice
+    (declare a def vs. assign before read).
+    """
+    dsl = '\n'.join([
+        'state Root {',
+        '    state Idle {',
+        '        enter {',
+        '            tracker = nowhere_else + 1;',
+        '        }',
+        '    }',
+        '    [*] -> Idle;',
+        '}',
+    ])
+    _, _, diagnostics = _collect_codes_from_dsl(dsl)
+    undef_diags = [d for d in diagnostics if d.code == 'E_UNDEFINED_VAR']
+    assert undef_diags
+    # ``nowhere_else`` is the unknown identifier; it has no file-top
+    # def and is not assigned later in this block.
+    nowhere_diags = [d for d in undef_diags if d.refs.get('var_name') == 'nowhere_else']
+    assert nowhere_diags, f'expected diag for "nowhere_else", got {[d.refs for d in undef_diags]}'
+    for d in nowhere_diags:
+        assert d.refs.get('is_temporary') is False, (
+            f'real undefined (no later assignment) should have is_temporary=False; '
+            f'refs={d.refs}'
+        )

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -397,3 +397,47 @@ def test_collect_mode_accumulates_import_and_model_errors(tmp_path):
     # neither aborted the other.
     assert 'E_IMPORT_NOT_FOUND' in codes
     assert 'E_DANGLING_TRANSITION' in codes
+
+
+@pytest.mark.unittest
+def test_undefined_var_emits_per_identifier():
+    """``E_UNDEFINED_VAR`` must emit one diagnostic per undefined
+    identifier, and ``refs['var_name']`` must be a ``str`` — not a list.
+
+    The schema (``pyfcstm/diagnostics/codes.yaml``) declares
+    ``var_name: type: str, required: true``. Bundling multiple unknown
+    names into a list violates the schema type contract and diverges
+    from jsfcstm, which emits one diagnostic per identifier so VSCode
+    can highlight each one independently.
+
+    This fixture has three undefined identifiers inside a *single*
+    guard expression — the only way to surface the difference between
+    list-emit and per-identifier-emit behaviour.
+    """
+    dsl = '\n'.join([
+        'def int counter = 0;',
+        'state Root {',
+        '    state A;',
+        '    state B;',
+        '    [*] -> A;',
+        '    A -> B : if [foo > 0 && bar < 10 && baz == 0];',
+        '}',
+    ])
+    codes, _ = _collect_codes_from_dsl(dsl)
+    assert codes.count('E_UNDEFINED_VAR') == 3, (
+        f'expected one E_UNDEFINED_VAR per undefined identifier '
+        f'(foo/bar/baz), got {codes}'
+    )
+
+    ast = parse_with_grammar_entry(dsl, 'state_machine_dsl')
+    _, diagnostics = parse_dsl_node_to_state_machine(ast, collect=True)
+    undef_diags = [d for d in diagnostics if d.code == 'E_UNDEFINED_VAR']
+    var_names = sorted(d.refs['var_name'] for d in undef_diags)
+    assert var_names == ['bar', 'baz', 'foo'], (
+        f'expected per-identifier var_name values, got {var_names}'
+    )
+    for d in undef_diags:
+        assert isinstance(d.refs['var_name'], str), (
+            f'refs.var_name must be str per schema, got '
+            f'{type(d.refs["var_name"]).__name__}={d.refs["var_name"]!r}'
+        )

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -589,6 +589,42 @@ def test_undefined_var_is_temporary_false_when_no_later_assignment():
 
 
 @pytest.mark.unittest
+def test_is_temporary_flattens_across_if_branches():
+    """I5 lockdown (PR #116 re-review): a name assigned in one
+    ``if`` branch but read in another is reported with
+    ``is_temporary=True`` — the heuristic is intentionally flattened
+    across branches, matching jsfcstm's
+    ``analyzeOperationStatements`` behaviour. A future tightening to
+    per-path precision would diverge the two ends, so this test pins
+    the current contract."""
+    dsl = '\n'.join([
+        'state Root {',
+        '    state Idle {',
+        '        enter {',
+        '            if [1 > 0] { x = 1; }',
+        '            else { y = x + 1; }',
+        '        }',
+        '    }',
+        '    [*] -> Idle;',
+        '}',
+    ])
+    _, _, diagnostics = _collect_codes_from_dsl(dsl)
+    x_reads = [
+        d for d in diagnostics
+        if d.code == 'E_UNDEFINED_VAR' and d.refs.get('var_name') == 'x'
+    ]
+    assert x_reads, (
+        f'expected E_UNDEFINED_VAR for "x" in else branch, '
+        f'got {[d.refs for d in diagnostics]}'
+    )
+    for d in x_reads:
+        assert d.refs.get('is_temporary') is True, (
+            f'x is assigned in the if-branch sibling; the flag should '
+            f'flatten across branches per docstring; refs={d.refs}'
+        )
+
+
+@pytest.mark.unittest
 def test_lookup_api_codes_never_fire_in_static_pipeline():
     """I-b from PR #115 review: E_EVENT_REF_INVALID / E_EVENT_NOT_FOUND
     are marked ``emit_tier: lookup_api`` because they only fire when a

--- a/test/diagnostics/test_imports_emit_static_audit.py
+++ b/test/diagnostics/test_imports_emit_static_audit.py
@@ -1,0 +1,66 @@
+"""
+Static audit of every ``_emit_import_diag`` call site in
+``pyfcstm/model/imports.py``.
+
+I-e from PR #115 review: the runtime parity tests can only catch
+schema↔emit drift on emit paths that some fixture actually walks.
+Several import-error code paths (E_IMPORT_MAPPING_INVALID variants,
+specific E_IMPORT_DUPLICATE_MAPPING reachability) are not exercised
+by the current showcase fixtures yet exist in the source — a static
+scan over the AST is the only way to keep them honest until a fixture
+catches up.
+
+This test parses ``imports.py`` and asserts that every kwarg-style
+call to ``_emit_import_diag`` includes the schema-required ``refs``
+fields declared in ``codes.yaml``.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from pyfcstm.diagnostics import CODE_REGISTRY
+
+IMPORTS_PY = Path(__file__).resolve().parents[2] / 'pyfcstm' / 'model' / 'imports.py'
+
+
+def _audit_imports_emits():
+    tree = ast.parse(IMPORTS_PY.read_text(encoding='utf-8'))
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == '_emit_import_diag'):
+            continue
+        if len(node.args) < 2:
+            continue
+        code_arg = node.args[1]
+        if not isinstance(code_arg, ast.Constant) or not isinstance(code_arg.value, str):
+            continue
+        code = code_arg.value
+        spec = CODE_REGISTRY.get(code)
+        if spec is None:
+            violations.append((node.lineno, code, 'UNKNOWN_CODE', '<no schema>'))
+            continue
+        provided = {kw.arg for kw in node.keywords if kw.arg is not None}
+        for field in spec.required_fields():
+            if field not in provided:
+                violations.append((node.lineno, code, 'MISSING_REQUIRED', field))
+    return violations
+
+
+@pytest.mark.unittest
+def test_imports_py_emits_match_schema_required_fields():
+    violations = _audit_imports_emits()
+    formatted = '\n'.join(
+        f'  imports.py:{line} {code} {kind} {detail}'
+        for line, code, kind, detail in violations
+    )
+    assert not violations, (
+        f'Found {len(violations)} schema-required-field violation(s) in '
+        f'pyfcstm/model/imports.py:\n{formatted}\n\n'
+        f'Each ``_emit_import_diag(sink, CODE, message, **kwargs)`` call must '
+        f'pass every required ``refs`` key declared for CODE in codes.yaml.'
+    )

--- a/test/diagnostics/test_imports_emit_static_audit.py
+++ b/test/diagnostics/test_imports_emit_static_audit.py
@@ -50,7 +50,14 @@ def _audit_imports_emits():
             continue
 
         code_arg = node.args[1]
-        if not isinstance(code_arg, ast.Constant) or not isinstance(code_arg.value, str):
+        # Python 3.7 returns ``_ast.Str`` for string literals; 3.8+
+        # uses ``ast.Constant``. Support both so the audit runs on
+        # the full Python version envelope this repo targets.
+        if isinstance(code_arg, ast.Constant) and isinstance(code_arg.value, str):
+            code = code_arg.value
+        elif isinstance(code_arg, getattr(ast, 'Str', tuple())):  # Python 3.7
+            code = code_arg.s
+        else:
             # I2 lockdown: dynamically constructed code arguments
             # bypass the schema audit. We reject them up-front so a
             # future refactor that introduces ``code = some_var;
@@ -59,7 +66,6 @@ def _audit_imports_emits():
             code_repr = ast.unparse(code_arg) if hasattr(ast, 'unparse') else repr(code_arg)
             violations.append((node.lineno, '<code>', 'NON_LITERAL_CODE', code_repr))
             continue
-        code = code_arg.value
         spec = CODE_REGISTRY.get(code)
         if spec is None:
             violations.append((node.lineno, code, 'UNKNOWN_CODE', '<no schema>'))

--- a/test/diagnostics/test_imports_emit_static_audit.py
+++ b/test/diagnostics/test_imports_emit_static_audit.py
@@ -36,14 +36,42 @@ def _audit_imports_emits():
             continue
         if len(node.args) < 2:
             continue
+
+        # I2 lockdown (review of PR #116): the first positional arg
+        # must be the local ``sink`` identifier (or the literal None
+        # placeholder used only inside ``_emit_import_diag`` itself —
+        # not present in actual call sites). Catching ``None`` here
+        # prevents a future refactor from re-introducing the
+        # ``_emit_import_diag(None, ...)`` pattern that C-E removed.
+        sink_arg = node.args[0]
+        if not (isinstance(sink_arg, ast.Name) and sink_arg.id == 'sink'):
+            sink_repr = ast.unparse(sink_arg) if hasattr(ast, 'unparse') else repr(sink_arg)
+            violations.append((node.lineno, '<sink>', 'INVALID_SINK_ARG', sink_repr))
+            continue
+
         code_arg = node.args[1]
         if not isinstance(code_arg, ast.Constant) or not isinstance(code_arg.value, str):
+            # I2 lockdown: dynamically constructed code arguments
+            # bypass the schema audit. We reject them up-front so a
+            # future refactor that introduces ``code = some_var;
+            # _emit_import_diag(sink, code, ...)`` cannot slip past
+            # this safeguard.
+            code_repr = ast.unparse(code_arg) if hasattr(ast, 'unparse') else repr(code_arg)
+            violations.append((node.lineno, '<code>', 'NON_LITERAL_CODE', code_repr))
             continue
         code = code_arg.value
         spec = CODE_REGISTRY.get(code)
         if spec is None:
             violations.append((node.lineno, code, 'UNKNOWN_CODE', '<no schema>'))
             continue
+
+        # I2 lockdown: ``**kwargs`` expansion hides field names from
+        # this audit. Reject up-front so callers cannot bypass the
+        # required-field check by unpacking a dict.
+        if any(kw.arg is None for kw in node.keywords):
+            violations.append((node.lineno, code, 'KWARG_UNPACK', '**unpacked dict not allowed'))
+            continue
+
         provided = {kw.arg for kw in node.keywords if kw.arg is not None}
         for field in spec.required_fields():
             if field not in provided:

--- a/test/model/test_diagnostic_emit.py
+++ b/test/model/test_diagnostic_emit.py
@@ -75,7 +75,7 @@ state Root {
 }
 """)
         assert diag.code == 'E_UNDEFINED_VAR'
-        assert diag.refs['var_name'] == ['unknown']
+        assert diag.refs['var_name'] == 'unknown'
         assert diag.refs['referenced_in'] == 'guard'
         _assert_refs_match_schema(diag)
 

--- a/test/model/test_model.py
+++ b/test/model/test_model.py
@@ -1013,7 +1013,9 @@ class TestModelModel:
 
         err = ei.value
         assert isinstance(err, SyntaxError)
-        assert "Unknown guard variable c, d in transition:" in err.msg
+        # Per-identifier emit (PR-A-fix C-B): strict mode raises on
+        # the first undefined name encountered, which is ``c``.
+        assert "Unknown guard variable c in transition:" in err.msg
         assert "LX1 -> [*] : if [a == 0 && c > 0 || a - d > 0];" in err.msg
 
     def test_parse_unknown_transition_effect_variable(self):


### PR DESCRIPTION
## Summary

Stacks 14 commits on top of #115 to close the C-class issues surfaced by the senior review on the parent PR (see #115 comments 4566109702 and 4566148255). After this PR is merged into ``dev/issue104-pr-a-inspect-model``, the #115 → main merge will carry both the original Layer 2 scaffolding AND the corrected schema↔emit contract.

This PR targets ``dev/issue104-pr-a-inspect-model``, NOT ``main``, so it can be reviewed/merged before #115 lands.

## Critical fixes (5)

- **C-A** (c231c722) — jsfcstm ``E_INITIAL_TRANSITION_INVALID.reason`` switched from the off-schema ``'no_initial_transition'`` to the codes.yaml-declared ``'missing_entry'``.
- **C-B** (2d3f8b9c) — pyfcstm ``E_UNDEFINED_VAR`` now emits one diagnostic per undefined identifier with ``refs.var_name: str`` matching the schema; was previously batching as ``list[str]``.
- **C-C** (a10e6b5a) — jsfcstm threads accurate ``referenced_in`` stage (``enter`` / ``during`` / ``exit`` / ``effect`` / ``during_aspect``) through operation analysis; was emitting the off-schema ``'operation_block'`` literal.
- **C-D** (9e3b478e) — jsfcstm ``E_IMPORT_*`` emits now fill all schema-required ``data`` fields (``alias`` / ``host_state_path`` / ``conflicting_kind`` / ``cycle_chain`` / ``mapping_kind`` / ``duplicated_name`` / ``direction`` / ``reason``). Five emit sites updated.
- **C-E** (aa494771) — pyfcstm ``imports.py`` mapping helpers are now sink-aware: 25 emit sites switched from ``_emit_import_diag(None, ...)`` to ``_emit_import_diag(sink, ...)``. 10 helper signatures take ``sink: DiagnosticSink``. Multiple per-import diagnostics now accumulate in collect mode instead of fail-fast'ing on the first one.

## Mechanical safeguards (1)

- **I-e** (fba4a7fc) — ``test/diagnostics/_schema_check.py`` runtime helper asserts every emitted ``ModelDiagnostic.refs`` conforms to the schema (required keys present, enum values in range, runtime types match). Wired into every fixture in ``test_cross_end_parity.py``. ``test_imports_emit_static_audit.py`` AST-walks ``imports.py`` and asserts every literal-code call to ``_emit_import_diag`` lists every schema-required ``refs`` field. Repaired 15 pre-existing static violations the audit surfaced.

## Important fixes (8)

- **I-a** (4903ec3b) — backfill ``for_llm`` on the 14 grandfathered ``E_*`` codes (+283 lines of structured LLM guidance).
- **I-b** (239ab941) — add ``emit_tier`` schema field; mark ``E_EVENT_REF_INVALID`` / ``E_EVENT_NOT_FOUND`` as ``lookup_api`` and ``E_TYPE_MISMATCH`` as ``partial_static_pipeline``. Two regression tests pin the "never fires in static pipeline" contract.
- **I-c** (bd6a02d4) — lock the brace-only state composite classification (state with actions but no substates/imports = leaf) with two new ast.test.ts cases; add a comment to ``model-assembly.ts:1005`` clarifying the post-import-resolution timing of the composite check.
- **I-d** (ec407230) — make ``sync-runtime-assets.js --phase=src`` and ``--phase=dist`` independently idempotent. Previously ``--phase=src`` wrote to both ``src/`` and ``dist/``, and ``--phase=dist`` never re-read ``codes.yaml`` for the dist copy, leaving the bundled VSIX asset stale after between-phase edits.
- **I-f** (dedb9146) — extend jsfcstm ``addDuringAspectInvalidDiagnostics`` to cover all three scenarios pyfcstm flags: (a) leaf + local ``during before/after``, (b) composite + bare ``during``, (c) leaf + global ``>> during``. Add showcase fixtures ``07a`` / ``07b``.
- **I-g** (cc957405) — drop the contradictory ``enum: ['before', 'after']`` from ``E_DURING_ASPECT_INVALID.aspect`` (``type: str_or_null`` already constrains the value space; null is intentional for the bare-during case).
- **I-h + I-i** (5df88957) — pyfcstm now emits ``is_temporary`` on ``E_UNDEFINED_VAR`` (was missing despite being declared in codes.yaml since PR-A). Pre-scans operation blocks for assignment-LHS names so the flag accurately distinguishes read-before-assign-of-temp from genuinely-undefined identifiers. New parity fixture ``11-temporary-read-before-assign`` mirrors jsfcstm showcase.
- **I-j** (9c401944) — restructure ``E_IMPORT_NOT_FOUND.for_llm`` to branch ``recommended_actions`` by ``refs.reason`` via a new ``applies_to_reason`` key per action. LLM consumers can now match ``file_not_found`` / ``read_error`` / ``parse_error`` / ``no_root_state`` to distinct fixes instead of one-size-fits-all.

## Test plan

- [x] ``SKIP_SLOW_TESTS=1 make unittest`` — 1964 passing locally
- [x] ``npm test`` in ``editors/jsfcstm`` — 456 passing
- [x] All commits include ``[skip-slow]``
- [x] ``make rst_auto`` was not re-run; the commits touch only diagnostics-layer / template-fix files. Reviewer can run it to be safe.

## Migration / BREAKING notes

- ``state.composite`` semantics: a state like ``state X { enter {x=0;} }`` (brace-only, no substates, no imports) is now classified as **leaf**, not composite. VSCode SVG preview renders it as a leaf box instead of drawing a composite container. This is an intentional fix to the Layer 1 ambiguity; downstream consumers that previously branched on "has braces" must switch to ``substates ∪ imports > 0``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)