### PR TITLE
诊断 PR-C2：Layer 0 use-def 数据流闭包与 3 个变量诊断

### DIFF
--- a/docs/source/api_doc/diagnostics/analyzers/index.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/index.rst
@@ -18,6 +18,7 @@ pyfcstm.diagnostics.analyzers
     thresholds
     transition_info
     type_shape
+    use_def
 
 \_\_all\_\_
 -----------------------------------------------------

--- a/docs/source/api_doc/diagnostics/analyzers/use_def.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/use_def.rst
@@ -1,0 +1,25 @@
+pyfcstm.diagnostics.analyzers.use\_def
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.analyzers.use_def
+
+.. automodule:: pyfcstm.diagnostics.analyzers.use_def
+
+
+UseDefGraph
+-----------------------------------------------------
+
+.. autoclass:: UseDefGraph
+    :members: dependencies_of,affecting_variables,edges,dependencies_by_target
+
+
+build\_use\_def\_graph
+-----------------------------------------------------
+
+.. autofunction:: build_use_def_graph
+
+
+collect\_expr\_variables
+-----------------------------------------------------
+
+.. autofunction:: collect_expr_variables

--- a/docs/source/api_doc/diagnostics/inspect.rst
+++ b/docs/source/api_doc/diagnostics/inspect.rst
@@ -42,7 +42,7 @@ VariableInfo
 -----------------------------------------------------
 
 .. autoclass:: VariableInfo
-    :members: name,type,init_value,read_in_states,written_in_states,read_in_guards,written_in_effects,participates_directly,participates_indirectly,abstract_actions_in_scope,float_literal_assignments
+    :members: name,type,init_value,read_in_states,written_in_states,read_in_guards,written_in_effects,affects_guard_directly,affects_guard_indirectly,abstract_actions_in_scope,float_literal_assignments
 
 
 EventInfo

--- a/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
@@ -2,6 +2,9 @@ import type {ModelDiagnosticJson, VariableInfo} from '../inspect';
 import type {StateMachine} from '../../model/runtime';
 import {collectExprVariables} from './use-def';
 
