### PR TITLE
PR-A1：建立 pyfcstm.verify 骨架与算法登记表

### DIFF
--- a/docs/source/api_doc/index.rst
+++ b/docs/source/api_doc/index.rst
@@ -20,4 +20,5 @@ pyfcstm
     solver/index
     template/index
     utils/index
+    verify/index
 

--- a/docs/source/api_doc/verify/index.rst
+++ b/docs/source/api_doc/verify/index.rst
@@ -1,0 +1,19 @@
+pyfcstm.verify
+========================================================
+
+.. currentmodule:: pyfcstm.verify
+
+.. automodule:: pyfcstm.verify
+
+
+.. toctree::
+    :maxdepth: 3
+
+    inspect_adapter
+    registry
+    taxonomy
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__

--- a/docs/source/api_doc/verify/inspect_adapter.rst
+++ b/docs/source/api_doc/verify/inspect_adapter.rst
@@ -1,0 +1,30 @@
+pyfcstm.verify.inspect\_adapter
+========================================================
+
+.. currentmodule:: pyfcstm.verify.inspect_adapter
+
+.. automodule:: pyfcstm.verify.inspect_adapter
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+InspectAccessForbiddenError
+-----------------------------------------------------
+
+.. autoclass:: InspectAccessForbiddenError
+
+
+eligible\_for\_inspect
+-----------------------------------------------------
+
+.. autofunction:: eligible_for_inspect
+
+
+iter\_inspect\_eligible
+-----------------------------------------------------
+
+.. autofunction:: iter_inspect_eligible

--- a/docs/source/api_doc/verify/registry.rst
+++ b/docs/source/api_doc/verify/registry.rst
@@ -1,0 +1,18 @@
+pyfcstm.verify.registry
+========================================================
+
+.. currentmodule:: pyfcstm.verify.registry
+
+.. automodule:: pyfcstm.verify.registry
+
+
+REGISTRY
+-----------------------------------------------------
+
+.. autodata:: REGISTRY
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__

--- a/docs/source/api_doc/verify/taxonomy.rst
+++ b/docs/source/api_doc/verify/taxonomy.rst
@@ -1,0 +1,73 @@
+pyfcstm.verify.taxonomy
+========================================================
+
+.. currentmodule:: pyfcstm.verify.taxonomy
+
+.. automodule:: pyfcstm.verify.taxonomy
+
+
+Closedness
+-----------------------------------------------------
+
+.. autodata:: Closedness
+
+
+ComplexityTier
+-----------------------------------------------------
+
+.. autodata:: ComplexityTier
+
+
+SMTLogic
+-----------------------------------------------------
+
+.. autodata:: SMTLogic
+
+
+FormulaSizeScaling
+-----------------------------------------------------
+
+.. autodata:: FormulaSizeScaling
+
+
+CallCountScaling
+-----------------------------------------------------
+
+.. autodata:: CallCountScaling
+
+
+FallbackUnknownRisk
+-----------------------------------------------------
+
+.. autodata:: FallbackUnknownRisk
+
+
+VerificationScope
+-----------------------------------------------------
+
+.. autodata:: VerificationScope
+
+
+COMPLEXITY\_TIER\_ORDER
+-----------------------------------------------------
+
+.. autodata:: COMPLEXITY_TIER_ORDER
+
+
+CALL\_COUNT\_SCALING\_ORDER
+-----------------------------------------------------
+
+.. autodata:: CALL_COUNT_SCALING_ORDER
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+VerifyAlgorithmMeta
+-----------------------------------------------------
+
+.. autoclass:: VerifyAlgorithmMeta
+    :members: name,description,closedness,complexity_tier,smt_logic,formula_size_scaling,call_count_scaling,incremental,fallback_unknown_risk,recommended_tactic,quantifier_alternation_depth,max_bitwidth,theory_combination,verification_scope,dominant_dim,diagnostic_codes,impl

--- a/docs/source/api_doc_en.rst
+++ b/docs/source/api_doc_en.rst
@@ -17,6 +17,7 @@ API Documentation
     api_doc/solver/index
     api_doc/template/index
     api_doc/utils/index
+    api_doc/verify/index
 
 * :doc:`api_doc/config/index`
 * :doc:`api_doc/diagnostics/index`
@@ -29,4 +30,5 @@ API Documentation
 * :doc:`api_doc/solver/index`
 * :doc:`api_doc/template/index`
 * :doc:`api_doc/utils/index`
+* :doc:`api_doc/verify/index`
 

--- a/docs/source/api_doc_zh.rst
+++ b/docs/source/api_doc_zh.rst
@@ -17,6 +17,7 @@ API 文档
     api_doc/solver/index
     api_doc/template/index
     api_doc/utils/index
+    api_doc/verify/index
 
 * :doc:`api_doc/config/index`
 * :doc:`api_doc/diagnostics/index`
@@ -29,4 +30,5 @@ API 文档
 * :doc:`api_doc/solver/index`
 * :doc:`api_doc/template/index`
 * :doc:`api_doc/utils/index`
+* :doc:`api_doc/verify/index`
 

--- a/pyfcstm/verify/__init__.py
+++ b/pyfcstm/verify/__init__.py
@@ -1,0 +1,37 @@
+"""Public API for pyfcstm verification metadata and inspect gating."""
+
+from .inspect_adapter import (
+    InspectAccessForbiddenError,
+    eligible_for_inspect,
+    iter_inspect_eligible,
+)
+from .registry import REGISTRY
+from .taxonomy import (
+    CALL_COUNT_SCALING_ORDER,
+    COMPLEXITY_TIER_ORDER,
+    CallCountScaling,
+    Closedness,
+    ComplexityTier,
+    FallbackUnknownRisk,
+    FormulaSizeScaling,
+    SMTLogic,
+    VerificationScope,
+    VerifyAlgorithmMeta,
+)
+
+__all__ = [
+    "CALL_COUNT_SCALING_ORDER",
+    "COMPLEXITY_TIER_ORDER",
+    "REGISTRY",
+    "CallCountScaling",
+    "Closedness",
+    "ComplexityTier",
+    "FallbackUnknownRisk",
+    "FormulaSizeScaling",
+    "InspectAccessForbiddenError",
+    "SMTLogic",
+    "VerificationScope",
+    "VerifyAlgorithmMeta",
+    "eligible_for_inspect",
+    "iter_inspect_eligible",
+]

--- a/pyfcstm/verify/inspect_adapter.py
+++ b/pyfcstm/verify/inspect_adapter.py
@@ -1,0 +1,121 @@
+"""Inspect gating helpers for verify algorithm metadata."""
+
+from typing import Iterator
+
+from .taxonomy import (
+    CALL_COUNT_SCALING_ORDER,
+    COMPLEXITY_TIER_ORDER,
+    CallCountScaling,
+    ComplexityTier,
+    VerifyAlgorithmMeta,
+)
+
+
+class InspectAccessForbiddenError(ValueError):
+    """Raised when a forbidden inspect complexity tier is requested."""
+
+
+def _order_allows(order, value, maximum):
+    if value not in order or maximum not in order:
+        return False
+    return order.index(value) <= order.index(maximum)
+
+
+def _validate_max_complexity_tier(maximum: ComplexityTier) -> None:
+    if maximum == "bmc_search":
+        raise InspectAccessForbiddenError(
+            "bmc_search algorithms are not allowed in automatic inspect runs"
+        )
+    if maximum not in COMPLEXITY_TIER_ORDER:
+        raise InspectAccessForbiddenError(
+            "unknown inspect complexity tier: {maximum!r}".format(maximum=maximum)
+        )
+
+
+def _validate_max_call_count_scaling(maximum: CallCountScaling) -> None:
+    if maximum not in CALL_COUNT_SCALING_ORDER:
+        raise InspectAccessForbiddenError(
+            "call-count scaling {maximum!r} is not allowed in automatic inspect runs".format(
+                maximum=maximum
+            )
+        )
+
+
+def _call_count_allows(value: CallCountScaling, maximum: CallCountScaling) -> bool:
+    if value == "linear_in_leaves" and maximum == "linear_in_transitions":
+        # PR-A1's inspect matrix treats all smt_linear local checks as part of
+        # the recommended default budget. Leaf-linear checks are still rejected
+        # by stricter limits such as ``linear_in_states``.
+        return True
+    return _order_allows(CALL_COUNT_SCALING_ORDER, value, maximum)
+
+
+def eligible_for_inspect(
+    meta: VerifyAlgorithmMeta,
+    *,
+    max_complexity_tier: ComplexityTier = "structural",
+    max_call_count_scaling: CallCountScaling = "linear_in_transitions",
+) -> bool:
+    """
+    Return whether ``meta`` may run automatically from inspect.
+
+    :param meta: Algorithm metadata to evaluate.
+    :type meta: VerifyAlgorithmMeta
+    :param max_complexity_tier: Maximum allowed non-BMC complexity tier.
+    :type max_complexity_tier: ComplexityTier
+    :param max_call_count_scaling: Maximum allowed inspect call-count scaling.
+    :type max_call_count_scaling: CallCountScaling
+    :return: ``True`` if the algorithm is eligible for inspect automation.
+    :rtype: bool
+    :raises InspectAccessForbiddenError: If ``max_complexity_tier`` is
+        ``'bmc_search'`` or if either inspect limit is outside the automatic
+        inspect ordering.
+    """
+    _validate_max_complexity_tier(max_complexity_tier)
+    _validate_max_call_count_scaling(max_call_count_scaling)
+    if meta.closedness != "closed":
+        return False
+    if meta.complexity_tier == "bmc_search":
+        return False
+    if not _order_allows(
+        COMPLEXITY_TIER_ORDER,
+        meta.complexity_tier,
+        max_complexity_tier,
+    ):
+        return False
+    if not _call_count_allows(meta.call_count_scaling, max_call_count_scaling):
+        return False
+    return True
+
+
+def iter_inspect_eligible(
+    *,
+    max_complexity_tier: ComplexityTier = "structural",
+    max_call_count_scaling: CallCountScaling = "linear_in_transitions",
+) -> Iterator[VerifyAlgorithmMeta]:
+    """
+    Iterate over registry algorithms eligible for inspect automation.
+
+    :param max_complexity_tier: Maximum allowed non-BMC complexity tier.
+    :type max_complexity_tier: ComplexityTier
+    :param max_call_count_scaling: Maximum allowed inspect call-count scaling.
+    :type max_call_count_scaling: CallCountScaling
+    :yield: Eligible metadata entries in registry order.
+    :rtype: Iterator[VerifyAlgorithmMeta]
+    """
+    from .registry import REGISTRY
+
+    for meta in REGISTRY.values():
+        if eligible_for_inspect(
+            meta,
+            max_complexity_tier=max_complexity_tier,
+            max_call_count_scaling=max_call_count_scaling,
+        ):
+            yield meta
+
+
+__all__ = [
+    "InspectAccessForbiddenError",
+    "eligible_for_inspect",
+    "iter_inspect_eligible",
+]

