### PR TITLE
诊断 PR-C4：inspect_model diagnostics 在 VSCode Problems 面板全量可见

### DIFF
--- a/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
@@ -108,6 +108,7 @@ export function collectConstFoldWarnings(machine: StateMachine | null | undefine
                     transition.toState,
                     transition.sourceKind,
                     transition.targetKind,
+                    state.path,
                     foldedGuard,
                 ));
             }
@@ -206,6 +207,7 @@ function guardConstDiagnostic(
     toState: string,
     sourceKind: 'init' | 'state',
     targetKind: 'state' | 'exit',
+    parentPath: readonly string[],
     value: boolean,
 ): ModelDiagnosticJson {
     const label = value ? 'true' : 'false';
@@ -216,7 +218,12 @@ function guardConstDiagnostic(
         severity: 'warning',
         message: `Transition ${JSON.stringify(sourceLabel)} -> ${JSON.stringify(targetLabel)} has a guard that is statically ${label}.`,
         span: null,
-        refs: {transition_span: null, folded_value: value},
+        refs: {
+            transition_span: null,
+            folded_value: value,
+            from_path: transitionSourcePath(parentPath, fromState, sourceKind),
+            to_path: transitionTargetPath(parentPath, toState, targetKind),
+        },
     };
 }
 
@@ -226,6 +233,22 @@ function transitionSourceLabel(value: string, sourceKind: 'init' | 'state'): str
 
 function transitionTargetLabel(value: string, targetKind: 'state' | 'exit'): string {
     return targetKind === 'exit' ? '[*]' : value;
+}
+
+function transitionSourcePath(
+    parentPath: readonly string[],
+    value: string,
+    sourceKind: 'init' | 'state',
+): string {
+    return sourceKind === 'init' ? '[*]' : [...parentPath, value].join('.');
+}
+
+function transitionTargetPath(
+    parentPath: readonly string[],
+    value: string,
+    targetKind: 'state' | 'exit',
+): string {
+    return targetKind === 'exit' ? '[*]' : [...parentPath, value].join('.');
 }
 
 function jsonStableNumber(value: ConstValue | null): number | null {

--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -94,7 +94,12 @@ function collectGuardConstFalseDiagnostics(transitions: TransitionInfo[]): Model
             severity: 'warning',
             message: `Transition ${JSON.stringify(transition.from_path)} -> ${JSON.stringify(transition.to_path)} has a guard that is statically false.`,
             span: null,
-            refs: {transition_span: null, folded_value: false},
+            refs: {
+                transition_span: null,
+                folded_value: false,
+                from_path: transition.from_path,
+                to_path: transition.to_path,
+            },
         });
     }
     return out;

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -327,6 +327,7 @@ function addTransitionDiagnostics(
                 source: 'fcstm',
                 code: FCSTM_DIAGNOSTIC_CODES.guardConstFalse,
                 data: {
+                    transition_span: null,
                     folded_value: false,
                 },
                 relatedInformation: sourceState

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -971,20 +971,11 @@ function addInitialTransitionInvalidDiagnostics(
     }
 }
 