+const INIT_MARK = '[*]';
+const EXIT_MARK = '[*]';
+
 export function collectDataFlowWarnings(
     variables: VariableInfo[],
     machine?: StateMachine,
@@ -88,12 +91,16 @@ function collectGuardVarsNeverChangeDiagnostics(
                 .sort();
             if (guardVars.length === 0) continue;
             if (guardVars.some(name => writtenVars.has(name))) continue;
+            const fromPath = transitionEndpoint(state.path, transition.fromState, true);
+            const toPath = transitionEndpoint(state.path, transition.toState, false);
             out.push({
                 code: 'W_GUARD_VARS_NEVER_CHANGE',
                 severity: 'warning',
                 message: 'Transition guard reads only variables that are never changed by actions or effects.',
                 span: null,
                 refs: {
+                    from_path: fromPath,
+                    to_path: toPath,
                     transition_span: null,
                     guard_vars: guardVars,
                 },
@@ -101,4 +108,24 @@ function collectGuardVarsNeverChangeDiagnostics(
         }
     }
     return out;
+}
+
+function dottedPath(path: readonly string[]): string {
+    return path.filter(item => item !== null && item !== undefined).join('.');
+}
+
+function resolveSiblingPath(parentPath: readonly string[], name: string): string {
+    const parent = dottedPath(parentPath);
+    return parent ? `${parent}.${name}` : name;
+}
+
+function transitionEndpoint(
+    parentPath: readonly string[],
+    marker: string,
+    isSource: boolean,
+): string {
+    if (marker === 'INIT_STATE' || marker === 'EXIT_STATE') {
+        return isSource ? INIT_MARK : EXIT_MARK;
+    }
+    return resolveSiblingPath(parentPath, marker);
 }

--- a/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
@@ -101,7 +101,6 @@ function collectGuardVarsNeverChangeDiagnostics(
                 refs: {
                     from_path: fromPath,
                     to_path: toPath,
-                    transition_span: null,
                     guard_vars: guardVars,
                 },
             });

--- a/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
@@ -1,12 +1,43 @@
 import type {ModelDiagnosticJson, VariableInfo} from '../inspect';
+import type {StateMachine} from '../../model/runtime';
+import {collectExprVariables} from './use-def';
 
-export function collectDataFlowWarnings(variables: VariableInfo[]): ModelDiagnosticJson[] {
+export function collectDataFlowWarnings(
+    variables: VariableInfo[],
+    machine?: StateMachine,
+): ModelDiagnosticJson[] {
     const out: ModelDiagnosticJson[] = [];
     for (const variable of variables) {
         const readStates = new Set(variable.read_in_states);
         for (const [source] of variable.read_in_guards) readStates.add(source);
         const writeStates = new Set(variable.written_in_states);
         for (const [source] of variable.written_in_effects) writeStates.add(source);
+        if (!variable.affects_guard_directly && !variable.affects_guard_indirectly) {
+            if (variable.abstract_actions_in_scope.length > 0) {
+                out.push({
+                    code: 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT',
+                    severity: 'info',
+                    message: `Variable ${JSON.stringify(variable.name)} does not affect any transition guard, but abstract actions may use it.`,
+                    span: null,
+                    refs: {
+                        var_name: variable.name,
+                        abstract_actions_in_scope: variable.abstract_actions_in_scope,
+                    },
+                });
+            } else {
+                out.push({
+                    code: 'W_UNREFERENCED_VAR',
+                    severity: 'warning',
+                    message: `Variable ${JSON.stringify(variable.name)} does not affect any transition guard.`,
+                    span: null,
+                    refs: {
+                        var_name: variable.name,
+                        init_value: variable.init_value,
+                    },
+                });
+            }
+            continue;
+        }
         if (readStates.size > 0 && writeStates.size === 0) {
             out.push({
                 code: 'W_UNWRITTEN_READ_VAR',
@@ -29,6 +60,42 @@ export function collectDataFlowWarnings(variables: VariableInfo[]): ModelDiagnos
                 refs: {
                     var_name: variable.name,
                     written_states: Array.from(writeStates).sort(),
+                },
+            });
+        }
+    }
+    out.push(...collectGuardVarsNeverChangeDiagnostics(variables, machine));
+    return out;
+}
+
+function collectGuardVarsNeverChangeDiagnostics(
+    variables: VariableInfo[],
+    machine?: StateMachine,
+): ModelDiagnosticJson[] {
+    if (!machine) return [];
+    const declaredVars = new Set(variables.map(variable => variable.name));
+    const writtenVars = new Set(
+        variables
+            .filter(variable => variable.written_in_states.length > 0 || variable.written_in_effects.length > 0)
+            .map(variable => variable.name),
+    );
+    const out: ModelDiagnosticJson[] = [];
+    for (const state of machine.allStates) {
+        for (const transition of state.transitions) {
+            if (!transition.guard) continue;
+            const guardVars = collectExprVariables(transition.guard)
+                .filter(name => declaredVars.has(name))
+                .sort();
+            if (guardVars.length === 0) continue;
+            if (guardVars.some(name => writtenVars.has(name))) continue;
+            out.push({
+                code: 'W_GUARD_VARS_NEVER_CHANGE',
+                severity: 'warning',
+                message: 'Transition guard reads only variables that are never changed by actions or effects.',
+                span: null,
+                refs: {
+                    transition_span: null,
+                    guard_vars: guardVars,
                 },
             });
         }

--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -51,7 +51,7 @@ export function collectDesignHealthWarnings(
         ...collectThresholdWarnings(states, metrics, thresholdOptions),
         ...collectNamingWarnings(actions),
         ...collectTypeWarnings(variables),
-        ...collectDataFlowWarnings(variables),
+        ...collectDataFlowWarnings(variables, machine),
         ...collectRedundancyWarnings(transitions, events, states),
         ...collectTransitionInfos(states, transitions),
     ];

--- a/editors/jsfcstm/src/diagnostics/analyzers/index.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/index.ts
@@ -8,3 +8,4 @@ export {collectNamingWarnings} from './naming';
 export {collectThresholdWarnings} from './thresholds';
 export {collectTransitionInfos} from './transition-info';
 export {collectTypeWarnings} from './type-shape';
+export {buildUseDefGraph, collectExprVariables, UseDefGraph} from './use-def';

--- a/editors/jsfcstm/src/diagnostics/analyzers/use-def.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/use-def.ts
@@ -101,7 +101,9 @@ function walkBlock(
                 walkBlock(branch.statements, branchEnclosing, edges);
                 for (const item of thisCond) accumulated.add(item);
             }
+            continue;
         }
+        throw new TypeError(`Unhandled OperationStatement subclass: ${stmt.constructor.name}`);
     }
 }
 

--- a/editors/jsfcstm/src/diagnostics/analyzers/use-def.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/use-def.ts
@@ -1,8 +1,11 @@
 import {
     BinaryOp,
+    BooleanExpr,
     ConditionalOp,
     Expr,
+    Float,
     IfBlock,
+    Integer,
     Operation,
     OperationStatement,
     StateMachine,
@@ -36,8 +39,8 @@ export class UseDefGraph {
         const seen = new Set(direct);
         const out = new Set<string>();
         const queue = Array.from(direct);
-        while (queue.length > 0) {
-            const target = queue.shift()!;
+        for (let index = 0; index < queue.length; index++) {
+            const target = queue[index];
             for (const source of this.dependenciesOf(target)) {
                 if (seen.has(source)) continue;
                 seen.add(source);
@@ -120,7 +123,10 @@ function walkExprCollect(expr: Expr, out: string[]): void {
         walkExprCollect(expr.cond, out);
         walkExprCollect(expr.ifTrue, out);
         walkExprCollect(expr.ifFalse, out);
+        return;
     }
+    if (expr instanceof Integer || expr instanceof Float || expr instanceof BooleanExpr) return;
+    throw new TypeError(`Unhandled Expr subclass: ${expr.constructor.name}`);
 }
 
 function joinEdge(source: string, target: string): string {

--- a/editors/jsfcstm/src/diagnostics/analyzers/use-def.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/use-def.ts
@@ -1,0 +1,141 @@
+import {
+    BinaryOp,
+    ConditionalOp,
+    Expr,
+    IfBlock,
+    Operation,
+    OperationStatement,
+    StateMachine,
+    UFunc,
+    UnaryOp,
+    Variable,
+} from '../../model/runtime';
+
+export class UseDefGraph {
+    readonly edges: Array<[string, string]>;
+    readonly dependenciesByTarget: Record<string, string[]>;
+
+    constructor(edges: Array<[string, string]>) {
+        this.edges = [...edges].sort(comparePair);
+        const deps: Record<string, string[]> = {};
+        for (const [source, target] of this.edges) {
+            deps[target] = [...(deps[target] ?? []), source];
+        }
+        this.dependenciesByTarget = {};
+        for (const target of Object.keys(deps).sort()) {
+            this.dependenciesByTarget[target] = deps[target];
+        }
+    }
+
+    dependenciesOf(target: string): string[] {
+        return this.dependenciesByTarget[target] ?? [];
+    }
+
+    affectingVariables(directVariables: Iterable<string>): string[] {
+        const direct = new Set(directVariables);
+        const seen = new Set(direct);
+        const out = new Set<string>();
+        const queue = Array.from(direct);
+        while (queue.length > 0) {
+            const target = queue.shift()!;
+            for (const source of this.dependenciesOf(target)) {
+                if (seen.has(source)) continue;
+                seen.add(source);
+                out.add(source);
+                queue.push(source);
+            }
+        }
+        return Array.from(out).sort();
+    }
+}
+
+export function buildUseDefGraph(machine: StateMachine): UseDefGraph {
+    const edges = new Set<string>();
+
+    for (const state of machine.allStates) {
+        for (const collection of [state.onEnters, state.onDurings, state.onExits, state.onDuringAspects]) {
+            for (const action of collection) {
+                if (action.isAbstract) continue;
+                walkBlock(action.operations ?? [], new Set(), edges);
+            }
+        }
+        for (const transition of state.transitions) {
+            walkBlock(transition.effects ?? [], new Set(), edges);
+        }
+    }
+
+    return new UseDefGraph(Array.from(edges).map(splitEdge));
+}
+
+export function collectExprVariables(expr: Expr): string[] {
+    const out: string[] = [];
+    walkExprCollect(expr, out);
+    return Array.from(new Set(out));
+}
+
+function walkBlock(
+    statements: OperationStatement[],
+    enclosingCondVars: Set<string>,
+    edges: Set<string>,
+): void {
+    for (const stmt of statements) {
+        if (stmt instanceof Operation) {
+            const deps = new Set([...collectExprVariables(stmt.expr), ...enclosingCondVars]);
+            for (const source of deps) {
+                edges.add(joinEdge(source, stmt.varName));
+            }
+            continue;
+        }
+        if (stmt instanceof IfBlock) {
+            const accumulated = new Set<string>();
+            for (const branch of stmt.branches) {
+                const thisCond = new Set(branch.condition ? collectExprVariables(branch.condition) : []);
+                const branchEnclosing = new Set([
+                    ...enclosingCondVars,
+                    ...accumulated,
+                    ...thisCond,
+                ]);
+                walkBlock(branch.statements, branchEnclosing, edges);
+                for (const item of thisCond) accumulated.add(item);
+            }
+        }
+    }
+}
+
+function walkExprCollect(expr: Expr, out: string[]): void {
+    if (expr instanceof Variable) {
+        out.push(expr.name);
+        return;
+    }
+    if (expr instanceof UnaryOp || expr instanceof UFunc) {
+        walkExprCollect(expr.x, out);
+        return;
+    }
+    if (expr instanceof BinaryOp) {
+        walkExprCollect(expr.x, out);
+        walkExprCollect(expr.y, out);
+        return;
+    }
+    if (expr instanceof ConditionalOp) {
+        walkExprCollect(expr.cond, out);
+        walkExprCollect(expr.ifTrue, out);
+        walkExprCollect(expr.ifFalse, out);
+    }
+}
+
+function joinEdge(source: string, target: string): string {
+    return `${source}\u0001${target}`;
+}
+
+function splitEdge(edge: string): [string, string] {
+    const [source, target] = edge.split('\u0001');
+    return [source, target];
+}
+
+function comparePair(left: [string, string], right: [string, string]): number {
+    if (left[0] < right[0]) return -1;
+    if (left[0] > right[0]) return 1;
+    if (left[1] < right[1]) return -1;
+    if (left[1] > right[1]) return 1;
+    return 0;
+}

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -30,6 +30,7 @@ import {
     Variable,
 } from '../model/runtime';
 import {collectDesignHealthWarnings} from './analyzers';
+import {buildUseDefGraph} from './analyzers/use-def';
 import type {RawFcstmModelForcedTransition} from '../model/raw';
 
 const INIT_MARK = '[*]';
@@ -126,8 +127,8 @@ export interface VariableInfo {
     written_in_states: string[];
     read_in_guards: Array<[string, string]>;
     written_in_effects: Array<[string, string]>;
-    participates_directly: boolean;
-    participates_indirectly: boolean;
+    affects_guard_directly: boolean;
+    affects_guard_indirectly: boolean;
     abstract_actions_in_scope: string[];
     float_literal_assignments: string[];
 }
@@ -541,6 +542,14 @@ function buildVariableInfos(machine: StateMachine, states: StateInfo[]): Variabl
         return out;
     };
 
+    const useDefGraph = buildUseDefGraph(machine);
+    const directGuardVars = new Set(
+        Object.entries(readGuards)
+            .filter(([, entries]) => entries.length > 0)
+            .map(([name]) => name),
+    );
+    const indirectGuardVars = new Set(useDefGraph.affectingVariables(directGuardVars));
+
     const out: VariableInfo[] = [];
     for (const name of Object.keys(machine.defines)) {
         const def = machine.defines[name];
@@ -548,7 +557,6 @@ function buildVariableInfos(machine: StateMachine, states: StateInfo[]): Variabl
         const writtenStates = dedupe(writesByState[name]);
         const readGuardEntries = dedupePairs(readGuards[name]);
         const writtenEffectEntries = dedupePairs(writtenEffects[name]);
-        const participatesDirectly = readStates.length > 0 || readGuardEntries.length > 0;
         const abstractActions = abstractActionsInScope(
             stateLookup,
             readStates,
@@ -562,8 +570,8 @@ function buildVariableInfos(machine: StateMachine, states: StateInfo[]): Variabl
             written_in_states: writtenStates,
             read_in_guards: readGuardEntries,
             written_in_effects: writtenEffectEntries,
-            participates_directly: participatesDirectly,
-            participates_indirectly: false,
+            affects_guard_directly: directGuardVars.has(name),
+            affects_guard_indirectly: !directGuardVars.has(name) && indirectGuardVars.has(name),
             abstract_actions_in_scope: abstractActions,
             float_literal_assignments: dedupe(floatLiteralAssignments[name]),
         });
@@ -878,14 +886,13 @@ function abstractActionsInScope(
     readStates: string[],
     writtenStates: string[],
 ): string[] {
-    const touched = new Set<string>([...readStates, ...writtenStates]);
-    if (touched.size === 0) return [];
+    void readStates;
+    void writtenStates;
     const out: string[] = [];
-    for (const path of Array.from(touched).sort()) {
+    for (const path of Object.keys(stateLookup).sort()) {
         const info = stateLookup[path];
         if (!info || !info.has_abstract_action) continue;
-        const label = `${info.path}:<abstract>`;
-        if (!out.includes(label)) out.push(label);
+        out.push(`${info.path}:<abstract>`);
     }
     return out;
 }

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -30,7 +30,7 @@ import {
     Variable,
 } from '../model/runtime';
 import {collectDesignHealthWarnings} from './analyzers';
-import {buildUseDefGraph} from './analyzers/use-def';
+import {buildUseDefGraph, collectExprVariables} from './analyzers/use-def';
 import type {RawFcstmModelForcedTransition} from '../model/raw';
 
 const INIT_MARK = '[*]';
@@ -604,41 +604,7 @@ function collectActionReadsWrites(state: {
 
 function walkExprVariables(expr: Expr | null | undefined): string[] {
     if (!expr) return [];
-    const out: string[] = [];
-    walkExprCollect(expr, out);
-    return out;
-}
-
-function walkExprCollect(expr: Expr, out: string[]): void {
-    const anyExpr = expr as unknown as {
-        pyModelType: string;
-        name?: string;
-        x?: Expr;
-        y?: Expr;
-        cond?: Expr;
-        ifTrue?: Expr;
-        ifFalse?: Expr;
-    };
-    switch (anyExpr.pyModelType) {
-        case 'Variable':
-            if (anyExpr.name) out.push(anyExpr.name);
-            return;
-        case 'UnaryOp':
-        case 'UFunc':
-            if (anyExpr.x) walkExprCollect(anyExpr.x, out);
-            return;
-        case 'BinaryOp':
-            if (anyExpr.x) walkExprCollect(anyExpr.x, out);
-            if (anyExpr.y) walkExprCollect(anyExpr.y, out);
-            return;
-        case 'ConditionalOp':
-            if (anyExpr.cond) walkExprCollect(anyExpr.cond, out);
-            if (anyExpr.ifTrue) walkExprCollect(anyExpr.ifTrue, out);
-            if (anyExpr.ifFalse) walkExprCollect(anyExpr.ifFalse, out);
-            return;
-        default:
-            return;
-    }
+    return collectExprVariables(expr);
 }
 
 function walkStmtReadsWrites(

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -159,7 +159,208 @@ state Root {
             assert.ok(temp);
             assert.equal(temp!.read_in_states.length, 0);
             assert.equal(temp!.written_in_states.length, 0);
-            assert.equal(temp!.participates_directly, false);
+            assert.equal(temp!.affects_guard_directly, false);
+            assert.equal(temp!.affects_guard_indirectly, false);
+        });
+    });
+
+    describe('guard-affect data flow', () => {
+        it('tracks nested branch conditions in the use-def graph', async () => {
+            const {buildUseDefGraph} = await import('../dist/diagnostics/analyzers/use-def');
+            const graph = buildUseDefGraph(await buildMachine(`
+def int x = 0;
+def int y = 0;
+def int z = 0;
+def int flag = 0;
+def int dedupe = 0;
+state Root {
+    state Active {
+        during {
+            dedupe = x + x;
+            if [x >= 10] {
+                if [x % 2 == 0] {
+                    y = x + 10;
+                } else {
+                    y = x + 12;
+                    z = x * y - 2;
+                }
+            } else if [flag > 0] {
+                z = y + flag;
+            } else {
+                z = y - 10;
+                x = x + 2;
+            }
+        }
+    }
+    [*] -> Active;
+}
+`));
+            const edges = new Set(graph.edges.map(([source, target]) => `${source}->${target}`));
+            assert.ok(edges.has('x->y'));
+            assert.ok(edges.has('x->z'));
+            assert.ok(edges.has('y->z'));
+            assert.ok(edges.has('flag->z'));
+            assert.ok(edges.has('x->x'));
+            assert.ok(edges.has('flag->x'));
+        });
+
+        it('keeps use-def graph ordering stable for duplicate edge input', async () => {
+            const {UseDefGraph} = await import('../dist/diagnostics/analyzers/use-def');
+            const graph = new UseDefGraph([
+                ['b', 'target'],
+                ['a', 'target'],
+                ['a', 'target'],
+            ]);
+
+            assert.deepEqual(graph.edges, [
+                ['a', 'target'],
+                ['a', 'target'],
+                ['b', 'target'],
+            ]);
+            assert.deepEqual(graph.dependenciesOf('target'), ['a', 'a', 'b']);
+        });
+
+        it('marks direct and indirect guard-affect variables', async () => {
+            const report = inspectModel(await buildMachine(`
+def int source = 0;
+def int middle = 0;
+def int guard_value = 0;
+def int direct = 0;
+def int ternary_only = 0;
+def int unused = 0;
+state Root {
+    state Idle {
+        during {
+            middle = source + 1;
+            guard_value = middle;
+            unused = (ternary_only > 0) ? 1 : 2;
+        }
+    }
+    state Done;
+    [*] -> Idle : if [direct > 0];
+    Idle -> Done : if [guard_value > 0];
+    Done -> [*] : if [direct > 1];
+}
+`));
+            const variables = new Map(report.variables.map(v => [v.name, v]));
+            assert.equal(variables.get('direct')!.affects_guard_directly, true);
+            assert.equal(variables.get('direct')!.affects_guard_indirectly, false);
+            assert.equal(variables.get('guard_value')!.affects_guard_directly, true);
+            assert.equal(variables.get('guard_value')!.affects_guard_indirectly, false);
+            assert.equal(variables.get('middle')!.affects_guard_directly, false);
+            assert.equal(variables.get('middle')!.affects_guard_indirectly, true);
+            assert.equal(variables.get('source')!.affects_guard_directly, false);
+            assert.equal(variables.get('source')!.affects_guard_indirectly, true);
+            assert.equal(variables.get('ternary_only')!.affects_guard_directly, false);
+            assert.equal(variables.get('ternary_only')!.affects_guard_indirectly, false);
+            assert.equal(variables.get('unused')!.affects_guard_directly, false);
+            assert.equal(variables.get('unused')!.affects_guard_indirectly, false);
+        });
+
+        it('emits unreferenced variables as warning or info based on abstract actions', async () => {
+            const noAbstract = inspectModel(await buildMachine(`
+def int unused = 0;
+def int driver = 0;
+state Root {
+    state Idle;
+    state Done;
+    [*] -> Idle;
+    Idle -> Done : if [driver > 0];
+}
+`));
+            assert.deepEqual(
+                noAbstract.diagnostics
+                    .filter(d => d.code === 'W_UNREFERENCED_VAR')
+                    .map(d => d.refs),
+                [{var_name: 'unused', init_value: '0'}],
+            );
+            assert.equal(
+                noAbstract.diagnostics.filter(d => d.code === 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT').length,
+                0,
+            );
+
+            const withAbstract = inspectModel(await buildMachine(`
+def int maybe_external = 0;
+def int driver = 0;
+state Root {
+    state Idle { enter abstract ExternalHook; }
+    state Done;
+    [*] -> Idle;
+    Idle -> Done : if [driver > 0];
+}
+`));
+            assert.deepEqual(
+                withAbstract.diagnostics
+                    .filter(d => d.code === 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT')
+                    .map(d => d.refs),
+                [{
+                    var_name: 'maybe_external',
+                    abstract_actions_in_scope: ['Root.Idle:<abstract>'],
+                }],
+            );
+        });
+
+        it('does not report indirect guard dependencies as unreferenced', async () => {
+            const report = inspectModel(await buildMachine(`
+def int source = 0;
+def int guard_value = 0;
+state Root {
+    state Idle { during { guard_value = source + 1; } }
+    state Done;
+    [*] -> Idle;
+    Idle -> Done : if [guard_value > 0];
+}
+`));
+            const sourceCodes = report.diagnostics
+                .filter(d => d.refs.var_name === 'source')
+                .map(d => d.code);
+            assert.deepEqual(sourceCodes, ['W_UNWRITTEN_READ_VAR']);
+        });
+
+        it('reports guard vars that never change per transition', async () => {
+            const report = inspectModel(await buildMachine(`
+def int stable = 0;
+def int changing = 0;
+state Root {
+    state Idle { during { changing = changing + 1; } }
+    state StableBlocked;
+    state DynamicAllowed;
+    [*] -> Idle;
+    Idle -> StableBlocked : if [stable > 0];
+    Idle -> DynamicAllowed : if [changing > 0];
+}
+`));
+            assert.deepEqual(
+                report.diagnostics
+                    .filter(d => d.code === 'W_GUARD_VARS_NEVER_CHANGE')
+                    .map(d => d.refs),
+                [{
+                    transition_span: null,
+                    guard_vars: ['stable'],
+                }],
+            );
+        });
+
+        it('keeps the write-only branch available for affecting payloads', async () => {
+            const {collectDataFlowWarnings} = await import('../dist/diagnostics/analyzers/data-flow');
+            const diagnostics = collectDataFlowWarnings([{
+                name: 'write_only',
+                type: 'int',
+                init_value: '0',
+                read_in_states: [],
+                written_in_states: ['Root.Idle'],
+                read_in_guards: [],
+                written_in_effects: [],
+                affects_guard_directly: true,
+                affects_guard_indirectly: false,
+                abstract_actions_in_scope: [],
+                float_literal_assignments: [],
+            }]);
+
+            assert.deepEqual(diagnostics.map(d => d.refs), [{
+                var_name: 'write_only',
+                written_states: ['Root.Idle'],
+            }]);
         });
     });
 
@@ -256,7 +457,16 @@ state Root {
         });
 
         it('diagnostics array empty for clean model without design-health warnings', async () => {
-            const report = inspectModel(await buildMachine(SIMPLE_DSL));
+            const report = inspectModel(await buildMachine(`
+def int counter = 0;
+state Root {
+    state Idle;
+    state Active { during { counter = counter + 1; } }
+    [*] -> Idle;
+    Idle -> Active : if [counter > 0];
+    Active -> Idle :: Pause;
+}
+`));
             assert.deepEqual(report.diagnostics, []);
         });
 
@@ -497,6 +707,16 @@ state Root {
                     refs: {from_path: 'Root.Active', to_path: 'Root.Trapped', forced_span: null, normal_span: null},
                 },
                 {
+                    code: 'W_GUARD_VARS_NEVER_CHANGE',
+                    severity: 'warning',
+                    refs: {transition_span: null, guard_vars: ['read_only']},
+                },
+                {
+                    code: 'W_GUARD_VARS_NEVER_CHANGE',
+                    severity: 'warning',
+                    refs: {transition_span: null, guard_vars: ['read_only']},
+                },
+                {
                     code: 'W_INITIAL_UNCONDITIONAL_MISSING',
                     severity: 'warning',
                     refs: {composite_path: 'Root', existing_conditional_count: 1},
@@ -550,14 +770,14 @@ state Root {
                     refs: {state_path: 'Root.Orphan'},
                 },
                 {
+                    code: 'W_UNREFERENCED_VAR',
+                    severity: 'warning',
+                    refs: {var_name: 'write_only', init_value: '0'},
+                },
+                {
                     code: 'W_UNWRITTEN_READ_VAR',
                     severity: 'warning',
                     refs: {var_name: 'read_only', read_states: ['Root.Idle'], init_value: '0'},
-                },
-                {
-                    code: 'W_WRITE_ONLY_VAR',
-                    severity: 'warning',
-                    refs: {var_name: 'write_only', written_states: ['Root.Idle']},
                 },
             ].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))));
         });

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -337,7 +337,6 @@ state Root {
                 [{
                     from_path: 'Root.Idle',
                     to_path: 'Root.StableBlocked',
-                    transition_span: null,
                     guard_vars: ['stable'],
                 }],
             );
@@ -390,6 +389,45 @@ state Root {
             assert.throws(
                 () => collectExprVariables(new UnknownExpr()),
                 /Unhandled Expr subclass: UnknownExpr/,
+            );
+        });
+
+        it('rejects unknown operation statement subclasses in the use-def graph', async () => {
+            const {buildUseDefGraph} = await import('../dist/diagnostics/analyzers/use-def');
+            const {OperationStatement} = await import('../dist/model/runtime');
+
+            class UnknownStatement extends OperationStatement {
+                constructor() {
+                    super(
+                        'operationStatement',
+                        'UnknownStatement' as any,
+                        {
+                            start: {line: 0, character: 0},
+                            end: {line: 0, character: 0},
+                        },
+                        'unknown',
+                    );
+                }
+
+                to_ast_node(): any {
+                    return {};
+                }
+            }
+
+            assert.throws(
+                () => buildUseDefGraph({
+                    allStates: [{
+                        onEnters: [{
+                            isAbstract: false,
+                            operations: [new UnknownStatement()],
+                        }],
+                        onDurings: [],
+                        onExits: [],
+                        onDuringAspects: [],
+                        transitions: [],
+                    }],
+                } as any),
+                /Unhandled OperationStatement subclass: UnknownStatement/,
             );
         });
     });
