### PR TITLE
诊断 PR-C3：suggested_fix 与 VSCode quick-fix auto-apply

### DIFF
--- a/docs/source/api_doc/diagnostics/codes.rst
+++ b/docs/source/api_doc/diagnostics/codes.rst
@@ -32,11 +32,18 @@ ForLlmSpec
     :members: summary,recommended_actions,do_not
 
 
+SuggestedFixSpec
+-----------------------------------------------------
+
+.. autoclass:: SuggestedFixSpec
+    :members: kind,target,anchor_ref,text_template,rationale
+
+
 CodeSpec
 -----------------------------------------------------
 
 .. autoclass:: CodeSpec
-    :members: required_fields,code,severity,description,refs_schema,example_dsl,capability,for_llm,emit_tier
+    :members: required_fields,code,severity,description,refs_schema,example_dsl,capability,for_llm,emit_tier,suggested_fix
 
 
 load\_codes

--- a/docs/source/api_doc/diagnostics/index.rst
+++ b/docs/source/api_doc/diagnostics/index.rst
@@ -13,6 +13,7 @@ pyfcstm.diagnostics
     codes
     inspect
     sink
+    suggested_fix
 
 \_\_all\_\_
 -----------------------------------------------------

--- a/docs/source/api_doc/diagnostics/suggested_fix.rst
+++ b/docs/source/api_doc/diagnostics/suggested_fix.rst
@@ -16,5 +16,3 @@ refs\_with\_suggested\_fix
 -----------------------------------------------------
 
 .. autofunction:: refs_with_suggested_fix
-
-

--- a/docs/source/api_doc/diagnostics/suggested_fix.rst
+++ b/docs/source/api_doc/diagnostics/suggested_fix.rst
@@ -1,0 +1,20 @@
+pyfcstm.diagnostics.suggested\_fix
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.suggested_fix
+
+.. automodule:: pyfcstm.diagnostics.suggested_fix
+
+
+render\_suggested\_fix
+-----------------------------------------------------
+
+.. autofunction:: render_suggested_fix
+
+
+refs\_with\_suggested\_fix
+-----------------------------------------------------
+
+.. autofunction:: refs_with_suggested_fix
+
+

--- a/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/data-flow.ts
@@ -28,15 +28,19 @@ export function collectDataFlowWarnings(
                     },
                 });
             } else {
+                const refs: Record<string, unknown> = {
+                    var_name: variable.name,
+                    init_value: variable.init_value,
+                };
+                if (readStates.size === 0 && writeStates.size === 0) {
+                    refs.definition_delete_anchor = variable.name;
+                }
                 out.push({
                     code: 'W_UNREFERENCED_VAR',
                     severity: 'warning',
                     message: `Variable ${JSON.stringify(variable.name)} does not affect any transition guard.`,
                     span: null,
-                    refs: {
-                        var_name: variable.name,
-                        init_value: variable.init_value,
-                    },
+                    refs,
                 });
             }
             continue;

--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -9,6 +9,7 @@ import type {
     VariableInfo,
 } from '../inspect';
 import type {StateMachine} from '../../model/runtime';
+import {refsWithSuggestedFix} from '../suggested-fix';
 import {collectConstFoldWarnings} from './const-fold';
 import {collectDataFlowWarnings} from './data-flow';
 import {collectNamingWarnings} from './naming';
@@ -36,7 +37,7 @@ export function collectDesignHealthWarnings(
         largeCompositeThreshold: 12,
         varToLeafRatioThreshold: 2.0,
     };
