### PR TITLE
PR-A3：组 1 拓扑验证算法实装（#114）

### DIFF
--- a/docs/source/api_doc/verify/index.rst
+++ b/docs/source/api_doc/verify/index.rst
@@ -12,6 +12,7 @@ pyfcstm.verify
     inspect_adapter
     registry
     taxonomy
+    topology
 
 \_\_all\_\_
 -----------------------------------------------------

--- a/docs/source/api_doc/verify/topology.rst
+++ b/docs/source/api_doc/verify/topology.rst
@@ -79,5 +79,3 @@ event\_emission\_to\_consumer\_reachable
 -----------------------------------------------------
 
 .. autofunction:: event_emission_to_consumer_reachable
-
-

--- a/docs/source/api_doc/verify/topology.rst
+++ b/docs/source/api_doc/verify/topology.rst
@@ -79,3 +79,5 @@ event\_emission\_to\_consumer\_reachable
 -----------------------------------------------------
 
 .. autofunction:: event_emission_to_consumer_reachable
+
+

--- a/docs/source/api_doc/verify/topology.rst
+++ b/docs/source/api_doc/verify/topology.rst
@@ -1,0 +1,81 @@
+pyfcstm.verify.topology
+========================================================
+
+.. currentmodule:: pyfcstm.verify.topology
+
+.. automodule:: pyfcstm.verify.topology
+
+
+EXIT\_ROOT\_SINK
+-----------------------------------------------------
+
+.. autodata:: EXIT_ROOT_SINK
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+LeafLevelGraph
+-----------------------------------------------------
+
+.. autoclass:: LeafLevelGraph
+    :members: nodes,edges
+
+
+FinitenessReport
+-----------------------------------------------------
+
+.. autoclass:: FinitenessReport
+    :members: finite,counterexamples
+
+
+InevitabilityReport
+-----------------------------------------------------
+
+.. autoclass:: InevitabilityReport
+    :members: inevitable,counterexample_path
+
+
+build\_leaf\_level\_macro\_graph
+-----------------------------------------------------
+
+.. autofunction:: build_leaf_level_macro_graph
+
+
+topological\_reachable\_set
+-----------------------------------------------------
+
+.. autofunction:: topological_reachable_set
+
+
+unreachable\_states
+-----------------------------------------------------
+
+.. autofunction:: unreachable_states
+
+
+strongly\_connected\_components
+-----------------------------------------------------
+
+.. autofunction:: strongly_connected_components
+
+
+topological\_finite
+-----------------------------------------------------
+
+.. autofunction:: topological_finite
+
+
+topological\_inevitable\_terminator
+-----------------------------------------------------
+
+.. autofunction:: topological_inevitable_terminator
+
+
+event\_emission\_to\_consumer\_reachable
+-----------------------------------------------------
+
+.. autofunction:: event_emission_to_consumer_reachable

--- a/docs/source/api_doc/verify/topology.rst
+++ b/docs/source/api_doc/verify/topology.rst
@@ -22,7 +22,7 @@ LeafLevelGraph
 -----------------------------------------------------
 
 .. autoclass:: LeafLevelGraph
-    :members: nodes,edges
+    :members: __post_init__,nodes,edges
 
 
 FinitenessReport

--- a/pyfcstm/verify/registry.py
+++ b/pyfcstm/verify/registry.py
@@ -3,6 +3,7 @@
 from types import MappingProxyType
 from typing import Mapping, Tuple
 
+from . import topology
 from .taxonomy import CallCountScaling, FallbackUnknownRisk, VerifyAlgorithmMeta
 
 
@@ -30,7 +31,7 @@ def _structural(
         verification_scope="topological_only",
         dominant_dim=dominant_dim,
         diagnostic_codes=diagnostic_codes,
-        impl=None,
+        impl=getattr(topology, name),
     )
 
 

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -217,9 +217,12 @@ def build_leaf_level_macro_graph(machine: StateMachine) -> LeafLevelGraph:
 
     The projection follows normal leaf-to-leaf transitions, expands composite
     targets through their initial transitions, and bubbles ``Leaf -> [*]``
-    transitions through parent outgoing transitions. If a non-root parent has no
-    outgoing transition, the bubble is an off-cliff exit and contributes no edge.
-    A root leaf is treated as root-exit-capable by adding an edge to
+    transitions through parent outgoing transitions. Parent-level transitions
+    whose source is a composite state are therefore considered only after a
+    descendant leaf explicitly exits to that parent; they are not copied onto
+    every active descendant leaf. If a non-root parent has no outgoing
+    transition, the bubble is an off-cliff exit and contributes no edge. A root
+    leaf is treated as root-exit-capable by adding an edge to
     :data:`EXIT_ROOT_SINK`.
 
     :param machine: State machine to project.

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -239,29 +239,30 @@ def _scc_components(
 ) -> Tuple[Tuple[str, ...], ...]:
     node_set = set(nodes)
     ordered_nodes = sorted(node_set)
-    discovered: Set[str] = set()
+    visited: Set[str] = set()
     finish_order: List[str] = []
 
     for start in ordered_nodes:
-        if start in discovered:
+        if start in visited:
             continue
 
-        discovered.add(start)
         visit_stack: List[Tuple[str, bool]] = [(start, False)]
         while visit_stack:
             node, expanded = visit_stack.pop()
             if expanded:
                 finish_order.append(node)
                 continue
+            if node in visited:
+                continue
 
+            visited.add(node)
             visit_stack.append((node, True))
             successors = [
                 successor
                 for successor in edges.get(node, tuple())
-                if successor in node_set and successor not in discovered
+                if successor in node_set and successor not in visited
             ]
             for successor in reversed(sorted(successors)):
-                discovered.add(successor)
                 visit_stack.append((successor, False))
 
     reverse_edges: Dict[str, List[str]] = {node: [] for node in ordered_nodes}

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -162,6 +162,9 @@ def build_leaf_level_macro_graph(machine: StateMachine) -> LeafLevelGraph:
                 _project_target(parent_state, transition.to_state)
             )
 
+    if machine.root_state.is_leaf_state:
+        edge_sets.setdefault(_state_path(machine.root_state), set()).add(EXIT_ROOT_SINK)
+
     edges = {node: tuple(sorted(targets)) for node, targets in edge_sets.items()}
     edges.setdefault(EXIT_ROOT_SINK, tuple())
     return LeafLevelGraph(nodes=nodes, edges=edges)
@@ -231,46 +234,60 @@ def unreachable_states(machine: StateMachine) -> Tuple[str, ...]:
     )
 
 