@@ -742,7 +780,6 @@ state Root {
                     refs: {
                         from_path: 'Root.Idle',
                         to_path: 'Root.Active',
-                        transition_span: null,
                         guard_vars: ['read_only'],
                     },
                 },
@@ -752,7 +789,6 @@ state Root {
                     refs: {
                         from_path: 'Root.Idle',
                         to_path: 'Root.Active',
-                        transition_span: null,
                         guard_vars: ['read_only'],
                     },
                 },

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -335,6 +335,8 @@ state Root {
                     .filter(d => d.code === 'W_GUARD_VARS_NEVER_CHANGE')
                     .map(d => d.refs),
                 [{
+                    from_path: 'Root.Idle',
+                    to_path: 'Root.StableBlocked',
                     transition_span: null,
                     guard_vars: ['stable'],
                 }],
@@ -361,6 +363,34 @@ state Root {
                 var_name: 'write_only',
                 written_states: ['Root.Idle'],
             }]);
+        });
+
+        it('rejects unknown expression subclasses in the shared variable collector', async () => {
+            const {collectExprVariables} = await import('../dist/diagnostics/analyzers/use-def');
+            const {Expr} = await import('../dist/model/runtime');
+
+            class UnknownExpr extends Expr {
+                constructor() {
+                    super(
+                        'expression',
+                        'UnknownExpr' as any,
+                        {
+                            start: {line: 0, character: 0},
+                            end: {line: 0, character: 0},
+                        },
+                        'unknown',
+                    );
+                }
+
+                to_ast_node(): any {
+                    return {};
+                }
+            }
+
+            assert.throws(
+                () => collectExprVariables(new UnknownExpr()),
+                /Unhandled Expr subclass: UnknownExpr/,
+            );
         });
     });
 