-    return [
+    const diagnostics = [
         ...collectUnreachableStateDiagnostics(states, reachabilityGraph, rootStatePath),
         ...(machine ? collectConstFoldWarnings(machine) : collectGuardConstFalseDiagnostics(transitions)),
         ...collectUnusedEventDiagnostics(events),
@@ -55,6 +56,10 @@ export function collectDesignHealthWarnings(
         ...collectRedundancyWarnings(transitions, events, states),
         ...collectTransitionInfos(states, transitions),
     ];
+    return diagnostics.map(diag => ({
+        ...diag,
+        refs: refsWithSuggestedFix(diag.code, diag.refs),
+    }));
 }
 
 function collectUnreachableStateDiagnostics(

--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -100,19 +100,30 @@ function isLifecycleFreeLeaf(statePath: string, statesByPath: Map<string, StateI
 }
 
 function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
+    const counts = new Map<string, number>();
+    for (const transition of transitions) {
+        for (const varName of transition.effect_self_assigns) {
+            const key = JSON.stringify([transition.from_path, varName]);
+            counts.set(key, (counts.get(key) ?? 0) + 1);
+        }
+    }
     const out: ModelDiagnosticJson[] = [];
     for (const transition of transitions) {
         for (const varName of transition.effect_self_assigns) {
+            const refs: Record<string, unknown> = {
+                state_path: transition.from_path,
+                transition_span: null,
+                var_name: varName,
+            };
+            if (counts.get(JSON.stringify([transition.from_path, varName])) === 1) {
+                refs.effect_self_assign_anchor = varName;
+            }
             out.push({
                 code: 'W_EFFECT_SELF_ASSIGN',
                 severity: 'warning',
                 message: `Transition effect assigns ${JSON.stringify(varName)} to itself.`,
                 span: null,
-                refs: {
-                    state_path: transition.from_path,
-                    transition_span: null,
-                    var_name: varName,
-                },
+                refs,
             });
         }
     }

--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -115,7 +115,10 @@ function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDi
                 transition_span: null,
                 var_name: varName,
             };
-            if (counts.get(JSON.stringify([transition.from_path, varName])) === 1) {
+            if (
+                transition.from_path !== '[*]' &&
+                counts.get(JSON.stringify([transition.from_path, varName])) === 1
+            ) {
                 refs.effect_self_assign_anchor = varName;
             }
             out.push({

--- a/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
@@ -36,15 +36,19 @@ function collectDeadlockLeafWarnings(
     for (const state of states) {
         if (!state.is_leaf || state.is_pseudo) continue;
         if ((outgoing[state.path] ?? 0) > 0) continue;
+        const refs: Record<string, unknown> = {
+            state_path: state.path,
+            reason: 'no_outgoing_transition',
+        };
+        if (state.parent_path !== null) {
+            refs.parent_path = state.parent_path;
+        }
         out.push({
             code: 'W_DEADLOCK_LEAF',
             severity: 'warning',
             message: `Leaf state ${JSON.stringify(state.path)} has no outgoing transition.`,
             span: null,
-            refs: {
-                state_path: state.path,
-                reason: 'no_outgoing_transition',
-            },
+            refs,
         });
     }
     return out;

--- a/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
@@ -56,18 +56,29 @@ function collectInitialUnconditionalMissingWarnings(states: StateInfo[]): ModelD
         if (!state.is_composite) continue;
         const hasUnconditional = state.initial_targets.some(item => item.is_unconditional);
         if (hasUnconditional) continue;
+        const refs: Record<string, unknown> = {
+            composite_path: state.path,
+            existing_conditional_count: state.initial_targets.length,
+        };
+        const firstChildName = firstChildNameOf(state);
+        if (firstChildName !== null) {
+            refs.first_child_name = firstChildName;
+        }
         out.push({
             code: 'W_INITIAL_UNCONDITIONAL_MISSING',
             severity: 'warning',
             message: `Composite state ${JSON.stringify(state.path)} has no unconditional [*] entry transition.`,
             span: null,
-            refs: {
-                composite_path: state.path,
-                existing_conditional_count: state.initial_targets.length,
-            },
+            refs,
         });
     }
     return out;
+}
+
+function firstChildNameOf(state: StateInfo): string | null {
+    if (state.substates.length === 0) return null;
+    const parts = state.substates[0].split('.');
+    return parts.length > 0 ? parts[parts.length - 1] : null;
 }
 
 function collectForcedNeverExpandsWarnings(

--- a/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/structural.ts
@@ -56,6 +56,7 @@ function collectDeadlockLeafWarnings(
 
 function collectInitialUnconditionalMissingWarnings(states: StateInfo[]): ModelDiagnosticJson[] {
     const out: ModelDiagnosticJson[] = [];
+    const statesByPath = new Map(states.map(state => [state.path, state]));
     for (const state of states) {
         if (!state.is_composite) continue;
         const hasUnconditional = state.initial_targets.some(item => item.is_unconditional);
@@ -64,7 +65,7 @@ function collectInitialUnconditionalMissingWarnings(states: StateInfo[]): ModelD
             composite_path: state.path,
             existing_conditional_count: state.initial_targets.length,
         };
-        const firstChildName = firstChildNameOf(state);
+        const firstChildName = firstChildNameOf(state, statesByPath);
         if (firstChildName !== null) {
             refs.first_child_name = firstChildName;
         }
@@ -79,10 +80,15 @@ function collectInitialUnconditionalMissingWarnings(states: StateInfo[]): ModelD
     return out;
 }
 
-function firstChildNameOf(state: StateInfo): string | null {
-    if (state.substates.length === 0) return null;
-    const parts = state.substates[0].split('.');
-    return parts.length > 0 ? parts[parts.length - 1] : null;
+function firstChildNameOf(state: StateInfo, statesByPath: Map<string, StateInfo>): string | null {
+    for (const childPath of state.substates) {
+        const child = statesByPath.get(childPath);
+        if (child && !child.is_pseudo) {
+            const parts = childPath.split('.');
+            return parts.length > 0 ? parts[parts.length - 1] : null;
+        }
+    }
+    return null;
 }
 
 function collectForcedNeverExpandsWarnings(

--- a/editors/jsfcstm/src/diagnostics/codes.ts
+++ b/editors/jsfcstm/src/diagnostics/codes.ts
@@ -34,6 +34,17 @@ export interface ForLlmSpec {
 }
 
 /**
+ * Structured auto-fix metadata declared by ``codes.yaml``.
+ */
+export interface SuggestedFixSpec {
+    kind: 'insert' | 'delete' | 'replace';
+    target: string;
+    anchor_ref: string;
+    text_template?: string;
+    rationale: string;
+}
+
+/**
  * Specification for a single diagnostic code as expressed in
  * ``codes.yaml``.
  */
@@ -43,6 +54,7 @@ export interface CodeSpec {
     refs?: Record<string, CodeFieldSpec>;
     capability?: 'pure_static' | 'const_fold' | 'requires_solver' | 'requires_simulation';
     for_llm?: ForLlmSpec;
+    suggested_fix?: SuggestedFixSpec;
     example_dsl?: string;
 }
 

--- a/editors/jsfcstm/src/diagnostics/index.ts
+++ b/editors/jsfcstm/src/diagnostics/index.ts
@@ -1,3 +1,4 @@
 export * from './codes';
 export * from './inspect';
 export * from './schema';
+export * from './suggested-fix';

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -111,6 +111,8 @@ export interface TransitionInfo {
     event_scope: 'local' | 'chain' | 'absolute' | null;
     guard: string | null;
     effect: string | null;
+    // Duplicate names are preserved so suggested-fix emitters can detect
+    // ambiguous occurrences for the same source state and variable.
     effect_self_assigns: string[];
     is_forced: boolean;
     forced_origin: string | null;
@@ -634,7 +636,7 @@ function effectSelfAssigns(effects: OperationStatement[] | undefined): string[] 
     for (const stmt of effects ?? []) {
         walkStmtSelfAssigns(stmt, out);
     }
-    return Array.from(new Set(out));
+    return out;
 }
 
 function walkStmtSelfAssigns(stmt: OperationStatement, out: string[]): void {

--- a/editors/jsfcstm/src/diagnostics/suggested-fix.ts
+++ b/editors/jsfcstm/src/diagnostics/suggested-fix.ts
@@ -1,0 +1,98 @@
+import type {CodeRegistry} from './codes';
+
+// Import the JSON payload directly. In ts-node source tests, resolving
+// ``./codes`` prefers ``codes.json`` over ``codes.ts``; using the explicit
+// filename keeps source and built-package execution aligned.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const codesContents = require('./codes.json') as CodeRegistry;
+
+export interface SuggestedFixPayload {
+    kind: 'insert' | 'delete' | 'replace';
+    target: string;
+    anchor: {
+        type: 'ref';
+        ref: string;
+    };
+    text: string;
+    rationale: string;
+}
+
+function lastPathSegment(value: unknown): string | undefined {
+    if (typeof value !== 'string') return undefined;
+    const parts = value.split('.');
+    return parts[parts.length - 1];
+}
+
+function templateFieldNames(template: string): string[] {
+    const out: string[] = [];
+    const pattern = /\{([A-Za-z_][A-Za-z0-9_]*)\}/g;
+    let match = pattern.exec(template);
+    while (match !== null) {
+        out.push(match[1]);
+        match = pattern.exec(template);
+    }
+    return out;
+}
+
+function formatTemplate(template: string, values: Record<string, unknown>): string | null {
+    for (const field of templateFieldNames(template)) {
+        if (values[field] === undefined || values[field] === null) {
+            return null;
+        }
+    }
+    return template.replace(/\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, field: string) => String(values[field]));
+}
+
+/**
+ * Render a ``codes.yaml`` suggested-fix template for one diagnostic emit.
+ */
+export function renderSuggestedFix(
+    code: string,
+    refs: Record<string, unknown>,
+): SuggestedFixPayload | null {
+    const spec = codesContents[code];
+    const suggested = spec?.suggested_fix;
+    if (!suggested) return null;
+    if (!suggested.anchor_ref.startsWith('refs.')) return null;
+    const anchorField = suggested.anchor_ref.slice('refs.'.length);
+    if (refs[anchorField] === undefined || refs[anchorField] === null) return null;
+
+    const values: Record<string, unknown> = {...refs};
+    const stateName = lastPathSegment(values.state_path);
+    if (stateName !== undefined && values.state_name === undefined) {
+        values.state_name = stateName;
+    }
+    const compositeName = lastPathSegment(values.composite_path);
+    if (compositeName !== undefined && values.composite_name === undefined) {
+        values.composite_name = compositeName;
+    }
+
+    const text = formatTemplate(suggested.text_template ?? '', values);
+    if (text === null) return null;
+    return {
+        kind: suggested.kind,
+        target: suggested.target,
+        anchor: {
+            type: 'ref',
+            ref: suggested.anchor_ref,
+        },
+        text,
+        rationale: suggested.rationale,
+    };
+}
+
+/**
+ * Copy ``refs`` and attach ``suggested_fix`` when code metadata can be
+ * rendered safely for the current payload.
+ */
+export function refsWithSuggestedFix(
+    code: string,
+    refs: Record<string, unknown>,
+): Record<string, unknown> {
+    const out: Record<string, unknown> = {...refs};
+    const fix = renderSuggestedFix(code, out);
+    if (fix) {
+        out.suggested_fix = fix;
+    }
+    return out;
+}

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -57,6 +57,11 @@ export const FCSTM_DIAGNOSTIC_CODES = {
     unreachableState: 'W_UNREACHABLE_STATE',
     guardConstFalse: 'W_GUARD_CONST_FALSE',
     unusedEvent: 'W_UNUSED_EVENT',
+    guardConstTrue: 'W_GUARD_CONST_TRUE',
+    deadlockLeaf: 'W_DEADLOCK_LEAF',
+    initialUnconditionalMissing: 'W_INITIAL_UNCONDITIONAL_MISSING',
+    unreferencedVar: 'W_UNREFERENCED_VAR',
+    effectSelfAssign: 'W_EFFECT_SELF_ASSIGN',
 } as const;
 
 function isFalseLiteral(expression: FcstmAstExpression): boolean {

--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -1,12 +1,13 @@
 import {pathToFileURL} from 'node:url';
 
+import {inspectModel} from '../diagnostics';
 import type {FcstmSemanticDocument, FcstmSemanticImport, FcstmSemanticVariable} from '../semantics';
 import {FcstmDiagnostic, TextDocumentLike, TextRange, createRange} from '../utils/text';
 import {getWorkspaceGraph} from '../workspace';
 import {FCSTM_DIAGNOSTIC_CODES} from './analyzers';
 import {rangeIntersects} from './ranges';
 import type {FcstmWorkspaceEdit} from './references';
-import {planSuggestedFixEdit, suggestedFixFromDiagnostic} from './suggested-fixes';
+import {planSuggestedFixEdit, suggestedFixDiagnosticRange, suggestedFixFromDiagnostic} from './suggested-fixes';
 
 export type FcstmCodeActionKind = 'quickfix' | 'refactor.rename';
 
@@ -109,6 +110,44 @@ function uniqueCaseInsensitiveStateCandidates(
     )];
 }
 
+function diagnosticKey(diagnostic: FcstmDiagnostic): string {
+    return JSON.stringify([diagnostic.code ?? null, diagnostic.data ?? null]);
+}
+
+function fullDocumentRange(document: TextDocumentLike): TextRange {
+    const lastLine = Math.max(0, document.lineCount - 1);
+    return createRange(0, 0, lastLine, document.lineAt(lastLine).text.length);
+}
+
+function collectSuggestedFixDesignDiagnostics(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    model: Parameters<typeof inspectModel>[0],
+    range: TextRange,
+    existingDiagnostics: FcstmDiagnostic[],
+): FcstmDiagnostic[] {
+    const existing = new Set(existingDiagnostics.map(diagnosticKey));
+    const fullRange = fullDocumentRange(document);
+    const diagnostics: FcstmDiagnostic[] = [];
+    for (const item of inspectModel(model).diagnostics) {
+        const diagnostic: FcstmDiagnostic = {
+            range: fullRange,
+            message: item.message,
+            severity: item.severity,
+            source: 'fcstm',
+            code: item.code,
+            data: item.refs,
+        };
+        const suggestedFix = suggestedFixFromDiagnostic(diagnostic);
+        if (!suggestedFix) continue;
+        diagnostic.range = suggestedFixDiagnosticRange(document, semantic, diagnostic);
+        if (!rangeIntersects(diagnostic.range, range)) continue;
+        if (existing.has(diagnosticKey(diagnostic))) continue;
+        diagnostics.push(diagnostic);
+    }
+    return diagnostics;
+}
+
 /**
  * Build code actions / quick fixes for the selected FCSTM range.
  */
@@ -117,7 +156,9 @@ export async function collectCodeActions(
     range: TextRange,
     diagnostics: FcstmDiagnostic[] = []
 ): Promise<FcstmCodeAction[]> {
-    const semantic = await getWorkspaceGraph().getSemanticDocument(document);
+    const snapshot = await getWorkspaceGraph().buildSnapshotForDocument(document);
+    const node = snapshot.nodes[snapshot.rootFile];
+    const semantic = node?.semantic;
     /* c8 ignore start */
     // Defensive: code-action provider only invokes against parsed
     // documents in the workspace graph; semantic is always present.
@@ -128,6 +169,15 @@ export async function collectCodeActions(
 
     const actions: FcstmCodeAction[] = [];
     const relevantDiagnostics = diagnostics.filter(item => rangeIntersects(item.range, range));
+    if (node?.model) {
+        relevantDiagnostics.push(...collectSuggestedFixDesignDiagnostics(
+            document,
+            semantic,
+            node.model,
+            range,
+            relevantDiagnostics,
+        ));
+    }
 
     for (const diagnostic of relevantDiagnostics) {
         const suggestedFix = suggestedFixFromDiagnostic(diagnostic);

--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -7,7 +7,7 @@ import {getWorkspaceGraph} from '../workspace';
 import {FCSTM_DIAGNOSTIC_CODES} from './analyzers';
 import {rangeIntersects} from './ranges';
 import type {FcstmWorkspaceEdit} from './references';
-import {planSuggestedFixEdit, suggestedFixDiagnosticRange, suggestedFixFromDiagnostic} from './suggested-fixes';
+import {planSuggestedFixEdit, suggestedFixFromDiagnostic, suggestedFixIssueRange} from './suggested-fixes';
 
 export type FcstmCodeActionKind = 'quickfix' | 'refactor.rename';
 
@@ -123,7 +123,6 @@ function collectSuggestedFixDesignDiagnostics(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
     model: Parameters<typeof inspectModel>[0],
-    range: TextRange,
     existingDiagnostics: FcstmDiagnostic[],
 ): FcstmDiagnostic[] {
     const existing = new Set(existingDiagnostics.map(diagnosticKey));
@@ -140,8 +139,7 @@ function collectSuggestedFixDesignDiagnostics(
         };
         const suggestedFix = suggestedFixFromDiagnostic(diagnostic);
         if (!suggestedFix) continue;
-        diagnostic.range = suggestedFixDiagnosticRange(document, semantic, diagnostic);
-        if (!rangeIntersects(diagnostic.range, range)) continue;
+        diagnostic.range = suggestedFixIssueRange(document, semantic, diagnostic);
         if (existing.has(diagnosticKey(diagnostic))) continue;
         diagnostics.push(diagnostic);
     }
@@ -168,15 +166,22 @@ export async function collectCodeActions(
     /* c8 ignore stop */
 
     const actions: FcstmCodeAction[] = [];
-    const relevantDiagnostics = diagnostics.filter(item => rangeIntersects(item.range, range));
+    const relevantDiagnostics = diagnostics.filter(item => (
+        !suggestedFixFromDiagnostic(item) && rangeIntersects(item.range, range)
+    ));
     if (node?.model) {
-        relevantDiagnostics.push(...collectSuggestedFixDesignDiagnostics(
+        const existing = new Set(relevantDiagnostics.map(diagnosticKey));
+        for (const diagnostic of collectSuggestedFixDesignDiagnostics(
             document,
             semantic,
             node.model,
-            range,
             relevantDiagnostics,
-        ));
+        )) {
+            if (!rangeIntersects(diagnostic.range, range)) continue;
+            if (existing.has(diagnosticKey(diagnostic))) continue;
+            existing.add(diagnosticKey(diagnostic));
+            relevantDiagnostics.push(diagnostic);
+        }
     }
 
     for (const diagnostic of relevantDiagnostics) {

--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -6,6 +6,7 @@ import {getWorkspaceGraph} from '../workspace';
 import {FCSTM_DIAGNOSTIC_CODES} from './analyzers';
 import {rangeIntersects} from './ranges';
 import type {FcstmWorkspaceEdit} from './references';
+import {planSuggestedFixEdit, suggestedFixFromDiagnostic} from './suggested-fixes';
 
 export type FcstmCodeActionKind = 'quickfix' | 'refactor.rename';
 
@@ -129,6 +130,20 @@ export async function collectCodeActions(
     const relevantDiagnostics = diagnostics.filter(item => rangeIntersects(item.range, range));
 
     for (const diagnostic of relevantDiagnostics) {
+        const suggestedFix = suggestedFixFromDiagnostic(diagnostic);
+        if (suggestedFix) {
+            const plan = planSuggestedFixEdit(document, semantic, diagnostic);
+            if (plan) {
+                actions.push({
+                    title: `${suggestedFix.rationale} (${diagnostic.code ?? 'suggested fix'})`,
+                    kind: 'quickfix',
+                    diagnostics: [diagnostic],
+                    edit: createWorkspaceEdit(document, plan.range, plan.newText),
+                });
+            }
+            continue;
+        }
+
         if (diagnostic.code === FCSTM_DIAGNOSTIC_CODES.importNotFound) {
             const importItem = findImportByRange(semantic, diagnostic.range);
             if (importItem) {

--- a/editors/jsfcstm/src/editor/index.ts
+++ b/editors/jsfcstm/src/editor/index.ts
@@ -11,6 +11,7 @@ export * from './ranges';
 export * from './selection';
 export * from './semantic-tokens';
 export * from './symbols';
+export * from './suggested-fixes';
 export {
     collectDocumentHighlights,
     collectReferences,

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -206,31 +206,29 @@ function isSelfAssignStatement(statement: FcstmAstAssignmentStatement, varName: 
         statement.expression.name === varName;
 }
 
-function findSelfAssignStatement(
+function collectSelfAssignStatements(
     statements: readonly FcstmAstOperationStatement[],
     varName: string,
-): FcstmAstAssignmentStatement | null {
+    out: FcstmAstAssignmentStatement[],
+): void {
     for (const statement of statements) {
         if (statement.kind === 'assignmentStatement' && isSelfAssignStatement(statement, varName)) {
-            return statement;
+            out.push(statement);
         }
         if (statement.kind === 'ifStatement') {
-            const found = findSelfAssignInIf(statement, varName);
-            if (found) return found;
+            collectSelfAssignsInIf(statement, varName, out);
         }
     }
-    return null;
 }
 
-function findSelfAssignInIf(
+function collectSelfAssignsInIf(
     statement: FcstmAstIfStatement,
     varName: string,
-): FcstmAstAssignmentStatement | null {
+    out: FcstmAstAssignmentStatement[],
+): void {
     for (const branch of statement.branches) {
-        const found = findSelfAssignStatement(branch.statements, varName);
-        if (found) return found;
+        collectSelfAssignStatements(branch.statements, varName, out);
     }
-    return null;
 }
 
 function effectSelfAssignRange(
@@ -239,12 +237,16 @@ function effectSelfAssignRange(
     statePath: string | undefined,
     varName: string,
 ): TextRange | null {
+    const matches: TextRange[] = [];
     for (const transition of semantic.transitions) {
         if (statePath && transition.sourceStatePath?.join('.') !== statePath) continue;
-        const statement = findSelfAssignStatement(transition.ast.effect?.statements ?? [], varName);
-        if (statement) return statementDeleteRange(document, statement);
+        const statements: FcstmAstAssignmentStatement[] = [];
+        collectSelfAssignStatements(transition.ast.effect?.statements ?? [], varName, statements);
+        for (const statement of statements) {
+            matches.push(statementDeleteRange(document, statement));
+        }
     }
-    return null;
+    return matches.length === 1 ? matches[0] : null;
 }
 
 function spanLikeToRange(value: unknown): TextRange | null {

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -1,0 +1,291 @@
+import type {
+    FcstmAstAssignmentStatement,
+    FcstmAstIfStatement,
+    FcstmAstOperationStatement,
+} from '../ast';
+import type {FcstmSemanticDocument} from '../semantics';
+import {
+    createRange,
+    FcstmDiagnostic,
+    TextDocumentLike,
+    TextRange,
+} from '../utils/text';
+export interface SuggestedFixEditPlan {
+    range: TextRange;
+    newText: string;
+}
+
+interface SuggestedFixPayload {
+    kind: 'insert' | 'delete' | 'replace';
+    target: string;
+    anchor: {
+        type: 'ref';
+        ref: string;
+    };
+    text: string;
+    rationale: string;
+}
+
+function isSuggestedFixPayload(value: unknown): value is SuggestedFixPayload {
+    if (typeof value !== 'object' || value === null) return false;
+    const payload = value as Record<string, unknown>;
+    const anchor = payload.anchor;
+    return (
+        (payload.kind === 'insert' || payload.kind === 'delete' || payload.kind === 'replace') &&
+        typeof payload.target === 'string' &&
+        typeof payload.text === 'string' &&
+        typeof payload.rationale === 'string' &&
+        typeof anchor === 'object' &&
+        anchor !== null &&
+        (anchor as Record<string, unknown>).type === 'ref' &&
+        typeof (anchor as Record<string, unknown>).ref === 'string'
+    );
+}
+
+export function suggestedFixFromDiagnostic(diagnostic: FcstmDiagnostic): SuggestedFixPayload | null {
+    const data = diagnostic.data;
+    if (!data) return null;
+    const direct = data.suggested_fix;
+    if (isSuggestedFixPayload(direct)) return direct;
+    const refs = data.refs;
+    if (typeof refs === 'object' && refs !== null) {
+        const nested = (refs as Record<string, unknown>).suggested_fix;
+        if (isSuggestedFixPayload(nested)) return nested;
+    }
+    return null;
+}
+
+function lineIndent(document: TextDocumentLike, line: number): string {
+    const text = document.lineAt(Math.max(0, Math.min(line, document.lineCount - 1))).text;
+    return text.match(/^\s*/)?.[0] ?? '';
+}
+
+function fullLineRange(document: TextDocumentLike, range: TextRange): TextRange {
+    const startLine = range.start.line;
+    if (startLine + 1 < document.lineCount) {
+        return createRange(startLine, 0, startLine + 1, 0);
+    }
+    const lineText = document.lineAt(startLine).text;
+    return createRange(startLine, 0, startLine, lineText.length);
+}
+
+function trimComparable(value: string): string {
+    return value.trim().replace(/\s+/g, ' ');
+}
+
+function statementDeleteRange(document: TextDocumentLike, statement: FcstmAstAssignmentStatement): TextRange {
+    const line = document.lineAt(statement.range.start.line).text;
+    if (trimComparable(line) === trimComparable(statement.text)) {
+        return fullLineRange(document, statement.range);
+    }
+    return statement.range;
+}
+
+function variableDefinitionRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    varName: string,
+): TextRange | null {
+    const variable = semantic.variables.find(item => item.name === varName);
+    return variable ? fullLineRange(document, variable.range) : null;
+}
+
+function resolveStatePath(semantic: FcstmSemanticDocument, statePath: string) {
+    return semantic.states.find(item => item.identity.qualifiedName === statePath);
+}
+
+function insertionAfterLine(line: number): TextRange {
+    return createRange(line + 1, 0, line + 1, 0);
+}
+
+function indentedTextForInsertion(
+    document: TextDocumentLike,
+    range: TextRange,
+    text: string,
+): string {
+    if (text.length === 0) return text;
+    const indent = lineIndent(document, range.start.line);
+    return text
+        .split('\n')
+        .map((line, index, lines) => {
+            if (line === '' && index === lines.length - 1) return line;
+            return line.startsWith(indent) ? line : `${indent}${line}`;
+        })
+        .join('\n');
+}
+
+function deadlockLeafInsertion(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    statePath: string,
+    text: string,
+): SuggestedFixEditPlan | null {
+    const state = resolveStatePath(semantic, statePath);
+    if (!state) return null;
+    const range = insertionAfterLine(state.range.end.line);
+    return {
+        range,
+        newText: indentedTextForInsertion(document, state.range, text),
+    };
+}
+
+function initialTransitionInsertion(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    compositePath: string,
+    text: string,
+): SuggestedFixEditPlan | null {
+    const composite = resolveStatePath(semantic, compositePath);
+    if (!composite) return null;
+    const firstChild = semantic.states.find(item => item.parentStateId === composite.identity.id);
+    const anchorRange = firstChild?.range ?? composite.range;
+    const range = insertionAfterLine(anchorRange.end.line);
+    return {
+        range,
+        newText: indentedTextForInsertion(document, anchorRange, text),
+    };
+}
+
+function isSelfAssignStatement(statement: FcstmAstAssignmentStatement, varName: string): boolean {
+    return statement.targetName === varName &&
+        statement.expression.expressionKind === 'identifier' &&
+        statement.expression.name === varName;
+}
+
+function findSelfAssignStatement(
+    statements: readonly FcstmAstOperationStatement[],
+    varName: string,
+): FcstmAstAssignmentStatement | null {
+    for (const statement of statements) {
+        if (statement.kind === 'assignmentStatement' && isSelfAssignStatement(statement, varName)) {
+            return statement;
+        }
+        if (statement.kind === 'ifStatement') {
+            const found = findSelfAssignInIf(statement, varName);
+            if (found) return found;
+        }
+    }
+    return null;
+}
+
+function findSelfAssignInIf(
+    statement: FcstmAstIfStatement,
+    varName: string,
+): FcstmAstAssignmentStatement | null {
+    for (const branch of statement.branches) {
+        const found = findSelfAssignStatement(branch.statements, varName);
+        if (found) return found;
+    }
+    return null;
+}
+
+function effectSelfAssignRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    statePath: string | undefined,
+    varName: string,
+): TextRange | null {
+    for (const transition of semantic.transitions) {
+        if (statePath && transition.sourceStatePath?.join('.') !== statePath) continue;
+        const statement = findSelfAssignStatement(transition.ast.effect?.statements ?? [], varName);
+        if (statement) return statementDeleteRange(document, statement);
+    }
+    return null;
+}
+
+function spanLikeToRange(value: unknown): TextRange | null {
+    if (typeof value !== 'object' || value === null) return null;
+    const obj = value as Record<string, unknown>;
+    const start = obj.start as Record<string, unknown> | undefined;
+    const end = obj.end as Record<string, unknown> | undefined;
+    if (
+        typeof start?.line === 'number' &&
+        typeof start?.character === 'number' &&
+        typeof end?.line === 'number' &&
+        typeof end?.character === 'number'
+    ) {
+        return createRange(start.line, start.character, end.line, end.character);
+    }
+    if (typeof obj.line === 'number' && typeof obj.column === 'number') {
+        const startLine = Math.max(0, obj.line - 1);
+        const startColumn = Math.max(0, obj.column - 1);
+        const endLine = typeof obj.end_line === 'number' ? Math.max(0, obj.end_line - 1) : startLine;
+        const endColumn = typeof obj.end_column === 'number' ? Math.max(0, obj.end_column - 1) : startColumn;
+        return createRange(startLine, startColumn, endLine, endColumn);
+    }
+    return null;
+}
+
+function referencedValue(
+    diagnostic: FcstmDiagnostic,
+    payload: SuggestedFixPayload,
+): unknown {
+    const ref = payload.anchor.ref;
+    if (!ref.startsWith('refs.')) return undefined;
+    const field = ref.slice('refs.'.length);
+    const direct = diagnostic.data?.[field];
+    if (direct !== undefined) return direct;
+    const refs = diagnostic.data?.refs;
+    if (typeof refs === 'object' && refs !== null) {
+        return (refs as Record<string, unknown>)[field];
+    }
+    return undefined;
+}
+
+export function planSuggestedFixEdit(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    diagnostic: FcstmDiagnostic,
+): SuggestedFixEditPlan | null {
+    const payload = suggestedFixFromDiagnostic(diagnostic);
+    if (!payload) return null;
+    const anchorValue = referencedValue(diagnostic, payload);
+    if (anchorValue === undefined || anchorValue === null) return null;
+
+    if (payload.target === 'variable_definition' && typeof diagnostic.data?.var_name === 'string') {
+        const range = variableDefinitionRange(document, semantic, diagnostic.data.var_name);
+        return range ? {range, newText: ''} : null;
+    }
+    if (payload.target === 'effect_self_assign_statement' && typeof diagnostic.data?.var_name === 'string') {
+        const range = effectSelfAssignRange(
+            document,
+            semantic,
+            typeof diagnostic.data.state_path === 'string' ? diagnostic.data.state_path : undefined,
+            diagnostic.data.var_name,
+        );
+        return range ? {range, newText: ''} : null;
+    }
+    if (payload.target === 'deadlock_leaf_exit_transition' && typeof diagnostic.data?.state_path === 'string') {
+        return deadlockLeafInsertion(document, semantic, diagnostic.data.state_path, payload.text);
+    }
+    if (payload.target === 'unconditional_initial_transition' && typeof diagnostic.data?.composite_path === 'string') {
+        return initialTransitionInsertion(document, semantic, diagnostic.data.composite_path, payload.text);
+    }
+
+    const spanRange = spanLikeToRange(anchorValue);
+    if (!spanRange) return null;
+    if (payload.kind === 'insert') {
+        return {
+            range: createRange(
+                spanRange.end.line,
+                spanRange.end.character,
+                spanRange.end.line,
+                spanRange.end.character,
+            ),
+            newText: payload.text,
+        };
+    }
+    return {
+        range: spanRange,
+        newText: payload.kind === 'delete' ? '' : payload.text,
+    };
+}
+
+export function suggestedFixDiagnosticRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    diagnostic: FcstmDiagnostic,
+): TextRange {
+    const plan = planSuggestedFixEdit(document, semantic, diagnostic);
+    return plan?.range ?? diagnostic.range;
+}

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -87,15 +87,48 @@ function variableDefinitionRange(
     varName: string,
 ): TextRange | null {
     const variable = semantic.variables.find(item => item.name === varName);
-    return variable ? fullLineRange(document, variable.range) : null;
+    if (!variable) return null;
+    const line = document.lineAt(variable.range.start.line).text;
+    if (trimComparable(line) === trimComparable(variable.ast.text)) {
+        return fullLineRange(document, variable.range);
+    }
+    return variable.range;
 }
 
 function resolveStatePath(semantic: FcstmSemanticDocument, statePath: string) {
     return semantic.states.find(item => item.identity.qualifiedName === statePath);
 }
 
-function insertionAfterLine(line: number): TextRange {
-    return createRange(line + 1, 0, line + 1, 0);
+function resolveStateId(semantic: FcstmSemanticDocument, stateId: string | undefined) {
+    if (!stateId) return undefined;
+    return semantic.states.find(item => item.identity.id === stateId);
+}
+
+function textAtIndent(text: string, indent: string): string {
+    const trimmed = text.trimEnd();
+    if (trimmed.length === 0) return '';
+    return trimmed
+        .split('\n')
+        .map(line => line.length > 0 ? `${indent}${line}` : line)
+        .join('\n');
+}
+
+function insertionAfterLinePlan(
+    document: TextDocumentLike,
+    line: number,
+    newText: string,
+): SuggestedFixEditPlan {
+    if (line + 1 < document.lineCount) {
+        return {
+            range: createRange(line + 1, 0, line + 1, 0),
+            newText,
+        };
+    }
+    const lineText = document.lineAt(line).text;
+    return {
+        range: createRange(line, lineText.length, line, lineText.length),
+        newText: `\n${newText}`,
+    };
 }
 
 function indentedTextForInsertion(
@@ -114,6 +147,25 @@ function indentedTextForInsertion(
         .join('\n');
 }
 
+function insertionBeforeStateClose(
+    document: TextDocumentLike,
+    stateRange: TextRange,
+    text: string,
+): SuggestedFixEditPlan | null {
+    const closeLine = stateRange.end.line;
+    const lineText = document.lineAt(closeLine).text;
+    const searchEnd = Math.min(stateRange.end.character, lineText.length);
+    const closeColumn = lineText.lastIndexOf('}', Math.max(0, searchEnd - 1));
+    if (closeColumn < 0) return null;
+    const parentIndent = lineIndent(document, stateRange.start.line);
+    const inserted = textAtIndent(text, `${parentIndent}    `);
+    if (inserted.length === 0) return null;
+    return {
+        range: createRange(closeLine, closeColumn, closeLine, closeColumn),
+        newText: `\n${inserted}\n${parentIndent}`,
+    };
+}
+
 function deadlockLeafInsertion(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
@@ -122,11 +174,13 @@ function deadlockLeafInsertion(
 ): SuggestedFixEditPlan | null {
     const state = resolveStatePath(semantic, statePath);
     if (!state) return null;
-    const range = insertionAfterLine(state.range.end.line);
-    return {
-        range,
-        newText: indentedTextForInsertion(document, state.range, text),
-    };
+    const parent = resolveStateId(semantic, state.parentStateId);
+    if (!parent) return null;
+    const newText = indentedTextForInsertion(document, state.range, text);
+    if (state.range.end.line < parent.range.end.line) {
+        return insertionAfterLinePlan(document, state.range.end.line, newText);
+    }
+    return insertionBeforeStateClose(document, parent.range, text);
 }
 
 function initialTransitionInsertion(
@@ -138,12 +192,12 @@ function initialTransitionInsertion(
     const composite = resolveStatePath(semantic, compositePath);
     if (!composite) return null;
     const firstChild = semantic.states.find(item => item.parentStateId === composite.identity.id);
-    const anchorRange = firstChild?.range ?? composite.range;
-    const range = insertionAfterLine(anchorRange.end.line);
-    return {
-        range,
-        newText: indentedTextForInsertion(document, anchorRange, text),
-    };
+    if (!firstChild) return null;
+    const newText = indentedTextForInsertion(document, firstChild.range, text);
+    if (firstChild.range.end.line < composite.range.end.line) {
+        return insertionAfterLinePlan(document, firstChild.range.end.line, newText);
+    }
+    return insertionBeforeStateClose(document, composite.range, text);
 }
 
 function isSelfAssignStatement(statement: FcstmAstAssignmentStatement, varName: string): boolean {

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -191,6 +191,20 @@ function initialTransitionInsertion(
 ): SuggestedFixEditPlan | null {
     const composite = resolveStatePath(semantic, compositePath);
     if (!composite) return null;
+    const initialTransitions = semantic.transitions
+        .filter(item => item.ownerStateId === composite.identity.id && item.sourceKind === 'init')
+        .sort((a, b) => (
+            a.range.end.line - b.range.end.line ||
+            a.range.end.character - b.range.end.character
+        ));
+    const lastInitial = initialTransitions[initialTransitions.length - 1];
+    if (lastInitial) {
+        const newText = indentedTextForInsertion(document, lastInitial.range, text);
+        if (lastInitial.range.end.line < composite.range.end.line) {
+            return insertionAfterLinePlan(document, lastInitial.range.end.line, newText);
+        }
+        return insertionBeforeStateClose(document, composite.range, text);
+    }
     const firstChild = semantic.states.find(item => item.parentStateId === composite.identity.id);
     if (!firstChild) return null;
     const newText = indentedTextForInsertion(document, firstChild.range, text);

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -86,8 +86,9 @@ function variableDefinitionRange(
     semantic: FcstmSemanticDocument,
     varName: string,
 ): TextRange | null {
-    const variable = semantic.variables.find(item => item.name === varName);
-    if (!variable) return null;
+    const variables = semantic.variables.filter(item => item.name === varName);
+    if (variables.length !== 1) return null;
+    const variable = variables[0];
     const line = document.lineAt(variable.range.start.line).text;
     if (trimComparable(line) === trimComparable(variable.ast.text)) {
         return fullLineRange(document, variable.range);
@@ -317,10 +318,12 @@ export function planSuggestedFixEdit(
         return range ? {range, newText: ''} : null;
     }
     if (payload.target === 'effect_self_assign_statement' && typeof diagnostic.data?.var_name === 'string') {
+        const statePath = typeof diagnostic.data.state_path === 'string' ? diagnostic.data.state_path : undefined;
+        if (!statePath || statePath === '[*]') return null;
         const range = effectSelfAssignRange(
             document,
             semantic,
-            typeof diagnostic.data.state_path === 'string' ? diagnostic.data.state_path : undefined,
+            statePath,
             diagnostic.data.var_name,
         );
         return range ? {range, newText: ''} : null;
@@ -349,6 +352,36 @@ export function planSuggestedFixEdit(
         range: spanRange,
         newText: payload.kind === 'delete' ? '' : payload.text,
     };
+}
+
+export function suggestedFixIssueRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    diagnostic: FcstmDiagnostic,
+): TextRange {
+    const payload = suggestedFixFromDiagnostic(diagnostic);
+    if (!payload) return diagnostic.range;
+
+    if (payload.target === 'variable_definition' && typeof diagnostic.data?.var_name === 'string') {
+        return variableDefinitionRange(document, semantic, diagnostic.data.var_name) ?? diagnostic.range;
+    }
+    if (payload.target === 'effect_self_assign_statement' && typeof diagnostic.data?.var_name === 'string') {
+        const statePath = typeof diagnostic.data.state_path === 'string' ? diagnostic.data.state_path : undefined;
+        if (!statePath || statePath === '[*]') return diagnostic.range;
+        return effectSelfAssignRange(
+            document,
+            semantic,
+            statePath,
+            diagnostic.data.var_name,
+        ) ?? diagnostic.range;
+    }
+    if (payload.target === 'deadlock_leaf_exit_transition' && typeof diagnostic.data?.state_path === 'string') {
+        return resolveStatePath(semantic, diagnostic.data.state_path)?.range ?? diagnostic.range;
+    }
+    if (payload.target === 'unconditional_initial_transition' && typeof diagnostic.data?.composite_path === 'string') {
+        return resolveStatePath(semantic, diagnostic.data.composite_path)?.range ?? diagnostic.range;
+    }
+    return diagnostic.range;
 }
 
 export function suggestedFixDiagnosticRange(

--- a/editors/jsfcstm/src/lsp/converters.ts
+++ b/editors/jsfcstm/src/lsp/converters.ts
@@ -62,7 +62,9 @@ export function toLspDiagnostic(item: FcstmDiagnostic): Diagnostic {
         message: item.message,
         severity: item.severity === 'error'
             ? DiagnosticSeverity.Error
-            : DiagnosticSeverity.Warning,
+            : item.severity === 'info'
+                ? DiagnosticSeverity.Information
+                : DiagnosticSeverity.Warning,
         source: item.source,
         code: item.code,
         data: item.data,

--- a/editors/jsfcstm/src/lsp/core.ts
+++ b/editors/jsfcstm/src/lsp/core.ts
@@ -675,7 +675,11 @@ export class FcstmLanguageServerCore {
         const actions = await collectCodeActions(document, range, diagnostics.map(item => ({
             range: item.range,
             message: item.message,
-            severity: item.severity === 1 ? 'error' : 'warning',
+            severity: item.severity === 1
+                ? 'error'
+                : item.severity === 3
+                    ? 'info'
+                    : 'warning',
             source: item.source || 'fcstm',
             code: item.code ? String(item.code) : undefined,
             data: item.data as Record<string, unknown> | undefined,

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -20,16 +20,20 @@ describe('jsfcstm analyzers and code actions', () => {
     }
 
     function applySingleEdit(text: string, edit: {range: {start: {line: number; character: number}; end: {line: number; character: number}}; newText: string}): string {
-        const lines = text.split('\n');
-        const before = [
-            ...lines.slice(0, edit.range.start.line),
-            lines[edit.range.start.line].slice(0, edit.range.start.character),
-        ].join('\n');
-        const after = [
-            lines[edit.range.end.line].slice(edit.range.end.character),
-            ...lines.slice(edit.range.end.line + 1),
-        ].join('\n');
-        return `${before}${edit.newText}${after}`;
+        function offsetAt(position: {line: number; character: number}): number {
+            const lines = text.split('\n');
+            if (position.line >= lines.length) {
+                return text.length;
+            }
+            let offset = 0;
+            for (let line = 0; line < position.line; line += 1) {
+                offset += lines[line].length + 1;
+            }
+            return offset + Math.min(position.character, lines[position.line].length);
+        }
+        const start = offsetAt(edit.range.start);
+        const end = offsetAt(edit.range.end);
+        return `${text.slice(0, start)}${edit.newText}${text.slice(end)}`;
     }
 
     async function assertParses(text: string, filePath: string): Promise<void> {
@@ -224,7 +228,7 @@ describe('jsfcstm analyzers and code actions', () => {
         assert.ok(diag, 'expected W_UNREFERENCED_VAR suggested fix diagnostic');
 
         const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
-        const action = actions.find(item => /variable declaration/.test(item.title));
+        const action = actions.find(item => /declaration-only variable/.test(item.title));
         assert.ok(action, `expected delete suggested-fix action, got ${JSON.stringify(actions)}`);
         const edit = Object.values(action.edit?.changes || {}).flat()[0];
         assert.equal(edit.newText, '');
@@ -319,6 +323,113 @@ describe('jsfcstm analyzers and code actions', () => {
         );
     });
 
+    it('does not offer declaration delete when an unreferenced variable is still read', async () => {
+        const text = [
+            'def int unused = 0;',
+            'def int driver = 0;',
+            'state Root {',
+            '    state Idle {',
+            '        enter { temp = unused + 1; }',
+            '    }',
+            '    state Done;',
+            '    [*] -> Idle;',
+            '    Idle -> Done : if [driver > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-read-var-no-delete.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_UNREFERENCED_VAR');
+        assert.ok(diag, 'expected W_UNREFERENCED_VAR diagnostic');
+        assert.equal(packageModule.suggestedFixFromDiagnostic(diag), null);
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        assert.equal(
+            actions.some(item => /variable declaration/.test(item.title)),
+            false,
+        );
+    });
+
+    it('does not offer deadlock leaf insertion for a root leaf state', async () => {
+        const text = 'state Root;';
+        const filePath = '/tmp/root-deadlock-no-fix.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_DEADLOCK_LEAF');
+        assert.ok(diag, 'expected W_DEADLOCK_LEAF diagnostic');
+        assert.equal(packageModule.suggestedFixFromDiagnostic(diag), null);
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        assert.equal(
+            actions.some(item => /exit transition/.test(item.title)),
+            false,
+        );
+    });
+
+    it('keeps suggested-fix insertions valid inside single-line composite states', async () => {
+        const deadlockText = 'state Root { state Idle; [*] -> Idle; }';
+        const deadlockPath = '/tmp/single-line-deadlock-fix.fcstm';
+        const deadlockDocument = createDocument(deadlockText, deadlockPath);
+        const deadlockDiagnostics = await inspectDiagnosticsAsEditorDiagnostics(deadlockText, deadlockPath);
+        const deadlock = deadlockDiagnostics.find(item => item.code === 'W_DEADLOCK_LEAF');
+        assert.ok(deadlock, 'expected W_DEADLOCK_LEAF diagnostic');
+        const deadlockActions = await packageModule.collectCodeActions(
+            deadlockDocument,
+            deadlock.range,
+            [deadlock],
+        );
+        const deadlockEdit = Object.values(deadlockActions[0].edit?.changes || {}).flat()[0];
+        const deadlockUpdated = applySingleEdit(deadlockText, deadlockEdit);
+        assert.ok(deadlockUpdated.includes('Idle -> [*];'));
+        await assertParses(deadlockUpdated, deadlockPath);
+
+        const initialText = [
+            'def int ready = 0;',
+            'state Root { state Idle; [*] -> Idle : if [ready > 0]; }',
+        ].join('\n');
+        const initialPath = '/tmp/single-line-initial-fix.fcstm';
+        const initialDocument = createDocument(initialText, initialPath);
+        const initialDiagnostics = await inspectDiagnosticsAsEditorDiagnostics(initialText, initialPath);
+        const initial = initialDiagnostics.find(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING');
+        assert.ok(initial, 'expected W_INITIAL_UNCONDITIONAL_MISSING diagnostic');
+        const initialActions = await packageModule.collectCodeActions(
+            initialDocument,
+            initial.range,
+            [initial],
+        );
+        const initialEdit = Object.values(initialActions[0].edit?.changes || {}).flat()[0];
+        const initialUpdated = applySingleEdit(initialText, initialEdit);
+        assert.ok(initialUpdated.includes('[*] -> Idle;'));
+        await assertParses(initialUpdated, initialPath);
+    });
+
+    it('provides design-health suggested-fix actions without prepublished diagnostics', async () => {
+        const text = [
+            'def int unused = 0;',
+            'def int driver = 0;',
+            'state Root {',
+            '    state Idle;',
+            '    state Done;',
+            '    [*] -> Idle;',
+            '    Idle -> Done : if [driver > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/editor-design-suggested-fix.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        assert.equal(
+            diagnostics.some(item => item.code === 'W_UNREFERENCED_VAR' || item.code === 'W_DEADLOCK_LEAF'),
+            false,
+        );
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            rangeOf(text, 'unused'),
+            diagnostics,
+        );
+        assert.ok(actions.some(item => /declaration-only variable/.test(item.title)));
+    });
+
     it('applies suggested-fix replace actions from span-backed diagnostic payloads', async () => {
         const text = [
             'state Root {',
@@ -338,12 +449,12 @@ describe('jsfcstm analyzers and code actions', () => {
             source: 'fcstm',
             code: 'W_GUARD_CONST_TRUE',
             data: {
-                transition_span: guardRange,
+                guard_span: guardRange,
                 folded_value: true,
                 suggested_fix: {
                     kind: 'replace',
                     target: 'transition_guard',
-                    anchor: {type: 'ref', ref: 'refs.transition_span'},
+                    anchor: {type: 'ref', ref: 'refs.guard_span'},
                     text: '',
                     rationale: 'Remove the redundant constant-true guard.',
                 },

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -457,6 +457,54 @@ describe('jsfcstm analyzers and code actions', () => {
         await assertParses(updated, filePath);
     });
 
+    it('uses a non-pseudo child for missing unconditional initial quick fixes', async () => {
+        const text = [
+            'def int ready = 1;',
+            'state Root {',
+            '    pseudo state Choice;',
+            '    state A;',
+            '    [*] -> A : if [ready > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-initial-skip-pseudo.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING');
+        assert.ok(diag, 'expected W_INITIAL_UNCONDITIONAL_MISSING suggested fix diagnostic');
+        assert.equal(diag.data?.first_child_name, 'A');
+        assert.match(JSON.stringify(diag.data?.suggested_fix), /\[\*\] -> A;/);
+
+        const actions = await packageModule.collectCodeActions(document, rangeOf(text, 'Root'), []);
+        const action = actions.find(item => /fallback entry transition/.test(item.title));
+        assert.ok(action, `expected fallback initial action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.match(edit.newText, /\[\*\] -> A;\n/);
+        const updated = applySingleEdit(text, edit);
+        await assertParses(updated, filePath);
+    });
+
+    it('omits missing unconditional initial quick fixes when every child is pseudo', async () => {
+        const text = [
+            'def int ready = 1;',
+            'state Root {',
+            '    pseudo state Choice;',
+            '    [*] -> Choice : if [ready > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-initial-only-pseudo-no-fix.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING');
+        assert.ok(diag, 'expected W_INITIAL_UNCONDITIONAL_MISSING diagnostic');
+        assert.equal(packageModule.suggestedFixFromDiagnostic(diag), null);
+
+        const actions = await packageModule.collectCodeActions(document, rangeOf(text, 'Root'), []);
+        assert.equal(
+            actions.some(item => /fallback entry transition/.test(item.title)),
+            false,
+        );
+    });
+
     it('does not offer declaration delete when an unreferenced variable is still read', async () => {
         const text = [
             'def int unused = 0;',
@@ -480,6 +528,122 @@ describe('jsfcstm analyzers and code actions', () => {
         const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
         assert.equal(
             actions.some(item => /variable declaration/.test(item.title)),
+            false,
+        );
+    });
+
+    it('does not trust stale or forged client-supplied suggested-fix payloads', async () => {
+        const text = [
+            'def int used = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B : if [used > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-stale-client-payload.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = [
+            {
+                range: rangeOf(text, 'used > 0'),
+                message: 'Stale unreferenced variable diagnostic.',
+                severity: 'warning' as const,
+                source: 'fcstm',
+                code: 'W_UNREFERENCED_VAR',
+                data: {
+                    var_name: 'used',
+                    definition_delete_anchor: 'used',
+                    suggested_fix: {
+                        kind: 'delete',
+                        target: 'variable_definition',
+                        anchor: {type: 'ref', ref: 'refs.definition_delete_anchor'},
+                        text: '',
+                        rationale: 'Remove declaration-only variable.',
+                    },
+                },
+            },
+            {
+                range: rangeOf(text, 'used > 0'),
+                message: 'Forged guard range diagnostic.',
+                severity: 'warning' as const,
+                source: 'fcstm',
+                code: 'W_GUARD_CONST_TRUE',
+                data: {
+                    guard_span: packageModule.createRange(0, 0, 1, 0),
+                    suggested_fix: {
+                        kind: 'delete',
+                        target: 'transition_guard',
+                        anchor: {type: 'ref', ref: 'refs.guard_span'},
+                        text: '',
+                        rationale: 'Remove forged range.',
+                    },
+                },
+            },
+        ];
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            rangeOf(text, 'used > 0'),
+            diagnostics,
+        );
+        assert.equal(
+            actions.some(item => /declaration-only variable|forged range/.test(item.title)),
+            false,
+        );
+    });
+
+    it('does not offer declaration delete when duplicate variables make the occurrence ambiguous', async () => {
+        const text = [
+            'def int x = 0;',
+            'def int x = 1;',
+            'def int driver = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B : if [driver > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-duplicate-var-no-delete.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            packageModule.createRange(0, 0, document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length),
+            diagnostics,
+        );
+        assert.equal(
+            actions.some(item => /declaration-only variable/.test(item.title)),
+            false,
+        );
+    });
+
+    it('does not offer self-assignment delete for initial transition effects', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    [*] -> A effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-initial-effect-no-fix.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+        assert.ok(diag, 'expected W_EFFECT_SELF_ASSIGN diagnostic for initial effect');
+        assert.equal(packageModule.suggestedFixFromDiagnostic(diag), null);
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            packageModule.createRange(0, 0, document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length),
+            [diag],
+        );
+        assert.equal(
+            actions.some(item => /self-assignment/.test(item.title)),
             false,
         );
     });
@@ -512,7 +676,9 @@ describe('jsfcstm analyzers and code actions', () => {
             deadlock.range,
             [deadlock],
         );
-        const deadlockEdit = Object.values(deadlockActions[0].edit?.changes || {}).flat()[0];
+        const deadlockAction = deadlockActions.find(item => /exit transition/.test(item.title));
+        assert.ok(deadlockAction, `expected deadlock action, got ${JSON.stringify(deadlockActions)}`);
+        const deadlockEdit = Object.values(deadlockAction.edit?.changes || {}).flat()[0];
         const deadlockUpdated = applySingleEdit(deadlockText, deadlockEdit);
         assert.ok(deadlockUpdated.includes('Idle -> [*];'));
         await assertParses(deadlockUpdated, deadlockPath);
@@ -531,7 +697,9 @@ describe('jsfcstm analyzers and code actions', () => {
             initial.range,
             [initial],
         );
-        const initialEdit = Object.values(initialActions[0].edit?.changes || {}).flat()[0];
+        const initialAction = initialActions.find(item => /fallback entry transition/.test(item.title));
+        assert.ok(initialAction, `expected initial action, got ${JSON.stringify(initialActions)}`);
+        const initialEdit = Object.values(initialAction.edit?.changes || {}).flat()[0];
         const initialUpdated = applySingleEdit(initialText, initialEdit);
         assert.ok(initialUpdated.includes('[*] -> Idle;'));
         assert.ok(
@@ -568,7 +736,48 @@ describe('jsfcstm analyzers and code actions', () => {
         assert.ok(actions.some(item => /declaration-only variable/.test(item.title)));
     });
 
-    it('applies suggested-fix replace actions from span-backed diagnostic payloads', async () => {
+    it('provides design-health insert actions from issue ranges without prepublished diagnostics', async () => {
+        const deadlockText = [
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n');
+        const deadlockPath = '/tmp/editor-design-deadlock-issue-range.fcstm';
+        const deadlockDocument = createDocument(deadlockText, deadlockPath);
+        const deadlockDiagnostics = await packageModule.collectDocumentDiagnostics(deadlockDocument);
+        const deadlockActions = await packageModule.collectCodeActions(
+            deadlockDocument,
+            rangeOf(deadlockText, 'Idle'),
+            deadlockDiagnostics,
+        );
+        assert.ok(deadlockActions.some(item => /exit transition/.test(item.title)));
+
+        const initialText = [
+            'def int ready = 0;',
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle : if [ready > 0];',
+            '}',
+        ].join('\n');
+        const initialPath = '/tmp/editor-design-initial-issue-range.fcstm';
+        const initialDocument = createDocument(initialText, initialPath);
+        const initialDiagnostics = await packageModule.collectDocumentDiagnostics(initialDocument);
+        const rootActions = await packageModule.collectCodeActions(
+            initialDocument,
+            rangeOf(initialText, 'Root'),
+            initialDiagnostics,
+        );
+        assert.ok(rootActions.some(item => /fallback entry transition/.test(item.title)));
+        const guardedInitialActions = await packageModule.collectCodeActions(
+            initialDocument,
+            rangeOf(initialText, '[*] -> Idle : if'),
+            initialDiagnostics,
+        );
+        assert.ok(guardedInitialActions.some(item => /fallback entry transition/.test(item.title)));
+    });
+
+    it('plans synthetic suggested-fix replace edits from span-backed diagnostic payloads', async () => {
         const text = [
             'state Root {',
             '    state A;',
@@ -599,18 +808,19 @@ describe('jsfcstm analyzers and code actions', () => {
             },
         };
 
-        const actions = await packageModule.collectCodeActions(document, guardRange, [diagnostic]);
-        const action = actions.find(item => /constant-true guard/.test(item.title));
-        assert.ok(action, `expected replace guard action, got ${JSON.stringify(actions)}`);
-        const edit = Object.values(action.edit?.changes || {}).flat()[0];
-        assert.equal(edit.newText, '');
-        const updated = applySingleEdit(text, edit);
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        assert.ok(semantic);
+
+        const plan = packageModule.planSuggestedFixEdit(document, semantic, diagnostic);
+        assert.ok(plan, 'expected replace guard edit plan');
+        assert.equal(plan.newText, '');
+        const updated = applySingleEdit(text, plan);
         assert.equal(updated.includes(': if [true]'), false);
         assert.ok(updated.includes('A -> B;'));
         await assertParses(updated, filePath);
     });
 
-    it('applies nested suggested-fix payloads with one-based span anchors', async () => {
+    it('plans synthetic nested suggested-fix edits with one-based span anchors', async () => {
         const text = [
             'state Root {',
             '    state A;',
@@ -651,11 +861,9 @@ describe('jsfcstm analyzers and code actions', () => {
         const plannedRange = packageModule.suggestedFixDiagnosticRange(document, semantic, diagnostic);
         assert.deepEqual(plannedRange, packageModule.createRange(4, 10, 4, 10));
 
-        const actions = await packageModule.collectCodeActions(document, diagnostic.range, [diagnostic]);
-        const action = actions.find(item => /trigger before the semicolon/.test(item.title));
-        assert.ok(action, `expected nested insert action, got ${JSON.stringify(actions)}`);
-        const edit = Object.values(action.edit?.changes || {}).flat()[0];
-        const updated = applySingleEdit(text, edit);
+        const plan = packageModule.planSuggestedFixEdit(document, semantic, diagnostic);
+        assert.ok(plan, 'expected nested insert edit plan');
+        const updated = applySingleEdit(text, plan);
         assert.ok(updated.includes('A -> B : Go;'));
         await assertParses(updated, filePath);
     });

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -265,6 +265,77 @@ describe('jsfcstm analyzers and code actions', () => {
         await assertParses(updated, filePath);
     });
 
+    it('does not offer self-assignment delete when the effect occurrence is ambiguous', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    state C;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '    };',
+            '    A -> C effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-delete-effect-ambiguous.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const selfAssigns = diagnostics.filter(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+        assert.equal(selfAssigns.length, 2);
+        assert.equal(
+            selfAssigns.every(item => packageModule.suggestedFixFromDiagnostic(item) === null),
+            true,
+        );
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            packageModule.createRange(0, 0, document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length),
+            selfAssigns,
+        );
+        assert.equal(
+            actions.some(item => /self-assignment/.test(item.title)),
+            false,
+        );
+    });
+
+    it('does not offer self-assignment delete for duplicate occurrences inside one effect', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-delete-effect-duplicate.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const selfAssigns = diagnostics.filter(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+        assert.equal(selfAssigns.length, 2);
+        assert.equal(
+            selfAssigns.every(item => packageModule.suggestedFixFromDiagnostic(item) === null),
+            true,
+        );
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            packageModule.createRange(0, 0, document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length),
+            selfAssigns,
+        );
+        assert.equal(
+            actions.some(item => /self-assignment/.test(item.title)),
+            false,
+        );
+    });
+
     it('applies suggested-fix insert actions for deadlock leaves', async () => {
         const text = [
             'state Root {',

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -386,12 +386,43 @@ describe('jsfcstm analyzers and code actions', () => {
         const edit = Object.values(action.edit?.changes || {}).flat()[0];
         assert.match(edit.newText, /\[\*\] -> Idle;\n/);
         const updated = applySingleEdit(text, edit);
+        assert.ok(
+            updated.indexOf('[*] -> Idle : if [ready > 0];') < updated.indexOf('[*] -> Idle;'),
+            'fallback entry transition must stay after existing guarded initial transitions',
+        );
         await assertParses(updated, filePath);
         const followup = await inspectDiagnosticsAsEditorDiagnostics(updated, filePath);
         assert.equal(
             followup.some(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING'),
             false,
         );
+    });
+
+    it('keeps fallback initial transition after existing guarded initial transitions', async () => {
+        const text = [
+            'def int ready = 1;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> B : if [ready > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-insert-initial-fallback-order.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING');
+        assert.ok(diag, 'expected W_INITIAL_UNCONDITIONAL_MISSING suggested fix diagnostic');
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        const action = actions.find(item => /fallback entry transition/.test(item.title));
+        assert.ok(action, `expected insert initial action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        const updated = applySingleEdit(text, edit);
+        assert.ok(
+            updated.indexOf('[*] -> B : if [ready > 0];') < updated.indexOf('[*] -> A;'),
+            'fallback entry transition must not outrank existing guarded initial transition',
+        );
+        await assertParses(updated, filePath);
     });
 
     it('does not offer declaration delete when an unreferenced variable is still read', async () => {
@@ -471,6 +502,10 @@ describe('jsfcstm analyzers and code actions', () => {
         const initialEdit = Object.values(initialActions[0].edit?.changes || {}).flat()[0];
         const initialUpdated = applySingleEdit(initialText, initialEdit);
         assert.ok(initialUpdated.includes('[*] -> Idle;'));
+        assert.ok(
+            initialUpdated.indexOf('[*] -> Idle : if [ready > 0];') < initialUpdated.indexOf('[*] -> Idle;'),
+            'fallback entry transition must stay after the guarded transition in single-line composites',
+        );
         await assertParses(initialUpdated, initialPath);
     });
 

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -265,6 +265,38 @@ describe('jsfcstm analyzers and code actions', () => {
         await assertParses(updated, filePath);
     });
 
+    it('applies suggested-fix delete actions for nested effect self assignments', async () => {
+        const text = [
+            'def int x = 0;',
+            'def int enabled = 1;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        if [enabled > 0] {',
+            '            x = x;',
+            '        }',
+            '    };',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-delete-nested-effect.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+        assert.ok(diag, 'expected W_EFFECT_SELF_ASSIGN suggested fix diagnostic inside nested if');
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        const action = actions.find(item => /self-assignment/.test(item.title));
+        assert.ok(action, `expected nested delete self-assignment action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.equal(edit.newText, '');
+        const updated = applySingleEdit(text, edit);
+        assert.equal(updated.includes('x = x;'), false);
+        assert.ok(updated.includes('if [enabled > 0]'));
+        await assertParses(updated, filePath);
+    });
+
     it('does not offer self-assignment delete when the effect occurrence is ambiguous', async () => {
         const text = [
             'def int x = 0;',
@@ -673,6 +705,39 @@ describe('jsfcstm analyzers and code actions', () => {
                     },
                 },
             },
+            {
+                range: rangeOf(text, 'A -> [*]'),
+                message: 'Missing anchor.',
+                severity: 'warning' as const,
+                source: 'fcstm',
+                code: 'W_MISSING_ANCHOR',
+                data: {
+                    suggested_fix: {
+                        kind: 'insert',
+                        target: 'transition_suffix',
+                        anchor: {type: 'ref', ref: 'refs.transition_span'},
+                        text: ' : Go',
+                        rationale: 'Add missing anchor trigger.',
+                    },
+                },
+            },
+            {
+                range: rangeOf(text, 'A -> [*]'),
+                message: 'Invalid anchor.',
+                severity: 'warning' as const,
+                source: 'fcstm',
+                code: 'W_INVALID_ANCHOR',
+                data: {
+                    transition_span: 'not-a-span',
+                    suggested_fix: {
+                        kind: 'insert',
+                        target: 'transition_suffix',
+                        anchor: {type: 'ref', ref: 'refs.transition_span'},
+                        text: ' : Go',
+                        rationale: 'Add invalid anchor trigger.',
+                    },
+                },
+            },
         ];
 
         assert.equal(packageModule.suggestedFixFromDiagnostic(diagnostics[1]), null);
@@ -682,7 +747,7 @@ describe('jsfcstm analyzers and code actions', () => {
             diagnostics,
         );
         assert.equal(
-            actions.some(item => /Remove missing variable|Invalid kind/.test(item.title)),
+            actions.some(item => /Remove missing variable|Invalid kind|missing anchor trigger|invalid anchor trigger/.test(item.title)),
             false,
         );
         assert.equal(packageModule.renderSuggestedFix(

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -8,6 +8,57 @@ describe('jsfcstm analyzers and code actions', () => {
         packageModule.getWorkspaceGraph().clearOverlays();
     });
 
+    function rangeOf(text: string, needle: string) {
+        const lines = text.split('\n');
+        for (let line = 0; line < lines.length; line += 1) {
+            const column = lines[line].indexOf(needle);
+            if (column >= 0) {
+                return packageModule.createRange(line, column, line, column + needle.length);
+            }
+        }
+        throw new Error(`needle not found: ${needle}`);
+    }
+
+    function applySingleEdit(text: string, edit: {range: {start: {line: number; character: number}; end: {line: number; character: number}}; newText: string}): string {
+        const lines = text.split('\n');
+        const before = [
+            ...lines.slice(0, edit.range.start.line),
+            lines[edit.range.start.line].slice(0, edit.range.start.character),
+        ].join('\n');
+        const after = [
+            lines[edit.range.end.line].slice(edit.range.end.character),
+            ...lines.slice(edit.range.end.line + 1),
+        ].join('\n');
+        return `${before}${edit.newText}${after}`;
+    }
+
+    async function assertParses(text: string, filePath: string): Promise<void> {
+        const document = createDocument(text, filePath);
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        assert.equal(
+            diagnostics.some(item => item.severity === 'error'),
+            false,
+            `expected edited DSL to parse and semantically validate, got ${JSON.stringify(diagnostics)}`,
+        );
+    }
+
+    async function inspectDiagnosticsAsEditorDiagnostics(text: string, filePath: string) {
+        const document = createDocument(text, filePath);
+        const ast = await packageModule.parseAstDocument(document);
+        const machine = packageModule.buildStateMachineModel(ast);
+        assert.ok(machine, 'expected state-machine model');
+        const report = packageModule.inspectModel(machine);
+        const fullRange = packageModule.createRange(0, 0, document.lineCount - 1, document.lineAt(document.lineCount - 1).text.length);
+        return report.diagnostics.map(item => ({
+            range: fullRange,
+            message: item.message,
+            severity: item.severity,
+            source: 'fcstm',
+            code: item.code,
+            data: item.refs,
+        }));
+    }
+
     it('reports semantic analyzer diagnostics for unreachable states, dead transitions, unused events, mappings, and unresolved refs', async () => {
         const dir = trackTempDir('jsfcstm-analyzers-');
         const hostFile = path.join(dir, 'host.fcstm');
@@ -153,6 +204,274 @@ describe('jsfcstm analyzers and code actions', () => {
         // The action list may be empty (no matching code) - the important
         // property is that the analyzer produced a targeted diagnostic at all.
         assert.ok(Array.isArray(actions));
+    });
+
+    it('applies suggested-fix delete actions for unreferenced variable definitions', async () => {
+        const text = [
+            'def int unused = 0;',
+            'def int driver = 0;',
+            'state Root {',
+            '    state Idle;',
+            '    state Done;',
+            '    [*] -> Idle;',
+            '    Idle -> Done : if [driver > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-delete-var.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_UNREFERENCED_VAR');
+        assert.ok(diag, 'expected W_UNREFERENCED_VAR suggested fix diagnostic');
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        const action = actions.find(item => /variable declaration/.test(item.title));
+        assert.ok(action, `expected delete suggested-fix action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.equal(edit.newText, '');
+        const updated = applySingleEdit(text, edit);
+        assert.equal(updated.includes('def int unused = 0;'), false);
+        await assertParses(updated, filePath);
+    });
+
+    it('applies suggested-fix delete actions for effect self assignments', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-delete-effect.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+        assert.ok(diag, 'expected W_EFFECT_SELF_ASSIGN suggested fix diagnostic');
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        const action = actions.find(item => /self-assignment/.test(item.title));
+        assert.ok(action, `expected delete self-assignment action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.equal(edit.newText, '');
+        const updated = applySingleEdit(text, edit);
+        assert.equal(updated.includes('x = x;'), false);
+        await assertParses(updated, filePath);
+    });
+
+    it('applies suggested-fix insert actions for deadlock leaves', async () => {
+        const text = [
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-insert-deadlock.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => (
+            item.code === 'W_DEADLOCK_LEAF' &&
+            item.data?.state_path === 'Root.Idle'
+        ));
+        assert.ok(diag, 'expected W_DEADLOCK_LEAF suggested fix diagnostic');
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        const action = actions.find(item => /exit transition/.test(item.title));
+        assert.ok(action, `expected insert deadlock action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.match(edit.newText, /Idle -> \[\*\];\n/);
+        const updated = applySingleEdit(text, edit);
+        await assertParses(updated, filePath);
+        const followup = await inspectDiagnosticsAsEditorDiagnostics(updated, filePath);
+        assert.equal(
+            followup.some(item => item.code === 'W_DEADLOCK_LEAF' && item.data?.state_path === 'Root.Idle'),
+            false,
+        );
+    });
+
+    it('applies suggested-fix insert actions for missing unconditional initial transitions', async () => {
+        const text = [
+            'def int ready = 0;',
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle : if [ready > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-insert-initial.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await inspectDiagnosticsAsEditorDiagnostics(text, filePath);
+        const diag = diagnostics.find(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING');
+        assert.ok(diag, 'expected W_INITIAL_UNCONDITIONAL_MISSING suggested fix diagnostic');
+
+        const actions = await packageModule.collectCodeActions(document, diag.range, [diag]);
+        const action = actions.find(item => /fallback entry transition/.test(item.title));
+        assert.ok(action, `expected insert initial action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.match(edit.newText, /\[\*\] -> Idle;\n/);
+        const updated = applySingleEdit(text, edit);
+        await assertParses(updated, filePath);
+        const followup = await inspectDiagnosticsAsEditorDiagnostics(updated, filePath);
+        assert.equal(
+            followup.some(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING'),
+            false,
+        );
+    });
+
+    it('applies suggested-fix replace actions from span-backed diagnostic payloads', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B : if [true];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-replace-guard.fcstm';
+        const document = createDocument(text, filePath);
+        const guardRange = rangeOf(text, ' : if [true]');
+        const diagnostic = {
+            range: guardRange,
+            message: 'Guard is statically true.',
+            severity: 'warning' as const,
+            source: 'fcstm',
+            code: 'W_GUARD_CONST_TRUE',
+            data: {
+                transition_span: guardRange,
+                folded_value: true,
+                suggested_fix: {
+                    kind: 'replace',
+                    target: 'transition_guard',
+                    anchor: {type: 'ref', ref: 'refs.transition_span'},
+                    text: '',
+                    rationale: 'Remove the redundant constant-true guard.',
+                },
+            },
+        };
+
+        const actions = await packageModule.collectCodeActions(document, guardRange, [diagnostic]);
+        const action = actions.find(item => /constant-true guard/.test(item.title));
+        assert.ok(action, `expected replace guard action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.equal(edit.newText, '');
+        const updated = applySingleEdit(text, edit);
+        assert.equal(updated.includes(': if [true]'), false);
+        assert.ok(updated.includes('A -> B;'));
+        await assertParses(updated, filePath);
+    });
+
+    it('applies nested suggested-fix payloads with one-based span anchors', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-nested-span.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostic = {
+            range: rangeOf(text, 'A -> B'),
+            message: 'Synthetic insertion.',
+            severity: 'warning' as const,
+            source: 'fcstm',
+            code: 'W_SYNTHETIC_INSERT',
+            data: {
+                refs: {
+                    transition_span: {
+                        line: 5,
+                        column: 11,
+                        end_line: 5,
+                        end_column: 11,
+                    },
+                    suggested_fix: {
+                        kind: 'insert',
+                        target: 'transition_suffix',
+                        anchor: {type: 'ref', ref: 'refs.transition_span'},
+                        text: ' : Go',
+                        rationale: 'Add a trigger before the semicolon.',
+                    },
+                },
+            },
+        };
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        assert.ok(semantic);
+
+        const plannedRange = packageModule.suggestedFixDiagnosticRange(document, semantic, diagnostic);
+        assert.deepEqual(plannedRange, packageModule.createRange(4, 10, 4, 10));
+
+        const actions = await packageModule.collectCodeActions(document, diagnostic.range, [diagnostic]);
+        const action = actions.find(item => /trigger before the semicolon/.test(item.title));
+        assert.ok(action, `expected nested insert action, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        const updated = applySingleEdit(text, edit);
+        assert.ok(updated.includes('A -> B : Go;'));
+        await assertParses(updated, filePath);
+    });
+
+    it('ignores malformed or unanchored suggested-fix payloads', async () => {
+        const text = [
+            'def int used = 0;',
+            'state Root {',
+            '    state A;',
+            '    [*] -> A;',
+            '    A -> [*] : if [used > 0];',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-invalid.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = [
+            {
+                range: rangeOf(text, 'def int used'),
+                message: 'Missing variable target.',
+                severity: 'warning' as const,
+                source: 'fcstm',
+                code: 'W_UNREFERENCED_VAR',
+                data: {
+                    var_name: 'missing',
+                    suggested_fix: {
+                        kind: 'delete',
+                        target: 'variable_definition',
+                        anchor: {type: 'ref', ref: 'refs.var_name'},
+                        text: '',
+                        rationale: 'Remove missing variable.',
+                    },
+                },
+            },
+            {
+                range: rangeOf(text, 'A -> [*]'),
+                message: 'Malformed payload.',
+                severity: 'warning' as const,
+                source: 'fcstm',
+                code: 'W_BAD_PAYLOAD',
+                data: {
+                    suggested_fix: {
+                        kind: 'move',
+                        target: 'transition',
+                        anchor: {type: 'ref', ref: 'refs.transition_span'},
+                        text: '',
+                        rationale: 'Invalid kind.',
+                    },
+                },
+            },
+        ];
+
+        assert.equal(packageModule.suggestedFixFromDiagnostic(diagnostics[1]), null);
+        const actions = await packageModule.collectCodeActions(
+            document,
+            packageModule.createRange(0, 0, 5, 1),
+            diagnostics,
+        );
+        assert.equal(
+            actions.some(item => /Remove missing variable|Invalid kind/.test(item.title)),
+            false,
+        );
+        assert.equal(packageModule.renderSuggestedFix(
+            'W_INITIAL_UNCONDITIONAL_MISSING',
+            {composite_path: 'Root', existing_conditional_count: 1},
+        ), null);
     });
 
     it('does not flag undefined variables in transitions that are legitimate state names', async () => {

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -778,7 +778,12 @@ state Root {
                 {
                     code: 'W_EFFECT_SELF_ASSIGN',
                     severity: 'warning',
-                    refs: {state_path: 'Root.Active', transition_span: null, var_name: 'stable'},
+                    refs: {
+                        state_path: 'Root.Active',
+                        transition_span: null,
+                        var_name: 'stable',
+                        effect_self_assign_anchor: 'stable',
+                    },
                 },
                 {
                     code: 'W_FORCED_NEVER_EXPANDS',
@@ -1100,6 +1105,7 @@ state Root {
                     state_path: 'Root.A',
                     transition_span: null,
                     var_name: 'x',
+                    effect_self_assign_anchor: 'x',
                 })],
             );
         });

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -69,6 +69,10 @@ async function buildMachine(src: string) {
     return machine;
 }
 
+function expectedRefsWithSuggestedFix(code: string, refs: Record<string, unknown>): Record<string, unknown> {
+    return packageModule.refsWithSuggestedFix(code, refs);
+}
+
 describe('diagnostics/inspect', () => {
     describe('basic structure', () => {
         it('returns top-level shape', async () => {
@@ -272,7 +276,7 @@ state Root {
                 noAbstract.diagnostics
                     .filter(d => d.code === 'W_UNREFERENCED_VAR')
                     .map(d => d.refs),
-                [{var_name: 'unused', init_value: '0'}],
+                [expectedRefsWithSuggestedFix('W_UNREFERENCED_VAR', {var_name: 'unused', init_value: '0'})],
             );
             assert.equal(
                 noAbstract.diagnostics.filter(d => d.code === 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT').length,
@@ -795,7 +799,7 @@ state Root {
                 {
                     code: 'W_INITIAL_UNCONDITIONAL_MISSING',
                     severity: 'warning',
-                    refs: {composite_path: 'Root', existing_conditional_count: 1},
+                    refs: {composite_path: 'Root', existing_conditional_count: 1, first_child_name: 'Idle'},
                 },
                 {
                     code: 'W_REDUNDANT_TRANSITION',
@@ -855,7 +859,10 @@ state Root {
                     severity: 'warning',
                     refs: {var_name: 'read_only', read_states: ['Root.Idle'], init_value: '0'},
                 },
-            ].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))));
+            ].map(item => ({
+                ...item,
+                refs: expectedRefsWithSuggestedFix(item.code, item.refs),
+            })).sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))));
         });
 
         it('keeps guard and chain path in forced transition origin text', async () => {
@@ -1077,11 +1084,11 @@ state Root {
                 report.diagnostics
                     .filter(d => d.code === 'W_EFFECT_SELF_ASSIGN')
                     .map(d => d.refs),
-                [{
+                [expectedRefsWithSuggestedFix('W_EFFECT_SELF_ASSIGN', {
                     state_path: 'Root.A',
                     transition_span: null,
                     var_name: 'x',
-                }],
+                })],
             );
         });
     });

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -276,7 +276,11 @@ state Root {
                 noAbstract.diagnostics
                     .filter(d => d.code === 'W_UNREFERENCED_VAR')
                     .map(d => d.refs),
-                [expectedRefsWithSuggestedFix('W_UNREFERENCED_VAR', {var_name: 'unused', init_value: '0'})],
+                [expectedRefsWithSuggestedFix('W_UNREFERENCED_VAR', {
+                    var_name: 'unused',
+                    init_value: '0',
+                    definition_delete_anchor: 'unused',
+                })],
             );
             assert.equal(
                 noAbstract.diagnostics.filter(d => d.code === 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT').length,
@@ -751,12 +755,20 @@ state Root {
                 {
                     code: 'W_DEADLOCK_LEAF',
                     severity: 'warning',
-                    refs: {state_path: 'Root.LeafForced', reason: 'no_outgoing_transition'},
+                    refs: {
+                        state_path: 'Root.LeafForced',
+                        parent_path: 'Root',
+                        reason: 'no_outgoing_transition',
+                    },
                 },
                 {
                     code: 'W_DEADLOCK_LEAF',
                     severity: 'warning',
-                    refs: {state_path: 'Root.Orphan', reason: 'no_outgoing_transition'},
+                    refs: {
+                        state_path: 'Root.Orphan',
+                        parent_path: 'Root',
+                        reason: 'no_outgoing_transition',
+                    },
                 },
                 {
                     code: 'W_DEAD_NAMED_ACTION',

--- a/editors/jsfcstm/test/lsp-coverage.test.ts
+++ b/editors/jsfcstm/test/lsp-coverage.test.ts
@@ -1068,7 +1068,11 @@ describe('jsfcstm lsp coverage support', () => {
         assert.ok(selectionRanges[0]?.parent);
         assert.ok(semanticTokens.data.length > 0);
         assert.ok(workspaceSymbols.some(item => item.name === 'Worker'));
-        assert.deepEqual(codeActions, []);
+        assert.ok(codeActions.some(item => (
+            (item as { kind?: string }).kind === CodeActionKind.QuickFix
+            && (item as { diagnostics?: Array<{ code?: string }> }).diagnostics
+                ?.some(diagnostic => diagnostic.code === 'W_UNREFERENCED_VAR')
+        )));
 
         fakeConnection.handlers.initialized?.();
         await fakeConnection.workspaceFolderHandler?.({

--- a/editors/jsfcstm/test/lsp.test.ts
+++ b/editors/jsfcstm/test/lsp.test.ts
@@ -200,33 +200,28 @@ describe('jsfcstm lsp core', () => {
             '    state A;',
             '    state B;',
             '    [*] -> A;',
-            '    A -> B;',
+            '    A -> B : if [missing > 0];',
             '}',
         ].join('\n');
         const core = new packageModule.FcstmLanguageServerCore();
         await core.openTextDocument(makeTextDocumentItem(hostFile, text));
 
-        const diagnosticRange = packageModule.toLspRange(packageModule.createRange(4, 4, 4, 10));
-        const anchorRange = packageModule.toLspRange(packageModule.createRange(4, 10, 4, 10));
+        const missingColumn = text.split('\n')[4].indexOf('missing');
+        const diagnosticRange = packageModule.toLspRange(packageModule.createRange(
+            4,
+            missingColumn,
+            4,
+            missingColumn + 'missing'.length,
+        ));
         const actions = await core.provideCodeActions(
             hostUri,
             diagnosticRange,
             [{
                 range: diagnosticRange,
-                message: 'Synthetic informational suggested fix.',
+                message: 'Variable "missing" is not defined.',
                 severity: DiagnosticSeverity.Information,
                 source: 'fcstm',
-                code: 'W_SYNTHETIC_INFO',
-                data: {
-                    transition_span: anchorRange,
-                    suggested_fix: {
-                        kind: 'insert',
-                        target: 'transition_suffix',
-                        anchor: {type: 'ref', ref: 'refs.transition_span'},
-                        text: ' : Go',
-                        rationale: 'Add informational trigger.',
-                    },
-                },
+                code: packageModule.FCSTM_DIAGNOSTIC_CODES.undefinedVar,
                 relatedInformation: [{
                     location: {
                         uri: hostUri,
@@ -237,8 +232,8 @@ describe('jsfcstm lsp core', () => {
             }]
         );
 
-        const action = actions.find(item => /informational trigger/.test(item.title));
-        assert.ok(action, `expected informational suggested-fix action, got ${JSON.stringify(actions)}`);
+        const action = actions.find(item => /Define "missing"/.test(item.title));
+        assert.ok(action, `expected define-variable action, got ${JSON.stringify(actions)}`);
         const actionDiagnostic = action.diagnostics?.[0];
         assert.equal(actionDiagnostic?.severity, DiagnosticSeverity.Information);
         assert.equal(actionDiagnostic?.relatedInformation?.[0]?.message, 'Related state declaration.');

--- a/editors/jsfcstm/test/lsp.test.ts
+++ b/editors/jsfcstm/test/lsp.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 
-import {CodeActionKind, TextDocumentSyncKind} from 'vscode-languageserver/node';
+import {CodeActionKind, DiagnosticSeverity, TextDocumentSyncKind} from 'vscode-languageserver/node';
 import type {CancellationToken, MarkupContent} from 'vscode-languageserver/node';
 
 import {packageModule, trackTempDir, writeFile} from './support';
@@ -187,6 +187,62 @@ describe('jsfcstm lsp core', () => {
             item.kind === CodeActionKind.QuickFix
             && item.diagnostics?.some(diagnostic => diagnostic.code === 'W_UNREFERENCED_VAR')
         )));
+
+        core.dispose();
+    });
+
+    it('preserves diagnostic severity and related information on code actions', async () => {
+        const dir = trackTempDir('jsfcstm-lsp-codeaction-');
+        const hostFile = path.join(dir, 'host.fcstm');
+        const hostUri = toUri(hostFile);
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const core = new packageModule.FcstmLanguageServerCore();
+        await core.openTextDocument(makeTextDocumentItem(hostFile, text));
+
+        const diagnosticRange = packageModule.toLspRange(packageModule.createRange(4, 4, 4, 10));
+        const anchorRange = packageModule.toLspRange(packageModule.createRange(4, 10, 4, 10));
+        const actions = await core.provideCodeActions(
+            hostUri,
+            diagnosticRange,
+            [{
+                range: diagnosticRange,
+                message: 'Synthetic informational suggested fix.',
+                severity: DiagnosticSeverity.Information,
+                source: 'fcstm',
+                code: 'W_SYNTHETIC_INFO',
+                data: {
+                    transition_span: anchorRange,
+                    suggested_fix: {
+                        kind: 'insert',
+                        target: 'transition_suffix',
+                        anchor: {type: 'ref', ref: 'refs.transition_span'},
+                        text: ' : Go',
+                        rationale: 'Add informational trigger.',
+                    },
+                },
+                relatedInformation: [{
+                    location: {
+                        uri: hostUri,
+                        range: packageModule.toLspRange(packageModule.createRange(1, 4, 1, 12)),
+                    },
+                    message: 'Related state declaration.',
+                }],
+            }]
+        );
+
+        const action = actions.find(item => /informational trigger/.test(item.title));
+        assert.ok(action, `expected informational suggested-fix action, got ${JSON.stringify(actions)}`);
+        const actionDiagnostic = action.diagnostics?.[0];
+        assert.equal(actionDiagnostic?.severity, DiagnosticSeverity.Information);
+        assert.equal(actionDiagnostic?.relatedInformation?.[0]?.message, 'Related state declaration.');
+        assert.equal(actionDiagnostic?.relatedInformation?.[0]?.location.uri, hostUri);
 
         core.dispose();
     });

--- a/editors/jsfcstm/test/lsp.test.ts
+++ b/editors/jsfcstm/test/lsp.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 
-import {TextDocumentSyncKind} from 'vscode-languageserver/node';
+import {CodeActionKind, TextDocumentSyncKind} from 'vscode-languageserver/node';
 import type {CancellationToken, MarkupContent} from 'vscode-languageserver/node';
 
 import {packageModule, trackTempDir, writeFile} from './support';
@@ -183,7 +183,10 @@ describe('jsfcstm lsp core', () => {
             packageModule.toLspRange(packageModule.createRange(0, 0, 3, 1)),
             []
         );
-        assert.deepEqual(codeActions, []);
+        assert.ok(codeActions.some(item => (
+            item.kind === CodeActionKind.QuickFix
+            && item.diagnostics?.some(diagnostic => diagnostic.code === 'W_UNREFERENCED_VAR')
+        )));
 
         core.dispose();
     });

--- a/pyfcstm/diagnostics/__init__.py
+++ b/pyfcstm/diagnostics/__init__.py
@@ -27,6 +27,7 @@ from .codes import (
     CodeSpec,
     CodesSchemaError,
     ForLlmSpec,
+    SuggestedFixSpec,
     load_codes,
 )
 from .inspect import (
@@ -44,6 +45,7 @@ from .inspect import (
     inspect_model,
 )
 from .sink import DiagnosticSink
+from .suggested_fix import refs_with_suggested_fix, render_suggested_fix
 
 __all__ = [
     'CODE_REGISTRY',
@@ -61,8 +63,11 @@ __all__ = [
     'ModelInspect',
     'ModelMetrics',
     'StateInfo',
+    'SuggestedFixSpec',
     'TransitionInfo',
     'VariableInfo',
     'inspect_model',
     'load_codes',
+    'refs_with_suggested_fix',
+    'render_suggested_fix',
 ]

--- a/pyfcstm/diagnostics/analyzers/data_flow.py
+++ b/pyfcstm/diagnostics/analyzers/data_flow.py
@@ -40,6 +40,12 @@ def collect_data_flow_warnings(
                     },
                 ))
             else:
+                refs = {
+                    'var_name': variable.name,
+                    'init_value': variable.init_value,
+                }
+                if not read_states and not write_states:
+                    refs['definition_delete_anchor'] = variable.name
                 diagnostics.append(ModelDiagnostic(
                     code='W_UNREFERENCED_VAR',
                     severity='warning',
@@ -47,10 +53,7 @@ def collect_data_flow_warnings(
                         f'Variable {variable.name!r} does not affect any '
                         'transition guard.'
                     ),
-                    refs={
-                        'var_name': variable.name,
-                        'init_value': variable.init_value,
-                    },
+                    refs=refs,
                 ))
             continue
         if read_states and not write_states:

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -1,8 +1,10 @@
 """Design-health diagnostics derived from inspect-surface data."""
 
 import re
+from dataclasses import replace
 from typing import TYPE_CHECKING, Iterable, List, Optional
 
+from ..suggested_fix import refs_with_suggested_fix
 from ...utils.validate import ModelDiagnostic
 from .const_fold import collect_const_fold_warnings
 from .data_flow import collect_data_flow_warnings
@@ -81,7 +83,14 @@ def collect_design_health_warnings(
     diagnostics.extend(collect_data_flow_warnings(variables, machine))
     diagnostics.extend(collect_redundancy_warnings(transitions, events, states))
     diagnostics.extend(collect_transition_infos(states, transitions))
-    return diagnostics
+    return _with_suggested_fixes(diagnostics)
+
+
+def _with_suggested_fixes(diagnostics: List[ModelDiagnostic]) -> List[ModelDiagnostic]:
+    return [
+        replace(diag, refs=refs_with_suggested_fix(diag.code, diag.refs))
+        for diag in diagnostics
+    ]
 
 
 def _resolve_root_state_path(states, root_state_path):

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -1,5 +1,6 @@
 """Redundancy and overlap design-health diagnostics."""
 
+from collections import Counter
 from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
 
 from ...utils.validate import ModelDiagnostic
@@ -105,18 +106,26 @@ def _is_lifecycle_free_leaf(state_path: str, states_by_path) -> bool:
 
 
 def _effect_self_assign_warnings(transitions) -> List[ModelDiagnostic]:
+    counts = Counter(
+        (t.from_path, var_name)
+        for t in transitions
+        for var_name in getattr(t, 'effect_self_assigns', ())
+    )
     diagnostics: List[ModelDiagnostic] = []
     for t in transitions:
         for var_name in getattr(t, 'effect_self_assigns', ()):
+            refs = {
+                'state_path': t.from_path,
+                'transition_span': None,
+                'var_name': var_name,
+            }
+            if counts[(t.from_path, var_name)] == 1:
+                refs['effect_self_assign_anchor'] = var_name
             diagnostics.append(ModelDiagnostic(
                 code='W_EFFECT_SELF_ASSIGN',
                 severity='warning',
                 message=f'Transition effect assigns {var_name!r} to itself.',
-                refs={
-                    'state_path': t.from_path,
-                    'transition_span': None,
-                    'var_name': var_name,
-                },
+                refs=refs,
             ))
     return diagnostics
 

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -119,7 +119,7 @@ def _effect_self_assign_warnings(transitions) -> List[ModelDiagnostic]:
                 'transition_span': None,
                 'var_name': var_name,
             }
-            if counts[(t.from_path, var_name)] == 1:
+            if t.from_path != '[*]' and counts[(t.from_path, var_name)] == 1:
                 refs['effect_self_assign_anchor'] = var_name
             diagnostics.append(ModelDiagnostic(
                 code='W_EFFECT_SELF_ASSIGN',

--- a/pyfcstm/diagnostics/analyzers/structural.py
+++ b/pyfcstm/diagnostics/analyzers/structural.py
@@ -103,6 +103,7 @@ def _deadlock_leaf_refs(state) -> Dict[str, str]:
 
 def _initial_unconditional_missing_warnings(states) -> List[ModelDiagnostic]:
     diagnostics: List[ModelDiagnostic] = []
+    states_by_path = {state.path: state for state in states}
     for state in states:
         if not state.is_composite:
             continue
@@ -116,7 +117,7 @@ def _initial_unconditional_missing_warnings(states) -> List[ModelDiagnostic]:
             'composite_path': state.path,
             'existing_conditional_count': len(state.initial_targets),
         }
-        first_child_name = _first_child_name(state)
+        first_child_name = _first_child_name(state, states_by_path)
         if first_child_name is not None:
             refs['first_child_name'] = first_child_name
         diagnostics.append(ModelDiagnostic(
@@ -131,11 +132,12 @@ def _initial_unconditional_missing_warnings(states) -> List[ModelDiagnostic]:
     return diagnostics
 
 
-def _first_child_name(state) -> Optional[str]:
-    if not state.substates:
-        return None
-    first_path = state.substates[0]
-    return first_path.rsplit('.', 1)[-1]
+def _first_child_name(state, states_by_path) -> Optional[str]:
+    for child_path in state.substates:
+        child = states_by_path.get(child_path)
+        if child is not None and not child.is_pseudo:
+            return child_path.rsplit('.', 1)[-1]
+    return None
 
 
 def _forced_never_expands_warnings(forced_transitions) -> List[ModelDiagnostic]:

--- a/pyfcstm/diagnostics/analyzers/structural.py
+++ b/pyfcstm/diagnostics/analyzers/structural.py
@@ -86,12 +86,19 @@ def _deadlock_leaf_warnings(states, transitions) -> List[ModelDiagnostic]:
             code='W_DEADLOCK_LEAF',
             severity='warning',
             message=f'Leaf state {state.path!r} has no outgoing transition.',
-            refs={
-                'state_path': state.path,
-                'reason': 'no_outgoing_transition',
-            },
+            refs=_deadlock_leaf_refs(state),
         ))
     return diagnostics
+
+
+def _deadlock_leaf_refs(state) -> Dict[str, str]:
+    refs = {
+        'state_path': state.path,
+        'reason': 'no_outgoing_transition',
+    }
+    if state.parent_path is not None:
+        refs['parent_path'] = state.parent_path
+    return refs
 
 
 def _initial_unconditional_missing_warnings(states) -> List[ModelDiagnostic]:

--- a/pyfcstm/diagnostics/analyzers/structural.py
+++ b/pyfcstm/diagnostics/analyzers/structural.py
@@ -105,6 +105,13 @@ def _initial_unconditional_missing_warnings(states) -> List[ModelDiagnostic]:
         ]
         if unconditional:
             continue
+        refs = {
+            'composite_path': state.path,
+            'existing_conditional_count': len(state.initial_targets),
+        }
+        first_child_name = _first_child_name(state)
+        if first_child_name is not None:
+            refs['first_child_name'] = first_child_name
         diagnostics.append(ModelDiagnostic(
             code='W_INITIAL_UNCONDITIONAL_MISSING',
             severity='warning',
@@ -112,12 +119,16 @@ def _initial_unconditional_missing_warnings(states) -> List[ModelDiagnostic]:
                 f'Composite state {state.path!r} has no unconditional '
                 '[*] entry transition.'
             ),
-            refs={
-                'composite_path': state.path,
-                'existing_conditional_count': len(state.initial_targets),
-            },
+            refs=refs,
         ))
     return diagnostics
+
+
+def _first_child_name(state) -> Optional[str]:
+    if not state.substates:
+        return None
+    first_path = state.substates[0]
+    return first_path.rsplit('.', 1)[-1]
 
 
 def _forced_never_expands_warnings(forced_transitions) -> List[ModelDiagnostic]:

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -101,6 +101,8 @@ _ALLOWED_EMIT_TIERS = (
     'partial_static_pipeline',
 )
 
+_ALLOWED_SUGGESTED_FIX_KINDS = ('insert', 'delete', 'replace')
+
 #: Required keys for the ``for_llm`` payload when present on a code.
 #: ``summary`` is a one-line description aimed at downstream LLM consumers;
 #: ``recommended_actions`` is a list of dicts describing concrete fixes;
@@ -125,6 +127,7 @@ _ALLOWED_REF_TYPES = (
     'float',
     'number',
     'bool',
+    'dict',
     'Span',
     'list[str]',
 )
@@ -199,6 +202,31 @@ class ForLlmSpec:
 
 
 @dataclass(frozen=True)
+class SuggestedFixSpec:
+    """Structured auto-fix metadata declared by ``codes.yaml``.
+
+    :param kind: Edit operation kind: ``insert``, ``delete``, or ``replace``.
+    :type kind: str
+    :param target: Semantic target kind, such as ``variable_definition``.
+    :type target: str
+    :param anchor_ref: Reference to a field in the emitted refs payload,
+        written as ``refs.<field>``.
+    :type anchor_ref: str
+    :param text_template: Optional edit text template. ``insert`` and
+        ``replace`` use it; ``delete`` normally leaves it empty.
+    :type text_template: str
+    :param rationale: Short reason suitable for LLM/UI display.
+    :type rationale: str
+    """
+
+    kind: str
+    target: str
+    anchor_ref: str
+    text_template: str
+    rationale: str
+
+
+@dataclass(frozen=True)
 class CodeSpec:
     """
     Full specification for a single diagnostic code.
@@ -249,6 +277,7 @@ class CodeSpec:
     capability: str = 'pure_static'
     for_llm: Optional[ForLlmSpec] = None
     emit_tier: str = 'static_pipeline'
+    suggested_fix: Optional[SuggestedFixSpec] = None
 
     def required_fields(self) -> List[str]:
         """
@@ -400,6 +429,7 @@ def _validate_code(path: str, code: str, raw: Any) -> CodeSpec:
         ))
 
     for_llm = _validate_for_llm(path, code, raw.get('for_llm'))
+    suggested_fix = _validate_suggested_fix(path, code, raw.get('suggested_fix'))
 
     return CodeSpec(
         code=code,
@@ -410,6 +440,62 @@ def _validate_code(path: str, code: str, raw: Any) -> CodeSpec:
         capability=capability,
         for_llm=for_llm,
         emit_tier=emit_tier,
+        suggested_fix=suggested_fix,
+    )
+
+
+def _validate_suggested_fix(path: str, code: str, raw: Any) -> Optional[SuggestedFixSpec]:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} 'suggested_fix' must be a mapping when present,",
+            f"got {type(raw).__name__}.",
+        ))
+
+    kind = raw.get('kind')
+    if kind not in _ALLOWED_SUGGESTED_FIX_KINDS:
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} 'suggested_fix.kind' must be one of",
+            f"{_ALLOWED_SUGGESTED_FIX_KINDS!r}, got {kind!r}.",
+        ))
+
+    target = raw.get('target')
+    if not isinstance(target, str) or not target.strip():
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} 'suggested_fix.target' must be a non-empty string.",
+        ))
+
+    anchor_ref = raw.get('anchor_ref')
+    if not isinstance(anchor_ref, str) or not anchor_ref.startswith('refs.'):
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} 'suggested_fix.anchor_ref' must be a refs.<field> string.",
+        ))
+
+    text_template = raw.get('text_template', '')
+    if not isinstance(text_template, str):
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} 'suggested_fix.text_template' must be a string.",
+        ))
+
+    rationale = raw.get('rationale')
+    if not isinstance(rationale, str) or not rationale.strip():
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} 'suggested_fix.rationale' must be a non-empty string.",
+        ))
+
+    return SuggestedFixSpec(
+        kind=kind,
+        target=target.strip(),
+        anchor_ref=anchor_ref,
+        text_template=text_template,
+        rationale=rationale.strip(),
     )
 
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -17,7 +17,7 @@
 # Allowed `refs.*.type` tokens (must mirror `_ALLOWED_REF_TYPES` in
 # codes.py — that tuple is the single source of truth, this comment block
 # is documentation; a test asserts the two stay aligned):
-#   str | str_or_null | int | int_or_null | float | number | bool | Span | list[str]
+#   str | str_or_null | int | int_or_null | float | number | bool | dict | Span | list[str]
 #
 # Adding a new code: append a new top-level entry here AND add a fixture
 # test that triggers it from a real DSL snippet. The loader in `codes.py`
@@ -1089,6 +1089,18 @@ W_GUARD_CONST_TRUE:
       type: bool
       required: true
       description: Constant-folded guard value (always ``true``).
+    suggested_fix:
+      type: dict
+      required: false
+      description: >-
+        Optional structured quick-fix payload. Emitted only when the
+        transition guard has a stable source anchor.
+  suggested_fix:
+    kind: replace
+    target: transition_guard
+    anchor_ref: refs.transition_span
+    text_template: ""
+    rationale: Remove the redundant constant-true guard.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``true`` and does
@@ -1210,6 +1222,16 @@ W_DEADLOCK_LEAF:
       required: true
       description: Why the leaf is considered a deadlock.
       enum: ['no_outgoing_transition']
+    suggested_fix:
+      type: dict
+      required: false
+      description: Structured quick-fix payload for adding a parent exit transition.
+  suggested_fix:
+    kind: insert
+    target: deadlock_leaf_exit_transition
+    anchor_ref: refs.state_path
+    text_template: "{state_name} -> [*];\n"
+    rationale: Add an exit transition so the leaf can finish its parent state.
   for_llm:
     summary: >-
       This leaf state has no outgoing transition, so once the machine
@@ -1246,6 +1268,21 @@ W_INITIAL_UNCONDITIONAL_MISSING:
       type: int
       required: true
       description: Number of existing initial transitions that are not unconditional.
+    first_child_name:
+      type: str
+      required: false
+      description: >-
+        First declared child state name used as the fallback insertion target.
+    suggested_fix:
+      type: dict
+      required: false
+      description: Structured quick-fix payload for inserting an unconditional entry transition.
+  suggested_fix:
+    kind: insert
+    target: unconditional_initial_transition
+    anchor_ref: refs.composite_path
+    text_template: "[*] -> {first_child_name};\n"
+    rationale: Add an unconditional fallback entry transition for the composite state.
   for_llm:
     summary: >-
       The composite state can fail to choose an initial child because no
@@ -1356,6 +1393,16 @@ W_UNREFERENCED_VAR:
       type: str
       required: true
       description: Source text of the initial value.
+    suggested_fix:
+      type: dict
+      required: false
+      description: Structured quick-fix payload for removing the variable definition.
+  suggested_fix:
+    kind: delete
+    target: variable_definition
+    anchor_ref: refs.var_name
+    text_template: ""
+    rationale: Remove the variable declaration because it cannot affect transition guards.
   for_llm:
     summary: >-
       This variable does not participate in model decisions. It is dead
@@ -1637,6 +1684,16 @@ W_EFFECT_SELF_ASSIGN:
       type: str
       required: true
       description: Variable assigned to itself.
+    suggested_fix:
+      type: dict
+      required: false
+      description: Structured quick-fix payload for removing the no-op effect statement.
+  suggested_fix:
+    kind: delete
+    target: effect_self_assign_statement
+    anchor_ref: refs.var_name
+    text_template: ""
+    rationale: Remove the no-op self-assignment statement.
   for_llm:
     summary: >-
       The assignment does not change model state and is likely dead code.

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1085,6 +1085,13 @@ W_GUARD_CONST_TRUE:
       type: Span
       required: false
       description: Source span of the transition declaration.
+    guard_span:
+      type: Span
+      required: false
+      description: >-
+        Source span of the removable guard suffix, including the leading
+        trigger separator when needed. Reserved for future emitters that
+        can provide a stable guard-only span.
     folded_value:
       type: bool
       required: true
@@ -1098,7 +1105,7 @@ W_GUARD_CONST_TRUE:
   suggested_fix:
     kind: replace
     target: transition_guard
-    anchor_ref: refs.transition_span
+    anchor_ref: refs.guard_span
     text_template: ""
     rationale: Remove the redundant constant-true guard.
   for_llm:
@@ -1217,6 +1224,12 @@ W_DEADLOCK_LEAF:
       type: str
       required: true
       description: Dotted path of the deadlocking leaf state.
+    parent_path:
+      type: str
+      required: false
+      description: >-
+        Dotted path of the leaf state's parent. Present only when an
+        exit-transition quick-fix can be inserted inside a parent state.
     reason:
       type: str
       required: true
@@ -1229,7 +1242,7 @@ W_DEADLOCK_LEAF:
   suggested_fix:
     kind: insert
     target: deadlock_leaf_exit_transition
-    anchor_ref: refs.state_path
+    anchor_ref: refs.parent_path
     text_template: "{state_name} -> [*];\n"
     rationale: Add an exit transition so the leaf can finish its parent state.
   for_llm:
@@ -1393,6 +1406,12 @@ W_UNREFERENCED_VAR:
       type: str
       required: true
       description: Source text of the initial value.
+    definition_delete_anchor:
+      type: str
+      required: false
+      description: >-
+        Variable name repeated only when the declaration has no DSL reads
+        or writes, so deleting the declaration alone is a safe quick-fix.
     suggested_fix:
       type: dict
       required: false
@@ -1400,9 +1419,9 @@ W_UNREFERENCED_VAR:
   suggested_fix:
     kind: delete
     target: variable_definition
-    anchor_ref: refs.var_name
+    anchor_ref: refs.definition_delete_anchor
     text_template: ""
-    rationale: Remove the variable declaration because it cannot affect transition guards.
+    rationale: Remove the declaration-only variable because it has no DSL reads or writes.
   for_llm:
     summary: >-
       This variable does not participate in model decisions. It is dead

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1703,6 +1703,13 @@ W_EFFECT_SELF_ASSIGN:
       type: str
       required: true
       description: Variable assigned to itself.
+    effect_self_assign_anchor:
+      type: str
+      required: false
+      description: >-
+        Variable name repeated only when the self-assignment occurrence
+        can be uniquely mapped back to an effect statement for the same
+        source state and variable.
     suggested_fix:
       type: dict
       required: false
@@ -1710,7 +1717,7 @@ W_EFFECT_SELF_ASSIGN:
   suggested_fix:
     kind: delete
     target: effect_self_assign_statement
-    anchor_ref: refs.var_name
+    anchor_ref: refs.effect_self_assign_anchor
     text_template: ""
     rationale: Remove the no-op self-assignment statement.
   for_llm:

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1092,24 +1092,11 @@ W_GUARD_CONST_TRUE:
         Source span of the removable guard suffix, including the leading
         trigger separator when needed. This is reserved for future emitters
         that can provide a stable guard-only span; the current inspect
-        emitters intentionally omit it, so this suggested fix is not wired
-        yet.
+        emitters intentionally omit it.
     folded_value:
       type: bool
       required: true
       description: Constant-folded guard value (always ``true``).
-    suggested_fix:
-      type: dict
-      required: false
-      description: >-
-        Optional structured quick-fix payload. Emitted only when the
-        transition guard has a stable source anchor.
-  suggested_fix:
-    kind: replace
-    target: transition_guard
-    anchor_ref: refs.guard_span
-    text_template: ""
-    rationale: Remove the redundant constant-true guard.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``true`` and does
@@ -1287,7 +1274,8 @@ W_INITIAL_UNCONDITIONAL_MISSING:
       type: str
       required: false
       description: >-
-        First declared child state name used as the fallback insertion target.
+        First declared non-pseudo child state name used as the fallback
+        insertion target.
     suggested_fix:
       type: dict
       required: false
@@ -1695,7 +1683,7 @@ W_EFFECT_SELF_ASSIGN:
   refs:
     state_path:
       type: str
-      required: false
+      required: true
       description: Source state path when known.
     transition_span:
       type: Span
@@ -1710,8 +1698,8 @@ W_EFFECT_SELF_ASSIGN:
       required: false
       description: >-
         Variable name repeated only when the self-assignment occurrence
-        can be uniquely mapped back to an effect statement for the same
-        source state and variable.
+        can be uniquely mapped back to a non-initial effect statement for
+        the same source state and variable.
     suggested_fix:
       type: dict
       required: false

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1090,8 +1090,10 @@ W_GUARD_CONST_TRUE:
       required: false
       description: >-
         Source span of the removable guard suffix, including the leading
-        trigger separator when needed. Reserved for future emitters that
-        can provide a stable guard-only span.
+        trigger separator when needed. This is reserved for future emitters
+        that can provide a stable guard-only span; the current inspect
+        emitters intentionally omit it, so this suggested fix is not wired
+        yet.
     folded_value:
       type: bool
       required: true

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -155,7 +155,8 @@ class TransitionInfo:
     :type effect: Optional[str]
     :param effect_self_assigns: Variable names assigned to themselves
         anywhere inside the transition effect block, including nested
-        ``if`` branches.
+        ``if`` branches. Duplicate names are preserved so quick-fix
+        emitters can detect ambiguous occurrences.
     :type effect_self_assigns: Tuple[str, ...]
     :param is_forced: ``True`` when the transition was expanded from a
         ``!``-prefixed forced transition.
@@ -522,13 +523,7 @@ def _effect_self_assigns(effects: List['OperationStatement']) -> Tuple[str, ...]
     out: List[str] = []
     for stmt in effects:
         _walk_stmt_self_assigns(stmt, out)
-    seen = set()
-    deduped: List[str] = []
-    for name in out:
-        if name not in seen:
-            seen.add(name)
-            deduped.append(name)
-    return tuple(deduped)
+    return tuple(out)
 
 
 def _walk_stmt_self_assigns(stmt: 'OperationStatement', out: List[str]) -> None:

--- a/pyfcstm/diagnostics/schema.json
+++ b/pyfcstm/diagnostics/schema.json
@@ -306,6 +306,35 @@
         }
       }
     },
+    "SuggestedFixPayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "target", "anchor", "text", "rationale"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": ["insert", "delete", "replace"]
+        },
+        "target": { "type": "string", "minLength": 1 },
+        "anchor": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "ref"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ref"]
+            },
+            "ref": {
+              "type": "string",
+              "pattern": "^refs\\.[A-Za-z_][A-Za-z0-9_]*$"
+            }
+          }
+        },
+        "text": { "type": "string" },
+        "rationale": { "type": "string", "minLength": 1 }
+      }
+    },
     "ModelDiagnostic": {
       "type": "object",
       "additionalProperties": false,
@@ -333,7 +362,13 @@
             }
           ]
         },
-        "refs": { "type": "object" }
+        "refs": {
+          "type": "object",
+          "properties": {
+            "suggested_fix": { "$ref": "#/$defs/SuggestedFixPayload" }
+          },
+          "additionalProperties": true
+        }
       }
     }
   }

--- a/pyfcstm/diagnostics/schema.json
+++ b/pyfcstm/diagnostics/schema.json
@@ -365,7 +365,7 @@
         "refs": {
           "type": "object",
           "properties": {
-            "suggested_fix": { "$ref": "#/$defs/SuggestedFixPayload" }
+            "suggested_fix": { "$ref": "#/definitions/SuggestedFixPayload" }
           },
           "additionalProperties": true
         }

--- a/pyfcstm/diagnostics/suggested_fix.py
+++ b/pyfcstm/diagnostics/suggested_fix.py
@@ -1,0 +1,75 @@
+"""Helpers for rendering structured diagnostic suggested fixes."""
+
+from string import Formatter
+from typing import Any, Dict, Mapping, Optional, Set
+
+from .codes import CODE_REGISTRY
+
+
+def _template_field_names(template: str) -> Set[str]:
+    out: Set[str] = set()
+    for _, field_name, _, _ in Formatter().parse(template):
+        if field_name:
+            out.add(field_name)
+    return out
+
+
+def render_suggested_fix(
+        code: str,
+        refs: Mapping[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Render the ``codes.yaml`` suggested-fix template for one emit.
+
+    :param code: Diagnostic code.
+    :type code: str
+    :param refs: Already-rendered diagnostic refs payload.
+    :type refs: Mapping[str, Any]
+    :return: JSON-friendly suggested-fix payload, or ``None`` if the code
+        has no suggested-fix metadata.
+    :rtype: Optional[Dict[str, Any]]
+    """
+    spec = CODE_REGISTRY.get(code)
+    if spec is None or spec.suggested_fix is None:
+        return None
+
+    values = dict(refs)
+    state_path = values.get('state_path')
+    if isinstance(state_path, str):
+        values.setdefault('state_name', state_path.rsplit('.', 1)[-1])
+    composite_path = values.get('composite_path')
+    if isinstance(composite_path, str):
+        values.setdefault('composite_name', composite_path.rsplit('.', 1)[-1])
+
+    suggested = spec.suggested_fix
+    if not suggested.anchor_ref.startswith('refs.'):
+        return None
+    anchor_field = suggested.anchor_ref[5:]
+    if values.get(anchor_field) is None:
+        return None
+    for field_name in _template_field_names(suggested.text_template):
+        if values.get(field_name) is None:
+            return None
+
+    text = suggested.text_template.format(**values)
+    return {
+        'kind': suggested.kind,
+        'target': suggested.target,
+        'anchor': {
+            'type': 'ref',
+            'ref': suggested.anchor_ref,
+        },
+        'text': text,
+        'rationale': suggested.rationale,
+    }
+
+
+def refs_with_suggested_fix(
+        code: str,
+        refs: Mapping[str, Any],
+) -> Dict[str, Any]:
+    """Return ``refs`` copied with ``suggested_fix`` attached when declared."""
+    out = dict(refs)
+    fix = render_suggested_fix(code, out)
+    if fix is not None:
+        out['suggested_fix'] = fix
+    return out

--- a/test/diagnostics/_schema_check.py
+++ b/test/diagnostics/_schema_check.py
@@ -27,6 +27,7 @@ _TYPE_PREDICATES = {
         isinstance(v, (int, float)) and not isinstance(v, bool)
     ),
     'bool': lambda v: isinstance(v, bool),
+    'dict': lambda v: isinstance(v, dict),
     'list[str]': lambda v: isinstance(v, list) and all(isinstance(item, str) for item in v),
     'Span': lambda v: v is None or hasattr(v, 'line'),
     'str_or_null': lambda v: v is None or isinstance(v, str),
@@ -101,6 +102,36 @@ def assert_refs_match_schema(diag: ModelDiagnostic, *, context: str = '') -> Non
             f'has runtime type {type(value).__name__}, expected schema '
             f'type {field_spec.type!r}'
         )
+        if field_name == 'suggested_fix' and value is not None:
+            _assert_suggested_fix_payload(value, prefix=prefix, code=diag.code)
+
+
+def _assert_suggested_fix_payload(value, *, prefix: str, code: str) -> None:
+    assert isinstance(value, dict), (
+        f'{prefix}{code} refs[\'suggested_fix\'] must be a dict payload'
+    )
+    assert value.get('kind') in {'insert', 'delete', 'replace'}, (
+        f'{prefix}{code} suggested_fix.kind invalid: {value.get("kind")!r}'
+    )
+    assert isinstance(value.get('target'), str) and value.get('target'), (
+        f'{prefix}{code} suggested_fix.target must be non-empty string'
+    )
+    anchor = value.get('anchor')
+    assert isinstance(anchor, dict), (
+        f'{prefix}{code} suggested_fix.anchor must be a dict'
+    )
+    assert anchor.get('type') == 'ref', (
+        f'{prefix}{code} suggested_fix.anchor.type must be ref'
+    )
+    assert isinstance(anchor.get('ref'), str) and anchor.get('ref', '').startswith('refs.'), (
+        f'{prefix}{code} suggested_fix.anchor.ref must be refs.<field>'
+    )
+    assert isinstance(value.get('text'), str), (
+        f'{prefix}{code} suggested_fix.text must be string'
+    )
+    assert isinstance(value.get('rationale'), str) and value.get('rationale'), (
+        f'{prefix}{code} suggested_fix.rationale must be non-empty string'
+    )
 
 
 def assert_all_diags_match_schema(

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -461,17 +461,18 @@ class TestLoaderValidation:
     def test_refs_with_suggested_fix_renders_declared_payload(self):
         refs = refs_with_suggested_fix(
             'W_UNREFERENCED_VAR',
-            {'var_name': 'unused', 'init_value': '0'},
+            {
+                'var_name': 'unused',
+                'init_value': '0',
+                'definition_delete_anchor': 'unused',
+            },
         )
         assert refs['suggested_fix'] == {
             'kind': 'delete',
             'target': 'variable_definition',
-            'anchor': {'type': 'ref', 'ref': 'refs.var_name'},
+            'anchor': {'type': 'ref', 'ref': 'refs.definition_delete_anchor'},
             'text': '',
-            'rationale': (
-                'Remove the variable declaration because it cannot affect '
-                'transition guards.'
-            ),
+            'rationale': 'Remove the declaration-only variable because it has no DSL reads or writes.',
         }
 
     @pytest.mark.parametrize('type_token', ['float', 'number'])

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -20,6 +20,8 @@ from pyfcstm.diagnostics import (
     CodeSpec,
     CodesSchemaError,
     load_codes,
+    refs_with_suggested_fix,
+    render_suggested_fix,
 )
 from pyfcstm.diagnostics.codes import _ALLOWED_REF_TYPES, _ALLOWED_SEVERITIES
 
@@ -368,6 +370,109 @@ class TestLoaderValidation:
         reg = load_codes(path)
         spec = reg['E_FOO'].refs_schema['bar']
         assert spec.enum == ('a', 'b', 'c')
+
+    def test_loads_suggested_fix_metadata(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            W_FOO:
+              severity: warning
+              capability: pure_static
+              description: With suggested fix.
+              refs:
+                name:
+                  type: str
+                  required: true
+                  description: Name payload.
+              suggested_fix:
+                kind: delete
+                target: variable_definition
+                anchor_ref: refs.name
+                text_template: ""
+                rationale: Remove the unused declaration.
+        """)
+        reg = load_codes(path)
+        fix = reg['W_FOO'].suggested_fix
+        assert fix is not None
+        assert fix.kind == 'delete'
+        assert fix.anchor_ref == 'refs.name'
+
+    def test_rejects_bad_suggested_fix_kind(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            W_FOO:
+              severity: warning
+              capability: pure_static
+              description: Bad suggested fix.
+              refs:
+                name:
+                  type: str
+                  required: true
+                  description: Name payload.
+              suggested_fix:
+                kind: move
+                target: variable_definition
+                anchor_ref: refs.name
+                rationale: Invalid kind.
+        """)
+        with pytest.raises(CodesSchemaError, match='suggested_fix.kind'):
+            load_codes(path)
+
+    def test_rejects_bad_suggested_fix_anchor_ref(self, tmp_path):
+        path = self._write_yaml(tmp_path, """
+            W_FOO:
+              severity: warning
+              capability: pure_static
+              description: Bad suggested fix anchor.
+              refs:
+                name:
+                  type: str
+                  required: true
+                  description: Name payload.
+              suggested_fix:
+                kind: delete
+                target: variable_definition
+                anchor_ref: name
+                rationale: Invalid anchor.
+        """)
+        with pytest.raises(CodesSchemaError, match='suggested_fix.anchor_ref'):
+            load_codes(path)
+
+    def test_catalog_suggested_fix_refs_are_declared(self):
+        for code, spec in CODE_REGISTRY.items():
+            if spec.suggested_fix is None:
+                continue
+            anchor_field = spec.suggested_fix.anchor_ref.split('.', 1)[1]
+            assert anchor_field in spec.refs_schema, (
+                f"{code} suggested_fix anchor {spec.suggested_fix.anchor_ref!r} "
+                f"must point to a declared refs field"
+            )
+            assert 'suggested_fix' in spec.refs_schema, (
+                f"{code} emits refs.suggested_fix and must declare it in refs"
+            )
+
+    def test_render_suggested_fix_skips_missing_anchors_or_template_values(self):
+        assert render_suggested_fix(
+            'W_GUARD_CONST_TRUE',
+            {'transition_span': None, 'folded_value': True},
+        ) is None
+        assert render_suggested_fix(
+            'W_INITIAL_UNCONDITIONAL_MISSING',
+            {'composite_path': 'Root', 'existing_conditional_count': 1},
+        ) is None
+
+    def test_refs_with_suggested_fix_renders_declared_payload(self):
+        refs = refs_with_suggested_fix(
+            'W_UNREFERENCED_VAR',
+            {'var_name': 'unused', 'init_value': '0'},
+        )
+        assert refs['suggested_fix'] == {
+            'kind': 'delete',
+            'target': 'variable_definition',
+            'anchor': {'type': 'ref', 'ref': 'refs.var_name'},
+            'text': '',
+            'rationale': (
+                'Remove the variable declaration because it cannot affect '
+                'transition guards.'
+            ),
+        }
 
     @pytest.mark.parametrize('type_token', ['float', 'number'])
     def test_loads_numeric_ref_type_tokens(self, tmp_path, type_token):

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -66,7 +66,14 @@ def _expected_with_suggested_fixes(expected):
     out = []
     for item in expected:
         enriched = dict(item)
-        enriched['refs'] = refs_with_suggested_fix(item['code'], item['refs'])
+        refs = dict(item['refs'])
+        if (
+                item['code'] == 'W_DEADLOCK_LEAF'
+                and 'parent_path' not in refs
+                and '.' in refs.get('state_path', '')
+        ):
+            refs['parent_path'] = refs['state_path'].rsplit('.', 1)[0]
+        enriched['refs'] = refs_with_suggested_fix(item['code'], refs)
         out.append(enriched)
     return out
 
@@ -994,6 +1001,7 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'var_name': 'extra',
                     'init_value': '0',
+                    'definition_delete_anchor': 'extra',
                 },
             },
             {
@@ -1002,6 +1010,7 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'var_name': 'truncated',
                     'init_value': '3.5',
+                    'definition_delete_anchor': 'truncated',
                 },
             },
         ],

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -845,6 +845,7 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                     'state_path': 'Root.Active',
                     'transition_span': None,
                     'var_name': 'stable',
+                    'effect_self_assign_anchor': 'stable',
                 },
             },
             {

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -11,7 +11,7 @@ import json
 import pytest
 
 from pyfcstm.dsl import parse_with_grammar_entry
-from pyfcstm.diagnostics import inspect_model
+from pyfcstm.diagnostics import inspect_model, refs_with_suggested_fix
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.utils.validate import ModelDiagnostic
 
@@ -60,6 +60,15 @@ def _normalize_inspect_diagnostics(diags):
             json.dumps(item['refs'], sort_keys=True),
         ),
     )
+
+
+def _expected_with_suggested_fixes(expected):
+    out = []
+    for item in expected:
+        enriched = dict(item)
+        enriched['refs'] = refs_with_suggested_fix(item['code'], item['refs'])
+        out.append(enriched)
+    return out
 
 
 def _py_inspect_normalized_diagnostics(dsl: str):
@@ -737,6 +746,7 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'composite_path': 'Root',
                     'existing_conditional_count': 1,
+                    'first_child_name': 'Idle',
                 },
             },
             {
@@ -1144,7 +1154,9 @@ def test_multi_file_fixture_emits_expected_codes(name, files, entry, must_fire, 
     item[0] for item in DESIGN_HEALTH_INSPECT_FIXTURES
 ])
 def test_design_health_inspect_diagnostics_match_inlined_expected(name, dsl, expected):
-    normalized_expected = _normalize_inspect_diagnostics(expected)
+    normalized_expected = _normalize_inspect_diagnostics(
+        _expected_with_suggested_fixes(expected),
+    )
     py_diags = _py_inspect_normalized_diagnostics(dsl)
     assert py_diags == normalized_expected, (
         f'{name}: pyfcstm inspect diagnostics mismatch: {py_diags}'

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -821,18 +821,41 @@ class TestInspectModelGuardAffectDiagnostics:
         unused_refs = by_code['W_UNREFERENCED_VAR'][0].refs
         assert unused_refs['var_name'] == 'unused'
         assert unused_refs['init_value'] == '0'
+        assert unused_refs['definition_delete_anchor'] == 'unused'
         assert unused_refs['suggested_fix'] == {
             'kind': 'delete',
             'target': 'variable_definition',
-            'anchor': {'type': 'ref', 'ref': 'refs.var_name'},
+            'anchor': {'type': 'ref', 'ref': 'refs.definition_delete_anchor'},
             'text': '',
-            'rationale': (
-                'Remove the variable declaration because it cannot affect '
-                'transition guards.'
-            ),
+            'rationale': 'Remove the declaration-only variable because it has no DSL reads or writes.',
         }
-        assert set(unused_refs) == {'var_name', 'init_value', 'suggested_fix'}
+        assert set(unused_refs) == {
+            'var_name',
+            'init_value',
+            'definition_delete_anchor',
+            'suggested_fix',
+        }
         assert 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT' not in by_code
+
+    def test_unreferenced_variable_fix_is_omitted_when_variable_is_read(self):
+        by_code = self._diagnostics_by_code("""
+        def int unused = 0;
+        def int driver = 0;
+        state Root {
+            state Idle {
+                enter { temp = unused + 1; }
+            }
+            state Done;
+            [*] -> Idle;
+            Idle -> Done : if [driver > 0];
+        }
+        """)
+
+        unused_refs = by_code['W_UNREFERENCED_VAR'][0].refs
+        assert unused_refs == {
+            'var_name': 'unused',
+            'init_value': '0',
+        }
 
     def test_structural_suggested_fixes_are_attached_to_safe_insertions(self):
         by_code = self._diagnostics_by_code("""
@@ -843,10 +866,11 @@ class TestInspectModelGuardAffectDiagnostics:
         """)
 
         deadlock_fix = by_code['W_DEADLOCK_LEAF'][0].refs['suggested_fix']
+        assert by_code['W_DEADLOCK_LEAF'][0].refs['parent_path'] == 'Root'
         assert deadlock_fix == {
             'kind': 'insert',
             'target': 'deadlock_leaf_exit_transition',
-            'anchor': {'type': 'ref', 'ref': 'refs.state_path'},
+            'anchor': {'type': 'ref', 'ref': 'refs.parent_path'},
             'text': 'Idle -> [*];\n',
             'rationale': (
                 'Add an exit transition so the leaf can finish its parent state.'
@@ -864,6 +888,17 @@ class TestInspectModelGuardAffectDiagnostics:
                 'Add an unconditional fallback entry transition for the '
                 'composite state.'
             ),
+        }
+
+    def test_root_deadlock_leaf_fix_is_omitted(self):
+        by_code = self._diagnostics_by_code("""
+        state Root;
+        """)
+
+        deadlock_refs = by_code['W_DEADLOCK_LEAF'][0].refs
+        assert deadlock_refs == {
+            'state_path': 'Root',
+            'reason': 'no_outgoing_transition',
         }
 
     def test_const_true_fix_is_omitted_when_transition_span_is_unavailable(self):

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -914,6 +914,35 @@ class TestInspectModelGuardAffectDiagnostics:
             ),
         }
 
+    def test_initial_fallback_suggested_fix_skips_pseudo_first_child(self):
+        by_code = self._diagnostics_by_code("""
+        def int ready = 1;
+        state Root {
+            pseudo state Choice;
+            state A;
+            [*] -> A : if [ready > 0];
+        }
+        """)
+
+        initial_refs = by_code['W_INITIAL_UNCONDITIONAL_MISSING'][0].refs
+        assert initial_refs['first_child_name'] == 'A'
+        assert initial_refs['suggested_fix']['text'] == '[*] -> A;\n'
+
+    def test_initial_fallback_suggested_fix_is_omitted_for_only_pseudo_children(self):
+        by_code = self._diagnostics_by_code("""
+        def int ready = 1;
+        state Root {
+            pseudo state Choice;
+            [*] -> Choice : if [ready > 0];
+        }
+        """)
+
+        initial_refs = by_code['W_INITIAL_UNCONDITIONAL_MISSING'][0].refs
+        assert initial_refs == {
+            'composite_path': 'Root',
+            'existing_conditional_count': 1,
+        }
+
     def test_root_deadlock_leaf_fix_is_omitted(self):
         by_code = self._diagnostics_by_code("""
         state Root;
@@ -1510,6 +1539,28 @@ class TestInspectModelRedundancySemantics:
         assert len(refs) == 2
         assert all('effect_self_assign_anchor' not in ref for ref in refs)
         assert all('suggested_fix' not in ref for ref in refs)
+
+    def test_initial_transition_self_assignment_does_not_get_fix(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            [*] -> A effect {
+                x = x;
+            };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        refs = [
+            d.refs for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(refs) == 1
+        assert refs[0] == {
+            'state_path': '[*]',
+            'transition_span': None,
+            'var_name': 'x',
+        }
 
 
 @pytest.mark.unittest

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -295,32 +295,56 @@ class TestInspectModelToJson:
 class TestSchemaJsonValidates:
     """Verify the schema.json contract validates a real inspection."""
 
-    def test_schema_exists(self):
-        path = os.path.join(
+    @staticmethod
+    def _schema_path():
+        return os.path.join(
             os.path.dirname(__file__), '..', '..',
             'pyfcstm', 'diagnostics', 'schema.json',
         )
-        assert os.path.exists(path)
+
+    @staticmethod
+    def _load_schema():
+        with open(TestSchemaJsonValidates._schema_path(), 'r', encoding='utf-8') as f:
+            return json.load(f)
+
+    def test_schema_exists(self):
+        assert os.path.exists(self._schema_path())
 
     def test_schema_is_valid_json(self):
-        path = os.path.join(
-            os.path.dirname(__file__), '..', '..',
-            'pyfcstm', 'diagnostics', 'schema.json',
-        )
-        with open(path, 'r', encoding='utf-8') as f:
-            data = json.load(f)
+        data = self._load_schema()
         assert data['title'] == 'ModelInspect'
+
+    def test_schema_local_refs_resolve(self):
+        schema = self._load_schema()
+        refs = []
+
+        def walk(node):
+            if isinstance(node, dict):
+                ref = node.get('$ref')
+                if isinstance(ref, str):
+                    refs.append(ref)
+                for value in node.values():
+                    walk(value)
+            elif isinstance(node, list):
+                for value in node:
+                    walk(value)
+
+        walk(schema)
+        assert refs
+        for ref in refs:
+            assert ref.startswith('#/'), f'non-local schema ref is unsupported: {ref!r}'
+            target = schema
+            for raw_part in ref[2:].split('/'):
+                part = raw_part.replace('~1', '/').replace('~0', '~')
+                assert isinstance(target, dict), f'{ref!r} resolves through non-object'
+                assert part in target, f'{ref!r} cannot resolve missing part {part!r}'
+                target = target[part]
 
     def test_schema_validates_simple_inspect(self):
         # Light-weight structural validation rather than pulling in
         # jsonschema as a hard test dep — verify each required top-level
         # key from the schema is present in the inspect output.
-        path = os.path.join(
-            os.path.dirname(__file__), '..', '..',
-            'pyfcstm', 'diagnostics', 'schema.json',
-        )
-        with open(path, 'r', encoding='utf-8') as f:
-            schema = json.load(f)
+        schema = self._load_schema()
         required = set(schema['required'])
         payload = inspect_model(_parse(SIMPLE_DSL)).to_json()
         assert required.issubset(set(payload.keys())), (

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -1433,13 +1433,59 @@ class TestInspectModelRedundancySemantics:
         assert refs[0]['state_path'] == 'Root.A'
         assert refs[0]['transition_span'] is None
         assert refs[0]['var_name'] == 'x'
+        assert refs[0]['effect_self_assign_anchor'] == 'x'
         assert refs[0]['suggested_fix'] == {
             'kind': 'delete',
             'target': 'effect_self_assign_statement',
-            'anchor': {'type': 'ref', 'ref': 'refs.var_name'},
+            'anchor': {'type': 'ref', 'ref': 'refs.effect_self_assign_anchor'},
             'text': '',
             'rationale': 'Remove the no-op self-assignment statement.',
         }
+
+    def test_effect_self_assignment_fix_is_omitted_when_occurrence_is_ambiguous(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B effect { x = x; };
+            A -> C effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        refs = [
+            d.refs for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(refs) == 2
+        assert all(ref['state_path'] == 'Root.A' for ref in refs)
+        assert all(ref['var_name'] == 'x' for ref in refs)
+        assert all('effect_self_assign_anchor' not in ref for ref in refs)
+        assert all('suggested_fix' not in ref for ref in refs)
+
+    def test_duplicate_self_assignments_in_one_effect_do_not_get_fix(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect {
+                x = x;
+                x = x;
+            };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        refs = [
+            d.refs for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(refs) == 2
+        assert all('effect_self_assign_anchor' not in ref for ref in refs)
+        assert all('suggested_fix' not in ref for ref in refs)
 
 
 @pytest.mark.unittest

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -818,11 +818,69 @@ class TestInspectModelGuardAffectDiagnostics:
         }
         """)
 
-        assert by_code['W_UNREFERENCED_VAR'][0].refs == {
-            'var_name': 'unused',
-            'init_value': '0',
+        unused_refs = by_code['W_UNREFERENCED_VAR'][0].refs
+        assert unused_refs['var_name'] == 'unused'
+        assert unused_refs['init_value'] == '0'
+        assert unused_refs['suggested_fix'] == {
+            'kind': 'delete',
+            'target': 'variable_definition',
+            'anchor': {'type': 'ref', 'ref': 'refs.var_name'},
+            'text': '',
+            'rationale': (
+                'Remove the variable declaration because it cannot affect '
+                'transition guards.'
+            ),
         }
+        assert set(unused_refs) == {'var_name', 'init_value', 'suggested_fix'}
         assert 'I_UNREFERENCED_VAR_MAYBE_ABSTRACT' not in by_code
+
+    def test_structural_suggested_fixes_are_attached_to_safe_insertions(self):
+        by_code = self._diagnostics_by_code("""
+        state Root {
+            state Idle;
+            [*] -> Idle : if [true];
+        }
+        """)
+
+        deadlock_fix = by_code['W_DEADLOCK_LEAF'][0].refs['suggested_fix']
+        assert deadlock_fix == {
+            'kind': 'insert',
+            'target': 'deadlock_leaf_exit_transition',
+            'anchor': {'type': 'ref', 'ref': 'refs.state_path'},
+            'text': 'Idle -> [*];\n',
+            'rationale': (
+                'Add an exit transition so the leaf can finish its parent state.'
+            ),
+        }
+
+        initial_refs = by_code['W_INITIAL_UNCONDITIONAL_MISSING'][0].refs
+        assert initial_refs['first_child_name'] == 'Idle'
+        assert initial_refs['suggested_fix'] == {
+            'kind': 'insert',
+            'target': 'unconditional_initial_transition',
+            'anchor': {'type': 'ref', 'ref': 'refs.composite_path'},
+            'text': '[*] -> Idle;\n',
+            'rationale': (
+                'Add an unconditional fallback entry transition for the '
+                'composite state.'
+            ),
+        }
+
+    def test_const_true_fix_is_omitted_when_transition_span_is_unavailable(self):
+        by_code = self._diagnostics_by_code("""
+        state Root {
+            state Idle;
+            state Done;
+            [*] -> Idle;
+            Idle -> Done : if [(1 + 2) == 3];
+        }
+        """)
+
+        const_true_refs = by_code['W_GUARD_CONST_TRUE'][0].refs
+        assert const_true_refs == {
+            'transition_span': None,
+            'folded_value': True,
+        }
 
     def test_unreferenced_variable_with_abstract_action_is_info(self):
         by_code = self._diagnostics_by_code("""
@@ -1332,14 +1390,21 @@ class TestInspectModelRedundancySemantics:
         }
         """
         report = inspect_model(_parse(dsl))
-        assert [
+        refs = [
             d.refs for d in report.diagnostics
             if d.code == 'W_EFFECT_SELF_ASSIGN'
-        ] == [{
-            'state_path': 'Root.A',
-            'transition_span': None,
-            'var_name': 'x',
-        }]
+        ]
+        assert len(refs) == 1
+        assert refs[0]['state_path'] == 'Root.A'
+        assert refs[0]['transition_span'] is None
+        assert refs[0]['var_name'] == 'x'
+        assert refs[0]['suggested_fix'] == {
+            'kind': 'delete',
+            'target': 'effect_self_assign_statement',
+            'anchor': {'type': 'ref', 'ref': 'refs.var_name'},
+            'text': '',
+            'rationale': 'Remove the no-op self-assignment statement.',
+        }
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
> 上游伞 PR：#122
> 跟踪 issue：#104
> Base：`dev/issue104-pr-c`
> Head：`dev/issue104-pr-c3-suggested-fix`
> 当前 head commit：`0473ec674f566218576bf4925b0d9ff2fa8496d8`
> 状态：最新 review（#issuecomment-4586525427）中的 C/I/M 已修复并 push；GitHub Actions 已在最新 head 全绿；claude / codex / deepseek 三路中文 C/I/M review 均无 C/I 且明确 Ready to merge。当前 PR-C3 ready，等待 owner 下一步指示，不擅自 merge。

## 背景

PR-C1 #123 已合并，交付 const folder 与 3 个 const-fold 诊断。PR-C2 #125 已合并，交付 Layer 0 use-def 数据流闭包与 3 个变量诊断。

本 PR-C3 是 PR-C 收尾：把部分高置信度 warning 的修复建议从纯文本引导升级为结构化 `suggested_fix` payload，并让 jsfcstm / VSCode editor code-action 能把这些 payload 转成可自动应用的 quick-fix。

## 本 PR 已实现内容

1. `codes.yaml` / Python loader 支持 code 级可选 `suggested_fix` 元信息。
2. `schema.json` / Python `_schema_check` 支持 `refs.suggested_fix` structured payload。
3. Python 新增 `pyfcstm.diagnostics.suggested_fix`：
   - `render_suggested_fix(code, refs)`
   - `refs_with_suggested_fix(code, refs)`
4. JS 新增 `editors/jsfcstm/src/diagnostics/suggested-fix.ts`，与 Python helper 对齐。
5. Python / JS design-health diagnostics emit 时统一把安全可渲染的 `suggested_fix` 附到 `refs`。
6. VSCode/editor code-action 读取 diagnostic data 中的 `suggested_fix`，生成 quick-fix edit。
7. 支持三类 edit kind：`insert` / `delete` / `replace`。
8. 所有 quick-fix 测试 apply 后都 parse-back，避免生成不可解析 DSL。
9. `info` severity 转 LSP `Information`，避免 info 诊断在 LSP 里继续显示成 warning。
10. `make rst_auto` 已同步 diagnostics API docs。

## 首轮 review 后已修复

1. `W_UNREFERENCED_VAR` 删除变量定义的 quick-fix 只在变量没有任何 DSL read/write 时输出；如果变量仍被 action/effect 读取，只保留诊断，不提供删除声明的 auto-fix。
2. `W_DEADLOCK_LEAF` 对 root leaf 不再输出 exit-transition quick-fix；非 root leaf 通过 `parent_path` 作为稳定 anchor。
3. jsfcstm quick-fix 插入逻辑支持单行 composite，在 closing `}` 前插入，apply 后 parse-back 通过。
4. `W_GUARD_CONST_TRUE` 的 auto-fix anchor 改为 `guard_span`，避免未来误用整条 `transition_span` 做 replace。
5. VSCode/editor code-action 在请求时按需 inspect design-health suggested-fix，不扩大实时 diagnostics 发布面。
6. LSP severity mapping 补齐 `info -> Information`。
7. `W_EFFECT_SELF_ASSIGN` 只有同一 source state + variable 能唯一定位到一个 effect statement 时才输出 delete quick-fix；如果同一状态多条 transition 或同一 effect 内重复出现自赋值，仍保留诊断但不提供危险 auto-fix。
8. `W_INITIAL_UNCONDITIONAL_MISSING` 的 fallback quick-fix 改为插在最后一个已有 initial transition 后面，避免抢占 guarded initial transition 的声明顺序语义。
9. 清理 `docs/source/api_doc/diagnostics/suggested_fix.rst` 末尾空白行，`git diff --check base...HEAD` 已干净。

## 二轮 review 后已修复

1. 修复 `pyfcstm/diagnostics/schema.json` 中 `refs.suggested_fix` 的 JSON Schema `$ref` 死链，从 `#/$defs/SuggestedFixPayload` 改为 `#/definitions/SuggestedFixPayload`。
2. 新增 schema 本地 `$ref` 解析测试，避免未来再次出现公开 schema 契约引用不可解析的问题。
3. 明确 `W_GUARD_CONST_TRUE.guard_span` 是未来 emitter 预留字段；当前 inspect emitter 未提供稳定 guard-only span，因此该 suggested-fix metadata 暂不实际渲染。

## 最新 review 后已修复

1. LSP/editor code-action 不再信任 client-supplied `suggested_fix` payload；请求 quick-fix 时改由当前 server `inspectModel` 重新生成 suggested-fix diagnostics，避免 stale/forged payload 删除有效代码。
2. `W_UNREFERENCED_VAR` 删除声明 quick-fix 在 JS 侧要求同名变量定义唯一；重复变量声明时只保留诊断，不提供危险删除。
3. On-demand design suggested-fix 改用问题本身的可发现 range：变量声明、self-assignment statement、deadlock state declaration、composite state declaration / guarded initial 附近都能触发对应 action。
4. Initial transition effect 的 `W_EFFECT_SELF_ASSIGN` 不再输出 delete quick-fix；JS 侧也拒绝 `state_path` 缺失或 `[*]` 的 self-assignment edit。
5. 移除 `W_GUARD_CONST_TRUE` 的 future-only `suggested_fix` metadata，等后续有稳定 guard-only span 后再启用。
6. `W_INITIAL_UNCONDITIONAL_MISSING` fallback 只选择第一个非 pseudo child；如果 composite 只有 pseudo children，就不给 fallback auto-fix。

## 覆盖率补测

1. 新增 jsfcstm code-action 测试，覆盖 effect 内嵌套 `if` 分支中的 self-assignment delete quick-fix。
2. 扩展 malformed / unanchored suggested-fix payload 测试，覆盖缺失 anchor 与非法 span anchor 时不输出危险 action。
3. 新增 LSP core 测试，确认 `provideCodeActions` 保留 `Information` severity 与 `relatedInformation`。
4. 新增 stale/forged client payload、重复变量声明、initial effect self-assignment、pseudo child fallback、on-demand issue range 的 JS 测试。
5. 新增 Python inspect 测试，覆盖 pseudo-first-child、only-pseudo children、initial transition self-assignment 不出 fix。
6. 新增用例全部使用各自测试树内 inline DSL，不调用对侧运行时，不读取对侧 fixture。

## suggested_fix payload 契约

`refs.suggested_fix` 只接受结构化对象，不接受裸字符串：

```json
{
  "kind": "insert | delete | replace",
  "target": "semantic_target_name",
  "anchor": {"type": "ref", "ref": "refs.<field_name>"},
  "text": "...",
  "rationale": "..."
}
```

安全原则：如果当前 refs 没有稳定 anchor 或模板字段不完整，就不输出 `suggested_fix`。例如 `W_GUARD_CONST_TRUE` 当前 inspect surface 尚未提供稳定 `guard_span`，因此暂不输出 auto-fix；VSCode 侧仍覆盖 span-backed replace planner，供后续 guard-only span 可用时直接消费。

## 已覆盖 code

| code | fix kind | 当前行为 |
|---|---|---|
| `W_UNREFERENCED_VAR` | delete | 删除对应变量定义行；同名变量定义不唯一时不给 auto-fix |
| `W_EFFECT_SELF_ASSIGN` | delete | 只在非 initial effect 的 self-assignment occurrence 能唯一定位时删除自赋值 statement；歧义或 `[*]` initial transition 时不给 auto-fix |
| `W_DEADLOCK_LEAF` | insert | 在 dead leaf 后插入 `StateName -> [*];` |
| `W_INITIAL_UNCONDITIONAL_MISSING` | insert | 在 composite 内插入 fallback `[*] -> FirstNonPseudoChild;`，并保持在已有 guarded initial transitions 之后；只有 pseudo children 时不给 auto-fix |
| `W_GUARD_CONST_TRUE` | replace | 当前只保留诊断，不输出 auto-fix；等待稳定 guard-only span 后再启用 |

明确不给 fix：所有 `E_*`、所有 `I_*`、`W_UNWRITTEN_READ_VAR` / `W_WRITE_ONLY_VAR`、阈值类重构建议、rename 类 brittle 诊断。

## 测试与覆盖

已在本地通过：

```bash
git diff --check
pytest test/diagnostics/test_inspect_model.py test/diagnostics/test_cross_end_parity.py test/diagnostics/test_codes_yaml.py -q
cd editors/jsfcstm && npm run build
cd editors/jsfcstm && npx mocha --require ts-node/register/transpile-only --extension ts test/analyzers-code-actions.test.ts test/lsp.test.ts --reporter dot
cd editors/jsfcstm && npm run test:coverage
SKIP_SLOW_TESTS=1 make unittest COV_TYPES="term-missing"
```

结果摘要：

- diagnostics pytest：`370 passed`
- jsfcstm build：通过
- jsfcstm code-action / LSP 定向：`40 passing`
- jsfcstm coverage：`546 passing`，总体 `96.04%` lines；`src/editor/code-actions.ts` 100% lines/statements，`src/diagnostics/analyzers/structural.ts` 98.89% lines，`src/editor/suggested-fixes.ts` 91.87% lines
- Python fast-path unittest：`8964 passed, 164 skipped, 63 deselected`
- commit message skip-token 检查：只匹配 `[skip-slow]`

## 测试隔离约束

- Python 测试不调用 Node/JS，不读取 JS 测试资源。
- jsfcstm 测试不调用 Python，不读取 repo-level `test/` 作为新增 fixture。
- 新增 DSL fixture 以 inline 字面量形式维护在各自测试文件内。
- 任一侧测试树或另一端实现被删除时，本侧测试仍应稳定运行。

## CI 与 review 门禁

- push 后先等 GitHub Actions 全绿。
- CI 不全绿时只修 CI，不启动 review。
- CI 全绿后启动三路 review：
  - `claude -p --permission-mode bypassPermissions --output-format text`
  - `codex exec --dangerously-bypass-approvals-and-sandbox -C /home/hansbug/oo-projects/pyfcstm -`
  - `codex-deepseek exec --dangerously-bypass-approvals-and-sandbox -C /home/hansbug/oo-projects/pyfcstm -`
- 三路 reviewer 都必须拿到：本 PR URL、issue #104、上游伞 PR #122、PR-C1/#123 与 PR-C2/#125 已合并背景、当前 head commit、本地验证与 CI 状态、测试隔离约束、no broad catch、no new deps、suggested_fix payload 契约。
- 本次 review 的重中之重：**fix 意见质量**。reviewer 必须亲自尝试 quick-fix 行为；如果认为 fix 有问题，C/I 意见必须带：最小 DSL 例子、应用前文本、应用后文本、为什么这个 fix 对解决问题无帮助或有害。
- 三路 review 都直接在本 PR 下用中文按 C/I/M 三级评论。
- reviewer 的 PR comment 首行必须亮明身份，且三路身份必须分别是“我是 claude reviewer”、“我是 codex reviewer”、“我是 deepseek reviewer”；`codex-deepseek` 只是执行命令名，不能在评论身份里写成 codex，否则该路 review 不算完成。
- C/I 自动修复，重新测试、push、等 CI、再三路 review。
- 循环到 claude / codex / deepseek 都无 C/I 且明确 `Ready to merge`。
- 本 PR ready 后等待 owner 指示，不擅自 merge。

## 三路 review 结论

- claude reviewer：Ready to merge，无 C/I；仅 M 级观察 3 项（UX/格式/默认 fallback 选择），不阻塞。https://github.com/HansBug/pyfcstm/pull/126#issuecomment-4586614965
- codex reviewer：Ready to merge，无 C/I/M；实际跑了 focused Python/JS 回归和 8 个 JS `collectCodeActions` 最小场景。https://github.com/HansBug/pyfcstm/pull/126#issuecomment-4586612270
- deepseek reviewer：Ready to merge，无 C/I；仅 M 级观察 3 项，已核实 Python duplicate var 场景会在模型加载阶段失败，不进入 Python `inspect_model`。https://github.com/HansBug/pyfcstm/pull/126#issuecomment-4586609016

Codecov 最新 comment 显示 patch coverage `87.81457%`、project coverage `94.11%`。三路 reviewer 均检查覆盖率并认为核心新增路径没有必须补的阻塞缺口；本地 JS coverage 中 `code-actions.ts` 100% lines/statements，`suggested-fixes.ts` 91.87% lines，diagnostics suggested-fix helper 100% lines。

## 验收标准

- [x] 空 PR 已创建，body 写明完整执行计划和验收标准。
- [x] `codes.yaml` 支持可选 suggested_fix metadata。
- [x] `schema.json` 与 Python / JS schema 校验支持 structured `refs.suggested_fix`。
- [x] Python / JS 两端 analyzer 能输出等价 suggested_fix payload。
- [x] 覆盖 `insert` / `delete` / `replace` 三种 edit kind。
- [x] 强制优先的 4 个 code 完成安全 fix。
- [x] 不适合 auto-fix 的 code 不输出 suggested_fix。
- [x] cross-end parity 对 `code + severity + refs` 含 suggested_fix 后仍无 diff。
- [x] VSCode/editor quick-fix 能读取 diagnostic data 并 apply 三类 edit。
- [x] quick-fix apply 后 parse-back 通过。
- [x] 最新 review（#issuecomment-4586525427）中的 C/I/M 已修复。
- [x] 本地 Python / JS / fast-path full unittest 验证通过。
- [x] GitHub Actions 在最新 head 上全绿。
- [x] Codecov patch coverage 对核心新增路径无必须补的缺口。
- [x] Claude / Codex / deepseek 三路中文 C/I/M review 均无 C/I，并明确 `Ready to merge`。
- [x] 不 merge，等待 owner 下一步指示。