-def _tarjan_scc(
+def _scc_components(
     nodes: Sequence[str], edges: Dict[str, Tuple[str, ...]]
 ) -> Tuple[Tuple[str, ...], ...]:
-    index = 0
-    indexes: Dict[str, int] = {}
-    lowlinks: Dict[str, int] = {}
-    stack: List[str] = []
-    on_stack: Set[str] = set()
-    components: List[Tuple[str, ...]] = []
+    node_set = set(nodes)
+    ordered_nodes = sorted(node_set)
+    discovered: Set[str] = set()
+    finish_order: List[str] = []
 
-    def strongconnect(node: str) -> None:
-        nonlocal index
-        indexes[node] = index
-        lowlinks[node] = index
-        index += 1
-        stack.append(node)
-        on_stack.add(node)
+    for start in ordered_nodes:
+        if start in discovered:
+            continue
 
-        for successor in edges.get(node, tuple()):
-            if successor == EXIT_ROOT_SINK:
+        discovered.add(start)
+        visit_stack: List[Tuple[str, bool]] = [(start, False)]
+        while visit_stack:
+            node, expanded = visit_stack.pop()
+            if expanded:
+                finish_order.append(node)
                 continue
-            if successor not in indexes:
-                strongconnect(successor)
-                lowlinks[node] = min(lowlinks[node], lowlinks[successor])
-            elif successor in on_stack:
-                lowlinks[node] = min(lowlinks[node], indexes[successor])
 
-        if lowlinks[node] == indexes[node]:
-            component: List[str] = []
-            while True:
-                item = stack.pop()
-                on_stack.remove(item)
-                component.append(item)
-                if item == node:
-                    break
-            components.append(tuple(sorted(component)))
+            visit_stack.append((node, True))
+            successors = [
+                successor
+                for successor in edges.get(node, tuple())
+                if successor in node_set and successor not in discovered
+            ]
+            for successor in reversed(sorted(successors)):
+                discovered.add(successor)
+                visit_stack.append((successor, False))
 
-    for node in sorted(nodes):
-        if node not in indexes:
-            strongconnect(node)
+    reverse_edges: Dict[str, List[str]] = {node: [] for node in ordered_nodes}
+    for source in ordered_nodes:
+        for target in edges.get(source, tuple()):
+            if target in node_set:
+                reverse_edges[target].append(source)
+
+    components: List[Tuple[str, ...]] = []
+    assigned: Set[str] = set()
+    for start in reversed(finish_order):
+        if start in assigned:
+            continue
+
+        component: List[str] = []
+        collect_stack = [start]
+        assigned.add(start)
+        while collect_stack:
+            node = collect_stack.pop()
+            component.append(node)
+            for predecessor in reversed(sorted(reverse_edges.get(node, []))):
+                if predecessor not in assigned:
+                    assigned.add(predecessor)
+                    collect_stack.append(predecessor)
+
+        components.append(tuple(sorted(component)))
 
     return tuple(sorted(components))
 
@@ -282,8 +299,9 @@ def _is_cyclic_component(
     if len(component) > 1:
         return True
     if len(component) == 0:  # pragma: no cover
-        # Tarjan only emits non-empty components. Keep this guard so the helper
-        # remains total if it is reused with hand-built component data.
+        # SCC decomposition only emits non-empty components. Keep this guard so
+        # the helper remains total if it is reused with hand-built component
+        # data.
         return False
     node = component[0]
     return node in edges.get(node, tuple())
@@ -300,7 +318,7 @@ def strongly_connected_components(machine: StateMachine) -> Tuple[Tuple[str, ...
     graph = build_leaf_level_macro_graph(machine)
     return tuple(
         component
-        for component in _tarjan_scc(graph.nodes, graph.edges)
+        for component in _scc_components(graph.nodes, graph.edges)
         if _is_cyclic_component(component, graph.edges)
     )
 

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -634,37 +634,12 @@ def topological_inevitable_terminator(machine: StateMachine) -> InevitabilityRep
     return InevitabilityReport(inevitable=True, counterexample_path=None)
 
 
-def _event_consumers(machine: StateMachine) -> Dict[str, Set[str]]:
-    consumers: Dict[str, Set[str]] = {}
-    for parent_state in machine.walk_states():
-        parent_path = _state_path(parent_state)
-        for transition in parent_state.transitions:
-            event = transition.event
-            if event is None:
-                continue
-
-            event_name = event.path_name
-            if transition.from_state is INIT_STATE:
-                source_path = parent_path
-            elif isinstance(transition.from_state, str):
-                source_path = _state_path(parent_state.substates[transition.from_state])
-            else:
-                raise TypeError(  # pragma: no cover
-                    # Grammar-produced non-init transition sources are strings.
-                    # A future model endpoint type should be made explicit here.
-                    f"Unsupported transition source: {transition.from_state!r}."
-                )
-            consumers.setdefault(event_name, set()).add(source_path)
-    return consumers
-
-
-def _root_reachable_state_paths(
+def _root_reachable_initial_state_paths(
     machine: StateMachine,
     graph: LeafLevelGraph,
 ) -> Set[str]:
     reachable_leaves = _root_reachable_leaf_paths(machine, graph)
-    reachable_paths = set(reachable_leaves)
-    reachable_paths.add(_state_path(machine.root_state))
+    reachable_paths = {_state_path(machine.root_state)}
 
     for state in machine.walk_states():
         if state.is_leaf_state:
@@ -674,15 +649,95 @@ def _root_reachable_state_paths(
     return reachable_paths
 
 
+def _root_reachable_boundary_state_paths(
+    machine: StateMachine,
+    graph: LeafLevelGraph,
+) -> Set[str]:
+    reachable_leaves = _root_reachable_leaf_paths(machine, graph)
+    boundary_paths: Set[str] = set()
+    queue: Deque[State] = deque()
+
+    def add_boundary(state: State) -> None:
+        state_path = _state_path(state)
+        if state_path in boundary_paths:
+            return
+        boundary_paths.add(state_path)
+        queue.append(state)
+
+    for leaf in _leaf_states(machine):
+        if _state_path(leaf) not in reachable_leaves:
+            continue
+        if not any(transition.to_state is EXIT_STATE for transition in leaf.transitions_from):
+            continue
+
+        parent = leaf.parent
+        if parent is not None and not parent.is_root_state:
+            add_boundary(parent)
+
+    while queue:
+        state = queue.popleft()
+        for transition in state.transitions_from:
+            if transition.to_state is not EXIT_STATE:
+                continue
+
+            parent = state.parent
+            if parent is not None and not parent.is_root_state:
+                add_boundary(parent)
+
+    return boundary_paths
+
+
+def _event_consumer_reachability(
+    machine: StateMachine,
+    graph: LeafLevelGraph,
+) -> Dict[str, List[bool]]:
+    active_leaves = _root_reachable_leaf_paths(machine, graph)
+    init_sources = _root_reachable_initial_state_paths(machine, graph)
+    boundary_sources = _root_reachable_boundary_state_paths(machine, graph)
+    consumers: Dict[str, List[bool]] = {}
+
+    for parent_state in machine.walk_states():
+        parent_path = _state_path(parent_state)
+        for transition in parent_state.transitions:
+            event = transition.event
+            if event is None:
+                continue
+
+            event_name = event.path_name
+            if transition.from_state is INIT_STATE:
+                reachable = parent_path in init_sources
+            elif isinstance(transition.from_state, str):
+                source_state = parent_state.substates[transition.from_state]
+                source_path = _state_path(source_state)
+                if source_state.is_leaf_state:
+                    reachable = source_path in active_leaves
+                else:
+                    reachable = source_path in boundary_sources
+            else:
+                raise TypeError(  # pragma: no cover
+                    # Grammar-produced non-init transition sources are strings.
+                    # A future model endpoint type should be made explicit here.
+                    f"Unsupported transition source: {transition.from_state!r}."
+                )
+            consumers.setdefault(event_name, []).append(reachable)
+    return consumers
+
+
 def event_emission_to_consumer_reachable(machine: StateMachine) -> Tuple[str, ...]:
     """
     Return events whose consumer source states are all unreachable.
 
     Unused declared events are ignored here; they remain the responsibility of
     the existing design-health unused-event check.
-    A transition is treated as an event consumer at its source state. If every
-    consumer source for a used event is outside the root-reachable topology, the
-    event's qualified name is returned.
+    A transition is treated as an event consumer at the point where its source
+    can be selected. Leaf-source consumers are reachable when their leaf is
+    root-reachable. Initial-transition consumers are reachable when the owning
+    composite can be entered. Composite-source consumers are reachable only when
+    a root-reachable descendant leaf can explicitly exit to the composite
+    boundary, because parent-level transitions are considered after
+    ``Leaf -> [*]`` bubble semantics rather than while any descendant leaf is
+    merely active. If every consumer source for a used event is outside these
+    root-reachable topology points, the event's qualified name is returned.
 
     :param machine: State machine to inspect.
     :type machine: StateMachine
@@ -708,10 +763,11 @@ def event_emission_to_consumer_reachable(machine: StateMachine) -> Tuple[str, ..
         ('Root.Panic',)
     """
     graph = build_leaf_level_macro_graph(machine)
-    reachable = _root_reachable_state_paths(machine, graph)
     unreachable_events = []
-    for event_name, sources in _event_consumers(machine).items():
-        if sources and all(source not in reachable for source in sources):
+    for event_name, source_reachability in _event_consumer_reachability(
+        machine, graph
+    ).items():
+        if source_reachability and not any(source_reachability):
             unreachable_events.append(event_name)
     return tuple(sorted(unreachable_events))
 

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -1,9 +1,45 @@
 """Topological verification algorithms for :mod:`pyfcstm.verify`.
 
-The algorithms in this module intentionally stay at the structural layer. They
-ignore guard satisfiability, event availability, and runtime variable evolution;
-their results therefore describe topological reachability rather than concrete
-execution reachability.
+This module implements the group-1 verification algorithms that work only on
+the hierarchical state topology. The algorithms project a
+:class:`pyfcstm.model.StateMachine` into a leaf-level macro graph and then run
+structural graph queries over that projection. They intentionally ignore guard
+satisfiability, event availability, transition ordering, and runtime variable
+evolution; positive reachability results are therefore over-approximations of
+runtime behavior, while unreachable results describe structural topology facts.
+
+The module contains:
+
+* :class:`LeafLevelGraph` - Immutable container for the projected leaf graph.
+* :class:`FinitenessReport` - Report object for
+  :func:`topological_finite`.
+* :class:`InevitabilityReport` - Report object for
+  :func:`topological_inevitable_terminator`.
+* :func:`build_leaf_level_macro_graph` - Build the guard-agnostic projection.
+* :func:`topological_reachable_set` - Compute reachable leaf states.
+* :func:`unreachable_states` - Find structurally unreachable leaf states.
+* :func:`strongly_connected_components` - Find cyclic leaf-level regions.
+* :func:`topological_finite` - Detect reachable no-exit regions.
+* :func:`topological_inevitable_terminator` - Detect non-terminating topology.
+* :func:`event_emission_to_consumer_reachable` - Detect events whose consumers
+  are all unreachable.
+
+.. note::
+   The graph projection is independent from the diagnostics package.
+   Diagnostic integration is expected to wrap these functions and translate
+   their plain Python return values into diagnostic payloads.
+
+Example::
+
+    >>> from pyfcstm.dsl import parse_with_grammar_entry
+    >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+    >>> ast = parse_with_grammar_entry("state Root;", "state_machine_dsl")
+    >>> machine = parse_dsl_node_to_state_machine(ast)
+    >>> graph = build_leaf_level_macro_graph(machine)
+    >>> graph.nodes
+    ('Root',)
+    >>> graph.edges[EXIT_ROOT_SINK]
+    ()
 """
 
 from collections import deque
@@ -24,13 +60,31 @@ EXIT_ROOT_SINK = "⊥_root"
 
 @dataclass(frozen=True)
 class LeafLevelGraph:
-    """Leaf-level macro graph projected from a hierarchical state machine.
+    """
+    Leaf-level macro graph projected from a hierarchical state machine.
+
+    Each node is a dotted path for a leaf state in the source model. Edges
+    describe guard-agnostic macro steps between leaf states after expanding
+    composite targets through their initial transitions and bubbling leaf exits
+    through parent transitions. The synthetic :data:`EXIT_ROOT_SINK` key is
+    present in :attr:`edges` so callers can query root termination uniformly.
 
     :param nodes: Dotted paths of leaf states in stable sorted order.
     :type nodes: Tuple[str, ...]
     :param edges: Mapping from each leaf path, and optionally
         :data:`EXIT_ROOT_SINK`, to sorted successor paths.
     :type edges: Dict[str, Tuple[str, ...]]
+
+    Example::
+
+        >>> graph = LeafLevelGraph(
+        ...     nodes=("Root.Idle",),
+        ...     edges={"Root.Idle": (EXIT_ROOT_SINK,), EXIT_ROOT_SINK: ()},
+        ... )
+        >>> graph.nodes
+        ('Root.Idle',)
+        >>> graph.edges["Root.Idle"]
+        ('⊥_root',)
     """
 
     nodes: Tuple[str, ...]
@@ -39,7 +93,13 @@ class LeafLevelGraph:
 
 @dataclass(frozen=True)
 class FinitenessReport:
-    """Result for :func:`topological_finite`.
+    """
+    Result for :func:`topological_finite`.
+
+    The report is true when every root-reachable leaf can eventually reach the
+    synthetic root-exit sink in the topology graph. Counterexamples are plain
+    tuples so later diagnostic layers can choose their own payload shape without
+    coupling the topology package to the diagnostics package.
 
     :param finite: ``True`` when every root-reachable leaf can reach the root
         exit sink in the topological graph.
@@ -47,6 +107,16 @@ class FinitenessReport:
     :param counterexamples: Counterexamples as ``('trap_cycle', scc_tuple)`` or
         ``('deadlock', state_path)`` entries.
     :type counterexamples: Tuple[Tuple[Literal['trap_cycle', 'deadlock'], object], ...]
+
+    Example::
+
+        >>> report = FinitenessReport(finite=False, counterexamples=(
+        ...     ("deadlock", "Root.Stuck"),
+        ... ))
+        >>> report.finite
+        False
+        >>> report.counterexamples[0][0]
+        'deadlock'
     """
 
     finite: bool
@@ -55,7 +125,13 @@ class FinitenessReport:
 
 @dataclass(frozen=True)
 class InevitabilityReport:
-    """Result for :func:`topological_inevitable_terminator`.
+    """
+    Result for :func:`topological_inevitable_terminator`.
+
+    The report is true only when the topology has no root-reachable cycle or
+    deadlock that could keep execution away from the root terminator forever.
+    A false report contains one representative path or SCC; it is not intended
+    to enumerate every possible non-terminating region.
 
     :param inevitable: ``True`` when no root-reachable topological path can stay
         in a cycle or deadlock forever.
@@ -63,6 +139,17 @@ class InevitabilityReport:
     :param counterexample_path: Representative non-terminating SCC or deadlock
         path, or ``None`` when :attr:`inevitable` is true.
     :type counterexample_path: Optional[Tuple[str, ...]]
+
+    Example::
+
+        >>> report = InevitabilityReport(
+        ...     inevitable=False,
+        ...     counterexample_path=("Root.Loop",),
+        ... )
+        >>> report.inevitable
+        False
+        >>> report.counterexample_path
+        ('Root.Loop',)
     """
 
     inevitable: bool
@@ -125,17 +212,39 @@ def _initial_leaf_targets(state: State) -> Tuple[str, ...]:
 
 
 def build_leaf_level_macro_graph(machine: StateMachine) -> LeafLevelGraph:
-    """Build the guard-agnostic leaf-level macro graph for ``machine``.
+    """
+    Build the guard-agnostic leaf-level macro graph for ``machine``.
 
     The projection follows normal leaf-to-leaf transitions, expands composite
     targets through their initial transitions, and bubbles ``Leaf -> [*]``
     transitions through parent outgoing transitions. If a non-root parent has no
     outgoing transition, the bubble is an off-cliff exit and contributes no edge.
+    A root leaf is treated as root-exit-capable by adding an edge to
+    :data:`EXIT_ROOT_SINK`.
 
     :param machine: State machine to project.
     :type machine: StateMachine
     :return: Leaf-level macro graph.
     :rtype: LeafLevelGraph
+    :raises TypeError: If a transition endpoint uses a model object type that
+        is not produced by the FCSTM grammar pipeline.
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state Idle;
+        ...     [*] -> Idle;
+        ...     Idle -> [*];
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> graph = build_leaf_level_macro_graph(machine)
+        >>> graph.edges["Root.Idle"]
+        ('⊥_root',)
     """
     leaves = _leaf_states(machine)
     nodes = tuple(sorted(_state_path(state) for state in leaves))
@@ -188,16 +297,36 @@ def _closure_from(
 
 
 def topological_reachable_set(machine: StateMachine) -> Dict[str, Tuple[str, ...]]:
-    """Compute guard-agnostic reachable leaf states for every model state.
+    """
+    Compute guard-agnostic reachable leaf states for every model state.
 
     Composite states are first projected through their initial descent and then
     closed over the leaf-level macro graph. Leaf-state results omit the leaf
     itself, matching the existing inspect reachability convention for cycles.
+    The returned mapping is keyed by dotted state paths for all states, not only
+    leaves.
 
     :param machine: State machine to inspect.
     :type machine: StateMachine
     :return: Mapping from every state path to sorted reachable leaf paths.
     :rtype: Dict[str, Tuple[str, ...]]
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     state B;
+        ...     [*] -> A;
+        ...     A -> B;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> topological_reachable_set(machine)["Root.A"]
+        ('Root.B',)
     """
     graph = build_leaf_level_macro_graph(machine)
     result: Dict[str, Tuple[str, ...]] = {}
@@ -213,12 +342,33 @@ def topological_reachable_set(machine: StateMachine) -> Dict[str, Tuple[str, ...
 
 
 def unreachable_states(machine: StateMachine) -> Tuple[str, ...]:
-    """Return non-pseudo leaf states unreachable from the root topology.
+    """
+    Return non-pseudo leaf states unreachable from the root topology.
+
+    The result uses topology reachability from the root initial descent and
+    filters out pseudo leaf states. Composite states are not returned directly;
+    their unreachable leaf descendants are reported instead.
 
     :param machine: State machine to inspect.
     :type machine: StateMachine
     :return: Sorted unreachable leaf state paths.
     :rtype: Tuple[str, ...]
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     state Lost;
+        ...     [*] -> A;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> unreachable_states(machine)
+        ('Root.Lost',)
     """
     root_path = _state_path(machine.root_state)
     reachable = set(topological_reachable_set(machine).get(root_path, tuple()))
@@ -309,12 +459,35 @@ def _is_cyclic_component(
 
 
 def strongly_connected_components(machine: StateMachine) -> Tuple[Tuple[str, ...], ...]:
-    """Return non-trivial SCCs in the leaf-level topology graph.
+    """
+    Return non-trivial SCCs in the leaf-level topology graph.
+
+    A non-trivial SCC is either a component with more than one leaf or a single
+    leaf with a self-loop. The implementation is iterative so deeply nested or
+    wide generated models are not limited by Python's recursion depth.
 
     :param machine: State machine to inspect.
     :type machine: StateMachine
     :return: Sorted non-trivial SCCs.
     :rtype: Tuple[Tuple[str, ...], ...]
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     state B;
+        ...     [*] -> A;
+        ...     A -> B;
+        ...     B -> A;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> strongly_connected_components(machine)
+        (('Root.A', 'Root.B'),)
     """
     graph = build_leaf_level_macro_graph(machine)
     return tuple(
@@ -349,12 +522,38 @@ def _nodes_that_can_reach_sink(graph: LeafLevelGraph) -> Set[str]:
 
 
 def topological_finite(machine: StateMachine) -> FinitenessReport:
-    """Check whether all root-reachable leaves can reach the root exit sink.
+    """
+    Check whether all root-reachable leaves can reach the root exit sink.
+
+    This check accepts models where every reachable leaf has at least one
+    topological route to termination, even if runtime guards could block that
+    route. It reports closed trap cycles that cannot reach the root sink and
+    deadlock leaves with no outgoing projected edge.
 
     :param machine: State machine to inspect.
     :type machine: StateMachine
     :return: Finiteness report with trap-cycle and deadlock counterexamples.
     :rtype: FinitenessReport
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     state B;
+        ...     [*] -> A;
+        ...     A -> B;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> report = topological_finite(machine)
+        >>> report.finite
+        False
+        >>> report.counterexamples
+        (('deadlock', 'Root.B'),)
     """
     graph = build_leaf_level_macro_graph(machine)
     reachable = _root_reachable_leaf_paths(machine, graph)
@@ -380,7 +579,8 @@ def topological_finite(machine: StateMachine) -> FinitenessReport:
 
 
 def topological_inevitable_terminator(machine: StateMachine) -> InevitabilityReport:
-    """Check whether every topological path must eventually terminate.
+    """
+    Check whether every topological path must eventually terminate.
 
     This is an intentionally structural check: any root-reachable deadlock or
     cycle is enough to produce a non-inevitability counterexample, even when
@@ -390,6 +590,26 @@ def topological_inevitable_terminator(machine: StateMachine) -> InevitabilityRep
     :type machine: StateMachine
     :return: Inevitability report.
     :rtype: InevitabilityReport
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     [*] -> A;
+        ...     A -> A;
+        ...     A -> [*];
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> report = topological_inevitable_terminator(machine)
+        >>> report.inevitable
+        False
+        >>> report.counterexample_path
+        ('Root.A',)
     """
     graph = build_leaf_level_macro_graph(machine)
     reachable = _root_reachable_leaf_paths(machine, graph)
@@ -452,15 +672,37 @@ def _root_reachable_state_paths(
 
 
 def event_emission_to_consumer_reachable(machine: StateMachine) -> Tuple[str, ...]:
-    """Return events whose consumer source states are all unreachable.
+    """
+    Return events whose consumer source states are all unreachable.
 
     Unused declared events are ignored here; they remain the responsibility of
     the existing design-health unused-event check.
+    A transition is treated as an event consumer at its source state. If every
+    consumer source for a used event is outside the root-reachable topology, the
+    event's qualified name is returned.
 
     :param machine: State machine to inspect.
     :type machine: StateMachine
     :return: Sorted qualified event names whose consumers are all unreachable.
     :rtype: Tuple[str, ...]
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     event Panic;
+        ...     state A;
+        ...     state Lost;
+        ...     [*] -> A;
+        ...     Lost -> A : Panic;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> event_emission_to_consumer_reachable(machine)
+        ('Root.Panic',)
     """
     graph = build_leaf_level_macro_graph(machine)
     reachable = _root_reachable_state_paths(machine, graph)

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -42,9 +42,23 @@ Example::
     ()
 """
 
+from __future__ import annotations
+
 from collections import deque
 from dataclasses import dataclass
-from typing import Deque, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from types import MappingProxyType
+from typing import (
+    TYPE_CHECKING,
+    Deque,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+)
 
 try:
     from typing import Literal
@@ -52,7 +66,9 @@ except ImportError:  # pragma: no cover - Python < 3.8 compatibility
     from typing_extensions import Literal
 
 from ..dsl import EXIT_STATE, INIT_STATE
-from ..model import State, StateMachine
+
+if TYPE_CHECKING:
+    from ..model import State, StateMachine
 
 EXIT_ROOT_SINK = "⊥_root"
 """Synthetic sink used for transitions that exit the root state."""
@@ -72,8 +88,9 @@ class LeafLevelGraph:
     :param nodes: Dotted paths of leaf states in stable sorted order.
     :type nodes: Tuple[str, ...]
     :param edges: Mapping from each leaf path, and optionally
-        :data:`EXIT_ROOT_SINK`, to sorted successor paths.
-    :type edges: Dict[str, Tuple[str, ...]]
+        :data:`EXIT_ROOT_SINK`, to sorted successor paths. The mapping is copied
+        into a read-only proxy during initialization.
+    :type edges: Mapping[str, Tuple[str, ...]]
 
     Example::
 
@@ -85,10 +102,23 @@ class LeafLevelGraph:
         ('Root.Idle',)
         >>> graph.edges["Root.Idle"]
         ('⊥_root',)
+        >>> graph.edges["Root.Idle"] = ("Root.Other",)
+        Traceback (most recent call last):
+        ...
+        TypeError: 'mappingproxy' object does not support item assignment
     """
 
     nodes: Tuple[str, ...]
-    edges: Dict[str, Tuple[str, ...]]
+    edges: Mapping[str, Tuple[str, ...]]
+
+    def __post_init__(self) -> None:
+        """
+        Freeze the edge mapping after dataclass initialization.
+
+        :return: ``None``.
+        :rtype: None
+        """
+        object.__setattr__(self, "edges", MappingProxyType(dict(self.edges)))
 
 
 @dataclass(frozen=True)
@@ -168,7 +198,7 @@ def _dedupe_sorted(items: Iterable[str]) -> Tuple[str, ...]:
     return tuple(sorted(set(items)))
 
 
-def _successors(edges: Dict[str, Tuple[str, ...]], node: str) -> Tuple[str, ...]:
+def _successors(edges: Mapping[str, Tuple[str, ...]], node: str) -> Tuple[str, ...]:
     return edges.get(node, tuple())
 
 
@@ -283,7 +313,7 @@ def build_leaf_level_macro_graph(machine: StateMachine) -> LeafLevelGraph:
 
 
 def _closure_from(
-    edges: Dict[str, Tuple[str, ...]],
+    edges: Mapping[str, Tuple[str, ...]],
     starts: Iterable[str],
 ) -> Set[str]:
     seen: Set[str] = set()
@@ -388,7 +418,7 @@ def unreachable_states(machine: StateMachine) -> Tuple[str, ...]:
 
 
 def _scc_components(
-    nodes: Sequence[str], edges: Dict[str, Tuple[str, ...]]
+    nodes: Sequence[str], edges: Mapping[str, Tuple[str, ...]]
 ) -> Tuple[Tuple[str, ...], ...]:
     node_set = set(nodes)
     ordered_nodes = sorted(node_set)
@@ -448,7 +478,7 @@ def _scc_components(
 
 def _is_cyclic_component(
     component: Tuple[str, ...],
-    edges: Dict[str, Tuple[str, ...]],
+    edges: Mapping[str, Tuple[str, ...]],
 ) -> bool:
     if len(component) > 1:
         return True

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -1,0 +1,467 @@
+"""Topological verification algorithms for :mod:`pyfcstm.verify`.
+
+The algorithms in this module intentionally stay at the structural layer. They
+ignore guard satisfiability, event availability, and runtime variable evolution;
+their results therefore describe topological reachability rather than concrete
+execution reachability.
+"""
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+try:
+    from typing import Literal
+except ImportError:  # pragma: no cover - Python < 3.8 compatibility
+    from typing_extensions import Literal
+
+from ..dsl import EXIT_STATE, INIT_STATE
+from ..model import State, StateMachine
+
+EXIT_ROOT_SINK = "⊥_root"
+"""Synthetic sink used for transitions that exit the root state."""
+
+
+@dataclass(frozen=True)
+class LeafLevelGraph:
+    """Leaf-level macro graph projected from a hierarchical state machine.
+
+    :param nodes: Dotted paths of leaf states in stable sorted order.
+    :type nodes: Tuple[str, ...]
+    :param edges: Mapping from each leaf path, and optionally
+        :data:`EXIT_ROOT_SINK`, to sorted successor paths.
+    :type edges: Dict[str, Tuple[str, ...]]
+    """
+
+    nodes: Tuple[str, ...]
+    edges: Dict[str, Tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class FinitenessReport:
+    """Result for :func:`topological_finite`.
+
+    :param finite: ``True`` when every root-reachable leaf can reach the root
+        exit sink in the topological graph.
+    :type finite: bool
+    :param counterexamples: Counterexamples as ``('trap_cycle', scc_tuple)`` or
+        ``('deadlock', state_path)`` entries.
+    :type counterexamples: Tuple[Tuple[Literal['trap_cycle', 'deadlock'], object], ...]
+    """
+
+    finite: bool
+    counterexamples: Tuple[Tuple[Literal["trap_cycle", "deadlock"], object], ...]
+
+
+@dataclass(frozen=True)
+class InevitabilityReport:
+    """Result for :func:`topological_inevitable_terminator`.
+
+    :param inevitable: ``True`` when no root-reachable topological path can stay
+        in a cycle or deadlock forever.
+    :type inevitable: bool
+    :param counterexample_path: Representative non-terminating SCC or deadlock
+        path, or ``None`` when :attr:`inevitable` is true.
+    :type counterexample_path: Optional[Tuple[str, ...]]
+    """
+
+    inevitable: bool
+    counterexample_path: Optional[Tuple[str, ...]]
+
+
+def _state_path(state: State) -> str:
+    return ".".join(state.path)
+
+
+def _leaf_states(machine: StateMachine) -> Tuple[State, ...]:
+    return tuple(state for state in machine.walk_states() if state.is_leaf_state)
+
+
+def _dedupe_sorted(items: Iterable[str]) -> Tuple[str, ...]:
+    return tuple(sorted(set(items)))
+
+
+def _successors(edges: Dict[str, Tuple[str, ...]], node: str) -> Tuple[str, ...]:
+    return edges.get(node, tuple())
+
+
+def _project_target(parent_state: State, target: object) -> Tuple[str, ...]:
+    """Project a transition target into leaf-level graph successors."""
+    if target is EXIT_STATE:
+        if parent_state.is_root_state:
+            return (EXIT_ROOT_SINK,)
+
+        parent_parent = parent_state.parent
+        assert parent_parent is not None
+        projected: List[str] = []
+        for transition in parent_state.transitions_from:
+            if transition.to_state is EXIT_STATE:
+                projected.extend(_project_target(parent_parent, EXIT_STATE))
+            else:
+                projected.extend(_project_target(parent_parent, transition.to_state))
+        return _dedupe_sorted(projected)
+
+    if isinstance(target, str):
+        target_state = parent_state.substates[target]
+        return _initial_leaf_targets(target_state)
+
+    raise TypeError(  # pragma: no cover
+        # Grammar-produced model transitions use only string state names and
+        # INIT/EXIT singletons. This guard exposes future model extensions
+        # loudly instead of silently treating an unknown endpoint as safe.
+        f"Unsupported transition target: {target!r}."
+    )
+
+
+def _initial_leaf_targets(state: State) -> Tuple[str, ...]:
+    """Project entering ``state`` to the leaves reached by initial descent."""
+    if state.is_leaf_state:
+        return (_state_path(state),)
+
+    projected: List[str] = []
+    for transition in state.init_transitions:
+        projected.extend(_project_target(state, transition.to_state))
+    return _dedupe_sorted(projected)
+
+
+def build_leaf_level_macro_graph(machine: StateMachine) -> LeafLevelGraph:
+    """Build the guard-agnostic leaf-level macro graph for ``machine``.
+
+    The projection follows normal leaf-to-leaf transitions, expands composite
+    targets through their initial transitions, and bubbles ``Leaf -> [*]``
+    transitions through parent outgoing transitions. If a non-root parent has no
+    outgoing transition, the bubble is an off-cliff exit and contributes no edge.
+
+    :param machine: State machine to project.
+    :type machine: StateMachine
+    :return: Leaf-level macro graph.
+    :rtype: LeafLevelGraph
+    """
+    leaves = _leaf_states(machine)
+    nodes = tuple(sorted(_state_path(state) for state in leaves))
+    edge_sets: Dict[str, Set[str]] = {node: set() for node in nodes}
+
+    for parent_state in machine.walk_states():
+        for transition in parent_state.transitions:
+            if transition.from_state is INIT_STATE:
+                continue
+
+            if not isinstance(transition.from_state, str):
+                raise TypeError(  # pragma: no cover
+                    # Grammar-produced non-init transition sources are strings.
+                    # A future model endpoint type should be made explicit here.
+                    f"Unsupported transition source: {transition.from_state!r}."
+                )
+
+            source_state = parent_state.substates[transition.from_state]
+            if not source_state.is_leaf_state:
+                continue
+
+            source_path = _state_path(source_state)
+            edge_sets.setdefault(source_path, set()).update(
+                _project_target(parent_state, transition.to_state)
+            )
+
+    edges = {node: tuple(sorted(targets)) for node, targets in edge_sets.items()}
+    edges.setdefault(EXIT_ROOT_SINK, tuple())
+    return LeafLevelGraph(nodes=nodes, edges=edges)
+
+
+def _closure_from(
+    edges: Dict[str, Tuple[str, ...]],
+    starts: Iterable[str],
+) -> Set[str]:
+    seen: Set[str] = set()
+    queue: Deque[str] = deque(starts)
+    while queue:
+        node = queue.popleft()
+        if node in seen:
+            continue
+        seen.add(node)
+        for successor in _successors(edges, node):
+            if successor not in seen:
+                queue.append(successor)
+    return seen
+
+
+def topological_reachable_set(machine: StateMachine) -> Dict[str, Tuple[str, ...]]:
+    """Compute guard-agnostic reachable leaf states for every model state.
+
+    Composite states are first projected through their initial descent and then
+    closed over the leaf-level macro graph. Leaf-state results omit the leaf
+    itself, matching the existing inspect reachability convention for cycles.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :return: Mapping from every state path to sorted reachable leaf paths.
+    :rtype: Dict[str, Tuple[str, ...]]
+    """
+    graph = build_leaf_level_macro_graph(machine)
+    result: Dict[str, Tuple[str, ...]] = {}
+    for state in machine.walk_states():
+        state_path = _state_path(state)
+        starts = _initial_leaf_targets(state)
+        reachable = _closure_from(graph.edges, starts)
+        reachable.discard(EXIT_ROOT_SINK)
+        if state.is_leaf_state:
+            reachable.discard(state_path)
+        result[state_path] = tuple(sorted(reachable))
+    return result
+
+
+def unreachable_states(machine: StateMachine) -> Tuple[str, ...]:
+    """Return non-pseudo leaf states unreachable from the root topology.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :return: Sorted unreachable leaf state paths.
+    :rtype: Tuple[str, ...]
+    """
+    root_path = _state_path(machine.root_state)
+    reachable = set(topological_reachable_set(machine).get(root_path, tuple()))
+    reachable.add(root_path)
+    return tuple(
+        sorted(
+            _state_path(state)
+            for state in machine.walk_states()
+            if state.is_leaf_state
+            and not state.is_pseudo
+            and _state_path(state) not in reachable
+        )
+    )
+
+
+def _tarjan_scc(
+    nodes: Sequence[str], edges: Dict[str, Tuple[str, ...]]
+) -> Tuple[Tuple[str, ...], ...]:
+    index = 0
+    indexes: Dict[str, int] = {}
+    lowlinks: Dict[str, int] = {}
+    stack: List[str] = []
+    on_stack: Set[str] = set()
+    components: List[Tuple[str, ...]] = []
+
+    def strongconnect(node: str) -> None:
+        nonlocal index
+        indexes[node] = index
+        lowlinks[node] = index
+        index += 1
+        stack.append(node)
+        on_stack.add(node)
+
+        for successor in edges.get(node, tuple()):
+            if successor == EXIT_ROOT_SINK:
+                continue
+            if successor not in indexes:
+                strongconnect(successor)
+                lowlinks[node] = min(lowlinks[node], lowlinks[successor])
+            elif successor in on_stack:
+                lowlinks[node] = min(lowlinks[node], indexes[successor])
+
+        if lowlinks[node] == indexes[node]:
+            component: List[str] = []
+            while True:
+                item = stack.pop()
+                on_stack.remove(item)
+                component.append(item)
+                if item == node:
+                    break
+            components.append(tuple(sorted(component)))
+
+    for node in sorted(nodes):
+        if node not in indexes:
+            strongconnect(node)
+
+    return tuple(sorted(components))
+
+
+def _is_cyclic_component(
+    component: Tuple[str, ...],
+    edges: Dict[str, Tuple[str, ...]],
+) -> bool:
+    if len(component) > 1:
+        return True
+    if len(component) == 0:  # pragma: no cover
+        # Tarjan only emits non-empty components. Keep this guard so the helper
+        # remains total if it is reused with hand-built component data.
+        return False
+    node = component[0]
+    return node in edges.get(node, tuple())
+
+
+def strongly_connected_components(machine: StateMachine) -> Tuple[Tuple[str, ...], ...]:
+    """Return non-trivial SCCs in the leaf-level topology graph.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :return: Sorted non-trivial SCCs.
+    :rtype: Tuple[Tuple[str, ...], ...]
+    """
+    graph = build_leaf_level_macro_graph(machine)
+    return tuple(
+        component
+        for component in _tarjan_scc(graph.nodes, graph.edges)
+        if _is_cyclic_component(component, graph.edges)
+    )
+
+
+def _root_reachable_leaf_paths(
+    machine: StateMachine,
+    graph: LeafLevelGraph,
+) -> Set[str]:
+    reachable = _closure_from(graph.edges, _initial_leaf_targets(machine.root_state))
+    reachable.discard(EXIT_ROOT_SINK)
+    return reachable
+
+
+def _nodes_that_can_reach_sink(graph: LeafLevelGraph) -> Set[str]:
+    reverse_edges: Dict[str, Set[str]] = {node: set() for node in graph.nodes}
+    reverse_edges[EXIT_ROOT_SINK] = set()
+    for source, targets in graph.edges.items():
+        for target in targets:
+            reverse_edges.setdefault(target, set()).add(source)
+
+    can_reach = _closure_from(
+        {node: tuple(sorted(targets)) for node, targets in reverse_edges.items()},
+        (EXIT_ROOT_SINK,),
+    )
+    can_reach.discard(EXIT_ROOT_SINK)
+    return can_reach
+
+
+def topological_finite(machine: StateMachine) -> FinitenessReport:
+    """Check whether all root-reachable leaves can reach the root exit sink.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :return: Finiteness report with trap-cycle and deadlock counterexamples.
+    :rtype: FinitenessReport
+    """
+    graph = build_leaf_level_macro_graph(machine)
+    reachable = _root_reachable_leaf_paths(machine, graph)
+    can_reach_sink = _nodes_that_can_reach_sink(graph)
+
+    counterexamples: List[Tuple[Literal["trap_cycle", "deadlock"], object]] = []
+    for component in strongly_connected_components(machine):
+        if not reachable.intersection(component):
+            continue
+        if not any(node in can_reach_sink for node in component):
+            counterexamples.append(("trap_cycle", component))
+
+    for node in sorted(reachable):
+        if node in can_reach_sink:
+            continue
+        if len(graph.edges.get(node, tuple())) == 0:
+            counterexamples.append(("deadlock", node))
+
+    return FinitenessReport(
+        finite=not counterexamples,
+        counterexamples=tuple(counterexamples),
+    )
+
+
+def topological_inevitable_terminator(machine: StateMachine) -> InevitabilityReport:
+    """Check whether every topological path must eventually terminate.
+
+    This is an intentionally structural check: any root-reachable deadlock or
+    cycle is enough to produce a non-inevitability counterexample, even when
+    another outgoing edge could exit at runtime.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :return: Inevitability report.
+    :rtype: InevitabilityReport
+    """
+    graph = build_leaf_level_macro_graph(machine)
+    reachable = _root_reachable_leaf_paths(machine, graph)
+
+    for component in strongly_connected_components(machine):
+        if reachable.intersection(component):
+            return InevitabilityReport(
+                inevitable=False,
+                counterexample_path=component,
+            )
+
+    for node in sorted(reachable):
+        if len(graph.edges.get(node, tuple())) == 0:
+            return InevitabilityReport(
+                inevitable=False,
+                counterexample_path=(node,),
+            )
+
+    return InevitabilityReport(inevitable=True, counterexample_path=None)
+
+
+def _event_consumers(machine: StateMachine) -> Dict[str, Set[str]]:
+    consumers: Dict[str, Set[str]] = {}
+    for parent_state in machine.walk_states():
+        parent_path = _state_path(parent_state)
+        for transition in parent_state.transitions:
+            event = transition.event
+            if event is None:
+                continue
+
+            event_name = event.path_name
+            if transition.from_state is INIT_STATE:
+                source_path = parent_path
+            elif isinstance(transition.from_state, str):
+                source_path = _state_path(parent_state.substates[transition.from_state])
+            else:
+                raise TypeError(  # pragma: no cover
+                    # Grammar-produced non-init transition sources are strings.
+                    # A future model endpoint type should be made explicit here.
+                    f"Unsupported transition source: {transition.from_state!r}."
+                )
+            consumers.setdefault(event_name, set()).add(source_path)
+    return consumers
+
+
+def _root_reachable_state_paths(
+    machine: StateMachine,
+    graph: LeafLevelGraph,
+) -> Set[str]:
+    reachable_leaves = _root_reachable_leaf_paths(machine, graph)
+    reachable_paths = set(reachable_leaves)
+    reachable_paths.add(_state_path(machine.root_state))
+
+    for state in machine.walk_states():
+        if state.is_leaf_state:
+            continue
+        if reachable_leaves.intersection(_initial_leaf_targets(state)):
+            reachable_paths.add(_state_path(state))
+    return reachable_paths
+
+
+def event_emission_to_consumer_reachable(machine: StateMachine) -> Tuple[str, ...]:
+    """Return events whose consumer source states are all unreachable.
+
+    Unused declared events are ignored here; they remain the responsibility of
+    the existing design-health unused-event check.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :return: Sorted qualified event names whose consumers are all unreachable.
+    :rtype: Tuple[str, ...]
+    """
+    graph = build_leaf_level_macro_graph(machine)
+    reachable = _root_reachable_state_paths(machine, graph)
+    unreachable_events = []
+    for event_name, sources in _event_consumers(machine).items():
+        if sources and all(source not in reachable for source in sources):
+            unreachable_events.append(event_name)
+    return tuple(sorted(unreachable_events))
+
+
+__all__ = [
+    "EXIT_ROOT_SINK",
+    "FinitenessReport",
+    "InevitabilityReport",
+    "LeafLevelGraph",
+    "build_leaf_level_macro_graph",
+    "event_emission_to_consumer_reachable",
+    "strongly_connected_components",
+    "topological_finite",
+    "topological_inevitable_terminator",
+    "topological_reachable_set",
+    "unreachable_states",
+]

--- a/pyfcstm/verify/topology.py
+++ b/pyfcstm/verify/topology.py
@@ -67,7 +67,7 @@ except ImportError:  # pragma: no cover - Python < 3.8 compatibility
 
 from ..dsl import EXIT_STATE, INIT_STATE
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover - imports used only by static type checkers
     from ..model import State, StateMachine
 
 EXIT_ROOT_SINK = "⊥_root"

--- a/test/verify/test_registry.py
+++ b/test/verify/test_registry.py
@@ -61,6 +61,33 @@ def test_registry_module_does_not_expose_mutable_backing_store():
     assert not hasattr(registry_module, "_REGISTRY")
 
 
+def test_registry_import_does_not_transitively_import_diagnostics():
+    import subprocess
+    import sys
+
+    script = """
+import sys
+
+before = set(sys.modules)
+import pyfcstm.verify.registry  # noqa: F401
+loaded = sorted(
+    name for name in set(sys.modules) - before
+    if name == 'pyfcstm.diagnostics' or name.startswith('pyfcstm.diagnostics.')
+)
+if loaded:
+    raise SystemExit("\\n".join(loaded))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_group1_topology_metadata_contract():
     for name in GROUP1_TOPOLOGY:
         meta = REGISTRY[name]

--- a/test/verify/test_registry.py
+++ b/test/verify/test_registry.py
@@ -42,14 +42,17 @@ def test_registry_contains_exactly_all_pr_a_algorithms_in_stable_order():
     assert len(REGISTRY) == 19
 
 
-def test_registry_keys_match_meta_names_and_all_impls_are_placeholders():
+def test_registry_keys_match_meta_names_and_pr_a3_impl_state():
     assert not hasattr(REGISTRY, "__setitem__")
     assert len(set(REGISTRY)) == len(REGISTRY)
     for name, meta in REGISTRY.items():
         assert meta.name == name
         assert meta.description
         assert meta.quantifier_alternation_depth == 0
-        assert meta.impl is None
+        if name in GROUP1_TOPOLOGY:
+            assert meta.impl is not None
+        else:
+            assert meta.impl is None
 
 
 def test_registry_module_does_not_expose_mutable_backing_store():
@@ -122,8 +125,7 @@ def test_group2_smt_local_metadata_contract():
     assert REGISTRY["forced_guard_unsat_under_init"].fallback_unknown_risk == "low"
     assert REGISTRY["transition_shadowed_by_predecessor"].incremental is True
     assert (
-        REGISTRY["enter_postcondition_implies_during_precondition"].incremental
-        is True
+        REGISTRY["enter_postcondition_implies_during_precondition"].incremental is True
     )
     assert (
         REGISTRY["enter_postcondition_implies_during_precondition"].call_count_scaling
@@ -275,13 +277,12 @@ def test_verify_package_does_not_import_diagnostics():
     assert bad == []
 
 
-def test_verify_package_does_not_create_algorithm_modules():
+def test_verify_package_does_not_create_later_algorithm_modules():
     import pathlib
 
     forbidden_paths = (
         "pyfcstm/verify/search.py",
         "pyfcstm/verify/reachability.py",
-        "pyfcstm/verify/topology.py",
         "pyfcstm/verify/smt_local.py",
     )
     assert [path for path in forbidden_paths if pathlib.Path(path).exists()] == []

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -204,6 +204,51 @@ def test_build_leaf_level_macro_graph_handles_root_exit_sink_once():
     assert graph.edges[topology.EXIT_ROOT_SINK] == tuple()
 
 
+def test_build_leaf_level_macro_graph_bubbles_parent_exit_to_root_sink():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state Outer {
+                state A;
+                [*] -> A;
+                A -> [*];
+            }
+            [*] -> Outer;
+            Outer -> [*];
+        }
+        """
+    )
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+
+    assert graph.edges["Root.Outer.A"] == (topology.EXIT_ROOT_SINK,)
+
+
+def test_topological_reachable_set_handles_diamond_closure_without_duplicates():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state B;
+            state C;
+            state D;
+            [*] -> A;
+            A -> B;
+            A -> C;
+            B -> D;
+            C -> D;
+            D -> [*];
+        }
+        """
+    )
+
+    reachable = topology.topological_reachable_set(machine)
+
+    assert reachable["Root.A"] == ("Root.B", "Root.C", "Root.D")
+
+
 def test_topological_finite_ignores_unreachable_trap_cycle():
     topology = _import_topology()
     machine = _parse(
@@ -460,6 +505,25 @@ def test_topological_inevitable_terminator_reports_self_loop_even_with_exit():
 
     assert report.inevitable is False
     assert report.counterexample_path == ("Root.A",)
+
+
+def test_topological_inevitable_terminator_reports_deadlock_leaf():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+    )
+
+    report = topology.topological_inevitable_terminator(machine)
+
+    assert report.inevitable is False
+    assert report.counterexample_path == ("Root.B",)
 
 
 def test_event_emission_to_consumer_reachable_reports_fully_unreachable_event():

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -1,4 +1,5 @@
 import inspect
+from dataclasses import FrozenInstanceError
 from typing import cast
 
 import pytest
@@ -68,6 +69,20 @@ def test_build_leaf_level_macro_graph_flat_edges():
     assert graph.nodes == ("Root.Active", "Root.Idle")
     assert graph.edges["Root.Idle"] == ("Root.Active",)
     assert graph.edges["Root.Active"] == (topology.EXIT_ROOT_SINK,)
+
+
+def test_leaf_level_graph_is_immutable_value_object():
+    topology = _import_topology()
+
+    graph = topology.LeafLevelGraph(
+        nodes=("Root.A",),
+        edges={"Root.A": (topology.EXIT_ROOT_SINK,)},
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        graph.nodes = ("Root.B",)  # pyright: ignore[reportAttributeAccessIssue]
+    with pytest.raises(TypeError):
+        graph.edges["Root.A"] = ("Root.B",)  # pyright: ignore[reportIndexIssue]
 
 
 def test_build_leaf_level_macro_graph_init_cascade_and_leaf_bubble():

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -392,6 +392,26 @@ def test_strongly_connected_components_handles_deep_chain_without_recursion():
     assert topology.topological_finite(machine).finite is True
 
 
+def test_strongly_connected_components_keeps_diamond_join_acyclic():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B;
+            A -> C;
+            B -> C;
+            C -> [*];
+        }
+        """
+    )
+
+    assert topology.strongly_connected_components(machine) == tuple()
+
+
 def test_topological_finite_accepts_every_reachable_leaf_with_exit_path():
     topology = _import_topology()
     machine = _parse(

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -352,6 +352,135 @@ def test_event_consumer_reachability_handles_nested_composite_sources():
     )
 
 
+def test_event_consumer_reachability_requires_bubble_for_composite_sources():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state System {
+                event Stop;
+                state Running {
+                    state Active;
+                    [*] -> Active;
+                }
+                [*] -> Running;
+                Running -> [*] : Stop;
+            }
+            [*] -> System;
+            System -> [*];
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == (
+        "Root.System.Stop",
+    )
+
+
+def test_event_consumer_reachability_follows_chained_composite_boundary_exits():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event RootStop;
+            event InnerStop;
+            state Outer {
+                state Inner {
+                    state Active;
+                    [*] -> Active;
+                    Active -> [*];
+                }
+                [*] -> Inner;
+                Inner -> [*] : InnerStop;
+            }
+            [*] -> Outer;
+            Outer -> [*] : RootStop;
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == tuple()
+
+
+def test_event_consumer_reachability_deduplicates_boundary_exits():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event Stop;
+            state Outer {
+                state Inner {
+                    state A;
+                    state B;
+                    [*] -> A;
+                    A -> B;
+                    A -> [*];
+                    B -> [*];
+                }
+                [*] -> Inner;
+                Inner -> [*] : Stop;
+            }
+            [*] -> Outer;
+            Outer -> [*];
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == tuple()
+
+
+def test_event_consumer_reachability_ignores_non_exit_boundary_transition():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event Stop;
+            state Outer {
+                state Inner {
+                    state Active;
+                    [*] -> Active;
+                    Active -> [*];
+                }
+                state Done;
+                [*] -> Inner;
+                Inner -> Done;
+            }
+            [*] -> Outer;
+            Outer -> [*] : Stop;
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == (
+        "Root.Stop",
+    )
+
+
+def test_event_consumer_reachability_reports_unexposed_outer_boundary_event():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event RootStop;
+            state Outer {
+                state Inner {
+                    state Active;
+                    [*] -> Active;
+                    Active -> [*];
+                }
+                [*] -> Inner;
+            }
+            [*] -> Outer;
+            Outer -> [*] : RootStop;
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == (
+        "Root.RootStop",
+    )
+
+
 def test_topological_reachable_set_handles_diamond_closure_without_duplicates():
     topology = _import_topology()
     machine = _parse(

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -204,6 +204,18 @@ def test_build_leaf_level_macro_graph_handles_root_exit_sink_once():
     assert graph.edges[topology.EXIT_ROOT_SINK] == tuple()
 
 
+def test_build_leaf_level_macro_graph_treats_root_leaf_as_exit_capable():
+    topology = _import_topology()
+    machine = _parse("state Root;")
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+
+    assert graph.nodes == ("Root",)
+    assert graph.edges["Root"] == (topology.EXIT_ROOT_SINK,)
+    assert topology.topological_finite(machine).finite is True
+    assert topology.topological_inevitable_terminator(machine).inevitable is True
+
+
 def test_build_leaf_level_macro_graph_bubbles_parent_exit_to_root_sink():
     topology = _import_topology()
     machine = _parse(
@@ -361,6 +373,23 @@ def test_strongly_connected_components_ignores_acyclic_graph():
     )
 
     assert topology.strongly_connected_components(machine) == tuple()
+
+
+def test_strongly_connected_components_handles_deep_chain_without_recursion():
+    topology = _import_topology()
+    n_states = 1050
+    lines = ["state Root {"]
+    for index in range(n_states):
+        lines.append("    state S%d;" % index)
+    lines.append("    [*] -> S0;")
+    for index in range(n_states - 1):
+        lines.append("    S%d -> S%d;" % (index, index + 1))
+    lines.append("    S%d -> [*];" % (n_states - 1))
+    lines.append("}")
+    machine = _parse("\n".join(lines))
+
+    assert topology.strongly_connected_components(machine) == tuple()
+    assert topology.topological_finite(machine).finite is True
 
 
 def test_topological_finite_accepts_every_reachable_leaf_with_exit_path():

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -1,0 +1,561 @@
+import inspect
+from typing import cast
+
+import pytest
+
+from pyfcstm.diagnostics import inspect_model
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import StateMachine, parse_dsl_node_to_state_machine
+from pyfcstm.verify.registry import REGISTRY
+
+
+pytestmark = pytest.mark.unittest
+
+
+GROUP1_TOPOLOGY = (
+    "topological_reachable_set",
+    "unreachable_states",
+    "strongly_connected_components",
+    "topological_finite",
+    "topological_inevitable_terminator",
+    "event_emission_to_consumer_reachable",
+)
+
+GROUP2_AND_GROUP3 = (
+    "dead_guard",
+    "guard_tautology",
+    "forced_guard_unsat_under_init",
+    "effect_no_op_under_guard",
+    "effect_contradicts_guard",
+    "transition_shadowed_by_predecessor",
+    "enter_postcondition_implies_during_precondition",
+    "composite_init_guards_incomplete",
+    "bounded_reachability",
+    "symbolic_bfs",
+    "bounded_safety",
+    "bounded_invariant",
+    "path_witness",
+)
+
+
+def _parse(src: str) -> StateMachine:
+    ast = parse_with_grammar_entry(src, "state_machine_dsl")
+    return cast(StateMachine, parse_dsl_node_to_state_machine(ast))
+
+
+def _import_topology():
+    from pyfcstm.verify import topology
+
+    return topology
+
+
+def test_build_leaf_level_macro_graph_flat_edges():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state Idle;
+            state Active;
+            [*] -> Idle;
+            Idle -> Active;
+            Active -> [*];
+        }
+        """
+    )
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+
+    assert graph.nodes == ("Root.Active", "Root.Idle")
+    assert graph.edges["Root.Idle"] == ("Root.Active",)
+    assert graph.edges["Root.Active"] == (topology.EXIT_ROOT_SINK,)
+
+
+def test_build_leaf_level_macro_graph_init_cascade_and_leaf_bubble():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state System {
+            state Working {
+                state Active;
+                state Idle;
+                [*] -> Active;
+                Active -> Idle;
+                Idle -> [*];
+            }
+            state Done;
+            state Orphan;
+            [*] -> Working;
+            Working -> Done;
+            Done -> [*];
+        }
+        """
+    )
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+
+    assert graph.edges["System.Working.Active"] == ("System.Working.Idle",)
+    assert graph.edges["System.Working.Idle"] == ("System.Done",)
+    assert graph.edges["System.Done"] == (topology.EXIT_ROOT_SINK,)
+    assert graph.edges["System.Orphan"] == tuple()
+
+
+def test_build_leaf_level_macro_graph_uses_forced_expansion_and_parent_bubble():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A {
+                state A1;
+                state A2;
+                [*] -> A1;
+            }
+            state Error;
+            [*] -> A;
+            !A -> Error :: Crash;
+        }
+        """
+    )
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+
+    assert graph.edges["Root.A.A1"] == ("Root.Error",)
+    assert graph.edges["Root.A.A2"] == ("Root.Error",)
+
+
+def test_topological_reachable_set_handles_nested_hierarchy_and_bubble():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state System {
+            state Working {
+                state Active;
+                state Idle;
+                [*] -> Active;
+                Active -> Idle;
+                Idle -> [*];
+            }
+            state Done;
+            state Orphan;
+            [*] -> Working;
+            Working -> Done;
+            Done -> [*];
+        }
+        """
+    )
+
+    reachable = topology.topological_reachable_set(machine)
+
+    assert reachable["System"] == (
+        "System.Done",
+        "System.Working.Active",
+        "System.Working.Idle",
+    )
+    assert reachable["System.Working"] == (
+        "System.Done",
+        "System.Working.Active",
+        "System.Working.Idle",
+    )
+    assert reachable["System.Working.Active"] == (
+        "System.Done",
+        "System.Working.Idle",
+    )
+    assert reachable["System.Working.Idle"] == ("System.Done",)
+    assert reachable["System.Done"] == tuple()
+    assert reachable["System.Orphan"] == tuple()
+
+
+def test_topological_reachable_set_matches_inspect_on_flat_model():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state Idle;
+            state Active;
+            [*] -> Idle;
+            Idle -> Active;
+            Active -> Idle;
+        }
+        """
+    )
+
+    actual = topology.topological_reachable_set(machine)
+    expected = inspect_model(machine).reachability_graph
+
+    assert {name: set(value) for name, value in actual.items()} == {
+        name: set(value) for name, value in expected.items()
+    }
+
+
+def test_build_leaf_level_macro_graph_handles_root_exit_sink_once():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            [*] -> A;
+            A -> [*];
+        }
+        """
+    )
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+
+    assert graph.edges["Root.A"] == (topology.EXIT_ROOT_SINK,)
+    assert graph.edges[topology.EXIT_ROOT_SINK] == tuple()
+
+
+def test_topological_finite_ignores_unreachable_trap_cycle():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state Lost1;
+            state Lost2;
+            [*] -> A;
+            A -> [*];
+            Lost1 -> Lost2;
+            Lost2 -> Lost1;
+        }
+        """
+    )
+
+    report = topology.topological_finite(machine)
+
+    assert report.finite is True
+    assert report.counterexamples == tuple()
+
+
+def test_unreachable_states_reports_unreachable_leaves_only():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state OrphanComposite {
+                state Lost;
+                [*] -> Lost;
+            }
+            state OrphanLeaf;
+            [*] -> A;
+        }
+        """
+    )
+
+    assert topology.unreachable_states(machine) == (
+        "Root.OrphanComposite.Lost",
+        "Root.OrphanLeaf",
+    )
+
+
+def test_unreachable_states_ignores_unreachable_pseudo_states():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            pseudo state Crash;
+            [*] -> A;
+        }
+        """
+    )
+
+    assert topology.unreachable_states(machine) == tuple()
+
+
+def test_strongly_connected_components_reports_two_node_cycle():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Controller {
+            state Idle;
+            state Running;
+            state Stopped;
+            [*] -> Idle;
+            Idle -> Running;
+            Running -> Idle;
+            Running -> Stopped;
+            Stopped -> [*];
+        }
+        """
+    )
+
+    assert topology.strongly_connected_components(machine) == (
+        ("Controller.Idle", "Controller.Running"),
+    )
+
+
+def test_strongly_connected_components_reports_self_loop():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state Loop;
+            [*] -> Loop;
+            Loop -> Loop;
+            Loop -> [*];
+        }
+        """
+    )
+
+    assert topology.strongly_connected_components(machine) == (("Root.Loop",),)
+
+
+def test_strongly_connected_components_ignores_acyclic_graph():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+            B -> [*];
+        }
+        """
+    )
+
+    assert topology.strongly_connected_components(machine) == tuple()
+
+
+def test_topological_finite_accepts_every_reachable_leaf_with_exit_path():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+            B -> [*];
+        }
+        """
+    )
+
+    report = topology.topological_finite(machine)
+
+    assert report.finite is True
+    assert report.counterexamples == tuple()
+
+
+def test_topological_finite_reports_trap_cycle():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state System {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+            B -> A;
+        }
+        """
+    )
+
+    report = topology.topological_finite(machine)
+
+    assert report.finite is False
+    assert report.counterexamples == (("trap_cycle", ("System.A", "System.B")),)
+
+
+def test_topological_finite_reports_deadlock():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state System {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+    )
+
+    report = topology.topological_finite(machine)
+
+    assert report.finite is False
+    assert report.counterexamples == (("deadlock", "System.B"),)
+
+
+def test_topological_finite_treats_parent_off_cliff_exit_as_deadlock():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state Outer {
+                state A;
+                [*] -> A;
+                A -> [*];
+            }
+            [*] -> Outer;
+        }
+        """
+    )
+
+    report = topology.topological_finite(machine)
+
+    assert report.finite is False
+    assert report.counterexamples == (("deadlock", "Root.Outer.A"),)
+
+
+def test_topological_inevitable_terminator_accepts_straight_exit():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state Done;
+            [*] -> A;
+            A -> Done;
+            Done -> [*];
+        }
+        """
+    )
+
+    report = topology.topological_inevitable_terminator(machine)
+
+    assert report.inevitable is True
+    assert report.counterexample_path is None
+
+
+def test_topological_inevitable_terminator_reports_branch_to_cycle():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state System {
+            state Init;
+            state Cycle;
+            state Done;
+            [*] -> Init;
+            Init -> Cycle;
+            Init -> Done;
+            Done -> [*];
+            Cycle -> Cycle;
+        }
+        """
+    )
+
+    report = topology.topological_inevitable_terminator(machine)
+
+    assert report.inevitable is False
+    assert report.counterexample_path == ("System.Cycle",)
+
+
+def test_topological_inevitable_terminator_reports_self_loop_even_with_exit():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state A;
+            state Done;
+            [*] -> A;
+            A -> A;
+            A -> Done;
+            Done -> [*];
+        }
+        """
+    )
+
+    report = topology.topological_inevitable_terminator(machine)
+
+    assert report.inevitable is False
+    assert report.counterexample_path == ("Root.A",)
+
+
+def test_event_emission_to_consumer_reachable_reports_fully_unreachable_event():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event PanicEvt;
+            state A;
+            state Unreachable1;
+            state Unreachable2;
+            [*] -> A;
+            A -> A;
+            Unreachable1 -> Unreachable2 : PanicEvt;
+            Unreachable2 -> A : PanicEvt;
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == ("Root.PanicEvt",)
+
+
+def test_event_emission_to_consumer_reachable_allows_partially_reachable_event():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event NormalEvt;
+            state A;
+            state B;
+            state Unreachable;
+            [*] -> A;
+            A -> B : NormalEvt;
+            Unreachable -> A : NormalEvt;
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == tuple()
+
+
+def test_event_emission_to_consumer_reachable_ignores_unused_declared_event():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event Unused;
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == tuple()
+
+
+def test_event_emission_to_consumer_reachable_handles_init_event_source_as_reachable():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event Boot;
+            state A;
+            [*] -> A : Boot;
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == tuple()
+
+
+def test_registry_wires_group1_impls_and_preserves_later_placeholders():
+    topology = _import_topology()
+
+    expected_impls = {
+        "topological_reachable_set": topology.topological_reachable_set,
+        "unreachable_states": topology.unreachable_states,
+        "strongly_connected_components": topology.strongly_connected_components,
+        "topological_finite": topology.topological_finite,
+        "topological_inevitable_terminator": (
+            topology.topological_inevitable_terminator
+        ),
+        "event_emission_to_consumer_reachable": (
+            topology.event_emission_to_consumer_reachable
+        ),
+    }
+    for name in GROUP1_TOPOLOGY:
+        assert REGISTRY[name].impl is expected_impls[name]
+    for name in GROUP2_AND_GROUP3:
+        assert REGISTRY[name].impl is None
+
+
+def test_topology_module_stays_independent_from_diagnostics_package():
+    topology = _import_topology()
+
+    source = inspect.getsource(topology)
+
+    assert "pyfcstm.diagnostics" not in source
+    assert "from ..diagnostics" not in source

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -237,6 +237,121 @@ def test_build_leaf_level_macro_graph_bubbles_parent_exit_to_root_sink():
     assert graph.edges["Root.Outer.A"] == (topology.EXIT_ROOT_SINK,)
 
 