@@ -709,12 +739,22 @@ state Root {
                 {
                     code: 'W_GUARD_VARS_NEVER_CHANGE',
                     severity: 'warning',
-                    refs: {transition_span: null, guard_vars: ['read_only']},
+                    refs: {
+                        from_path: 'Root.Idle',
+                        to_path: 'Root.Active',
+                        transition_span: null,
+                        guard_vars: ['read_only'],
+                    },
                 },
                 {
                     code: 'W_GUARD_VARS_NEVER_CHANGE',
                     severity: 'warning',
-                    refs: {transition_span: null, guard_vars: ['read_only']},
+                    refs: {
+                        from_path: 'Root.Idle',
+                        to_path: 'Root.Active',
+                        transition_span: null,
+                        guard_vars: ['read_only'],
+                    },
                 },
                 {
                     code: 'W_INITIAL_UNCONDITIONAL_MISSING',

--- a/pyfcstm/diagnostics/analyzers/__init__.py
+++ b/pyfcstm/diagnostics/analyzers/__init__.py
@@ -10,6 +10,7 @@ from .naming import collect_naming_warnings
 from .thresholds import collect_threshold_warnings
 from .transition_info import collect_transition_infos
 from .type_shape import collect_type_warnings
+from .use_def import UseDefGraph, build_use_def_graph, collect_expr_variables
 
 __all__ = [
     'collect_const_fold_warnings',
@@ -20,4 +21,7 @@ __all__ = [
     'collect_threshold_warnings',
     'collect_transition_infos',
     'collect_type_warnings',
+    'UseDefGraph',
+    'build_use_def_graph',
+    'collect_expr_variables',
 ]

--- a/pyfcstm/diagnostics/analyzers/data_flow.py
+++ b/pyfcstm/diagnostics/analyzers/data_flow.py
@@ -1,6 +1,6 @@
 """Variable data-flow design-health diagnostics."""
 
-from typing import TYPE_CHECKING, Iterable, List, Optional, Set
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional
 
 from ...utils.validate import ModelDiagnostic
 from .use_def import collect_expr_variables
@@ -8,6 +8,9 @@ from .use_def import collect_expr_variables
 if TYPE_CHECKING:  # pragma: no cover
     from ..inspect import VariableInfo
     from ...model.model import StateMachine
+
+_INIT_MARK = '[*]'
+_EXIT_MARK = '[*]'
 
 
 def collect_data_flow_warnings(
@@ -102,6 +105,16 @@ def _guard_vars_never_change_diagnostics(
                 continue
             if any(v in written_vars for v in guard_vars):
                 continue
+            from_path = _transition_endpoint(
+                state,
+                transition.from_state,
+                is_source=True,
+            )
+            to_path = _transition_endpoint(
+                state,
+                transition.to_state,
+                is_source=False,
+            )
             diagnostics.append(ModelDiagnostic(
                 code='W_GUARD_VARS_NEVER_CHANGE',
                 severity='warning',
@@ -110,8 +123,30 @@ def _guard_vars_never_change_diagnostics(
                     'changed by actions or effects.'
                 ),
                 refs={
+                    'from_path': from_path,
+                    'to_path': to_path,
                     'transition_span': None,
                     'guard_vars': guard_vars,
                 },
             ))
     return diagnostics
+
+
+def _state_path(state: Any) -> str:
+    path = getattr(state, 'path', None)
+    if not path:  # pragma: no cover
+        return ''
+    return '.'.join(p for p in path if p is not None)
+
+
+def _resolve_sibling_path(parent_state: Any, name: str) -> str:
+    parent_path = _state_path(parent_state)
+    return f'{parent_path}.{name}' if parent_path else name
+
+
+def _transition_endpoint(parent_state: Any, marker_or_name: Any, is_source: bool) -> str:
+    if marker_or_name.__class__.__name__ == '_StateSingletonMark':
+        return _INIT_MARK if is_source else _EXIT_MARK
+    if isinstance(marker_or_name, str):
+        return _resolve_sibling_path(parent_state, marker_or_name)
+    return str(marker_or_name)  # pragma: no cover

--- a/pyfcstm/diagnostics/analyzers/data_flow.py
+++ b/pyfcstm/diagnostics/analyzers/data_flow.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional
 
+from ...dsl import EXIT_STATE, INIT_STATE
 from ...utils.validate import ModelDiagnostic
 from .use_def import collect_expr_variables
 
@@ -125,7 +126,6 @@ def _guard_vars_never_change_diagnostics(
                 refs={
                     'from_path': from_path,
                     'to_path': to_path,
-                    'transition_span': None,
                     'guard_vars': guard_vars,
                 },
             ))
@@ -145,8 +145,10 @@ def _resolve_sibling_path(parent_state: Any, name: str) -> str:
 
 
 def _transition_endpoint(parent_state: Any, marker_or_name: Any, is_source: bool) -> str:
-    if marker_or_name.__class__.__name__ == '_StateSingletonMark':
-        return _INIT_MARK if is_source else _EXIT_MARK
+    if marker_or_name is INIT_STATE:
+        return _INIT_MARK
+    if marker_or_name is EXIT_STATE:
+        return _EXIT_MARK
     if isinstance(marker_or_name, str):
         return _resolve_sibling_path(parent_state, marker_or_name)
     return str(marker_or_name)  # pragma: no cover

--- a/pyfcstm/diagnostics/analyzers/data_flow.py
+++ b/pyfcstm/diagnostics/analyzers/data_flow.py
@@ -1,20 +1,54 @@
 """Variable data-flow design-health diagnostics."""
 
-from typing import TYPE_CHECKING, Iterable, List
+from typing import TYPE_CHECKING, Iterable, List, Optional, Set
 
 from ...utils.validate import ModelDiagnostic
+from .use_def import collect_expr_variables
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..inspect import VariableInfo
+    from ...model.model import StateMachine
 
 
-def collect_data_flow_warnings(variables: Iterable['VariableInfo']) -> List[ModelDiagnostic]:
+def collect_data_flow_warnings(
+        variables: Iterable['VariableInfo'],
+        machine: Optional['StateMachine'] = None,
+) -> List[ModelDiagnostic]:
     diagnostics: List[ModelDiagnostic] = []
+    variables = list(variables)
     for variable in variables:
         read_states = set(variable.read_in_states)
         read_states.update(src for src, _ in variable.read_in_guards)
         write_states = set(variable.written_in_states)
         write_states.update(src for src, _ in variable.written_in_effects)
+        if not variable.affects_guard_directly and not variable.affects_guard_indirectly:
+            if variable.abstract_actions_in_scope:
+                diagnostics.append(ModelDiagnostic(
+                    code='I_UNREFERENCED_VAR_MAYBE_ABSTRACT',
+                    severity='info',
+                    message=(
+                        f'Variable {variable.name!r} does not affect any '
+                        'transition guard, but abstract actions may use it.'
+                    ),
+                    refs={
+                        'var_name': variable.name,
+                        'abstract_actions_in_scope': list(variable.abstract_actions_in_scope),
+                    },
+                ))
+            else:
+                diagnostics.append(ModelDiagnostic(
+                    code='W_UNREFERENCED_VAR',
+                    severity='warning',
+                    message=(
+                        f'Variable {variable.name!r} does not affect any '
+                        'transition guard.'
+                    ),
+                    refs={
+                        'var_name': variable.name,
+                        'init_value': variable.init_value,
+                    },
+                ))
+            continue
         if read_states and not write_states:
             diagnostics.append(ModelDiagnostic(
                 code='W_UNWRITTEN_READ_VAR',
@@ -37,6 +71,47 @@ def collect_data_flow_warnings(variables: Iterable['VariableInfo']) -> List[Mode
                 refs={
                     'var_name': variable.name,
                     'written_states': sorted(write_states),
+                },
+            ))
+    diagnostics.extend(_guard_vars_never_change_diagnostics(variables, machine))
+    return diagnostics
+
+
+def _guard_vars_never_change_diagnostics(
+        variables: List['VariableInfo'],
+        machine: Optional['StateMachine'],
+) -> List[ModelDiagnostic]:
+    if machine is None:
+        return []
+    written_vars = {
+        variable.name
+        for variable in variables
+        if variable.written_in_states or variable.written_in_effects
+    }
+    declared_vars = {variable.name for variable in variables}
+    diagnostics: List[ModelDiagnostic] = []
+    for state in machine.walk_states():
+        for transition in state.transitions:
+            if transition.guard is None:
+                continue
+            guard_vars = sorted(
+                v for v in collect_expr_variables(transition.guard)
+                if v in declared_vars
+            )
+            if not guard_vars:
+                continue
+            if any(v in written_vars for v in guard_vars):
+                continue
+            diagnostics.append(ModelDiagnostic(
+                code='W_GUARD_VARS_NEVER_CHANGE',
+                severity='warning',
+                message=(
+                    'Transition guard reads only variables that are never '
+                    'changed by actions or effects.'
+                ),
+                refs={
+                    'transition_span': None,
+                    'guard_vars': guard_vars,
                 },
             ))
     return diagnostics

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -78,7 +78,7 @@ def collect_design_health_warnings(
     ))
     diagnostics.extend(collect_naming_warnings(actions))
     diagnostics.extend(collect_type_warnings(variables))
-    diagnostics.extend(collect_data_flow_warnings(variables))
+    diagnostics.extend(collect_data_flow_warnings(variables, machine))
     diagnostics.extend(collect_redundancy_warnings(transitions, events, states))
     diagnostics.extend(collect_transition_infos(states, transitions))
     return diagnostics

--- a/pyfcstm/diagnostics/analyzers/use_def.py
+++ b/pyfcstm/diagnostics/analyzers/use_def.py
@@ -30,8 +30,10 @@ class UseDefGraph:
         seen: Set[str] = set(direct)
         out: Set[str] = set()
         queue = list(direct)
-        while queue:
-            target = queue.pop(0)
+        index = 0
+        while index < len(queue):
+            target = queue[index]
+            index += 1
             for source in self.dependencies_of(target):
                 if source in seen:
                     continue
@@ -118,7 +120,10 @@ def _walk_block(
 def _walk_expr_collect(expr: 'Expr', out: List[str]) -> None:
     from ...model.expr import (
         BinaryOp,
+        Boolean,
         ConditionalOp,
+        Float,
+        Integer,
         UFunc,
         UnaryOp,
         Variable,
@@ -141,3 +146,7 @@ def _walk_expr_collect(expr: 'Expr', out: List[str]) -> None:
         return
     if isinstance(expr, UFunc):
         _walk_expr_collect(expr.x, out)
+        return
+    if isinstance(expr, (Integer, Float, Boolean)):
+        return
+    raise TypeError(f'unhandled Expr subclass: {type(expr).__name__}')

--- a/pyfcstm/diagnostics/analyzers/use_def.py
+++ b/pyfcstm/diagnostics/analyzers/use_def.py
@@ -1,0 +1,143 @@
+"""Use-def graph construction for guard-affect data-flow analysis."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Iterable, List, Set, Tuple
+
+if TYPE_CHECKING:  # pragma: no cover - import-time type hints only
+    from ...model.expr import Expr
+    from ...model.model import OperationStatement, StateMachine
+
+
+@dataclass(frozen=True)
+class UseDefGraph:
+    """Directed variable dependency graph.
+
+    Each edge is ``(source, target)`` and means that ``target``'s value may
+    depend on ``source`` through an assignment expression or an enclosing
+    operation-block condition.
+    """
+
+    edges: Tuple[Tuple[str, str], ...]
+    dependencies_by_target: Dict[str, Tuple[str, ...]]
+
+    def dependencies_of(self, target: str) -> Tuple[str, ...]:
+        """Return variables that may affect ``target``."""
+        return self.dependencies_by_target.get(target, tuple())
+
+    def affecting_variables(self, direct_variables: Iterable[str]) -> Tuple[str, ...]:
+        """Return all variables that can flow into ``direct_variables``."""
+        direct = set(direct_variables)
+        seen: Set[str] = set(direct)
+        out: Set[str] = set()
+        queue = list(direct)
+        while queue:
+            target = queue.pop(0)
+            for source in self.dependencies_of(target):
+                if source in seen:
+                    continue
+                seen.add(source)
+                out.add(source)
+                queue.append(source)
+        return tuple(sorted(out))
+
+
+def build_use_def_graph(machine: 'StateMachine') -> UseDefGraph:
+    """Build a conservative use-def graph from concrete actions/effects."""
+    edges: Set[Tuple[str, str]] = set()
+
+    for state in machine.walk_states():
+        for collection in (
+                state.on_enters,
+                state.on_durings,
+                state.on_exits,
+                state.on_during_aspects,
+        ):
+            for action in collection:
+                if getattr(action, 'is_abstract', False):
+                    continue
+                _walk_block(action.operations or [], set(), edges)
+
+        for transition in state.transitions:
+            _walk_block(transition.effects or [], set(), edges)
+
+    ordered_edges = tuple(sorted(edges))
+    deps: Dict[str, List[str]] = {}
+    for source, target in ordered_edges:
+        deps.setdefault(target, []).append(source)
+    return UseDefGraph(
+        edges=ordered_edges,
+        dependencies_by_target={
+            target: tuple(sources)
+            for target, sources in sorted(deps.items())
+        },
+    )
+
+
+def collect_expr_variables(expr: 'Expr') -> Tuple[str, ...]:
+    """Return variable names read by ``expr`` in stable first-seen order."""
+    out: List[str] = []
+    _walk_expr_collect(expr, out)
+    seen = set()
+    deduped: List[str] = []
+    for name in out:
+        if name in seen:
+            continue
+        seen.add(name)
+        deduped.append(name)
+    return tuple(deduped)
+
+
+def _walk_block(
+        statements: Iterable['OperationStatement'],
+        enclosing_cond_vars: Set[str],
+        edges: Set[Tuple[str, str]],
+) -> None:
+    from ...model.model import IfBlock, Operation
+
+    for stmt in statements:
+        if isinstance(stmt, Operation):
+            deps = set(collect_expr_variables(stmt.expr)) | set(enclosing_cond_vars)
+            for source in deps:
+                edges.add((source, stmt.var_name))
+            continue
+        if isinstance(stmt, IfBlock):
+            accumulated: Set[str] = set()
+            for branch in stmt.branches:
+                this_cond = (
+                    set(collect_expr_variables(branch.condition))
+                    if branch.condition is not None
+                    else set()
+                )
+                branch_enclosing = (
+                    set(enclosing_cond_vars) | accumulated | this_cond
+                )
+                _walk_block(branch.statements, branch_enclosing, edges)
+                accumulated.update(this_cond)
+
+
+def _walk_expr_collect(expr: 'Expr', out: List[str]) -> None:
+    from ...model.expr import (
+        BinaryOp,
+        ConditionalOp,
+        UFunc,
+        UnaryOp,
+        Variable,
+    )
+
+    if isinstance(expr, Variable):
+        out.append(expr.name)
+        return
+    if isinstance(expr, UnaryOp):
+        _walk_expr_collect(expr.x, out)
+        return
+    if isinstance(expr, BinaryOp):
+        _walk_expr_collect(expr.x, out)
+        _walk_expr_collect(expr.y, out)
+        return
+    if isinstance(expr, ConditionalOp):
+        _walk_expr_collect(expr.cond, out)
+        _walk_expr_collect(expr.if_true, out)
+        _walk_expr_collect(expr.if_false, out)
+        return
+    if isinstance(expr, UFunc):
+        _walk_expr_collect(expr.x, out)

--- a/pyfcstm/diagnostics/analyzers/use_def.py
+++ b/pyfcstm/diagnostics/analyzers/use_def.py
@@ -115,6 +115,10 @@ def _walk_block(
                 )
                 _walk_block(branch.statements, branch_enclosing, edges)
                 accumulated.update(this_cond)
+            continue
+        raise TypeError(
+            f'unhandled OperationStatement subclass: {type(stmt).__name__}'
+        )
 
 
 def _walk_expr_collect(expr: 'Expr', out: List[str]) -> None:

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1394,7 +1394,10 @@ I_UNREFERENCED_VAR_MAYBE_ABSTRACT:
     abstract_actions_in_scope:
       type: list[str]
       required: true
-      description: Abstract action owners that may access the variable.
+      description: >-
+        Abstract action owners that may access the variable. FCSTM
+        variables are global, so this is the full machine abstract-action
+        inventory.
   for_llm:
     summary: >-
       This variable is unused by DSL guard-affect data-flow, but abstract
@@ -1427,6 +1430,14 @@ W_GUARD_VARS_NEVER_CHANGE:
     lifecycle action or transition effect, so the guard only depends on
     initial values.
   refs:
+    from_path:
+      type: str
+      required: true
+      description: Source state path of the transition, or [*] for an entry marker.
+    to_path:
+      type: str
+      required: true
+      description: Target state path of the transition, or [*] for an exit marker.
     transition_span:
       type: Span
       required: false
@@ -1448,6 +1459,7 @@ W_GUARD_VARS_NEVER_CHANGE:
         rationale: Simplify or remove the guard if the initial value is intentional.
     do_not:
       - "Do not add a meaningless self-assignment; it does not model a real change."
+      - "Do not rewrite the guard to a meaningless constant only to silence this diagnostic."
   emit_tier: static_pipeline
   example_dsl: |
     def int ready = 0;

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1340,6 +1340,124 @@ W_DEAD_NAMED_ACTION:
         [*] -> A;
     }
 
+W_UNREFERENCED_VAR:
+  severity: warning
+  capability: pure_static
+  description: >-
+    A variable cannot affect any transition guard either directly or
+    through the action/effect use-def graph, and no abstract action is
+    visible that might use it outside the DSL.
+  refs:
+    var_name:
+      type: str
+      required: true
+      description: Variable name.
+    init_value:
+      type: str
+      required: true
+      description: Source text of the initial value.
+  for_llm:
+    summary: >-
+      This variable does not participate in model decisions. It is dead
+      from the DSL's guard-affect data-flow perspective.
+    recommended_actions:
+      - kind: remove_variable
+        target: variable_definition
+        rationale: Remove the variable and related writes if it was speculative scaffolding.
+      - kind: connect_to_guard
+        target: guard_or_assignment
+        rationale: Add the missing data-flow path if the variable should affect a transition decision.
+    do_not:
+      - "Do not add a dummy guard reference only to silence the diagnostic."
+  emit_tier: static_pipeline
+  example_dsl: |
+    def int unused = 0;
+    def int ready = 0;
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B : if [ready > 0];
+    }
+
+I_UNREFERENCED_VAR_MAYBE_ABSTRACT:
+  severity: info
+  capability: pure_static
+  description: >-
+    A variable cannot affect any transition guard through DSL data-flow,
+    but at least one visible abstract action may use it outside the DSL.
+  refs:
+    var_name:
+      type: str
+      required: true
+      description: Variable name.
+    abstract_actions_in_scope:
+      type: list[str]
+      required: true
+      description: Abstract action owners that may access the variable.
+  for_llm:
+    summary: >-
+      This variable is unused by DSL guard-affect data-flow, but abstract
+      action implementations may still use it.
+    recommended_actions:
+      - kind: inspect_abstract_action
+        target: abstract_action
+        rationale: Check the external implementation before removing the variable.
+      - kind: remove_variable
+        target: variable_definition
+        rationale: Remove it only if the abstract action does not need it.
+    do_not:
+      - "Do not remove the variable without checking the abstract implementation."
+  emit_tier: static_pipeline
+  example_dsl: |
+    def int maybe_external = 0;
+    def int ready = 0;
+    state Root {
+        state A { enter abstract ExternalHook; }
+        state B;
+        [*] -> A;
+        A -> B : if [ready > 0];
+    }
+
+W_GUARD_VARS_NEVER_CHANGE:
+  severity: warning
+  capability: pure_static
+  description: >-
+    A transition guard reads variables that are never changed by any
+    lifecycle action or transition effect, so the guard only depends on
+    initial values.
+  refs:
+    transition_span:
+      type: Span
+      required: false
+      description: Source span of the transition declaration.
+    guard_vars:
+      type: list[str]
+      required: true
+      description: Guard variables that never change.
+  for_llm:
+    summary: >-
+      This guard is controlled only by initial variable values. If those
+      values never change, the transition condition is effectively fixed.
+    recommended_actions:
+      - kind: add_write
+        target: action_or_effect
+        rationale: Add the missing state update if the guard should evolve at runtime.
+      - kind: simplify_guard
+        target: transition
+        rationale: Simplify or remove the guard if the initial value is intentional.
+    do_not:
+      - "Do not add a meaningless self-assignment; it does not model a real change."
+  emit_tier: static_pipeline
+  example_dsl: |
+    def int ready = 0;
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B : if [ready > 0];
+    }
+
 W_UNWRITTEN_READ_VAR:
   severity: warning
   capability: pure_static

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1438,10 +1438,6 @@ W_GUARD_VARS_NEVER_CHANGE:
       type: str
       required: true
       description: Target state path of the transition, or [*] for an exit marker.
-    transition_span:
-      type: Span
-      required: false
-      description: Source span of the transition declaration.
     guard_vars:
       type: list[str]
       required: true

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -49,7 +49,11 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from .analyzers import build_use_def_graph, collect_design_health_warnings
+from .analyzers import (
+    build_use_def_graph,
+    collect_design_health_warnings,
+    collect_expr_variables,
+)
 from ..utils.validate import ModelDiagnostic
 
 if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
@@ -207,10 +211,11 @@ class VariableInfo:
         a transition guard through the conservative use-def graph.
     :type affects_guard_indirectly: bool
     :param abstract_actions_in_scope: Function names of abstract actions
-        whose enclosing state is on the ancestor chain or sub-tree of
-        any state that touches this variable. Downstream diagnostics can
-        use this to distinguish high-confidence unused variables from
-        variables that may be touched by abstract behavior.
+        that may access this variable. FCSTM variables are global, so any
+        abstract action in the machine is conservatively visible here.
+        Downstream diagnostics can use this to distinguish high-confidence
+        unused variables from variables that may be touched by abstract
+        behavior.
     :type abstract_actions_in_scope: Tuple[str, ...]
     :param float_literal_assignments: Source text of float literal
         assignments to this variable from lifecycle actions or transition
@@ -489,38 +494,7 @@ def _walk_expr_variables(expr: Optional['Expr']) -> List[str]:
     """Return variable names read by ``expr`` in left-to-right order."""
     if expr is None:
         return []
-    seen: List[str] = []
-    _walk_expr_collect(expr, seen)
-    return seen
-
-
-def _walk_expr_collect(expr: 'Expr', out: List[str]) -> None:
-    from ..model.expr import (
-        BinaryOp,
-        ConditionalOp,
-        UFunc,
-        UnaryOp,
-        Variable,
-    )
-    if isinstance(expr, Variable):
-        out.append(expr.name)
-        return
-    # Constants have no children.
-    if isinstance(expr, UnaryOp):
-        _walk_expr_collect(expr.x, out)
-        return
-    if isinstance(expr, BinaryOp):
-        _walk_expr_collect(expr.x, out)
-        _walk_expr_collect(expr.y, out)
-        return
-    if isinstance(expr, ConditionalOp):
-        _walk_expr_collect(expr.cond, out)
-        _walk_expr_collect(expr.if_true, out)
-        _walk_expr_collect(expr.if_false, out)
-        return
-    if isinstance(expr, UFunc):
-        _walk_expr_collect(expr.x, out)
-        return
+    return list(collect_expr_variables(expr))
 
 
 def _walk_stmt_reads_writes(
@@ -895,7 +869,7 @@ def _build_variable_infos(
         written_states = _dedupe_ordered(var_writes_by_state[name])
         read_guards = _dedupe_pairs(var_read_guards[name])
         written_effects = _dedupe_pairs(var_written_effects[name])
-        abstract_actions = _abstract_actions_in_scope(state_lookup, read_states, written_states)
+        abstract_actions = _abstract_actions_in_scope(state_lookup)
         float_assignments = _dedupe_ordered(var_float_literal_assignments[name])
         out.append(VariableInfo(
             name=name,
@@ -917,8 +891,6 @@ def _build_variable_infos(
 
 def _abstract_actions_in_scope(
         state_lookup: Dict[str, StateInfo],
-        read_states: Tuple[str, ...],
-        written_states: Tuple[str, ...],
 ) -> Tuple[str, ...]:
     """Return abstract action labels that can see global variables."""
     return tuple(

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -19,7 +19,7 @@ The module exposes the following dataclasses:
 * :class:`StateInfo` — per-state structural summary
 * :class:`TransitionInfo` — per-transition structural summary
 * :class:`VariableInfo` — per-variable structural summary plus
-  participation flags used by ``W_UNREFERENCED_VAR``
+  guard-affect flags used by ``W_UNREFERENCED_VAR``
 * :class:`EventInfo` — per-event structural summary
 * :class:`ModelMetrics` — aggregate counts and ratios
 * :class:`ModelInspect` — top-level container including diagnostics
@@ -49,7 +49,7 @@ import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
-from .analyzers import collect_design_health_warnings
+from .analyzers import build_use_def_graph, collect_design_health_warnings
 from ..utils.validate import ModelDiagnostic
 
 if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
@@ -176,9 +176,9 @@ class TransitionInfo:
 @dataclass(frozen=True)
 class VariableInfo:
     """
-    Structural summary of a variable definition plus participation flags.
+    Structural summary of a variable definition plus guard-affect flags.
 
-    The ``participates_directly`` and ``participates_indirectly`` flags
+    The ``affects_guard_directly`` and ``affects_guard_indirectly`` flags
     are precomputed here so that unreferenced-variable diagnostics can
     be expressed as a one-line filter against this object.
 
@@ -200,15 +200,12 @@ class VariableInfo:
     :param written_in_effects: Tuples ``(from_path, to_path)`` of
         transitions whose effect block writes this variable.
     :type written_in_effects: Tuple[Tuple[str, str], ...]
-    :param participates_directly: ``True`` when the variable is read by
-        at least one guard, transition effect, or action operation.
-    :type participates_directly: bool
-    :param participates_indirectly: ``True`` when the variable is not
-        directly referenced but is transitively reachable through
-        write-then-read data dependency across blocks. The current
-        inspect implementation keeps this field as ``False`` for
-        variables that lack any read.
-    :type participates_indirectly: bool
+    :param affects_guard_directly: ``True`` when the variable is read by
+        at least one transition guard.
+    :type affects_guard_directly: bool
+    :param affects_guard_indirectly: ``True`` when the variable reaches
+        a transition guard through the conservative use-def graph.
+    :type affects_guard_indirectly: bool
     :param abstract_actions_in_scope: Function names of abstract actions
         whose enclosing state is on the ancestor chain or sub-tree of
         any state that touches this variable. Downstream diagnostics can
@@ -228,8 +225,8 @@ class VariableInfo:
     written_in_states: Tuple[str, ...]
     read_in_guards: Tuple[Tuple[str, str], ...]
     written_in_effects: Tuple[Tuple[str, str], ...]
-    participates_directly: bool
-    participates_indirectly: bool
+    affects_guard_directly: bool
+    affects_guard_indirectly: bool
     abstract_actions_in_scope: Tuple[str, ...]
     float_literal_assignments: Tuple[str, ...] = field(default_factory=tuple)
 
@@ -885,13 +882,19 @@ def _build_variable_infos(
                 out.append(x)
         return tuple(out)
 
+    use_def_graph = build_use_def_graph(machine)
+    direct_guard_vars = {
+        name for name, entries in var_read_guards.items()
+        if entries
+    }
+    indirect_guard_vars = set(use_def_graph.affecting_variables(direct_guard_vars))
+
     out: List[VariableInfo] = []
     for name, var_define in machine.defines.items():
         read_states = _dedupe_ordered(var_reads_by_state[name])
         written_states = _dedupe_ordered(var_writes_by_state[name])
         read_guards = _dedupe_pairs(var_read_guards[name])
         written_effects = _dedupe_pairs(var_written_effects[name])
-        participates_directly = bool(read_states or read_guards)
         abstract_actions = _abstract_actions_in_scope(state_lookup, read_states, written_states)
         float_assignments = _dedupe_ordered(var_float_literal_assignments[name])
         out.append(VariableInfo(
@@ -902,8 +905,10 @@ def _build_variable_infos(
             written_in_states=written_states,
             read_in_guards=read_guards,
             written_in_effects=written_effects,
-            participates_directly=participates_directly,
-            participates_indirectly=False,
+            affects_guard_directly=name in direct_guard_vars,
+            affects_guard_indirectly=(
+                name not in direct_guard_vars and name in indirect_guard_vars
+            ),
             abstract_actions_in_scope=abstract_actions,
             float_literal_assignments=float_assignments,
         ))
@@ -915,26 +920,12 @@ def _abstract_actions_in_scope(
         read_states: Tuple[str, ...],
         written_states: Tuple[str, ...],
 ) -> Tuple[str, ...]:
-    """Return abstract action labels visible from any touching state."""
-    touched = set(read_states) | set(written_states)
-    if not touched:
-        # Variable touches no state — declared but unused. There is no
-        # abstract-action scope to inspect from here.
-        return tuple()
-    out: List[str] = []
-    for path in sorted(touched):
-        info = state_lookup.get(path)
-        if info is None:  # pragma: no cover
-            # Defensive: ``touched`` paths come from VariableInfo
-            # read_in_states / written_in_states, which are populated
-            # only with paths that exist in state_lookup. Unreachable
-            # in the current pipeline; kept as a safety net.
-            continue
-        if info.has_abstract_action:
-            label = f'{info.path}:<abstract>'
-            if label not in out:
-                out.append(label)
-    return tuple(out)
+    """Return abstract action labels that can see global variables."""
+    return tuple(
+        f'{info.path}:<abstract>'
+        for info in sorted(state_lookup.values(), key=lambda item: item.path)
+        if info.has_abstract_action
+    )
 
 
 def _build_event_infos(machine: 'StateMachine', transitions: Tuple[TransitionInfo, ...]) -> Tuple[EventInfo, ...]:

--- a/pyfcstm/diagnostics/schema.json
+++ b/pyfcstm/diagnostics/schema.json
@@ -179,7 +179,7 @@
         "name", "type", "init_value",
         "read_in_states", "written_in_states",
         "read_in_guards", "written_in_effects",
-        "participates_directly", "participates_indirectly",
+        "affects_guard_directly", "affects_guard_indirectly",
         "abstract_actions_in_scope", "float_literal_assignments"
       ],
       "properties": {
@@ -206,8 +206,8 @@
             "maxItems": 2
           }
         },
-        "participates_directly": { "type": "boolean" },
-        "participates_indirectly": { "type": "boolean" },
+        "affects_guard_directly": { "type": "boolean" },
+        "affects_guard_indirectly": { "type": "boolean" },
         "abstract_actions_in_scope": {
           "type": "array",
           "items": { "type": "string" }

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -776,6 +776,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'code': 'W_GUARD_VARS_NEVER_CHANGE',
                 'severity': 'warning',
                 'refs': {
+                    'from_path': 'Root.Idle',
+                    'to_path': 'Root.Active',
                     'transition_span': None,
                     'guard_vars': ['read_only'],
                 },
@@ -784,6 +786,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'code': 'W_GUARD_VARS_NEVER_CHANGE',
                 'severity': 'warning',
                 'refs': {
+                    'from_path': 'Root.Idle',
+                    'to_path': 'Root.Active',
                     'transition_span': None,
                     'guard_vars': ['read_only'],
                 },
@@ -1049,6 +1053,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'code': 'W_GUARD_VARS_NEVER_CHANGE',
                 'severity': 'warning',
                 'refs': {
+                    'from_path': 'Root.Idle',
+                    'to_path': 'Root.StableBlocked',
                     'transition_span': None,
                     'guard_vars': ['stable'],
                 },

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -541,27 +541,35 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 },
             },
             {
-                'code': 'W_WRITE_ONLY_VAR',
+                'code': 'W_UNREFERENCED_VAR',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'dynamic',
+                    'init_value': '0',
+                },
+            },
+            {
+                'code': 'W_UNREFERENCED_VAR',
                 'severity': 'warning',
                 'refs': {
                     'var_name': 'stable',
-                    'written_states': ['Root.Idle'],
+                    'init_value': '0',
                 },
             },
             {
-                'code': 'W_WRITE_ONLY_VAR',
+                'code': 'W_UNREFERENCED_VAR',
                 'severity': 'warning',
                 'refs': {
                     'var_name': 'wide',
-                    'written_states': ['Root.Idle'],
+                    'init_value': '0',
                 },
             },
             {
-                'code': 'W_WRITE_ONLY_VAR',
+                'code': 'W_UNREFERENCED_VAR',
                 'severity': 'warning',
                 'refs': {
                     'var_name': 'powered',
-                    'written_states': ['Root.Idle'],
+                    'init_value': '0.0',
                 },
             },
         ],
@@ -596,11 +604,11 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 },
             },
             {
-                'code': 'W_WRITE_ONLY_VAR',
+                'code': 'W_UNREFERENCED_VAR',
                 'severity': 'warning',
                 'refs': {
                     'var_name': 'angle',
-                    'written_states': ['Root.Wrapper.Idle'],
+                    'init_value': '0.0',
                 },
             },
         ],
