### PR TITLE
诊断：PR-B3 收尾：阈值、信息、命名与类型诊断

### DIFF
--- a/docs/source/api_doc/diagnostics/analyzers/index.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/index.rst
@@ -9,7 +9,14 @@ pyfcstm.diagnostics.analyzers
 .. toctree::
     :maxdepth: 3
 
+    data_flow
     design_health
+    naming
+    redundancy
+    structural
+    thresholds
+    transition_info
+    type_shape
 
 \_\_all\_\_
 -----------------------------------------------------

--- a/docs/source/api_doc/diagnostics/analyzers/naming.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/naming.rst
@@ -1,0 +1,12 @@
+pyfcstm.diagnostics.analyzers.naming
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.analyzers.naming
+
+.. automodule:: pyfcstm.diagnostics.analyzers.naming
+
+
+collect\_naming\_warnings
+-----------------------------------------------------
+
+.. autofunction:: collect_naming_warnings

--- a/docs/source/api_doc/diagnostics/analyzers/thresholds.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/thresholds.rst
@@ -1,0 +1,12 @@
+pyfcstm.diagnostics.analyzers.thresholds
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.analyzers.thresholds
+
+.. automodule:: pyfcstm.diagnostics.analyzers.thresholds
+
+
+collect\_threshold\_warnings
+-----------------------------------------------------
+
+.. autofunction:: collect_threshold_warnings

--- a/docs/source/api_doc/diagnostics/analyzers/transition_info.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/transition_info.rst
@@ -1,0 +1,12 @@
+pyfcstm.diagnostics.analyzers.transition\_info
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.analyzers.transition_info
+
+.. automodule:: pyfcstm.diagnostics.analyzers.transition_info
+
+
+collect\_transition\_infos
+-----------------------------------------------------
+
+.. autofunction:: collect_transition_infos

--- a/docs/source/api_doc/diagnostics/analyzers/type_shape.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/type_shape.rst
@@ -1,0 +1,12 @@
+pyfcstm.diagnostics.analyzers.type\_shape
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.analyzers.type_shape
+
+.. automodule:: pyfcstm.diagnostics.analyzers.type_shape
+
+
+collect\_type\_warnings
+-----------------------------------------------------
+
+.. autofunction:: collect_type_warnings

--- a/docs/source/api_doc/diagnostics/codes.rst
+++ b/docs/source/api_doc/diagnostics/codes.rst
@@ -36,7 +36,7 @@ CodeSpec
 -----------------------------------------------------
 
 .. autoclass:: CodeSpec
-    :members: required_fields,code,severity,description,refs_schema,example_dsl,capability,for_llm
+    :members: required_fields,code,severity,description,refs_schema,example_dsl,capability,for_llm,emit_tier
 
 
 load\_codes

--- a/docs/source/api_doc/diagnostics/inspect.rst
+++ b/docs/source/api_doc/diagnostics/inspect.rst
@@ -6,6 +6,24 @@ pyfcstm.diagnostics.inspect
 .. automodule:: pyfcstm.diagnostics.inspect
 
 
+DEFAULT\_DEEP\_HIERARCHY\_THRESHOLD
+-----------------------------------------------------
+
+.. autodata:: DEFAULT_DEEP_HIERARCHY_THRESHOLD
+
+
+DEFAULT\_LARGE\_COMPOSITE\_THRESHOLD
+-----------------------------------------------------
+
+.. autodata:: DEFAULT_LARGE_COMPOSITE_THRESHOLD
+
+
+DEFAULT\_VAR\_TO\_LEAF\_RATIO\_THRESHOLD
+-----------------------------------------------------
+
+.. autodata:: DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD
+
+
 StateInfo
 -----------------------------------------------------
 
@@ -24,7 +42,7 @@ VariableInfo
 -----------------------------------------------------
 
 .. autoclass:: VariableInfo
-    :members: name,type,init_value,read_in_states,written_in_states,read_in_guards,written_in_effects,participates_directly,participates_indirectly,abstract_actions_in_scope
+    :members: name,type,init_value,read_in_states,written_in_states,read_in_guards,written_in_effects,participates_directly,participates_indirectly,abstract_actions_in_scope,float_literal_assignments
 
 
 EventInfo
@@ -66,4 +84,3 @@ inspect\_model
 -----------------------------------------------------
 
 .. autofunction:: inspect_model
-

--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -3,13 +3,18 @@ import type {
     EventInfo,
     ForcedTransitionInfo,
     ModelDiagnosticJson,
+    ModelMetrics,
     StateInfo,
     TransitionInfo,
     VariableInfo,
 } from '../inspect';
 import {collectDataFlowWarnings} from './data-flow';
+import {collectNamingWarnings} from './naming';
 import {collectRedundancyWarnings} from './redundancy';
 import {collectStructuralWarnings} from './structural';
+import {collectThresholdWarnings, type ThresholdOptions} from './thresholds';
+import {collectTransitionInfos} from './transition-info';
+import {collectTypeWarnings} from './type-shape';
 
 export function collectDesignHealthWarnings(
     states: StateInfo[],
@@ -18,9 +23,16 @@ export function collectDesignHealthWarnings(
     events: EventInfo[],
     actions: ActionInfo[],
     forcedTransitions: ForcedTransitionInfo[],
+    metrics: ModelMetrics,
     reachabilityGraph: Record<string, string[]>,
     rootStatePath?: string,
+    thresholds?: ThresholdOptions,
 ): ModelDiagnosticJson[] {
+    const thresholdOptions = thresholds ?? {
+        deepHierarchyThreshold: 6,
+        largeCompositeThreshold: 12,
+        varToLeafRatioThreshold: 2.0,
+    };
     return [
         ...collectUnreachableStateDiagnostics(states, reachabilityGraph, rootStatePath),
         ...collectGuardConstFalseDiagnostics(transitions),
@@ -33,8 +45,12 @@ export function collectDesignHealthWarnings(
             reachabilityGraph,
             rootStatePath,
         ),
+        ...collectThresholdWarnings(states, metrics, thresholdOptions),
+        ...collectNamingWarnings(actions),
+        ...collectTypeWarnings(variables),
         ...collectDataFlowWarnings(variables),
         ...collectRedundancyWarnings(transitions, events, states),
+        ...collectTransitionInfos(states, transitions),
     ];
 }
 

--- a/editors/jsfcstm/src/diagnostics/analyzers/index.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/index.ts
@@ -1,1 +1,5 @@
 export {collectDesignHealthWarnings} from './design-health';
+export {collectNamingWarnings} from './naming';
+export {collectThresholdWarnings} from './thresholds';
+export {collectTransitionInfos} from './transition-info';
+export {collectTypeWarnings} from './type-shape';

--- a/editors/jsfcstm/src/diagnostics/analyzers/naming.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/naming.ts
@@ -1,0 +1,38 @@
+import type {ActionInfo, ModelDiagnosticJson} from '../inspect';
+
+export function collectNamingWarnings(actions: ActionInfo[]): ModelDiagnosticJson[] {
+    const byName = new Map<string, ActionInfo[]>();
+    for (const action of actions) {
+        if (!action.name || action.is_ref) continue;
+        byName.set(action.name, [...(byName.get(action.name) ?? []), action]);
+    }
+
+    const out: ModelDiagnosticJson[] = [];
+    for (const [functionName, items] of byName.entries()) {
+        const sorted = [...items].sort((a, b) => a.state_path.localeCompare(b.state_path));
+        for (const inner of sorted) {
+            const ancestors = sorted.filter(outer =>
+                isStrictAncestor(outer.state_path, inner.state_path)
+            );
+            if (ancestors.length === 0) continue;
+            ancestors.sort((a, b) => b.state_path.length - a.state_path.length);
+            const outer = ancestors[0];
+            out.push({
+                code: 'W_NAMED_ACTION_SHADOWS_ANCESTOR',
+                severity: 'warning',
+                message: `Named action ${JSON.stringify(functionName)} in ${JSON.stringify(inner.state_path)} shadows ancestor action in ${JSON.stringify(outer.state_path)}.`,
+                span: null,
+                refs: {
+                    function_name: functionName,
+                    inner_state_path: inner.state_path,
+                    outer_state_path: outer.state_path,
+                },
+            });
+        }
+    }
+    return out;
+}
+
+function isStrictAncestor(outerPath: string, innerPath: string): boolean {
+    return outerPath.length > 0 && innerPath.startsWith(`${outerPath}.`);
+}

--- a/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
@@ -18,6 +18,7 @@ export function collectStructuralWarnings(
         ...collectDeadlockLeafWarnings(states, transitions),
         ...collectInitialUnconditionalMissingWarnings(states),
         ...collectForcedNeverExpandsWarnings(forcedTransitions),
+        ...collectAspectNoDescendantLeafWarnings(states),
         ...collectDeadNamedActionWarnings(states, actions, reachabilityGraph, rootStatePath),
     ];
 }
@@ -87,6 +88,40 @@ function collectForcedNeverExpandsWarnings(
         });
     }
     return out;