-export async function collectSemanticAnalysisDiagnostics(
-    document: TextDocumentLike
-): Promise<FcstmDiagnostic[]> {
+export function collectSemanticAnalysisDiagnosticsFromSemantic(
+    semantic: FcstmSemanticDocument,
+    document: TextDocumentLike,
+): FcstmDiagnostic[] {
     const diagnostics: FcstmDiagnostic[] = [];
-    const semantic = await getWorkspaceGraph().getSemanticDocument(document);
-    // Defensive: callers always invoke against documents with a
-    // semantic analysis available; this guard exists for hypothetical
-    // future async paths.
-    /* c8 ignore start */
-    if (!semantic) {
-        return diagnostics;
-    }
-    /* c8 ignore stop */
-
     addImportMappingDiagnostics(semantic, document, diagnostics);
     addUnreachableStateDiagnostics(semantic, document, diagnostics);
     addTransitionDiagnostics(semantic, document, diagnostics);
@@ -998,6 +989,22 @@ export async function collectSemanticAnalysisDiagnostics(
     addInitialTransitionInvalidDiagnostics(semantic, document, diagnostics);
     addTypeMismatchDiagnostics(semantic, document, diagnostics);
     return diagnostics;
+}
+
+export async function collectSemanticAnalysisDiagnostics(
+    document: TextDocumentLike
+): Promise<FcstmDiagnostic[]> {
+    const semantic = await getWorkspaceGraph().getSemanticDocument(document);
+    // Defensive: callers always invoke against documents with a
+    // semantic analysis available; this guard exists for hypothetical
+    // future async paths.
+    /* c8 ignore start */
+    if (!semantic) {
+        return [];
+    }
+    /* c8 ignore stop */
+
+    return collectSemanticAnalysisDiagnosticsFromSemantic(semantic, document);
 }
 
 // -------------------------------------------------------------------------

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -70,6 +70,25 @@ function isFalseLiteral(expression: FcstmAstExpression): boolean {
         && /^(false|False)$/i.test(expression.valueText);
 }
 
+function dottedPath(path: readonly string[] | undefined): string | null {
+    return path && path.length > 0 ? path.join('.') : null;
+}
+
+function transitionDiagnosticEndpointPaths(
+    transition: FcstmSemanticTransition,
+): {from_path?: string; to_path?: string} {
+    const fromPath = transition.sourceKind === 'init'
+        ? '[*]'
+        : dottedPath(transition.sourceStatePath) ?? transition.sourceStateName ?? null;
+    const toPath = transition.targetKind === 'exit'
+        ? '[*]'
+        : dottedPath(transition.targetStatePath) ?? transition.targetStateName ?? null;
+    return {
+        ...(fromPath ? {from_path: fromPath} : {}),
+        ...(toPath ? {to_path: toPath} : {}),
+    };
+}
+
 function toFileUri(document: TextDocumentLike): string {
     const filePath = document.filePath || document.uri?.fsPath;
     return filePath ? pathToFileURL(filePath).toString() : 'untitled:fcstm';
@@ -329,6 +348,7 @@ function addTransitionDiagnostics(
                 data: {
                     transition_span: null,
                     folded_value: false,
+                    ...transitionDiagnosticEndpointPaths(transition),
                 },
                 relatedInformation: sourceState
                     ? [{

--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -1,10 +1,11 @@
 import {pathToFileURL} from 'node:url';
 
+import {inspectModel} from '../diagnostics';
 import type {FcstmSemanticDocument, FcstmSemanticImport, FcstmSemanticVariable} from '../semantics';
 import {FcstmDiagnostic, TextDocumentLike, TextRange, createRange} from '../utils/text';
 import {getWorkspaceGraph} from '../workspace';
 import {FCSTM_DIAGNOSTIC_CODES} from './analyzers';
-import {collectInspectModelDiagnostics, diagnosticKey} from './diagnostics';
+import {collectInspectDiagnosticsFromItems, diagnosticKey} from './diagnostics';
 import {rangeIntersects} from './ranges';
 import type {FcstmWorkspaceEdit} from './references';
 import {planSuggestedFixEdit, suggestedFixFromDiagnostic} from './suggested-fixes';
@@ -135,18 +136,19 @@ export async function collectCodeActions(
     ));
     if (node?.model) {
         const existing = new Set<string>();
+        const inspectDiagnostics = inspectModel(node.model).diagnostics;
         const serverSuggestedKeysAtRange = new Set(
-            collectInspectModelDiagnostics(document, semantic, node.model)
+            collectInspectDiagnosticsFromItems(document, semantic, inspectDiagnostics)
                 .filter(diagnostic => (
                     suggestedFixFromDiagnostic(diagnostic) &&
                     rangeIntersects(diagnostic.range, range)
                 ))
                 .map(diagnosticKey),
         );
-        for (const diagnostic of collectInspectModelDiagnostics(
+        for (const diagnostic of collectInspectDiagnosticsFromItems(
             document,
             semantic,
-            node.model,
+            inspectDiagnostics,
             [],
             {rangeMode: 'issue'},
         )) {

--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -1,13 +1,13 @@
 import {pathToFileURL} from 'node:url';
 
-import {inspectModel} from '../diagnostics';
 import type {FcstmSemanticDocument, FcstmSemanticImport, FcstmSemanticVariable} from '../semantics';
 import {FcstmDiagnostic, TextDocumentLike, TextRange, createRange} from '../utils/text';
 import {getWorkspaceGraph} from '../workspace';
 import {FCSTM_DIAGNOSTIC_CODES} from './analyzers';
+import {collectInspectModelDiagnostics, diagnosticKey} from './diagnostics';
 import {rangeIntersects} from './ranges';
 import type {FcstmWorkspaceEdit} from './references';
-import {planSuggestedFixEdit, suggestedFixFromDiagnostic, suggestedFixIssueRange} from './suggested-fixes';
+import {planSuggestedFixEdit, suggestedFixFromDiagnostic} from './suggested-fixes';
 
 export type FcstmCodeActionKind = 'quickfix' | 'refactor.rename';
 
@@ -110,42 +110,6 @@ function uniqueCaseInsensitiveStateCandidates(
     )];
 }
 
-function diagnosticKey(diagnostic: FcstmDiagnostic): string {
-    return JSON.stringify([diagnostic.code ?? null, diagnostic.data ?? null]);
-}
-
-function fullDocumentRange(document: TextDocumentLike): TextRange {
-    const lastLine = Math.max(0, document.lineCount - 1);
-    return createRange(0, 0, lastLine, document.lineAt(lastLine).text.length);
-}
-
-function collectSuggestedFixDesignDiagnostics(
-    document: TextDocumentLike,
-    semantic: FcstmSemanticDocument,
-    model: Parameters<typeof inspectModel>[0],
-    existingDiagnostics: FcstmDiagnostic[],
-): FcstmDiagnostic[] {
-    const existing = new Set(existingDiagnostics.map(diagnosticKey));
-    const fullRange = fullDocumentRange(document);
-    const diagnostics: FcstmDiagnostic[] = [];
-    for (const item of inspectModel(model).diagnostics) {
-        const diagnostic: FcstmDiagnostic = {
-            range: fullRange,
-            message: item.message,
-            severity: item.severity,
-            source: 'fcstm',
-            code: item.code,
-            data: item.refs,
-        };
-        const suggestedFix = suggestedFixFromDiagnostic(diagnostic);
-        if (!suggestedFix) continue;
-        diagnostic.range = suggestedFixIssueRange(document, semantic, diagnostic);
-        if (existing.has(diagnosticKey(diagnostic))) continue;
-        diagnostics.push(diagnostic);
-    }
-    return diagnostics;
-}
-
 /**
  * Build code actions / quick fixes for the selected FCSTM range.
  */
@@ -171,12 +135,14 @@ export async function collectCodeActions(
     ));
     if (node?.model) {
         const existing = new Set(relevantDiagnostics.map(diagnosticKey));
-        for (const diagnostic of collectSuggestedFixDesignDiagnostics(
+        for (const diagnostic of collectInspectModelDiagnostics(
             document,
             semantic,
             node.model,
             relevantDiagnostics,
+            {rangeMode: 'issue'},
         )) {
+            if (!suggestedFixFromDiagnostic(diagnostic)) continue;
             if (!rangeIntersects(diagnostic.range, range)) continue;
             if (existing.has(diagnosticKey(diagnostic))) continue;
             existing.add(diagnosticKey(diagnostic));

--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -134,18 +134,31 @@ export async function collectCodeActions(
         !suggestedFixFromDiagnostic(item) && rangeIntersects(item.range, range)
     ));
     if (node?.model) {
-        const existing = new Set(relevantDiagnostics.map(diagnosticKey));
+        const existing = new Set<string>();
+        const serverSuggestedKeysAtRange = new Set(
+            collectInspectModelDiagnostics(document, semantic, node.model)
+                .filter(diagnostic => (
+                    suggestedFixFromDiagnostic(diagnostic) &&
+                    rangeIntersects(diagnostic.range, range)
+                ))
+                .map(diagnosticKey),
+        );
         for (const diagnostic of collectInspectModelDiagnostics(
             document,
             semantic,
             node.model,
-            relevantDiagnostics,
+            [],
             {rangeMode: 'issue'},
         )) {
             if (!suggestedFixFromDiagnostic(diagnostic)) continue;
-            if (!rangeIntersects(diagnostic.range, range)) continue;
-            if (existing.has(diagnosticKey(diagnostic))) continue;
-            existing.add(diagnosticKey(diagnostic));
+            const key = diagnosticKey(diagnostic);
+            // Suggested-fix diagnostics can have two useful server-derived
+            // ranges: an edit-oriented published range and a broader issue
+            // range for cursor discovery. Never use client-supplied
+            // suggested_fix payloads as authorization for either range.
+            if (!rangeIntersects(diagnostic.range, range) && !serverSuggestedKeysAtRange.has(key)) continue;
+            if (existing.has(key)) continue;
+            existing.add(key);
             relevantDiagnostics.push(diagnostic);
         }
     }

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -13,9 +13,11 @@ import {getWorkspaceGraph} from '../workspace';
 import {resolveRangeFromRefs} from './inspect-ranges';
 import {suggestedFixDiagnosticRange, suggestedFixIssueRange} from './suggested-fixes';
 
+// Only suppress inspect codes that the semantic analyzer already reports with
+// equivalent coverage. Const-folded false guards stay inspect-backed because
+// the semantic analyzer only recognizes literal `false`.
 export const SUPPRESSED_FROM_INSPECT_SURFACE = new Set([
     'W_UNREACHABLE_STATE',
-    'W_GUARD_CONST_FALSE',
     'W_UNUSED_EVENT',
 ]);
 

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -21,8 +21,28 @@ export const SUPPRESSED_FROM_INSPECT_SURFACE = new Set([
     'W_UNUSED_EVENT',
 ]);
 
+function canonicalDiagnosticData(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(item => canonicalDiagnosticData(item));
+    }
+    if (typeof value !== 'object' || value === null) {
+        return value;
+    }
+
+    const out: Record<string, unknown> = {};
+    const item = value as Record<string, unknown>;
+    for (const key of Object.keys(item).sort()) {
+        if (key === 'suggested_fix') continue;
+        out[key] = canonicalDiagnosticData(item[key]);
+    }
+    return out;
+}
+
 export function diagnosticKey(diagnostic: FcstmDiagnostic): string {
-    return JSON.stringify([diagnostic.code ?? null, diagnostic.data ?? null]);
+    return JSON.stringify([
+        diagnostic.code ?? null,
+        canonicalDiagnosticData(diagnostic.data ?? null),
+    ]);
 }
 
 function consumeDiagnosticCount(counts: Map<string, number>, key: string): boolean {

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -1,11 +1,77 @@
 import {getParser, ParseError} from '../dsl/parser';
-import {collectSemanticAnalysisDiagnostics} from './analyzers';
+import {inspectModel} from '../diagnostics';
+import type {FcstmSemanticDocument} from '../semantics';
+import {collectSemanticAnalysisDiagnosticsFromSemantic} from './analyzers';
 import {
     createRange,
     FcstmDiagnostic,
     TextDocumentLike,
+    TextRange,
 } from '../utils/text';
 import {getImportWorkspaceIndex} from '../workspace/imports';
+import {getWorkspaceGraph} from '../workspace';
+import {resolveRangeFromRefs} from './inspect-ranges';
+import {suggestedFixDiagnosticRange, suggestedFixIssueRange} from './suggested-fixes';
+
+export const SUPPRESSED_FROM_INSPECT_SURFACE = new Set([
+    'W_UNREACHABLE_STATE',
+    'W_GUARD_CONST_FALSE',
+    'W_UNUSED_EVENT',
+]);
+
+export function diagnosticKey(diagnostic: FcstmDiagnostic): string {
+    return JSON.stringify([diagnostic.code ?? null, diagnostic.data ?? null]);
+}
+
+export function fullDocumentRange(document: TextDocumentLike): TextRange {
+    const lastLine = Math.max(0, document.lineCount - 1);
+    return createRange(0, 0, lastLine, document.lineAt(lastLine).text.length);
+}
+
+function rangeEquals(left: TextRange, right: TextRange): boolean {
+    return left.start.line === right.start.line &&
+        left.start.character === right.start.character &&
+        left.end.line === right.end.line &&
+        left.end.character === right.end.character;
+}
+
+export interface CollectInspectModelDiagnosticsOptions {
+    rangeMode?: 'diagnostic' | 'issue';
+}
+
+export function collectInspectModelDiagnostics(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    model: Parameters<typeof inspectModel>[0],
+    existingDiagnostics: FcstmDiagnostic[] = [],
+    options: CollectInspectModelDiagnosticsOptions = {},
+): FcstmDiagnostic[] {
+    const existing = new Set(existingDiagnostics.map(diagnosticKey));
+    const fullRange = fullDocumentRange(document);
+    const diagnostics: FcstmDiagnostic[] = [];
+
+    for (const item of inspectModel(model).diagnostics) {
+        if (SUPPRESSED_FROM_INSPECT_SURFACE.has(item.code)) continue;
+        const diagnostic: FcstmDiagnostic = {
+            range: fullRange,
+            message: item.message,
+            severity: item.severity,
+            source: 'fcstm',
+            code: item.code,
+            data: item.refs,
+        };
+        const suggestedRange = options.rangeMode === 'issue'
+            ? suggestedFixIssueRange(document, semantic, diagnostic)
+            : suggestedFixDiagnosticRange(document, semantic, diagnostic);
+        diagnostic.range = rangeEquals(suggestedRange, fullRange)
+            ? resolveRangeFromRefs(document, semantic, item.refs) ?? fullRange
+            : suggestedRange;
+        if (existing.has(diagnosticKey(diagnostic))) continue;
+        diagnostics.push(diagnostic);
+    }
+
+    return diagnostics;
+}
 
 export function convertParseErrorToDiagnostic(
     error: ParseError,
@@ -39,6 +105,13 @@ export async function collectDocumentDiagnostics(
     const parseResult = await getParser().parse(document.getText());
     const diagnostics = parseResult.errors.map(error => convertParseErrorToDiagnostic(error, document));
     diagnostics.push(...await getImportWorkspaceIndex().collectImportDiagnostics(document));
-    diagnostics.push(...await collectSemanticAnalysisDiagnostics(document));
+    const snapshot = await getWorkspaceGraph().buildSnapshotForDocument(document);
+    const node = snapshot.nodes[snapshot.rootFile];
+    if (node?.semantic) {
+        diagnostics.push(...collectSemanticAnalysisDiagnosticsFromSemantic(node.semantic, document));
+        if (node.model) {
+            diagnostics.push(...collectInspectModelDiagnostics(document, node.semantic, node.model, diagnostics));
+        }
+    }
     return diagnostics;
 }

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -1,5 +1,5 @@
 import {getParser, ParseError} from '../dsl/parser';
-import {inspectModel} from '../diagnostics';
+import {inspectModel, type ModelDiagnosticJson} from '../diagnostics';
 import type {FcstmSemanticDocument} from '../semantics';
 import {collectSemanticAnalysisDiagnosticsFromSemantic} from './analyzers';
 import {
@@ -72,22 +72,23 @@ export interface CollectInspectModelDiagnosticsOptions {
     rangeMode?: 'diagnostic' | 'issue';
 }
 
-export function collectInspectModelDiagnostics(
+export function collectInspectDiagnosticsFromItems(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
-    model: Parameters<typeof inspectModel>[0],
+    items: readonly ModelDiagnosticJson[],
     existingDiagnostics: FcstmDiagnostic[] = [],
     options: CollectInspectModelDiagnosticsOptions = {},
 ): FcstmDiagnostic[] {
     const existingCounts = new Map<string, number>();
     for (const diagnostic of existingDiagnostics) {
+        if (!diagnostic.code) continue;
         const key = diagnosticKey(diagnostic);
         existingCounts.set(key, (existingCounts.get(key) ?? 0) + 1);
     }
     const fullRange = fullDocumentRange(document);
     const diagnostics: FcstmDiagnostic[] = [];
 
-    for (const item of inspectModel(model).diagnostics) {
+    for (const item of items) {
         if (SUPPRESSED_FROM_INSPECT_SURFACE.has(item.code)) continue;
         const diagnostic: FcstmDiagnostic = {
             range: fullRange,
@@ -108,6 +109,22 @@ export function collectInspectModelDiagnostics(
     }
 
     return diagnostics;
+}
+
+export function collectInspectModelDiagnostics(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    model: Parameters<typeof inspectModel>[0],
+    existingDiagnostics: FcstmDiagnostic[] = [],
+    options: CollectInspectModelDiagnosticsOptions = {},
+): FcstmDiagnostic[] {
+    return collectInspectDiagnosticsFromItems(
+        document,
+        semantic,
+        inspectModel(model).diagnostics,
+        existingDiagnostics,
+        options,
+    );
 }
 
 export function convertParseErrorToDiagnostic(

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -25,6 +25,17 @@ export function diagnosticKey(diagnostic: FcstmDiagnostic): string {
     return JSON.stringify([diagnostic.code ?? null, diagnostic.data ?? null]);
 }
 
+function consumeDiagnosticCount(counts: Map<string, number>, key: string): boolean {
+    const count = counts.get(key) ?? 0;
+    if (count <= 0) return false;
+    if (count === 1) {
+        counts.delete(key);
+    } else {
+        counts.set(key, count - 1);
+    }
+    return true;
+}
+
 export function fullDocumentRange(document: TextDocumentLike): TextRange {
     const lastLine = Math.max(0, document.lineCount - 1);
     return createRange(0, 0, lastLine, document.lineAt(lastLine).text.length);
@@ -48,7 +59,11 @@ export function collectInspectModelDiagnostics(
     existingDiagnostics: FcstmDiagnostic[] = [],
     options: CollectInspectModelDiagnosticsOptions = {},
 ): FcstmDiagnostic[] {
-    const existing = new Set(existingDiagnostics.map(diagnosticKey));
+    const existingCounts = new Map<string, number>();
+    for (const diagnostic of existingDiagnostics) {
+        const key = diagnosticKey(diagnostic);
+        existingCounts.set(key, (existingCounts.get(key) ?? 0) + 1);
+    }
     const fullRange = fullDocumentRange(document);
     const diagnostics: FcstmDiagnostic[] = [];
 
@@ -68,7 +83,7 @@ export function collectInspectModelDiagnostics(
         diagnostic.range = rangeEquals(suggestedRange, fullRange)
             ? resolveRangeFromRefs(document, semantic, item.refs) ?? fullRange
             : suggestedRange;
-        if (existing.has(diagnosticKey(diagnostic))) continue;
+        if (consumeDiagnosticCount(existingCounts, diagnosticKey(diagnostic))) continue;
         diagnostics.push(diagnostic);
     }
 

--- a/editors/jsfcstm/src/editor/index.ts
+++ b/editors/jsfcstm/src/editor/index.ts
@@ -6,6 +6,7 @@ export * from './diagnostics';
 export * from './folding';
 export * from './formatter';
 export * from './hover';
+export * from './inspect-ranges';
 export * from './navigation';
 export * from './ranges';
 export * from './selection';

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -51,7 +51,7 @@ export function resolveRangeFromRefs(
     if (typeof refs !== 'object' || refs === null) return null;
     const refMap = refs as Record<string, unknown>;
 
-    for (const key of ['state_path', 'composite_path', 'parent_path']) {
+    for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path']) {
         const range = statePathRange(document, semantic, stringRef(refMap, key));
         if (range) return range;
     }

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -1,0 +1,74 @@
+import type {FcstmSemanticDocument} from '../semantics';
+import type {TextDocumentLike, TextRange} from '../utils/text';
+import {findIdentifierRange} from './ranges';
+import {resolveStatePath, spanLikeToRange, variableDefinitionRange} from './suggested-fixes';
+
+function stringRef(refs: Record<string, unknown>, key: string): string | null {
+    const value = refs[key];
+    return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function statePathRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    path: string | null,
+): TextRange | null {
+    if (!path || path === '[*]') return null;
+    const state = resolveStatePath(semantic, path);
+    return state ? findIdentifierRange(document, state.name, state.range) : null;
+}
+
+function eventRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    qualifiedName: string | null,
+): TextRange | null {
+    if (!qualifiedName) return null;
+    const event = semantic.events.find(item => item.identity.qualifiedName === qualifiedName);
+    if (!event) return null;
+    return findIdentifierRange(document, event.name, event.declarationAst?.range ?? event.range);
+}
+
+function arrayFirstRange(value: unknown): TextRange | null {
+    if (!Array.isArray(value)) return null;
+    for (const item of value) {
+        const range = spanLikeToRange(item);
+        if (range) return range;
+    }
+    return null;
+}
+
+/**
+ * Resolve inspect diagnostic refs into the best source range available in the
+ * editor semantic document. Returning null lets callers fall back to a full
+ * document range, which keeps anchor-less inspect diagnostics visible.
+ */
+export function resolveRangeFromRefs(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    refs: unknown,
+): TextRange | null {
+    if (typeof refs !== 'object' || refs === null) return null;
+    const refMap = refs as Record<string, unknown>;
+
+    for (const key of ['state_path', 'composite_path', 'parent_path']) {
+        const range = statePathRange(document, semantic, stringRef(refMap, key));
+        if (range) return range;
+    }
+
+    const variableName = stringRef(refMap, 'var_name');
+    if (variableName) {
+        const range = variableDefinitionRange(document, semantic, variableName);
+        if (range) return range;
+    }
+
+    const resolvedEventRange = eventRange(document, semantic, stringRef(refMap, 'event_qualified_name'));
+    if (resolvedEventRange) return resolvedEventRange;
+
+    for (const key of ['transition_span', 'guard_span']) {
+        const range = spanLikeToRange(refMap[key]);
+        if (range) return range;
+    }
+
+    return arrayFirstRange(refMap.duplicate_spans);
+}

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -81,7 +81,7 @@ function statementDeleteRange(document: TextDocumentLike, statement: FcstmAstAss
     return statement.range;
 }
 
-function variableDefinitionRange(
+export function variableDefinitionRange(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
     varName: string,
@@ -96,7 +96,7 @@ function variableDefinitionRange(
     return variable.range;
 }
 
-function resolveStatePath(semantic: FcstmSemanticDocument, statePath: string) {
+export function resolveStatePath(semantic: FcstmSemanticDocument, statePath: string) {
     return semantic.states.find(item => item.identity.qualifiedName === statePath);
 }
 
@@ -264,7 +264,7 @@ function effectSelfAssignRange(
     return matches.length === 1 ? matches[0] : null;
 }
 
-function spanLikeToRange(value: unknown): TextRange | null {
+export function spanLikeToRange(value: unknown): TextRange | null {
     if (typeof value !== 'object' || value === null) return null;
     const obj = value as Record<string, unknown>;
     const start = obj.start as Record<string, unknown> | undefined;

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -593,6 +593,118 @@ describe('jsfcstm analyzers and code actions', () => {
         );
     });
 
+    it('does not let forged client diagnostic ranges unlock current suggested fixes', async () => {
+        const text = [
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-forged-real-key-range.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const deadlockDiagnostic = diagnostics.find(item => item.code === 'W_DEADLOCK_LEAF');
+        assert.ok(deadlockDiagnostic, `expected W_DEADLOCK_LEAF, got ${JSON.stringify(diagnostics)}`);
+        const forgedDiagnostic = {
+            ...deadlockDiagnostic,
+            range: rangeOf(text, 'Root'),
+        };
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            forgedDiagnostic.range,
+            [forgedDiagnostic],
+        );
+        assert.equal(
+            actions.some(item => /exit transition/.test(item.title)),
+            false,
+        );
+    });
+
+    it('keeps current suggested fixes available when client diagnostics omit suggested-fix payloads', async () => {
+        const text = [
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n');
+        const filePath = '/tmp/suggested-stripped-client-payload.fcstm';
+        const document = createDocument(text, filePath);
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const deadlockDiagnostic = diagnostics.find(item => item.code === 'W_DEADLOCK_LEAF');
+        assert.ok(deadlockDiagnostic, `expected W_DEADLOCK_LEAF, got ${JSON.stringify(diagnostics)}`);
+        const strippedDiagnostic = {
+            ...deadlockDiagnostic,
+            data: {...deadlockDiagnostic.data},
+        };
+        delete strippedDiagnostic.data.suggested_fix;
+        assert.equal(
+            packageModule.diagnosticKey(deadlockDiagnostic),
+            packageModule.diagnosticKey(strippedDiagnostic),
+        );
+
+        const actions = await packageModule.collectCodeActions(
+            document,
+            strippedDiagnostic.range,
+            [strippedDiagnostic],
+        );
+        assert.equal(
+            actions.some(item => /exit transition/.test(item.title)),
+            true,
+        );
+    });
+
+    it('keys diagnostics by stable identity refs instead of suggested-fix payload details', () => {
+        const first = {
+            range: packageModule.createRange(0, 0, 0, 1),
+            message: 'first',
+            severity: 'warning' as const,
+            source: 'fcstm',
+            code: 'W_DEADLOCK_LEAF',
+            data: {
+                state_path: 'Root.Idle',
+                parent_path: 'Root',
+                reason: 'no_outgoing_transition',
+                suggested_fix: {
+                    kind: 'insert',
+                    target: 'deadlock_leaf_exit_transition',
+                    anchor: {type: 'ref', ref: 'refs.parent_path'},
+                    text: 'Idle -> [*];\n',
+                    rationale: 'Add old text.',
+                },
+            },
+        };
+        const second = {
+            range: packageModule.createRange(3, 0, 3, 1),
+            message: 'second',
+            severity: 'warning' as const,
+            source: 'fcstm',
+            code: 'W_DEADLOCK_LEAF',
+            data: {
+                suggested_fix: {
+                    rationale: 'Add new text.',
+                    text: 'Idle -> [*];\n',
+                    anchor: {ref: 'refs.parent_path', type: 'ref'},
+                    target: 'deadlock_leaf_exit_transition',
+                    kind: 'insert',
+                },
+                reason: 'no_outgoing_transition',
+                parent_path: 'Root',
+                state_path: 'Root.Idle',
+            },
+        };
+        const differentState = {
+            ...second,
+            data: {
+                ...second.data,
+                state_path: 'Root.Other',
+            },
+        };
+
+        assert.equal(packageModule.diagnosticKey(first), packageModule.diagnosticKey(second));
+        assert.notEqual(packageModule.diagnosticKey(first), packageModule.diagnosticKey(differentState));
+    });
+
     it('does not offer declaration delete when duplicate variables make the occurrence ambiguous', async () => {
         const text = [
             'def int x = 0;',
@@ -775,6 +887,27 @@ describe('jsfcstm analyzers and code actions', () => {
             initialDiagnostics,
         );
         assert.ok(guardedInitialActions.some(item => /fallback entry transition/.test(item.title)));
+    });
+
+    it('provides design-health insert actions from published diagnostic ranges', async () => {
+        const deadlockText = [
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n');
+        const deadlockPath = '/tmp/editor-design-deadlock-published-range.fcstm';
+        const deadlockDocument = createDocument(deadlockText, deadlockPath);
+        const deadlockDiagnostics = await packageModule.collectDocumentDiagnostics(deadlockDocument);
+        const deadlockDiagnostic = deadlockDiagnostics.find(item => item.code === 'W_DEADLOCK_LEAF');
+        assert.ok(deadlockDiagnostic, `expected W_DEADLOCK_LEAF, got ${JSON.stringify(deadlockDiagnostics)}`);
+
+        const actions = await packageModule.collectCodeActions(
+            deadlockDocument,
+            deadlockDiagnostic.range,
+            [deadlockDiagnostic],
+        );
+        assert.ok(actions.some(item => /exit transition/.test(item.title)));
     });
 
     it('plans synthetic suggested-fix replace edits from span-backed diagnostic payloads', async () => {

--- a/editors/jsfcstm/test/analyzers-code-actions.test.ts
+++ b/editors/jsfcstm/test/analyzers-code-actions.test.ts
@@ -709,7 +709,7 @@ describe('jsfcstm analyzers and code actions', () => {
         await assertParses(initialUpdated, initialPath);
     });
 
-    it('provides design-health suggested-fix actions without prepublished diagnostics', async () => {
+    it('provides design-health suggested-fix actions from published inspect diagnostics', async () => {
         const text = [
             'def int unused = 0;',
             'def int driver = 0;',
@@ -725,7 +725,7 @@ describe('jsfcstm analyzers and code actions', () => {
         const diagnostics = await packageModule.collectDocumentDiagnostics(document);
         assert.equal(
             diagnostics.some(item => item.code === 'W_UNREFERENCED_VAR' || item.code === 'W_DEADLOCK_LEAF'),
-            false,
+            true,
         );
 
         const actions = await packageModule.collectCodeActions(

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -621,6 +621,8 @@ state Root {
             assert.deepEqual(constFalse!.refs, {
                 transition_span: null,
                 folded_value: false,
+                from_path: 'Root.Active',
+                to_path: 'Root.Blocked',
             });
 
             const unreachable = report.diagnostics.find(d => d.code === 'W_UNREACHABLE_STATE');
@@ -681,18 +683,43 @@ state Root {
 `));
             const constTrue = report.diagnostics.filter(d => d.code === 'W_GUARD_CONST_TRUE');
             assert.equal(constTrue.length, 4);
-            for (const item of constTrue) {
-                assert.deepEqual(item.refs, {
-                    transition_span: null,
-                    folded_value: true,
-                });
-            }
+            assert.deepEqual(
+                constTrue.map(item => item.refs).sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))),
+                [
+                    {
+                        transition_span: null,
+                        folded_value: true,
+                        from_path: 'Root.Blocked',
+                        to_path: 'Root.WideTrue',
+                    },
+                    {
+                        transition_span: null,
+                        folded_value: true,
+                        from_path: 'Root.Idle',
+                        to_path: 'Root.Active',
+                    },
+                    {
+                        transition_span: null,
+                        folded_value: true,
+                        from_path: 'Root.ModuloTrue',
+                        to_path: 'Root.PowerTrue',
+                    },
+                    {
+                        transition_span: null,
+                        folded_value: true,
+                        from_path: 'Root.WideTrue',
+                        to_path: 'Root.ModuloTrue',
+                    },
+                ].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))),
+            );
 
             const constFalse = report.diagnostics.find(d => d.code === 'W_GUARD_CONST_FALSE');
             assert.ok(constFalse);
             assert.deepEqual(constFalse!.refs, {
                 transition_span: null,
                 folded_value: false,
+                from_path: 'Root.Active',
+                to_path: 'Root.Blocked',
             });
 
             const duringRefs = report.diagnostics

--- a/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
+++ b/editors/jsfcstm/test/diagnostics-showcase-demos.test.ts
@@ -361,6 +361,10 @@ function tallyCodes(codes: Array<string | undefined>): Map<string, number> {
     return tally;
 }
 
+function isInspectSurfaceSideEffect(code: string): boolean {
+    return code.startsWith('W_') || code.startsWith('I_');
+}
+
 function consumeOne(tally: Map<string, number>, code: string): boolean {
     const n = tally.get(code) ?? 0;
     if (n === 0) return false;
@@ -427,14 +431,17 @@ describe('diagnostics showcase: jsfcstm collectDocumentDiagnostics parity', () =
 
             // 3. Anything left over after consuming mustFire entries
             //    must be a declared side effect (or a leftover instance
-            //    of a mustFire code, which is also fine).
+            //    of a mustFire code, which is also fine). The editor
+            //    surface also includes inspectModel W/I design-health
+            //    diagnostics, so W_/I_ leftovers are allowed unless the
+            //    fixture explicitly lists them under mustNotFire.
             const allowedExtras = new Set<string>([
                 ...fixture.mustFire,
                 ...(fixture.sideEffects ?? []),
             ]);
             for (const code of tally.keys()) {
                 assert.ok(
-                    allowedExtras.has(code),
+                    allowedExtras.has(code) || isInspectSurfaceSideEffect(code),
                     `${fixture.name} emitted unexpected code ${code} (declared mustFire=[${fixture.mustFire.join(', ')}], sideEffects=[${(fixture.sideEffects ?? []).join(', ')}])`,
                 );
             }

--- a/editors/jsfcstm/test/imports.test.ts
+++ b/editors/jsfcstm/test/imports.test.ts
@@ -228,9 +228,15 @@ describe('jsfcstm import workspace support', () => {
             + '}\n',
             hostFile,
         );
-        // Successful import should produce no diagnostics on either end.
+        // Successful import should produce no blocking import/semantic errors.
+        // collectDocumentDiagnostics also surfaces inspectModel W/I
+        // design-health diagnostics, so warnings are no longer evidence of
+        // import failure.
         const diagnostics = await packageModule.collectDocumentDiagnostics(document);
-        assert.deepEqual(diagnostics, [],
-            `expected clean import, got ${JSON.stringify(diagnostics)}`);
+        assert.deepEqual(
+            diagnostics.filter(item => item.severity === 'error'),
+            [],
+            `expected clean import, got ${JSON.stringify(diagnostics)}`,
+        );
     });
 });

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -413,6 +413,40 @@ state Root {
         assert.ok(diagnostics.every(item => item.source === 'fcstm'));
     });
 
+    it('does not let unkeyed existing diagnostics consume inspect diagnostics', async () => {
+        const text = `
+state Root {
+    state Idle;
+    [*] -> Idle;
+}
+`;
+        const {document, semantic} = await semanticFor(text, '/tmp/unkeyed-existing-diagnostic.fcstm');
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(
+            document,
+            semantic,
+            [{
+                code: 'W_DEADLOCK_LEAF',
+                severity: 'warning' as const,
+                message: 'Leaf state has no outgoing transition.',
+                span: null,
+                refs: {
+                    state_path: 'Root.Idle',
+                    parent_path: 'Root',
+                    reason: 'no_outgoing_transition',
+                },
+            }],
+            [{
+                range: packageModule.createRange(0, 0, 0, 1),
+                message: 'Parser diagnostic without a stable code.',
+                severity: 'error' as const,
+                source: 'fcstm',
+            }],
+        );
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(diagnostics[0].code, 'W_DEADLOCK_LEAF');
+    });
+
     it('tolerates workspace snapshots without root node data', async () => {
         const text = `
 state Root;

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-import {createDocument, packageModule} from './support';
+import {createDocument, packageModule, withPatchedProperty} from './support';
 
 const SUPPRESSED_FROM_INSPECT_SURFACE = new Set([
     'W_UNREACHABLE_STATE',
@@ -207,6 +207,82 @@ describe('editor inspect diagnostics surface parity', () => {
         }
     });
 
+    it('surfaces inspect diagnostics without suggested fixes, including W_WRITE_ONLY_VAR', async () => {
+        const text = `
+def int write_only = 0;
+state Root {
+    state Idle { enter { write_only = 1; } }
+    [*] -> Idle;
+}
+`;
+        const document = createDocument(text, '/tmp/synthetic-write-only.fcstm');
+        const inspectModule = await import('../dist/diagnostics/inspect');
+
+        await withPatchedProperty(inspectModule, 'inspectModel', (() => ({
+            root_state_path: 'Root',
+            states: [],
+            transitions: [],
+            variables: [],
+            events: [],
+            actions: [],
+            forced_transitions: [],
+            metrics: {
+                n_states_leaf: 0,
+                n_states_composite: 0,
+                n_states_pseudo: 0,
+                max_hierarchy_depth: 0,
+                n_transitions_normal: 0,
+                n_transitions_forced: 0,
+                n_events: 0,
+                n_variables: 0,
+                var_to_leaf_ratio: 0,
+                aspect_coverage: {},
+                abstract_action_inventory: [],
+            },
+            reachability_graph: {},
+            event_emission_map: {},
+            var_dataflow: {},
+            aspect_impact_map: {},
+            action_ref_graph: {},
+            diagnostics: [{
+                code: 'W_WRITE_ONLY_VAR',
+                severity: 'warning',
+                message: 'Synthetic write-only variable diagnostic.',
+                span: null,
+                refs: {
+                    var_name: 'write_only',
+                    written_states: ['Root.Idle'],
+                },
+            }],
+        })) as typeof inspectModule.inspectModel, async () => {
+            const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+            const diagnostic = diagnostics.find(item => item.code === 'W_WRITE_ONLY_VAR');
+            assert.ok(diagnostic, 'expected W_WRITE_ONLY_VAR to be surfaced');
+            assert.equal(diagnostic.data?.var_name, 'write_only');
+            assert.equal(
+                document.lineAt(diagnostic.range.start.line).text.includes('def int write_only = 0;'),
+                true,
+            );
+        });
+    });
+
+    it('keeps the async semantic analyzer wrapper aligned with the shared implementation', async () => {
+        const text = `
+state Root {
+    event Unused;
+    state Idle;
+    [*] -> Idle;
+}
+`;
+        const document = createDocument(text, '/tmp/semantic-wrapper.fcstm');
+        const diagnostics = await packageModule.collectSemanticAnalysisDiagnostics(document);
+
+        assert.ok(
+            diagnostics.some(item => item.code === 'W_UNUSED_EVENT'),
+            'expected the async wrapper to reuse semantic analyzer diagnostics',
+        );
+    });
+
     it('resolves representative inspect refs to editor source ranges', async () => {
         const text = `
 def int counter = 0;
@@ -245,5 +321,10 @@ state Root {
             packageModule.resolveRangeFromRefs(document, semantic, {transition_span: null, duplicate_spans: [duplicateRange]}),
             duplicateRange,
         );
+        assert.equal(
+            packageModule.resolveRangeFromRefs(document, semantic, {duplicate_spans: ['not-a-range']}),
+            null,
+        );
+        assert.equal(packageModule.resolveRangeFromRefs(document, semantic, null), null);
     });
 });

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -350,6 +350,44 @@ state Root {
         ]);
     });
 
+    it('keeps same-endpoint inspect-only folded false guards when a literal false guard exists', async () => {
+        const text = `
+state Root {
+    state Idle;
+    state Blocked;
+    [*] -> Idle;
+    Idle -> Blocked : if [false];
+    Idle -> Blocked : if [1 == 2];
+}
+`;
+        const filePath = '/tmp/same-endpoint-mixed-false-guards.fcstm';
+        const diagnostics = await packageModule.collectDocumentDiagnostics(
+            createDocument(text, filePath),
+        );
+        const guardRefs = diagnostics
+            .filter(item => item.code === 'W_GUARD_CONST_FALSE')
+            .map(item => item.data);
+
+        assert.deepEqual(guardRefs, [
+            {
+                transition_span: null,
+                folded_value: false,
+                from_path: 'Root.Idle',
+                to_path: 'Root.Blocked',
+            },
+            {
+                transition_span: null,
+                folded_value: false,
+                from_path: 'Root.Idle',
+                to_path: 'Root.Blocked',
+            },
+        ]);
+        assertBagCovers(
+            await editorDiagnosticKeys(text, filePath),
+            await inspectDiagnosticKeys(text, filePath),
+        );
+    });
+
     it('keeps the async semantic analyzer wrapper aligned with the shared implementation', async () => {
         const text = `
 state Root {

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -4,7 +4,6 @@ import {createDocument, packageModule, withPatchedProperty} from './support';
 
 const SUPPRESSED_FROM_INSPECT_SURFACE = new Set([
     'W_UNREACHABLE_STATE',
-    'W_GUARD_CONST_FALSE',
     'W_UNUSED_EVENT',
 ]);
 
@@ -34,6 +33,18 @@ state Root {
     }
     [*] -> Idle;
     Idle -> [*] : if [stable > 0];
+}
+`,
+    },
+    {
+        name: 'constant false guard expression',
+        code: 'W_GUARD_CONST_FALSE',
+        text: `
+state Root {
+    state Idle;
+    state Blocked;
+    [*] -> Idle;
+    Idle -> Blocked : if [1 == 2];
 }
 `,
     },
@@ -266,6 +277,42 @@ state Root {
         });
     });
 
+    it('deduplicates editor-covered literal false guards while keeping inspect-only const folds', async () => {
+        const literalFalse = `
+state Root {
+    state Idle;
+    state Blocked;
+    [*] -> Idle;
+    Idle -> Blocked : if [false];
+}
+`;
+        const literalDiagnostics = await packageModule.collectDocumentDiagnostics(
+            createDocument(literalFalse, '/tmp/literal-false-guard.fcstm'),
+        );
+        assert.equal(
+            literalDiagnostics.filter(item => item.code === 'W_GUARD_CONST_FALSE').length,
+            1,
+        );
+
+        const foldedFalse = `
+state Root {
+    state Idle;
+    state Blocked;
+    [*] -> Idle;
+    Idle -> Blocked : if [1 == 2];
+}
+`;
+        const foldedDiagnostics = await packageModule.collectDocumentDiagnostics(
+            createDocument(foldedFalse, '/tmp/folded-false-guard.fcstm'),
+        );
+        const folded = foldedDiagnostics.find(item => item.code === 'W_GUARD_CONST_FALSE');
+        assert.ok(folded, 'expected inspect-only constant false guard diagnostic');
+        assert.deepEqual(folded.data, {
+            transition_span: null,
+            folded_value: false,
+        });
+    });
+
     it('keeps the async semantic analyzer wrapper aligned with the shared implementation', async () => {
         const text = `
 state Root {
@@ -325,6 +372,16 @@ state Root {
         assert.equal(document.lineAt(stateRange!.start.line).text.slice(
             stateRange!.start.character,
             stateRange!.end.character,
+        ), 'Idle');
+
+        const fromPathRange = packageModule.resolveRangeFromRefs(document, semantic, {
+            from_path: 'Root.Idle',
+            to_path: 'Root.Done',
+            transition_span: null,
+        });
+        assert.equal(document.lineAt(fromPathRange!.start.line).text.slice(
+            fromPathRange!.start.character,
+            fromPathRange!.end.character,
         ), 'Idle');
 
         const variableRange = packageModule.resolveRangeFromRefs(document, semantic, {var_name: 'counter'});

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -283,6 +283,29 @@ state Root {
         );
     });
 
+    it('returns parse diagnostics without requiring a semantic snapshot', async () => {
+        const document = createDocument('state Root {', '/tmp/parse-only.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+
+        assert.ok(diagnostics.length > 0, 'expected parser diagnostics for malformed input');
+        assert.ok(diagnostics.every(item => item.source === 'fcstm'));
+    });
+
+    it('tolerates workspace snapshots without root node data', async () => {
+        const text = `
+state Root;
+`;
+        const document = createDocument(text, '/tmp/no-semantic-snapshot.fcstm');
+        const graph = packageModule.getWorkspaceGraph();
+
+        await withPatchedProperty(graph, 'buildSnapshotForDocument', (async () => ({
+            rootFile: document.filePath,
+            nodes: {},
+        })) as typeof graph.buildSnapshotForDocument, async () => {
+            assert.deepEqual(await packageModule.collectDocumentDiagnostics(document), []);
+        });
+    });
+
     it('resolves representative inspect refs to editor source ranges', async () => {
         const text = `
 def int counter = 0;
@@ -326,5 +349,32 @@ state Root {
             null,
         );
         assert.equal(packageModule.resolveRangeFromRefs(document, semantic, null), null);
+    });
+
+    it('resolves missing and implicit event refs without requiring declarations', async () => {
+        const text = `
+state Root {
+    state Idle;
+    state Done;
+    [*] -> Idle;
+    Idle -> Done :: Tick;
+}
+`;
+        const {document, semantic} = await semanticFor(text, '/tmp/implicit-event-ranges.fcstm');
+
+        assert.equal(
+            packageModule.resolveRangeFromRefs(document, semantic, {event_qualified_name: 'Root.Missing'}),
+            null,
+        );
+        const implicitEventRange = packageModule.resolveRangeFromRefs(
+            document,
+            semantic,
+            {event_qualified_name: 'Root.Idle.Tick'},
+        );
+        assert.ok(implicitEventRange, 'expected implicit transition event range');
+        assert.equal(document.lineAt(implicitEventRange.start.line).text.slice(
+            implicitEventRange.start.character,
+            implicitEventRange.end.character,
+        ), 'Tick');
     });
 });

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -1,0 +1,249 @@
+import assert from 'node:assert/strict';
+
+import {createDocument, packageModule} from './support';
+
+const SUPPRESSED_FROM_INSPECT_SURFACE = new Set([
+    'W_UNREACHABLE_STATE',
+    'W_GUARD_CONST_FALSE',
+    'W_UNUSED_EVENT',
+]);
+
+const TARGETED_FIXTURES: Array<{name: string; code: string; text: string}> = [
+    {
+        name: 'unwritten read variable',
+        code: 'W_UNWRITTEN_READ_VAR',
+        text: `
+def int source = 0;
+def int guard_value = 0;
+state Root {
+    state Idle { during { guard_value = source + 1; } }
+    state Done;
+    [*] -> Idle;
+    Idle -> Done : if [guard_value > 0];
+}
+`,
+    },
+    {
+        name: 'constant during assignment',
+        code: 'W_DURING_CONST_ASSIGN',
+        text: `
+def int stable = 0;
+state Root {
+    state Idle {
+        during { stable = 20; }
+    }
+    [*] -> Idle;
+    Idle -> [*] : if [stable > 0];
+}
+`,
+    },
+    {
+        name: 'eventless unguarded transition info',
+        code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+        text: `
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B;
+}
+`,
+    },
+    {
+        name: 'large composite',
+        code: 'W_LARGE_COMPOSITE',
+        text: `
+state Root {
+    state S1 {
+        state S2 {
+            state S3 {
+                state S4 {
+                    state S5 {
+                        state S6 {
+                            state S7;
+                            [*] -> S7;
+                        }
+                        [*] -> S6;
+                    }
+                    [*] -> S5;
+                }
+                [*] -> S4;
+            }
+            [*] -> S3;
+        }
+        [*] -> S2;
+    }
+    state A2;
+    state A3;
+    state A4;
+    state A5;
+    state A6;
+    state A7;
+    state A8;
+    state A9;
+    state A10;
+    state A11;
+    state A12;
+    state A13;
+    [*] -> S1;
+}
+`,
+    },
+    {
+        name: 'deep hierarchy',
+        code: 'W_DEEP_HIERARCHY',
+        text: `
+state Root {
+    state S1 {
+        state S2 {
+            state S3 {
+                state S4 {
+                    state S5 {
+                        state S6 {
+                            state S7;
+                            [*] -> S7;
+                        }
+                        [*] -> S6;
+                    }
+                    [*] -> S5;
+                }
+                [*] -> S4;
+            }
+            [*] -> S3;
+        }
+        [*] -> S2;
+    }
+    [*] -> S1;
+}
+`,
+    },
+    {
+        name: 'literal type narrowing',
+        code: 'W_LITERAL_TYPE_NARROWING',
+        text: `
+def int truncated = 3.5;
+state Root {
+    state A;
+    [*] -> A;
+}
+`,
+    },
+];
+
+function isInspectSurfaceCode(code: unknown): code is string {
+    return typeof code === 'string' && (code.startsWith('W_') || code.startsWith('I_'));
+}
+
+function stableKey(code: string, refs: unknown): string {
+    return JSON.stringify([code, refs ?? null]);
+}
+
+async function inspectDiagnosticKeys(text: string, filePath: string): Promise<string[]> {
+    const document = createDocument(text, filePath);
+    const ast = await packageModule.parseAstDocument(document);
+    const model = packageModule.buildStateMachineModel(ast);
+    assert.ok(model, 'expected state-machine model');
+    return packageModule.inspectModel(model).diagnostics
+        .filter(item => isInspectSurfaceCode(item.code))
+        .filter(item => !SUPPRESSED_FROM_INSPECT_SURFACE.has(item.code))
+        .map(item => stableKey(item.code, item.refs))
+        .sort();
+}
+
+async function editorDiagnosticKeys(text: string, filePath: string): Promise<string[]> {
+    const document = createDocument(text, filePath);
+    const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+    return diagnostics
+        .filter(item => isInspectSurfaceCode(item.code))
+        .map(item => stableKey(item.code as string, item.data ?? null))
+        .sort();
+}
+
+function assertBagCovers(actualKeys: string[], expectedKeys: string[]): void {
+    const remaining = new Map<string, number>();
+    for (const key of actualKeys) {
+        remaining.set(key, (remaining.get(key) ?? 0) + 1);
+    }
+
+    const missing: string[] = [];
+    for (const key of expectedKeys) {
+        const count = remaining.get(key) ?? 0;
+        if (count <= 0) {
+            missing.push(key);
+            continue;
+        }
+        remaining.set(key, count - 1);
+    }
+
+    assert.deepEqual(missing, []);
+}
+
+async function semanticFor(text: string, filePath: string) {
+    const document = createDocument(text, filePath);
+    const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+    assert.ok(semantic, 'expected semantic document');
+    return {document, semantic};
+}
+
+describe('editor inspect diagnostics surface parity', () => {
+    for (const fixture of TARGETED_FIXTURES) {
+        it(`surfaces ${fixture.code} from ${fixture.name}`, async () => {
+            const document = createDocument(fixture.text, `/tmp/${fixture.code}.fcstm`);
+            const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+            assert.ok(
+                diagnostics.some(item => item.code === fixture.code),
+                `expected collectDocumentDiagnostics to surface ${fixture.code}`,
+            );
+        });
+    }
+
+    it('covers inspectModel W/I code+refs bag except deduped editor-analyzer codes', async () => {
+        for (const fixture of TARGETED_FIXTURES) {
+            const filePath = `/tmp/parity-${fixture.code}.fcstm`;
+            assertBagCovers(
+                await editorDiagnosticKeys(fixture.text, filePath),
+                await inspectDiagnosticKeys(fixture.text, filePath),
+            );
+        }
+    });
+
+    it('resolves representative inspect refs to editor source ranges', async () => {
+        const text = `
+def int counter = 0;
+state Root {
+    event Tick;
+    state Idle;
+    state Done;
+    [*] -> Idle;
+    Idle -> Done : Tick;
+}
+`;
+        const {document, semantic} = await semanticFor(text, '/tmp/inspect-ranges.fcstm');
+        const transitionRange = packageModule.createRange(6, 4, 6, 24);
+        const duplicateRange = packageModule.createRange(3, 10, 3, 14);
+
+        const stateRange = packageModule.resolveRangeFromRefs(document, semantic, {state_path: 'Root.Idle'});
+        assert.equal(document.lineAt(stateRange!.start.line).text.slice(
+            stateRange!.start.character,
+            stateRange!.end.character,
+        ), 'Idle');
+
+        const variableRange = packageModule.resolveRangeFromRefs(document, semantic, {var_name: 'counter'});
+        assert.equal(document.lineAt(variableRange!.start.line).text.includes('def int counter = 0;'), true);
+
+        const eventRange = packageModule.resolveRangeFromRefs(document, semantic, {event_qualified_name: 'Root.Tick'});
+        assert.equal(document.lineAt(eventRange!.start.line).text.slice(
+            eventRange!.start.character,
+            eventRange!.end.character,
+        ), 'Tick');
+
+        assert.deepEqual(
+            packageModule.resolveRangeFromRefs(document, semantic, {transition_span: transitionRange}),
+            transitionRange,
+        );
+        assert.deepEqual(
+            packageModule.resolveRangeFromRefs(document, semantic, {transition_span: null, duplicate_spans: [duplicateRange]}),
+            duplicateRange,
+        );
+    });
+});

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -310,7 +310,44 @@ state Root {
         assert.deepEqual(folded.data, {
             transition_span: null,
             folded_value: false,
+            from_path: 'Root.Idle',
+            to_path: 'Root.Blocked',
         });
+    });
+
+    it('keeps inspect-only folded false guards when literal false guards share the file', async () => {
+        const text = `
+state Root {
+    state Idle;
+    state LiteralBlocked;
+    state FoldedBlocked;
+    [*] -> Idle;
+    Idle -> LiteralBlocked : if [false];
+    Idle -> FoldedBlocked : if [1 == 2];
+}
+`;
+        const diagnostics = await packageModule.collectDocumentDiagnostics(
+            createDocument(text, '/tmp/mixed-false-guards.fcstm'),
+        );
+        const guardRefs = diagnostics
+            .filter(item => item.code === 'W_GUARD_CONST_FALSE')
+            .map(item => item.data)
+            .sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)));
+
+        assert.deepEqual(guardRefs, [
+            {
+                transition_span: null,
+                folded_value: false,
+                from_path: 'Root.Idle',
+                to_path: 'Root.FoldedBlocked',
+            },
+            {
+                transition_span: null,
+                folded_value: false,
+                from_path: 'Root.Idle',
+                to_path: 'Root.LiteralBlocked',
+            },
+        ]);
     });
 
     it('keeps the async semantic analyzer wrapper aligned with the shared implementation', async () => {

--- a/editors/jsfcstm/test/lsp.test.ts
+++ b/editors/jsfcstm/test/lsp.test.ts
@@ -67,10 +67,13 @@ describe('jsfcstm lsp core', () => {
         const hostText = [
             'def int counter = 0;',
             'state Root {',
+            '    event Done;',
             '    import "./worker.fcstm" as Worker;',
             '    [*] -> Worker;',
+            '    Worker -> [*] : Done;',
             '}',
         ].join('\n');
+        const importLine = 3;
 
         const publications: packageModule.FcstmPublishedDiagnostics[] = [];
         const core = new packageModule.FcstmLanguageServerCore({
@@ -100,7 +103,7 @@ describe('jsfcstm lsp core', () => {
         assert.ok(triggerCharacters.includes('_'));
         assert.ok(initializeResult.capabilities.semanticTokensProvider?.legend.tokenTypes.includes('class'));
         assert.equal(publications.length, 1);
-        assert.deepEqual(publications[0].diagnostics, []);
+        assert.deepEqual(publications[0].diagnostics.map(item => item.code), ['W_UNREFERENCED_VAR']);
 
         const symbols = await core.provideDocumentSymbols(toUri(hostFile));
         assert.equal(symbols[0]?.name, 'counter');
@@ -126,32 +129,32 @@ describe('jsfcstm lsp core', () => {
         assert.match(keywordHoverContent?.value || '', /State Definition/);
 
         const definition = await core.provideDefinition(toUri(hostFile), {
-            line: 2,
+            line: importLine,
             character: 15,
         });
         assert.equal(definition?.[0]?.uri, toUri(workerFile));
 
         const references = await core.provideReferences(toUri(hostFile), {
-            line: 2,
-            character: hostText.split('\n')[2].indexOf('Worker') + 1,
+            line: importLine,
+            character: hostText.split('\n')[importLine].indexOf('Worker') + 1,
         }, true);
         assert.ok(references.length >= 1);
 
         const highlights = await core.provideDocumentHighlights(toUri(hostFile), {
-            line: 2,
-            character: hostText.split('\n')[2].indexOf('Worker') + 1,
+            line: importLine,
+            character: hostText.split('\n')[importLine].indexOf('Worker') + 1,
         });
         assert.ok(highlights.length >= 1);
 
         const renameRange = await core.providePrepareRename(toUri(hostFile), {
-            line: 2,
-            character: hostText.split('\n')[2].indexOf('Worker') + 1,
+            line: importLine,
+            character: hostText.split('\n')[importLine].indexOf('Worker') + 1,
         });
         assert.ok(renameRange);
 
         const renameEdit = await core.provideRename(toUri(hostFile), {
-            line: 2,
-            character: hostText.split('\n')[2].indexOf('Worker') + 1,
+            line: importLine,
+            character: hostText.split('\n')[importLine].indexOf('Worker') + 1,
         }, 'Motor');
         assert.ok(Object.values(renameEdit?.changes || {}).flat().length >= 1);
 
@@ -160,15 +163,15 @@ describe('jsfcstm lsp core', () => {
         assert.equal(links[0].target, toUri(workerFile));
 
         const foldingRanges = await core.provideFoldingRanges(toUri(hostFile));
-        assert.ok(foldingRanges.some(item => item.startLine === 1 && item.endLine === 4));
+        assert.ok(foldingRanges.some(item => item.startLine === 1 && item.endLine === 6));
 
         const selectionRanges = await core.provideSelectionRanges(toUri(hostFile), [{
-            line: 2,
-            character: hostText.split('\n')[2].indexOf('Worker') + 1,
+            line: importLine,
+            character: hostText.split('\n')[importLine].indexOf('Worker') + 1,
         }]);
         assert.deepEqual(selectionRanges[0]?.range, {
-            start: {line: 2, character: hostText.split('\n')[2].indexOf('Worker')},
-            end: {line: 2, character: hostText.split('\n')[2].indexOf('Worker') + 'Worker'.length},
+            start: {line: importLine, character: hostText.split('\n')[importLine].indexOf('Worker')},
+            end: {line: importLine, character: hostText.split('\n')[importLine].indexOf('Worker') + 'Worker'.length},
         });
         assert.ok(selectionRanges[0]?.parent);
 
@@ -254,13 +257,14 @@ describe('jsfcstm lsp core', () => {
             },
         });
 
-        await core.openTextDocument(makeTextDocumentItem(hostFile, 'state Root;'));
+        const cleanText = 'state Root { event Done; state Idle; [*] -> Idle; Idle -> [*] : Done; }';
+        await core.openTextDocument(makeTextDocumentItem(hostFile, cleanText));
         assert.equal(publications.length, 1);
 
         await core.changeTextDocument(toUri(hostFile), 2, [{text: 'state Root'}]);
         assert.equal(scheduler.size(), 1);
 
-        await core.changeTextDocument(toUri(hostFile), 3, [{text: 'state Root;'}]);
+        await core.changeTextDocument(toUri(hostFile), 3, [{text: cleanText}]);
         assert.equal(scheduler.size(), 1);
 
         await scheduler.flushAll();

--- a/pyfcstm/diagnostics/analyzers/const_fold.py
+++ b/pyfcstm/diagnostics/analyzers/const_fold.py
@@ -259,8 +259,25 @@ def _guard_const_diagnostic(transition, value: bool) -> ModelDiagnostic:
             f'Transition {source_label!r} -> {target_label!r} '
             f'has a guard that is statically {label}.'
         ),
-        refs={'transition_span': None, 'folded_value': value},
+        refs={
+            'transition_span': None,
+            'folded_value': value,
+            'from_path': _transition_endpoint_path(transition, is_source=True),
+            'to_path': _transition_endpoint_path(transition, is_source=False),
+        },
     )
+
+
+def _transition_endpoint_path(transition, *, is_source: bool) -> str:
+    from ...dsl import EXIT_STATE, INIT_STATE
+
+    endpoint = transition.from_state if is_source else transition.to_state
+    if endpoint is INIT_STATE or endpoint is EXIT_STATE:
+        return '[*]'
+    parent = transition.parent
+    if parent is None:  # pragma: no cover - model-built transitions always have parents.
+        return str(endpoint)
+    return '.'.join(str(part) for part in (*parent.path, endpoint) if part is not None)
 
 
 def _transition_endpoint_label(value) -> str:

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -133,7 +133,12 @@ def _guard_const_false_diagnostics(transitions) -> List[ModelDiagnostic]:
                         f'Transition {transition.from_path!r} -> {transition.to_path!r} '
                         'has a guard that is statically false.'
                     ),
-                    refs={'transition_span': None, 'folded_value': False},
+                    refs={
+                        'transition_span': None,
+                        'folded_value': False,
+                        'from_path': transition.from_path,
+                        'to_path': transition.to_path,
+                    },
                 )
             )
     return diagnostics

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1051,6 +1051,14 @@ W_GUARD_CONST_FALSE:
       type: bool
       required: true
       description: Constant-folded guard value (always ``false``).
+    from_path:
+      type: str
+      required: false
+      description: Source state path of the transition, or ``[*]`` for an initial transition.
+    to_path:
+      type: str
+      required: false
+      description: Target state path of the transition, or ``[*]`` for an exit transition.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``false`` and the
@@ -1097,6 +1105,14 @@ W_GUARD_CONST_TRUE:
       type: bool
       required: true
       description: Constant-folded guard value (always ``true``).
+    from_path:
+      type: str
+      required: false
+      description: Source state path of the transition, or ``[*]`` for an initial transition.
+    to_path:
+      type: str
+      required: false
+      description: Target state path of the transition, or ``[*]`` for an exit transition.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``true`` and does

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -405,6 +405,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': False,
+                    'from_path': 'Root.Active',
+                    'to_path': 'Root.Blocked',
                 },
             },
             {
@@ -449,6 +451,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': False,
+                    'from_path': 'Root.Idle',
+                    'to_path': 'Root.Active',
                 },
             },
         ],
@@ -522,6 +526,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': False,
+                    'from_path': 'Root.Active',
+                    'to_path': 'Root.Blocked',
                 },
             },
             {
@@ -530,6 +536,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': True,
+                    'from_path': 'Root.Idle',
+                    'to_path': 'Root.Active',
                 },
             },
             {
@@ -538,6 +546,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': True,
+                    'from_path': 'Root.Blocked',
+                    'to_path': 'Root.WideTrue',
                 },
             },
             {
@@ -546,6 +556,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': True,
+                    'from_path': 'Root.WideTrue',
+                    'to_path': 'Root.ModuloTrue',
                 },
             },
             {
@@ -554,6 +566,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': True,
+                    'from_path': 'Root.ModuloTrue',
+                    'to_path': 'Root.PowerTrue',
                 },
             },
             {
@@ -677,6 +691,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': False,
+                    'from_path': 'Root.Idle',
+                    'to_path': 'Root.Active',
                 },
             },
             {
@@ -685,6 +701,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'transition_span': None,
                     'folded_value': True,
+                    'from_path': 'Root.Active',
+                    'to_path': 'Root.Done',
                 },
             },
         ],

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -968,6 +968,8 @@ class TestInspectModelGuardAffectDiagnostics:
         assert const_true_refs == {
             'transition_span': None,
             'folded_value': True,
+            'from_path': 'Root.Idle',
+            'to_path': 'Root.Done',
         }
 
     def test_unreferenced_variable_with_abstract_action_is_info(self):
@@ -1273,6 +1275,8 @@ class TestInspectModelExtendedCoverage:
         const_false = next(d for d in diagnostics if d.code == 'W_GUARD_CONST_FALSE')
         assert const_false.refs['folded_value'] is False
         assert const_false.refs['transition_span'] is None
+        assert const_false.refs['from_path'] == 'Root.Active'
+        assert const_false.refs['to_path'] == 'Root.Blocked'
         unreachable = next(d for d in diagnostics if d.code == 'W_UNREACHABLE_STATE')
         assert unreachable.refs == {'state_path': 'Root.Orphan'}
 
@@ -1322,11 +1326,15 @@ class TestInspectModelExtendedCoverage:
         assert const_true.refs == {
             'transition_span': None,
             'folded_value': True,
+            'from_path': 'Root.Idle',
+            'to_path': 'Root.Active',
         }
         const_false = next(d for d in diagnostics if d.code == 'W_GUARD_CONST_FALSE')
         assert const_false.refs == {
             'transition_span': None,
             'folded_value': False,
+            'from_path': 'Root.Active',
+            'to_path': 'Root.Blocked',
         }
         during_refs = sorted(
             (d.refs for d in diagnostics if d.code == 'W_DURING_CONST_ASSIGN'),


### PR DESCRIPTION
> 上游伞 PR：#122
> 跟踪 issue：#104
> PR-C4 设计来源：#122 comment https://github.com/HansBug/pyfcstm/pull/122#issuecomment-4586640775
> Base：`dev/issue104-pr-c`
> Head：`dev/issue104-pr-c4-inspect-surface`
> 当前状态：实现已完成并 push 到 `dev/issue104-pr-c4-inspect-surface`。本地 jsfcstm build、targeted mocha、jsfcstm coverage、Python slow-skip unittest 均已通过；最新 GitHub Actions 全绿。Codecov 当前 patch coverage 为 `97.62846%`，缺口集中在既有 `editors/jsfcstm/src/editor/analyzers.ts` 分支覆盖；本轮 owner 已明确这点覆盖率缺口不阻塞 PR-C4，只要无 C/I 继续推进。下一步启动 claude / codex / deepseek / omx 四路正式代码 review。PR-C4 ready 后按 owner 指示 merge，并同步上游 PR-C #122。

## 背景

PR-C1 #123、PR-C2 #125、PR-C3 #126 已合入上游伞 PR-C 分支 `dev/issue104-pr-c`。PR-C4 是 PR-C 系列的 surface parity 收尾。

owner 的目标是：下游 LLM 研究使用 `inspect_model().diagnostics` / `inspectModel().diagnostics` 作为 feedback source，因此用户在 VSCode 打开 `.fcstm` 时，也应该能在 Problems 面板看到同一批 W/I 诊断条目。PR-C4 不要求为所有条目提供 detailed fix suggestion；条目可见是强制，fix payload 可选。

## 当前问题

PR-C3 之后，jsfcstm editor surface 已经能通过 `collectDocumentDiagnostics()` 暴露 7 个 W/I code：

- `editor/analyzers.ts` 直接报告：`W_UNREACHABLE_STATE` / `W_GUARD_CONST_FALSE` / `W_UNUSED_EVENT`
- PR-C3 suggested-fix 路径报告：`W_DEADLOCK_LEAF` / `W_UNREFERENCED_VAR` / `W_EFFECT_SELF_ASSIGN` / `W_INITIAL_UNCONDITIONAL_MISSING`

但 `inspectModel(model).diagnostics` 实际能 emit 27 个 W/I code，剩余 20 个 W/I 在 VSCode Problems 面板不可见。PR-C4 的目标是让 editor 实时诊断按 `code + refs` 集合覆盖 `inspectModel().diagnostics` 去除 3 个 dedupe 项后的结果。

20 个未通过 VSCode Problems surface 的 code 按 refs key 落地难度分为：

| 档 | 落地手段 | 代码 |
|---|---|---|
| T1 极易 | path / var_name / event_qualified_name 查表 | `W_UNWRITTEN_READ_VAR` / `W_WRITE_ONLY_VAR` / `W_DURING_CONST_ASSIGN` / `W_LITERAL_TYPE_NARROWING` / `W_DEAD_NAMED_ACTION` / `W_NAMED_ACTION_SHADOWS_ANCESTOR` / `W_ASPECT_NO_DESCENDANT_LEAF` / `W_FORCED_NEVER_EXPANDS` / `W_LARGE_COMPOSITE` / `W_SELF_TRANSITION_NOP` / `W_SHADOWED_EVENT` / `I_TRANSITION_TO_SELF_VIA_PARENT` / `I_UNREFERENCED_VAR_MAYBE_ABSTRACT` |
| T2 中 | transition_span / guard_span / duplicate_spans 已填则直接转 TextRange，否则 fullRange | `I_TRANSITION_NEVER_EVENT_TRIGGERED` / `W_GUARD_CONST_TRUE` / `W_GUARD_VARS_NEVER_CHANGE` / `W_REDUNDANT_TRANSITION` / `W_FORCED_OVERRIDES_NORMAL` |
| T3 聚合 | 无源码 anchor，落到 root state identifier 或 fullRange | `W_DEEP_HIERARCHY` / `W_HIGH_VAR_TO_LEAF_RATIO` |

## 目标

1. `collectDocumentDiagnostics(document)` 中的 W/I 诊断集合必须覆盖 `inspectModel(model).diagnostics` 中除 `SUPPRESSED_FROM_INSPECT_SURFACE` 以外的 code+refs 集合。
2. 去除 PR-C3 留下的 `hasSuggestedFix` 硬过滤，使没有 quick-fix 的 inspect diagnostics 也能出现在 VSCode Problems 面板。
3. 复用 PR-C3 已有的 quick-fix range 解析能力，保留有 suggested-fix 的条目优先使用 precise fix range。
4. 为没有 suggested-fix 的条目新增 refs-key based range fallback，优先定位到 state / variable / event / span；无法定位时退到全文档 range，保证条目可见。
5. 主体只改 jsfcstm editor surface；为修复 const-fold guard 诊断的 code+refs collision 并保持 py/js parity，最小同步 `W_GUARD_CONST_TRUE/FALSE` 的 Python/JS refs 与 `codes.yaml` 元数据（新增 `from_path` / `to_path`），不改 analyzer 语义、不改 suggested_fix payload。

## 实施计划

### 1. 先核对计划一致性

空 PR 创建后先启动四路 reviewer：

- claude：`claude -p --permission-mode bypassPermissions --output-format text`
- codex：`codex exec --dangerously-bypass-approvals-and-sandbox -C /home/hansbug/oo-projects/pyfcstm -`
- deepseek：`codex-deepseek exec --dangerously-bypass-approvals-and-sandbox -C /home/hansbug/oo-projects/pyfcstm -`
- omx：`source ~/.bashrc && omx exec ...`

四路 reviewer 的第一轮任务只核对：本 PR title/body 是否严格符合上游 PR-C #122 中 PR-C4 章节与 #122 comment `#issuecomment-4586640775` 的计划。review comment 必须中文 C/I/M，首行分别亮明身份：

- `我是 claude reviewer`
- `我是 codex reviewer`
- `我是 deepseek reviewer`
- `我是 omx reviewer`

如果发现 C/I，先只改 PR title/body 到一致；一致后再开始代码开发。

### 2. TDD：先写 failing tests

新增 jsfcstm 测试，先证明当前 head 的缺口：

1. `bagOfCodes(collectDocumentDiagnostics(doc).filter(W/I))` 必须覆盖 `bagOfCodes(inspectModel(model).diagnostics.filter(not in SUPPRESSED_FROM_INSPECT_SURFACE))`。
2. 至少覆盖 6 个之前不可见的代表 code：
   - `W_UNWRITTEN_READ_VAR`
   - `W_WRITE_ONLY_VAR`
   - `W_DURING_CONST_ASSIGN`
   - `I_TRANSITION_NEVER_EVENT_TRIGGERED`
   - `W_LARGE_COMPOSITE`
   - `W_DEEP_HIERARCHY`
3. 测试只断言诊断条目存在 + code 等于预期，不断言精确行列，避免 fixture 对格式细节过敏。
4. 新增 DSL fixture 使用 JS 测试文件内 inline string，不读取 Python `test/` fixture，不调用 Python。

### 3. 实现 editor surface

1. 在 `editors/jsfcstm/src/editor/diagnostics.ts` 中把 `collectSuggestedFixDesignDiagnostics` rename 为 `collectInspectModelDiagnostics`。
2. 移除 `hasSuggestedFix` 硬过滤，改为 `SUPPRESSED_FROM_INSPECT_SURFACE` 黑名单：
   - `W_UNREACHABLE_STATE`
   - `W_GUARD_CONST_FALSE`
   - `W_UNUSED_EVENT`
3. 保留 PR-C3 suggested-fix range 优先级：如果 `suggestedFixDiagnosticRange()` 能给出比 fullRange 更具体的 range，就优先用它。
4. 对没有 suggested-fix range 的 inspect diagnostic 调用新增 `resolveRangeFromRefs(document, semantic, refs)`。
5. 无法解析 range 时 fallback 到 `fullDocumentRange(document)`，保证 Problems 面板条目可见。

### 4. 新增 inspect range helper

新增 `editors/jsfcstm/src/editor/inspect-ranges.ts`：

- `resolveRangeFromRefs(document, semantic, refs)`：按 refs key 分发。
- state-keyed refs：`state_path` / `composite_path` / `parent_path` → state identifier range。
- variable-keyed refs：`var_name` → variable definition range。
- event-keyed refs：`event_qualified_name` → event identifier range。
- span-keyed refs：`transition_span` / `guard_span` / `duplicate_spans[0]` → `TextRange`。
- 其他 refs → `null`，调用方使用 fullRange。

### 5. 复用 PR-C3 helpers

在 `editors/jsfcstm/src/editor/suggested-fixes.ts` 中仅把以下 helper 从 module-private 改成 export，不改签名、不改语义：

- `resolveStatePath`
- `variableDefinitionRange`
- `spanLikeToRange`

按需要从 `editor/index.ts` re-export `inspect-ranges.ts`。

## W_WRITE_ONLY_VAR 测试说明

`W_WRITE_ONLY_VAR` 是 inspect diagnostic catalog 中的合法 code，但当前真实 DSL -> `inspectModel()` 构建路径下没有稳定自然 witness：变量如果完全不影响 guard 会先归入 `W_UNREFERENCED_VAR`；如果影响 guard，则当前 use-def 定义会伴随 guard read，不满足 write-only 条件。PR-C4 不修改 `inspect.ts` 或 analyzer 语义，因此针对该 code 的 surface 测试采用 monkeypatch `inspectModel()` 合成一个 `W_WRITE_ONLY_VAR` 诊断，验证 editor surface 不再因为缺少 suggested-fix 而过滤它。

### 6. 验证与覆盖率

本地至少运行：

```bash
cd editors/jsfcstm && npm run build
cd editors/jsfcstm && npx mocha --require ts-node/register/transpile-only --extension ts test/inspect-surface-parity.test.ts --reporter dot
cd editors/jsfcstm && npm run test:coverage
SKIP_SLOW_TESTS=1 make unittest COV_TYPES="term-missing"
```

如果 Codecov 指出 PR patch coverage 对 `inspect-ranges.ts` 或 `editor/diagnostics.ts` 有核心缺口，补测试后重新 push、重新等 CI。

## 明确非目标

- 不做 T2 transition 多匹配消歧；已有 `transition_span` / `guard_span` 就用，没有就 fallback。
- 不做 T3 aggregate diagnostics 的聪明 anchor；允许 root/fullRange。
- Python 端仅允许同步 `W_GUARD_CONST_TRUE/FALSE` 的 `from_path` / `to_path` refs 与对应测试，保持 py/js inspect payload parity；不得扩展新的诊断语义。
- 不修改 `editors/jsfcstm/src/diagnostics/inspect.ts`。
- 不修改 suggested_fix payload，不引入新的 schema 概念；`codes.yaml` 仅允许记录上述新增 refs。
- 不修改 PR-C3 已合 API 的语义；`suggestedFixDiagnosticRange()` 不 rename、不改行为。
- 不改 `editors/vscode/`，VSCode extension 通过 jsfcstm editor surface 自动 follow。
- 不引入新的 pip/npm runtime dependency。

## Review 门禁

- 实现 commit message 使用 `[skip-slow]`，并避免误触发 `ci skip` / `test skip` / `[python skip]`；本 PR 即使只改 jsfcstm 也禁止使用 `[js skip]`，因为需要完整 CI 信号。
- push 后先等 GitHub Actions 全绿。
- CI 不全绿时只修 CI，不启动正式代码 review。
- CI 全绿后启动四路 review：claude / codex / deepseek / omx。
- omx reviewer 必须用 `source ~/.bashrc && omx exec ...` 启动。
- 四路 reviewer 都必须拿到：PR URL、issue #104、上游伞 PR #122、PR-C1/#123、PR-C2/#125、PR-C3/#126 已合并背景、当前 head commit、CI 状态、本地验证、测试隔离约束、no broad catch、no new deps、PR-C4 非目标。
- 四路 reviewer 都必须直接在本 PR 下用中文按 C/I/M 三级 comment。
- reviewer comment 首行必须分别是：`我是 claude reviewer` / `我是 codex reviewer` / `我是 deepseek reviewer` / `我是 omx reviewer`。
- C/I 自动修复，重新测试、push、等 CI、再四路 review。
- 循环到四路都无 C/I 并明确 `Ready to merge`。
- PR-C4 ready 后等待 owner 指示，不擅自 merge。

## 测试隔离约束

- Python 测试不调用 Node/JS，不读取 JS 测试资源。
- jsfcstm 测试不调用 Python，不读取 repo-level `test/` 作为新增 fixture。
- 新增 DSL fixture 使用 JS 测试文件内 inline literal 或 `editors/jsfcstm/test/` 下资源。
- 任一侧测试树或另一端实现被删除时，本侧测试仍应稳定运行。

## 验收标准

- [x] 空 PR-C4 创建完成，base=`dev/issue104-pr-c`，head=`dev/issue104-pr-c4-inspect-surface`，PR body 写清完整计划和验收标准。
- [x] 四路 reviewer 确认 PR-C4 title/body 与上游 PR-C 的 PR-C4 计划一致；若不一致，已修到一致。
- [x] 实现 commit message 使用 `[skip-slow]` 且未误触发 `ci skip` / `test skip` / `[python skip]` / `[js skip]`。
- [x] `editors/jsfcstm/src/editor/diagnostics.ts` 中 `hasSuggestedFix` 硬过滤已替换为 `SUPPRESSED_FROM_INSPECT_SURFACE` code 黑名单，并保留 PR-C3 quick-fix range 优先级。
- [x] 新增 `editors/jsfcstm/src/editor/inspect-ranges.ts`，暴露 `resolveRangeFromRefs(document, semantic, refs)`。
- [x] `resolveRangeFromRefs` 覆盖 `state_path` / `composite_path` / `parent_path` / `var_name` / `event_qualified_name` / `transition_span` / `guard_span` / `duplicate_spans`。
- [x] `editors/jsfcstm/src/editor/suggested-fixes.ts` 中 `resolveStatePath` / `variableDefinitionRange` / `spanLikeToRange` 改为 `export function`，不改语义。
- [x] `collectSuggestedFixDesignDiagnostics` rename 为 `collectInspectModelDiagnostics`，调用点同步。
- [x] 新增 jsfcstm parity 测试：`collectDocumentDiagnostics` 的 W/I code+refs bag 覆盖 `inspectModel(model).diagnostics` 去除 suppressed 后的 bag。
- [x] 至少 6 个之前不可见的 W/I code 有最小 fixture 测试，并断言 Problems surface 中条目存在；其中 `W_WRITE_ONLY_VAR` 使用合成 inspect diagnostic 验证无 suggested-fix 条目不会被过滤。
- [x] Python 端仅最小同步 `W_GUARD_CONST_TRUE/FALSE` 的 `from_path` / `to_path` refs、`codes.yaml` 元数据与 parity 测试；未修改 `inspect.ts`，未改变 analyzer 语义，未修改 suggested-fix payload。
- [x] 本地 jsfcstm build / targeted mocha / `npm run test:coverage` 通过。
- [x] `SKIP_SLOW_TESTS=1 make unittest COV_TYPES="term-missing"` 通过。
- [x] GitHub Actions 在最新 head 上全绿。
- [x] Codecov 已更新到最新 head：patch coverage `97.62846%`，`editor/diagnostics.ts` / `inspect-ranges.ts` 等 PR-C4 核心 surface 文件本地覆盖为 100%；剩余缺口为 `editor/analyzers.ts` 既有分支覆盖，owner 已明确不作为 PR-C4 阻塞项。
- [ ] claude / codex / deepseek / omx 四路中文 C/I/M review 均无 C/I，并明确 `Ready to merge`。
- [ ] 不 merge，等待 owner 下一步指示。