@@ -757,11 +765,27 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 },
             },
             {
-                'code': 'W_WRITE_ONLY_VAR',
+                'code': 'W_UNREFERENCED_VAR',
                 'severity': 'warning',
                 'refs': {
                     'var_name': 'write_only',
-                    'written_states': ['Root.Idle'],
+                    'init_value': '0',
+                },
+            },
+            {
+                'code': 'W_GUARD_VARS_NEVER_CHANGE',
+                'severity': 'warning',
+                'refs': {
+                    'transition_span': None,
+                    'guard_vars': ['read_only'],
+                },
+            },
+            {
+                'code': 'W_GUARD_VARS_NEVER_CHANGE',
+                'severity': 'warning',
+                'refs': {
+                    'transition_span': None,
+                    'guard_vars': ['read_only'],
                 },
             },
             {
@@ -945,11 +969,106 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 },
             },
             {
-                'code': 'W_WRITE_ONLY_VAR',
+                'code': 'W_UNREFERENCED_VAR',
                 'severity': 'warning',
                 'refs': {
                     'var_name': 'assigned',
-                    'written_states': ['Root.B'],
+                    'init_value': '0',
+                },
+            },
+            {
+                'code': 'W_UNREFERENCED_VAR',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'extra',
+                    'init_value': '0',
+                },
+            },
+            {
+                'code': 'W_UNREFERENCED_VAR',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'truncated',
+                    'init_value': '3.5',
+                },
+            },
+        ],
+    ),
+    (
+        'design-health-guard-affect-data-flow',
+        '\n'.join([
+            'def int unused = 0;',
+            'def int maybe_external = 0;',
+            'def int source = 0;',
+            'def int guard_value = 0;',
+            'def int stable = 0;',
+            'def int changing = 0;',
+            'state Root {',
+            '    state Idle {',
+            '        enter abstract ExternalHook;',
+            '        during {',
+            '            guard_value = source + 1;',
+            '            changing = changing + 1;',
+            '        }',
+            '    }',
+            '    state StableBlocked;',
+            '    state DynamicAllowed;',
+            '    state Done;',
+            '    [*] -> Idle;',
+            '    Idle -> StableBlocked : if [stable > 0];',
+            '    StableBlocked -> DynamicAllowed : if [changing > 0];',
+            '    DynamicAllowed -> Done : if [guard_value > 0];',
+            '}',
+        ]),
+        [
+            {
+                'code': 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT',
+                'severity': 'info',
+                'refs': {
+                    'var_name': 'maybe_external',
+                    'abstract_actions_in_scope': ['Root.Idle:<abstract>'],
+                },
+            },
+            {
+                'code': 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT',
+                'severity': 'info',
+                'refs': {
+                    'var_name': 'unused',
+                    'abstract_actions_in_scope': ['Root.Idle:<abstract>'],
+                },
+            },
+            {
+                'code': 'W_DEADLOCK_LEAF',
+                'severity': 'warning',
+                'refs': {
+                    'state_path': 'Root.Done',
+                    'reason': 'no_outgoing_transition',
+                },
+            },
+            {
+                'code': 'W_GUARD_VARS_NEVER_CHANGE',
+                'severity': 'warning',
+                'refs': {
+                    'transition_span': None,
+                    'guard_vars': ['stable'],
+                },
+            },
+            {
+                'code': 'W_UNWRITTEN_READ_VAR',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'source',
+                    'read_states': ['Root.Idle'],
+                    'init_value': '0',
+                },
+            },
+            {
+                'code': 'W_UNWRITTEN_READ_VAR',
+                'severity': 'warning',
+                'refs': {
+                    'var_name': 'stable',
+                    'read_states': ['Root.Idle'],
+                    'init_value': '0',
                 },
             },
         ],

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -778,7 +778,6 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'from_path': 'Root.Idle',
                     'to_path': 'Root.Active',