+}
+
+function collectAspectNoDescendantLeafWarnings(states: StateInfo[]): ModelDiagnosticJson[] {
+    const out: ModelDiagnosticJson[] = [];
+    for (const state of states) {
+        if (!state.is_composite) continue;
+        const descendantLeafCount = states.filter(desc =>
+            desc.path !== state.path &&
+            desc.path.startsWith(`${state.path}.`) &&
+            desc.is_leaf &&
+            !desc.is_pseudo
+        ).length;
+        if (descendantLeafCount > 0) continue;
+        if (state.aspect_before.length > 0) {
+            out.push(aspectNoDescendantLeafDiagnostic(state.path, 'before'));
+        }
+        if (state.aspect_after.length > 0) {
+            out.push(aspectNoDescendantLeafDiagnostic(state.path, 'after'));
+        }
+    }
+    return out;
+}
+
+function aspectNoDescendantLeafDiagnostic(statePath: string, aspect: 'before' | 'after'): ModelDiagnosticJson {
+    return {
+        code: 'W_ASPECT_NO_DESCENDANT_LEAF',
+        severity: 'warning',
+        message: `Composite state ${JSON.stringify(statePath)} declares >> during ${aspect} but has no descendant non-pseudo leaf state.`,
+        span: null,
+        refs: {
+            composite_path: statePath,
+            aspect,
+        },
+    };
 }
 
 function collectDeadNamedActionWarnings(

--- a/editors/jsfcstm/src/diagnostics/analyzers/thresholds.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/thresholds.ts
@@ -1,0 +1,89 @@
+import type {ModelDiagnosticJson, ModelMetrics, StateInfo} from '../inspect';
+
+export interface ThresholdOptions {
+    deepHierarchyThreshold: number;
+    largeCompositeThreshold: number;
+    varToLeafRatioThreshold: number;
+}
+
+export function collectThresholdWarnings(
+    states: StateInfo[],
+    metrics: ModelMetrics,
+    options: ThresholdOptions,
+): ModelDiagnosticJson[] {
+    return [
+        ...collectHighVarToLeafRatioWarnings(metrics, options.varToLeafRatioThreshold),
+        ...collectDeepHierarchyWarnings(states, metrics, options.deepHierarchyThreshold),
+        ...collectLargeCompositeWarnings(states, options.largeCompositeThreshold),
+    ];
+}
+
+function collectHighVarToLeafRatioWarnings(
+    metrics: ModelMetrics,
+    threshold: number,
+): ModelDiagnosticJson[] {
+    const actual = metrics.var_to_leaf_ratio;
+    if (actual <= threshold) return [];
+    return [{
+        code: 'W_HIGH_VAR_TO_LEAF_RATIO',
+        severity: 'warning',
+        message: `Variable-to-leaf ratio ${JSON.stringify(actual)} exceeds threshold ${JSON.stringify(threshold)}.`,
+        span: null,
+        refs: {
+            n_vars: metrics.n_variables,
+            n_leaf_states: metrics.n_states_leaf,
+            actual,
+            threshold,
+        },
+    }];
+}
+
+function collectDeepHierarchyWarnings(
+    states: StateInfo[],
+    metrics: ModelMetrics,
+    threshold: number,
+): ModelDiagnosticJson[] {
+    const actual = metrics.max_hierarchy_depth;
+    if (actual <= threshold) return [];
+    const deepest = states
+        .filter(state => state.path.split('.').length - 1 === actual)
+        .map(state => state.path)
+        .sort()[0] ?? '';
+    return [{
+        code: 'W_DEEP_HIERARCHY',
+        severity: 'warning',
+        message: `Hierarchy depth ${JSON.stringify(actual)} exceeds threshold ${JSON.stringify(threshold)}.`,
+        span: null,
+        refs: {
+            max_depth: actual,
+            deepest_path: deepest,
+            actual,
+            threshold,
+        },
+    }];
+}
+
+function collectLargeCompositeWarnings(
+    states: StateInfo[],
+    threshold: number,
+): ModelDiagnosticJson[] {
+    const out: ModelDiagnosticJson[] = [];
+    for (const state of states) {
+        if (!state.is_composite) continue;
+        const actual = state.substates.length;
+        if (actual <= threshold) continue;
+        out.push({
+            code: 'W_LARGE_COMPOSITE',
+            severity: 'warning',
+            message: `Composite state ${JSON.stringify(state.path)} has ${JSON.stringify(actual)} direct children, exceeding threshold ${JSON.stringify(threshold)}.`,
+            span: null,
+            refs: {
+                composite_path: state.path,
+                n_children: actual,
+                actual,
+                threshold,
+            },
+        });
+    }
+    return out;
+}

--- a/editors/jsfcstm/src/diagnostics/analyzers/transition-info.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/transition-info.ts
@@ -1,0 +1,55 @@
+import type {ModelDiagnosticJson, StateInfo, TransitionInfo} from '../inspect';
+
+export function collectTransitionInfos(
+    states: StateInfo[],
+    transitions: TransitionInfo[],
+): ModelDiagnosticJson[] {
+    const statesByPath = new Map(states.map(state => [state.path, state]));
+    return [
+        ...collectCompositeSelfTransitionInfos(statesByPath, transitions),
+        ...collectEventlessGuardlessTransitionInfos(transitions),
+    ];
+}
+
+function collectCompositeSelfTransitionInfos(
+    statesByPath: Map<string, StateInfo>,
+    transitions: TransitionInfo[],
+): ModelDiagnosticJson[] {
+    const out: ModelDiagnosticJson[] = [];
+    for (const transition of transitions) {
+        if (transition.from_path !== transition.to_path) continue;
+        const state = statesByPath.get(transition.from_path);
+        if (!state || !state.is_composite) continue;
+        out.push({
+            code: 'I_TRANSITION_TO_SELF_VIA_PARENT',
+            severity: 'info',
+            message: `Composite state ${JSON.stringify(transition.from_path)} transitions to itself and may intentionally re-enter children.`,
+            span: null,
+            refs: {
+                state_path: transition.from_path,
+                crosses_composite: true,
+            },
+        });
+    }
+    return out;
+}
+
+function collectEventlessGuardlessTransitionInfos(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
+    const out: ModelDiagnosticJson[] = [];
+    for (const transition of transitions) {
+        if (transition.from_path === '[*]') continue;
+        if (transition.event !== null || transition.guard !== null) continue;
+        out.push({
+            code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+            severity: 'info',
+            message: `Transition ${JSON.stringify(transition.from_path)} -> ${JSON.stringify(transition.to_path)} has no event or guard.`,
+            span: null,
+            refs: {
+                from_path: transition.from_path,
+                to_path: transition.to_path,
+                transition_span: null,
+            },
+        });
+    }
+    return out;
+}

--- a/editors/jsfcstm/src/diagnostics/analyzers/type-shape.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/type-shape.ts
@@ -1,0 +1,50 @@
+import type {ModelDiagnosticJson, VariableInfo} from '../inspect';
+
+export function collectTypeWarnings(variables: VariableInfo[]): ModelDiagnosticJson[] {
+    return [
+        ...collectLiteralInitNarrowingWarnings(variables),
+        ...collectLiteralAssignmentNarrowingWarnings(variables),
+    ];
+}
+
+function collectLiteralInitNarrowingWarnings(variables: VariableInfo[]): ModelDiagnosticJson[] {
+    const out: ModelDiagnosticJson[] = [];
+    for (const variable of variables) {
+        if (variable.type !== 'int' || !isFloatLiteralText(variable.init_value)) continue;
+        out.push(narrowingDiagnostic(variable.name, variable.init_value));
+    }
+    return out;
+}
+
+function collectLiteralAssignmentNarrowingWarnings(variables: VariableInfo[]): ModelDiagnosticJson[] {
+    const out: ModelDiagnosticJson[] = [];
+    for (const variable of variables) {
+        if (variable.type !== 'int') continue;
+        for (const sourceExpr of variable.float_literal_assignments) {
+            out.push(narrowingDiagnostic(variable.name, sourceExpr));
+        }
+    }
+    return out;
+}
+
+function narrowingDiagnostic(varName: string, sourceExpr: string): ModelDiagnosticJson {
+    return {
+        code: 'W_LITERAL_TYPE_NARROWING',
+        severity: 'warning',
+        message: `Integer variable ${JSON.stringify(varName)} receives float literal expression ${JSON.stringify(sourceExpr)}.`,
+        span: null,
+        refs: {
+            var_name: varName,
+            target_type: 'int',
+            source_expr: sourceExpr,
+        },
+    };
+}
+
+function isFloatLiteralText(text: string): boolean {
+    const value = text.trim();
+    if (value.length === 0) return false;
+    const lowered = value.toLowerCase();
+    if (lowered === 'pi' || lowered === 'e' || lowered === 'tau') return true;
+    return (lowered.includes('.') || lowered.includes('e')) && Number.isFinite(Number(lowered));
+}

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -234,8 +234,14 @@ export interface ModelDiagnosticJson {
  * Run the structural inspector against a jsfcstm state-machine model.
  */
 export function inspectModel(machine: StateMachine, options: InspectModelOptions = {}): ModelInspect {
-    const deepHierarchyThreshold = options.deepHierarchyThreshold ?? DEFAULT_DEEP_HIERARCHY_THRESHOLD;
-    const largeCompositeThreshold = options.largeCompositeThreshold ?? DEFAULT_LARGE_COMPOSITE_THRESHOLD;
+    const deepHierarchyThreshold = normalizeIntThreshold(
+        'deepHierarchyThreshold',
+        options.deepHierarchyThreshold ?? DEFAULT_DEEP_HIERARCHY_THRESHOLD,
+    );
+    const largeCompositeThreshold = normalizeIntThreshold(
+        'largeCompositeThreshold',
+        options.largeCompositeThreshold ?? DEFAULT_LARGE_COMPOSITE_THRESHOLD,
+    );
     const varToLeafRatioThreshold = options.varToLeafRatioThreshold ?? DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD;
     const rootStatePath = dottedPath(machine.rootState.path);
     const states = buildStateInfos(machine);
@@ -277,6 +283,13 @@ export function inspectModel(machine: StateMachine, options: InspectModelOptions
             },
         ),
     };
+}
+
+function normalizeIntThreshold(name: string, value: number): number {
+    if (!Number.isFinite(value) || !Number.isInteger(value)) {
+        throw new Error(`${name} must be an integer threshold, got ${JSON.stringify(value)}`);
+    }
+    return value;
 }
 
 /**
@@ -980,7 +993,7 @@ function buildMetrics(
         n_transitions_forced: nForced,
         n_events: events.length,
         n_variables: variables.length,
-        var_to_leaf_ratio: nLeaf > 0 ? variables.length / nLeaf : 0,
+        var_to_leaf_ratio: variables.length / Math.max(nLeaf, 1),
         aspect_coverage: aspectCoverage,
         abstract_action_inventory: abstractInventory,
     };

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -242,7 +242,10 @@ export function inspectModel(machine: StateMachine, options: InspectModelOptions
         'largeCompositeThreshold',
         options.largeCompositeThreshold ?? DEFAULT_LARGE_COMPOSITE_THRESHOLD,
     );
-    const varToLeafRatioThreshold = options.varToLeafRatioThreshold ?? DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD;
+    const varToLeafRatioThreshold = normalizeNumberThreshold(
+        'varToLeafRatioThreshold',
+        options.varToLeafRatioThreshold ?? DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD,
+    );
     const rootStatePath = dottedPath(machine.rootState.path);
     const states = buildStateInfos(machine);
     const transitions = buildTransitionInfos(machine);
@@ -288,6 +291,13 @@ export function inspectModel(machine: StateMachine, options: InspectModelOptions
 function normalizeIntThreshold(name: string, value: number): number {
     if (!Number.isFinite(value) || !Number.isInteger(value)) {
         throw new Error(`${name} must be an integer threshold, got ${JSON.stringify(value)}`);
+    }
+    return value;
+}
+
+function normalizeNumberThreshold(name: string, value: number): number {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error(`${name} must be a finite numeric threshold, got ${JSON.stringify(value)}`);
     }
     return value;
 }

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -36,6 +36,10 @@ const INIT_MARK = '[*]';
 const EXIT_MARK = '[*]';
 const FLOAT_EPSILON = 1e-10;
 
+export const DEFAULT_DEEP_HIERARCHY_THRESHOLD = 6;
+export const DEFAULT_LARGE_COMPOSITE_THRESHOLD = 12;
+export const DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD = 2.0;
+
 const OP_PRECEDENCE: Record<string, number> = {
     'function_call': 90,
     'unary+': 80,
@@ -125,6 +129,13 @@ export interface VariableInfo {
     participates_directly: boolean;
     participates_indirectly: boolean;
     abstract_actions_in_scope: string[];
+    float_literal_assignments: string[];
+}
+
+export interface InspectModelOptions {
+    deepHierarchyThreshold?: number;
+    largeCompositeThreshold?: number;
+    varToLeafRatioThreshold?: number;
 }
 
 /**
@@ -222,7 +233,10 @@ export interface ModelDiagnosticJson {
 /**
  * Run the structural inspector against a jsfcstm state-machine model.
  */
-export function inspectModel(machine: StateMachine): ModelInspect {
+export function inspectModel(machine: StateMachine, options: InspectModelOptions = {}): ModelInspect {
+    const deepHierarchyThreshold = options.deepHierarchyThreshold ?? DEFAULT_DEEP_HIERARCHY_THRESHOLD;
+    const largeCompositeThreshold = options.largeCompositeThreshold ?? DEFAULT_LARGE_COMPOSITE_THRESHOLD;
+    const varToLeafRatioThreshold = options.varToLeafRatioThreshold ?? DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD;
     const rootStatePath = dottedPath(machine.rootState.path);
     const states = buildStateInfos(machine);
     const transitions = buildTransitionInfos(machine);
@@ -253,8 +267,14 @@ export function inspectModel(machine: StateMachine): ModelInspect {
             events,
             actions,
             forcedTransitions,
+            metrics,
             reachabilityGraph,
             rootStatePath,
+            {
+                deepHierarchyThreshold,
+                largeCompositeThreshold,
+                varToLeafRatioThreshold,
+            },
         ),
     };
 }
@@ -420,11 +440,13 @@ function buildVariableInfos(machine: StateMachine, states: StateInfo[]): Variabl
     const writesByState: Record<string, string[]> = {};
     const readGuards: Record<string, Array<[string, string]>> = {};
     const writtenEffects: Record<string, Array<[string, string]>> = {};
+    const floatLiteralAssignments: Record<string, string[]> = {};
     for (const name of Object.keys(machine.defines)) {
         readsByState[name] = [];
         writesByState[name] = [];
         readGuards[name] = [];
         writtenEffects[name] = [];
+        floatLiteralAssignments[name] = [];
     }
     const stateLookup: Record<string, StateInfo> = {};
     for (const info of states) {
@@ -433,11 +455,24 @@ function buildVariableInfos(machine: StateMachine, states: StateInfo[]): Variabl
     for (const state of machine.allStates) {
         const path = dottedPath(state.path);
         const {reads, writes} = collectActionReadsWrites(state);
+        const localFloatAssigns: Record<string, string[]> = {};
+        for (const collection of [state.onEnters, state.onDurings, state.onExits, state.onDuringAspects]) {
+            for (const action of collection) {
+                for (const stmt of action.operations ?? []) {
+                    walkStmtFloatLiteralAssignments(stmt, localFloatAssigns);
+                }
+            }
+        }
         for (const name of Object.keys(reads)) {
             if (name in readsByState) readsByState[name].push(path);
         }
         for (const name of Object.keys(writes)) {
             if (name in writesByState) writesByState[name].push(path);
+        }
+        for (const [name, assignments] of Object.entries(localFloatAssigns)) {
+            if (name in floatLiteralAssignments) {
+                floatLiteralAssignments[name].push(...assignments);
+            }
         }
         for (const t of state.transitions) {
             const fromPath = transitionEndpoint(state.path, t.fromState, true);
@@ -450,12 +485,19 @@ function buildVariableInfos(machine: StateMachine, states: StateInfo[]): Variabl
             for (const stmt of t.effects ?? []) {
                 const localReads: string[] = [];
                 const localWrites: string[] = [];
+                const localFloatEffectAssigns: Record<string, string[]> = {};
                 walkStmtReadsWrites(stmt, localReads, localWrites);
+                walkStmtFloatLiteralAssignments(stmt, localFloatEffectAssigns);
                 for (const v of localReads) {
                     if (v in readsByState) readsByState[v].push(fromPath);
                 }
                 for (const v of localWrites) {
                     if (v in writtenEffects) writtenEffects[v].push([fromPath, toPath]);
+                }
+                for (const [v, assignments] of Object.entries(localFloatEffectAssigns)) {
+                    if (v in floatLiteralAssignments) {
+                        floatLiteralAssignments[v].push(...assignments);
+                    }
                 }
             }
         }
@@ -499,6 +541,7 @@ function buildVariableInfos(machine: StateMachine, states: StateInfo[]): Variabl
             participates_directly: participatesDirectly,
             participates_indirectly: false,
             abstract_actions_in_scope: abstractActions,
+            float_literal_assignments: dedupe(floatLiteralAssignments[name]),
         });
     }
     return out;