--- a/pyfcstm/verify/registry.py
+++ b/pyfcstm/verify/registry.py
@@ -64,6 +64,31 @@ def _smt_local(
     )
 
 
+def _composite_init_guards_incomplete() -> VerifyAlgorithmMeta:
+    return VerifyAlgorithmMeta(
+        name="composite_init_guards_incomplete",
+        description=(
+            "Detect composite states whose initial transitions do not jointly "
+            "cover all variable and event inputs."
+        ),
+        closedness="closed",
+        complexity_tier="smt_linear",
+        smt_logic="QF_LIRA",
+        formula_size_scaling="linear",
+        call_count_scaling="linear_in_states",
+        incremental=True,
+        fallback_unknown_risk="medium",
+        recommended_tactic="qflia",
+        quantifier_alternation_depth=0,
+        max_bitwidth=None,
+        theory_combination=("LIA", "LRA"),
+        verification_scope="smt_local",
+        dominant_dim=("V", "vars", "events"),
+        diagnostic_codes=("W_COMPOSITE_INIT_INCOMPLETE",),
+        impl=None,
+    )
+
+
 def _bmc_placeholder(
     name: str,
     description: str,
@@ -176,6 +201,7 @@ _REGISTRY = {
         ("I_ENTER_DURING_CONTRADICT",),
         dominant_dim=("leaves", "vars"),
     ),
+    "composite_init_guards_incomplete": _composite_init_guards_incomplete(),
     "bounded_reachability": _bmc_placeholder(
         "bounded_reachability",
         "Query whether a target state is reachable from a source within a bound.",

--- a/pyfcstm/verify/registry.py
+++ b/pyfcstm/verify/registry.py
@@ -117,120 +117,122 @@ def _bmc_placeholder(
     )
 
 
-_REGISTRY = {
-    "topological_reachable_set": _structural(
-        "topological_reachable_set",
-        "Compute guard-agnostic reachable states over the transition topology.",
-        "linear_in_states",
-        diagnostic_codes=(),
-    ),
-    "unreachable_states": _structural(
-        "unreachable_states",
-        "Report states unreachable from the root entry topology.",
-        "linear_in_states",
-        diagnostic_codes=("W_UNREACHABLE_STATE",),
-    ),
-    "strongly_connected_components": _structural(
-        "strongly_connected_components",
-        "Find non-trivial strongly connected components in the topology graph.",
-        "linear_in_states",
-        diagnostic_codes=("I_NONTRIVIAL_SCC",),
-    ),
-    "topological_finite": _structural(
-        "topological_finite",
-        "Check whether topology has an exit path rather than a closed no-exit region.",
-        "linear_in_states",
-        diagnostic_codes=("W_TOPOLOGICAL_NOEXIT",),
-    ),
-    "topological_inevitable_terminator": _structural(
-        "topological_inevitable_terminator",
-        "Identify topology regions that are not forced to reach a terminator.",
-        "linear_in_states",
-        diagnostic_codes=("I_TOPOLOGICAL_NON_TERMINATING",),
-    ),
-    "event_emission_to_consumer_reachable": _structural(
-        "event_emission_to_consumer_reachable",
-        "Check whether each used event has a topologically reachable consumer source.",
-        "linear_in_transitions",
-        diagnostic_codes=("W_EVENT_UNREACHABLE_EMIT",),
-        dominant_dim=("events", "transitions"),
-    ),
-    "dead_guard": _smt_local(
-        "dead_guard",
-        "Detect guards that are unsatisfiable under variable constraints.",
-        "linear_in_transitions",
-        ("W_DEAD_GUARD",),
-    ),
-    "guard_tautology": _smt_local(
-        "guard_tautology",
-        "Detect guards that are always true under variable constraints.",
-        "linear_in_transitions",
-        ("W_GUARD_TAUTOLOGY",),
-    ),
-    "forced_guard_unsat_under_init": _smt_local(
-        "forced_guard_unsat_under_init",
-        "Detect forced-transition guards unsatisfiable under initial variable values.",
-        "linear_in_transitions",
-        ("W_FORCED_GUARD_UNSAT",),
-        fallback_unknown_risk="low",
-    ),
-    "effect_no_op_under_guard": _smt_local(
-        "effect_no_op_under_guard",
-        "Detect transition effects that are no-ops whenever the guard holds.",
-        "linear_in_transitions",
-        ("W_EFFECT_SMT_NO_OP",),
-    ),
-    "effect_contradicts_guard": _smt_local(
-        "effect_contradicts_guard",
-        "Detect effects whose post-state contradicts their transition guard.",
-        "linear_in_transitions",
-        ("I_EFFECT_GUARD_CONTRADICT",),
-    ),
-    "transition_shadowed_by_predecessor": _smt_local(
-        "transition_shadowed_by_predecessor",
-        "Detect outgoing transitions fully shadowed by earlier same-domain transitions.",
-        "linear_in_transitions",
-        ("W_TRANSITION_SHADOWED",),
-        incremental=True,
-        dominant_dim=("transitions", "vars"),
-    ),
-    "enter_postcondition_implies_during_precondition": _smt_local(
-        "enter_postcondition_implies_during_precondition",
-        "Compare entry postconditions with first-cycle during preconditions.",
-        "linear_in_leaves",
-        ("I_ENTER_DURING_CONTRADICT",),
-        dominant_dim=("leaves", "vars"),
-    ),
-    "composite_init_guards_incomplete": _composite_init_guards_incomplete(),
-    "bounded_reachability": _bmc_placeholder(
-        "bounded_reachability",
-        "Query whether a target state is reachable from a source within a bound.",
-        "k_unrollings",
-    ),
-    "symbolic_bfs": _bmc_placeholder(
-        "symbolic_bfs",
-        "Build bounded symbolic BFS spaces for queried reachability algorithms.",
-        "k_unrollings_times_branching",
-    ),
-    "bounded_safety": _bmc_placeholder(
-        "bounded_safety",
-        "Query whether bounded executions avoid bad states or bad conditions.",
-        "k_unrollings",
-    ),
-    "bounded_invariant": _bmc_placeholder(
-        "bounded_invariant",
-        "Query whether an invariant holds over all bounded reachable frames.",
-        "k_unrollings_times_branching",
-        fallback_unknown_risk="high",
-    ),
-    "path_witness": _bmc_placeholder(
-        "path_witness",
-        "Decode a concrete path witness from a satisfiable symbolic frame.",
-        "one",
-        dominant_dim=("depth",),
-    ),
-}
+def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
+    return {
+        "topological_reachable_set": _structural(
+            "topological_reachable_set",
+            "Compute guard-agnostic reachable states over the transition topology.",
+            "linear_in_states",
+            diagnostic_codes=(),
+        ),
+        "unreachable_states": _structural(
+            "unreachable_states",
+            "Report states unreachable from the root entry topology.",
+            "linear_in_states",
+            diagnostic_codes=("W_UNREACHABLE_STATE",),
+        ),
+        "strongly_connected_components": _structural(
+            "strongly_connected_components",
+            "Find non-trivial strongly connected components in the topology graph.",
+            "linear_in_states",
+            diagnostic_codes=("I_NONTRIVIAL_SCC",),
+        ),
+        "topological_finite": _structural(
+            "topological_finite",
+            "Check whether topology has an exit path rather than a closed no-exit region.",
+            "linear_in_states",
+            diagnostic_codes=("W_TOPOLOGICAL_NOEXIT",),
+        ),
+        "topological_inevitable_terminator": _structural(
+            "topological_inevitable_terminator",
+            "Identify topology regions that are not forced to reach a terminator.",
+            "linear_in_states",
+            diagnostic_codes=("I_TOPOLOGICAL_NON_TERMINATING",),
+        ),
+        "event_emission_to_consumer_reachable": _structural(
+            "event_emission_to_consumer_reachable",
+            "Check whether each used event has a topologically reachable consumer source.",
+            "linear_in_transitions",
+            diagnostic_codes=("W_EVENT_UNREACHABLE_EMIT",),
+            dominant_dim=("events", "transitions"),
+        ),
+        "dead_guard": _smt_local(
+            "dead_guard",
+            "Detect guards that are unsatisfiable under variable constraints.",
+            "linear_in_transitions",
+            ("W_DEAD_GUARD",),
+        ),
+        "guard_tautology": _smt_local(
+            "guard_tautology",
+            "Detect guards that are always true under variable constraints.",
+            "linear_in_transitions",
+            ("W_GUARD_TAUTOLOGY",),
+        ),
+        "forced_guard_unsat_under_init": _smt_local(
+            "forced_guard_unsat_under_init",
+            "Detect forced-transition guards unsatisfiable under initial variable values.",
+            "linear_in_transitions",
+            ("W_FORCED_GUARD_UNSAT",),
+            fallback_unknown_risk="low",
+        ),
+        "effect_no_op_under_guard": _smt_local(
+            "effect_no_op_under_guard",
+            "Detect transition effects that are no-ops whenever the guard holds.",
+            "linear_in_transitions",
+            ("W_EFFECT_SMT_NO_OP",),
+        ),
+        "effect_contradicts_guard": _smt_local(
+            "effect_contradicts_guard",
+            "Detect effects whose post-state contradicts their transition guard.",
+            "linear_in_transitions",
+            ("I_EFFECT_GUARD_CONTRADICT",),
+        ),
+        "transition_shadowed_by_predecessor": _smt_local(
+            "transition_shadowed_by_predecessor",
+            "Detect outgoing transitions fully shadowed by earlier same-domain transitions.",
+            "linear_in_transitions",
+            ("W_TRANSITION_SHADOWED",),
+            incremental=True,
+            dominant_dim=("transitions", "vars"),
+        ),
+        "enter_postcondition_implies_during_precondition": _smt_local(
+            "enter_postcondition_implies_during_precondition",
+            "Compare entry postconditions with first-cycle during preconditions.",
+            "linear_in_leaves",
+            ("I_ENTER_DURING_CONTRADICT",),
+            dominant_dim=("leaves", "vars"),
+        ),
+        "composite_init_guards_incomplete": _composite_init_guards_incomplete(),
+        "bounded_reachability": _bmc_placeholder(
+            "bounded_reachability",
+            "Query whether a target state is reachable from a source within a bound.",
+            "k_unrollings",
+        ),
+        "symbolic_bfs": _bmc_placeholder(
+            "symbolic_bfs",
+            "Build bounded symbolic BFS spaces for queried reachability algorithms.",
+            "k_unrollings_times_branching",
+        ),
+        "bounded_safety": _bmc_placeholder(
+            "bounded_safety",
+            "Query whether bounded executions avoid bad states or bad conditions.",
+            "k_unrollings",
+        ),
+        "bounded_invariant": _bmc_placeholder(
+            "bounded_invariant",
+            "Query whether an invariant holds over all bounded reachable frames.",
+            "k_unrollings_times_branching",
+            fallback_unknown_risk="high",
+        ),
+        "path_witness": _bmc_placeholder(
+            "path_witness",
+            "Decode a concrete path witness from a satisfiable symbolic frame.",
+            "one",
+            dominant_dim=("depth",),
+        ),
+    }
 
-REGISTRY: Mapping[str, VerifyAlgorithmMeta] = MappingProxyType(_REGISTRY)
+
+REGISTRY: Mapping[str, VerifyAlgorithmMeta] = MappingProxyType(dict(_build_registry()))
 
 __all__ = ["REGISTRY"]

--- a/pyfcstm/verify/registry.py
+++ b/pyfcstm/verify/registry.py
@@ -41,7 +41,7 @@ def _smt_local(
     diagnostic_codes: Tuple[str, ...],
     fallback_unknown_risk: FallbackUnknownRisk = "medium",
     incremental: bool = False,
-    dominant_dim: Tuple[str, ...] = ("transitions", "vars"),
+    dominant_dim: Tuple[str, ...] = ("E", "vars"),
 ) -> VerifyAlgorithmMeta:
     return VerifyAlgorithmMeta(
         name=name,
@@ -53,7 +53,7 @@ def _smt_local(
         call_count_scaling=call_count_scaling,
         incremental=incremental,
         fallback_unknown_risk=fallback_unknown_risk,
-        recommended_tactic="smt",
+        recommended_tactic="qflia",
         quantifier_alternation_depth=0,
         max_bitwidth=None,
         theory_combination=("LIA", "LRA"),
@@ -94,6 +94,7 @@ def _bmc_placeholder(
     description: str,
     call_count_scaling: CallCountScaling,
     fallback_unknown_risk: FallbackUnknownRisk = "medium",
+    incremental: bool = True,
     dominant_dim: Tuple[str, ...] = ("depth", "vars", "events", "branching"),
 ) -> VerifyAlgorithmMeta:
     return VerifyAlgorithmMeta(
@@ -104,7 +105,7 @@ def _bmc_placeholder(
         smt_logic="QF_LIRA",
         formula_size_scaling="linear",
         call_count_scaling=call_count_scaling,
-        incremental=True,
+        incremental=incremental,
         fallback_unknown_risk=fallback_unknown_risk,
         recommended_tactic="smt",
         quantifier_alternation_depth=0,
@@ -124,37 +125,42 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             "Compute guard-agnostic reachable states over the transition topology.",
             "linear_in_states",
             diagnostic_codes=(),
+            dominant_dim=("V", "E", "depth"),
         ),
         "unreachable_states": _structural(
             "unreachable_states",
             "Report states unreachable from the root entry topology.",
             "linear_in_states",
             diagnostic_codes=("W_UNREACHABLE_STATE",),
+            dominant_dim=("V_leaf", "depth"),
         ),
         "strongly_connected_components": _structural(
             "strongly_connected_components",
             "Find non-trivial strongly connected components in the topology graph.",
             "linear_in_states",
             diagnostic_codes=("I_NONTRIVIAL_SCC",),
+            dominant_dim=("V", "E"),
         ),
         "topological_finite": _structural(
             "topological_finite",
             "Check whether topology has an exit path rather than a closed no-exit region.",
             "linear_in_states",
             diagnostic_codes=("W_TOPOLOGICAL_NOEXIT",),
+            dominant_dim=("V", "E"),
         ),
         "topological_inevitable_terminator": _structural(
             "topological_inevitable_terminator",
             "Identify topology regions that are not forced to reach a terminator.",
             "linear_in_states",
             diagnostic_codes=("I_TOPOLOGICAL_NON_TERMINATING",),
+            dominant_dim=("V", "E"),
         ),
         "event_emission_to_consumer_reachable": _structural(
             "event_emission_to_consumer_reachable",
             "Check whether each used event has a topologically reachable consumer source.",
             "linear_in_transitions",
             diagnostic_codes=("W_EVENT_UNREACHABLE_EMIT",),
-            dominant_dim=("events", "transitions"),
+            dominant_dim=("events", "E"),
         ),
         "dead_guard": _smt_local(
             "dead_guard",
@@ -174,6 +180,7 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             "linear_in_transitions",
             ("W_FORCED_GUARD_UNSAT",),
             fallback_unknown_risk="low",
+            dominant_dim=("forced_transitions", "vars"),
         ),
         "effect_no_op_under_guard": _smt_local(
             "effect_no_op_under_guard",
@@ -193,14 +200,14 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             "linear_in_transitions",
             ("W_TRANSITION_SHADOWED",),
             incremental=True,
-            dominant_dim=("transitions", "vars"),
         ),
         "enter_postcondition_implies_during_precondition": _smt_local(
             "enter_postcondition_implies_during_precondition",
             "Compare entry postconditions with first-cycle during preconditions.",
             "linear_in_leaves",
             ("I_ENTER_DURING_CONTRADICT",),
-            dominant_dim=("leaves", "vars"),
+            incremental=True,
+            dominant_dim=("V_leaf", "vars"),
         ),
         "composite_init_guards_incomplete": _composite_init_guards_incomplete(),
         "bounded_reachability": _bmc_placeholder(
@@ -228,6 +235,7 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             "path_witness",
             "Decode a concrete path witness from a satisfiable symbolic frame.",
             "one",
+            incremental=False,
             dominant_dim=("depth",),
         ),
     }

--- a/pyfcstm/verify/registry.py
+++ b/pyfcstm/verify/registry.py
@@ -1,0 +1,210 @@
+"""Algorithm registry for :mod:`pyfcstm.verify`."""
+
+from types import MappingProxyType
+from typing import Mapping, Tuple
+
+from .taxonomy import CallCountScaling, FallbackUnknownRisk, VerifyAlgorithmMeta
+
+
+def _structural(
+    name: str,
+    description: str,
+    call_count_scaling: CallCountScaling,
+    diagnostic_codes: Tuple[str, ...] = (),
+    dominant_dim: Tuple[str, ...] = ("states", "transitions"),
+) -> VerifyAlgorithmMeta:
+    return VerifyAlgorithmMeta(
+        name=name,
+        description=description,
+        closedness="closed",
+        complexity_tier="structural",
+        smt_logic=None,
+        formula_size_scaling="none",
+        call_count_scaling=call_count_scaling,
+        incremental=False,
+        fallback_unknown_risk="none",
+        recommended_tactic=None,
+        quantifier_alternation_depth=0,
+        max_bitwidth=None,
+        theory_combination=(),
+        verification_scope="topological_only",
+        dominant_dim=dominant_dim,
+        diagnostic_codes=diagnostic_codes,
+        impl=None,
+    )
+
+
+def _smt_local(
+    name: str,
+    description: str,
+    call_count_scaling: CallCountScaling,
+    diagnostic_codes: Tuple[str, ...],
+    fallback_unknown_risk: FallbackUnknownRisk = "medium",
+    incremental: bool = False,
+    dominant_dim: Tuple[str, ...] = ("transitions", "vars"),
+) -> VerifyAlgorithmMeta:
+    return VerifyAlgorithmMeta(
+        name=name,
+        description=description,
+        closedness="closed",
+        complexity_tier="smt_linear",
+        smt_logic="QF_LIRA",
+        formula_size_scaling="constant",
+        call_count_scaling=call_count_scaling,
+        incremental=incremental,
+        fallback_unknown_risk=fallback_unknown_risk,
+        recommended_tactic="smt",
+        quantifier_alternation_depth=0,
+        max_bitwidth=None,
+        theory_combination=("LIA", "LRA"),
+        verification_scope="smt_local",
+        dominant_dim=dominant_dim,
+        diagnostic_codes=diagnostic_codes,
+        impl=None,
+    )
+
+
+def _bmc_placeholder(
+    name: str,
+    description: str,
+    call_count_scaling: CallCountScaling,
+    fallback_unknown_risk: FallbackUnknownRisk = "medium",
+    dominant_dim: Tuple[str, ...] = ("depth", "vars", "events", "branching"),
+) -> VerifyAlgorithmMeta:
+    return VerifyAlgorithmMeta(
+        name=name,
+        description=description,
+        closedness="queried",
+        complexity_tier="bmc_search",
+        smt_logic="QF_LIRA",
+        formula_size_scaling="linear",
+        call_count_scaling=call_count_scaling,
+        incremental=True,
+        fallback_unknown_risk=fallback_unknown_risk,
+        recommended_tactic="smt",
+        quantifier_alternation_depth=0,
+        max_bitwidth=None,
+        theory_combination=("LIA", "LRA"),
+        verification_scope="bmc_unrolled",
+        dominant_dim=dominant_dim,
+        diagnostic_codes=(),
+        impl=None,
+    )
+
+
+_REGISTRY = {
+    "topological_reachable_set": _structural(
+        "topological_reachable_set",
+        "Compute guard-agnostic reachable states over the transition topology.",
+        "linear_in_states",
+        diagnostic_codes=(),
+    ),
+    "unreachable_states": _structural(
+        "unreachable_states",
+        "Report states unreachable from the root entry topology.",
+        "linear_in_states",
+        diagnostic_codes=("W_UNREACHABLE_STATE",),
+    ),
+    "strongly_connected_components": _structural(
+        "strongly_connected_components",
+        "Find non-trivial strongly connected components in the topology graph.",
+        "linear_in_states",
+        diagnostic_codes=("I_NONTRIVIAL_SCC",),
+    ),
+    "topological_finite": _structural(
+        "topological_finite",
+        "Check whether topology has an exit path rather than a closed no-exit region.",
+        "linear_in_states",
+        diagnostic_codes=("W_TOPOLOGICAL_NOEXIT",),
+    ),
+    "topological_inevitable_terminator": _structural(
+        "topological_inevitable_terminator",
+        "Identify topology regions that are not forced to reach a terminator.",
+        "linear_in_states",
+        diagnostic_codes=("I_TOPOLOGICAL_NON_TERMINATING",),
+    ),
+    "event_emission_to_consumer_reachable": _structural(
+        "event_emission_to_consumer_reachable",
+        "Check whether each used event has a topologically reachable consumer source.",
+        "linear_in_transitions",
+        diagnostic_codes=("W_EVENT_UNREACHABLE_EMIT",),
+        dominant_dim=("events", "transitions"),
+    ),
+    "dead_guard": _smt_local(
+        "dead_guard",
+        "Detect guards that are unsatisfiable under variable constraints.",
+        "linear_in_transitions",
+        ("W_DEAD_GUARD",),
+    ),
+    "guard_tautology": _smt_local(
+        "guard_tautology",
+        "Detect guards that are always true under variable constraints.",
+        "linear_in_transitions",
+        ("W_GUARD_TAUTOLOGY",),
+    ),
+    "forced_guard_unsat_under_init": _smt_local(
+        "forced_guard_unsat_under_init",
+        "Detect forced-transition guards unsatisfiable under initial variable values.",
+        "linear_in_transitions",
+        ("W_FORCED_GUARD_UNSAT",),
+        fallback_unknown_risk="low",
+    ),
+    "effect_no_op_under_guard": _smt_local(
+        "effect_no_op_under_guard",
+        "Detect transition effects that are no-ops whenever the guard holds.",
+        "linear_in_transitions",
+        ("W_EFFECT_SMT_NO_OP",),
+    ),
+    "effect_contradicts_guard": _smt_local(
+        "effect_contradicts_guard",
+        "Detect effects whose post-state contradicts their transition guard.",
+        "linear_in_transitions",
+        ("I_EFFECT_GUARD_CONTRADICT",),
+    ),
+    "transition_shadowed_by_predecessor": _smt_local(
+        "transition_shadowed_by_predecessor",
+        "Detect outgoing transitions fully shadowed by earlier same-domain transitions.",
+        "linear_in_transitions",
+        ("W_TRANSITION_SHADOWED",),
+        incremental=True,
+        dominant_dim=("transitions", "vars"),
+    ),
+    "enter_postcondition_implies_during_precondition": _smt_local(
+        "enter_postcondition_implies_during_precondition",
+        "Compare entry postconditions with first-cycle during preconditions.",
+        "linear_in_leaves",
+        ("I_ENTER_DURING_CONTRADICT",),
+        dominant_dim=("leaves", "vars"),
+    ),
+    "bounded_reachability": _bmc_placeholder(
+        "bounded_reachability",
+        "Query whether a target state is reachable from a source within a bound.",
+        "k_unrollings",
+    ),
+    "symbolic_bfs": _bmc_placeholder(
+        "symbolic_bfs",
+        "Build bounded symbolic BFS spaces for queried reachability algorithms.",
+        "k_unrollings_times_branching",
+    ),
+    "bounded_safety": _bmc_placeholder(
+        "bounded_safety",
+        "Query whether bounded executions avoid bad states or bad conditions.",
+        "k_unrollings",
+    ),
+    "bounded_invariant": _bmc_placeholder(
+        "bounded_invariant",
+        "Query whether an invariant holds over all bounded reachable frames.",
+        "k_unrollings_times_branching",
+        fallback_unknown_risk="high",
+    ),
+    "path_witness": _bmc_placeholder(
+        "path_witness",
+        "Decode a concrete path witness from a satisfiable symbolic frame.",
+        "one",
+        dominant_dim=("depth",),
+    ),
+}
+
+REGISTRY: Mapping[str, VerifyAlgorithmMeta] = MappingProxyType(_REGISTRY)
+
+__all__ = ["REGISTRY"]

--- a/pyfcstm/verify/taxonomy.py
+++ b/pyfcstm/verify/taxonomy.py
@@ -1,0 +1,167 @@
+"""
+Formal verification algorithm taxonomy for pyfcstm.
+
+This module defines the metadata contract used by :mod:`pyfcstm.verify`
+to classify verification algorithms before they are implemented or wired
+into diagnostics. The taxonomy is intentionally independent from
+``pyfcstm.diagnostics`` so Track A can evolve without depending on the
+Layer 2 inspect surface.
+"""
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
+
+try:
+    from typing import Literal
+except ImportError:  # pragma: no cover - Python < 3.8 compatibility
+    from typing_extensions import Literal
+
+Closedness = Literal["closed", "queried"]
+ComplexityTier = Literal[
+    "structural",
+    "smt_linear",
+    "smt_nonlinear_decidable",
+    "smt_undecidable_heuristic",
+    "bmc_search",
+]
+SMTLogic = Literal[
+    "QF_UF",
+    "QF_LIA",
+    "QF_LRA",
+    "QF_LIRA",
+    "QF_UFLIA",
+    "QF_UFLRA",
+    "QF_BV",
+    "QF_FP",
+    "QF_NIA",
+    "QF_NRA",
+    "QF_UFNRA",
+    "QF_NIRA",
+    "transcendental",
+]
+FormulaSizeScaling = Literal[
+    "none",
+    "constant",
+    "linear",
+    "quadratic",
+    "exponential_in_bitwidth",
+    "exponential_in_vars",
+    "doubly_exponential",
+]
+CallCountScaling = Literal[
+    "none",
+    "one",
+    "linear_in_states",
+    "linear_in_transitions",
+    "linear_in_vars",
+    "linear_in_leaves",
+    "quadratic_in_outgoing_per_state",
+    "quadratic_in_states",
+    "vars_times_transitions",
+    "k_unrollings",
+    "k_unrollings_times_branching",
+]
+FallbackUnknownRisk = Literal[
+    "none",
+    "low",
+    "medium",
+    "high",
+    "guaranteed_possible",
+]
+VerificationScope = Literal[
+    "topological_only",
+    "smt_local",
+    "bmc_unrolled",
+]
+
+COMPLEXITY_TIER_ORDER = (
+    "structural",
+    "smt_linear",
+    "smt_nonlinear_decidable",
+    "smt_undecidable_heuristic",
+)
+CALL_COUNT_SCALING_ORDER = (
+    "none",
+    "one",
+    "linear_in_states",
+    "linear_in_transitions",
+    "linear_in_vars",
+    "linear_in_leaves",
+    "quadratic_in_outgoing_per_state",
+    "quadratic_in_states",
+    "vars_times_transitions",
+)
+
+
+@dataclass(frozen=True)
+class VerifyAlgorithmMeta:
+    """
+    Metadata describing one verification algorithm.
+
+    :param name: Stable registry key and public algorithm name.
+    :type name: str
+    :param description: Short human-readable algorithm summary.
+    :type description: str
+    :param closedness: Whether the algorithm can run without an explicit query.
+    :type closedness: Closedness
+    :param complexity_tier: Engineering complexity tier used by inspect gating.
+    :type complexity_tier: ComplexityTier
+    :param smt_logic: SMT-LIB logic family, or ``None`` for structural algorithms.
+    :type smt_logic: Optional[SMTLogic]
+    :param formula_size_scaling: Size growth of each generated formula.
+    :type formula_size_scaling: FormulaSizeScaling
+    :param call_count_scaling: Number of algorithm or solver calls over model size.
+    :type call_count_scaling: CallCountScaling
+    :param incremental: Whether the implementation is expected to reuse solver state.
+    :type incremental: bool
+    :param fallback_unknown_risk: Risk that the algorithm must return inconclusive.
+    :type fallback_unknown_risk: FallbackUnknownRisk
+    :param recommended_tactic: Z3 tactic name, or ``None`` when no solver is used.
+    :type recommended_tactic: Optional[str]
+    :param quantifier_alternation_depth: Quantifier alternation depth of formulas.
+    :type quantifier_alternation_depth: int
+    :param max_bitwidth: Maximum fixed bit-width if applicable, otherwise ``None``.
+    :type max_bitwidth: Optional[int]
+    :param theory_combination: SMT theory names combined by the algorithm.
+    :type theory_combination: Tuple[str, ...]
+    :param verification_scope: Boundary label for downstream result consumers.
+    :type verification_scope: Optional[VerificationScope]
+    :param dominant_dim: Dominant model dimensions for cost explanations.
+    :type dominant_dim: Tuple[str, ...]
+    :param diagnostic_codes: Diagnostics the algorithm may emit when integrated.
+    :type diagnostic_codes: Tuple[str, ...]
+    :param impl: Implementation callable, or ``None`` while the algorithm is pending.
+    :type impl: Optional[Callable]
+    """
+
+    name: str
+    description: str
+    closedness: Closedness
+    complexity_tier: ComplexityTier
+    smt_logic: Optional[SMTLogic]
+    formula_size_scaling: FormulaSizeScaling
+    call_count_scaling: CallCountScaling
+    incremental: bool
+    fallback_unknown_risk: FallbackUnknownRisk
+    recommended_tactic: Optional[str]
+    quantifier_alternation_depth: int
+    max_bitwidth: Optional[int]
+    theory_combination: Tuple[str, ...]
+    verification_scope: Optional[VerificationScope]
+    dominant_dim: Tuple[str, ...]
+    diagnostic_codes: Tuple[str, ...]
+    impl: Optional[Callable]
+
+
+__all__ = [
+    "CALL_COUNT_SCALING_ORDER",
+    "COMPLEXITY_TIER_ORDER",
+    "CallCountScaling",
+    "Closedness",
+    "ComplexityTier",
+    "FallbackUnknownRisk",
+    "FormulaSizeScaling",
+    "SMTLogic",
+    "VerificationScope",
+    "VerifyAlgorithmMeta",
+]

--- a/test/verify/test_inspect_adapter.py
+++ b/test/verify/test_inspect_adapter.py
@@ -177,6 +177,7 @@ def test_iter_inspect_eligible_preserves_registry_order():
         "effect_contradicts_guard",
         "transition_shadowed_by_predecessor",
         "enter_postcondition_implies_during_precondition",
+        "composite_init_guards_incomplete",
     )
     assert tuple(
         meta.name
@@ -190,4 +191,5 @@ def test_iter_inspect_eligible_preserves_registry_order():
         "strongly_connected_components",
         "topological_finite",
         "topological_inevitable_terminator",
+        "composite_init_guards_incomplete",
     )

--- a/test/verify/test_inspect_adapter.py
+++ b/test/verify/test_inspect_adapter.py
@@ -1,0 +1,193 @@
+from typing import cast
+
+import pytest
+
+from pyfcstm.verify import (
+    REGISTRY,
+    InspectAccessForbiddenError,
+    eligible_for_inspect,
+    iter_inspect_eligible,
+)
+from pyfcstm.verify.taxonomy import (
+    CallCountScaling,
+    ComplexityTier,
+    VerifyAlgorithmMeta,
+)
+
+
+pytestmark = pytest.mark.unittest
+
+
+def _meta(**overrides):
+    values = {
+        "name": "custom",
+        "description": "custom algorithm",
+        "closedness": "closed",
+        "complexity_tier": "structural",
+        "smt_logic": None,
+        "formula_size_scaling": "none",
+        "call_count_scaling": "one",
+        "incremental": False,
+        "fallback_unknown_risk": "none",
+        "recommended_tactic": None,
+        "quantifier_alternation_depth": 0,
+        "max_bitwidth": None,
+        "theory_combination": (),
+        "verification_scope": "topological_only",
+        "dominant_dim": ("states",),
+        "diagnostic_codes": (),
+        "impl": None,
+    }
+    values.update(overrides)
+    return VerifyAlgorithmMeta(**values)
+
+
+def test_structural_closed_algorithm_is_eligible_by_default():
+    assert eligible_for_inspect(REGISTRY["topological_reachable_set"]) is True
+
+
+def test_smt_linear_requires_opt_in_complexity_tier():
+    assert eligible_for_inspect(REGISTRY["dead_guard"]) is False
+    assert (
+        eligible_for_inspect(
+            REGISTRY["dead_guard"],
+            max_complexity_tier="smt_linear",
+        )
+        is True
+    )
+    assert (
+        eligible_for_inspect(
+            REGISTRY["enter_postcondition_implies_during_precondition"],
+            max_complexity_tier="smt_linear",
+        )
+        is True
+    )
+
+
+def test_queried_and_bmc_algorithms_are_never_eligible():
+    assert (
+        eligible_for_inspect(
+            REGISTRY["bounded_reachability"],
+            max_complexity_tier="smt_undecidable_heuristic",
+            max_call_count_scaling="vars_times_transitions",
+        )
+        is False
+    )
+    queried_structural = _meta(closedness="queried", complexity_tier="structural")
+    assert eligible_for_inspect(queried_structural) is False
+    closed_bmc = _meta(
+        closedness="closed",
+        complexity_tier="bmc_search",
+        call_count_scaling="k_unrollings",
+    )
+    assert eligible_for_inspect(closed_bmc) is False
+
+
+def test_bmc_search_max_complexity_tier_is_forbidden():
+    with pytest.raises(InspectAccessForbiddenError, match="bmc_search"):
+        eligible_for_inspect(
+            REGISTRY["topological_reachable_set"],
+            max_complexity_tier="bmc_search",
+        )
+
+
+def test_call_count_limit_blocks_more_expensive_closed_algorithm():
+    assert (
+        eligible_for_inspect(
+            REGISTRY["topological_reachable_set"],
+            max_call_count_scaling="one",
+        )
+        is False
+    )
+    assert (
+        eligible_for_inspect(
+            REGISTRY["topological_reachable_set"],
+            max_call_count_scaling="linear_in_states",
+        )
+        is True
+    )
+
+
+def test_call_count_scaling_outside_inspect_order_is_not_eligible():
+    k_unroll = _meta(call_count_scaling="k_unrollings")
+    assert (
+        eligible_for_inspect(
+            k_unroll,
+            max_complexity_tier="smt_undecidable_heuristic",
+            max_call_count_scaling="vars_times_transitions",
+        )
+        is False
+    )
+
+
+def test_invalid_inspect_limits_raise_instead_of_disabling_all_algorithms():
+    for invalid_tier in ("smt_lienar", None):
+        with pytest.raises(InspectAccessForbiddenError):
+            eligible_for_inspect(
+                REGISTRY["topological_reachable_set"],
+                max_complexity_tier=cast(ComplexityTier, invalid_tier),
+            )
+
+    for invalid_call_count in (
+        "linear_in_transition",
+        "k_unrollings",
+        "k_unrollings_times_branching",
+        None,
+    ):
+        with pytest.raises(InspectAccessForbiddenError):
+            eligible_for_inspect(
+                REGISTRY["topological_reachable_set"],
+                max_call_count_scaling=cast(CallCountScaling, invalid_call_count),
+            )
+
+
+def test_nonlinear_and_undecidable_tier_boundaries_have_no_extra_algorithms():
+    expected = tuple(
+        meta.name for meta in iter_inspect_eligible(max_complexity_tier="smt_linear")
+    )
+    for tier in ("smt_nonlinear_decidable", "smt_undecidable_heuristic"):
+        assert (
+            tuple(meta.name for meta in iter_inspect_eligible(max_complexity_tier=tier))
+            == expected
+        )
+
+
+def test_iter_inspect_eligible_preserves_registry_order():
+    assert tuple(meta.name for meta in iter_inspect_eligible()) == (
+        "topological_reachable_set",
+        "unreachable_states",
+        "strongly_connected_components",
+        "topological_finite",
+        "topological_inevitable_terminator",
+        "event_emission_to_consumer_reachable",
+    )
+    assert tuple(
+        meta.name for meta in iter_inspect_eligible(max_complexity_tier="smt_linear")
+    ) == (
+        "topological_reachable_set",
+        "unreachable_states",
+        "strongly_connected_components",
+        "topological_finite",
+        "topological_inevitable_terminator",
+        "event_emission_to_consumer_reachable",
+        "dead_guard",
+        "guard_tautology",
+        "forced_guard_unsat_under_init",
+        "effect_no_op_under_guard",
+        "effect_contradicts_guard",
+        "transition_shadowed_by_predecessor",
+        "enter_postcondition_implies_during_precondition",
+    )
+    assert tuple(
+        meta.name
+        for meta in iter_inspect_eligible(
+            max_complexity_tier="smt_linear",
+            max_call_count_scaling="linear_in_states",
+        )
+    ) == (
+        "topological_reachable_set",
+        "unreachable_states",
+        "strongly_connected_components",
+        "topological_finite",
+        "topological_inevitable_terminator",
+    )

--- a/test/verify/test_registry.py
+++ b/test/verify/test_registry.py
@@ -23,6 +23,7 @@ GROUP2_SMT_LOCAL = (
     "effect_contradicts_guard",
     "transition_shadowed_by_predecessor",
     "enter_postcondition_implies_during_precondition",
+    "composite_init_guards_incomplete",
 )
 
 GROUP3_BMC_PLACEHOLDERS = (
@@ -38,7 +39,7 @@ ALL_ALGORITHMS = GROUP1_TOPOLOGY + GROUP2_SMT_LOCAL + GROUP3_BMC_PLACEHOLDERS
 
 def test_registry_contains_exactly_all_pr_a_algorithms_in_stable_order():
     assert tuple(REGISTRY) == ALL_ALGORITHMS
-    assert len(REGISTRY) == 18
+    assert len(REGISTRY) == 19
 
 
 def test_registry_keys_match_meta_names_and_all_impls_are_placeholders():
@@ -91,9 +92,7 @@ def test_group2_smt_local_metadata_contract():
         assert meta.closedness == "closed"
         assert meta.complexity_tier == "smt_linear"
         assert meta.smt_logic == "QF_LIRA"
-        assert meta.formula_size_scaling == "constant"
         assert meta.fallback_unknown_risk in {"low", "medium"}
-        assert meta.recommended_tactic == "smt"
         assert meta.theory_combination == ("LIA", "LRA")
         assert meta.verification_scope == "smt_local"
 
@@ -103,10 +102,32 @@ def test_group2_smt_local_metadata_contract():
         REGISTRY["enter_postcondition_implies_during_precondition"].call_count_scaling
         == "linear_in_leaves"
     )
+    assert (
+        REGISTRY["composite_init_guards_incomplete"].call_count_scaling
+        == "linear_in_states"
+    )
+    assert REGISTRY["composite_init_guards_incomplete"].formula_size_scaling == "linear"
+    assert REGISTRY["composite_init_guards_incomplete"].incremental is True
+    assert REGISTRY["composite_init_guards_incomplete"].recommended_tactic == "qflia"
+    assert REGISTRY["composite_init_guards_incomplete"].dominant_dim == (
+        "V",
+        "vars",
+        "events",
+    )
+    assert REGISTRY["composite_init_guards_incomplete"].fallback_unknown_risk == (
+        "medium"
+    )
+    assert REGISTRY["composite_init_guards_incomplete"].theory_combination == (
+        "LIA",
+        "LRA",
+    )
     for name in set(GROUP2_SMT_LOCAL) - {
-        "enter_postcondition_implies_during_precondition"
+        "enter_postcondition_implies_during_precondition",
+        "composite_init_guards_incomplete",
     }:
         assert REGISTRY[name].call_count_scaling == "linear_in_transitions"
+        assert REGISTRY[name].formula_size_scaling == "constant"
+        assert REGISTRY[name].recommended_tactic == "smt"
 
     expected_codes = {
         "dead_guard": ("W_DEAD_GUARD",),
@@ -118,6 +139,7 @@ def test_group2_smt_local_metadata_contract():
         "enter_postcondition_implies_during_precondition": (
             "I_ENTER_DURING_CONTRADICT",
         ),
+        "composite_init_guards_incomplete": ("W_COMPOSITE_INIT_INCOMPLETE",),
     }
     for name, codes in expected_codes.items():
         assert REGISTRY[name].diagnostic_codes == codes

--- a/test/verify/test_registry.py
+++ b/test/verify/test_registry.py
@@ -1,0 +1,217 @@
+import pytest
+
+from pyfcstm.verify import REGISTRY
+
+
+pytestmark = pytest.mark.unittest
+
+
+GROUP1_TOPOLOGY = (
+    "topological_reachable_set",
+    "unreachable_states",
+    "strongly_connected_components",
+    "topological_finite",
+    "topological_inevitable_terminator",
+    "event_emission_to_consumer_reachable",
+)
+
+GROUP2_SMT_LOCAL = (
+    "dead_guard",
+    "guard_tautology",
+    "forced_guard_unsat_under_init",
+    "effect_no_op_under_guard",
+    "effect_contradicts_guard",
+    "transition_shadowed_by_predecessor",
+    "enter_postcondition_implies_during_precondition",
+)
+
+GROUP3_BMC_PLACEHOLDERS = (
+    "bounded_reachability",
+    "symbolic_bfs",
+    "bounded_safety",
+    "bounded_invariant",
+    "path_witness",
+)
+
+ALL_ALGORITHMS = GROUP1_TOPOLOGY + GROUP2_SMT_LOCAL + GROUP3_BMC_PLACEHOLDERS
+
+
+def test_registry_contains_exactly_all_pr_a_algorithms_in_stable_order():
+    assert tuple(REGISTRY) == ALL_ALGORITHMS
+    assert len(REGISTRY) == 18
+
+
+def test_registry_keys_match_meta_names_and_all_impls_are_placeholders():
+    assert not hasattr(REGISTRY, "__setitem__")
+    assert len(set(REGISTRY)) == len(REGISTRY)
+    for name, meta in REGISTRY.items():
+        assert meta.name == name
+        assert meta.description
+        assert meta.quantifier_alternation_depth == 0
+        assert meta.impl is None
+
+
+def test_group1_topology_metadata_contract():
+    for name in GROUP1_TOPOLOGY:
+        meta = REGISTRY[name]
+        assert meta.closedness == "closed"
+        assert meta.complexity_tier == "structural"
+        assert meta.smt_logic is None
+        assert meta.formula_size_scaling == "none"
+        assert meta.fallback_unknown_risk == "none"
+        assert meta.recommended_tactic is None
+        assert meta.theory_combination == ()
+        assert meta.verification_scope == "topological_only"
+        assert meta.incremental is False
+
+    assert (
+        REGISTRY["event_emission_to_consumer_reachable"].call_count_scaling
+        == "linear_in_transitions"
+    )
+    for name in set(GROUP1_TOPOLOGY) - {"event_emission_to_consumer_reachable"}:
+        assert REGISTRY[name].call_count_scaling == "linear_in_states"
+
+    assert REGISTRY["topological_reachable_set"].diagnostic_codes == ()
+    assert REGISTRY["unreachable_states"].diagnostic_codes == ("W_UNREACHABLE_STATE",)
+    assert REGISTRY["strongly_connected_components"].diagnostic_codes == (
+        "I_NONTRIVIAL_SCC",
+    )
+    assert REGISTRY["topological_finite"].diagnostic_codes == ("W_TOPOLOGICAL_NOEXIT",)
+    assert REGISTRY["topological_inevitable_terminator"].diagnostic_codes == (
+        "I_TOPOLOGICAL_NON_TERMINATING",
+    )
+    assert REGISTRY["event_emission_to_consumer_reachable"].diagnostic_codes == (
+        "W_EVENT_UNREACHABLE_EMIT",
+    )
+
+
+def test_group2_smt_local_metadata_contract():
+    for name in GROUP2_SMT_LOCAL:
+        meta = REGISTRY[name]
+        assert meta.closedness == "closed"
+        assert meta.complexity_tier == "smt_linear"
+        assert meta.smt_logic == "QF_LIRA"
+        assert meta.formula_size_scaling == "constant"
+        assert meta.fallback_unknown_risk in {"low", "medium"}
+        assert meta.recommended_tactic == "smt"
+        assert meta.theory_combination == ("LIA", "LRA")
+        assert meta.verification_scope == "smt_local"
+
+    assert REGISTRY["forced_guard_unsat_under_init"].fallback_unknown_risk == "low"
+    assert REGISTRY["transition_shadowed_by_predecessor"].incremental is True
+    assert (
+        REGISTRY["enter_postcondition_implies_during_precondition"].call_count_scaling
+        == "linear_in_leaves"
+    )
+    for name in set(GROUP2_SMT_LOCAL) - {
+        "enter_postcondition_implies_during_precondition"
+    }:
+        assert REGISTRY[name].call_count_scaling == "linear_in_transitions"
+
+    expected_codes = {
+        "dead_guard": ("W_DEAD_GUARD",),
+        "guard_tautology": ("W_GUARD_TAUTOLOGY",),
+        "forced_guard_unsat_under_init": ("W_FORCED_GUARD_UNSAT",),
+        "effect_no_op_under_guard": ("W_EFFECT_SMT_NO_OP",),
+        "effect_contradicts_guard": ("I_EFFECT_GUARD_CONTRADICT",),
+        "transition_shadowed_by_predecessor": ("W_TRANSITION_SHADOWED",),
+        "enter_postcondition_implies_during_precondition": (
+            "I_ENTER_DURING_CONTRADICT",
+        ),
+    }
+    for name, codes in expected_codes.items():
+        assert REGISTRY[name].diagnostic_codes == codes
+
+
+def test_group3_bmc_placeholder_metadata_contract():
+    for name in GROUP3_BMC_PLACEHOLDERS:
+        meta = REGISTRY[name]
+        assert meta.closedness == "queried"
+        assert meta.complexity_tier == "bmc_search"
+        assert meta.smt_logic == "QF_LIRA"
+        assert meta.formula_size_scaling == "linear"
+        assert meta.incremental is True
+        assert meta.recommended_tactic == "smt"
+        assert meta.verification_scope == "bmc_unrolled"
+        assert meta.diagnostic_codes == ()
+
+    assert REGISTRY["bounded_reachability"].call_count_scaling == "k_unrollings"
+    assert REGISTRY["bounded_safety"].call_count_scaling == "k_unrollings"
+    assert REGISTRY["symbolic_bfs"].call_count_scaling == "k_unrollings_times_branching"
+    assert (
+        REGISTRY["bounded_invariant"].call_count_scaling
+        == "k_unrollings_times_branching"
+    )
+    assert REGISTRY["path_witness"].call_count_scaling == "one"
+    assert REGISTRY["bounded_invariant"].fallback_unknown_risk == "high"
+    for name in set(GROUP3_BMC_PLACEHOLDERS) - {"bounded_invariant"}:
+        assert REGISTRY[name].fallback_unknown_risk == "medium"
+
+
+def test_structural_smt_and_bmc_metadata_are_mutually_consistent():
+    for meta in REGISTRY.values():
+        if meta.complexity_tier == "structural":
+            assert meta.smt_logic is None
+            assert meta.verification_scope == "topological_only"
+            assert meta.theory_combination == ()
+        if meta.complexity_tier == "smt_linear":
+            assert meta.closedness == "closed"
+            assert meta.smt_logic == "QF_LIRA"
+            assert meta.verification_scope == "smt_local"
+        if meta.complexity_tier == "bmc_search":
+            assert meta.closedness == "queried"
+            assert meta.verification_scope == "bmc_unrolled"
+
+
+def test_verify_package_does_not_import_diagnostics():
+    import ast
+    import pathlib
+
+    def resolved_import_from(path, node):
+        parts = list(path.with_suffix("").parts)
+        if path.name == "__init__.py":
+            current_module = parts
+        else:
+            current_module = parts[:-1]
+        if node.level:
+            prefix = current_module[: len(current_module) - node.level + 1]
+            if node.module:
+                prefix.extend(node.module.split("."))
+            return ".".join(prefix)
+        return node.module or ""
+
+    bad = []
+    for path in pathlib.Path("pyfcstm/verify").rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "pyfcstm.diagnostics" or alias.name.startswith(
+                        "pyfcstm.diagnostics."
+                    ):
+                        bad.append((path, node.lineno, alias.name))
+            elif isinstance(node, ast.ImportFrom):
+                module = resolved_import_from(path, node)
+                if module == "pyfcstm.diagnostics" or module.startswith(
+                    "pyfcstm.diagnostics."
+                ):
+                    bad.append((path, node.lineno, module))
+                if module == "pyfcstm" and any(
+                    alias.name == "diagnostics" for alias in node.names
+                ):
+                    bad.append((path, node.lineno, "from pyfcstm import diagnostics"))
+    assert bad == []
+
+
+def test_pr_a1_does_not_create_later_verify_or_solver_modules():
+    import pathlib
+
+    forbidden_paths = (
+        "pyfcstm/verify/search.py",
+        "pyfcstm/verify/reachability.py",
+        "pyfcstm/verify/topology.py",
+        "pyfcstm/verify/smt_local.py",
+        "pyfcstm/solver/logical.py",
+        "pyfcstm/solver/safety.py",
+    )
+    assert [path for path in forbidden_paths if pathlib.Path(path).exists()] == []

--- a/test/verify/test_registry.py
+++ b/test/verify/test_registry.py
@@ -52,6 +52,12 @@ def test_registry_keys_match_meta_names_and_all_impls_are_placeholders():
         assert meta.impl is None
 
 
+def test_registry_module_does_not_expose_mutable_backing_store():
+    import pyfcstm.verify.registry as registry_module
+
+    assert not hasattr(registry_module, "_REGISTRY")
+
+
 def test_group1_topology_metadata_contract():
     for name in GROUP1_TOPOLOGY:
         meta = REGISTRY[name]

--- a/test/verify/test_registry.py
+++ b/test/verify/test_registry.py
@@ -71,6 +71,23 @@ def test_group1_topology_metadata_contract():
         assert meta.verification_scope == "topological_only"
         assert meta.incremental is False
 
+    assert REGISTRY["topological_reachable_set"].dominant_dim == (
+        "V",
+        "E",
+        "depth",
+    )
+    assert REGISTRY["unreachable_states"].dominant_dim == ("V_leaf", "depth")
+    for name in {
+        "strongly_connected_components",
+        "topological_finite",
+        "topological_inevitable_terminator",
+    }:
+        assert REGISTRY[name].dominant_dim == ("V", "E")
+    assert REGISTRY["event_emission_to_consumer_reachable"].dominant_dim == (
+        "events",
+        "E",
+    )
+
     assert (
         REGISTRY["event_emission_to_consumer_reachable"].call_count_scaling
         == "linear_in_transitions"
@@ -105,6 +122,10 @@ def test_group2_smt_local_metadata_contract():
     assert REGISTRY["forced_guard_unsat_under_init"].fallback_unknown_risk == "low"
     assert REGISTRY["transition_shadowed_by_predecessor"].incremental is True
     assert (
+        REGISTRY["enter_postcondition_implies_during_precondition"].incremental
+        is True
+    )
+    assert (
         REGISTRY["enter_postcondition_implies_during_precondition"].call_count_scaling
         == "linear_in_leaves"
     )
@@ -127,13 +148,29 @@ def test_group2_smt_local_metadata_contract():
         "LIA",
         "LRA",
     )
+    assert REGISTRY["forced_guard_unsat_under_init"].dominant_dim == (
+        "forced_transitions",
+        "vars",
+    )
+    assert REGISTRY["enter_postcondition_implies_during_precondition"].dominant_dim == (
+        "V_leaf",
+        "vars",
+    )
+    for name in set(GROUP2_SMT_LOCAL) - {
+        "enter_postcondition_implies_during_precondition",
+        "composite_init_guards_incomplete",
+        "forced_guard_unsat_under_init",
+    }:
+        assert REGISTRY[name].dominant_dim == ("E", "vars")
+
     for name in set(GROUP2_SMT_LOCAL) - {
         "enter_postcondition_implies_during_precondition",
         "composite_init_guards_incomplete",
     }:
         assert REGISTRY[name].call_count_scaling == "linear_in_transitions"
         assert REGISTRY[name].formula_size_scaling == "constant"
-        assert REGISTRY[name].recommended_tactic == "smt"
+    for name in GROUP2_SMT_LOCAL:
+        assert REGISTRY[name].recommended_tactic == "qflia"
 
     expected_codes = {
         "dead_guard": ("W_DEAD_GUARD",),
@@ -158,10 +195,20 @@ def test_group3_bmc_placeholder_metadata_contract():
         assert meta.complexity_tier == "bmc_search"
         assert meta.smt_logic == "QF_LIRA"
         assert meta.formula_size_scaling == "linear"
-        assert meta.incremental is True
         assert meta.recommended_tactic == "smt"
         assert meta.verification_scope == "bmc_unrolled"
         assert meta.diagnostic_codes == ()
+
+    for name in set(GROUP3_BMC_PLACEHOLDERS) - {"path_witness"}:
+        assert REGISTRY[name].incremental is True
+        assert REGISTRY[name].dominant_dim == (
+            "depth",
+            "vars",
+            "events",
+            "branching",
+        )
+    assert REGISTRY["path_witness"].incremental is False
+    assert REGISTRY["path_witness"].dominant_dim == ("depth",)
 
     assert REGISTRY["bounded_reachability"].call_count_scaling == "k_unrollings"
     assert REGISTRY["bounded_safety"].call_count_scaling == "k_unrollings"
@@ -197,10 +244,7 @@ def test_verify_package_does_not_import_diagnostics():
 
     def resolved_import_from(path, node):
         parts = list(path.with_suffix("").parts)
-        if path.name == "__init__.py":
-            current_module = parts
-        else:
-            current_module = parts[:-1]
+        current_module = parts[:-1]
         if node.level:
             prefix = current_module[: len(current_module) - node.level + 1]
             if node.module:

--- a/test/verify/test_taxonomy.py
+++ b/test/verify/test_taxonomy.py
@@ -1,0 +1,177 @@
+import dataclasses
+
+try:
+    from typing import get_args
+except ImportError:  # pragma: no cover - Python 3.7 compatibility
+    from typing_extensions import get_args
+
+import pytest
+
+from pyfcstm.verify.taxonomy import (
+    CALL_COUNT_SCALING_ORDER,
+    COMPLEXITY_TIER_ORDER,
+    CallCountScaling,
+    Closedness,
+    ComplexityTier,
+    FallbackUnknownRisk,
+    FormulaSizeScaling,
+    SMTLogic,
+    VerificationScope,
+    VerifyAlgorithmMeta,
+)
+
+
+pytestmark = pytest.mark.unittest
+
+
+EXPECTED_FIELDS = (
+    "name",
+    "description",
+    "closedness",
+    "complexity_tier",
+    "smt_logic",
+    "formula_size_scaling",
+    "call_count_scaling",
+    "incremental",
+    "fallback_unknown_risk",
+    "recommended_tactic",
+    "quantifier_alternation_depth",
+    "max_bitwidth",
+    "theory_combination",
+    "verification_scope",
+    "dominant_dim",
+    "diagnostic_codes",
+    "impl",
+)
+
+
+def test_verify_algorithm_meta_has_exact_contract_fields():
+    assert dataclasses.is_dataclass(VerifyAlgorithmMeta)
+    assert getattr(VerifyAlgorithmMeta, "__dataclass_params__").frozen is True
+    assert (
+        tuple(field.name for field in dataclasses.fields(VerifyAlgorithmMeta))
+        == EXPECTED_FIELDS
+    )
+
+
+def test_verify_algorithm_meta_is_frozen():
+    meta = VerifyAlgorithmMeta(
+        name="example",
+        description="example algorithm",
+        closedness="closed",
+        complexity_tier="structural",
+        smt_logic=None,
+        formula_size_scaling="none",
+        call_count_scaling="one",
+        incremental=False,
+        fallback_unknown_risk="none",
+        recommended_tactic=None,
+        quantifier_alternation_depth=0,
+        max_bitwidth=None,
+        theory_combination=(),
+        verification_scope="topological_only",
+        dominant_dim=("states",),
+        diagnostic_codes=(),
+        impl=None,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(meta, "name", "changed")
+
+
+def test_literal_value_sets_match_issue_contract():
+    assert set(get_args(Closedness)) == {"closed", "queried"}
+    assert set(get_args(ComplexityTier)) == {
+        "structural",
+        "smt_linear",
+        "smt_nonlinear_decidable",
+        "smt_undecidable_heuristic",
+        "bmc_search",
+    }
+    assert set(get_args(SMTLogic)) == {
+        "QF_UF",
+        "QF_LIA",
+        "QF_LRA",
+        "QF_LIRA",
+        "QF_UFLIA",
+        "QF_UFLRA",
+        "QF_BV",
+        "QF_FP",
+        "QF_NIA",
+        "QF_NRA",
+        "QF_UFNRA",
+        "QF_NIRA",
+        "transcendental",
+    }
+    assert set(get_args(FormulaSizeScaling)) == {
+        "none",
+        "constant",
+        "linear",
+        "quadratic",
+        "exponential_in_bitwidth",
+        "exponential_in_vars",
+        "doubly_exponential",
+    }
+    assert set(get_args(CallCountScaling)) == {
+        "none",
+        "one",
+        "linear_in_states",
+        "linear_in_transitions",
+        "linear_in_vars",
+        "linear_in_leaves",
+        "quadratic_in_outgoing_per_state",
+        "quadratic_in_states",
+        "vars_times_transitions",
+        "k_unrollings",
+        "k_unrollings_times_branching",
+    }
+    assert set(get_args(FallbackUnknownRisk)) == {
+        "none",
+        "low",
+        "medium",
+        "high",
+        "guaranteed_possible",
+    }
+    assert set(get_args(VerificationScope)) == {
+        "topological_only",
+        "smt_local",
+        "bmc_unrolled",
+    }
+
+
+def test_inspect_order_constants_exclude_bmc_search_and_k_unrollings():
+    assert COMPLEXITY_TIER_ORDER == (
+        "structural",
+        "smt_linear",
+        "smt_nonlinear_decidable",
+        "smt_undecidable_heuristic",
+    )
+    assert "bmc_search" not in COMPLEXITY_TIER_ORDER
+    assert CALL_COUNT_SCALING_ORDER == (
+        "none",
+        "one",
+        "linear_in_states",
+        "linear_in_transitions",
+        "linear_in_vars",
+        "linear_in_leaves",
+        "quadratic_in_outgoing_per_state",
+        "quadratic_in_states",
+        "vars_times_transitions",
+    )
+    assert "k_unrollings" not in CALL_COUNT_SCALING_ORDER
+    assert "k_unrollings_times_branching" not in CALL_COUNT_SCALING_ORDER
+
+
+def test_public_verify_package_reexports_core_contract():
+    import pyfcstm.verify as verify
+
+    for name in (
+        "VerifyAlgorithmMeta",
+        "REGISTRY",
+        "InspectAccessForbiddenError",
+        "eligible_for_inspect",
+        "iter_inspect_eligible",
+        "COMPLEXITY_TIER_ORDER",
+        "CALL_COUNT_SCALING_ORDER",
+    ):
+        assert hasattr(verify, name)
+        assert name in verify.__all__


### PR DESCRIPTION
## 总览

本 PR 是 Layer 3 / issue #114 / PR-A umbrella (#127) 之下的 **PR-A1：`pyfcstm.verify` 骨架 PR**。

本 PR 已在 stacked PR 工作槽位内完成 TDD 实装，base 指向 `dev/issue114-pr-a-verify`。它只负责 PR-A1 卡片约定的 verify 基础设施，不实现拓扑算法、不实现 SMT 局部算法、不接入 `inspect_model()`。

## 分支关系

- umbrella PR：#127
- umbrella 分支：`dev/issue114-pr-a-verify`
- 本 PR 分支：`dev/issue114-pr-a1-skeleton`
- 本 PR base：`dev/issue114-pr-a-verify`
- 关联 issue：#114

本 PR 合入后，后续 PR-A2 / PR-A3 从更新后的 umbrella 分支继续开 stacked sub-PR。

说明：issue #114 PR-A1 卡片中的 “main 起点 / 无前置” 指内容前置为 main；本仓库实际按 PR-A umbrella (#127) 采用 stacked PR 流程，因此本 PR 以 `dev/issue114-pr-a-verify` 为 base。该 umbrella 当前是零文件改动空提交分支，内容上等价于 main + scaffold commit，但本 PR 的局部验收仍以 umbrella/base 分支为准。

## 分支与验收基准

本 PR 是 stacked sub-PR，base 固定为 umbrella 分支 `dev/issue114-pr-a-verify`。因此本 PR 的 forbidden diff 以 `origin/dev/issue114-pr-a-verify...HEAD` 为准，而不是直接以 `main` 为准。

当前 umbrella 分支只比 `main` 多一个空提交，所以两者文件内容暂时等价；但为了避免后续 stacked PR 或 base 前移时误判，PR-A1 的机械验收必须使用 umbrella/base 分支作为 PR-local diff 基准。

## 本 PR 范围

### 新增生产代码

- `pyfcstm/verify/__init__.py`
  - 仅 re-export taxonomy types、`REGISTRY`、inspect adapter 函数与错误类型
  - 不暴露组 3 / dev/verify 预留 API
  - 禁止 import `pyfcstm.diagnostics.*`
- `pyfcstm/verify/taxonomy.py`
  - 定义 verify 分类学 Literal 类型
  - 定义 inspect 准入偏序常量
  - 定义 `VerifyAlgorithmMeta` frozen dataclass
- `pyfcstm/verify/registry.py`
  - 定义只读 `REGISTRY: Mapping[str, VerifyAlgorithmMeta]`
  - 登记 19 条算法元数据
  - 本 PR 中所有 `impl=None`
  - 通过局部 builder 构造 registry，并避免暴露模块级 mutable backing store
- `pyfcstm/verify/inspect_adapter.py`
  - 定义 `InspectAccessForbiddenError`
  - 实现 `eligible_for_inspect()`
  - 实现 `iter_inspect_eligible()`

### 新增测试

- `test/verify/__init__.py`
- `test/verify/test_taxonomy.py`
- `test/verify/test_registry.py`
- `test/verify/test_inspect_adapter.py`

## 明确不在本 PR 范围

本 PR 不得：

- import `pyfcstm.diagnostics.*`
- import `pyfcstm.diagnostics`
- `from pyfcstm import diagnostics`
- 依赖 `pyfcstm.diagnostics.inspect` 内部 dataclass / helper
- 修改 `pyfcstm/diagnostics/**`
- 修改 `pyfcstm/model/**`
- 修改 `pyfcstm/diagnostics/codes.yaml`
- 修改 `pyfcstm/diagnostics/schema.json`
- 修改 `editors/**`，包括 `editors/jsfcstm/**` 与 `editors/vscode/**`
- 创建 `pyfcstm/verify/search.py`
- 创建 `pyfcstm/verify/reachability.py`
- 实现 `pyfcstm/verify/topology.py`
- 实现 `pyfcstm/verify/smt_local.py`
- 新增 `pyfcstm/solver/logical.py`
- 新增 `pyfcstm/solver/safety.py`
- 接入 `inspect_model()`、CLI、jsfcstm 或任何 Layer 2 流程

## 关键契约

### taxonomy Literal 类型

本 PR 需要定义以下 Literal 类型，取值必须与 issue #114 PR-A1 卡片一致：

```python
ComplexityTier = Literal[
    'structural',
    'smt_linear',
    'smt_nonlinear_decidable',
    'smt_undecidable_heuristic',
    'bmc_search',
]

SMTLogic = Literal[
    'QF_UF', 'QF_LIA', 'QF_LRA', 'QF_LIRA', 'QF_UFLIA', 'QF_UFLRA',
    'QF_BV', 'QF_FP', 'QF_NIA', 'QF_NRA', 'QF_UFNRA', 'QF_NIRA',
    'transcendental',
]
```

还需要定义：

- `FormulaSizeScaling`
- `CallCountScaling`
- `FallbackUnknownRisk`
- `VerificationScope`
- `Closedness`

### inspect 准入偏序

本 PR 需要提供 inspect adapter 使用的偏序常量：

```python
COMPLEXITY_TIER_ORDER = (
    'structural',
    'smt_linear',
    'smt_nonlinear_decidable',
    'smt_undecidable_heuristic',
)

CALL_COUNT_SCALING_ORDER = (
    'none',
    'one',
    'linear_in_states',
    'linear_in_transitions',
    'linear_in_vars',
    'linear_in_leaves',
    'quadratic_in_outgoing_per_state',
    'quadratic_in_states',
    'vars_times_transitions',
)
```

`bmc_search`、`k_unrollings`、`k_unrollings_times_branching` 不得进入 inspect 自动准入偏序。它们只允许作为 registry 占位元数据存在，且在 PR-A1 中 `impl=None`。

### `VerifyAlgorithmMeta`

本 PR 将按 issue #114 PR-A1 卡片实现 17 字段 frozen dataclass：

```python
@dataclass(frozen=True)
class VerifyAlgorithmMeta:
    name: str
    description: str
    closedness: Closedness
    complexity_tier: ComplexityTier
    smt_logic: Optional[SMTLogic]
    formula_size_scaling: FormulaSizeScaling
    call_count_scaling: CallCountScaling
    incremental: bool
    fallback_unknown_risk: FallbackUnknownRisk
    recommended_tactic: Optional[str]
    quantifier_alternation_depth: int
    max_bitwidth: Optional[int]
    theory_combination: Tuple[str, ...]
    verification_scope: Optional[VerificationScope]
    dominant_dim: Tuple[str, ...]
    diagnostic_codes: Tuple[str, ...]
    impl: Optional[Callable]
```

### `REGISTRY`

本 PR 将登记 19 条算法：

组 1 拓扑算法：

- `topological_reachable_set`
- `unreachable_states`
- `strongly_connected_components`
- `topological_finite`
- `topological_inevitable_terminator`
- `event_emission_to_consumer_reachable`

组 2 SMT 局部算法：

- `dead_guard`
- `guard_tautology`
- `forced_guard_unsat_under_init`
- `effect_no_op_under_guard`
- `effect_contradicts_guard`
- `transition_shadowed_by_predecessor`
- `enter_postcondition_implies_during_precondition`
- `composite_init_guards_incomplete`

组 3 查询占位算法：

- `bounded_reachability`
- `symbolic_bfs`
- `bounded_safety`
- `bounded_invariant`
- `path_witness`

本 PR 中 19 条算法均保持 `impl=None`。在 `registry.py` 层面，A3 / A4 后续 PR 仅将对应算法条目的 `impl` 从 `None` 替换为实现函数指针；算法实现文件与测试文件由对应 PR-A3 / PR-A4 另行新增。

### `eligible_for_inspect()`

本 PR 将实现 inspect 准入 gate：

1. 校验 `max_complexity_tier` 必须在自动 inspect 偏序中；若为 `bmc_search` 或未知值，抛出 `InspectAccessForbiddenError`
2. 校验 `max_call_count_scaling` 必须在自动 inspect 偏序中；若为 `k_unrollings` / `k_unrollings_times_branching` 或未知值，抛出 `InspectAccessForbiddenError`
3. 若 `meta.closedness != 'closed'`，返回 `False`
4. 若 `meta.complexity_tier == 'bmc_search'`，返回 `False`
5. 按复杂度偏序检查 `meta.complexity_tier <= max_complexity_tier`
6. 按 call-count 偏序检查 `meta.call_count_scaling <= max_call_count_scaling`
7. v9 inspect 矩阵特例：`linear_in_leaves` 在 `max_call_count_scaling == 'linear_in_transitions'` 时视为准入，以保证 `max_complexity_tier='smt_linear'` 的推荐默认预算放行组 2 全部算法；更严格的 `linear_in_states` 仍会拒绝 leaf 级算法
8. 其余返回 `True`

## TDD 计划

本 PR 会按以下顺序开发：

1. 先写 `test_taxonomy.py`
   - 验证 dataclass frozen
   - 验证字段完整性
   - 验证 Literal 取值集合
   - 验证 inspect 准入偏序不包含 `bmc_search` / `k_unrollings` / `k_unrollings_times_branching`
2. 再写 `test_registry.py`
   - 验证 registry 长度为 19
   - 验证 name 与 key 一致
   - 验证 19 条算法齐全
   - 验证本 PR 全部 `impl is None`
   - 验证 closed / queried、tier、scope、diagnostic_codes 等关键元数据
3. 再写 `test_inspect_adapter.py`
   - 验证 structural 默认准入
   - 验证 queried 永不准入
   - 验证 `bmc_search` 永不准入
   - 验证 forbidden / unknown max tier 和 forbidden / unknown call-count 上限都抛 `InspectAccessForbiddenError`
   - 验证 tier / call-count 边界，包含 `linear_in_leaves` 在 `linear_in_transitions` 推荐预算下的 v9 特例
   - 验证 `iter_inspect_eligible()` 顺序稳定
4. 最后补实现，直到测试全绿并满足覆盖率要求

## 验收命令

本 PR 完成后至少跑：

```bash
pytest test/verify/ -v

python -c 'from pyfcstm.verify import VerifyAlgorithmMeta, REGISTRY; assert len(REGISTRY) == 19'

python - <<'PY'
import ast
import pathlib
import sys

bad = []
for path in pathlib.Path("pyfcstm/verify").rglob("*.py"):
    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
    for node in ast.walk(tree):
        if isinstance(node, ast.Import):
            for alias in node.names:
                if alias.name == "pyfcstm.diagnostics" or alias.name.startswith("pyfcstm.diagnostics."):
                    bad.append((path, node.lineno, alias.name))
        elif isinstance(node, ast.ImportFrom):
            module = node.module or ""
            if module == "pyfcstm.diagnostics" or module.startswith("pyfcstm.diagnostics."):
                bad.append((path, node.lineno, module))
            if module == "pyfcstm" and any(alias.name == "diagnostics" for alias in node.names):
                bad.append((path, node.lineno, "from pyfcstm import diagnostics"))

if bad:
    for item in bad:
        print(item)
    sys.exit(1)
PY

git fetch origin dev/issue114-pr-a-verify
git diff --exit-code origin/dev/issue114-pr-a-verify...HEAD -- \
  pyfcstm/diagnostics/ \
  pyfcstm/model/ \
  pyfcstm/diagnostics/codes.yaml \
  pyfcstm/diagnostics/schema.json \
  editors/ \
  pyfcstm/verify/search.py \
  pyfcstm/verify/reachability.py
```

预期：

- `pytest test/verify/ -v` 全绿
- registry 长度断言通过
- AST import 检查无 forbidden diagnostics import
- forbidden diff 退出码为 0 且无输出

## review 约定

本 PR 后续进入 review 阶段时，会使用 5 路 reviewer。reviewer 身份使用 `reviewer-alpha`、`reviewer-beta`、`reviewer-gamma`、`reviewer-delta`、`reviewer-epsilon`；问题等级使用三级：

- `C`：Critical，必须修复，否则不能进入 ready-to-merge
- `I`：Important，应修复，除非有明确理由豁免
- `M`：Minor，非阻塞但应尽量处理

review 结论会通过 `gh pr comment` 直接评论到本 PR，便于保留审查记录。

## 当前状态

PR-A1 已完成 TDD 实装并推送到 `dev/issue114-pr-a1-skeleton`，当前 head 为 `dd2aee3a fix(verify): align registry metadata with issue contract [skip-slow]`。

本次实现内容：

- 新增 `pyfcstm.verify` taxonomy、registry、inspect adapter 和 public re-export。
- 登记 19 条算法 metadata；本 PR 全部保持 `impl=None`。
- `REGISTRY` 以只读 `MappingProxyType` 公开，并移除模块级 mutable backing store，避免外部直接篡改全局登记表。
- `eligible_for_inspect()` 对非法 inspect 上限 fail fast，`bmc_search` 与 `k_unrollings*` 仍禁止进入自动 inspect；同时显式保留 `linear_in_leaves` 在 `linear_in_transitions` 推荐预算下的 v9 矩阵准入特例。
- 已按 issue #114 v9 / 上游 comment 追加 `composite_init_guards_incomplete` 元数据：组 2 SMT-local、`impl=None`、诊断码 `W_COMPOSITE_INIT_INCOMPLETE`。
- 已根据 5 路 C/I/M review 对齐 issue #114 逐算法元数据 spec：组 2 SMT-local `recommended_tactic='qflia'`，`enter_postcondition_implies_during_precondition.incremental=True`，`path_witness.incremental=False`，并补齐/修正各算法 `dominant_dim`。
- `max_complexity_tier='smt_linear'` 按 issue #114 v9 准入矩阵放行组 1 + 组 2 全部 14 条；更严格的 `max_call_count_scaling='linear_in_states'` 仍拒绝 transition/leaf 级算法，但会放行 `linear_in_states` 的 `composite_init_guards_incomplete`。
- 补充 `test/verify/` 契约测试和 `make rst_auto` 生成的 API docs；同时把 `verify/index` 纳入 `docs/source/api_doc/index.rst`。

本地验收记录（均使用仓库本地 `./venv`）：

```bash
pytest test/verify/ -q
# 23 passed

pytest test/verify/ --cov=pyfcstm.verify --cov-report=term-missing -q
# TOTAL 89 stmts, 0 miss, 100%; 23 passed

pyright pyfcstm/verify test/verify
# 0 errors, 0 warnings, 0 informations

ruff check pyfcstm/verify test/verify
# All checks passed!

SKIP_SLOW_TESTS=1 make unittest
# 8877 passed, 164 skipped, 63 deselected; total coverage 94%

make rst_auto
# 已运行；无额外需要提交的生成文件噪声
```

PR-A1 的 forbidden import / forbidden diff 机械检查也已本地通过；本 PR 未修改 `pyfcstm/diagnostics/**`、`pyfcstm/model/**`、`editors/**`，也未创建后续 PR 预留的 `pyfcstm/verify/search.py`、`reachability.py`、`topology.py`、`smt_local.py`、`pyfcstm/solver/logical.py`、`safety.py`。

当前等待 GitHub Actions 针对 `dd2aee3a` 的新一轮 CI 全绿；CI 通过后会按约定继续发起 reviewer-alpha / reviewer-beta / reviewer-gamma / reviewer-delta / reviewer-epsilon 五路 C/I/M review，并由各 subagent 自己把 review 记录评论到本 PR。