-                    'transition_span': None,
                     'guard_vars': ['read_only'],
                 },
             },
@@ -788,7 +787,6 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'from_path': 'Root.Idle',
                     'to_path': 'Root.Active',
-                    'transition_span': None,
                     'guard_vars': ['read_only'],
                 },
             },
@@ -1055,7 +1053,6 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'from_path': 'Root.Idle',
                     'to_path': 'Root.StableBlocked',
-                    'transition_span': None,
                     'guard_vars': ['stable'],
                 },
             },

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -729,6 +729,31 @@ class TestInspectModelGuardAffectDataFlow:
         with pytest.raises(TypeError, match='UnknownExpr'):
             collect_expr_variables(UnknownExpr())
 
+    def test_build_use_def_graph_rejects_unknown_statement_subclass(self):
+        from types import SimpleNamespace
+
+        from pyfcstm.diagnostics.analyzers.use_def import build_use_def_graph
+        from pyfcstm.model.model import OperationStatement
+
+        class UnknownStatement(OperationStatement):
+            pass
+
+        machine = SimpleNamespace(
+            walk_states=lambda: [SimpleNamespace(
+                on_enters=[SimpleNamespace(
+                    is_abstract=False,
+                    operations=[UnknownStatement()],
+                )],
+                on_durings=[],
+                on_exits=[],
+                on_during_aspects=[],
+                transitions=[],
+            )],
+        )
+
+        with pytest.raises(TypeError, match='UnknownStatement'):
+            build_use_def_graph(machine)
+
     def test_variable_info_marks_direct_and_indirect_guard_affect(self):
         dsl = """
         def int source = 0;
@@ -855,7 +880,6 @@ class TestInspectModelGuardAffectDiagnostics:
         assert [diag.refs for diag in by_code['W_GUARD_VARS_NEVER_CHANGE']] == [{
             'from_path': 'Root.Idle',
             'to_path': 'Root.StableBlocked',
-            'transition_span': None,
             'guard_vars': ['stable'],
         }]
 

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -130,11 +130,14 @@ class TestInspectModelBasic:
         assert 'Root.Active' in counter.written_in_states
         # guard read should also be captured
         assert any('Root.Idle' == fp for fp, _ in counter.read_in_guards)
+        assert counter.affects_guard_directly is True
+        assert counter.affects_guard_indirectly is False
         # ``temp`` has no participation in this DSL.
         temp = vars_by_name['temp']
         assert temp.read_in_states == tuple()
         assert temp.written_in_states == tuple()
-        assert temp.participates_directly is False
+        assert temp.affects_guard_directly is False
+        assert temp.affects_guard_indirectly is False
 
     def test_event_payload(self, report):
         events_by_name = {e.qualified_name: e for e in report.events}
@@ -275,7 +278,17 @@ class TestInspectModelToJson:
         assert isinstance(payload['variables'][0]['read_in_states'], list)
 
     def test_to_json_diagnostics_empty_for_clean_model(self, report):
-        assert report.to_json()['diagnostics'] == []
+        clean = """
+        def int counter = 0;
+        state Root {
+            state Idle;
+            state Active { during { counter = counter + 1; } }
+            [*] -> Idle;
+            Idle -> Active : if [counter > 0];
+            Active -> Idle :: Pause;
+        }
+        """
+        assert inspect_model(_parse(clean)).to_json()['diagnostics'] == []
 
 
 @pytest.mark.unittest
@@ -660,6 +673,201 @@ state Root {
         assert 'Root.A' in vars_by_name['x'].read_in_states
         # ``y`` is written in both branches.
         assert 'Root.A' in vars_by_name['y'].written_in_states
+
+
+@pytest.mark.unittest
+class TestInspectModelGuardAffectDataFlow:
+    """Layer-0 use-def closure behind guard-affect participation flags."""
+
+    def test_use_def_graph_tracks_nested_branch_conditions(self):
+        from pyfcstm.diagnostics.analyzers.use_def import build_use_def_graph
+
+        dsl = """
+        def int x = 0;
+        def int y = 0;
+        def int z = 0;
+        def int flag = 0;
+        def int dedupe = 0;
+        state Root {
+            state Active {
+                during {
+                    dedupe = x + x;
+                    if [x >= 10] {
+                        if [x % 2 == 0] {
+                            y = x + 10;
+                        } else {
+                            y = x + 12;
+                            z = x * y - 2;
+                        }
+                    } else if [flag > 0] {
+                        z = y + flag;
+                    } else {
+                        z = y - 10;
+                        x = x + 2;
+                    }
+                }
+            }
+            [*] -> Active;
+        }
+        """
+        graph = build_use_def_graph(_parse(dsl))
+
+        assert ('x', 'y') in graph.edges
+        assert ('x', 'z') in graph.edges
+        assert ('y', 'z') in graph.edges
+        assert ('flag', 'z') in graph.edges
+        assert ('x', 'x') in graph.edges
+        assert ('flag', 'x') in graph.edges
+
+    def test_variable_info_marks_direct_and_indirect_guard_affect(self):
+        dsl = """
+        def int source = 0;
+        def int middle = 0;
+        def int guard_value = 0;
+        def int direct = 0;
+        def int ternary_only = 0;
+        def int unused = 0;
+        state Root {
+            state Idle {
+                during {
+                    middle = source + 1;
+                    guard_value = middle;
+                    unused = (ternary_only > 0) ? 1 : 2;
+                }
+            }
+            state Done;
+            [*] -> Idle : if [direct > 0];
+            Idle -> Done : if [guard_value > 0];
+            Done -> [*] : if [direct > 1];
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        variables = {v.name: v for v in report.variables}
+
+        assert variables['direct'].affects_guard_directly is True
+        assert variables['direct'].affects_guard_indirectly is False
+        assert variables['guard_value'].affects_guard_directly is True
+        assert variables['guard_value'].affects_guard_indirectly is False
+        assert variables['middle'].affects_guard_directly is False
+        assert variables['middle'].affects_guard_indirectly is True
+        assert variables['source'].affects_guard_directly is False
+        assert variables['source'].affects_guard_indirectly is True
+        assert variables['ternary_only'].affects_guard_directly is False
+        assert variables['ternary_only'].affects_guard_indirectly is False
+        assert variables['unused'].affects_guard_directly is False
+        assert variables['unused'].affects_guard_indirectly is False
+
+
+@pytest.mark.unittest
+class TestInspectModelGuardAffectDiagnostics:
+    """Diagnostics whose trigger is the guard-affect closure."""
+
+    @staticmethod
+    def _diagnostics_by_code(dsl):
+        report = inspect_model(_parse(dsl))
+        assert_all_diags_match_schema(report.diagnostics, context='guard-affect-data-flow')
+        out = {}
+        for diag in report.diagnostics:
+            out.setdefault(diag.code, []).append(diag)
+        return out
+
+    def test_unreferenced_variable_without_abstract_action_is_warning(self):
+        by_code = self._diagnostics_by_code("""
+        def int unused = 0;
+        def int driver = 0;
+        state Root {
+            state Idle;
+            state Done;
+            [*] -> Idle;
+            Idle -> Done : if [driver > 0];
+        }
+        """)
+
+        assert by_code['W_UNREFERENCED_VAR'][0].refs == {
+            'var_name': 'unused',
+            'init_value': '0',
+        }
+        assert 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT' not in by_code
+
+    def test_unreferenced_variable_with_abstract_action_is_info(self):
+        by_code = self._diagnostics_by_code("""
+        def int maybe_external = 0;
+        def int driver = 0;
+        state Root {
+            state Idle { enter abstract ExternalHook; }
+            state Done;
+            [*] -> Idle;
+            Idle -> Done : if [driver > 0];
+        }
+        """)
+
+        assert by_code['I_UNREFERENCED_VAR_MAYBE_ABSTRACT'][0].refs == {
+            'var_name': 'maybe_external',
+            'abstract_actions_in_scope': ['Root.Idle:<abstract>'],
+        }
+        assert 'W_UNREFERENCED_VAR' not in by_code
+
+    def test_indirect_guard_dependency_is_not_reported_as_unreferenced(self):
+        by_code = self._diagnostics_by_code("""
+        def int source = 0;
+        def int guard_value = 0;
+        state Root {
+            state Idle { during { guard_value = source + 1; } }
+            state Done;
+            [*] -> Idle;
+            Idle -> Done : if [guard_value > 0];
+        }
+        """)
+
+        variable_codes = [
+            diag for diags in by_code.values() for diag in diags
+            if diag.refs.get('var_name') == 'source'
+        ]
+        variable_codes = [diag.code for diag in variable_codes]
+        assert 'W_UNREFERENCED_VAR' not in variable_codes
+        assert 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT' not in variable_codes
+        assert variable_codes == ['W_UNWRITTEN_READ_VAR']
+
+    def test_guard_vars_never_change_is_per_transition(self):
+        by_code = self._diagnostics_by_code("""
+        def int stable = 0;
+        def int changing = 0;
+        state Root {
+            state Idle { during { changing = changing + 1; } }
+            state StableBlocked;
+            state DynamicAllowed;
+            [*] -> Idle;
+            Idle -> StableBlocked : if [stable > 0];
+            Idle -> DynamicAllowed : if [changing > 0];
+        }
+        """)
+
+        assert [diag.refs for diag in by_code['W_GUARD_VARS_NEVER_CHANGE']] == [{
+            'transition_span': None,
+            'guard_vars': ['stable'],
+        }]
+
+    def test_write_only_branch_remains_available_for_affecting_payload(self):
+        from pyfcstm.diagnostics.analyzers.data_flow import collect_data_flow_warnings
+
+        variable = VariableInfo(
+            name='write_only',
+            type='int',
+            init_value='0',
+            read_in_states=tuple(),
+            written_in_states=('Root.Idle',),
+            read_in_guards=tuple(),
+            written_in_effects=tuple(),
+            affects_guard_directly=True,
+            affects_guard_indirectly=False,
+            abstract_actions_in_scope=tuple(),
+            float_literal_assignments=tuple(),
+        )
+
+        assert [diag.refs for diag in collect_data_flow_warnings([variable])] == [{
+            'var_name': 'write_only',
+            'written_states': ['Root.Idle'],
+        }]
 
 
 @pytest.mark.unittest

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -719,6 +719,16 @@ class TestInspectModelGuardAffectDataFlow:
         assert ('x', 'x') in graph.edges
         assert ('flag', 'x') in graph.edges
 
+    def test_collect_expr_variables_rejects_unknown_expr_subclass(self):
+        from pyfcstm.diagnostics.analyzers.use_def import collect_expr_variables
+        from pyfcstm.model.expr import Expr
+
+        class UnknownExpr(Expr):
+            pass
+
+        with pytest.raises(TypeError, match='UnknownExpr'):
+            collect_expr_variables(UnknownExpr())
+
     def test_variable_info_marks_direct_and_indirect_guard_affect(self):
         dsl = """
         def int source = 0;
@@ -843,6 +853,8 @@ class TestInspectModelGuardAffectDiagnostics:
         """)
 
         assert [diag.refs for diag in by_code['W_GUARD_VARS_NEVER_CHANGE']] == [{
+            'from_path': 'Root.Idle',
+            'to_path': 'Root.StableBlocked',
             'transition_span': None,
             'guard_vars': ['stable'],
         }]