@@ -607,6 +650,25 @@ function walkStmtSelfAssigns(stmt: OperationStatement, out: string[]): void {
         for (const branch of stmt.branches) {
             for (const inner of branch.statements) {
                 walkStmtSelfAssigns(inner, out);
+            }
+        }
+    }
+}
+
+function walkStmtFloatLiteralAssignments(
+    stmt: OperationStatement,
+    out: Record<string, string[]>,
+): void {
+    if (stmt instanceof Operation) {
+        if (stmt.expr instanceof Float) {
+            out[stmt.varName] = [...(out[stmt.varName] ?? []), exprText(stmt.expr) ?? ''];
+        }
+        return;
+    }
+    if (stmt instanceof IfBlock) {
+        for (const branch of stmt.branches) {
+            for (const inner of branch.statements) {
+                walkStmtFloatLiteralAssignments(inner, out);
             }
         }
     }

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict';
 
 import {createDocument, packageModule} from './support';
 
-const {inspectModel} = packageModule;
+const {
+    DEFAULT_DEEP_HIERARCHY_THRESHOLD,
+    DEFAULT_LARGE_COMPOSITE_THRESHOLD,
+    DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD,
+    inspectModel,
+} = packageModule;
 
 const SIMPLE_DSL = `
 def int counter = 0;
@@ -171,6 +176,12 @@ state Root {
             assert.equal(m.n_variables, 2);
             assert.equal(m.var_to_leaf_ratio, 1.0);
             assert.equal(m.max_hierarchy_depth, 1);
+        });
+
+        it('exports default threshold constants', () => {
+            assert.equal(DEFAULT_DEEP_HIERARCHY_THRESHOLD, 6);
+            assert.equal(DEFAULT_LARGE_COMPOSITE_THRESHOLD, 12);
+            assert.equal(DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD, 2.0);
         });
     });
 
@@ -367,6 +378,16 @@ state Root {
                 .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
 
             assert.deepEqual(normalized, [
+                {
+                    code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+                    severity: 'info',
+                    refs: {from_path: 'Root.Active', to_path: 'Root.Active', transition_span: null},
+                },
+                {
+                    code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+                    severity: 'info',
+                    refs: {from_path: 'Root.Active', to_path: 'Root.Idle', transition_span: null},
+                },
                 {
                     code: 'W_DEADLOCK_LEAF',
                     severity: 'warning',
@@ -908,6 +929,177 @@ state Root {
             );
             assert.ok(t);
             assert.ok(typeof t!.effect === 'string' && t!.effect!.length > 0);
+        });
+    });
+
+    describe('threshold, info, naming, and type diagnostics', () => {
+        function diagnosticsByCode(report: ReturnType<typeof inspectModel>) {
+            const out = new Map<string, typeof report.diagnostics>();
+            for (const diagnostic of report.diagnostics) {
+                out.set(diagnostic.code, [...(out.get(diagnostic.code) ?? []), diagnostic]);
+            }
+            return out;
+        }
+
+        it('emits threshold diagnostics with actual and threshold refs', async () => {
+            const report = inspectModel(await buildMachine(`
+def int a = 0;
+def int b = 0;
+def int c = 0;
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+    A -> B :: Next;
+    B -> C :: Next;
+    C -> A :: Next;
+}
+`), {
+                varToLeafRatioThreshold: 0.5,
+                largeCompositeThreshold: 2,
+                deepHierarchyThreshold: 0,
+            });
+            const byCode = diagnosticsByCode(report);
+
+            assert.deepEqual(byCode.get('W_HIGH_VAR_TO_LEAF_RATIO')![0].refs, {
+                n_vars: 3,
+                n_leaf_states: 3,
+                actual: 1.0,
+                threshold: 0.5,
+            });
+            assert.deepEqual(byCode.get('W_LARGE_COMPOSITE')![0].refs, {
+                composite_path: 'Root',
+                n_children: 3,
+                actual: 3,
+                threshold: 2,
+            });
+            assert.deepEqual(byCode.get('W_DEEP_HIERARCHY')![0].refs, {
+                max_depth: 1,
+                deepest_path: 'Root.A',
+                actual: 1,
+                threshold: 0,
+            });
+        });
+
+        it('does not emit threshold diagnostics with defaults for a small model', async () => {
+            const report = inspectModel(await buildMachine(SIMPLE_DSL));
+            const codes = new Set(report.diagnostics.map(d => d.code));
+            assert.equal(codes.has('W_HIGH_VAR_TO_LEAF_RATIO'), false);
+            assert.equal(codes.has('W_LARGE_COMPOSITE'), false);
+            assert.equal(codes.has('W_DEEP_HIERARCHY'), false);
+        });
+
+        it('emits named action shadow diagnostics', async () => {
+            const report = inspectModel(await buildMachine(`
+state Root {
+    enter Sync { }
+    state Child {
+        enter Sync { }
+    }
+    [*] -> Child;
+}
+`));
+            assert.deepEqual(
+                diagnosticsByCode(report).get('W_NAMED_ACTION_SHADOWS_ANCESTOR')![0].refs,
+                {
+                    function_name: 'Sync',
+                    inner_state_path: 'Root.Child',
+                    outer_state_path: 'Root',
+                },
+            );
+        });
+
+        it('emits literal type narrowing diagnostics for int initializers', async () => {
+            const report = inspectModel(await buildMachine(`
+def int truncated = 3.5;
+state Root {
+    state A;
+    [*] -> A;
+}
+`));
+            assert.deepEqual(
+                diagnosticsByCode(report).get('W_LITERAL_TYPE_NARROWING')![0].refs,
+                {
+                    var_name: 'truncated',
+                    target_type: 'int',
+                    source_expr: '3.5',
+                },
+            );
+        });
+
+        it('emits literal type narrowing diagnostics for int assignments', async () => {
+            const report = inspectModel(await buildMachine(`
+def int truncated = 0;
+state Root {
+    state A {
+        during { truncated = 2.25; }
+    }
+    [*] -> A;
+}
+`));
+            assert.deepEqual(
+                diagnosticsByCode(report).get('W_LITERAL_TYPE_NARROWING')![0].refs,
+                {
+                    var_name: 'truncated',
+                    target_type: 'int',
+                    source_expr: '2.25',
+                },
+            );
+        });
+
+        it('emits aspect diagnostics for aspects with no descendant leaves', async () => {
+            const report = inspectModel(await buildMachine(`
+state Root {
+    pseudo state Marker;
+    [*] -> Marker;
+    >> during before { }
+}
+`));
+            assert.deepEqual(
+                diagnosticsByCode(report).get('W_ASPECT_NO_DESCENDANT_LEAF')![0].refs,
+                {
+                    composite_path: 'Root',
+                    aspect: 'before',
+                },
+            );
+        });
+
+        it('emits info for composite self re-entry transitions', async () => {
+            const report = inspectModel(await buildMachine(`
+state Root {
+    state Active {
+        state Leaf;
+        [*] -> Leaf;
+    }
+    [*] -> Active;
+    Active -> Active;
+}
+`));
+            const diagnostic = diagnosticsByCode(report).get('I_TRANSITION_TO_SELF_VIA_PARENT')![0];
+            assert.equal(diagnostic.severity, 'info');
+            assert.deepEqual(diagnostic.refs, {
+                state_path: 'Root.Active',
+                crosses_composite: true,
+            });
+        });
+
+        it('emits info for eventless and guardless transitions', async () => {
+            const report = inspectModel(await buildMachine(`
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B;
+}
+`));
+            const diagnostic = diagnosticsByCode(report).get('I_TRANSITION_NEVER_EVENT_TRIGGERED')![0];
+            assert.equal(diagnostic.severity, 'info');
+            assert.deepEqual(diagnostic.refs, {
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                transition_span: null,
+            });
         });
     });
 });

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -982,6 +982,69 @@ state Root {
             });
         });
 
+        it('uses one as the minimum denominator for variable-to-leaf ratio', async () => {
+            const report = inspectModel(await buildMachine(`
+def int a = 0;
+def int b = 0;
+def int c = 0;
+state Root {
+    pseudo state Marker;
+    [*] -> Marker;
+}
+`), {
+                varToLeafRatioThreshold: 2.0,
+            });
+            assert.deepEqual(diagnosticsByCode(report).get('W_HIGH_VAR_TO_LEAF_RATIO')![0].refs, {
+                n_vars: 3,
+                n_leaf_states: 0,
+                actual: 3.0,
+                threshold: 2.0,
+            });
+        });
+
+        it('rejects fractional count thresholds', async () => {
+            const machine = await buildMachine(`
+state Root {
+    state A;
+    [*] -> A;
+}
+`);
+            assert.throws(
+                () => inspectModel(machine, {deepHierarchyThreshold: 0.5}),
+                /deepHierarchyThreshold/,
+            );
+            assert.throws(
+                () => inspectModel(machine, {largeCompositeThreshold: 2.5}),
+                /largeCompositeThreshold/,
+            );
+        });
+
+        it('normalizes integer-valued count thresholds before emitting refs', async () => {
+            const report = inspectModel(await buildMachine(`
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+}
+`), {
+                deepHierarchyThreshold: 0.0,
+                largeCompositeThreshold: 2.0,
+            });
+            assert.deepEqual(diagnosticsByCode(report).get('W_DEEP_HIERARCHY')![0].refs, {
+                max_depth: 1,
+                deepest_path: 'Root.A',
+                actual: 1,
+                threshold: 0,
+            });
+            assert.deepEqual(diagnosticsByCode(report).get('W_LARGE_COMPOSITE')![0].refs, {
+                composite_path: 'Root',
+                n_children: 3,
+                actual: 3,
+                threshold: 2,
+            });
+        });
+
         it('does not emit threshold diagnostics with defaults for a small model', async () => {
             const report = inspectModel(await buildMachine(SIMPLE_DSL));
             const codes = new Set(report.diagnostics.map(d => d.code));

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -1019,6 +1019,23 @@ state Root {
             );
         });
 
+        it('rejects non-finite variable-to-leaf ratio thresholds', async () => {
+            const machine = await buildMachine(`
+state Root {
+    state A;
+    [*] -> A;
+}
+`);
+            assert.throws(
+                () => inspectModel(machine, {varToLeafRatioThreshold: true as unknown as number}),
+                /varToLeafRatioThreshold/,
+            );
+            assert.throws(
+                () => inspectModel(machine, {varToLeafRatioThreshold: Number.NaN}),
+                /varToLeafRatioThreshold/,
+            );
+        });
+
         it('normalizes integer-valued count thresholds before emitting refs', async () => {
             const report = inspectModel(await buildMachine(`
 state Root {
@@ -1161,6 +1178,23 @@ state Root {
             assert.deepEqual(diagnostic.refs, {
                 from_path: 'Root.A',
                 to_path: 'Root.B',
+                transition_span: null,
+            });
+        });
+
+        it('emits info for eventless and guardless exit transitions', async () => {
+            const report = inspectModel(await buildMachine(`
+state Root {
+    state A;
+    [*] -> A;
+    A -> [*];
+}
+`));
+            const diagnostic = diagnosticsByCode(report).get('I_TRANSITION_NEVER_EVENT_TRIGGERED')![0];
+            assert.equal(diagnostic.severity, 'info');
+            assert.deepEqual(diagnostic.refs, {
+                from_path: 'Root.A',
+                to_path: '[*]',
                 transition_span: null,
             });
         });

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -61,5 +61,21 @@ describe('diagnostics resources (PR-A)', () => {
                 }
             }
         });