+def test_build_leaf_level_macro_graph_requires_leaf_exit_before_parent_transition():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state Running {
+                state Active;
+                state Idle;
+                [*] -> Active;
+                Active -> Idle;
+            }
+            state Error;
+            [*] -> Running;
+            Running -> Error;
+            Error -> [*];
+        }
+        """
+    )
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+    reachable = topology.topological_reachable_set(machine)
+
+    assert graph.edges["Root.Running.Active"] == ("Root.Running.Idle",)
+    assert graph.edges["Root.Running.Idle"] == tuple()
+    assert reachable["Root"] == ("Root.Running.Active", "Root.Running.Idle")
+    assert reachable["Root.Running"] == (
+        "Root.Running.Active",
+        "Root.Running.Idle",
+    )
+    assert topology.unreachable_states(machine) == ("Root.Error",)
+    assert topology.topological_finite(machine).counterexamples == (
+        ("deadlock", "Root.Running.Idle"),
+    )
+    assert topology.topological_inevitable_terminator(
+        machine
+    ).counterexample_path == ("Root.Running.Idle",)
+
+
+def test_build_leaf_level_macro_graph_bubbles_multi_level_exit_to_nested_target():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            state Outer {
+                state Inner {
+                    state Active;
+                    [*] -> Active;
+                    Active -> [*];
+                }
+                state Cleanup {
+                    state Flush;
+                    [*] -> Flush;
+                    Flush -> [*];
+                }
+                [*] -> Inner;
+                Inner -> Cleanup;
+                Cleanup -> [*];
+            }
+            state Done;
+            [*] -> Outer;
+            Outer -> Done;
+            Done -> [*];
+        }
+        """
+    )
+
+    graph = topology.build_leaf_level_macro_graph(machine)
+    reachable = topology.topological_reachable_set(machine)
+
+    assert graph.edges["Root.Outer.Inner.Active"] == (
+        "Root.Outer.Cleanup.Flush",
+    )
+    assert graph.edges["Root.Outer.Cleanup.Flush"] == ("Root.Done",)
+    assert graph.edges["Root.Done"] == (topology.EXIT_ROOT_SINK,)
+    assert reachable["Root"] == (
+        "Root.Done",
+        "Root.Outer.Cleanup.Flush",
+        "Root.Outer.Inner.Active",
+    )
+    assert topology.topological_finite(machine).finite is True
+    assert topology.topological_inevitable_terminator(machine).inevitable is True
+
+
+def test_event_consumer_reachability_handles_nested_composite_sources():
+    topology = _import_topology()
+    machine = _parse(
+        """
+        state Root {
+            event Stop;
+            event Lost;
+            state System {
+                state Running {
+                    state Active;
+                    [*] -> Active;
+                    Active -> [*];
+                }
+                [*] -> Running;
+                Running -> [*] : Stop;
+            }
+            state Orphan {
+                state LostLeaf;
+                [*] -> LostLeaf;
+                LostLeaf -> LostLeaf : Lost;
+            }
+            [*] -> System;
+            System -> [*];
+        }
+        """
+    )
+
+    assert topology.event_emission_to_consumer_reachable(machine) == (
+        "Root.Orphan.Lost",
+    )
+
+
 def test_topological_reachable_set_handles_diamond_closure_without_duplicates():
     topology = _import_topology()
     machine = _parse(


### PR DESCRIPTION
## 总览

本 PR 是 Layer 3 / issue #114 / PR-A umbrella (#127) 之下的 **PR-A3：组 1 拓扑实装（6 个算法）**。

本 PR 采用 stacked PR 流程：base 指向 `dev/issue114-pr-a-verify`。当前 base 已包含：

- PR-A1（#128）：`pyfcstm.verify` taxonomy / registry / inspect adapter 骨架
- PR-A2（#130）：`pyfcstm.solver.logical` 与 `pyfcstm.solver.safety` helper 层

当前实现提交 `bdf5fb96` 已按 TDD 完成组 1 拓扑算法实装、registry wiring、API docs 与本地验收；随后 `1d8cdc18` 补齐 Codecov 指出的 3 条边界分支覆盖；`d005f52c` 修复首轮强审发现的深链 SCC 递归栈与 root leaf 终止边界；`5f1d4b0c` 修复本地自查发现的 diamond join SCC finish-order 回归；`055f1461` 补齐 AGENTS.md 风格 pydoc；`9aad67d4` 追加复杂多层嵌套状态机对抗覆盖并诚实钉住 parent-level transition 必须由 leaf exit bubble 后才考虑的语义；`074e01f1` 修复复审发现的 composite-source event consumer reachability 漏报，并清理 PR diff 级 RST EOF whitespace。早期 empty scaffold commit `3aa25048` 保留作为 PR-A3 工作槽位与一致性 review 记录。

## 分支关系

- umbrella PR：#127
- umbrella 分支：`dev/issue114-pr-a-verify`
- 本 PR 分支：`dev/issue114-pr-a3-topology`
- 本 PR base：`dev/issue114-pr-a-verify`
- 本 PR base 当前已包含：PR-A1 #128、PR-A2 #130
- 逻辑前置：PR-A1 #128；PR-A3 不依赖 PR-A2 的 solver helper 或 timeout 设计，PR-A2 只是当前 umbrella base 的已合入内容
- 关联 issue：#114

本 PR 合入后，PR-A umbrella 将拥有组 1 拓扑算法的完整纯 Python 实装；PR-A4 仍负责组 2 SMT 局部算法，不在本 PR 内提前实现。PR-A3 只做 topological-only 结构分析：忽略 guard/event 的运行时真假，拓扑可达不等于真实执行可达。

## 本 PR 范围

### 新增生产代码

- `pyfcstm/verify/topology.py`
  - `LeafLevelGraph`
  - `FinitenessReport`
  - `InevitabilityReport`
  - `build_leaf_level_macro_graph()`
  - `topological_reachable_set()`
  - `unreachable_states()`
  - `strongly_connected_components()`
  - `topological_finite()`
  - `topological_inevitable_terminator()`
  - `event_emission_to_consumer_reachable()`

### 修改生产代码

- `pyfcstm/verify/registry.py`
  - 仅把组 1 拓扑 6 条算法的 `impl=None` 改为真实函数指针
  - 不改变算法 metadata 的名称、分类、诊断码与组 2 / 组 3 占位状态

### 新增/修改测试

- `test/verify/test_topology.py`
  - 覆盖 leaf-level graph 构建与 6 个算法，当前 focused topology/registry 合计 48 个测试用例
  - 所有 FCSTM fixture 均走 `parse_with_grammar_entry` + `parse_dsl_node_to_state_machine`
  - 增加与 `pyfcstm.diagnostics.inspect` 的对照测试，确认 `topological_reachable_set` 在 flat 对照模型上的可达集合一致
  - 验证 registry 中 6 个组 1 算法 `impl is not None`，组 2 / 组 3 仍保持 `impl is None`
  - 增加复杂多层嵌套状态机对抗用例：parent-level transition 不直接套到活跃子叶、multi-level `Leaf -> [*]` bubble 到嵌套 composite target、nested composite event consumer reachability

### 文档

- 已运行 `PATH="$PWD/venv/bin:$PATH" make rst_auto`
- 新增 `docs/source/api_doc/verify/topology.rst`，并把 `topology` 接入 `docs/source/api_doc/verify/index.rst`

## 明确不在本 PR 范围

本 PR不得：

- 修改 `pyfcstm/diagnostics/**`
- 修改 `pyfcstm/model/**`
- 修改 `pyfcstm/diagnostics/codes.yaml`
- 修改 `pyfcstm/diagnostics/schema.json`
- 修改 `editors/**`，包括 `editors/jsfcstm/**` 与 `editors/vscode/**`
- 创建或实现 `pyfcstm/verify/smt_local.py`
- 创建 `pyfcstm/verify/search.py`
- 创建 `pyfcstm/verify/reachability.py`
- 修改 PR-A2 的 `pyfcstm/solver/logical.py` / `pyfcstm/solver/safety.py` 行为契约
- 修改组 2 SMT 局部算法或组 3 BMC/search 占位算法的 `impl=None`
- 接入 `inspect_model()`、CLI、jsfcstm 或任何 Layer 2 流程
- 修改 `pyfcstm.diagnostics.inspect._build_reachability_graph`；本 PR 只把它作为对照 oracle 使用

## 算法清单与契约

| 算法 | 复杂度 | 触发诊断 | 说明 |
|---|---|---|---|
| `topological_reachable_set` | O(V·(V+E)) | 基础数据 | 基于 leaf-level macro graph 计算每个叶子状态可达叶子集合 |
| `unreachable_states` | O(V) | `W_UNREACHABLE_STATE` | 返回拓扑不可达的叶子状态 |
| `strongly_connected_components` | O(V+E) | `I_NONTRIVIAL_SCC` | 迭代 SCC；非平凡 SCC 是 info 级结构信息，不视为错误 |
| `topological_finite` | O(V+E) | `W_TOPOLOGICAL_NOEXIT` | 检查 root 可达叶子是否都存在到 root exit 的拓扑路径；反例包括 `trap_cycle` 与 `deadlock` |
| `topological_inevitable_terminator` | O(V+E) | `I_TOPOLOGICAL_NON_TERMINATING` | AND-OR 风格判断是否拓扑必然终止 |
| `event_emission_to_consumer_reachable` | O(events × E) | `W_EVENT_UNREACHABLE_EMIT` | 检查事件 emit 到 consumer 是否在拓扑上可达 |

## 关键 API 草案

```python
from pyfcstm.model import StateMachine


def build_leaf_level_macro_graph(machine: StateMachine) -> LeafLevelGraph: ...
# 含 [*] -> Composite 级联、Leaf -> [*] bubble、forced transition 展开、off-cliff 处理


def topological_reachable_set(machine: StateMachine) -> Dict[str, Tuple[str, ...]]: ...
def unreachable_states(machine: StateMachine) -> Tuple[str, ...]: ...
def strongly_connected_components(machine: StateMachine) -> Tuple[Tuple[str, ...], ...]: ...


@dataclass(frozen=True)
class FinitenessReport:
    finite: bool
    counterexamples: Tuple[Tuple[Literal['trap_cycle', 'deadlock'], object], ...]


def topological_finite(machine: StateMachine) -> FinitenessReport: ...


@dataclass(frozen=True)
class InevitabilityReport:
    inevitable: bool
    counterexample_path: Optional[Tuple[str, ...]]


def topological_inevitable_terminator(machine: StateMachine) -> InevitabilityReport: ...
def event_emission_to_consumer_reachable(machine: StateMachine) -> Tuple[str, ...]: ...
```

`event_emission_to_consumer_reachable()` 在 PR-A3 的 PR body / umbrella PR-A / issue #114 正文中以 `Tuple[str, ...]` 作为执行契约：返回所有消费者源完全不可达的事件限定名。issue 的详细 spec comment 早期示意写过 `Tuple[EventInfo, ...]`；本 PR 不引入新的 `EventInfo` dataclass，后续若 Track B 需要诊断 payload，可在接入层把事件限定名转换为诊断 `data.event_qualified_name`。

返回类型会保持 Python 3.7 兼容，优先使用 `typing.Dict` / `typing.Tuple` / `typing.Optional` 等旧版兼容写法；dataclass 使用 `frozen=True`，便于测试和下游稳定消费。

## 组 1 共同边界

- 所有算法都是 `verification_scope='topological_only'` 的结构分析。
- 本 PR 不求解 guard，不模拟 event 输入，也不判断 transition 在运行时是否真的可触发。
- 拓扑可达是 over-approximation；拓扑不可达可以作为结构事实，拓扑可达不等于真实执行可达。
- `topological_inevitable_terminator` 只产出 info 级结构提示，不能单独断言模型真实必然/非必然终止。

## TDD 与验收状态

本 PR 已按以下顺序推进：

1. 先新增 `test/verify/test_topology.py` 的失败测试，覆盖 graph 构建、6 个算法、registry impl 指针与 forbidden diff 边界。
2. 再最小实现 `pyfcstm/verify/topology.py`，保持算法独立于 Layer 2 inspect dataclass。
3. 仅更新 `pyfcstm/verify/registry.py` 中组 1 六条 `impl`。
4. 运行 `make rst_auto` 更新 API docs，并接入 `verify/topology.rst`。
5. 本地使用 venv 完成 focused、相关目录与 fast-path 全量验收后 push。
6. 已等待 `d005f52c` CI 全绿，并拉取 Codecov 覆盖率信息；随后 `5f1d4b0c` 修复本地自查发现的 SCC diamond join 回归，当前正等待新 head 的 CI 与 Codecov 更新。
7. 随后启动 5 路 reviewer-alpha/beta/gamma/delta/epsilon 做 C/I/M 强对抗 code review；每个 reviewer 都必须全量交叉检查 scope / API contract / tests / docs / CI / Codecov / stacked PR 边界，并直接 `gh pr comment` 到本 PR。
8. 修复 review 发现并迭代，直到 ready to merge。按用户要求，PR-A3 ready 后暂不 merge，等待下一步指示。

## 机械验收清单

- [x] `PYTHONPATH="$PWD" ./venv/bin/python -m pytest test/verify/test_topology.py test/verify/test_registry.py -q --cov=pyfcstm.verify.topology --cov=pyfcstm.verify.registry --cov-report=term-missing`：48 passed，`topology.py` 100%，`registry.py` 100%
- [x] `PYTHONPATH="$PWD" ./venv/bin/python -m pytest test/verify/ -q`：62 passed
- [x] `PYTHONPATH="$PWD" ./venv/bin/python -m pytest test/diagnostics/test_inspect_model.py -q`：81 passed
- [x] `PYTHONPATH="$PWD" ./venv/bin/python -m pytest test/solver/ -q`：176 passed
- [x] 每条算法的 FCSTM fixture 均通过 parse + semantic model conversion
- [x] `topological_reachable_set` 与 `pyfcstm.diagnostics.inspect` 在 flat 对照模型上的结果 set 相等
- [x] 6 个组 1 算法在 registry 中 `impl is not None`
- [x] 组 2 SMT 局部算法与组 3 占位算法仍保持 `impl is None`
- [x] `git diff origin/dev/issue114-pr-a-verify...HEAD -- pyfcstm/diagnostics pyfcstm/model pyfcstm/diagnostics/codes.yaml pyfcstm/diagnostics/schema.json editors` 返空
- [x] `git diff main -- pyfcstm/diagnostics pyfcstm/model pyfcstm/diagnostics/codes.yaml pyfcstm/diagnostics/schema.json editors` 返空
- [x] verify production module 不 import diagnostics；测试文件允许显式导入 diagnostics inspect 作为 oracle
- [x] `./venv/bin/python -m pyright pyfcstm/verify/topology.py pyfcstm/verify/registry.py test/verify/test_topology.py test/verify/test_registry.py`：0 errors
- [x] `./venv/bin/python -m ruff check pyfcstm/verify/topology.py pyfcstm/verify/registry.py test/verify/test_topology.py test/verify/test_registry.py`：All checks passed
- [x] `git diff --check` 通过；`git diff --check origin/dev/issue114-pr-a-verify...HEAD` 也通过
- [x] `PATH="$PWD/venv/bin:$PATH" make rst_auto` 已运行；topology API docs 已随 pydoc 更新
- [x] `SKIP_SLOW_TESTS=1 PATH="$PWD/venv/bin:$PATH" make unittest`：8958 passed, 164 skipped, 63 deselected
- [ ] GitHub Actions 全绿；`074e01f1` 新一轮 Code Test / Release Test / jsfcstm / CLI Build check 正在等待
- [ ] Codecov 对本 PR 新增/修改的可覆盖代码无明显缺口；`9aad67d4` comment 已显示 All modified and coverable lines are covered by tests，当前等待 Codecov 更新到 `074e01f1`
- [ ] 复杂嵌套 + pydoc-focused 5 路 C/I/M review 无 C/I 阻塞项；上一轮 alpha/gamma 对 `9aad67d4` 提出的 composite-source event consumer I 级阻塞已在 `074e01f1` 修复，等待重新复审

## 当前 PR 状态

当前包含：

```text
3aa25048 chore(verify): scaffold PR-A3 topology algorithms [skip-slow]
bdf5fb96 feat(verify): add topology verification algorithms [skip-slow]
1d8cdc18 test(verify): cover topology edge branches [skip-slow]
d005f52c fix(verify): harden topology edge cases [skip-slow]
5f1d4b0c fix(verify): correct iterative scc ordering [skip-slow]
055f1461 docs(verify): expand topology pydoc examples [skip-slow]
9aad67d4 test(verify): stress nested topology behavior [skip-slow]
074e01f1 fix(verify): require bubble reachability for event consumers [skip-slow]
```

实现提交已完成组 1 拓扑算法、registry wiring、测试与 API docs，并已把 `topology.py` focused coverage 拉到 100%。首轮强审发现的深链 SCC 递归栈与 root leaf 终止边界已在 `d005f52c` 修复并完成本地回归；本地自查发现的 diamond join SCC finish-order 回归已在 `5f1d4b0c` 修复，并通过 focused coverage、verify 目录、diagnostics/solver 相关回归、pyright、ruff、diff check、forbidden diff 与 fast-path 全量 unittest。`5f1d4b0c` 的 GitHub Actions 已全绿，Codecov comment 已更新且显示本 PR 所有 modified and coverable lines 均已覆盖；第二轮 5-agent 强审已完成且无 C/I 阻塞项。随后根据 reviewer 要求补充 `055f1461` 的 topology module/class/function pydoc 详细说明与 `Example::` doctest 风格示例。随后根据用户要求追加 `9aad67d4`，重点覆盖复杂多层嵌套状态机：parent-level transition 只在 descendant leaf `-> [*]` bubble 后生效、multi-level exit bubble 会递归投影到 nested composite target、nested composite event consumer reachability 正确区分可达/不可达事件。alpha/gamma 复审发现 composite-source event consumer reachability 仍把“composite 已进入”误当作“parent boundary 可选择”，已在 `074e01f1` 改成 mode-aware 的 consumer source reachability：leaf source 看 active leaf，init source 看 owning composite 可进入，composite source 必须存在 root-reachable descendant leaf 显式 `-> [*]` bubble 到该 composite boundary 才算可达；同时补 5 个对抗测试并清理 PR diff 级 RST EOF whitespace。当前等待 `074e01f1` 的 CI / Codecov 与重新复审。

## 第二轮 5-agent 强审结果

- reviewer-alpha：C=0 / I=0 / M=0，READY（https://github.com/HansBug/pyfcstm/pull/131#issuecomment-4587810677）
- reviewer-beta：C=0 / I=0 / M=2，READY（https://github.com/HansBug/pyfcstm/pull/131#issuecomment-4587814557）
- reviewer-gamma：C=0 / I=0 / M=1，READY（https://github.com/HansBug/pyfcstm/pull/131#issuecomment-4587822170）
- reviewer-delta：C=0 / I=0 / M=0，READY（https://github.com/HansBug/pyfcstm/pull/131#issuecomment-4587813783）
- reviewer-epsilon：C=0 / I=0 / M=0，READY（https://github.com/HansBug/pyfcstm/pull/131#issuecomment-4587818217）

第二轮 review 已把 `5f1d4b0c201a7a8c53d6caed9a1e280fd3302ec8` 的 GitHub Actions 全绿状态与 Codecov 最新 comment（head `5f1d4b0`、modified coverable lines covered、python flag patch 100.00%）纳入核查。


## Pydoc 补充轮次

- `055f1461 docs(verify): expand topology pydoc examples [skip-slow]` 已按 AGENTS.md 的 reST docstring 规范补充 `pyfcstm.verify.topology` 的 module / class / function pydoc：包含详细说明、`:param:` / `:type:` / `:return:` / `:rtype:` / `:raises:` 以及 `Example::` 示例。
- 已用 `doctest.testmod(pyfcstm.verify.topology)` 验证新增示例：63 attempted / 0 failed。
- 已重新运行 `make rst_auto` 并提交生成的 `docs/source/api_doc/verify/topology.rst` 更新。
- 后续 pydoc-focused review 会把 AGENTS.md docstring 格式、示例可运行性、reST 边界和 API docs 输出纳入重点检查。



## 复杂多层嵌套补强轮次

- `9aad67d4 test(verify): stress nested topology behavior [skip-slow]` 已按最新 review 关注点补强复杂多层嵌套状态机覆盖。
- 新增 parent-level transition 对抗用例：`Running -> Error` 不会被错误复制到 `Running.Active` / `Running.Idle` 这类活跃叶子上；只有 descendant leaf 先 `-> [*]` 退出到 parent 后，parent-level transition 才会被 bubble 语义考虑。这与 `SimulationRuntime` 文档和 runtime alignment 的 cross-hierarchy/post-child-exit 契约一致。
- 新增 multi-level bubble 用例：`Root.Outer.Inner.Active -> [*]` 会经 `Inner -> Cleanup` 进入 nested composite target，再通过 `Cleanup.Flush -> [*]` bubble 到 `Outer -> Done`，最终到 root sink。
- 新增 nested composite event consumer reachability 用例：可达 composite source 的事件消费者不触发警告，不可达 nested event consumer 仍会返回对应 qualified event name。
- 本轮本地验证：focused coverage `43 passed` 且 `topology.py` / `registry.py` 100%；`test/verify/` 为 `57 passed`；doctest `63 attempted / 0 failed`；pyright / ruff / diff check 通过；`make rst_auto` 已运行；`SKIP_SLOW_TESTS=1 make unittest` 为 `8953 passed, 164 skipped, 63 deselected`。



## Review 阻塞修复轮次

- `074e01f1 fix(verify): require bubble reachability for event consumers [skip-slow]` 已修复 reviewer-alpha / reviewer-gamma 指出的 I 级阻塞：`event_emission_to_consumer_reachable()` 不再把“composite 已进入”直接视为 composite-source event consumer 可达；composite-source consumer 现在必须能从 root-reachable descendant leaf 通过显式 `Leaf -> [*]` bubble 到该 composite boundary 后才算可达。
- 新增 5 个对抗测试：无 child exit 的 composite-source event 漏报回归、multi-level chained boundary exits、重复 boundary exits 去重、non-exit parent transition 不暴露外层 boundary、unexposed outer boundary event。
- 清理 `docs/source/api_doc/verify/topology.rst` 末尾多余空行；现在工作区 `git diff --check` 与 PR diff 级 `git diff --check origin/dev/issue114-pr-a-verify...HEAD` 都通过。
- 本轮本地验证：focused coverage `48 passed` 且 `topology.py` / `registry.py` 100%；`test/verify/` 为 `62 passed`；doctest `63 attempted / 0 failed`；pyright / ruff / forbidden diff 通过；`make rst_auto` 已运行；`SKIP_SLOW_TESTS=1 make unittest` 为 `8958 passed, 164 skipped, 63 deselected`。