### PR DESCRIPTION
> 上游伞 PR：#122
> 跟踪 issue：#104
> Base：`dev/issue104-pr-c`
> Head：`dev/issue104-pr-c2-use-def`
> 当前 head commit：`a64711bd0d065f41a363969ef647fc368f68e6c2`
> 状态：第三轮 Claude / Codex 双路中文 C/I/M review 已完成，两路均无 C/I 并明确 Ready to merge；最新 GitHub Actions 已全绿。本 PR ready 后等待 owner 指示，不擅自 merge。

## 背景

PR-C 在 2026-05-31 已做过一次大范围 spec 对齐：旧 #124 实现的是“既无 read 也无 write”的 syntactic 判定，并额外尝试实现 `W_VARIABLE_NEVER_READ_AFTER_FINAL_WRITE`；这与 issue #104 最新锁定的 Layer 0 语义不一致，因此旧 PR 已归档。

新 PR-C2 只做 **Layer 0 use-def 数据流闭包 + 3 个变量诊断码**。核心判定从“变量是否被读写”升级为：变量是否能直接或间接影响任一 transition guard（包括 `[*] -> X` / `X -> [*]` 的 conditional guard）。

`W_VARIABLE_NEVER_READ_AFTER_FINAL_WRITE` 已明确 drop，不属于本 PR，也不在 PR-C 后续范围内。

## 交付目标

本 PR 交付以下内容：

1. Python 与 jsfcstm 双端 use-def graph builder。
2. `VariableInfo` 公开字段：
   - `affects_guard_directly: bool`
   - `affects_guard_indirectly: bool`
3. 3 个新 diagnostics：

| code | severity | capability | refs | trigger |
|---|---|---|---|---|
| `W_UNREFERENCED_VAR` | warning | `pure_static` | `var_name`, `init_value` | `affects_guard_directly == False && affects_guard_indirectly == False`，且变量 visible scope 内无 abstract action |
| `I_UNREFERENCED_VAR_MAYBE_ABSTRACT` | info | `pure_static` | `var_name`, `abstract_actions_in_scope` | 同上，但变量 visible scope 内有 abstract action |
| `W_GUARD_VARS_NEVER_CHANGE` | warning | `pure_static` | `from_path`, `to_path`, `guard_vars` | 单条 transition guard 引用的所有变量都从未被 enter / during / exit action 或 transition effect 修改 |

## 算法契约

### use-def edge builder

遍历所有 DSL dataflow site：

- `enter { ... }`
- `during { ... }`
- `exit { ... }`
- transition `effect { ... }`

abstract action 不参与传播，因为实现位于 DSL 外，静态分析无法知道其 read/write。

核心伪代码：

```text
walk_block(stmts, enclosing_cond_vars):
    for stmt in stmts:
        if Operation(var=u, expr=e):
            deps = vars_in(e) ∪ enclosing_cond_vars
            for v in deps:
                add_edge(v -> u)
        elif IfBlock(branches):
            accumulated = ∅
            for branch in branches:
                this_cond = vars_in(branch.condition) if branch.condition else ∅
                branch_enclosing = enclosing_cond_vars ∪ accumulated ∪ this_cond
                walk_block(branch.statements, branch_enclosing)
                accumulated = accumulated ∪ this_cond
```

必须满足：

- `if/else` 视为 ternary 语法糖。
- `elif` 链 cond vars 要累加：`if c1 A elif c2 B else C` 中，A 依赖 `{c1}`，B 依赖 `{c1, c2}`，C 依赖 `{c1, c2}`。
- else 分支也依赖前面所有 cond vars。
- RHS ternary 不特殊化；`vars_in()` 正常收集 cond / true / false 三侧变量即可。
- 多写同一变量时 use-def 图允许 over-approximation：可以少报 unused，但不能误报实际能影响 guard 的变量。
- Python / JS expression walker 遇到未知 expression 节点必须 fail-fast，避免未来新增 AST 类型后静默漏边。

### affects_guard 推导

1. 终点集合只来自 transition guard 中直接出现的变量，包括：
   - 普通 transition guard。
   - initial transition `[*] -> X` 的 conditional guard。
   - exit transition `X -> [*]` 的 conditional guard。
2. ternary cond 不算 affects_guard 终点，它只是 expression 内部数据流。
3. direct guard vars 标记 `affects_guard_directly = True`。
4. 从 direct guard vars 出发，沿 use-def 入边反向 BFS：能到达但不是 direct 的变量标记 `affects_guard_indirectly = True`。
5. 两个 bool 都为 false 的变量，才进入 unreferenced / maybe-abstract 诊断分支。

### 变量类诊断互斥

单个变量最多 emit 以下四类之一，优先级固定：

1. `W_UNREFERENCED_VAR` 或 `I_UNREFERENCED_VAR_MAYBE_ABSTRACT`：变量不直接/间接影响任何 guard。
2. `W_UNWRITTEN_READ_VAR`：变量有 read 但没有任何 real write。
3. `W_WRITE_ONLY_VAR`：变量有 write 但没有任何 read。
4. 都不命中则不报变量类诊断。

abstract action 不计入 real write site；只用于把 high-confidence `W_UNREFERENCED_VAR` 降级为 `I_UNREFERENCED_VAR_MAYBE_ABSTRACT`。

## 文件级执行计划

### Python

- 新增 `pyfcstm/diagnostics/analyzers/use_def.py`
  - 定义 use-def edge graph 的轻量结构。
  - 提供 expression variable collector，并由 inspect / use-def 共用，避免重复 walker 漂移。
  - 提供 build API 给 inspect 与 analyzer 使用。