+
+        it('contains threshold, info, naming, and type diagnostic catalog entries', () => {
+            const registry = loadCodesRegistry();
+            for (const code of [
+                'W_NAMED_ACTION_SHADOWS_ANCESTOR',
+                'W_LITERAL_TYPE_NARROWING',
+                'W_ASPECT_NO_DESCENDANT_LEAF',
+                'W_HIGH_VAR_TO_LEAF_RATIO',
+                'W_DEEP_HIERARCHY',
+                'W_LARGE_COMPOSITE',
+                'I_TRANSITION_TO_SELF_VIA_PARENT',
+                'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+            ]) {
+                assert.ok(registry[code], `${code} missing from bundled codes registry`);
+            }
+        });
     });
 });

--- a/pyfcstm/diagnostics/__init__.py
+++ b/pyfcstm/diagnostics/__init__.py
@@ -31,6 +31,9 @@ from .codes import (
 )
 from .inspect import (
     ActionInfo,
+    DEFAULT_DEEP_HIERARCHY_THRESHOLD,
+    DEFAULT_LARGE_COMPOSITE_THRESHOLD,
+    DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD,
     EventInfo,
     ForcedTransitionInfo,
     ModelInspect,
@@ -48,6 +51,9 @@ __all__ = [
     'CodeFieldSpec',
     'CodeSpec',
     'CodesSchemaError',
+    'DEFAULT_DEEP_HIERARCHY_THRESHOLD',
+    'DEFAULT_LARGE_COMPOSITE_THRESHOLD',
+    'DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD',
     'DiagnosticSink',
     'EventInfo',
     'ForcedTransitionInfo',

--- a/pyfcstm/diagnostics/analyzers/__init__.py
+++ b/pyfcstm/diagnostics/analyzers/__init__.py
@@ -1,5 +1,15 @@
 """Analyzer helpers for :mod:`pyfcstm.diagnostics.inspect`."""
 
 from .design_health import collect_design_health_warnings
+from .naming import collect_naming_warnings
+from .thresholds import collect_threshold_warnings
+from .transition_info import collect_transition_infos
+from .type_shape import collect_type_warnings
 
-__all__ = ['collect_design_health_warnings']
+__all__ = [
+    'collect_design_health_warnings',
+    'collect_naming_warnings',
+    'collect_threshold_warnings',
+    'collect_transition_infos',
+    'collect_type_warnings',
+]

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -5,14 +5,19 @@ from typing import TYPE_CHECKING, Iterable, List, Optional
 
 from ...utils.validate import ModelDiagnostic
 from .data_flow import collect_data_flow_warnings
+from .naming import collect_naming_warnings
 from .redundancy import collect_redundancy_warnings
 from .structural import collect_structural_warnings
+from .thresholds import collect_threshold_warnings
+from .transition_info import collect_transition_infos
+from .type_shape import collect_type_warnings
 
 if TYPE_CHECKING:  # pragma: no cover - import-time type hints only
     from ..inspect import (
         ActionInfo,
         EventInfo,
         ForcedTransitionInfo,
+        ModelMetrics,
         StateInfo,
         TransitionInfo,
         VariableInfo,
@@ -26,8 +31,12 @@ def collect_design_health_warnings(
     events: Iterable['EventInfo'],
     actions: Iterable['ActionInfo'],
     forced_transitions: Iterable['ForcedTransitionInfo'],
+    metrics: 'ModelMetrics',
     reachability_graph,
     root_state_path: Optional[str] = None,
+    deep_hierarchy_threshold: int = 6,
+    large_composite_threshold: int = 12,
+    var_to_leaf_ratio_threshold: float = 2.0,
 ) -> List[ModelDiagnostic]:
     """Collect design-health warning diagnostics from inspect payloads."""
     diagnostics: List[ModelDiagnostic] = []
@@ -53,8 +62,18 @@ def collect_design_health_warnings(
         reachability_graph,
         root_state_path=resolved_root_state_path,
     ))
+    diagnostics.extend(collect_threshold_warnings(
+        states,
+        metrics,
+        deep_hierarchy_threshold=deep_hierarchy_threshold,
+        large_composite_threshold=large_composite_threshold,
+        var_to_leaf_ratio_threshold=var_to_leaf_ratio_threshold,
+    ))
+    diagnostics.extend(collect_naming_warnings(actions))
+    diagnostics.extend(collect_type_warnings(variables))
     diagnostics.extend(collect_data_flow_warnings(variables))
     diagnostics.extend(collect_redundancy_warnings(transitions, events, states))
+    diagnostics.extend(collect_transition_infos(states, transitions))
     return diagnostics
 
 

--- a/pyfcstm/diagnostics/analyzers/naming.py
+++ b/pyfcstm/diagnostics/analyzers/naming.py
@@ -1,0 +1,51 @@
+"""Naming and scope design-health diagnostics."""
+
+from typing import TYPE_CHECKING, Dict, Iterable, List
+
+from ...utils.validate import ModelDiagnostic
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..inspect import ActionInfo
+
+
+def collect_naming_warnings(actions: Iterable['ActionInfo']) -> List[ModelDiagnostic]:
+    """Collect diagnostics for confusing named-action scopes."""
+    return _named_action_shadows_ancestor_warnings(list(actions))
+
+
+def _named_action_shadows_ancestor_warnings(actions) -> List[ModelDiagnostic]:
+    by_name: Dict[str, List[object]] = {}
+    for action in actions:
+        if not action.name or action.is_ref:
+            continue
+        by_name.setdefault(action.name, []).append(action)
+
+    diagnostics: List[ModelDiagnostic] = []
+    for function_name, items in by_name.items():
+        sorted_items = sorted(items, key=lambda item: item.state_path)
+        for inner in sorted_items:
+            ancestors = [
+                outer for outer in sorted_items
+                if _is_strict_ancestor(outer.state_path, inner.state_path)
+            ]
+            if not ancestors:
+                continue
+            outer = max(ancestors, key=lambda item: len(item.state_path))
+            diagnostics.append(ModelDiagnostic(
+                code='W_NAMED_ACTION_SHADOWS_ANCESTOR',
+                severity='warning',
+                message=(
+                    f'Named action {function_name!r} in {inner.state_path!r} '
+                    f'shadows ancestor action in {outer.state_path!r}.'
+                ),
+                refs={
+                    'function_name': function_name,
+                    'inner_state_path': inner.state_path,
+                    'outer_state_path': outer.state_path,
+                },
+            ))
+    return diagnostics
+
+
+def _is_strict_ancestor(outer_path: str, inner_path: str) -> bool:
+    return bool(outer_path) and inner_path.startswith(f'{outer_path}.')

--- a/pyfcstm/diagnostics/analyzers/structural.py
+++ b/pyfcstm/diagnostics/analyzers/structural.py
@@ -24,6 +24,7 @@ def collect_structural_warnings(
     diagnostics.extend(_deadlock_leaf_warnings(states, transitions))
     diagnostics.extend(_initial_unconditional_missing_warnings(states))
     diagnostics.extend(_forced_never_expands_warnings(forced_transitions))
+    diagnostics.extend(_aspect_no_descendant_leaf_warnings(states))
     diagnostics.extend(_dead_named_action_warnings(
         states,
         actions,
@@ -31,6 +32,43 @@ def collect_structural_warnings(
         root_state_path,
     ))
     return diagnostics
+
+
+def _aspect_no_descendant_leaf_warnings(states) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    for state in states:
+        if not state.is_composite:
+            continue
+        descendant_leaf_count = sum(
+            1
+            for desc in states
+            if desc.path != state.path
+            and desc.path.startswith(state.path + '.')
+            and desc.is_leaf
+            and not desc.is_pseudo
+        )
+        if descendant_leaf_count > 0:
+            continue
+        for aspect in (['before'] if state.aspect_before else []):
+            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, aspect))
+        for aspect in (['after'] if state.aspect_after else []):
+            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, aspect))
+    return diagnostics
+
+
+def _aspect_no_descendant_leaf_diagnostic(state_path, aspect) -> ModelDiagnostic:
+    return ModelDiagnostic(
+        code='W_ASPECT_NO_DESCENDANT_LEAF',
+        severity='warning',
+        message=(
+            f'Composite state {state_path!r} declares >> during '
+            f'{aspect} but has no descendant non-pseudo leaf state.'
+        ),
+        refs={
+            'composite_path': state_path,
+            'aspect': aspect,
+        },
+    )
 
 
 def _deadlock_leaf_warnings(states, transitions) -> List[ModelDiagnostic]:

--- a/pyfcstm/diagnostics/analyzers/structural.py
+++ b/pyfcstm/diagnostics/analyzers/structural.py
@@ -49,10 +49,10 @@ def _aspect_no_descendant_leaf_warnings(states) -> List[ModelDiagnostic]:
         )
         if descendant_leaf_count > 0:
             continue
-        for aspect in (['before'] if state.aspect_before else []):
-            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, aspect))
-        for aspect in (['after'] if state.aspect_after else []):
-            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, aspect))
+        if state.aspect_before:
+            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, 'before'))
+        if state.aspect_after:
+            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, 'after'))
     return diagnostics
 
 

--- a/pyfcstm/diagnostics/analyzers/thresholds.py
+++ b/pyfcstm/diagnostics/analyzers/thresholds.py
@@ -1,0 +1,105 @@
+"""Threshold-based design-health diagnostics."""
+
+from typing import TYPE_CHECKING, Iterable, List
+
+from ...utils.validate import ModelDiagnostic
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..inspect import ModelMetrics, StateInfo
+
+
+def collect_threshold_warnings(
+    states: Iterable['StateInfo'],
+    metrics: 'ModelMetrics',
+    *,
+    deep_hierarchy_threshold: int,
+    large_composite_threshold: int,
+    var_to_leaf_ratio_threshold: float,
+) -> List[ModelDiagnostic]:
+    """Collect warnings controlled by inspect-model threshold options."""
+    states = list(states)
+    diagnostics: List[ModelDiagnostic] = []
+    diagnostics.extend(_high_var_to_leaf_ratio_warnings(
+        metrics,
+        var_to_leaf_ratio_threshold,
+    ))
+    diagnostics.extend(_deep_hierarchy_warnings(
+        states,
+        metrics,
+        deep_hierarchy_threshold,
+    ))
+    diagnostics.extend(_large_composite_warnings(
+        states,
+        large_composite_threshold,
+    ))
+    return diagnostics
+
+
+def _high_var_to_leaf_ratio_warnings(metrics, threshold) -> List[ModelDiagnostic]:
+    actual = metrics.var_to_leaf_ratio
+    if actual <= threshold:
+        return []
+    return [ModelDiagnostic(
+        code='W_HIGH_VAR_TO_LEAF_RATIO',
+        severity='warning',
+        message=(
+            f'Variable-to-leaf ratio {actual!r} exceeds threshold '
+            f'{threshold!r}.'
+        ),
+        refs={
+            'n_vars': metrics.n_variables,
+            'n_leaf_states': metrics.n_states_leaf,
+            'actual': actual,
+            'threshold': threshold,
+        },
+    )]
+
+
+def _deep_hierarchy_warnings(states, metrics, threshold) -> List[ModelDiagnostic]:
+    actual = metrics.max_hierarchy_depth
+    if actual <= threshold:
+        return []
+    deepest = [
+        state.path for state in states
+        if state.path.count('.') == actual
+    ]
+    deepest_path = sorted(deepest)[0] if deepest else ''
+    return [ModelDiagnostic(
+        code='W_DEEP_HIERARCHY',
+        severity='warning',
+        message=(
+            f'Hierarchy depth {actual!r} exceeds threshold '
+            f'{threshold!r}.'
+        ),
+        refs={
+            'max_depth': actual,
+            'deepest_path': deepest_path,
+            'actual': actual,
+            'threshold': threshold,
+        },
+    )]
+
+
+def _large_composite_warnings(states, threshold) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    for state in states:
+        if not state.is_composite:
+            continue
+        actual = len(state.substates)
+        if actual <= threshold:
+            continue
+        diagnostics.append(ModelDiagnostic(
+            code='W_LARGE_COMPOSITE',
+            severity='warning',
+            message=(
+                f'Composite state {state.path!r} has {actual!r} direct '
+                f'children, exceeding threshold {threshold!r}.'
+            ),
+            refs={
+                'composite_path': state.path,
+                'n_children': actual,
+                'actual': actual,
+                'threshold': threshold,
+            },
+        ))
+    return diagnostics