- 更新 `pyfcstm/diagnostics/inspect.py`
  - `VariableInfo` dataclass 增加 `affects_guard_directly` / `affects_guard_indirectly`。
  - `to_json()` 输出新增字段。
  - 计算 direct guard vars 与 indirect closure。
- 更新 `pyfcstm/diagnostics/analyzers/data_flow.py`
  - 按新 affects_guard 语义 emit `W_UNREFERENCED_VAR` / `I_UNREFERENCED_VAR_MAYBE_ABSTRACT`。
  - 保持并校正 `W_UNWRITTEN_READ_VAR` / `W_WRITE_ONLY_VAR` 互斥顺序。
  - 新增 `W_GUARD_VARS_NEVER_CHANGE`，refs 同时带 `from_path` / `to_path`，避免只靠 span 定位。
- 更新 `pyfcstm/diagnostics/codes.yaml`
  - 增加 3 个 code entry，字段完整。
- 更新 `pyfcstm/diagnostics/schema.json` 与 docs
  - schema 包含两个新 bool。
  - `make rst_auto` 生成公开 API 文档。

### jsfcstm

- 新增 `editors/jsfcstm/src/diagnostics/analyzers/use-def.ts`
  - 与 Python use-def builder 同构。
- 更新 `editors/jsfcstm/src/diagnostics/inspect.ts`
  - `VariableInfo` interface / `toJson()` 增加两个 bool。
  - inspect 复用 use-def 侧 expression variable collector。
- 更新 `editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts`
  - 与 Python analyzer 等价 emit 3 个 code。
- 同步 runtime assets
  - 从 `codes.yaml` 同步 `editors/jsfcstm/src/diagnostics/codes.json`。
  - 如 schema 同步脚本存在，使用既有脚本，不手写漂移文件。

### Tests

Python 测试仅放在 `test/diagnostics/`，JS 测试仅放在 `editors/jsfcstm/test/`。两边 DSL fixture 各自 inline 或放在各自测试树内；禁止互相读取，也禁止 Python 测试调用 Node/JS，禁止 JS 测试调用 Python。任一侧目录被删除时，另一侧测试仍应稳定运行。

## TDD 用例矩阵

先补失败用例，再实现。

### use-def builder

- `x = y + 1;` 产生 `y -> x`。
- `x = (a > 0) ? b : c;` 产生 `a -> x`、`b -> x`、`c -> x`。
- `if [c] { y = a; } else { y = b; }` 产生 `c -> y`、`a -> y`、`b -> y`。
- `if [c1] { y = a; } elif [c2] { y = b; } else { y = d; }` 中 else 写入依赖 `c1` 与 `c2`。
- 嵌套 if/else 示例覆盖 `x -> y`、`x -> z`、`y -> z`、`x -> x` 自循环。
- 多写覆盖场景确认 over-approximation：不会误报直接/间接影响 guard 的变量。
- 未知 expression 节点会 fail-fast 抛错，不允许静默跳过。

### affects_guard fields

- 变量直接出现在 guard：`affects_guard_directly=True`，`affects_guard_indirectly=False`。
- `y = x + 1;` 且 guard 使用 `y`：x indirect，y direct。
- guard 使用 `z`，use-def 链 `x -> y -> z`：x/y indirect，z direct。
- 只出现在 ternary cond 且结果不流向 guard：不标 direct。
- initial / exit transition guard 都计入 direct guard endpoint。

### diagnostics

- 不影响 guard 且无 abstract action：emit `W_UNREFERENCED_VAR`。
- 不影响 guard 且有 visible abstract action：emit `I_UNREFERENCED_VAR_MAYBE_ABSTRACT`。
- indirect 影响 guard 的变量不报 unreferenced。
- direct 影响 guard 的变量不报 unreferenced。
- guard 变量全部从未被 write：emit `W_GUARD_VARS_NEVER_CHANGE`，并带 `from_path` / `to_path`。
- guard 变量中只要有一个被 write，该 transition 不 emit `W_GUARD_VARS_NEVER_CHANGE`。
- 单变量互斥：unreferenced 优先于 `W_UNWRITTEN_READ_VAR` / `W_WRITE_ONLY_VAR`。
- abstract action 只影响 W->I 降级，不算 real write。
- refs 排序稳定，py/js parity 后集合 diff 为空。

### downstream smoke

- PR body 附一段可复制运行的 Python 示例，展示 3 个 code 的输出，方便从下游 `verify_pyfcstm_static.py` 迁移到 `inspect_model()`。

## 可复制运行示例

下面示例只依赖 Python 端 `inspect_model()`，可以直接复制运行，展示本 PR 新增的 3 个诊断码。

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.diagnostics import inspect_model

examples = {
    "no_abstract": """
def int unused = 0;
def int stable = 0;
state Root {
    state Idle;
    state Done;
    [*] -> Idle;
    Idle -> Done : if [stable > 0];
}
""",
    "with_abstract": """
def int maybe_external = 0;
def int driver = 0;
state Root {
    state Idle { enter abstract ExternalHook; }
    state Done;
    [*] -> Idle;
    Idle -> Done : if [driver > 0];
}
""",
}

interesting = {
    "W_UNREFERENCED_VAR",
    "I_UNREFERENCED_VAR_MAYBE_ABSTRACT",
    "W_GUARD_VARS_NEVER_CHANGE",
}

for label, dsl in examples.items():
    ast = parse_with_grammar_entry(dsl, "state_machine_dsl")
    machine = parse_dsl_node_to_state_machine(ast)
    report = inspect_model(machine)
    print(f"[{label}]")
    for diag in report.diagnostics:
        if diag.code in interesting:
            print(diag.code, diag.severity, diag.refs)
```

期望输出摘要：

```text
[no_abstract]
W_UNREFERENCED_VAR warning {'var_name': 'unused', 'init_value': '0'}
W_GUARD_VARS_NEVER_CHANGE warning {'from_path': 'Root.Idle', 'to_path': 'Root.Done', 'guard_vars': ['stable']}
[with_abstract]
I_UNREFERENCED_VAR_MAYBE_ABSTRACT info {'var_name': 'maybe_external', 'abstract_actions_in_scope': ['Root.Idle:<abstract>']}
W_GUARD_VARS_NEVER_CHANGE warning {'from_path': 'Root.Idle', 'to_path': 'Root.Done', 'guard_vars': ['driver']}
```

## 本地验证结果

最新 head `a64711bd0d065f41a363969ef647fc368f68e6c2` 已完成验证：

```bash
pytest test/diagnostics/test_inspect_model.py test/diagnostics/test_cross_end_parity.py test/diagnostics/test_codes_yaml.py -q
# 354 passed

python -m py_compile pyfcstm/diagnostics/inspect.py pyfcstm/diagnostics/analyzers/data_flow.py pyfcstm/diagnostics/analyzers/use_def.py
# passed

cd editors/jsfcstm && npm run build
# passed

cd editors/jsfcstm && npm run test:coverage
# 524 passing；use-def.ts 行覆盖 100%，data-flow.ts 行覆盖 100%

SKIP_SLOW_TESTS=1 make unittest COV_TYPES="term-missing"
# 8948 passed, 164 skipped, 63 deselected

git diff --check
# passed

git log -1 --format='%B' | grep -iE 'ci skip|test skip|\[skip-slow\]|\[python skip\]|\[js skip\]'
# 只命中 [skip-slow]
```

GitHub Actions #125 当前 head `a64711bd0d065f41a363969ef647fc368f68e6c2` 已全绿，包括 Ubuntu / Windows / macOS Python matrix、jsfcstm test、CLI Build、Release Test、VSCode Extension Build And Release。

Codecov 当前 patch coverage 以最新 bot comment 为准；PR 内新增核心 `use-def.ts` / `data-flow.ts` 已在 jsfcstm coverage 中达到行覆盖 100%。如果 review 或复核认为剩余 patch 行仍属于主路径缺口，则继续补测试后重新跑 CI / review。

## CI 与 review 门禁

- push 后先等 GitHub Actions 全绿。
- CI 不全绿时只修 CI，不启动 review。
- CI 全绿后启动双路 review：
  - `claude -p --permission-mode bypassPermissions --output-format text`
  - `codex exec --dangerously-bypass-approvals-and-sandbox -C /home/hansbug/oo-projects/pyfcstm -`
- 两路 review 都必须拿到：
  - 本 PR URL：#125
  - 上游伞 PR：#122
  - issue：#104
  - 旧 #124 归档原因
  - head commit
  - 本地验证与 CI 状态
  - 测试隔离 / no broad catch / no new deps / no final-write code 的约束
- 要求两路直接在本 PR 下用中文按 C/I/M 三级评论。
- C/I 自动修复，重新测试、push、等 CI、再双路 review。
- 循环到 Claude 与 Codex 都无 C/I 且明确 `Ready to merge`。
- 本 PR ready 后等待 owner 指示，不擅自 merge。

## 硬约束

- 不引入 z3 / SMT / 新 npm runtime / 新 pip 包。
- 不使用 worktree，不修改 `.claude/worktrees`。
- Python 测试与 jsfcstm 测试严格独立；任一侧目录被删除时另一侧测试仍应稳定运行。
- fixture 使用各自测试源码内 inline DSL 或本测试树内 fixture；禁止跨测试树引用资源。
- 代码、函数、模块、测试命名按行为命名，不使用 PR/phase/step 这类项目管理标签。
- 新代码遵守 no broad catch policy。
- use-def over-approximation 的方向必须安全：宁可少报 `W_UNREFERENCED_VAR`，不能把实际能影响 guard 的变量误报为 unused。
- commit message 全部带 `[skip-slow]`，且避免误触发 `ci skip` / `test skip`。

## 验收标准

- [x] pyfcstm 与 jsfcstm 都实现 use-def builder。
- [x] use-def builder 覆盖 operation RHS、ternary RHS、if/else、elif cond 累加、嵌套 if/else、自循环、多写 over-approximation。
- [x] 未知 expression 节点 fail-fast，不静默漏边。
- [x] `VariableInfo` 两端公开 `affects_guard_directly` / `affects_guard_indirectly`。
- [x] Python `to_json()`、JS `toJson()`、schema、docs 全部同步新增字段。
- [x] direct guard vars 只来自 transition guard，不来自 ternary cond。
- [x] indirect closure 从 direct guard vars 反向 BFS 得出，direct 变量不重复标 indirect。
- [x] 3 个 code 在 `codes.yaml` 与 jsfcstm runtime assets 中完整同步。
- [x] pyfcstm `inspect_model(...).diagnostics` 可 emit 3 个新 code。
- [x] jsfcstm `inspectModel(...).diagnostics` 可 emit 3 个新 code。
- [x] 变量类互斥契约成立：`W_UNREFERENCED_VAR` / `I_UNREFERENCED_VAR_MAYBE_ABSTRACT` / `W_UNWRITTEN_READ_VAR` / `W_WRITE_ONLY_VAR` 对单个变量最多 emit 一个。
- [x] abstract action 不计 real write，只用于 unreferenced W->I 降级。
- [x] `W_GUARD_VARS_NEVER_CHANGE` 按单条 transition guard 判定，不把不同 transition 的 guard vars 混成一个语义。
- [x] `W_GUARD_VARS_NEVER_CHANGE.refs` 包含 `from_path` / `to_path`，并已移除永远为 `None` 的 `transition_span` dead field。
- [x] Python 测试全部通过。
- [x] jsfcstm build 与 coverage 测试全部通过。
- [x] cross-end parity 通过，`code + severity + refs` 集合无 diff。
- [x] `SKIP_SLOW_TESTS=1 make unittest COV_TYPES="term-missing"` 通过。
- [x] `git diff --check` 通过。
- [x] 最新 head GitHub Actions 全绿。
- [x] PR body 已补可复制运行的 Python 示例与期望输出摘要。
- [x] Claude 与 Codex 第二轮中文 C/I/M review 均已评论到 PR。
- [x] 第二轮 Claude I 已修复并 push：移除 `W_GUARD_VARS_NEVER_CHANGE.transition_span` dead field，use-def block walker 未知 statement fail-fast。
- [x] 最新 head CI 全绿后，重新启动 Claude / Codex 双路 review。
- [x] 双路 review 最终均无 C/I，并明确 `Ready to merge`。