--- a/pyfcstm/diagnostics/analyzers/transition_info.py
+++ b/pyfcstm/diagnostics/analyzers/transition_info.py
@@ -1,0 +1,69 @@
+"""Informational transition diagnostics."""
+
+from typing import TYPE_CHECKING, Iterable, List
+
+from ...utils.validate import ModelDiagnostic
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..inspect import StateInfo, TransitionInfo
+
+
+def collect_transition_infos(
+    states: Iterable['StateInfo'],
+    transitions: Iterable['TransitionInfo'],
+) -> List[ModelDiagnostic]:
+    """Collect non-blocking transition observations."""
+    states_by_path = {state.path: state for state in states}
+    diagnostics: List[ModelDiagnostic] = []
+    diagnostics.extend(_composite_self_transition_infos(
+        states_by_path,
+        transitions,
+    ))
+    diagnostics.extend(_eventless_guardless_transition_infos(transitions))
+    return diagnostics
+
+
+def _composite_self_transition_infos(states_by_path, transitions) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    for transition in transitions:
+        if transition.from_path != transition.to_path:
+            continue
+        state = states_by_path.get(transition.from_path)
+        if state is None or not state.is_composite:
+            continue
+        diagnostics.append(ModelDiagnostic(
+            code='I_TRANSITION_TO_SELF_VIA_PARENT',
+            severity='info',
+            message=(
+                f'Composite state {transition.from_path!r} transitions '
+                'to itself and may intentionally re-enter children.'
+            ),
+            refs={
+                'state_path': transition.from_path,
+                'crosses_composite': True,
+            },
+        ))
+    return diagnostics
+
+
+def _eventless_guardless_transition_infos(transitions) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    for transition in transitions:
+        if transition.from_path == '[*]':
+            continue
+        if transition.event is not None or transition.guard is not None:
+            continue
+        diagnostics.append(ModelDiagnostic(
+            code='I_TRANSITION_NEVER_EVENT_TRIGGERED',
+            severity='info',
+            message=(
+                f'Transition {transition.from_path!r} -> '
+                f'{transition.to_path!r} has no event or guard.'
+            ),
+            refs={
+                'from_path': transition.from_path,
+                'to_path': transition.to_path,
+                'transition_span': None,
+            },
+        ))
+    return diagnostics

--- a/pyfcstm/diagnostics/analyzers/type_shape.py
+++ b/pyfcstm/diagnostics/analyzers/type_shape.py
@@ -36,11 +36,8 @@ def _literal_assignment_narrowing_warnings(variables) -> List[ModelDiagnostic]:
     for variable in variables:
         if variable.type != 'int':
             continue
-        for source_expr in getattr(variable, 'float_literal_assignments', ()):
+        for source_expr in variable.float_literal_assignments:
             diagnostics.append(_narrowing_diagnostic(variable.name, source_expr))
-    # Future-proof: if VariableInfo comes from older construction paths
-    # without ``float_literal_assignments``, scan nothing rather than
-    # inferring from formatted effect text.
     return diagnostics
 
 

--- a/pyfcstm/diagnostics/analyzers/type_shape.py
+++ b/pyfcstm/diagnostics/analyzers/type_shape.py
@@ -1,0 +1,80 @@
+"""Type-shape design-health diagnostics."""
+
+from typing import TYPE_CHECKING, Iterable, List, Optional
+
+from ...utils.validate import ModelDiagnostic
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..inspect import VariableInfo
+
+
+def collect_type_warnings(
+    variables: Iterable['VariableInfo'],
+) -> List[ModelDiagnostic]:
+    """Collect diagnostics for simple type-shape hazards."""
+    variables = list(variables)
+    diagnostics: List[ModelDiagnostic] = []
+    diagnostics.extend(_literal_init_narrowing_warnings(variables))
+    diagnostics.extend(_literal_assignment_narrowing_warnings(variables))
+    return diagnostics
+
+
+def _literal_init_narrowing_warnings(variables) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    for variable in variables:
+        if variable.type != 'int' or not _is_float_literal_text(variable.init_value):
+            continue
+        diagnostics.append(_narrowing_diagnostic(
+            variable.name,
+            variable.init_value,
+        ))
+    return diagnostics
+
+
+def _literal_assignment_narrowing_warnings(variables) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    for variable in variables:
+        if variable.type != 'int':
+            continue
+        for source_expr in getattr(variable, 'float_literal_assignments', ()):
+            diagnostics.append(_narrowing_diagnostic(variable.name, source_expr))
+    # Future-proof: if VariableInfo comes from older construction paths
+    # without ``float_literal_assignments``, scan nothing rather than
+    # inferring from formatted effect text.
+    return diagnostics
+
+
+def _narrowing_diagnostic(var_name: str, source_expr: str) -> ModelDiagnostic:
+    return ModelDiagnostic(
+        code='W_LITERAL_TYPE_NARROWING',
+        severity='warning',
+        message=(
+            f'Integer variable {var_name!r} receives float literal '
+            f'expression {source_expr!r}.'
+        ),
+        refs={
+            'var_name': var_name,
+            'target_type': 'int',
+            'source_expr': source_expr,
+        },
+    )
+
+
+def _is_float_literal_text(text: Optional[str]) -> bool:
+    if text is None:
+        return False
+    value = text.strip()
+    if not value:
+        return False
+    lowered = value.lower()
+    if lowered in {'pi', 'e', 'tau'}:
+        return True
+    return any(ch in lowered for ch in ('.', 'e')) and _looks_numeric(lowered)
+
+
+def _looks_numeric(text: str) -> bool:
+    try:
+        float(text)
+    except ValueError:
+        return False
+    return True

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -122,6 +122,8 @@ _ALLOWED_REF_TYPES = (
     'str_or_null',
     'int',
     'int_or_null',
+    'float',
+    'number',
     'bool',
     'Span',
     'list[str]',

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -17,7 +17,7 @@
 # Allowed `refs.*.type` tokens (must mirror `_ALLOWED_REF_TYPES` in
 # codes.py — that tuple is the single source of truth, this comment block
 # is documentation; a test asserts the two stay aligned):
-#   str | str_or_null | int | int_or_null | bool | Span | list[str]
+#   str | str_or_null | int | int_or_null | float | number | bool | Span | list[str]
 #
 # Adding a new code: append a new top-level entry here AND add a fixture
 # test that triggers it from a real DSL snippet. The loader in `codes.py`
@@ -1533,4 +1533,324 @@ W_SHADOWED_EVENT:
         [*] -> A;
         A -> B : Tick;
         B -> A :: Tick;
+    }
+
+W_NAMED_ACTION_SHADOWS_ANCESTOR:
+  severity: warning
+  capability: pure_static
+  description: >-
+    A named lifecycle action reuses the same function name as an
+    ancestor-scoped named action.
+  refs:
+    function_name:
+      type: str
+      required: true
+      description: Reused named action identifier.
+    inner_state_path:
+      type: str
+      required: true
+      description: Dotted path of the state containing the shadowing action.
+    outer_state_path:
+      type: str
+      required: true
+      description: Dotted path of the ancestor state containing the shadowed action.
+  for_llm:
+    summary: >-
+      A nested state defines a named action with the same name as an
+      ancestor action. Relative action refs can become hard to audit
+      because the same leaf name means different functions at different
+      hierarchy levels.
+    recommended_actions:
+      - kind: rename_inner_action
+        target: named_action
+        rationale: Give the nested action a distinct name when it implements different behavior.
+      - kind: use_ref
+        target: action
+        rationale: Use ``ref`` to reuse the ancestor action when the behavior should be shared.
+    do_not:
+      - "Do not leave the shadowing name in place unless the scope distinction is intentional and documented outside the DSL."
+  emit_tier: static_pipeline
+  example_dsl: |
+    state Root {
+        enter Sync { }
+        state Child { enter Sync { } }
+        [*] -> Child;
+    }
+
+W_LITERAL_TYPE_NARROWING:
+  severity: warning
+  capability: pure_static
+  description: >-
+    An ``int`` variable is initialized or assigned from a floating-point
+    literal expression, which can imply silent narrowing in generated
+    code.
+  refs:
+    var_name:
+      type: str
+      required: true
+      description: Target variable name.
+    target_type:
+      type: str
+      required: true
+      description: Declared target variable type.
+      enum: ['int']
+    source_expr:
+      type: str
+      required: true
+      description: Source text of the float literal expression.
+  for_llm:
+    summary: >-
+      A value with float literal type flows into an ``int`` variable.
+      The model may truncate or generate target-language code with a
+      narrowing conversion.
+    recommended_actions:
+      - kind: change_type
+        target: variable_definition
+        rationale: Use ``def float`` when fractional values are intended.
+      - kind: change_literal
+        target: expression
+        rationale: Use an integer literal or explicit rounding expression when integer behavior is intended.
+    do_not:
+      - "Do not silently rely on target-language truncation rules."
+  emit_tier: static_pipeline
+  example_dsl: |
+    def int truncated = 3.5;
+    state Root { state A; [*] -> A; }
+
+W_ASPECT_NO_DESCENDANT_LEAF:
+  severity: warning
+  capability: pure_static
+  description: >-
+    A ``>> during`` aspect is attached to a state with no descendant
+    non-pseudo leaf states, so the aspect cannot affect any leaf cycle.
+  refs:
+    composite_path:
+      type: str
+      required: true
+      description: Dotted path of the state declaring the aspect.
+    aspect:
+      type: str
+      required: true
+      description: Aspect direction.
+      enum: ['before', 'after']
+  for_llm:
+    summary: >-
+      The aspect action has no descendant leaf state to wrap, so it has
+      no modeled runtime target.
+    recommended_actions:
+      - kind: add_leaf
+        target: composite_state
+        rationale: Add the intended descendant leaf state under this composite.
+      - kind: move_or_remove_aspect
+        target: aspect_action
+        rationale: Move the aspect to a composite with leaves, or remove it if it is dead scaffolding.
+    do_not:
+      - "Do not replace it with a normal during action unless the execution semantics really should change."
+  emit_tier: static_pipeline
+  example_dsl: |
+    state Root {
+        >> during before { }
+    }
+
+W_HIGH_VAR_TO_LEAF_RATIO:
+  severity: warning
+  capability: pure_static
+  description: >-
+    The number of variables is high relative to the number of non-pseudo
+    leaf states.
+  refs:
+    n_vars:
+      type: int
+      required: true
+      description: Number of top-level variable definitions.
+    n_leaf_states:
+      type: int
+      required: true
+      description: Number of non-pseudo leaf states.
+    actual:
+      type: number
+      required: true
+      description: Actual ``n_vars / max(n_leaf_states, 1)`` ratio.
+    threshold:
+      type: number
+      required: true
+      description: Effective threshold used for this inspection call.
+  for_llm:
+    summary: >-
+      The model has many variables for its number of leaf states, which
+      often indicates flag bloat or speculative state that does not
+      belong in the DSL.
+    recommended_actions:
+      - kind: audit_variables
+        target: variable_definitions
+        rationale: Remove or consolidate variables that do not represent durable machine state.
+      - kind: split_model
+        target: state_machine
+        rationale: If every variable is meaningful, consider whether the model is combining too many concerns.
+    do_not:
+      - "Do not raise the threshold without checking whether the variables influence behavior."
+  emit_tier: static_pipeline
+  example_dsl: |
+    def int a = 0;
+    def int b = 0;
+    def int c = 0;
+    state Root { state A; [*] -> A; }
+
+W_DEEP_HIERARCHY:
+  severity: warning
+  capability: pure_static
+  description: >-
+    The state hierarchy exceeds the configured maximum depth.
+  refs:
+    max_depth:
+      type: int
+      required: true
+      description: Maximum hierarchy depth found in the model.
+    deepest_path:
+      type: str
+      required: true
+      description: One deepest state path that triggered the warning.
+    actual:
+      type: int
+      required: true
+      description: Actual maximum hierarchy depth.
+    threshold:
+      type: int
+      required: true
+      description: Effective threshold used for this inspection call.
+  for_llm:
+    summary: >-
+      The hierarchy is deeper than the configured readability threshold,
+      making lifecycle order and transition scope harder to reason about.
+    recommended_actions:
+      - kind: flatten_hierarchy
+        target: state_tree
+        rationale: Collapse levels that do not add lifecycle or transition semantics.
+      - kind: extract_submachine
+        target: composite_state
+        rationale: Split a deeply nested concern into a separate machine when appropriate.
+    do_not:
+      - "Do not flatten a level that carries required enter, exit, during, or aspect semantics."
+  emit_tier: static_pipeline
+  example_dsl: |
+    state Root { state A { state B { state C; [*] -> C; } [*] -> B; } [*] -> A; }
+
+W_LARGE_COMPOSITE:
+  severity: warning
+  capability: pure_static
+  description: >-
+    A composite state has more direct children than the configured
+    threshold.
+  refs:
+    composite_path:
+      type: str
+      required: true
+      description: Dotted path of the large composite state.
+    n_children:
+      type: int
+      required: true
+      description: Number of direct child states.
+    actual:
+      type: int
+      required: true
+      description: Actual direct child count.
+    threshold:
+      type: int
+      required: true
+      description: Effective threshold used for this inspection call.
+  for_llm:
+    summary: >-
+      A single composite state owns many direct children, which can make
+      transition review and initial-state reasoning difficult.
+    recommended_actions:
+      - kind: group_children
+        target: composite_state
+        rationale: Introduce meaningful nested composites to group related child states.
+      - kind: split_machine
+        target: state_machine
+        rationale: Move unrelated child groups into separate machines if they represent separate concerns.
+    do_not:
+      - "Do not add arbitrary grouping states that have no semantic meaning."
+  emit_tier: static_pipeline
+  example_dsl: |
+    state Root { state A; state B; state C; [*] -> A; }
+
+I_TRANSITION_TO_SELF_VIA_PARENT:
+  severity: info
+  capability: pure_static
+  description: >-
+    A composite state transitions to itself, which can intentionally
+    force a re-entry path through child initialization and lifecycle
+    actions.
+  refs:
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the self-transitioning composite state.
+    crosses_composite:
+      type: bool
+      required: true
+      description: Always ``True`` for this info because the state is composite.
+  for_llm:
+    summary: >-
+      This is an informational observation rather than a defect: a
+      composite self-transition may be a deliberate reinitialization
+      pattern.
+    recommended_actions:
+      - kind: preserve_if_intentional
+        target: transition
+        rationale: Keep the transition when the model should re-run composite entry semantics.
+      - kind: review_lifecycle
+        target: composite_state
+        rationale: Confirm the enter/exit and initial-child actions are intended to run.
+    do_not:
+      - "Do not delete this transition automatically; it may be the intended reset path."
+  emit_tier: static_pipeline
+  example_dsl: |
+    state Root {
+        state Active { state Leaf; [*] -> Leaf; }
+        [*] -> Active;
+        Active -> Active;
+    }
+
+I_TRANSITION_NEVER_EVENT_TRIGGERED:
+  severity: info
+  capability: pure_static
+  description: >-
+    A normal transition has no event and no guard, so it is an
+    unconditional fall-through candidate.
+  refs:
+    from_path:
+      type: str
+      required: true
+      description: Dotted source state path.
+    to_path:
+      type: str
+      required: true
+      description: Dotted target state path.
+    transition_span:
+      type: Span
+      required: false
+      description: Source span of the transition when available.
+  for_llm:
+    summary: >-
+      The transition is not event-triggered and has no guard. This may
+      be a deliberate unconditional fall-through, so treat it as context
+      rather than a fix target.
+    recommended_actions:
+      - kind: keep_if_fallthrough
+        target: transition
+        rationale: Keep it when the state should immediately advance.
+      - kind: add_trigger_or_guard
+        target: transition
+        rationale: Add the missing event or guard if the transition should wait.
+    do_not:
+      - "Do not add a meaningless event just to silence this info."
+  emit_tier: static_pipeline
+  example_dsl: |
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B;
     }

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -3,7 +3,7 @@
 # integrations, evaluation scripts, and the jsfcstm visualization layer).
 #
 # Each entry documents:
-#   - `severity`       — 'error' or 'warning'
+#   - `severity`       — 'error', 'warning', or 'info'
 #   - `description`    — human-readable explanation of when this code fires
 #   - `refs`           — payload schema for `ModelDiagnostic.refs`. Each
 #                        field declares its type, whether it is required,
@@ -1649,6 +1649,8 @@ W_ASPECT_NO_DESCENDANT_LEAF:
   emit_tier: static_pipeline
   example_dsl: |
     state Root {
+        pseudo state Marker;
+        [*] -> Marker;
         >> during before { }
     }
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1581,9 +1581,10 @@ W_LITERAL_TYPE_NARROWING:
   severity: warning
   capability: pure_static
   description: >-
-    An ``int`` variable is initialized or assigned from a floating-point
-    literal expression, which can imply silent narrowing in generated
-    code.
+    An ``int`` variable is initialized or assigned directly from a
+    floating-point literal, which can imply silent narrowing in generated
+    code. Compound expressions containing floating-point literals are out
+    of scope for this warning.
   refs:
     var_name:
       type: str
@@ -1597,12 +1598,13 @@ W_LITERAL_TYPE_NARROWING:
     source_expr:
       type: str
       required: true
-      description: Source text of the float literal expression.
+      description: Source text of the direct float literal.
   for_llm:
     summary: >-
-      A value with float literal type flows into an ``int`` variable.
-      The model may truncate or generate target-language code with a
-      narrowing conversion.
+      A direct float literal value flows into an ``int`` variable. The
+      model may truncate or generate target-language code with a
+      narrowing conversion; compound expressions such as ``3.0 + 0.5``
+      are intentionally outside this warning's scope.
     recommended_actions:
       - kind: change_type
         target: variable_definition

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -1255,6 +1255,10 @@ def inspect_model(
         'large_composite_threshold',
         large_composite_threshold,
     )
+    var_to_leaf_ratio_threshold = _normalize_float_threshold(
+        'var_to_leaf_ratio_threshold',
+        var_to_leaf_ratio_threshold,
+    )
     states = _build_state_infos(machine)
     transitions = _build_transition_infos(machine)
     variables = _build_variable_infos(machine, states)
@@ -1305,6 +1309,17 @@ def _normalize_int_threshold(name: str, value: int) -> int:
             return int(value)
         raise ValueError(f'{name} must be an integer threshold, got {value!r}')
     raise TypeError(f'{name} must be an integer threshold, got {type(value).__name__}')
+
+
+def _normalize_float_threshold(name: str, value: float) -> float:
+    if isinstance(value, bool):
+        raise TypeError(f'{name} must be a finite numeric threshold, got bool')
+    if isinstance(value, (int, float)):
+        normalized = float(value)
+        if math.isfinite(normalized):
+            return normalized
+        raise ValueError(f'{name} must be a finite numeric threshold, got {value!r}')
+    raise TypeError(f'{name} must be a finite numeric threshold, got {type(value).__name__}')
 
 
 def _to_json_dataclass(obj: Any) -> Any:

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -45,6 +45,7 @@ Example::
     2
 """
 
+import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
@@ -1079,7 +1080,7 @@ def _build_metrics(
         n_transitions_forced=n_forced,
         n_events=len(events),
         n_variables=len(variables),
-        var_to_leaf_ratio=(len(variables) / n_leaf) if n_leaf else 0.0,
+        var_to_leaf_ratio=len(variables) / max(n_leaf, 1),
         aspect_coverage=aspect_coverage,
         abstract_action_inventory=tuple(sorted(abstract_inventory)),
     )
@@ -1246,6 +1247,14 @@ def inspect_model(
         >>> sorted(report.reachability_graph['Root.Sub.A'])
         ['Root.Sub.B']
     """
+    deep_hierarchy_threshold = _normalize_int_threshold(
+        'deep_hierarchy_threshold',
+        deep_hierarchy_threshold,
+    )
+    large_composite_threshold = _normalize_int_threshold(
+        'large_composite_threshold',
+        large_composite_threshold,
+    )
     states = _build_state_infos(machine)
     transitions = _build_transition_infos(machine)
     variables = _build_variable_infos(machine, states)
@@ -1284,6 +1293,18 @@ def inspect_model(
             var_to_leaf_ratio_threshold=var_to_leaf_ratio_threshold,
         )),
     )
+
+
+def _normalize_int_threshold(name: str, value: int) -> int:
+    if isinstance(value, bool):
+        raise TypeError(f'{name} must be an integer threshold, got bool')
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value) and value.is_integer():
+            return int(value)
+        raise ValueError(f'{name} must be an integer threshold, got {value!r}')
+    raise TypeError(f'{name} must be an integer threshold, got {type(value).__name__}')
 
 
 def _to_json_dataclass(obj: Any) -> Any:

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -62,6 +62,11 @@ if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
     )
 
 
+DEFAULT_DEEP_HIERARCHY_THRESHOLD = 6
+DEFAULT_LARGE_COMPOSITE_THRESHOLD = 12
+DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD = 2.0
+
+
 @dataclass(frozen=True)
 class StateInfo:
     """
@@ -209,6 +214,10 @@ class VariableInfo:
         use this to distinguish high-confidence unused variables from
         variables that may be touched by abstract behavior.
     :type abstract_actions_in_scope: Tuple[str, ...]
+    :param float_literal_assignments: Source text of float literal
+        assignments to this variable from lifecycle actions or transition
+        effects.
+    :type float_literal_assignments: Tuple[str, ...]
     """
 
     name: str
@@ -221,6 +230,7 @@ class VariableInfo:
     participates_directly: bool
     participates_indirectly: bool
     abstract_actions_in_scope: Tuple[str, ...]
+    float_literal_assignments: Tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -562,6 +572,22 @@ def _walk_stmt_self_assigns(stmt: 'OperationStatement', out: List[str]) -> None:
                 _walk_stmt_self_assigns(inner, out)
 
 
+def _walk_stmt_float_literal_assignments(
+        stmt: 'OperationStatement',
+        out: Dict[str, List[str]],
+) -> None:
+    from ..model.expr import Float
+    from ..model.model import IfBlock, Operation
+    if isinstance(stmt, Operation):
+        if isinstance(stmt.expr, Float):
+            out.setdefault(stmt.var_name, []).append(_expr_text(stmt.expr) or '')
+        return
+    if isinstance(stmt, IfBlock):
+        for branch in stmt.branches:
+            for inner in branch.statements:
+                _walk_stmt_float_literal_assignments(inner, out)
+
+
 def _stage_function_label(stage_item: 'OnStage') -> str:
     """Choose a stable label for an action (named, abstract, or inline)."""
     if stage_item.name:
@@ -789,17 +815,33 @@ def _build_variable_infos(
     var_writes_by_state: Dict[str, List[str]] = {name: [] for name in machine.defines}
     var_read_guards: Dict[str, List[Tuple[str, str]]] = {name: [] for name in machine.defines}
     var_written_effects: Dict[str, List[Tuple[str, str]]] = {name: [] for name in machine.defines}
+    var_float_literal_assignments: Dict[str, List[str]] = {
+        name: [] for name in machine.defines
+    }
     state_lookup: Dict[str, StateInfo] = {s.path: s for s in states}
 
     for state in machine.walk_states():
         path = _state_path(state)
         reads, writes = _collect_action_reads_writes(state)
+        float_assigns: Dict[str, List[str]] = {}
+        for collection in (
+                state.on_enters,
+                state.on_durings,
+                state.on_exits,
+                state.on_during_aspects,
+        ):
+            for action in collection:
+                for stmt in action.operations:
+                    _walk_stmt_float_literal_assignments(stmt, float_assigns)
         for var_name in reads:
             if var_name in var_reads_by_state:
                 var_reads_by_state[var_name].append(path)
         for var_name in writes:
             if var_name in var_writes_by_state:
                 var_writes_by_state[var_name].append(path)
+        for var_name, assignments in float_assigns.items():
+            if var_name in var_float_literal_assignments:
+                var_float_literal_assignments[var_name].extend(assignments)
 
         for transition in state.transitions:
             from_path = _transition_endpoint(state, transition.from_state, is_source=True)
@@ -811,12 +853,17 @@ def _build_variable_infos(
                 lreads: List[str] = []
                 lwrites: List[str] = []
                 _walk_stmt_reads_writes(stmt, lreads, lwrites)
+                lfloat_assigns: Dict[str, List[str]] = {}
+                _walk_stmt_float_literal_assignments(stmt, lfloat_assigns)
                 for v in lreads:
                     if v in var_reads_by_state:
                         var_reads_by_state[v].append(from_path)
                 for v in lwrites:
                     if v in var_written_effects:
                         var_written_effects[v].append((from_path, to_path))
+                for v, assignments in lfloat_assigns.items():
+                    if v in var_float_literal_assignments:
+                        var_float_literal_assignments[v].extend(assignments)
 
     # Stable, deduped sequences for the public payload.
     def _dedupe_ordered(seq: List[str]) -> Tuple[str, ...]:
@@ -845,6 +892,7 @@ def _build_variable_infos(
         written_effects = _dedupe_pairs(var_written_effects[name])
         participates_directly = bool(read_states or read_guards)
         abstract_actions = _abstract_actions_in_scope(state_lookup, read_states, written_states)
+        float_assignments = _dedupe_ordered(var_float_literal_assignments[name])
         out.append(VariableInfo(
             name=name,
             type=var_define.type,
@@ -856,6 +904,7 @@ def _build_variable_infos(
             participates_directly=participates_directly,
             participates_indirectly=False,
             abstract_actions_in_scope=abstract_actions,
+            float_literal_assignments=float_assignments,
         ))
     return tuple(out)
 
@@ -1164,7 +1213,13 @@ def _function_signature(state: Any, default_path: Optional[str], action: Any) ->
     return f'{normalized}:{leaf}' if normalized else leaf
 
 
-def inspect_model(machine: 'StateMachine') -> ModelInspect:
+def inspect_model(
+        machine: 'StateMachine',
+        *,
+        deep_hierarchy_threshold: int = DEFAULT_DEEP_HIERARCHY_THRESHOLD,
+        large_composite_threshold: int = DEFAULT_LARGE_COMPOSITE_THRESHOLD,
+        var_to_leaf_ratio_threshold: float = DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD,
+) -> ModelInspect:
     """
     Build a structured inspection report for a state machine model.
 
@@ -1174,6 +1229,14 @@ def inspect_model(machine: 'StateMachine') -> ModelInspect:
 
     :param machine: The state machine model to inspect.
     :type machine: pyfcstm.model.StateMachine
+    :param deep_hierarchy_threshold: Maximum accepted hierarchy depth.
+    :type deep_hierarchy_threshold: int
+    :param large_composite_threshold: Maximum accepted number of direct
+        child states in one composite.
+    :type large_composite_threshold: int
+    :param var_to_leaf_ratio_threshold: Maximum accepted variable to
+        non-pseudo leaf-state ratio.
+    :type var_to_leaf_ratio_threshold: float
     :return: Structured view of the model.
     :rtype: ModelInspect
 
@@ -1213,8 +1276,12 @@ def inspect_model(machine: 'StateMachine') -> ModelInspect:
             events,
             actions,
             forced_transitions,
+            metrics,
             reachability_graph,
             root_state_path=root_state_path,
+            deep_hierarchy_threshold=deep_hierarchy_threshold,
+            large_composite_threshold=large_composite_threshold,
+            var_to_leaf_ratio_threshold=var_to_leaf_ratio_threshold,
         )),
     )
 

--- a/pyfcstm/diagnostics/schema.json
+++ b/pyfcstm/diagnostics/schema.json
@@ -180,7 +180,7 @@
         "read_in_states", "written_in_states",
         "read_in_guards", "written_in_effects",
         "participates_directly", "participates_indirectly",
-        "abstract_actions_in_scope"
+        "abstract_actions_in_scope", "float_literal_assignments"
       ],
       "properties": {
         "name": { "type": "string" },
@@ -209,6 +209,10 @@
         "participates_directly": { "type": "boolean" },
         "participates_indirectly": { "type": "boolean" },
         "abstract_actions_in_scope": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "float_literal_assignments": {
           "type": "array",
           "items": { "type": "string" }
         }

--- a/pyfcstm/utils/validate.py
+++ b/pyfcstm/utils/validate.py
@@ -85,7 +85,7 @@ class Span:
     end_column: Optional[int] = None
 
 
-_ALLOWED_SEVERITIES = ('error', 'warning')
+_ALLOWED_SEVERITIES = ('error', 'warning', 'info')
 
 
 @dataclass(frozen=True)
@@ -119,7 +119,7 @@ class ModelDiagnostic:
     :param code: Stable diagnostic code, e.g. ``'E_UNDEFINED_VAR'``,
         ``'W_DEADLOCK_LEAF'``. Always treated as the public contract.
     :type code: str
-    :param severity: Either ``'error'`` or ``'warning'``.
+    :param severity: Either ``'error'``, ``'warning'``, or ``'info'``.
     :type severity: str
     :param message: Human-readable rendering of the diagnostic. **Not** part
         of the contract — downstream tools must not regex-match against it.
@@ -149,7 +149,7 @@ class ModelDiagnostic:
     """
 
     code: str
-    severity: Literal['error', 'warning']
+    severity: Literal['error', 'warning', 'info']
     message: str
     span: Optional[Span] = None
     refs: Dict[str, Any] = field(default_factory=dict)

--- a/pyfcstm/utils/validate.py
+++ b/pyfcstm/utils/validate.py
@@ -106,9 +106,9 @@ class ModelDiagnostic:
     time so that experimental codes can be emitted in tests.
 
     :attr:`severity` is enforced at construction time to be one of
-    ``'error'`` / ``'warning'`` — a typo such as ``'Error'`` would otherwise
-    cause :meth:`is_error` to silently return ``False`` and skew downstream
-    dispatch.
+    ``'error'`` / ``'warning'`` / ``'info'`` — a typo such as ``'Error'``
+    would otherwise cause :meth:`is_error` to silently return ``False`` and
+    skew downstream dispatch.
 
     The dataclass is frozen so the public contract surface (``code`` /
     ``severity`` / ``message`` / ``span``) cannot be mutated after

--- a/test/diagnostics/_schema_check.py
+++ b/test/diagnostics/_schema_check.py
@@ -22,6 +22,10 @@ from pyfcstm.utils import ModelDiagnostic
 _TYPE_PREDICATES = {
     'str': lambda v: isinstance(v, str),
     'int': lambda v: isinstance(v, int) and not isinstance(v, bool),
+    'float': lambda v: isinstance(v, float),
+    'number': lambda v: (
+        isinstance(v, (int, float)) and not isinstance(v, bool)
+    ),
     'bool': lambda v: isinstance(v, bool),
     'list[str]': lambda v: isinstance(v, list) and all(isinstance(item, str) for item in v),
     'Span': lambda v: v is None or hasattr(v, 'line'),

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -75,6 +75,13 @@ class TestCodeRegistryShape:
                     f"warning code {code} must start with 'W_'"
                 )
 
+    def test_info_codes_use_I_prefix(self):
+        for code, spec in CODE_REGISTRY.items():
+            if spec.severity == 'info':
+                assert code.startswith('I_'), (
+                    f"info code {code} must start with 'I_'"
+                )
+
 
 @pytest.mark.unittest
 class TestPR1CodesPresence:

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -362,6 +362,22 @@ class TestLoaderValidation:
         spec = reg['E_FOO'].refs_schema['bar']
         assert spec.enum == ('a', 'b', 'c')
 
+    @pytest.mark.parametrize('type_token', ['float', 'number'])
+    def test_loads_numeric_ref_type_tokens(self, tmp_path, type_token):
+        path = self._write_yaml(tmp_path, f"""
+            W_FOO:
+              severity: warning
+              capability: pure_static
+              description: Numeric ref type.
+              refs:
+                value:
+                  type: {type_token}
+                  required: true
+                  description: Numeric payload.
+        """)
+        reg = load_codes(path)
+        assert reg['W_FOO'].refs_schema['value'].type == type_token
+
     def test_rejects_example_dsl_as_non_string(self, tmp_path):
         path = self._write_yaml(tmp_path, """
             E_FOO:

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -462,6 +462,24 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
         ]),
         [
             {
+                'code': 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+                'severity': 'info',
+                'refs': {
+                    'from_path': 'Root.Active',
+                    'to_path': 'Root.Active',
+                    'transition_span': None,
+                },
+            },
+            {
+                'code': 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+                'severity': 'info',
+                'refs': {
+                    'from_path': 'Root.Active',
+                    'to_path': 'Root.Idle',
+                    'transition_span': None,
+                },
+            },
+            {
                 'code': 'W_DEADLOCK_LEAF',
                 'severity': 'warning',
                 'refs': {
@@ -589,6 +607,112 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'severity': 'warning',
                 'refs': {
                     'state_path': 'Root.LeafForced',
+                },
+            },
+        ],
+    ),
+    (
+        'design-health-threshold-naming-type-info',
+        '\n'.join([
+            'def int truncated = 3.5;',
+            'def int assigned = 0;',
+            'def int extra = 0;',
+            'state Root {',
+            '    enter Sync { }',
+            '    state Active {',
+            '        enter Sync { }',
+            '        state Leaf;',
+            '        [*] -> Leaf;',
+            '    }',
+            '    state Sparse {',
+            '        pseudo state Marker;',
+            '        [*] -> Marker;',
+            '        >> during before { }',
+            '    }',
+            '    state B { during { assigned = 2.25; } }',
+            '    [*] -> Active;',
+            '    Active -> Active;',
+            '    Active -> Sparse;',
+            '    Sparse -> B :: Next;',
+            '    B -> Active :: Next;',
+            '}',
+        ]),
+        [
+            {
+                'code': 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+                'severity': 'info',
+                'refs': {
+                    'from_path': 'Root.Active',
+                    'to_path': 'Root.Active',
+                    'transition_span': None,
+                },
+            },
+            {
+                'code': 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+                'severity': 'info',
+                'refs': {
+                    'from_path': 'Root.Active',
+                    'to_path': 'Root.Sparse',
+                    'transition_span': None,
+                },
+            },
+            {
+                'code': 'I_TRANSITION_TO_SELF_VIA_PARENT',
+                'severity': 'info',
+                'refs': {
+                    'state_path': 'Root.Active',
+                    'crosses_composite': True,
+                },
+            },
+            {
+                'code': 'W_ASPECT_NO_DESCENDANT_LEAF',
+                'severity': 'warning',
+                'refs': {
+                    'composite_path': 'Root.Sparse',
+                    'aspect': 'before',
+                },
+            },
+            {
+                'code': 'W_DEADLOCK_LEAF',
+                'severity': 'warning',
+                'refs': {
+                    'state_path': 'Root.Active.Leaf',
+                    'reason': 'no_outgoing_transition',
+                },
+            },
+            {
+                'code': 'W_LITERAL_TYPE_NARROWING',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'assigned',
+                    'target_type': 'int',
+                    'source_expr': '2.25',
+                },
+            },
+            {
+                'code': 'W_LITERAL_TYPE_NARROWING',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'truncated',
+                    'target_type': 'int',
+                    'source_expr': '3.5',
+                },
+            },
+            {
+                'code': 'W_NAMED_ACTION_SHADOWS_ANCESTOR',
+                'severity': 'warning',
+                'refs': {
+                    'function_name': 'Sync',
+                    'inner_state_path': 'Root.Active',
+                    'outer_state_path': 'Root',
+                },
+            },
+            {
+                'code': 'W_WRITE_ONLY_VAR',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'assigned',
+                    'written_states': ['Root.B'],
                 },
             },
         ],

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -717,6 +717,27 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
             },
         ],
     ),
+    (
+        'transition-never-event-triggered-exit-transition',
+        '\n'.join([
+            'state Root {',
+            '    state A;',
+            '    [*] -> A;',
+            '    A -> [*];',
+            '}',
+        ]),
+        [
+            {
+                'code': 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+                'severity': 'info',
+                'refs': {
+                    'from_path': 'Root.A',
+                    'to_path': '[*]',
+                    'transition_span': None,
+                },
+            },
+        ],
+    ),
 ]
 
 

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -1108,6 +1108,18 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
         with pytest.raises(ValueError, match='large_composite_threshold'):
             inspect_model(_parse(dsl), large_composite_threshold=2.5)
 
+    def test_ratio_threshold_option_rejects_non_finite_values(self):
+        dsl = """
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+        with pytest.raises(TypeError, match='var_to_leaf_ratio_threshold'):
+            inspect_model(_parse(dsl), var_to_leaf_ratio_threshold=True)
+        with pytest.raises(ValueError, match='var_to_leaf_ratio_threshold'):
+            inspect_model(_parse(dsl), var_to_leaf_ratio_threshold=float('nan'))
+
     def test_integer_threshold_options_accept_integer_valued_float(self):
         dsl = """
         state Root {

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -15,6 +15,9 @@ import pytest
 
 from pyfcstm.diagnostics import (
     ActionInfo,
+    DEFAULT_DEEP_HIERARCHY_THRESHOLD,
+    DEFAULT_LARGE_COMPOSITE_THRESHOLD,
+    DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD,
     EventInfo,
     ForcedTransitionInfo,
     ModelInspect,
@@ -26,6 +29,8 @@ from pyfcstm.diagnostics import (
 )
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
+
+from ._schema_check import assert_all_diags_match_schema
 
 
 def _parse(src):
@@ -151,6 +156,11 @@ class TestInspectModelBasic:
         assert m.n_variables == 2
         assert m.var_to_leaf_ratio == 1.0
         assert m.max_hierarchy_depth == 1
+
+    def test_default_threshold_constants(self):
+        assert DEFAULT_DEEP_HIERARCHY_THRESHOLD == 6
+        assert DEFAULT_LARGE_COMPOSITE_THRESHOLD == 12
+        assert DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD == 2.0
 
 
 @pytest.mark.unittest
@@ -1006,3 +1016,168 @@ class TestInspectModelRedundancySemantics:
             'transition_span': None,
             'var_name': 'x',
         }]
+
+
+@pytest.mark.unittest
+class TestInspectModelThresholdNamingTypeDiagnostics:
+    """Threshold, info observation, naming, and type diagnostics."""
+
+    @staticmethod
+    def _diagnostics_by_code(dsl, **inspect_kwargs):
+        report = inspect_model(_parse(dsl), **inspect_kwargs)
+        assert_all_diags_match_schema(report.diagnostics, context='threshold-naming-type-inspect')
+        out = {}
+        for diag in report.diagnostics:
+            out.setdefault(diag.code, []).append(diag)
+        return out
+
+    def test_custom_thresholds_emit_with_actual_and_threshold_refs(self):
+        dsl = """
+        def int a = 0;
+        def int b = 0;
+        def int c = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B :: Next;
+            B -> C :: Next;
+            C -> A :: Next;
+        }
+        """
+        by_code = self._diagnostics_by_code(
+            dsl,
+            var_to_leaf_ratio_threshold=0.5,
+            large_composite_threshold=2,
+            deep_hierarchy_threshold=0,
+        )
+
+        high_ratio = by_code['W_HIGH_VAR_TO_LEAF_RATIO'][0]
+        assert high_ratio.refs == {
+            'n_vars': 3,
+            'n_leaf_states': 3,
+            'actual': 1.0,
+            'threshold': 0.5,
+        }
+
+        large = by_code['W_LARGE_COMPOSITE'][0]
+        assert large.refs == {
+            'composite_path': 'Root',
+            'n_children': 3,
+            'actual': 3,
+            'threshold': 2,
+        }
+
+        deep = by_code['W_DEEP_HIERARCHY'][0]
+        assert deep.refs == {
+            'max_depth': 1,
+            'deepest_path': 'Root.A',
+            'actual': 1,
+            'threshold': 0,
+        }
+
+    def test_default_thresholds_do_not_emit_for_simple_model(self):
+        diagnostics = inspect_model(_parse(SIMPLE_DSL)).diagnostics
+        codes = {diag.code for diag in diagnostics}
+        assert 'W_HIGH_VAR_TO_LEAF_RATIO' not in codes
+        assert 'W_LARGE_COMPOSITE' not in codes
+        assert 'W_DEEP_HIERARCHY' not in codes
+
+    def test_named_action_shadows_ancestor(self):
+        dsl = """
+        state Root {
+            enter Sync { }
+            state Child {
+                enter Sync { }
+            }
+            [*] -> Child;
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['W_NAMED_ACTION_SHADOWS_ANCESTOR'][0]
+        assert diag.refs == {
+            'function_name': 'Sync',
+            'inner_state_path': 'Root.Child',
+            'outer_state_path': 'Root',
+        }
+
+    def test_literal_type_narrowing_for_int_initializer(self):
+        dsl = """
+        def int truncated = 3.5;
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['W_LITERAL_TYPE_NARROWING'][0]
+        assert diag.refs == {
+            'var_name': 'truncated',
+            'target_type': 'int',
+            'source_expr': '3.5',
+        }
+
+    def test_literal_type_narrowing_for_int_assignment(self):
+        dsl = """
+        def int truncated = 0;
+        state Root {
+            state A {
+                during { truncated = 2.25; }
+            }
+            [*] -> A;
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['W_LITERAL_TYPE_NARROWING'][0]
+        assert diag.refs == {
+            'var_name': 'truncated',
+            'target_type': 'int',
+            'source_expr': '2.25',
+        }
+
+    def test_aspect_no_descendant_leaf(self):
+        dsl = """
+        state Root {
+            pseudo state Marker;
+            [*] -> Marker;
+            >> during before { }
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['W_ASPECT_NO_DESCENDANT_LEAF'][0]
+        assert diag.refs == {
+            'composite_path': 'Root',
+            'aspect': 'before',
+        }
+
+    def test_transition_to_self_via_parent_info(self):
+        dsl = """
+        state Root {
+            state Active {
+                state Leaf;
+                [*] -> Leaf;
+            }
+            [*] -> Active;
+            Active -> Active;
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['I_TRANSITION_TO_SELF_VIA_PARENT'][0]
+        assert diag.severity == 'info'
+        assert diag.refs == {
+            'state_path': 'Root.Active',
+            'crosses_composite': True,
+        }
+
+    def test_transition_never_event_triggered_info(self):
+        dsl = """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['I_TRANSITION_NEVER_EVENT_TRIGGERED'][0]
+        assert diag.severity == 'info'
+        assert diag.refs == {
+            'from_path': 'Root.A',
+            'to_path': 'Root.B',
+            'transition_span': None,
+        }

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -1077,6 +1077,58 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
             'threshold': 0,
         }
 
+    def test_var_to_leaf_ratio_uses_one_as_minimum_denominator(self):
+        dsl = """
+        def int a = 0;
+        def int b = 0;
+        def int c = 0;
+        state Root {
+            pseudo state Marker;
+            [*] -> Marker;
+        }
+        """
+        by_code = self._diagnostics_by_code(dsl, var_to_leaf_ratio_threshold=2.0)
+        high_ratio = by_code['W_HIGH_VAR_TO_LEAF_RATIO'][0]
+        assert high_ratio.refs == {
+            'n_vars': 3,
+            'n_leaf_states': 0,
+            'actual': 3.0,
+            'threshold': 2.0,
+        }
+
+    def test_integer_threshold_options_reject_fractional_values(self):
+        dsl = """
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+        with pytest.raises(ValueError, match='deep_hierarchy_threshold'):
+            inspect_model(_parse(dsl), deep_hierarchy_threshold=0.5)
+        with pytest.raises(ValueError, match='large_composite_threshold'):
+            inspect_model(_parse(dsl), large_composite_threshold=2.5)
+
+    def test_integer_threshold_options_accept_integer_valued_float(self):
+        dsl = """
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+        }
+        """
+        report = inspect_model(
+            _parse(dsl),
+            deep_hierarchy_threshold=0.0,
+            large_composite_threshold=2.0,
+        )
+        assert_all_diags_match_schema(report.diagnostics, context='integer-float-thresholds')
+        by_code = {}
+        for diag in report.diagnostics:
+            by_code.setdefault(diag.code, []).append(diag)
+        assert by_code['W_DEEP_HIERARCHY'][0].refs['threshold'] == 0
+        assert by_code['W_LARGE_COMPOSITE'][0].refs['threshold'] == 2
+
     def test_default_thresholds_do_not_emit_for_simple_model(self):
         diagnostics = inspect_model(_parse(SIMPLE_DSL)).diagnostics
         codes = {diag.code for diag in diagnostics}


### PR DESCRIPTION
> 跟踪 issue：#104
> 上级伞 PR：#118（PR-B，base：`main`，head：`dev/issue104-pr-b`）
> 本 PR：PR-B3，base：`dev/issue104-pr-b`，作为 PR-B 的收尾子 PR。PR-B1 #119 与 PR-B2 #120 已合入伞分支，本 PR 只处理 B3 范围，不提前做 PR-C / Layer 3 内容。

## 最终状态

本 PR 已 merge 到上级伞分支 `dev/issue104-pr-b`。

- Merge commit：`e3b4e2e037aa9f8f6041c66861cd7bb8a16dde9b`
- 合入时间：2026-05-30
- 合入前 head：`e6ba3aaff8d1efb4f6358c1ca3c1861dabf15831`
- 合入前 CI：GitHub Actions 全 SUCCESS。
- `claude -p` 复审：无 C/I，ready to merge。评论：`https://github.com/HansBug/pyfcstm/pull/121#issuecomment-4581600574`
- `codex exec` 复审：无 C/I，ready to merge。Review：`https://github.com/HansBug/pyfcstm/pull/121#pullrequestreview-4394326527`

## B3 范围

本 PR 落地 8 个诊断，全部在 `inspect_model(...).diagnostics` 与 `inspectModel(...).diagnostics` 两端对等 emit。

| code | 分组 | severity | capability |
|---|---|---|---|
| `W_NAMED_ACTION_SHADOWS_ANCESTOR` | 命名/作用域 | warning | pure_static |
| `W_LITERAL_TYPE_NARROWING` | 类型 | warning | pure_static |
| `W_ASPECT_NO_DESCENDANT_LEAF` | aspect | warning | pure_static |
| `W_HIGH_VAR_TO_LEAF_RATIO` | 阈值 | warning | pure_static |
| `W_DEEP_HIERARCHY` | 阈值 | warning | pure_static |
| `W_LARGE_COMPOSITE` | 阈值 | warning | pure_static |
| `I_TRANSITION_TO_SELF_VIA_PARENT` | info | info | pure_static |
| `I_TRANSITION_NEVER_EVENT_TRIGGERED` | info | info | pure_static |

## 关键契约

- Python：`inspect_model(machine, *, deep_hierarchy_threshold=6, large_composite_threshold=12, var_to_leaf_ratio_threshold=2.0)`
- jsfcstm：`inspectModel(model, { deepHierarchyThreshold = 6, largeCompositeThreshold = 12, varToLeafRatioThreshold = 2.0 } = {})`
- 默认值不写进 `codes.yaml.refs`；`refs` 只描述诊断 emit payload。
- refs schema 已扩展 `float` / `number` 支持，并在 `_schema_check` 覆盖真实 runtime 类型校验。
- `var_to_leaf_ratio` 使用 `n_vars / max(n_leaf_states, 1)`；零非 pseudo leaf 模型不会因为分母为 0 绕开阈值诊断。
- `W_LITERAL_TYPE_NARROWING` 仅覆盖 direct float literal；compound expression out of scope。
- `I_TRANSITION_NEVER_EVENT_TRIGGERED` 排除 `[*] -> X`，包含 `X -> [*]`。

## 验证记录

- `node ./scripts/sync-runtime-assets.js --phase=src`：通过，无额外 `codes.json` diff。
- `pytest test/diagnostics/test_cross_end_parity.py::test_design_health_inspect_diagnostics_match_inlined_expected test/diagnostics/test_inspect_model.py::TestInspectModelThresholdNamingTypeDiagnostics test/diagnostics/test_codes_yaml.py -q -m unittest`：223 passed。
- `npm run build`：通过。
- `npm run test:unit -- --grep "threshold, info, naming, and type diagnostics|diagnostics resources"`：19 passing。
- `pytest test/diagnostics -q -m unittest`：354 passed。
- `npm run test:coverage`：507 passing，覆盖率门槛通过。
- `SKIP_SLOW_TESTS=1 make unittest`：8854 passed，164 skipped，63 deselected，总覆盖率 94%。
- `git diff --check`：通过。
- GitHub Actions：全部 SUCCESS。

## 测试隔离与命名原则

- Python 单元测试不得调用 Node.js / jsfcstm，不读取 `editors/jsfcstm` 或 js 测试树。
- jsfcstm 单元测试不得调用 Python，不读取 Python `test/` 路径。
- 两端 fixture 各自独立维护，优先内联 DSL 字面量；即使对方测试树被移除，本端测试仍应稳定运行。
- 禁止用 `b1` / `b2` / `b3` 这类项目阶段名作为模块、函数、公共 API 命名。
- 本 PR 未引入 PR-C / Layer 3 / solver / `W_UNREFERENCED_VAR` 范围内容。