### PR TITLE
PR-A4：实装 pyfcstm.verify SMT 局部算法（#114）

### DIFF
--- a/pyfcstm/solver/expr.py
+++ b/pyfcstm/solver/expr.py
@@ -38,13 +38,51 @@ from typing import Dict, List, Union
 import z3
 
 from ..model.expr import (
-    Expr, Integer, Float, Boolean, Variable,
-    BinaryOp, UnaryOp, ConditionalOp, UFunc
+    Expr,
+    Integer,
+    Float,
+    Boolean,
+    Variable,
+    BinaryOp,
+    UnaryOp,
+    ConditionalOp,
+    UFunc,
 )
 from ..model.model import StateMachine, VarDefine
 
 
-def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -> Union[z3.ArithRef, z3.BoolRef]:
+def python_round_to_z3(operand: Union[z3.ArithRef, z3.BoolRef]) -> z3.ArithRef:
+    """Return a Z3 expression matching Python single-argument ``round``.
+
+    Python rounds half-way cases to the nearest even integer.  Keeping this
+    helper in the shared solver layer prevents raw verify algorithms from
+    drifting away from runtime expression semantics.
+
+    :param operand: Integer or real Z3 operand.
+    :type operand: Union[z3.ArithRef, z3.BoolRef]
+    :return: Rounded integer expression.
+    :rtype: z3.ArithRef
+    """
+    if z3.is_int(operand):
+        return operand
+    real_operand = operand if z3.is_real(operand) else z3.ToReal(operand)
+    floor_value = z3.ToInt(real_operand)
+    fraction = real_operand - z3.ToReal(floor_value)
+    half = z3.RealVal("1/2")
+    return z3.If(
+        fraction < half,
+        floor_value,
+        z3.If(
+            fraction > half,
+            floor_value + 1,
+            z3.If(floor_value % 2 == 0, floor_value, floor_value + 1),
+        ),
+    )
+
+
+def expr_to_z3(
+    expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+) -> Union[z3.ArithRef, z3.BoolRef]:
     """
     Convert a pyfcstm expression to a Z3 solver expression.
 
@@ -97,17 +135,17 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
         right = expr_to_z3(expr.y, z3_vars)
 
         # Arithmetic operators
-        if expr.op == '+':
+        if expr.op == "+":
             return left + right
-        elif expr.op == '-':
+        elif expr.op == "-":
             return left - right
-        elif expr.op == '*':
+        elif expr.op == "*":
             return left * right
-        elif expr.op == '/':
+        elif expr.op == "/":
             return left / right
-        elif expr.op == '%':
+        elif expr.op == "%":
             return left % right
-        elif expr.op == '**':
+        elif expr.op == "**":
             # Power operator in Z3 has different performance characteristics:
             # - x ** constant: Generally OK (e.g., x**2, x**3)
             # - constant ** x: Slower but acceptable (e.g., 2**x)
@@ -119,87 +157,87 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
 
             if left_is_var and right_is_var:
                 warnings.warn(
-                    f"Power operation with two variables (x ** y) may be very slow in Z3. "
-                    f"Z3's nonlinear arithmetic solver has limited support for this pattern. "
-                    f"Consider using alternative formulations or constraints if possible.",
+                    "Power operation with two variables (x ** y) may be very slow in Z3. "
+                    "Z3's nonlinear arithmetic solver has limited support for this pattern. "
+                    "Consider using alternative formulations or constraints if possible.",
                     UserWarning,
-                    stacklevel=2
+                    stacklevel=2,
                 )
             elif right_is_var:
                 warnings.warn(
-                    f"Power operation with variable exponent (constant ** x) may be slow in Z3. "
-                    f"Performance depends on the solver's ability to handle exponential constraints.",
+                    "Power operation with variable exponent (constant ** x) may be slow in Z3. "
+                    "Performance depends on the solver's ability to handle exponential constraints.",
                     UserWarning,
-                    stacklevel=2
+                    stacklevel=2,
                 )
             # x ** constant is generally fine, no warning needed
 
-            return left ** right
+            return left**right
 
         # Bitwise operators
         # Note: These work on Z3 Int but have limitations compared to BitVec
-        elif expr.op == '&':
+        elif expr.op == "&":
             warnings.warn(
-                f"Bitwise AND (&) on Z3 Int types has limited support. "
-                f"For full bitwise operation support, consider using Z3 BitVec types. "
-                f"The operation may not work as expected for negative numbers.",
+                "Bitwise AND (&) on Z3 Int types has limited support. "
+                "For full bitwise operation support, consider using Z3 BitVec types. "
+                "The operation may not work as expected for negative numbers.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return left & right
-        elif expr.op == '|':
+        elif expr.op == "|":
             warnings.warn(
-                f"Bitwise OR (|) on Z3 Int types has limited support. "
-                f"For full bitwise operation support, consider using Z3 BitVec types. "
-                f"The operation may not work as expected for negative numbers.",
+                "Bitwise OR (|) on Z3 Int types has limited support. "
+                "For full bitwise operation support, consider using Z3 BitVec types. "
+                "The operation may not work as expected for negative numbers.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return left | right
-        elif expr.op == '^':
+        elif expr.op == "^":
             warnings.warn(
-                f"Bitwise XOR (^) on Z3 Int types has limited support. "
-                f"For full bitwise operation support, consider using Z3 BitVec types. "
-                f"The operation may not work as expected for negative numbers.",
+                "Bitwise XOR (^) on Z3 Int types has limited support. "
+                "For full bitwise operation support, consider using Z3 BitVec types. "
+                "The operation may not work as expected for negative numbers.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return left ^ right
-        elif expr.op == '<<':
+        elif expr.op == "<<":
             warnings.warn(
-                f"Left shift (<<) on Z3 Int types has limited support. "
-                f"For full bitwise operation support, consider using Z3 BitVec types.",
+                "Left shift (<<) on Z3 Int types has limited support. "
+                "For full bitwise operation support, consider using Z3 BitVec types.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return left << right
-        elif expr.op == '>>':
+        elif expr.op == ">>":
             warnings.warn(
-                f"Right shift (>>) on Z3 Int types has limited support. "
-                f"For full bitwise operation support, consider using Z3 BitVec types.",
+                "Right shift (>>) on Z3 Int types has limited support. "
+                "For full bitwise operation support, consider using Z3 BitVec types.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return left >> right
 
         # Comparison operators
-        elif expr.op == '<':
+        elif expr.op == "<":
             return left < right
-        elif expr.op == '<=':
+        elif expr.op == "<=":
             return left <= right
-        elif expr.op == '>':
+        elif expr.op == ">":
             return left > right
-        elif expr.op == '>=':
+        elif expr.op == ">=":
             return left >= right
-        elif expr.op == '==':
+        elif expr.op == "==":
             return left == right
-        elif expr.op == '!=':
+        elif expr.op == "!=":
             return left != right
 
         # Logical operators
-        elif expr.op in ('&&', 'and'):
+        elif expr.op in ("&&", "and"):
             return z3.And(left, right)
-        elif expr.op in ('||', 'or'):
+        elif expr.op in ("||", "or"):
             return z3.Or(left, right)
 
         else:
@@ -209,20 +247,20 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
     elif isinstance(expr, UnaryOp):
         operand = expr_to_z3(expr.x, z3_vars)
 
-        if expr.op == '-':
+        if expr.op == "-":
             return -operand
-        elif expr.op == '+':
+        elif expr.op == "+":
             return operand
-        elif expr.op == '~':
+        elif expr.op == "~":
             warnings.warn(
-                f"Bitwise NOT (~) on Z3 Int types has limited support. "
-                f"For full bitwise operation support, consider using Z3 BitVec types. "
-                f"The operation may not work as expected.",
+                "Bitwise NOT (~) on Z3 Int types has limited support. "
+                "For full bitwise operation support, consider using Z3 BitVec types. "
+                "The operation may not work as expected.",
                 UserWarning,
-                stacklevel=2
+                stacklevel=2,
             )
             return ~operand
-        elif expr.op in ('!', 'not'):
+        elif expr.op in ("!", "not"):
             return z3.Not(operand)
         else:
             raise ValueError(f"Unsupported unary operator: {expr.op}")
@@ -239,11 +277,11 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
         operand = expr_to_z3(expr.x, z3_vars)
 
         # Absolute value and sign functions
-        if expr.func == 'abs':
+        if expr.func == "abs":
             # Use conditional expression for absolute value
             return z3.If(operand >= 0, operand, -operand)
 
-        elif expr.func == 'sign':
+        elif expr.func == "sign":
             # Sign function: returns -1, 0, or 1
             zero = z3.IntVal(0) if z3.is_int(operand) else z3.RealVal(0)
             one = z3.IntVal(1) if z3.is_int(operand) else z3.RealVal(1)
@@ -251,7 +289,7 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
             return z3.If(operand == zero, zero, z3.If(operand > zero, one, minus_one))
 
         # Rounding functions (for Real numbers)
-        elif expr.func == 'floor':
+        elif expr.func == "floor":
             # Z3 has ToInt which performs floor for non-negative reals
             # For general floor, we need to handle negative numbers
             if z3.is_real(operand):
@@ -263,7 +301,7 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
                 # Try to convert to Real first (silent conversion)
                 return z3.ToInt(z3.ToReal(operand))
 
-        elif expr.func == 'ceil':
+        elif expr.func == "ceil":
             # Ceiling: ceil(x) = -floor(-x)
             if z3.is_real(operand):
                 return -z3.ToInt(-operand)
@@ -274,7 +312,7 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
                 # Try to convert to Real first (silent conversion)
                 return -z3.ToInt(-z3.ToReal(operand))
 
-        elif expr.func == 'trunc':
+        elif expr.func == "trunc":
             # Truncate towards zero
             if z3.is_real(operand):
                 zero = z3.RealVal(0)
@@ -286,13 +324,17 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
                 # Try to convert to Real first (silent conversion)
                 real_operand = z3.ToReal(operand)
                 zero = z3.RealVal(0)
-                return z3.If(real_operand >= zero, z3.ToInt(real_operand), -z3.ToInt(-real_operand))
+                return z3.If(
+                    real_operand >= zero,
+                    z3.ToInt(real_operand),
+                    -z3.ToInt(-real_operand),
+                )
 
         # Min/Max functions (if operand is a comparison, we can use If)
         # Note: These would need special handling as they typically take 2 arguments
 
         # Power and root functions
-        elif expr.func == 'sqrt':
+        elif expr.func == "sqrt":
             # Z3 has limited support for sqrt
             # We can use z3.Sqrt for Real numbers in some theories
             if z3.is_real(operand):
@@ -306,55 +348,45 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
                     f"Cannot convert to Real."
                 )
 
-        elif expr.func == 'cbrt':
+        elif expr.func == "cbrt":
             # Cube root: x^(1/3)
             # Z3 doesn't have native cbrt, would need uninterpreted function
             raise NotImplementedError(
-                f"Mathematical function 'cbrt' is not directly supported in Z3. "
-                f"Consider using uninterpreted functions or polynomial constraints (y^3 = x)."
+                "Mathematical function 'cbrt' is not directly supported in Z3. "
+                "Consider using uninterpreted functions or polynomial constraints (y^3 = x)."
             )
 
-        elif expr.func == 'exp':
+        elif expr.func == "exp":
             # Exponential function
             raise NotImplementedError(
-                f"Mathematical function 'exp' is not directly supported in Z3. "
-                f"Consider using uninterpreted functions or approximations."
+                "Mathematical function 'exp' is not directly supported in Z3. "
+                "Consider using uninterpreted functions or approximations."
             )
 
         # Logarithmic functions
-        elif expr.func in ('log', 'log10', 'log2', 'log1p'):
+        elif expr.func in ("log", "log10", "log2", "log1p"):
             raise NotImplementedError(
                 f"Logarithmic function '{expr.func}' is not directly supported in Z3. "
                 f"Consider using uninterpreted functions or approximations."
             )
 
         # Trigonometric functions
-        elif expr.func in ('sin', 'cos', 'tan', 'asin', 'acos', 'atan'):
+        elif expr.func in ("sin", "cos", "tan", "asin", "acos", "atan"):
             raise NotImplementedError(
                 f"Trigonometric function '{expr.func}' is not directly supported in Z3. "
                 f"Consider using uninterpreted functions or approximations."
             )
 
         # Hyperbolic functions
-        elif expr.func in ('sinh', 'cosh', 'tanh', 'asinh', 'acosh', 'atanh'):
+        elif expr.func in ("sinh", "cosh", "tanh", "asinh", "acosh", "atanh"):
             raise NotImplementedError(
                 f"Hyperbolic function '{expr.func}' is not directly supported in Z3. "
                 f"Consider using uninterpreted functions or approximations."
             )
 
         # Round function
-        elif expr.func == 'round':
-            # Python's round function - rounds to nearest even
-            if z3.is_real(operand):
-                # Z3 doesn't have native round, approximate with floor(x + 0.5)
-                # This is "round half up" not "round half to even" but close enough
-                return z3.ToInt(operand + z3.RealVal(0.5))
-            elif z3.is_int(operand):
-                # Already an integer
-                return operand
-            else:
-                # Try to convert to Real first (silent conversion)
-                return z3.ToInt(z3.ToReal(operand) + z3.RealVal(0.5))
+        elif expr.func == "round":
+            return python_round_to_z3(operand)
 
         else:
             raise NotImplementedError(
@@ -367,7 +399,9 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
         raise ValueError(f"Unsupported expression type: {type(expr).__name__}")
 
 
-def create_z3_vars_from_models(models: Union[StateMachine, VarDefine, List[VarDefine]]) -> Dict[str, Union[z3.ArithRef, z3.BoolRef]]:
+def create_z3_vars_from_models(
+    models: Union[StateMachine, VarDefine, List[VarDefine]],
+) -> Dict[str, Union[z3.ArithRef, z3.BoolRef]]:
     """
     Create a dictionary of Z3 variables from model objects.
 
@@ -421,8 +455,10 @@ def create_z3_vars_from_models(models: Union[StateMachine, VarDefine, List[VarDe
     elif isinstance(models, list):
         var_defines = models
     else:
-        raise TypeError(f"Unsupported input type: {type(models).__name__}. "
-                        "Expected StateMachine, VarDefine, or List[VarDefine]")
+        raise TypeError(
+            f"Unsupported input type: {type(models).__name__}. "
+            "Expected StateMachine, VarDefine, or List[VarDefine]"
+        )
 
     # Create Z3 variables
     z3_vars = {}
@@ -431,12 +467,14 @@ def create_z3_vars_from_models(models: Union[StateMachine, VarDefine, List[VarDe
         var_name = var_def.name
         var_type = var_def.type.lower()
 
-        if var_type == 'int':
+        if var_type == "int":
             z3_vars[var_name] = z3.Int(var_name)
-        elif var_type == 'float':
+        elif var_type == "float":
             z3_vars[var_name] = z3.Real(var_name)
         else:
-            raise ValueError(f"Unsupported variable type '{var_type}' for variable '{var_name}'. "
-                             "Supported types: int, float")
+            raise ValueError(
+                f"Unsupported variable type '{var_type}' for variable '{var_name}'. "
+                "Supported types: int, float"
+            )
 
     return z3_vars

--- a/pyfcstm/solver/safety.py
+++ b/pyfcstm/solver/safety.py
@@ -1,8 +1,9 @@
-"""Expression safety checks for SMT-local verification algorithms.
+"""Optional expression safety scans for downstream SMT callers.
 
-The SMT-local verify algorithms operate in arithmetic theories.  This module
-provides a small syntactic pre-check that rejects expression shapes known to be
-outside that solver envelope before an algorithm attempts a Z3 translation.
+The core solver and verify algorithms are intentionally full-power by default:
+they translate the requested expression and let Z3 try the query.  This module
+provides a separate syntactic scanner for callers such as diagnostics adapters
+that want to apply their own policy before invoking those core algorithms.
 """
 
 from dataclasses import dataclass
@@ -51,10 +52,10 @@ _TRANSCENDENTAL_FUNCTIONS = frozenset(
 
 @dataclass(frozen=True)
 class SafetyCheck:
-    """Result of a solver-safety expression scan.
+    """Result of an optional solver-safety expression scan.
 
-    :param safe: Whether the expression or operation block is safe for the
-        arithmetic solver envelope.
+    :param safe: Whether the expression or operation block passes the optional
+        downstream policy.
     :type safe: bool
     :param reason: First unsafe reason found, defaults to ``None``.
     :type reason: Optional[SafetyReason], optional
@@ -86,20 +87,20 @@ def _unsafe(reason: SafetyReason, offending_node: Expr) -> SafetyCheck:
     :type reason: SafetyReason
     :param offending_node: Node that caused the result.
     :type offending_node: Expr
-    :return: Unsafe safety result.
+    :return: Policy rejection result.
     :rtype: SafetyCheck
     """
     return SafetyCheck(safe=False, reason=reason, offending_node=offending_node)
 
 
 def check_expr_safety(expr: Optional[Expr]) -> SafetyCheck:
-    """Check whether an expression is suitable for SMT-local arithmetic solving.
+    """Run an optional downstream policy scan over an expression.
 
     :param expr: Expression to scan, or ``None`` for optional missing
         expressions.
     :type expr: Optional[Expr]
-    :return: Safety result.  The first unsafe node in pre-order traversal is
-        reported when a hazard is found.
+    :return: Safety-policy result.  The first policy-rejected node in pre-order
+        traversal is reported when a hazard is found.
     :rtype: SafetyCheck
     """
     if expr is None:
@@ -135,13 +136,13 @@ def check_expr_safety(expr: Optional[Expr]) -> SafetyCheck:
 
 
 def check_expr_safety_for_effect(ops: Sequence[OperationStatement]) -> SafetyCheck:
-    """Check every expression inside an operation block for solver safety.
+    """Run an optional downstream policy scan over an operation block.
 
     :param ops: Operation statements from an ``enter`` / ``during`` / ``exit``
         / ``effect`` block.
     :type ops: Sequence[OperationStatement]
-    :return: First unsafe expression result, or a safe result if all scanned
-        expressions are acceptable.
+    :return: First policy-rejected expression result, or a safe result if all
+        scanned expressions are acceptable.
     :rtype: SafetyCheck
     """
     for statement in ops:

--- a/pyfcstm/solver/safety.py
+++ b/pyfcstm/solver/safety.py
@@ -21,6 +21,7 @@ SafetyReason = Literal[
     "transcendental",
     "double_var_power",
     "variable_exponent",
+    "nonlinear",
 ]
 
 _BITWISE_BINARY_OPERATORS = frozenset({"&", "|", "^", "<<", ">>"})
@@ -107,6 +108,10 @@ def check_expr_safety(expr: Optional[Expr]) -> SafetyCheck:
     if isinstance(expr, BinaryOp):
         if expr.op in _BITWISE_BINARY_OPERATORS:
             return _unsafe("bitwise", expr)
+        if expr.op == "*" and _contains_variable(expr.x) and _contains_variable(expr.y):
+            return _unsafe("nonlinear", expr)
+        if expr.op in {"/", "%"} and _contains_variable(expr.y):
+            return _unsafe("nonlinear", expr)
         if expr.op == "**":
             left_has_variable = _contains_variable(expr.x)
             right_has_variable = _contains_variable(expr.y)

--- a/pyfcstm/verify/registry.py
+++ b/pyfcstm/verify/registry.py
@@ -1,10 +1,20 @@
 """Algorithm registry for :mod:`pyfcstm.verify`."""
 
 from types import MappingProxyType
-from typing import Mapping, Tuple
+from typing import Callable, Mapping, Optional, Tuple
 
 from . import topology
 from .taxonomy import CallCountScaling, FallbackUnknownRisk, VerifyAlgorithmMeta
+from .smt_local import (
+    composite_init_guards_incomplete,
+    dead_guard,
+    effect_contradicts_guard,
+    effect_no_op_under_guard,
+    enter_postcondition_implies_during_precondition,
+    forced_guard_unsat_under_init,
+    guard_tautology,
+    transition_shadowed_by_predecessor,
+)
 
 
 def _structural(
@@ -43,6 +53,7 @@ def _smt_local(
     fallback_unknown_risk: FallbackUnknownRisk = "medium",
     incremental: bool = False,
     dominant_dim: Tuple[str, ...] = ("E", "vars"),
+    impl: Optional[Callable] = None,
 ) -> VerifyAlgorithmMeta:
     return VerifyAlgorithmMeta(
         name=name,
@@ -61,11 +72,13 @@ def _smt_local(
         verification_scope="smt_local",
         dominant_dim=dominant_dim,
         diagnostic_codes=diagnostic_codes,
-        impl=None,
+        impl=impl,
     )
 
 
-def _composite_init_guards_incomplete() -> VerifyAlgorithmMeta:
+def _composite_init_guards_incomplete(
+    impl: Optional[Callable] = None,
+) -> VerifyAlgorithmMeta:
     return VerifyAlgorithmMeta(
         name="composite_init_guards_incomplete",
         description=(
@@ -86,7 +99,7 @@ def _composite_init_guards_incomplete() -> VerifyAlgorithmMeta:
         verification_scope="smt_local",
         dominant_dim=("V", "vars", "events"),
         diagnostic_codes=("W_COMPOSITE_INIT_INCOMPLETE",),
-        impl=None,
+        impl=impl,
     )
 
 
@@ -168,12 +181,14 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             "Detect guards that are unsatisfiable under variable constraints.",
             "linear_in_transitions",
             ("W_DEAD_GUARD",),
+            impl=dead_guard,
         ),
         "guard_tautology": _smt_local(
             "guard_tautology",
             "Detect guards that are always true under variable constraints.",
             "linear_in_transitions",
             ("W_GUARD_TAUTOLOGY",),
+            impl=guard_tautology,
         ),
         "forced_guard_unsat_under_init": _smt_local(
             "forced_guard_unsat_under_init",
@@ -182,18 +197,21 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             ("W_FORCED_GUARD_UNSAT",),
             fallback_unknown_risk="low",
             dominant_dim=("forced_transitions", "vars"),
+            impl=forced_guard_unsat_under_init,
         ),
         "effect_no_op_under_guard": _smt_local(
             "effect_no_op_under_guard",
             "Detect transition effects that are no-ops whenever the guard holds.",
             "linear_in_transitions",
             ("W_EFFECT_SMT_NO_OP",),
+            impl=effect_no_op_under_guard,
         ),
         "effect_contradicts_guard": _smt_local(
             "effect_contradicts_guard",
             "Detect effects whose post-state contradicts their transition guard.",
             "linear_in_transitions",
             ("I_EFFECT_GUARD_CONTRADICT",),
+            impl=effect_contradicts_guard,
         ),
         "transition_shadowed_by_predecessor": _smt_local(
             "transition_shadowed_by_predecessor",
@@ -201,6 +219,7 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             "linear_in_transitions",
             ("W_TRANSITION_SHADOWED",),
             incremental=True,
+            impl=transition_shadowed_by_predecessor,
         ),
         "enter_postcondition_implies_during_precondition": _smt_local(
             "enter_postcondition_implies_during_precondition",
@@ -209,8 +228,11 @@ def _build_registry() -> Mapping[str, VerifyAlgorithmMeta]:
             ("I_ENTER_DURING_CONTRADICT",),
             incremental=True,
             dominant_dim=("V_leaf", "vars"),
+            impl=enter_postcondition_implies_during_precondition,
         ),
-        "composite_init_guards_incomplete": _composite_init_guards_incomplete(),
+        "composite_init_guards_incomplete": _composite_init_guards_incomplete(
+            impl=composite_init_guards_incomplete
+        ),
         "bounded_reachability": _bmc_placeholder(
             "bounded_reachability",
             "Query whether a target state is reachable from a source within a bound.",

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -49,6 +49,7 @@ class _ConditionPoint:
     condition: "Expr"
     z3_vars: _Z3Vars
     path_conditions: Tuple[z3.ExprRef, ...] = ()
+    source: str = "expression"
 
 
 def _dsl_nodes():
@@ -321,17 +322,61 @@ def _execute_operations_or_result(
         return None, _skip_result("undecidable_skip", str(err))
 
 
-def _execute_operation_prefix_conditions_or_result(
+def _path_reachability_or_result(
+    context_constraints: Optional[Sequence[z3.ExprRef]],
+    path_conditions: Sequence[z3.ExprRef],
+    *,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[Optional[bool], Optional[AlgorithmResult]]:
+    """Check whether a symbolic operation path is reachable.
+
+    ``context_constraints=None`` disables pruning for helper-level callers that
+    only want syntax-local prefix collection.  Raw verification algorithms pass
+    their already-built first-cycle context so unreachable branches can be
+    skipped before translating branch bodies.
+
+    :param context_constraints: Outer constraints for the analyzed execution
+        context, or ``None`` to disable pruning.
+    :type context_constraints: Optional[Sequence[z3.ExprRef]]
+    :param path_conditions: Branch predicates needed to reach the path.
+    :type path_conditions: Sequence[z3.ExprRef]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Reachability flag, or an indeterminate algorithm result.
+    :rtype: Tuple[Optional[bool], Optional[AlgorithmResult]]
+    """
+    if context_constraints is None:
+        return True, None
+
+    sat_result = is_sat(
+        [*context_constraints, *path_conditions],
+        timeout_ms=smt_timeout_ms,
+    )
+    if sat_result.kind == "sat":
+        return True, None
+    if sat_result.kind == "unsat":
+        return False, None
+    return None, _skip_result(sat_result.kind, getattr(sat_result, "reason", None))
+
+
+def _execute_operation_prefix_conditions_and_vars_or_result(
     operations: Sequence[OperationStatement],
     z3_vars: _Z3Vars,
     path_conditions: Sequence[z3.ExprRef] = (),
-) -> Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[AlgorithmResult]]:
-    """Collect condition expressions with point-in-time path predicates.
+    *,
+    context_constraints: Optional[Sequence[z3.ExprRef]] = None,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[
+    Optional[Tuple[_ConditionPoint, ...]],
+    Optional[_Z3Vars],
+    Optional[AlgorithmResult],
+]:
+    """Collect prefix conditions and execute operations path-sensitively.
 
-    The collected path predicates model the branch-selection predicates needed
-    to reach the condition point.  They let callers skip diagnostics for
-    syntactic conditions inside branches that are unreachable in the surrounding
-    first-cycle context.
+    When ``context_constraints`` are supplied, branch bodies whose path is
+    unsatisfiable in that context are not translated.  This preserves later
+    reachable diagnostics instead of letting dead branch expressions force the
+    entire algorithm into ``undecidable_skip``.
 
     :param operations: Operation statements to scan in execution order.
     :type operations: Sequence[OperationStatement]
@@ -339,9 +384,14 @@ def _execute_operation_prefix_conditions_or_result(
     :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
     :param path_conditions: Predicates that must hold before this block is run.
     :type path_conditions: Sequence[z3.ExprRef]
-    :return: Condition points, or an algorithm result when symbolic prefix
-        execution cannot be expressed.
-    :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[AlgorithmResult]]
+    :param context_constraints: Optional outer constraints used to prune
+        unreachable branch paths.
+    :type context_constraints: Optional[Sequence[z3.ExprRef]], optional
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Condition points, post-state variables, or an algorithm result
+        when symbolic prefix execution cannot be expressed.
+    :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[Dict[str, Union[z3.ArithRef, z3.BoolRef]]], Optional[AlgorithmResult]]
     """
     points: List[_ConditionPoint] = []
     current_vars = dict(z3_vars)
@@ -357,51 +407,138 @@ def _execute_operation_prefix_conditions_or_result(
                 [statement], current_vars
             )
             if result is not None:
-                return None, result
+                return None, None, result
             continue
 
         if isinstance(statement, _if_block_type()):
             prior_not_taken: List[z3.ExprRef] = []
+            branch_results = []
+            visible_names = tuple(current_vars.keys())
             for branch in statement.branches:
-                branch_path = [*current_path, *prior_not_taken]
+                evaluation_path = [*current_path, *prior_not_taken]
+                evaluation_reachable, result = _path_reachability_or_result(
+                    context_constraints,
+                    evaluation_path,
+                    smt_timeout_ms=smt_timeout_ms,
+                )
+                if result is not None:
+                    return None, None, result
+                if evaluation_reachable is False:
+                    break
+
+                branch_condition = None
+                branch_path = list(evaluation_path)
                 if branch.condition is not None:
                     branch_condition, result = _expr_to_z3_or_result(
                         branch.condition,
                         current_vars,
                     )
                     if result is not None:
-                        return None, result
+                        return None, None, result
                     points.append(
                         _ConditionPoint(
                             branch.condition,
                             dict(current_vars),
-                            tuple(branch_path),
+                            tuple(evaluation_path),
+                            "branch",
                         )
                     )
                     branch_path.append(branch_condition)
                     prior_not_taken.append(z3.Not(branch_condition))
-                branch_points, result = _execute_operation_prefix_conditions_or_result(
-                    branch.statements,
-                    current_vars,
+
+                branch_reachable, result = _path_reachability_or_result(
+                    context_constraints,
                     branch_path,
+                    smt_timeout_ms=smt_timeout_ms,
                 )
                 if result is not None:
-                    return None, result
-                points.extend(branch_points or ())
+                    return None, None, result
+                if branch_reachable is False:
+                    continue
 
-            current_vars, result = _execute_operations_or_result(
-                [statement], current_vars
-            )
-            if result is not None:
-                return None, result
+                branch_points, branch_vars, result = (
+                    _execute_operation_prefix_conditions_and_vars_or_result(
+                        branch.statements,
+                        current_vars,
+                        branch_path,
+                        context_constraints=context_constraints,
+                        smt_timeout_ms=smt_timeout_ms,
+                    )
+                )
+                if result is not None:
+                    return None, None, result
+                points.extend(branch_points or ())
+                branch_results.append((branch_condition, branch_vars or current_vars))
+
+                if branch.condition is None:
+                    break
+
+            merged_vars = dict(current_vars)
+            for name in visible_names:
+                merged_value = current_vars[name]
+                for branch_condition, branch_vars in reversed(branch_results):
+                    if branch_condition is None:
+                        merged_value = branch_vars[name]
+                    else:
+                        merged_value = z3.If(
+                            branch_condition,
+                            branch_vars[name],
+                            merged_value,
+                        )
+                merged_vars[name] = merged_value
+            current_vars = merged_vars
             continue
 
-        return None, _skip_result(
-            "undecidable_skip",
-            f"Unknown operation statement type {type(statement)!r}.",
+        return (
+            None,
+            None,
+            _skip_result(
+                "undecidable_skip",
+                f"Unknown operation statement type {type(statement)!r}.",
+            ),
         )
 
-    return tuple(points), None
+    return tuple(points), current_vars, None
+
+
+def _execute_operation_prefix_conditions_or_result(
+    operations: Sequence[OperationStatement],
+    z3_vars: _Z3Vars,
+    path_conditions: Sequence[z3.ExprRef] = (),
+    *,
+    context_constraints: Optional[Sequence[z3.ExprRef]] = None,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[AlgorithmResult]]:
+    """Collect condition expressions with point-in-time path predicates.
+
+    The collected path predicates model the branch-selection predicates needed
+    to reach the condition point.  They let callers skip diagnostics for
+    syntactic conditions inside branches that are unreachable in the surrounding
+    first-cycle context.
+
+    :param operations: Operation statements to scan in execution order.
+    :type operations: Sequence[OperationStatement]
+    :param z3_vars: Starting symbolic environment before the operation block.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param path_conditions: Predicates that must hold before this block is run.
+    :type path_conditions: Sequence[z3.ExprRef]
+    :param context_constraints: Optional outer constraints used to prune
+        unreachable branch paths.
+    :type context_constraints: Optional[Sequence[z3.ExprRef]], optional
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Condition points, or an algorithm result when symbolic prefix
+        execution cannot be expressed.
+    :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[AlgorithmResult]]
+    """
+    points, _, result = _execute_operation_prefix_conditions_and_vars_or_result(
+        operations,
+        z3_vars,
+        path_conditions,
+        context_constraints=context_constraints,
+        smt_timeout_ms=smt_timeout_ms,
+    )
+    return points, result
 
 
 def _transition_trigger_or_result(
@@ -1225,21 +1362,28 @@ def enter_postcondition_implies_during_precondition(
     if result is not None:
         return result
 
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    context_constraints = [
+        *init_constraints,
+        *(entry_constraints or ()),
+        *type_constraints,
+    ]
     condition_points, result = _execute_operation_prefix_conditions_or_result(
         first_cycle_operations,
         entry_vars,
+        context_constraints=context_constraints,
+        smt_timeout_ms=smt_timeout_ms,
     )
     if result is not None:
         return result
     if not condition_points:
         return AlgorithmResult(kind="sat")
 
-    type_constraints = _build_type_constraints(variables, z3_vars)
     diagnostics: List[dict] = []
     first_indeterminate_result: Optional[AlgorithmResult] = None
 
     context_check = is_sat(
-        [*init_constraints, *(entry_constraints or ()), *type_constraints],
+        context_constraints,
         timeout_ms=smt_timeout_ms,
     )
     if context_check.kind in {"unknown", "timeout"}:
@@ -1253,6 +1397,18 @@ def enter_postcondition_implies_during_precondition(
 
     for condition_point in condition_points:
         condition = condition_point.condition
+        condition_z3, result = _expr_to_z3_or_result(
+            condition,
+            condition_point.z3_vars,
+        )
+        if result is not None:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                result.kind,
+                result.reason,
+            )
+            continue
+
         point_context = [
             *init_constraints,
             *(entry_constraints or ()),
@@ -1273,18 +1429,6 @@ def enter_postcondition_implies_during_precondition(
             )
             continue
 
-        condition_z3, result = _expr_to_z3_or_result(
-            condition,
-            condition_point.z3_vars,
-        )
-        if result is not None:
-            first_indeterminate_result = _first_indeterminate(
-                first_indeterminate_result,
-                result.kind,
-                result.reason,
-            )
-            continue
-
         true_check = is_sat(
             [condition_z3, *point_context],
             timeout_ms=smt_timeout_ms,
@@ -1301,6 +1445,7 @@ def enter_postcondition_implies_during_precondition(
                     "enter_postcondition_implies_during_precondition",
                     state=_state_path(state),
                     condition=str(condition),
+                    condition_source=condition_point.source,
                     branch_taken="false",
                     verification_scope="smt_local",
                 )
@@ -1312,6 +1457,7 @@ def enter_postcondition_implies_during_precondition(
                     "enter_postcondition_implies_during_precondition",
                     state=_state_path(state),
                     condition=str(condition),
+                    condition_source=condition_point.source,
                     branch_taken="true",
                     verification_scope="smt_local",
                 )

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -723,6 +723,78 @@ def _expr_conditions_and_z3_or_result(
     )
 
 
+def _expr_z3_and_domains_or_result(
+    expr: Expr,
+    z3_vars: _Z3Vars,
+    path_conditions: Sequence[z3.ExprRef] = (),
+    *,
+    context_constraints: Optional[Sequence[z3.ExprRef]] = None,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[
+    Optional[_Z3Expr],
+    Optional[Tuple[z3.ExprRef, ...]],
+    Optional[AlgorithmResult],
+]:
+    """Translate an expression and return runtime-definedness constraints.
+
+    Z3 arithmetic is total for operators such as division and modulo, while the
+    FCSTM runtime aborts expression evaluation on invalid numeric domains.  Raw
+    guard and trigger algorithms therefore need both the translated expression
+    and the side constraints that make evaluating it well-defined.
+
+    :param expr: Expression to translate.
+    :type expr: Expr
+    :param z3_vars: Symbolic environment at this expression point.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param path_conditions: Predicates needed to reach this expression.
+    :type path_conditions: Sequence[z3.ExprRef]
+    :param context_constraints: Optional surrounding execution context.
+    :type context_constraints: Optional[Sequence[z3.ExprRef]], optional
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Z3 expression, runtime-definedness constraints, or a normalized
+        algorithm result.
+    :rtype: Tuple[Optional[Union[z3.ArithRef, z3.BoolRef]], Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]
+    """
+    domain_constraints: List[z3.ExprRef] = []
+    _, z3_expr, result = _expr_conditions_and_z3_or_result(
+        expr,
+        z3_vars,
+        path_conditions,
+        context_constraints=context_constraints,
+        smt_timeout_ms=smt_timeout_ms,
+        domain_constraints=domain_constraints,
+    )
+    if result is not None:
+        return None, None, result
+    return z3_expr, tuple(domain_constraints), None
+
+
+def _definedness_feasibility_or_result(
+    constraints: Sequence[z3.ExprRef],
+    *,
+    reason: str,
+    smt_timeout_ms: Optional[int] = None,
+) -> Optional[AlgorithmResult]:
+    """Return an indeterminate result when runtime-definedness is infeasible.
+
+    :param constraints: Context plus definedness constraints to check.
+    :type constraints: Sequence[z3.ExprRef]
+    :param reason: Reason to use when the context is unsatisfiable.
+    :type reason: str
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: ``None`` when feasible, otherwise an algorithm result.
+    :rtype: Optional[AlgorithmResult]
+    """
+    sat_result = is_sat(constraints, timeout_ms=smt_timeout_ms)
+    if sat_result.kind == "sat":
+        return None
+    if sat_result.kind == "unsat":
+        return _skip_result("undecidable_skip", reason)
+    return _skip_result(sat_result.kind, getattr(sat_result, "reason", None))
+
+
 def _path_reachability_or_result(
     context_constraints: Optional[Sequence[z3.ExprRef]],
     path_conditions: Sequence[z3.ExprRef],
@@ -825,8 +897,8 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
 
     for statement in operations:
         if isinstance(statement, _operation_type()):
-            expression_domains: List[z3.ExprRef] = []
             expression_path = (*current_path, *current_domains)
+            expression_domains: List[z3.ExprRef] = []
             expression_points, expression_value, result = (
                 _expr_conditions_and_z3_or_result(
                     statement.expr,
@@ -839,6 +911,21 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
             )
             if result is not None:
                 return None, None, None, result
+            if context_constraints is not None and expression_domains:
+                result = _definedness_feasibility_or_result(
+                    [
+                        *context_constraints,
+                        *expression_path,
+                        *expression_domains,
+                    ],
+                    reason=(
+                        "Operation expression runtime definedness constraints "
+                        "are unsatisfiable in context."
+                    ),
+                    smt_timeout_ms=smt_timeout_ms,
+                )
+                if result is not None:
+                    return None, None, None, result
             points.extend(expression_points or ())
             current_vars[statement.var_name] = expression_value
             _append_expr_domain_constraints(
@@ -864,13 +951,13 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
                     break
 
                 branch_condition = None
-                branch_condition_domains: List[z3.ExprRef] = []
                 branch_path = list(evaluation_path)
                 evaluation_selector = (
                     z3.And(*prior_not_taken) if prior_not_taken else None
                 )
                 branch_selector = evaluation_selector
                 if branch.condition is not None:
+                    branch_condition_domains: List[z3.ExprRef] = []
                     condition_points, branch_condition, result = (
                         _expr_conditions_and_z3_or_result(
                             branch.condition,
@@ -883,6 +970,21 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
                     )
                     if result is not None:
                         return None, None, None, result
+                    if context_constraints is not None and branch_condition_domains:
+                        result = _definedness_feasibility_or_result(
+                            [
+                                *context_constraints,
+                                *evaluation_path,
+                                *branch_condition_domains,
+                            ],
+                            reason=(
+                                "Branch condition runtime definedness "
+                                "constraints are unsatisfiable in context."
+                            ),
+                            smt_timeout_ms=smt_timeout_ms,
+                        )
+                        if result is not None:
+                            return None, None, None, result
                     points.extend(condition_points or ())
                     for item in branch_condition_domains:
                         if evaluation_selector is None:
@@ -1025,7 +1127,14 @@ def _transition_trigger_or_result(
     transition: Transition,
     z3_vars: _Z3Vars,
     event_vars: Optional[Dict[str, z3.BoolRef]] = None,
-) -> Tuple[Optional[z3.ExprRef], Optional[AlgorithmResult]]:
+    *,
+    context_constraints: Optional[Sequence[z3.ExprRef]] = None,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[
+    Optional[z3.ExprRef],
+    Optional[Tuple[z3.ExprRef, ...]],
+    Optional[AlgorithmResult],
+]:
     """Build a transition trigger expression in the supplied environment.
 
     :param transition: Transition whose event and guard should be encoded.
@@ -1034,10 +1143,18 @@ def _transition_trigger_or_result(
     :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
     :param event_vars: Optional shared event boolean variable mapping.
     :type event_vars: Optional[Dict[str, z3.BoolRef]], optional
-    :return: Trigger expression and optional failure result.
-    :rtype: Tuple[Optional[z3.ExprRef], Optional[AlgorithmResult]]
+    :param context_constraints: Optional context used to prune guard ternary
+        branches while translating.
+    :type context_constraints: Optional[Sequence[z3.ExprRef]], optional
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Trigger expression, runtime-definedness constraints, and optional
+        failure result.
+    :rtype: Tuple[Optional[z3.ExprRef], Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]
     """
     parts: List[z3.ExprRef] = []
+    domain_constraints: List[z3.ExprRef] = []
+    event_expr = None
     if transition.event is not None:
         event_key = _event_bool_name(transition)
         if event_vars is None:
@@ -1047,16 +1164,30 @@ def _transition_trigger_or_result(
         parts.append(event_expr)
 
     if transition.guard is not None:
-        guard_expr, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+        guard_expr, guard_domains, result = _expr_z3_and_domains_or_result(
+            transition.guard,
+            z3_vars,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+        )
         if result is not None:
-            return None, result
+            return None, None, result
+        domain_constraints.extend(guard_domains or ())
+        parts.extend(guard_domains or ())
         parts.append(guard_expr)
 
+    if event_expr is not None:
+        trigger_domains = tuple(
+            z3.Implies(event_expr, item) for item in domain_constraints
+        )
+    else:
+        trigger_domains = tuple(domain_constraints)
+
     if not parts:
-        return z3.BoolVal(True), None
+        return z3.BoolVal(True), trigger_domains, None
     if len(parts) == 1:
-        return parts[0], None
-    return z3.And(*parts), None
+        return parts[0], trigger_domains, None
+    return z3.And(*parts), trigger_domains, None
 
 
 def _root_initial_path_context(
@@ -1148,15 +1279,48 @@ def _root_initial_path_context(
 
         target_transition = None
         selected_constraints = None
+        selected_guard_domains = None
         prior_triggers: List[z3.ExprRef] = []
+        prior_guard_domains: List[z3.ExprRef] = []
         for transition in path_state.init_transitions:
-            trigger, result = _transition_trigger_or_result(transition, current_vars)
+            trigger, guard_domains, result = _transition_trigger_or_result(
+                transition,
+                current_vars,
+                context_constraints=[
+                    *base_constraints,
+                    *constraints,
+                    *domain_constraints,
+                    *prior_guard_domains,
+                    *type_constraints,
+                ],
+                smt_timeout_ms=smt_timeout_ms,
+            )
             if result is not None:
                 return None, None, None, result
+            if guard_domains:
+                result = _definedness_feasibility_or_result(
+                    [
+                        *base_constraints,
+                        *constraints,
+                        *domain_constraints,
+                        *prior_guard_domains,
+                        *guard_domains,
+                        *type_constraints,
+                    ],
+                    reason=(
+                        "Initial transition guard runtime definedness "
+                        "constraints are unsatisfiable in context."
+                    ),
+                    smt_timeout_ms=smt_timeout_ms,
+                )
+                if result is not None:
+                    return None, None, None, result
             if transition.to_state == child.name:
                 candidate_constraints = [
                     *constraints,
+                    *prior_guard_domains,
                     *(z3.Not(prior_trigger) for prior_trigger in prior_triggers),
+                    *(guard_domains or ()),
                     trigger,
                 ]
                 context_check = is_sat(
@@ -1181,10 +1345,16 @@ def _root_initial_path_context(
                 if context_check.kind == "sat":
                     target_transition = transition
                     selected_constraints = candidate_constraints
+                    selected_guard_domains = guard_domains
                     break
+            prior_guard_domains.extend(guard_domains or ())
             prior_triggers.append(trigger)
 
-        if target_transition is None or selected_constraints is None:
+        if (
+            target_transition is None
+            or selected_constraints is None
+            or selected_guard_domains is None
+        ):
             return None, None, None, None
         constraints = selected_constraints
 
@@ -1239,21 +1409,42 @@ def _build_init_constraints_or_result(
 def _guard_z3_or_result(
     transition: Transition,
     variables: Sequence[VarDefine],
-) -> Tuple[Optional[_Z3Expr], Optional[_Z3Vars], Optional[AlgorithmResult]]:
+    *,
+    context_constraints: Optional[Sequence[z3.ExprRef]] = None,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[
+    Optional[_Z3Expr],
+    Optional[_Z3Vars],
+    Optional[Tuple[z3.ExprRef, ...]],
+    Optional[AlgorithmResult],
+]:
     """Translate a transition guard.
 
     :param transition: Transition with a non-``None`` guard.
     :type transition: Transition
     :param variables: FCSTM variable definitions.
     :type variables: Sequence[VarDefine]
-    :return: Guard Z3 expression, variable mapping, and optional failure result.
+    :param context_constraints: Optional context used to prune guard ternary
+        branches while translating.
+    :type context_constraints: Optional[Sequence[z3.ExprRef]], optional
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Guard Z3 expression, variable mapping, runtime-definedness
+        constraints, and optional failure result.
     :rtype: tuple
     """
     z3_vars = _z3_vars(variables)
-    guard_expr, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+    if context_constraints is None:
+        context_constraints = _build_type_constraints(variables, z3_vars)
+    guard_expr, guard_domains, result = _expr_z3_and_domains_or_result(
+        transition.guard,
+        z3_vars,
+        context_constraints=context_constraints,
+        smt_timeout_ms=smt_timeout_ms,
+    )
     if result is not None:
-        return None, None, result
-    return guard_expr, z3_vars, None
+        return None, None, None, result
+    return guard_expr, z3_vars, guard_domains, None
 
 
 def _is_self_assign(statement: OperationStatement) -> bool:
@@ -1335,12 +1526,31 @@ def dead_guard(
     if transition.guard is None:
         return AlgorithmResult(kind="sat")
 
-    guard_z3, z3_vars, result = _guard_z3_or_result(transition, variables)
+    guard_z3, z3_vars, guard_domains, result = _guard_z3_or_result(
+        transition,
+        variables,
+        smt_timeout_ms=smt_timeout_ms,
+    )
     if result is not None:
         return result
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    if guard_domains:
+        result = _definedness_feasibility_or_result(
+            [*type_constraints, *guard_domains],
+            reason=(
+                "Transition guard runtime definedness constraints are unsatisfiable."
+            ),
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            return result
 
     sat_result = is_sat(
-        [guard_z3, *_build_type_constraints(variables, z3_vars)],
+        [
+            guard_z3,
+            *type_constraints,
+            *(guard_domains or ()),
+        ],
         timeout_ms=smt_timeout_ms,
     )
     if sat_result.kind == "unsat":
@@ -1378,12 +1588,31 @@ def guard_tautology(
     if transition.guard is None:
         return AlgorithmResult(kind="sat")
 
-    guard_z3, z3_vars, result = _guard_z3_or_result(transition, variables)
+    guard_z3, z3_vars, guard_domains, result = _guard_z3_or_result(
+        transition,
+        variables,
+        smt_timeout_ms=smt_timeout_ms,
+    )
     if result is not None:
         return result
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    if guard_domains:
+        result = _definedness_feasibility_or_result(
+            [*type_constraints, *guard_domains],
+            reason=(
+                "Transition guard runtime definedness constraints are unsatisfiable."
+            ),
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            return result
 
     sat_result = is_sat(
-        [z3.Not(guard_z3), *_build_type_constraints(variables, z3_vars)],
+        [
+            z3.Not(guard_z3),
+            *type_constraints,
+            *(guard_domains or ()),
+        ],
         timeout_ms=smt_timeout_ms,
     )
     if sat_result.kind == "unsat":
@@ -1421,15 +1650,32 @@ def forced_guard_unsat_under_init(
     if not transition.is_forced or transition.guard is None:
         return AlgorithmResult(kind="sat")
 
-    guard_z3, z3_vars, result = _guard_z3_or_result(transition, variables)
-    if result is not None:
-        return result
+    z3_vars = _z3_vars(variables)
     init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
     if result is not None:
         return result
+    guard_z3, guard_domains, result = _expr_z3_and_domains_or_result(
+        transition.guard,
+        z3_vars,
+        context_constraints=init_constraints,
+        smt_timeout_ms=smt_timeout_ms,
+    )
+    if result is not None:
+        return result
+    if guard_domains:
+        result = _definedness_feasibility_or_result(
+            [*init_constraints, *(guard_domains or ())],
+            reason=(
+                "Transition guard runtime definedness constraints are "
+                "unsatisfiable under initial values."
+            ),
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            return result
 
     sat_result = is_sat(
-        [guard_z3, *init_constraints],
+        [guard_z3, *init_constraints, *(guard_domains or ())],
         timeout_ms=smt_timeout_ms,
     )
     if sat_result.kind == "unsat":
@@ -1472,21 +1718,38 @@ def _effect_guard_context_or_result(
     """
     if transition.guard is None:
         guard_z3 = z3.BoolVal(True)
+        guard_domains: Tuple[z3.ExprRef, ...] = ()
     else:
-        guard_z3, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+        guard_z3, guard_domains, result = _expr_z3_and_domains_or_result(
+            transition.guard,
+            z3_vars,
+            smt_timeout_ms=smt_timeout_ms,
+        )
         if result is not None:
             return None, None, result
 
     type_constraints = _build_type_constraints(variables, z3_vars)
     guard_feasible = is_sat(
-        [guard_z3, *type_constraints],
+        [guard_z3, *type_constraints, *(guard_domains or ())],
         timeout_ms=smt_timeout_ms,
     )
     if guard_feasible.kind == "unsat":
+        if guard_domains:
+            return (
+                None,
+                None,
+                _skip_result(
+                    "undecidable_skip",
+                    (
+                        "Transition guard runtime definedness constraints are "
+                        "unsatisfiable."
+                    ),
+                ),
+            )
         return None, None, AlgorithmResult(kind="sat")
     if guard_feasible.kind != "sat":
         return None, None, AlgorithmResult(kind=guard_feasible.kind)
-    return guard_z3, type_constraints, None
+    return guard_z3, (*type_constraints, *(guard_domains or ())), None
 
 
 def _execute_effects_under_guard_or_result(
@@ -1541,10 +1804,11 @@ def _execute_effects_under_guard_or_result(
         timeout_ms=smt_timeout_ms,
     )
     if defined_effect_feasible.kind == "unsat":
-        return None, None, _skip_result(
+        result = _skip_result(
             "undecidable_skip",
             "Transition effect runtime definedness constraints are unsatisfiable under guard.",
         )
+        return None, None, result
     if defined_effect_feasible.kind != "sat":
         return None, None, AlgorithmResult(kind=defined_effect_feasible.kind)
     return after_vars, tuple(effect_domain_constraints or ()), None
@@ -1751,13 +2015,17 @@ def transition_shadowed_by_predecessor(
         z3_vars = _z3_vars(variables)
         event_vars: Dict[str, z3.BoolRef] = {}
         prior_triggers: List[z3.ExprRef] = []
+        prior_domain_constraints: List[z3.ExprRef] = []
         prior_payloads: List[dict] = []
+        type_constraints = _build_type_constraints(variables, z3_vars)
 
         for transition in outgoing:
-            trigger, result = _transition_trigger_or_result(
+            trigger, trigger_domains, result = _transition_trigger_or_result(
                 transition,
                 z3_vars,
                 event_vars,
+                context_constraints=type_constraints,
+                smt_timeout_ms=smt_timeout_ms,
             )
             if result is not None:
                 first_indeterminate_result = _first_indeterminate(
@@ -1766,18 +2034,35 @@ def transition_shadowed_by_predecessor(
                     result.reason,
                 )
                 continue
+            if trigger_domains:
+                result = _definedness_feasibility_or_result(
+                    [*type_constraints, *prior_domain_constraints, *trigger_domains],
+                    reason=(
+                        "Transition trigger runtime definedness constraints "
+                        "are unsatisfiable in context."
+                    ),
+                    smt_timeout_ms=smt_timeout_ms,
+                )
+                if result is not None:
+                    first_indeterminate_result = _first_indeterminate(
+                        first_indeterminate_result,
+                        result.kind,
+                        result.reason,
+                    )
+                    break
 
             current_payload = _transition_payload(transition)
             if prior_triggers:
                 formula = z3.And(
                     trigger,
                     *(z3.Not(prior_trigger) for prior_trigger in prior_triggers),
-                    *_build_type_constraints(variables, z3_vars),
+                    *prior_domain_constraints,
+                    *type_constraints,
                 )
                 sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
                 if sat_result.kind == "unsat":
                     trigger_sat = is_sat(
-                        [trigger, *_build_type_constraints(variables, z3_vars)],
+                        [trigger, *type_constraints, *(trigger_domains or ())],
                         timeout_ms=smt_timeout_ms,
                     )
                     if trigger_sat.kind == "unsat":
@@ -1832,6 +2117,7 @@ def transition_shadowed_by_predecessor(
                     )
 
             prior_triggers.append(trigger)
+            prior_domain_constraints.extend(trigger_domains or ())
             prior_payloads.append(current_payload)
 
     if diagnostics:
@@ -2208,11 +2494,14 @@ def composite_init_guards_incomplete(
         event_vars: Dict[str, z3.BoolRef] = {}
         triggers: List[z3.ExprRef] = []
         per_composite_failed = False
+        type_constraints = _build_type_constraints(variables, z3_vars)
         for transition in init_transitions:
-            trigger, result = _transition_trigger_or_result(
+            trigger, trigger_domains, result = _transition_trigger_or_result(
                 transition,
                 z3_vars,
                 event_vars,
+                context_constraints=type_constraints,
+                smt_timeout_ms=smt_timeout_ms,
             )
             if result is not None:
                 first_indeterminate_result = _first_indeterminate(
@@ -2222,6 +2511,8 @@ def composite_init_guards_incomplete(
                 )
                 per_composite_failed = True
                 break
+            if trigger_domains:
+                trigger = z3.And(trigger, *trigger_domains)
             triggers.append(trigger)
 
         if per_composite_failed or not triggers:
@@ -2231,7 +2522,7 @@ def composite_init_guards_incomplete(
         sat_result = is_sat(
             [
                 no_coverage,
-                *_build_type_constraints(variables, z3_vars),
+                *type_constraints,
             ],
             timeout_ms=smt_timeout_ms,
             get_model=True,

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -1903,6 +1903,11 @@ def effect_contradicts_guard(
 ) -> AlgorithmResult:
     """Detect effects after which the transition guard cannot still hold.
 
+    The post-effect guard counts as still holding only when it is both
+    runtime-defined and true.  If post-state guard definedness is itself
+    infeasible under the pre-guard/effect context, the raw algorithm returns
+    ``undecidable_skip`` instead of emitting a deterministic contradiction.
+
     :param transition: Transition to check.
     :type transition: Transition
     :param variables: Variable definitions available to the model.
@@ -1935,9 +1940,34 @@ def effect_contradicts_guard(
     )
     if result is not None:
         return result
-    guard_after, result = _expr_to_z3_or_result(transition.guard, after_vars)
+    guard_after, guard_after_domains, result = _expr_z3_and_domains_or_result(
+        transition.guard,
+        after_vars,
+        context_constraints=[
+            guard_before,
+            *(type_constraints or ()),
+            *(effect_domain_constraints or ()),
+        ],
+        smt_timeout_ms=smt_timeout_ms,
+    )
     if result is not None:
         return result
+    if guard_after_domains:
+        result = _definedness_feasibility_or_result(
+            [
+                guard_before,
+                *(type_constraints or ()),
+                *(effect_domain_constraints or ()),
+                *guard_after_domains,
+            ],
+            reason=(
+                "Post-effect transition guard runtime definedness "
+                "constraints are unsatisfiable."
+            ),
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            return result
 
     sat_result = is_sat(
         [
@@ -1945,6 +1975,7 @@ def effect_contradicts_guard(
             guard_after,
             *(type_constraints or ()),
             *(effect_domain_constraints or ()),
+            *(guard_after_domains or ()),
         ],
         timeout_ms=smt_timeout_ms,
     )
@@ -2053,14 +2084,48 @@ def transition_shadowed_by_predecessor(
 
             current_payload = _transition_payload(transition)
             if prior_triggers:
+                prior_disabled = tuple(
+                    z3.Not(prior_trigger) for prior_trigger in prior_triggers
+                )
                 formula = z3.And(
                     trigger,
-                    *(z3.Not(prior_trigger) for prior_trigger in prior_triggers),
+                    *prior_disabled,
                     *prior_domain_constraints,
                     *type_constraints,
                 )
                 sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
                 if sat_result.kind == "unsat":
+                    loose_formula = z3.And(
+                        trigger,
+                        *prior_disabled,
+                        *type_constraints,
+                    )
+                    loose_result = is_sat(
+                        [loose_formula],
+                        timeout_ms=smt_timeout_ms,
+                    )
+                    if loose_result.kind == "sat":
+                        first_indeterminate_result = _first_indeterminate(
+                            first_indeterminate_result,
+                            "undecidable_skip",
+                            (
+                                "Prior transition trigger runtime definedness "
+                                "constraints exclude the remaining candidate "
+                                "space."
+                            ),
+                        )
+                        prior_triggers.append(trigger)
+                        prior_domain_constraints.extend(trigger_domains or ())
+                        prior_payloads.append(current_payload)
+                        continue
+                    if loose_result.kind != "unsat":
+                        first_indeterminate_result = _first_indeterminate(
+                            first_indeterminate_result,
+                            loose_result.kind,
+                            getattr(loose_result, "reason", None),
+                        )
+                        continue
+
                     trigger_sat = is_sat(
                         [trigger, *type_constraints, *(trigger_domains or ())],
                         timeout_ms=smt_timeout_ms,

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -1904,8 +1904,8 @@ def effect_contradicts_guard(
     """Detect effects after which the transition guard cannot still hold.
 
     The post-effect guard counts as still holding only when it is both
-    runtime-defined and true.  If post-state guard definedness is itself
-    infeasible under the pre-guard/effect context, the raw algorithm returns
+    runtime-defined and true.  If post-state guard definedness is not guaranteed
+    under the pre-guard/effect context, the raw algorithm returns
     ``undecidable_skip`` instead of emitting a deterministic contradiction.
 
     :param transition: Transition to check.
@@ -1953,13 +1953,13 @@ def effect_contradicts_guard(
     if result is not None:
         return result
     if guard_after_domains:
+        post_context = [
+            guard_before,
+            *(type_constraints or ()),
+            *(effect_domain_constraints or ()),
+        ]
         result = _definedness_feasibility_or_result(
-            [
-                guard_before,
-                *(type_constraints or ()),
-                *(effect_domain_constraints or ()),
-                *guard_after_domains,
-            ],
+            [*post_context, *guard_after_domains],
             reason=(
                 "Post-effect transition guard runtime definedness "
                 "constraints are unsatisfiable."
@@ -1968,6 +1968,24 @@ def effect_contradicts_guard(
         )
         if result is not None:
             return result
+
+        undefined_post_guard = is_sat(
+            [*post_context, z3.Not(z3.And(*guard_after_domains))],
+            timeout_ms=smt_timeout_ms,
+        )
+        if undefined_post_guard.kind == "sat":
+            return _skip_result(
+                "undecidable_skip",
+                (
+                    "Post-effect transition guard runtime definedness "
+                    "constraints are not guaranteed."
+                ),
+            )
+        if undefined_post_guard.kind != "unsat":
+            return _skip_result(
+                undefined_post_guard.kind,
+                getattr(undefined_post_guard, "reason", None),
+            )
 
     sat_result = is_sat(
         [

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -29,14 +29,12 @@ if TYPE_CHECKING:  # pragma: no cover - imported only for static checkers
         Transition,
         VarDefine,
     )
-    from pyfcstm.solver.safety import SafetyCheck
 
 ResultKind = Literal[
     "sat",
     "unsat",
     "unknown",
     "timeout",
-    "unsafe_skip",
     "undecidable_skip",
 ]
 
@@ -105,20 +103,6 @@ def execute_operations(operations, z3_vars):
     from pyfcstm.solver.operation import execute_operations as impl
 
     return impl(operations, z3_vars)
-
-
-def check_expr_safety(expr):
-    """Delegate to :func:`pyfcstm.solver.safety.check_expr_safety`."""
-    from pyfcstm.solver.safety import check_expr_safety as impl
-
-    return impl(expr)
-
-
-def check_expr_safety_for_effect(ops):
-    """Delegate to :func:`pyfcstm.solver.safety.check_expr_safety_for_effect`."""
-    from pyfcstm.solver.safety import check_expr_safety_for_effect as impl
-
-    return impl(ops)
 
 
 @dataclass(frozen=True)
@@ -229,30 +213,6 @@ def _skip_result(kind: ResultKind, reason: Optional[str]) -> AlgorithmResult:
     return AlgorithmResult(kind=kind, diagnostics=(), reason=reason)
 
 
-def _unsafe_result(safety: SafetyCheck) -> AlgorithmResult:
-    """Create an unsafe-skip result from a safety check.
-
-    :param safety: Safety check result.
-    :type safety: SafetyCheck
-    :return: Unsafe-skip result.
-    :rtype: AlgorithmResult
-    """
-    return _skip_result("unsafe_skip", safety.reason)
-
-
-def _merge_safety_checks(*checks: SafetyCheck) -> Optional[AlgorithmResult]:
-    """Return the first unsafe check as an algorithm result.
-
-    :param checks: Safety checks to inspect.
-    :return: First unsafe result, or ``None`` if all checks are safe.
-    :rtype: Optional[AlgorithmResult]
-    """
-    for check in checks:
-        if not check.safe:
-            return _unsafe_result(check)
-    return None
-
-
 def _z3_vars(variables: Sequence[VarDefine]) -> _Z3Vars:
     """Create Z3 variables from a generic sequence of variable definitions.
 
@@ -304,7 +264,7 @@ def _expr_to_z3_or_result(
     except NotImplementedError as err:
         # NotImplementedError: expr_to_z3 raises this for unsupported math
         # functions such as logarithms or trigonometric functions.
-        return None, _skip_result("unsafe_skip", str(err))
+        return None, _skip_result("undecidable_skip", str(err))
     except ValueError as err:
         # ValueError: expr_to_z3 raises this for unknown variables or operators.
         return None, _skip_result("undecidable_skip", str(err))
@@ -336,7 +296,7 @@ def _execute_operations_or_result(
     except NotImplementedError as err:
         # NotImplementedError: execute_operations delegates expression
         # translation to expr_to_z3, which raises this for unsupported functions.
-        return None, _skip_result("unsafe_skip", str(err))
+        return None, _skip_result("undecidable_skip", str(err))
     except ValueError as err:
         # ValueError: execute_operations delegates to expr_to_z3, which raises
         # this for unknown variables or unsupported operators.
@@ -367,9 +327,6 @@ def _build_init_constraints_or_result(
     """
     constraints: List[z3.ExprRef] = []
     for variable in variables:
-        safety = check_expr_safety(variable.init)
-        if not safety.safe:
-            return None, _unsafe_result(safety)
         init_value, result = _expr_to_z3_or_result(variable.init, z3_vars)
         if result is not None:
             return None, result
@@ -381,7 +338,7 @@ def _guard_z3_or_result(
     transition: Transition,
     variables: Sequence[VarDefine],
 ) -> Tuple[Optional[_Z3Expr], Optional[_Z3Vars], Optional[AlgorithmResult]]:
-    """Check and translate a transition guard.
+    """Translate a transition guard.
 
     :param transition: Transition with a non-``None`` guard.
     :type transition: Transition
@@ -390,10 +347,6 @@ def _guard_z3_or_result(
     :return: Guard Z3 expression, variable mapping, and optional failure result.
     :rtype: tuple
     """
-    safety = check_expr_safety(transition.guard)
-    if not safety.safe:
-        return None, None, _unsafe_result(safety)
-
     z3_vars = _z3_vars(variables)
     guard_expr, result = _expr_to_z3_or_result(transition.guard, z3_vars)
     if result is not None:
@@ -449,7 +402,7 @@ def _first_indeterminate(
     """
     if current is not None:
         return current
-    if candidate_kind in {"unknown", "timeout", "unsafe_skip", "undecidable_skip"}:
+    if candidate_kind in {"unknown", "timeout", "undecidable_skip"}:
         return _skip_result(candidate_kind, reason)
     return None
 
@@ -615,13 +568,6 @@ def effect_no_op_under_guard(
     if _is_syntactically_self_assign_only(transition.effects):
         return AlgorithmResult(kind="sat")
 
-    result = _merge_safety_checks(
-        check_expr_safety(transition.guard),
-        check_expr_safety_for_effect(transition.effects),
-    )
-    if result is not None:
-        return result
-
     z3_vars = _z3_vars(variables)
     after_vars, result = _execute_operations_or_result(transition.effects, z3_vars)
     if result is not None:
@@ -690,13 +636,6 @@ def effect_contradicts_guard(
     """
     if transition.guard is None or not transition.effects:
         return AlgorithmResult(kind="sat")
-
-    result = _merge_safety_checks(
-        check_expr_safety(transition.guard),
-        check_expr_safety_for_effect(transition.effects),
-    )
-    if result is not None:
-        return result
 
     z3_vars = _z3_vars(variables)
     guard_before, result = _expr_to_z3_or_result(transition.guard, z3_vars)
@@ -849,16 +788,6 @@ def transition_shadowed_by_predecessor(
                 continue
 
             if key == "guard":
-                safety = check_expr_safety(transition.guard)
-                if not safety.safe:
-                    first_indeterminate_result = _first_indeterminate(
-                        first_indeterminate_result,
-                        "unsafe_skip",
-                        safety.reason,
-                    )
-                    prior_guards.append(transition)
-                    continue
-
                 z3_vars = _z3_vars(variables)
                 current_guard, result = _expr_to_z3_or_result(transition.guard, z3_vars)
                 if result is not None:
@@ -872,17 +801,8 @@ def transition_shadowed_by_predecessor(
 
                 predecessor_guards: List[z3.ExprRef] = []
                 predecessor_payloads = []
-                predecessor_unsafe = False
+                predecessor_failed = False
                 for prior_guard_transition in prior_guards:
-                    prior_safety = check_expr_safety(prior_guard_transition.guard)
-                    if not prior_safety.safe:
-                        first_indeterminate_result = _first_indeterminate(
-                            first_indeterminate_result,
-                            "unsafe_skip",
-                            prior_safety.reason,
-                        )
-                        predecessor_unsafe = True
-                        break
                     prior_guard, result = _expr_to_z3_or_result(
                         prior_guard_transition.guard,
                         z3_vars,
@@ -893,14 +813,14 @@ def transition_shadowed_by_predecessor(
                             result.kind,
                             result.reason,
                         )
-                        predecessor_unsafe = True
+                        predecessor_failed = True
                         break
                     predecessor_guards.append(z3.Not(prior_guard))
                     predecessor_payloads.append(
                         _transition_payload(prior_guard_transition)
                     )
 
-                if not predecessor_unsafe and predecessor_guards:
+                if not predecessor_failed and predecessor_guards:
                     formula = z3.And(
                         current_guard,
                         *predecessor_guards,
@@ -1005,28 +925,96 @@ def _concrete_before_aspect_operations(state: State) -> List[OperationStatement]
     )
 
 
-def _is_root_initial_leaf(state: State) -> bool:
-    """Return whether a leaf is reached only through initial transitions.
+def _state_path_from_root(state: State) -> Tuple[State, ...]:
+    """Return the state path from the root to ``state``.
 
-    ``enter_postcondition_implies_during_precondition`` pins variables to DSL
-    declaration initializers.  That pre-state is sound only for the global
-    initial leaf reached through root-to-leaf ``[*]`` transitions.
+    :param state: State whose ancestry should be collected.
+    :type state: State
+    :return: Root-to-state path.
+    :rtype: Tuple[State, ...]
+    """
+    path = []
+    current = state
+    while current is not None:
+        path.append(current)
+        current = current.parent
+    return tuple(reversed(path))
+
+
+def _root_initial_path_transitions(state: State) -> Optional[Tuple[Transition, ...]]:
+    """Return the root-to-leaf initial-transition chain for ``state``.
+
+    ``enter_postcondition_implies_during_precondition`` reasons about first
+    cycle entry from the global root.  This helper returns the concrete
+    declaration-order transition chain that reaches ``state`` when every
+    ancestor follows an initial transition.  A missing initial edge means the
+    leaf is not a root-initial leaf and should be ignored by this algorithm.
+
+    :param state: Leaf state to inspect.
+    :type state: State
+    :return: Initial transition chain, or ``None`` when no such chain exists.
+    :rtype: Optional[Tuple[Transition, ...]]
+    """
+    path = _state_path_from_root(state)
+    transitions: List[Transition] = []
+    for parent, child in zip(path, path[1:]):
+        transition = next(
+            (
+                item
+                for item in parent.init_transitions
+                if item.to_state == child.name
+            ),
+            None,
+        )
+        if transition is None:
+            return None
+        transitions.append(transition)
+    return tuple(transitions)
+
+
+def _is_root_initial_leaf(state: State) -> bool:
+    """Return whether a leaf is reachable through initial transitions.
 
     :param state: Leaf state to inspect.
     :type state: State
     :return: Whether the root-to-leaf path is initial-transition-only.
     :rtype: bool
     """
-    current = state
-    while current.parent is not None:
-        parent = current.parent
-        if not any(
-            transition.to_state == current.name
-            for transition in parent.init_transitions
-        ):
-            return False
-        current = parent
-    return True
+    return _root_initial_path_transitions(state) is not None
+
+
+def _root_initial_entry_operations(
+    state: State,
+    init_transitions: Sequence[Transition],
+) -> List[OperationStatement]:
+    """Collect first-entry operations from the root through ``state``.
+
+    The order mirrors :class:`pyfcstm.simulate.runtime.SimulationRuntime` for a
+    root initial entry: each entered state executes its ``enter`` actions, a
+    composite then executes local ``during before`` actions, then the selected
+    initial transition effect runs before entering the child.  Leaf ``during``
+    and cross-cutting ``>> during before`` aspect actions are intentionally left
+    to the caller because they form the first-cycle condition being inspected.
+
+    :param state: Leaf state reached by the initial chain.
+    :type state: State
+    :param init_transitions: Initial transition chain returned by
+        :func:`_root_initial_path_transitions`.
+    :type init_transitions: Sequence[Transition]
+    :return: Flattened operation stream before first leaf during.
+    :rtype: List[OperationStatement]
+    """
+    path = _state_path_from_root(state)
+    operations: List[OperationStatement] = []
+    for index, path_state in enumerate(path):
+        operations.extend(_action_operations(path_state.on_enters))
+        if not path_state.is_leaf_state:
+            operations.extend(
+                _action_operations(path_state.list_on_durings(aspect="before"))
+            )
+        if index < len(init_transitions):
+            operations.extend(init_transitions[index].effects)
+    return operations
 
 
 def enter_postcondition_implies_during_precondition(
@@ -1048,22 +1036,15 @@ def enter_postcondition_implies_during_precondition(
     """
     if not state.is_leaf_state or state.is_pseudo:
         return AlgorithmResult(kind="sat")
-    if not _is_root_initial_leaf(state):
+    init_transitions = _root_initial_path_transitions(state)
+    if init_transitions is None:
         return AlgorithmResult(kind="sat")
 
-    enter_operations = _action_operations(state.on_enters)
+    entry_operations = _root_initial_entry_operations(state, init_transitions)
     before_aspect_operations = _concrete_before_aspect_operations(state)
     during_operations = _action_operations(state.on_durings)
-    if not enter_operations or not during_operations:
+    if not during_operations:
         return AlgorithmResult(kind="sat")
-
-    result = _merge_safety_checks(
-        check_expr_safety_for_effect(enter_operations),
-        check_expr_safety_for_effect(before_aspect_operations),
-        check_expr_safety_for_effect(during_operations),
-    )
-    if result is not None:
-        return result
 
     conditions = tuple(_conditional_conditions_from_operations(during_operations))
     if not conditions:
@@ -1073,12 +1054,22 @@ def enter_postcondition_implies_during_precondition(
     init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
     if result is not None:
         return result
-    enter_vars, result = _execute_operations_or_result(enter_operations, z3_vars)
+    entry_constraints: List[z3.ExprRef] = []
+    for transition in init_transitions:
+        if transition.event is not None:
+            entry_constraints.append(z3.Bool(_event_bool_name(transition)))
+        if transition.guard is not None:
+            guard_z3, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+            if result is not None:
+                return result
+            entry_constraints.append(guard_z3)
+
+    entry_vars, result = _execute_operations_or_result(entry_operations, z3_vars)
     if result is not None:
         return result
     first_cycle_vars, result = _execute_operations_or_result(
         before_aspect_operations,
-        enter_vars,
+        entry_vars,
     )
     if result is not None:
         return result
@@ -1086,6 +1077,19 @@ def enter_postcondition_implies_during_precondition(
     type_constraints = _build_type_constraints(variables, z3_vars)
     diagnostics: List[dict] = []
     first_indeterminate_result: Optional[AlgorithmResult] = None
+
+    context_check = is_sat(
+        [*init_constraints, *entry_constraints, *type_constraints],
+        timeout_ms=smt_timeout_ms,
+    )
+    if context_check.kind in {"unknown", "timeout"}:
+        first_indeterminate_result = _first_indeterminate(
+            first_indeterminate_result,
+            context_check.kind,
+            getattr(context_check, "reason", None),
+        )
+    if context_check.kind == "unsat":
+        return AlgorithmResult(kind="sat")
 
     for condition in conditions:
         condition_z3, result = _expr_to_z3_or_result(condition, first_cycle_vars)
@@ -1098,11 +1102,21 @@ def enter_postcondition_implies_during_precondition(
             continue
 
         true_check = is_sat(
-            [condition_z3, *init_constraints, *type_constraints],
+            [
+                condition_z3,
+                *init_constraints,
+                *entry_constraints,
+                *type_constraints,
+            ],
             timeout_ms=smt_timeout_ms,
         )
         false_check = is_sat(
-            [z3.Not(condition_z3), *init_constraints, *type_constraints],
+            [
+                z3.Not(condition_z3),
+                *init_constraints,
+                *entry_constraints,
+                *type_constraints,
+            ],
             timeout_ms=smt_timeout_ms,
         )
 
@@ -1192,20 +1206,6 @@ def composite_init_guards_incomplete(
             transition.guard is None and transition.event is None
             for transition in init_transitions
         ):
-            continue
-
-        unsafe_safety: Optional[SafetyCheck] = None
-        for transition in init_transitions:
-            safety = check_expr_safety(transition.guard)
-            if not safety.safe:
-                unsafe_safety = safety
-                break
-        if unsafe_safety is not None:
-            first_indeterminate_result = _first_indeterminate(
-                first_indeterminate_result,
-                "unsafe_skip",
-                unsafe_safety.reason,
-            )
             continue
 
         z3_vars = _z3_vars(variables)

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -1,7 +1,13 @@
 """SMT-local verification algorithms for FCSTM models.
 
-This module implements the Track A / PR-A4 algorithms from issue #114.  The
-functions intentionally return lightweight dictionaries instead of
+This module implements the Track A / PR-A4 algorithms from issue #114.  Raw
+verify algorithms are full-power by default: they do not consult
+``pyfcstm.solver.safety`` or diagnostics/inspect policy gates, and
+``smt_timeout_ms=None`` leaves the underlying solver timeout unset.  Callers
+that need product-level limits can pass optional budgets or apply policy in an
+adapter layer.
+
+The functions intentionally return lightweight dictionaries instead of
 ``ModelDiagnostic`` objects; PR-B1 is responsible for adapting these raw
 algorithm results to the diagnostics layer.
 """
@@ -50,6 +56,7 @@ class _ConditionPoint:
     z3_vars: _Z3Vars
     path_conditions: Tuple[z3.ExprRef, ...] = ()
     source: str = "expression"
+    z3_condition: Optional[z3.ExprRef] = None
 
 
 def _dsl_nodes():
@@ -322,6 +329,418 @@ def _execute_operations_or_result(
         return None, _skip_result("undecidable_skip", str(err))
 
 
+def _binary_z3_or_result(
+    op: str,
+    left: _Z3Expr,
+    right: _Z3Expr,
+) -> Tuple[Optional[_Z3Expr], Optional[AlgorithmResult]]:
+    """Apply a binary operator to already translated Z3 operands.
+
+    This mirrors :func:`pyfcstm.solver.expr.expr_to_z3` for expression trees
+    whose children were translated path-sensitively.
+
+    :param op: DSL binary operator.
+    :type op: str
+    :param left: Left Z3 operand.
+    :type left: Union[z3.ArithRef, z3.BoolRef]
+    :param right: Right Z3 operand.
+    :type right: Union[z3.ArithRef, z3.BoolRef]
+    :return: Translated Z3 expression and optional normalized failure.
+    :rtype: Tuple[Optional[Union[z3.ArithRef, z3.BoolRef]], Optional[AlgorithmResult]]
+    """
+    try:
+        if op == "+":
+            return left + right, None
+        if op == "-":
+            return left - right, None
+        if op == "*":
+            return left * right, None
+        if op == "/":
+            return left / right, None
+        if op == "%":
+            return left % right, None
+        if op == "**":
+            return left**right, None
+        if op == "&":
+            return left & right, None
+        if op == "|":
+            return left | right, None
+        if op == "^":
+            return left ^ right, None
+        if op == "<<":
+            return left << right, None
+        if op == ">>":
+            return left >> right, None
+        if op == "<":
+            return left < right, None
+        if op == "<=":
+            return left <= right, None
+        if op == ">":
+            return left > right, None
+        if op == ">=":
+            return left >= right, None
+        if op == "==":
+            return left == right, None
+        if op == "!=":
+            return left != right, None
+        if op in ("&&", "and"):
+            return z3.And(left, right), None
+        if op in ("||", "or"):
+            return z3.Or(left, right), None
+        return None, _skip_result(
+            "undecidable_skip", f"Unsupported binary operator: {op}"
+        )
+    except TypeError as err:
+        # TypeError: Python/Z3 operator overloads reject unsupported operand
+        # combinations, for example bitwise Int expressions.
+        return None, _skip_result("undecidable_skip", str(err))
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 rejects sort/operator-domain mismatches.
+        return None, _skip_result("undecidable_skip", str(err))
+
+
+def _unary_z3_or_result(
+    op: str,
+    operand: _Z3Expr,
+) -> Tuple[Optional[_Z3Expr], Optional[AlgorithmResult]]:
+    """Apply a unary operator to an already translated Z3 operand.
+
+    :param op: DSL unary operator.
+    :type op: str
+    :param operand: Z3 operand.
+    :type operand: Union[z3.ArithRef, z3.BoolRef]
+    :return: Translated Z3 expression and optional normalized failure.
+    :rtype: Tuple[Optional[Union[z3.ArithRef, z3.BoolRef]], Optional[AlgorithmResult]]
+    """
+    try:
+        if op == "-":
+            return -operand, None
+        if op == "+":
+            return operand, None
+        if op == "~":
+            return ~operand, None
+        if op in ("!", "not"):
+            return z3.Not(operand), None
+        return None, _skip_result(
+            "undecidable_skip", f"Unsupported unary operator: {op}"
+        )
+    except TypeError as err:
+        # TypeError: Python/Z3 operator overloads reject unsupported operand
+        # combinations, for example bitwise NOT on arithmetic references.
+        return None, _skip_result("undecidable_skip", str(err))
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 rejects sort/operator-domain mismatches.
+        return None, _skip_result("undecidable_skip", str(err))
+
+
+def _ufunc_z3_or_result(
+    func: str,
+    operand: _Z3Expr,
+) -> Tuple[Optional[_Z3Expr], Optional[AlgorithmResult]]:
+    """Apply a supported unary math function to a Z3 operand.
+
+    :param func: Function name.
+    :type func: str
+    :param operand: Z3 operand.
+    :type operand: Union[z3.ArithRef, z3.BoolRef]
+    :return: Translated Z3 expression and optional normalized failure.
+    :rtype: Tuple[Optional[Union[z3.ArithRef, z3.BoolRef]], Optional[AlgorithmResult]]
+    """
+    try:
+        if func == "abs":
+            return z3.If(operand >= 0, operand, -operand), None
+        if func == "sign":
+            zero = z3.IntVal(0) if z3.is_int(operand) else z3.RealVal(0)
+            one = z3.IntVal(1) if z3.is_int(operand) else z3.RealVal(1)
+            minus_one = z3.IntVal(-1) if z3.is_int(operand) else z3.RealVal(-1)
+            return z3.If(
+                operand == zero, zero, z3.If(operand > zero, one, minus_one)
+            ), None
+        if func == "floor":
+            return (z3.ToInt(operand) if z3.is_real(operand) else operand), None
+        if func == "ceil":
+            return (-z3.ToInt(-operand) if z3.is_real(operand) else operand), None
+        if func == "trunc":
+            if z3.is_real(operand):
+                zero = z3.RealVal(0)
+                return z3.If(
+                    operand >= zero, z3.ToInt(operand), -z3.ToInt(-operand)
+                ), None
+            return operand, None
+        if func == "sqrt":
+            if z3.is_real(operand):
+                return z3.Sqrt(operand), None
+            if z3.is_int(operand):
+                return z3.Sqrt(z3.ToReal(operand)), None
+            return None, _skip_result(
+                "undecidable_skip",
+                f"sqrt requires Real or Int operand, got {operand.sort()}.",
+            )
+        if func == "round":
+            return _python_round_z3(operand), None
+        return None, _skip_result(
+            "undecidable_skip",
+            "Mathematical function {func!r} is not supported in Z3 conversion.".format(
+                func=func
+            ),
+        )
+    except TypeError as err:
+        # TypeError: Python/Z3 operator overloads reject unsupported operand
+        # combinations during function expansion.
+        return None, _skip_result("undecidable_skip", str(err))
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 rejects sort/operator-domain mismatches.
+        return None, _skip_result("undecidable_skip", str(err))
+
+
+def _python_round_z3(operand: _Z3Expr) -> z3.ArithRef:
+    """Return a Z3 expression matching Python's single-argument ``round``.
+
+    :param operand: Integer or real operand.
+    :type operand: Union[z3.ArithRef, z3.BoolRef]
+    :return: Rounded integer expression.
+    :rtype: z3.ArithRef
+    """
+    if z3.is_int(operand):
+        return operand
+    real_operand = operand if z3.is_real(operand) else z3.ToReal(operand)
+    floor_value = z3.ToInt(real_operand)
+    fraction = real_operand - z3.ToReal(floor_value)
+    half = z3.RealVal("1/2")
+    return z3.If(
+        fraction < half,
+        floor_value,
+        z3.If(
+            fraction > half,
+            floor_value + 1,
+            z3.If(floor_value % 2 == 0, floor_value, floor_value + 1),
+        ),
+    )
+
+
+def _expr_conditions_and_z3_or_result(
+    expr: Expr,
+    z3_vars: _Z3Vars,
+    path_conditions: Sequence[z3.ExprRef] = (),
+    *,
+    context_constraints: Optional[Sequence[z3.ExprRef]] = None,
+    smt_timeout_ms: Optional[int] = None,
+    domain_constraints: Optional[List[z3.ExprRef]] = None,
+) -> Tuple[
+    Optional[Tuple[_ConditionPoint, ...]],
+    Optional[_Z3Expr],
+    Optional[AlgorithmResult],
+]:
+    """Translate an expression while pruning unreachable ternary branches.
+
+    Expression-level ternaries have runtime short-circuit semantics: only the
+    selected value branch is evaluated.  When the caller supplies a symbolic
+    context, this helper avoids translating value branches that are unreachable
+    in that context, matching the path-sensitive handling used for operation
+    ``if`` blocks.
+
+    :param expr: Expression to translate.
+    :type expr: Expr
+    :param z3_vars: Symbolic environment at this expression point.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param path_conditions: Predicates needed to reach this expression.
+    :type path_conditions: Sequence[z3.ExprRef]
+    :param context_constraints: Optional surrounding execution context.
+    :type context_constraints: Optional[Sequence[z3.ExprRef]], optional
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :param domain_constraints: Optional accumulator for runtime definedness
+        constraints, such as non-zero divisors.  These constraints align Z3's
+        total arithmetic operators with FCSTM runtime evaluation, where numeric
+        domain errors abort the execution path instead of choosing an arbitrary
+        model value.
+    :type domain_constraints: Optional[List[z3.ExprRef]], optional
+    :return: Condition points, translated expression, or normalized failure.
+    :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[Union[z3.ArithRef, z3.BoolRef]], Optional[AlgorithmResult]]
+    """
+    from pyfcstm.model.expr import BinaryOp, Boolean, Float, Integer, UFunc, UnaryOp
+
+    if domain_constraints is None:
+        domain_constraints = []
+
+    if isinstance(expr, (Integer, Float, Boolean, _variable_type())):
+        z3_expr, result = _expr_to_z3_or_result(expr, z3_vars)
+        return (), z3_expr, result
+
+    if isinstance(expr, _conditional_op_type()):
+        points: List[_ConditionPoint] = []
+        condition_domains: List[z3.ExprRef] = []
+        cond_points, condition_z3, result = _expr_conditions_and_z3_or_result(
+            expr.cond,
+            z3_vars,
+            path_conditions,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+            domain_constraints=condition_domains,
+        )
+        if result is not None:
+            return None, None, result
+        domain_constraints.extend(condition_domains)
+        points.extend(cond_points or ())
+        points.append(
+            _ConditionPoint(
+                expr.cond,
+                dict(z3_vars),
+                (*path_conditions, *condition_domains),
+                z3_condition=condition_z3,
+            )
+        )
+
+        true_path = (*path_conditions, *condition_domains, condition_z3)
+        false_path = (*path_conditions, *condition_domains, z3.Not(condition_z3))
+        true_reachable, result = _path_reachability_or_result(
+            context_constraints,
+            true_path,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            return None, None, result
+        false_reachable, result = _path_reachability_or_result(
+            context_constraints,
+            false_path,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            return None, None, result
+
+        true_expr = false_expr = None
+        true_domains: List[z3.ExprRef] = []
+        false_domains: List[z3.ExprRef] = []
+        if true_reachable is not False:
+            true_points, true_expr, result = _expr_conditions_and_z3_or_result(
+                expr.if_true,
+                z3_vars,
+                true_path,
+                context_constraints=context_constraints,
+                smt_timeout_ms=smt_timeout_ms,
+                domain_constraints=true_domains,
+            )
+            if result is not None:
+                return None, None, result
+            points.extend(true_points or ())
+        if false_reachable is not False:
+            false_points, false_expr, result = _expr_conditions_and_z3_or_result(
+                expr.if_false,
+                z3_vars,
+                false_path,
+                context_constraints=context_constraints,
+                smt_timeout_ms=smt_timeout_ms,
+                domain_constraints=false_domains,
+            )
+            if result is not None:
+                return None, None, result
+            points.extend(false_points or ())
+
+        if true_reachable is False and false_reachable is False:
+            return (
+                None,
+                None,
+                _skip_result(
+                    "undecidable_skip",
+                    "Conditional expression has no reachable value branch.",
+                ),
+            )
+        if true_reachable is False:
+            domain_constraints.extend(false_domains)
+            return tuple(points), false_expr, None
+        if false_reachable is False:
+            domain_constraints.extend(true_domains)
+            return tuple(points), true_expr, None
+        for item in true_domains:
+            domain_constraints.append(z3.Implies(condition_z3, item))
+        for item in false_domains:
+            domain_constraints.append(z3.Implies(z3.Not(condition_z3), item))
+        try:
+            return tuple(points), z3.If(condition_z3, true_expr, false_expr), None
+        except z3.Z3Exception as err:
+            # Z3Exception: Z3 rejects If branches with incompatible sorts.
+            return None, None, _skip_result("undecidable_skip", str(err))
+
+    if isinstance(expr, BinaryOp):
+        points: List[_ConditionPoint] = []
+        left_points, left, result = _expr_conditions_and_z3_or_result(
+            expr.x,
+            z3_vars,
+            path_conditions,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+            domain_constraints=domain_constraints,
+        )
+        if result is not None:
+            return None, None, result
+        points.extend(left_points or ())
+
+        right_points, right, result = _expr_conditions_and_z3_or_result(
+            expr.y,
+            z3_vars,
+            path_conditions,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+            domain_constraints=domain_constraints,
+        )
+        if result is not None:
+            return None, None, result
+        points.extend(right_points or ())
+        if expr.op in ("/", "%"):
+            try:
+                domain_constraints.append(right != 0)
+            except (TypeError, z3.Z3Exception) as err:
+                # TypeError/Z3Exception: malformed arithmetic expressions can
+                # produce a denominator that Z3 cannot compare against zero.
+                return None, None, _skip_result("undecidable_skip", str(err))
+        z3_expr, result = _binary_z3_or_result(expr.op, left, right)
+        return tuple(points), z3_expr, result
+
+    if isinstance(expr, UnaryOp):
+        points, operand, result = _expr_conditions_and_z3_or_result(
+            expr.x,
+            z3_vars,
+            path_conditions,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+            domain_constraints=domain_constraints,
+        )
+        if result is not None:
+            return None, None, result
+        z3_expr, result = _unary_z3_or_result(expr.op, operand)
+        return points, z3_expr, result
+
+    if isinstance(expr, UFunc):
+        points, operand, result = _expr_conditions_and_z3_or_result(
+            expr.x,
+            z3_vars,
+            path_conditions,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+            domain_constraints=domain_constraints,
+        )
+        if result is not None:
+            return None, None, result
+        if expr.func == "sqrt":
+            try:
+                domain_constraints.append(operand >= 0)
+            except (TypeError, z3.Z3Exception) as err:
+                # TypeError/Z3Exception: malformed operands can be rejected
+                # before the Z3 sqrt expression is built.
+                return None, None, _skip_result("undecidable_skip", str(err))
+        z3_expr, result = _ufunc_z3_or_result(expr.func, operand)
+        return points, z3_expr, result
+
+    return (
+        None,
+        None,
+        _skip_result(
+            "undecidable_skip",
+            f"Unsupported expression type: {type(expr).__name__}",
+        ),
+    )
+
+
 def _path_reachability_or_result(
     context_constraints: Optional[Sequence[z3.ExprRef]],
     path_conditions: Sequence[z3.ExprRef],
@@ -359,6 +778,24 @@ def _path_reachability_or_result(
     return None, _skip_result(sat_result.kind, getattr(sat_result, "reason", None))
 
 
+def _append_expr_domain_constraints(
+    source_constraints: Sequence[z3.ExprRef],
+    target_constraints: List[z3.ExprRef],
+) -> None:
+    """Append expression-definedness constraints visible in ``z3_vars``.
+
+    :param source_constraints: Candidate constraints collected while
+        translating the expression assigned to one name.
+    :type source_constraints: Sequence[z3.ExprRef]
+    :param target_constraints: Mutable block-level domain constraint list.
+    :type target_constraints: List[z3.ExprRef]
+    :return: ``None``.
+    :rtype: None
+    """
+    if source_constraints:
+        target_constraints.extend(source_constraints)
+
+
 def _execute_operation_prefix_conditions_and_vars_or_result(
     operations: Sequence[OperationStatement],
     z3_vars: _Z3Vars,
@@ -366,9 +803,11 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
     *,
     context_constraints: Optional[Sequence[z3.ExprRef]] = None,
     smt_timeout_ms: Optional[int] = None,
+    domain_constraints: Optional[Sequence[z3.ExprRef]] = None,
 ) -> Tuple[
     Optional[Tuple[_ConditionPoint, ...]],
     Optional[_Z3Vars],
+    Optional[Tuple[z3.ExprRef, ...]],
     Optional[AlgorithmResult],
 ]:
     """Collect prefix conditions and execute operations path-sensitively.
@@ -389,25 +828,41 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
     :type context_constraints: Optional[Sequence[z3.ExprRef]], optional
     :param smt_timeout_ms: Optional solver timeout in milliseconds.
     :type smt_timeout_ms: Optional[int], optional
-    :return: Condition points, post-state variables, or an algorithm result
-        when symbolic prefix execution cannot be expressed.
-    :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[Dict[str, Union[z3.ArithRef, z3.BoolRef]]], Optional[AlgorithmResult]]
+    :param domain_constraints: Runtime definedness constraints already known
+        before this operation block.
+    :type domain_constraints: Optional[Sequence[z3.ExprRef]], optional
+    :return: Condition points, post-state variables, accumulated domain
+        constraints, or an algorithm result when symbolic prefix execution
+        cannot be expressed.
+    :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[Dict[str, Union[z3.ArithRef, z3.BoolRef]]], Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]
     """
     points: List[_ConditionPoint] = []
     current_vars = dict(z3_vars)
     current_path = tuple(path_conditions)
+    current_domains: List[z3.ExprRef] = list(domain_constraints or ())
 
     for statement in operations:
         if isinstance(statement, _operation_type()):
-            for condition in _conditional_conditions_from_expr(statement.expr):
-                points.append(
-                    _ConditionPoint(condition, dict(current_vars), current_path)
+            expression_domains: List[z3.ExprRef] = []
+            expression_path = (*current_path, *current_domains)
+            expression_points, expression_value, result = (
+                _expr_conditions_and_z3_or_result(
+                    statement.expr,
+                    current_vars,
+                    expression_path,
+                    context_constraints=context_constraints,
+                    smt_timeout_ms=smt_timeout_ms,
+                    domain_constraints=expression_domains,
                 )
-            current_vars, result = _execute_operations_or_result(
-                [statement], current_vars
             )
             if result is not None:
-                return None, None, result
+                return None, None, None, result
+            points.extend(expression_points or ())
+            current_vars[statement.var_name] = expression_value
+            _append_expr_domain_constraints(
+                expression_domains,
+                current_domains,
+            )
             continue
 
         if isinstance(statement, _if_block_type()):
@@ -415,35 +870,62 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
             branch_results = []
             visible_names = tuple(current_vars.keys())
             for branch in statement.branches:
-                evaluation_path = [*current_path, *prior_not_taken]
+                evaluation_path = [*current_path, *current_domains, *prior_not_taken]
                 evaluation_reachable, result = _path_reachability_or_result(
                     context_constraints,
                     evaluation_path,
                     smt_timeout_ms=smt_timeout_ms,
                 )
                 if result is not None:
-                    return None, None, result
+                    return None, None, None, result
                 if evaluation_reachable is False:
                     break
 
                 branch_condition = None
+                branch_condition_domains: List[z3.ExprRef] = []
                 branch_path = list(evaluation_path)
+                evaluation_selector = (
+                    z3.And(*prior_not_taken) if prior_not_taken else None
+                )
+                branch_selector = evaluation_selector
                 if branch.condition is not None:
-                    branch_condition, result = _expr_to_z3_or_result(
-                        branch.condition,
-                        current_vars,
+                    condition_points, branch_condition, result = (
+                        _expr_conditions_and_z3_or_result(
+                            branch.condition,
+                            current_vars,
+                            evaluation_path,
+                            context_constraints=context_constraints,
+                            smt_timeout_ms=smt_timeout_ms,
+                            domain_constraints=branch_condition_domains,
+                        )
                     )
                     if result is not None:
-                        return None, None, result
+                        return None, None, None, result
+                    points.extend(condition_points or ())
+                    for item in branch_condition_domains:
+                        if evaluation_selector is None:
+                            current_domains.append(item)
+                        else:
+                            current_domains.append(
+                                z3.Implies(evaluation_selector, item)
+                            )
                     points.append(
                         _ConditionPoint(
                             branch.condition,
                             dict(current_vars),
-                            tuple(evaluation_path),
+                            (*evaluation_path, *branch_condition_domains),
                             "branch",
+                            branch_condition,
                         )
                     )
+                    branch_path.extend(branch_condition_domains)
                     branch_path.append(branch_condition)
+                    branch_selector = (
+                        z3.And(*prior_not_taken, branch_condition)
+                        if prior_not_taken
+                        else branch_condition
+                    )
+                    prior_not_taken.extend(branch_condition_domains)
                     prior_not_taken.append(z3.Not(branch_condition))
 
                 branch_reachable, result = _path_reachability_or_result(
@@ -452,23 +934,32 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
                     smt_timeout_ms=smt_timeout_ms,
                 )
                 if result is not None:
-                    return None, None, result
+                    return None, None, None, result
                 if branch_reachable is False:
                     continue
 
-                branch_points, branch_vars, result = (
+                branch_domains: List[z3.ExprRef] = []
+                branch_points, branch_vars, branch_domains, result = (
                     _execute_operation_prefix_conditions_and_vars_or_result(
                         branch.statements,
                         current_vars,
                         branch_path,
                         context_constraints=context_constraints,
                         smt_timeout_ms=smt_timeout_ms,
+                        domain_constraints=branch_domains,
                     )
                 )
                 if result is not None:
-                    return None, None, result
+                    return None, None, None, result
                 points.extend(branch_points or ())
-                branch_results.append((branch_condition, branch_vars or current_vars))
+                branch_results.append(
+                    (
+                        branch_condition,
+                        branch_selector,
+                        branch_vars or current_vars,
+                        tuple(branch_domains or ()),
+                    )
+                )
 
                 if branch.condition is None:
                     break
@@ -476,7 +967,7 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
             merged_vars = dict(current_vars)
             for name in visible_names:
                 merged_value = current_vars[name]
-                for branch_condition, branch_vars in reversed(branch_results):
+                for branch_condition, _, branch_vars, _ in reversed(branch_results):
                     if branch_condition is None:
                         merged_value = branch_vars[name]
                     else:
@@ -486,10 +977,17 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
                             merged_value,
                         )
                 merged_vars[name] = merged_value
+            for _, branch_selector, _, branch_domains in branch_results:
+                for item in branch_domains:
+                    if branch_selector is None:
+                        current_domains.append(item)
+                    else:
+                        current_domains.append(z3.Implies(branch_selector, item))
             current_vars = merged_vars
             continue
 
         return (
+            None,
             None,
             None,
             _skip_result(
@@ -498,7 +996,7 @@ def _execute_operation_prefix_conditions_and_vars_or_result(
             ),
         )
 
-    return tuple(points), current_vars, None
+    return tuple(points), current_vars, tuple(current_domains), None
 
 
 def _execute_operation_prefix_conditions_or_result(
@@ -531,7 +1029,7 @@ def _execute_operation_prefix_conditions_or_result(
         execution cannot be expressed.
     :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[AlgorithmResult]]
     """
-    points, _, result = _execute_operation_prefix_conditions_and_vars_or_result(
+    points, _, _, result = _execute_operation_prefix_conditions_and_vars_or_result(
         operations,
         z3_vars,
         path_conditions,
@@ -612,10 +1110,11 @@ def _root_initial_path_context(
     """
     path = _state_path_from_root(state)
     if len(path) <= 1:
-        return (), (), [], None
+        return (), (), _action_operations(state.on_enters), None
 
     selected: List[Transition] = []
     constraints: List[z3.ExprRef] = []
+    domain_constraints: List[z3.ExprRef] = []
     operations: List[OperationStatement] = []
     current_vars: _Z3Vars = dict(z3_vars)
     type_constraints = _build_type_constraints(variables, z3_vars)
@@ -624,21 +1123,46 @@ def _root_initial_path_context(
         child = path[index + 1]
         enter_ops = _action_operations(path_state.on_enters)
         operations.extend(enter_ops)
-        current_vars, result = _execute_operations_or_result(enter_ops, current_vars)
+        _, current_vars, new_domains, result = (
+            _execute_operation_prefix_conditions_and_vars_or_result(
+                enter_ops,
+                current_vars,
+                context_constraints=[
+                    *base_constraints,
+                    *constraints,
+                    *domain_constraints,
+                    *type_constraints,
+                ],
+                smt_timeout_ms=smt_timeout_ms,
+                domain_constraints=domain_constraints,
+            )
+        )
         if result is not None:
             return None, None, None, result
+        domain_constraints = list(new_domains or ())
 
         if not path_state.is_leaf_state:
             during_before_ops = _action_operations(
                 path_state.list_on_durings(aspect="before")
             )
             operations.extend(during_before_ops)
-            current_vars, result = _execute_operations_or_result(
-                during_before_ops,
-                current_vars,
+            _, current_vars, new_domains, result = (
+                _execute_operation_prefix_conditions_and_vars_or_result(
+                    during_before_ops,
+                    current_vars,
+                    context_constraints=[
+                        *base_constraints,
+                        *constraints,
+                        *domain_constraints,
+                        *type_constraints,
+                    ],
+                    smt_timeout_ms=smt_timeout_ms,
+                    domain_constraints=domain_constraints,
+                )
             )
             if result is not None:
                 return None, None, None, result
+            domain_constraints = list(new_domains or ())
 
         target_transition = None
         selected_constraints = None
@@ -654,7 +1178,12 @@ def _root_initial_path_context(
                     trigger,
                 ]
                 context_check = is_sat(
-                    [*base_constraints, *candidate_constraints, *type_constraints],
+                    [
+                        *base_constraints,
+                        *candidate_constraints,
+                        *domain_constraints,
+                        *type_constraints,
+                    ],
                     timeout_ms=smt_timeout_ms,
                 )
                 if context_check.kind in {"unknown", "timeout"}:
@@ -679,12 +1208,23 @@ def _root_initial_path_context(
 
         selected.append(target_transition)
         operations.extend(target_transition.effects)
-        current_vars, result = _execute_operations_or_result(
-            target_transition.effects,
-            current_vars,
+        _, current_vars, new_domains, result = (
+            _execute_operation_prefix_conditions_and_vars_or_result(
+                target_transition.effects,
+                current_vars,
+                context_constraints=[
+                    *base_constraints,
+                    *constraints,
+                    *domain_constraints,
+                    *type_constraints,
+                ],
+                smt_timeout_ms=smt_timeout_ms,
+                domain_constraints=domain_constraints,
+            )
         )
         if result is not None:
             return None, None, None, result
+        domain_constraints = list(new_domains or ())
 
     leaf_enter_ops = _action_operations(state.on_enters)
     operations.extend(leaf_enter_ops)
@@ -1138,28 +1678,44 @@ def transition_shadowed_by_predecessor(
                 )
                 sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
                 if sat_result.kind == "unsat":
-                    if any(
+                    has_unconditional_catchall = any(
                         item["event"] is None and item["guard"] is None
                         for item in prior_payloads
-                    ):
+                    )
+                    if has_unconditional_catchall:
                         reason = "unconditional_catchall"
-                    elif (
-                        current_payload["event"] is not None
-                        and current_payload["guard"] is None
-                        and any(
-                            item["event"] == current_payload["event"]
-                            and item["guard"] is None
-                            for item in prior_payloads
-                        )
-                    ):
-                        reason = "duplicate_event"
-                    elif current_payload["guard"] is not None and all(
-                        item["event"] is None and item["guard"] is not None
-                        for item in prior_payloads
-                    ):
-                        reason = "guard_shadow"
                     else:
-                        reason = "prior_trigger_cover"
+                        trigger_sat = is_sat(
+                            [trigger, *_build_type_constraints(variables, z3_vars)],
+                            timeout_ms=smt_timeout_ms,
+                        )
+                        if trigger_sat.kind == "unsat":
+                            # A transition whose own trigger is unsatisfiable
+                            # belongs to dead_guard, not predecessor shadowing.
+                            continue
+                        if trigger_sat.kind != "sat":
+                            first_indeterminate_result = _first_indeterminate(
+                                first_indeterminate_result,
+                                trigger_sat.kind,
+                            )
+                            continue
+                        if (
+                            current_payload["event"] is not None
+                            and current_payload["guard"] is None
+                            and any(
+                                item["event"] == current_payload["event"]
+                                and item["guard"] is None
+                                for item in prior_payloads
+                            )
+                        ):
+                            reason = "duplicate_event"
+                        elif current_payload["guard"] is not None and all(
+                            item["event"] is None and item["guard"] is not None
+                            for item in prior_payloads
+                        ):
+                            reason = "guard_shadow"
+                        else:
+                            reason = "prior_trigger_cover"
                     diagnostics.append(
                         _make_diag(
                             "W_TRANSITION_SHADOWED",
@@ -1245,16 +1801,21 @@ def _conditional_conditions_from_operations(
                 yield from _conditional_conditions_from_operations(branch.statements)
 
 
-def _concrete_before_aspect_operations(state: State) -> List[OperationStatement]:
-    """Collect concrete ancestor ``>> during before`` operations in run order.
+def _concrete_during_operations(state: State) -> List[OperationStatement]:
+    """Collect the complete concrete first-cycle during chain in run order.
 
-    :param state: Leaf state whose first-cycle aspect prelude is inspected.
+    This mirrors :meth:`pyfcstm.model.State.iter_on_during_aspect_recursively`,
+    including ancestor ``>> during before`` actions, leaf ``during`` actions,
+    and ancestor ``>> during after`` actions.  Abstract actions are omitted
+    because raw SMT-local verification has no implementation body for them.
+
+    :param state: Leaf state whose first-cycle during chain is inspected.
     :type state: State
-    :return: Flattened concrete aspect operation statements.
+    :return: Flattened concrete operation statements.
     :rtype: List[OperationStatement]
     """
     return _action_operations(
-        [action for _, action in state.iter_on_during_before_aspect_recursively()]
+        [action for _, action in state.iter_on_during_aspect_recursively()]
     )
 
 
@@ -1351,16 +1912,9 @@ def enter_postcondition_implies_during_precondition(
     if init_transitions is None:
         return AlgorithmResult(kind="sat")
 
-    first_cycle_operations = [
-        *_concrete_before_aspect_operations(state),
-        *_action_operations(state.on_durings),
-    ]
+    first_cycle_operations = _concrete_during_operations(state)
     if not first_cycle_operations:
         return AlgorithmResult(kind="sat")
-
-    entry_vars, result = _execute_operations_or_result(entry_operations or (), z3_vars)
-    if result is not None:
-        return result
 
     type_constraints = _build_type_constraints(variables, z3_vars)
     context_constraints = [
@@ -1368,11 +1922,25 @@ def enter_postcondition_implies_during_precondition(
         *(entry_constraints or ()),
         *type_constraints,
     ]
-    condition_points, result = _execute_operation_prefix_conditions_or_result(
-        first_cycle_operations,
-        entry_vars,
-        context_constraints=context_constraints,
-        smt_timeout_ms=smt_timeout_ms,
+    _, entry_vars, entry_domain_constraints, result = (
+        _execute_operation_prefix_conditions_and_vars_or_result(
+            entry_operations or (),
+            z3_vars,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+    )
+    if result is not None:
+        return result
+    context_constraints.extend(entry_domain_constraints or ())
+
+    condition_points, _, _, result = (
+        _execute_operation_prefix_conditions_and_vars_or_result(
+            first_cycle_operations,
+            entry_vars,
+            context_constraints=context_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+        )
     )
     if result is not None:
         return result
@@ -1397,17 +1965,19 @@ def enter_postcondition_implies_during_precondition(
 
     for condition_point in condition_points:
         condition = condition_point.condition
-        condition_z3, result = _expr_to_z3_or_result(
-            condition,
-            condition_point.z3_vars,
-        )
-        if result is not None:
-            first_indeterminate_result = _first_indeterminate(
-                first_indeterminate_result,
-                result.kind,
-                result.reason,
+        condition_z3 = condition_point.z3_condition
+        if condition_z3 is None:
+            condition_z3, result = _expr_to_z3_or_result(
+                condition,
+                condition_point.z3_vars,
             )
-            continue
+            if result is not None:
+                first_indeterminate_result = _first_indeterminate(
+                    first_indeterminate_result,
+                    result.kind,
+                    result.reason,
+                )
+                continue
 
         point_context = [
             *init_constraints,

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -1541,7 +1541,10 @@ def _execute_effects_under_guard_or_result(
         timeout_ms=smt_timeout_ms,
     )
     if defined_effect_feasible.kind == "unsat":
-        return None, None, AlgorithmResult(kind="sat")
+        return None, None, _skip_result(
+            "undecidable_skip",
+            "Transition effect runtime definedness constraints are unsatisfiable under guard.",
+        )
     if defined_effect_feasible.kind != "sat":
         return None, None, AlgorithmResult(kind=defined_effect_feasible.kind)
     return after_vars, tuple(effect_domain_constraints or ()), None
@@ -2145,15 +2148,23 @@ def enter_postcondition_implies_during_precondition(
 
 
 def _event_bool_name(transition: Transition) -> str:
-    """Return a Z3-safe-ish event boolean variable name.
+    """Return an injective internal event boolean variable name.
+
+    FCSTM identifiers may contain underscores, so replacing ``.`` with ``__``
+    is not injective: ``S.A__B`` and ``S.A.B`` would collide.  Length-prefix
+    each path component instead so separate events always get separate Z3
+    symbols while diagnostics continue to expose the original event path.
 
     :param transition: Event transition.
     :type transition: Transition
     :return: Event boolean name.
     :rtype: str
     """
-    event = _event_name(transition) or "anonymous"
-    return "__event__" + event.replace(".", "__")
+    if transition.event is None:
+        return "__event__anonymous"
+    return "__event__" + "".join(
+        f"{len(part)}:{part}" for part in transition.event.path
+    )
 
 
 def composite_init_guards_incomplete(

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -1,0 +1,1203 @@
+"""SMT-local verification algorithms for FCSTM models.
+
+This module implements the Track A / PR-A4 algorithms from issue #114.  The
+functions intentionally return lightweight dictionaries instead of
+``ModelDiagnostic`` objects; PR-B1 is responsible for adapting these raw
+algorithm results to the diagnostics layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+try:
+    from typing import Literal
+except ImportError:  # pragma: no cover - Python < 3.8 compatibility
+    from typing_extensions import Literal
+
+import z3
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for static checkers
+    from pyfcstm.model.expr import Expr
+    from pyfcstm.model.model import (
+        OnAspect,
+        OnStage,
+        OperationStatement,
+        State,
+        StateMachine,
+        Transition,
+        VarDefine,
+    )
+    from pyfcstm.solver.safety import SafetyCheck
+
+ResultKind = Literal[
+    "sat",
+    "unsat",
+    "unknown",
+    "timeout",
+    "unsafe_skip",
+    "undecidable_skip",
+]
+
+_Z3Expr = Union[z3.ArithRef, z3.BoolRef]
+_Z3Vars = Dict[str, _Z3Expr]
+
+
+def _dsl_nodes():
+    """Import DSL node sentinels lazily to keep registry import lightweight."""
+    from pyfcstm.dsl import node as dsl_nodes
+
+    return dsl_nodes
+
+
+def _conditional_op_type():
+    """Import ``ConditionalOp`` lazily for runtime ``isinstance`` checks."""
+    from pyfcstm.model.expr import ConditionalOp
+
+    return ConditionalOp
+
+
+def _variable_type():
+    """Import ``Variable`` lazily for runtime ``isinstance`` checks."""
+    from pyfcstm.model.expr import Variable
+
+    return Variable
+
+
+def _operation_type():
+    """Import ``Operation`` lazily for runtime ``isinstance`` checks."""
+    from pyfcstm.model.model import Operation
+
+    return Operation
+
+
+def _if_block_type():
+    """Import ``IfBlock`` lazily for runtime ``isinstance`` checks."""
+    from pyfcstm.model.model import IfBlock
+
+    return IfBlock
+
+
+def create_z3_vars_from_models(models):
+    """Delegate to :func:`pyfcstm.solver.expr.create_z3_vars_from_models`."""
+    from pyfcstm.solver.expr import create_z3_vars_from_models as impl
+
+    return impl(models)
+
+
+def expr_to_z3(expr, z3_vars):
+    """Delegate to :func:`pyfcstm.solver.expr.expr_to_z3`."""
+    from pyfcstm.solver.expr import expr_to_z3 as impl
+
+    return impl(expr, z3_vars)
+
+
+def is_sat(constraints, *, timeout_ms=None, get_model=False):
+    """Delegate to :func:`pyfcstm.solver.logical.is_sat`."""
+    from pyfcstm.solver.logical import is_sat as impl
+
+    return impl(constraints, timeout_ms=timeout_ms, get_model=get_model)
+
+
+def execute_operations(operations, z3_vars):
+    """Delegate to :func:`pyfcstm.solver.operation.execute_operations`."""
+    from pyfcstm.solver.operation import execute_operations as impl
+
+    return impl(operations, z3_vars)
+
+
+def check_expr_safety(expr):
+    """Delegate to :func:`pyfcstm.solver.safety.check_expr_safety`."""
+    from pyfcstm.solver.safety import check_expr_safety as impl
+
+    return impl(expr)
+
+
+def check_expr_safety_for_effect(ops):
+    """Delegate to :func:`pyfcstm.solver.safety.check_expr_safety_for_effect`."""
+    from pyfcstm.solver.safety import check_expr_safety_for_effect as impl
+
+    return impl(ops)
+
+
+@dataclass(frozen=True)
+class AlgorithmResult:
+    """Result returned by one SMT-local verification algorithm.
+
+    :param kind: Normalized solver or skip outcome.
+    :type kind: ResultKind
+    :param diagnostics: Raw diagnostic dictionaries produced by the algorithm.
+        These stay diagnostics-layer independent until PR-B1.
+    :type diagnostics: Tuple[dict, ...]
+    :param reason: Optional reason for ``unknown`` / ``timeout`` / skip results,
+        defaults to ``None``.
+    :type reason: Optional[str], optional
+    """
+
+    kind: ResultKind
+    diagnostics: Tuple[dict, ...] = ()
+    reason: Optional[str] = None
+
+
+def _make_diag(code: str, algorithm_name: str, **data) -> dict:
+    """Create a raw verify diagnostic payload.
+
+    :param code: Future diagnostics code.
+    :type code: str
+    :param algorithm_name: Algorithm that emitted the payload.
+    :type algorithm_name: str
+    :param data: Algorithm-specific payload fields.
+    :return: Raw diagnostic dictionary.
+    :rtype: dict
+    """
+    return {
+        "code": code,
+        "algorithm_name": algorithm_name,
+        "data": data,
+    }
+
+
+def _state_path(state: Optional[State]) -> Optional[str]:
+    """Return a readable state path or ``None``.
+
+    :param state: State to format.
+    :type state: Optional[State]
+    :return: Dot-separated path.
+    :rtype: Optional[str]
+    """
+    if state is None:
+        return None
+    return ".".join(state.path)
+
+
+def _state_name(value) -> str:
+    """Return a readable transition endpoint name.
+
+    :param value: Transition endpoint value.
+    :return: Endpoint name.
+    :rtype: str
+    """
+    if value is _dsl_nodes().INIT_STATE:
+        return "[*]"
+    if value is _dsl_nodes().EXIT_STATE:
+        return "[*]"
+    return str(value)
+
+
+def _event_name(transition: Transition) -> Optional[str]:
+    """Return a transition event path when present.
+
+    :param transition: Transition to inspect.
+    :type transition: Transition
+    :return: Event path.
+    :rtype: Optional[str]
+    """
+    if transition.event is None:
+        return None
+    return transition.event.path_name
+
+
+def _transition_payload(transition: Transition) -> dict:
+    """Create a stable, diagnostics-layer-free transition payload.
+
+    :param transition: Transition to describe.
+    :type transition: Transition
+    :return: Transition payload.
+    :rtype: dict
+    """
+    return {
+        "parent": _state_path(transition.parent),
+        "from_state": _state_name(transition.from_state),
+        "to_state": _state_name(transition.to_state),
+        "event": _event_name(transition),
+        "guard": str(transition.guard) if transition.guard is not None else None,
+        "is_forced": transition.is_forced,
+    }
+
+
+def _skip_result(kind: ResultKind, reason: Optional[str]) -> AlgorithmResult:
+    """Create a skip or indeterminate result.
+
+    :param kind: Result kind.
+    :type kind: ResultKind
+    :param reason: Optional reason text.
+    :type reason: Optional[str]
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    return AlgorithmResult(kind=kind, diagnostics=(), reason=reason)
+
+
+def _unsafe_result(safety: SafetyCheck) -> AlgorithmResult:
+    """Create an unsafe-skip result from a safety check.
+
+    :param safety: Safety check result.
+    :type safety: SafetyCheck
+    :return: Unsafe-skip result.
+    :rtype: AlgorithmResult
+    """
+    return _skip_result("unsafe_skip", safety.reason)
+
+
+def _merge_safety_checks(*checks: SafetyCheck) -> Optional[AlgorithmResult]:
+    """Return the first unsafe check as an algorithm result.
+
+    :param checks: Safety checks to inspect.
+    :return: First unsafe result, or ``None`` if all checks are safe.
+    :rtype: Optional[AlgorithmResult]
+    """
+    for check in checks:
+        if not check.safe:
+            return _unsafe_result(check)
+    return None
+
+
+def _z3_vars(variables: Sequence[VarDefine]) -> _Z3Vars:
+    """Create Z3 variables from a generic sequence of variable definitions.
+
+    :param variables: FCSTM variable definitions.
+    :type variables: Sequence[VarDefine]
+    :return: Variable-name to Z3 expression mapping.
+    :rtype: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    """
+    return create_z3_vars_from_models(list(variables))
+
+
+def _build_type_constraints(
+    variables: Sequence[VarDefine],
+    z3_vars: _Z3Vars,
+) -> Tuple[z3.ExprRef, ...]:
+    """Build type-domain constraints for variable definitions.
+
+    The current solver layer models ``int`` / ``float`` as unbounded
+    ``z3.Int`` / ``z3.Real`` values, so no extra constraints are needed.
+    The helper exists to keep PR-A4 formulas aligned with the issue #114
+    pseudo-code and to give future bit-width work a single insertion point.
+
+    :param variables: FCSTM variable definitions.
+    :type variables: Sequence[VarDefine]
+    :param z3_vars: Z3 variable mapping.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :return: Type-domain constraints.
+    :rtype: Tuple[z3.ExprRef, ...]
+    """
+    _ = variables, z3_vars
+    return ()
+
+
+def _expr_to_z3_or_result(
+    expr: Expr,
+    z3_vars: _Z3Vars,
+) -> Tuple[Optional[_Z3Expr], Optional[AlgorithmResult]]:
+    """Translate an expression to Z3, normalizing expected translation failures.
+
+    :param expr: Expression to translate.
+    :type expr: Expr
+    :param z3_vars: Z3 variable mapping.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :return: Pair of translated expression and optional failure result.
+    :rtype: Tuple[Optional[Union[z3.ArithRef, z3.BoolRef]], Optional[AlgorithmResult]]
+    """
+    try:
+        return expr_to_z3(expr, z3_vars), None
+    except NotImplementedError as err:
+        # NotImplementedError: expr_to_z3 raises this for unsupported math
+        # functions such as logarithms or trigonometric functions.
+        return None, _skip_result("unsafe_skip", str(err))
+    except ValueError as err:
+        # ValueError: expr_to_z3 raises this for unknown variables or operators.
+        return None, _skip_result("undecidable_skip", str(err))
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 can reject otherwise parsed expressions for sort or
+        # operator-domain mismatches, for example modulo over Real operands.
+        return None, _skip_result("undecidable_skip", str(err))
+
+
+def _execute_operations_or_result(
+    operations: Sequence[OperationStatement],
+    z3_vars: _Z3Vars,
+) -> Tuple[Optional[_Z3Vars], Optional[AlgorithmResult]]:
+    """Symbolically execute operations, normalizing expected translation failures.
+
+    :param operations: Operation block to execute.
+    :type operations: Sequence[OperationStatement]
+    :param z3_vars: Starting symbolic environment.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :return: Pair of post-state environment and optional failure result.
+    :rtype: Tuple[Optional[Dict[str, Union[z3.ArithRef, z3.BoolRef]]], Optional[AlgorithmResult]]
+    """
+    try:
+        return execute_operations(list(operations), dict(z3_vars)), None
+    except NotImplementedError as err:
+        # NotImplementedError: execute_operations delegates expression
+        # translation to expr_to_z3, which raises this for unsupported functions.
+        return None, _skip_result("unsafe_skip", str(err))
+    except ValueError as err:
+        # ValueError: execute_operations delegates to expr_to_z3, which raises
+        # this for unknown variables or unsupported operators.
+        return None, _skip_result("undecidable_skip", str(err))
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 can reject symbolic operation expressions because of
+        # sort/operator-domain mismatches.
+        return None, _skip_result("undecidable_skip", str(err))
+
+
+def _build_init_constraints_or_result(
+    variables: Sequence[VarDefine],
+    z3_vars: _Z3Vars,
+) -> Tuple[Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]:
+    """Build constraints pinning variables to their DSL initial values.
+
+    :param variables: FCSTM variable definitions.
+    :type variables: Sequence[VarDefine]
+    :param z3_vars: Z3 variable mapping.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :return: Pair of constraints and optional failure result.
+    :rtype: Tuple[Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]
+    """
+    constraints: List[z3.ExprRef] = []
+    for variable in variables:
+        init_value, result = _expr_to_z3_or_result(variable.init, z3_vars)
+        if result is not None:
+            return None, result
+        constraints.append(z3_vars[variable.name] == init_value)
+    return tuple(constraints), None
+
+
+def _guard_z3_or_result(
+    transition: Transition,
+    variables: Sequence[VarDefine],
+) -> Tuple[Optional[_Z3Expr], Optional[_Z3Vars], Optional[AlgorithmResult]]:
+    """Check and translate a transition guard.
+
+    :param transition: Transition with a non-``None`` guard.
+    :type transition: Transition
+    :param variables: FCSTM variable definitions.
+    :type variables: Sequence[VarDefine]
+    :return: Guard Z3 expression, variable mapping, and optional failure result.
+    :rtype: tuple
+    """
+    safety = check_expr_safety(transition.guard)
+    if not safety.safe:
+        return None, None, _unsafe_result(safety)
+
+    z3_vars = _z3_vars(variables)
+    guard_expr, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+    if result is not None:
+        return None, None, result
+    return guard_expr, z3_vars, None
+
+
+def _is_self_assign(statement: OperationStatement) -> bool:
+    """Return whether a statement is a plain ``x = x`` assignment.
+
+    :param statement: Operation statement.
+    :type statement: OperationStatement
+    :return: Whether the statement is a self-assignment.
+    :rtype: bool
+    """
+    return (
+        isinstance(statement, _operation_type())
+        and isinstance(statement.expr, _variable_type())
+        and statement.expr.name == statement.var_name
+    )
+
+
+def _is_syntactically_self_assign_only(
+    operations: Sequence[OperationStatement],
+) -> bool:
+    """Return whether every statement in a block is syntactic self-assignment.
+
+    :param operations: Operation statements.
+    :type operations: Sequence[OperationStatement]
+    :return: Whether the block is only self-assignments.
+    :rtype: bool
+    """
+    return bool(operations) and all(
+        _is_self_assign(statement) for statement in operations
+    )
+
+
+def _first_indeterminate(
+    current: Optional[AlgorithmResult],
+    candidate_kind: str,
+    reason: Optional[str] = None,
+) -> Optional[AlgorithmResult]:
+    """Keep the first indeterminate result for aggregate algorithms.
+
+    :param current: Existing aggregate result.
+    :type current: Optional[AlgorithmResult]
+    :param candidate_kind: Candidate kind string from a solver result.
+    :type candidate_kind: str
+    :param reason: Optional reason.
+    :type reason: Optional[str]
+    :return: Existing or new aggregate result.
+    :rtype: Optional[AlgorithmResult]
+    """
+    if current is not None:
+        return current
+    if candidate_kind in {"unknown", "timeout", "unsafe_skip", "undecidable_skip"}:
+        return _skip_result(candidate_kind, reason)
+    return None
+
+
+def dead_guard(
+    transition: Transition,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect a transition guard that is unsatisfiable.
+
+    :param transition: Transition to check.
+    :type transition: Transition
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds, defaults to
+        ``1000``.  ``None`` is forwarded to the solver helper as no timeout.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    if transition.guard is None:
+        return AlgorithmResult(kind="sat")
+
+    guard_z3, z3_vars, result = _guard_z3_or_result(transition, variables)
+    if result is not None:
+        return result
+
+    sat_result = is_sat(
+        [guard_z3, *_build_type_constraints(variables, z3_vars)],
+        timeout_ms=smt_timeout_ms,
+    )
+    if sat_result.kind == "unsat":
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=(
+                _make_diag(
+                    "W_DEAD_GUARD",
+                    "dead_guard",
+                    transition=_transition_payload(transition),
+                    verification_scope="smt_local",
+                ),
+            ),
+        )
+    return AlgorithmResult(kind=sat_result.kind)
+
+
+def guard_tautology(
+    transition: Transition,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect a transition guard that is valid under all assignments.
+
+    :param transition: Transition to check.
+    :type transition: Transition
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    if transition.guard is None:
+        return AlgorithmResult(kind="sat")
+
+    guard_z3, z3_vars, result = _guard_z3_or_result(transition, variables)
+    if result is not None:
+        return result
+
+    sat_result = is_sat(
+        [z3.Not(guard_z3), *_build_type_constraints(variables, z3_vars)],
+        timeout_ms=smt_timeout_ms,
+    )
+    if sat_result.kind == "unsat":
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=(
+                _make_diag(
+                    "W_GUARD_TAUTOLOGY",
+                    "guard_tautology",
+                    transition=_transition_payload(transition),
+                    verification_scope="smt_local",
+                ),
+            ),
+        )
+    return AlgorithmResult(kind=sat_result.kind)
+
+
+def forced_guard_unsat_under_init(
+    transition: Transition,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect a forced-transition guard unsatisfiable under initial values.
+
+    :param transition: Transition to check.
+    :type transition: Transition
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    if not transition.is_forced or transition.guard is None:
+        return AlgorithmResult(kind="sat")
+
+    guard_z3, z3_vars, result = _guard_z3_or_result(transition, variables)
+    if result is not None:
+        return result
+    init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
+    if result is not None:
+        return result
+
+    sat_result = is_sat(
+        [guard_z3, *init_constraints],
+        timeout_ms=smt_timeout_ms,
+    )
+    if sat_result.kind == "unsat":
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=(
+                _make_diag(
+                    "W_FORCED_GUARD_UNSAT",
+                    "forced_guard_unsat_under_init",
+                    transition=_transition_payload(transition),
+                    verification_scope="smt_local",
+                ),
+            ),
+        )
+    return AlgorithmResult(kind=sat_result.kind)
+
+
+def effect_no_op_under_guard(
+    transition: Transition,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect transition effects that never change model variables.
+
+    :param transition: Transition to check.
+    :type transition: Transition
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    if not transition.effects:
+        return AlgorithmResult(kind="sat")
+    if _is_syntactically_self_assign_only(transition.effects):
+        return AlgorithmResult(kind="sat")
+
+    result = _merge_safety_checks(
+        check_expr_safety(transition.guard),
+        check_expr_safety_for_effect(transition.effects),
+    )
+    if result is not None:
+        return result
+
+    z3_vars = _z3_vars(variables)
+    after_vars, result = _execute_operations_or_result(transition.effects, z3_vars)
+    if result is not None:
+        return result
+
+    if transition.guard is None:
+        guard_z3 = z3.BoolVal(True)
+    else:
+        guard_z3, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+        if result is not None:
+            return result
+
+    changed_disjuncts = [
+        after_vars[variable.name] != z3_vars[variable.name] for variable in variables
+    ]
+    if not changed_disjuncts:
+        return AlgorithmResult(kind="sat")
+
+    formula = z3.And(
+        guard_z3,
+        z3.Or(*changed_disjuncts),
+        *_build_type_constraints(variables, z3_vars),
+    )
+    sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
+    if sat_result.kind == "unsat":
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=(
+                _make_diag(
+                    "W_EFFECT_SMT_NO_OP",
+                    "effect_no_op_under_guard",
+                    transition=_transition_payload(transition),
+                    verification_scope="smt_local",
+                ),
+            ),
+        )
+    return AlgorithmResult(kind=sat_result.kind)
+
+
+def effect_contradicts_guard(
+    transition: Transition,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect effects after which the transition guard cannot still hold.
+
+    :param transition: Transition to check.
+    :type transition: Transition
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    if transition.guard is None or not transition.effects:
+        return AlgorithmResult(kind="sat")
+
+    result = _merge_safety_checks(
+        check_expr_safety(transition.guard),
+        check_expr_safety_for_effect(transition.effects),
+    )
+    if result is not None:
+        return result
+
+    z3_vars = _z3_vars(variables)
+    guard_before, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+    if result is not None:
+        return result
+    after_vars, result = _execute_operations_or_result(transition.effects, z3_vars)
+    if result is not None:
+        return result
+    guard_after, result = _expr_to_z3_or_result(transition.guard, after_vars)
+    if result is not None:
+        return result
+    type_constraints = _build_type_constraints(variables, z3_vars)
+
+    guard_feasible = is_sat(
+        [guard_before, *type_constraints],
+        timeout_ms=smt_timeout_ms,
+    )
+    if guard_feasible.kind == "unsat":
+        return AlgorithmResult(kind="sat")
+    if guard_feasible.kind != "sat":
+        return AlgorithmResult(kind=guard_feasible.kind)
+
+    sat_result = is_sat(
+        [
+            guard_before,
+            guard_after,
+            *type_constraints,
+        ],
+        timeout_ms=smt_timeout_ms,
+    )
+    if sat_result.kind == "unsat":
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=(
+                _make_diag(
+                    "I_EFFECT_GUARD_CONTRADICT",
+                    "effect_contradicts_guard",
+                    transition=_transition_payload(transition),
+                    verification_scope="smt_local",
+                ),
+            ),
+        )
+    return AlgorithmResult(kind=sat_result.kind)
+
+
+def _domain_key(transition: Transition):
+    """Return the transition trigger domain key.
+
+    :param transition: Transition to inspect.
+    :type transition: Transition
+    :return: Domain key.
+    """
+    if transition.guard is not None:
+        return "guard"
+    if transition.event is not None:
+        return ("event", transition.event.path_name)
+    return "unconditional"
+
+
+def _iter_ordered_outgoing(
+    machine: StateMachine,
+) -> Iterable[Tuple[State, List[Transition]]]:
+    """Yield source states and their ordered outgoing transitions.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :yield: Source state and transitions in model order.
+    :rtype: Iterable[Tuple[State, List[Transition]]]
+    """
+    states_by_parent_and_name: Dict[Tuple[Tuple[str, ...], str], State] = {}
+    for state in machine.walk_states():
+        if state.parent is not None:
+            states_by_parent_and_name[(state.parent.path, state.name)] = state
+
+    for scope in machine.walk_states():
+        by_source: Dict[str, List[Transition]] = {}
+        for transition in scope.transitions:
+            if not isinstance(transition.from_state, str):
+                continue
+            by_source.setdefault(transition.from_state, []).append(transition)
+
+        for source_name, transitions in by_source.items():
+            source = states_by_parent_and_name.get((scope.path, source_name))
+            if source is not None:
+                yield source, transitions
+
+
+def transition_shadowed_by_predecessor(
+    machine: StateMachine,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect outgoing transitions shadowed by earlier transitions.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    diagnostics: List[dict] = []
+    first_indeterminate_result: Optional[AlgorithmResult] = None
+
+    for source, outgoing in _iter_ordered_outgoing(machine):
+        prior_unconditional: Optional[Transition] = None
+        prior_events: Dict[str, Transition] = {}
+        prior_guards: List[Transition] = []
+
+        for transition in outgoing:
+            if prior_unconditional is not None:
+                diagnostics.append(
+                    _make_diag(
+                        "W_TRANSITION_SHADOWED",
+                        "transition_shadowed_by_predecessor",
+                        transition=_transition_payload(transition),
+                        shadowed_by=(_transition_payload(prior_unconditional),),
+                        reason="unconditional_catchall",
+                        source=_state_path(source),
+                        verification_scope="topological_only",
+                    )
+                )
+                continue
+
+            key = _domain_key(transition)
+            if key == "unconditional":
+                prior_unconditional = transition
+                continue
+
+            if isinstance(key, tuple) and key[0] == "event":
+                event_name = key[1]
+                if event_name in prior_events:
+                    diagnostics.append(
+                        _make_diag(
+                            "W_TRANSITION_SHADOWED",
+                            "transition_shadowed_by_predecessor",
+                            transition=_transition_payload(transition),
+                            shadowed_by=(
+                                _transition_payload(prior_events[event_name]),
+                            ),
+                            reason="duplicate_event",
+                            source=_state_path(source),
+                            verification_scope="topological_only",
+                        )
+                    )
+                else:
+                    prior_events[event_name] = transition
+                continue
+
+            if key == "guard":
+                safety = check_expr_safety(transition.guard)
+                if not safety.safe:
+                    first_indeterminate_result = _first_indeterminate(
+                        first_indeterminate_result,
+                        "unsafe_skip",
+                        safety.reason,
+                    )
+                    prior_guards.append(transition)
+                    continue
+
+                z3_vars = _z3_vars(variables)
+                current_guard, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+                if result is not None:
+                    first_indeterminate_result = _first_indeterminate(
+                        first_indeterminate_result,
+                        result.kind,
+                        result.reason,
+                    )
+                    prior_guards.append(transition)
+                    continue
+
+                predecessor_guards: List[z3.ExprRef] = []
+                predecessor_payloads = []
+                predecessor_unsafe = False
+                for prior_guard_transition in prior_guards:
+                    prior_safety = check_expr_safety(prior_guard_transition.guard)
+                    if not prior_safety.safe:
+                        first_indeterminate_result = _first_indeterminate(
+                            first_indeterminate_result,
+                            "unsafe_skip",
+                            prior_safety.reason,
+                        )
+                        predecessor_unsafe = True
+                        break
+                    prior_guard, result = _expr_to_z3_or_result(
+                        prior_guard_transition.guard,
+                        z3_vars,
+                    )
+                    if result is not None:
+                        first_indeterminate_result = _first_indeterminate(
+                            first_indeterminate_result,
+                            result.kind,
+                            result.reason,
+                        )
+                        predecessor_unsafe = True
+                        break
+                    predecessor_guards.append(z3.Not(prior_guard))
+                    predecessor_payloads.append(
+                        _transition_payload(prior_guard_transition)
+                    )
+
+                if not predecessor_unsafe and predecessor_guards:
+                    formula = z3.And(
+                        current_guard,
+                        *predecessor_guards,
+                        *_build_type_constraints(variables, z3_vars),
+                    )
+                    sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
+                    if sat_result.kind == "unsat":
+                        diagnostics.append(
+                            _make_diag(
+                                "W_TRANSITION_SHADOWED",
+                                "transition_shadowed_by_predecessor",
+                                transition=_transition_payload(transition),
+                                shadowed_by=tuple(predecessor_payloads),
+                                reason="guard_shadow",
+                                source=_state_path(source),
+                                verification_scope="smt_local",
+                            )
+                        )
+                    else:
+                        first_indeterminate_result = _first_indeterminate(
+                            first_indeterminate_result,
+                            sat_result.kind,
+                        )
+
+                prior_guards.append(transition)
+
+    if diagnostics:
+        return AlgorithmResult(kind="unsat", diagnostics=tuple(diagnostics))
+    if first_indeterminate_result is not None:
+        return first_indeterminate_result
+    return AlgorithmResult(kind="sat")
+
+
+def _action_operations(
+    actions: Sequence[Union[OnStage, OnAspect]],
+) -> List[OperationStatement]:
+    """Collect concrete operation statements from lifecycle actions.
+
+    :param actions: Lifecycle actions.
+    :type actions: Sequence[Union[OnStage, OnAspect]]
+    :return: Flattened concrete operation statements.
+    :rtype: List[OperationStatement]
+    """
+    operations: List[OperationStatement] = []
+    for action in actions:
+        target = action.ref if action.is_ref else action
+        if target is None or target.is_abstract:
+            continue
+        operations.extend(target.operations)
+    return operations
+
+
+def _conditional_conditions_from_expr(expr: Expr) -> Iterable[Expr]:
+    """Yield every ternary condition inside an expression.
+
+    :param expr: Expression to scan.
+    :type expr: Expr
+    :yield: Ternary condition expressions.
+    :rtype: Iterable[Expr]
+    """
+    if isinstance(expr, _conditional_op_type()):
+        yield expr.cond
+    for child in expr._iter_subs():
+        yield from _conditional_conditions_from_expr(child)
+
+
+def _conditional_conditions_from_operations(
+    operations: Sequence[OperationStatement],
+) -> Iterable[Expr]:
+    """Yield conditions from ternary expressions and operation ``if`` blocks.
+
+    :param operations: Operation statements to scan.
+    :type operations: Sequence[OperationStatement]
+    :yield: Conditional expressions.
+    :rtype: Iterable[Expr]
+    """
+    for statement in operations:
+        if isinstance(statement, _operation_type()):
+            yield from _conditional_conditions_from_expr(statement.expr)
+            continue
+        if isinstance(statement, _if_block_type()):
+            for branch in statement.branches:
+                if branch.condition is not None:
+                    yield branch.condition
+                yield from _conditional_conditions_from_operations(branch.statements)
+
+
+def enter_postcondition_implies_during_precondition(
+    state: State,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect first-cycle during conditions determined by enter-time values.
+
+    :param state: State to inspect.
+    :type state: State
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    if not state.is_leaf_state or state.is_pseudo:
+        return AlgorithmResult(kind="sat")
+
+    enter_operations = _action_operations(state.on_enters)
+    during_operations = _action_operations(state.on_durings)
+    if not enter_operations or not during_operations:
+        return AlgorithmResult(kind="sat")
+
+    result = _merge_safety_checks(
+        check_expr_safety_for_effect(enter_operations),
+        check_expr_safety_for_effect(during_operations),
+    )
+    if result is not None:
+        return result
+
+    conditions = tuple(_conditional_conditions_from_operations(during_operations))
+    if not conditions:
+        return AlgorithmResult(kind="sat")
+
+    z3_vars = _z3_vars(variables)
+    init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
+    if result is not None:
+        return result
+    enter_vars, result = _execute_operations_or_result(enter_operations, z3_vars)
+    if result is not None:
+        return result
+
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    diagnostics: List[dict] = []
+    first_indeterminate_result: Optional[AlgorithmResult] = None
+
+    for condition in conditions:
+        condition_z3, result = _expr_to_z3_or_result(condition, enter_vars)
+        if result is not None:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                result.kind,
+                result.reason,
+            )
+            continue
+
+        true_check = is_sat(
+            [condition_z3, *init_constraints, *type_constraints],
+            timeout_ms=smt_timeout_ms,
+        )
+        false_check = is_sat(
+            [z3.Not(condition_z3), *init_constraints, *type_constraints],
+            timeout_ms=smt_timeout_ms,
+        )
+
+        if true_check.kind == "unsat":
+            diagnostics.append(
+                _make_diag(
+                    "I_ENTER_DURING_CONTRADICT",
+                    "enter_postcondition_implies_during_precondition",
+                    state=_state_path(state),
+                    condition=str(condition),
+                    branch_taken="false",
+                    verification_scope="smt_local",
+                )
+            )
+        elif false_check.kind == "unsat":
+            diagnostics.append(
+                _make_diag(
+                    "I_ENTER_DURING_CONTRADICT",
+                    "enter_postcondition_implies_during_precondition",
+                    state=_state_path(state),
+                    condition=str(condition),
+                    branch_taken="true",
+                    verification_scope="smt_local",
+                )
+            )
+        else:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                true_check.kind,
+            )
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                false_check.kind,
+            )
+
+    if diagnostics:
+        return AlgorithmResult(kind="unsat", diagnostics=tuple(diagnostics))
+    if first_indeterminate_result is not None:
+        return first_indeterminate_result
+    return AlgorithmResult(kind="sat")
+
+
+def _event_bool_name(transition: Transition) -> str:
+    """Return a Z3-safe-ish event boolean variable name.
+
+    :param transition: Event transition.
+    :type transition: Transition
+    :return: Event boolean name.
+    :rtype: str
+    """
+    event = _event_name(transition) or "anonymous"
+    return "__event__" + event.replace(".", "__")
+
+
+def composite_init_guards_incomplete(
+    machine: StateMachine,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = 1000,
+) -> AlgorithmResult:
+    """Detect composite states whose initial transitions do not cover inputs.
+
+    :param machine: State machine to inspect.
+    :type machine: StateMachine
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    diagnostics: List[dict] = []
+    first_indeterminate_result: Optional[AlgorithmResult] = None
+
+    for state in machine.walk_states():
+        if state.is_leaf_state:
+            continue
+
+        init_transitions = state.init_transitions
+        if not init_transitions:
+            continue
+        if any(
+            transition.guard is None and transition.event is None
+            for transition in init_transitions
+        ):
+            continue
+
+        unsafe_safety: Optional[SafetyCheck] = None
+        for transition in init_transitions:
+            safety = check_expr_safety(transition.guard)
+            if not safety.safe:
+                unsafe_safety = safety
+                break
+        if unsafe_safety is not None:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                "unsafe_skip",
+                unsafe_safety.reason,
+            )
+            continue
+
+        z3_vars = _z3_vars(variables)
+        event_vars: Dict[str, z3.BoolRef] = {}
+        triggers: List[z3.ExprRef] = []
+        per_composite_failed = False
+        for transition in init_transitions:
+            if transition.guard is not None:
+                guard_expr, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+                if result is not None:
+                    first_indeterminate_result = _first_indeterminate(
+                        first_indeterminate_result,
+                        result.kind,
+                        result.reason,
+                    )
+                    per_composite_failed = True
+                    break
+                triggers.append(guard_expr)
+                continue
+
+            event_key = _event_bool_name(transition)
+            event_vars.setdefault(event_key, z3.Bool(event_key))
+            triggers.append(event_vars[event_key])
+
+        if per_composite_failed or not triggers:
+            continue
+
+        no_coverage = z3.Not(z3.Or(*triggers))
+        sat_result = is_sat(
+            [
+                no_coverage,
+                *_build_type_constraints(variables, z3_vars),
+            ],
+            timeout_ms=smt_timeout_ms,
+            get_model=True,
+        )
+        if sat_result.kind == "sat":
+            diagnostics.append(
+                _make_diag(
+                    "W_COMPOSITE_INIT_INCOMPLETE",
+                    "composite_init_guards_incomplete",
+                    state=_state_path(state),
+                    init_transitions=tuple(
+                        _transition_payload(transition)
+                        for transition in init_transitions
+                    ),
+                    witness=str(sat_result.model)
+                    if sat_result.model is not None
+                    else None,
+                    verification_scope="smt_local",
+                )
+            )
+        else:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                sat_result.kind,
+            )
+
+    if diagnostics:
+        return AlgorithmResult(kind="sat", diagnostics=tuple(diagnostics))
+    if first_indeterminate_result is not None:
+        return first_indeterminate_result
+    return AlgorithmResult(kind="unsat")
+
+
+__all__ = [
+    "AlgorithmResult",
+    "ResultKind",
+    "composite_init_guards_incomplete",
+    "dead_guard",
+    "effect_contradicts_guard",
+    "effect_no_op_under_guard",
+    "enter_postcondition_implies_during_precondition",
+    "forced_guard_unsat_under_init",
+    "guard_tautology",
+    "transition_shadowed_by_predecessor",
+]

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -308,6 +308,10 @@ def _expr_to_z3_or_result(
     except ValueError as err:
         # ValueError: expr_to_z3 raises this for unknown variables or operators.
         return None, _skip_result("undecidable_skip", str(err))
+    except TypeError as err:
+        # TypeError: expr_to_z3 may delegate unsupported Python/Z3 operators
+        # before Z3 creates an expression, for example Int left-shift.
+        return None, _skip_result("undecidable_skip", str(err))
     except z3.Z3Exception as err:
         # Z3Exception: Z3 can reject otherwise parsed expressions for sort or
         # operator-domain mismatches, for example modulo over Real operands.
@@ -337,6 +341,11 @@ def _execute_operations_or_result(
         # ValueError: execute_operations delegates to expr_to_z3, which raises
         # this for unknown variables or unsupported operators.
         return None, _skip_result("undecidable_skip", str(err))
+    except TypeError as err:
+        # TypeError: execute_operations delegates to expr_to_z3 and can also
+        # surface unsupported Python/Z3 operator combinations before Z3 wraps
+        # them in Z3Exception.
+        return None, _skip_result("undecidable_skip", str(err))
     except z3.Z3Exception as err:
         # Z3Exception: Z3 can reject symbolic operation expressions because of
         # sort/operator-domain mismatches.
@@ -358,6 +367,9 @@ def _build_init_constraints_or_result(
     """
     constraints: List[z3.ExprRef] = []
     for variable in variables:
+        safety = check_expr_safety(variable.init)
+        if not safety.safe:
+            return None, _unsafe_result(safety)
         init_value, result = _expr_to_z3_or_result(variable.init, z3_vars)
         if result is not None:
             return None, result
@@ -446,16 +458,21 @@ def dead_guard(
     transition: Transition,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect a transition guard that is unsatisfiable.
+
+    This pure-guard variant does not pin variables to DSL declaration
+    initializers.  Use :func:`forced_guard_unsat_under_init` for the separate
+    forced-transition check that additionally evaluates guards under DSL
+    initial values.
 
     :param transition: Transition to check.
     :type transition: Transition
     :param variables: Variable definitions available to the model.
     :type variables: Sequence[VarDefine]
-    :param smt_timeout_ms: Optional solver timeout in milliseconds, defaults to
-        ``1000``.  ``None`` is forwarded to the solver helper as no timeout.
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+        ``None`` is forwarded to the solver helper as no timeout.
     :type smt_timeout_ms: Optional[int], optional
     :return: Algorithm result.
     :rtype: AlgorithmResult
@@ -490,7 +507,7 @@ def guard_tautology(
     transition: Transition,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect a transition guard that is valid under all assignments.
 
@@ -533,7 +550,7 @@ def forced_guard_unsat_under_init(
     transition: Transition,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect a forced-transition guard unsatisfiable under initial values.
 
@@ -568,6 +585,7 @@ def forced_guard_unsat_under_init(
                     "W_FORCED_GUARD_UNSAT",
                     "forced_guard_unsat_under_init",
                     transition=_transition_payload(transition),
+                    scope="dsl_def_init_only",
                     verification_scope="smt_local",
                 ),
             ),
@@ -579,7 +597,7 @@ def effect_no_op_under_guard(
     transition: Transition,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect transition effects that never change model variables.
 
@@ -616,6 +634,16 @@ def effect_no_op_under_guard(
         if result is not None:
             return result
 
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    guard_feasible = is_sat(
+        [guard_z3, *type_constraints],
+        timeout_ms=smt_timeout_ms,
+    )
+    if guard_feasible.kind == "unsat":
+        return AlgorithmResult(kind="sat")
+    if guard_feasible.kind != "sat":
+        return AlgorithmResult(kind=guard_feasible.kind)
+
     changed_disjuncts = [
         after_vars[variable.name] != z3_vars[variable.name] for variable in variables
     ]
@@ -625,7 +653,7 @@ def effect_no_op_under_guard(
     formula = z3.And(
         guard_z3,
         z3.Or(*changed_disjuncts),
-        *_build_type_constraints(variables, z3_vars),
+        *type_constraints,
     )
     sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
     if sat_result.kind == "unsat":
@@ -647,7 +675,7 @@ def effect_contradicts_guard(
     transition: Transition,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect effects after which the transition guard cannot still hold.
 
@@ -760,7 +788,7 @@ def transition_shadowed_by_predecessor(
     machine: StateMachine,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect outgoing transitions shadowed by earlier transitions.
 
@@ -777,27 +805,26 @@ def transition_shadowed_by_predecessor(
     first_indeterminate_result: Optional[AlgorithmResult] = None
 
     for source, outgoing in _iter_ordered_outgoing(machine):
-        prior_unconditional: Optional[Transition] = None
         prior_events: Dict[str, Transition] = {}
         prior_guards: List[Transition] = []
+        prior_unconditional: Optional[Transition] = None
 
         for transition in outgoing:
-            if prior_unconditional is not None:
-                diagnostics.append(
-                    _make_diag(
-                        "W_TRANSITION_SHADOWED",
-                        "transition_shadowed_by_predecessor",
-                        transition=_transition_payload(transition),
-                        shadowed_by=(_transition_payload(prior_unconditional),),
-                        reason="unconditional_catchall",
-                        source=_state_path(source),
-                        verification_scope="topological_only",
-                    )
-                )
-                continue
-
             key = _domain_key(transition)
             if key == "unconditional":
+                if prior_unconditional is not None:
+                    diagnostics.append(
+                        _make_diag(
+                            "W_TRANSITION_SHADOWED",
+                            "transition_shadowed_by_predecessor",
+                            transition=_transition_payload(transition),
+                            shadowed_by=(_transition_payload(prior_unconditional),),
+                            reason="unconditional_catchall",
+                            source=_state_path(source),
+                            verification_scope="topological_only",
+                        )
+                    )
+                    continue
                 prior_unconditional = transition
                 continue
 
@@ -912,6 +939,10 @@ def _action_operations(
 ) -> List[OperationStatement]:
     """Collect concrete operation statements from lifecycle actions.
 
+    Abstract actions cannot be symbolically executed in this raw solver layer,
+    so they are treated as identity and omitted from the collected operation
+    stream.
+
     :param actions: Lifecycle actions.
     :type actions: Sequence[Union[OnStage, OnAspect]]
     :return: Flattened concrete operation statements.
@@ -961,11 +992,48 @@ def _conditional_conditions_from_operations(
                 yield from _conditional_conditions_from_operations(branch.statements)
 
 
+def _concrete_before_aspect_operations(state: State) -> List[OperationStatement]:
+    """Collect concrete ancestor ``>> during before`` operations in run order.
+
+    :param state: Leaf state whose first-cycle aspect prelude is inspected.
+    :type state: State
+    :return: Flattened concrete aspect operation statements.
+    :rtype: List[OperationStatement]
+    """
+    return _action_operations(
+        [action for _, action in state.iter_on_during_before_aspect_recursively()]
+    )
+
+
+def _is_root_initial_leaf(state: State) -> bool:
+    """Return whether a leaf is reached only through initial transitions.
+
+    ``enter_postcondition_implies_during_precondition`` pins variables to DSL
+    declaration initializers.  That pre-state is sound only for the global
+    initial leaf reached through root-to-leaf ``[*]`` transitions.
+
+    :param state: Leaf state to inspect.
+    :type state: State
+    :return: Whether the root-to-leaf path is initial-transition-only.
+    :rtype: bool
+    """
+    current = state
+    while current.parent is not None:
+        parent = current.parent
+        if not any(
+            transition.to_state == current.name
+            for transition in parent.init_transitions
+        ):
+            return False
+        current = parent
+    return True
+
+
 def enter_postcondition_implies_during_precondition(
     state: State,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect first-cycle during conditions determined by enter-time values.
 
@@ -980,14 +1048,18 @@ def enter_postcondition_implies_during_precondition(
     """
     if not state.is_leaf_state or state.is_pseudo:
         return AlgorithmResult(kind="sat")
+    if not _is_root_initial_leaf(state):
+        return AlgorithmResult(kind="sat")
 
     enter_operations = _action_operations(state.on_enters)
+    before_aspect_operations = _concrete_before_aspect_operations(state)
     during_operations = _action_operations(state.on_durings)
     if not enter_operations or not during_operations:
         return AlgorithmResult(kind="sat")
 
     result = _merge_safety_checks(
         check_expr_safety_for_effect(enter_operations),
+        check_expr_safety_for_effect(before_aspect_operations),
         check_expr_safety_for_effect(during_operations),
     )
     if result is not None:
@@ -1004,13 +1076,19 @@ def enter_postcondition_implies_during_precondition(
     enter_vars, result = _execute_operations_or_result(enter_operations, z3_vars)
     if result is not None:
         return result
+    first_cycle_vars, result = _execute_operations_or_result(
+        before_aspect_operations,
+        enter_vars,
+    )
+    if result is not None:
+        return result
 
     type_constraints = _build_type_constraints(variables, z3_vars)
     diagnostics: List[dict] = []
     first_indeterminate_result: Optional[AlgorithmResult] = None
 
     for condition in conditions:
-        condition_z3, result = _expr_to_z3_or_result(condition, enter_vars)
+        condition_z3, result = _expr_to_z3_or_result(condition, first_cycle_vars)
         if result is not None:
             first_indeterminate_result = _first_indeterminate(
                 first_indeterminate_result,
@@ -1083,9 +1161,13 @@ def composite_init_guards_incomplete(
     machine: StateMachine,
     variables: Sequence[VarDefine],
     *,
-    smt_timeout_ms: Optional[int] = 1000,
+    smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect composite states whose initial transitions do not cover inputs.
+
+    The result ``kind`` follows the witness query: ``'sat'`` means a coverage
+    gap was found and diagnostics were emitted, while ``'unsat'`` means the
+    initial-transition triggers cover all modeled inputs.
 
     :param machine: State machine to inspect.
     :type machine: StateMachine

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -101,6 +101,13 @@ def create_z3_vars_from_models(models):
     return impl(models)
 
 
+def python_round_to_z3(operand):
+    """Delegate to :func:`pyfcstm.solver.expr.python_round_to_z3`."""
+    from pyfcstm.solver.expr import python_round_to_z3 as impl
+
+    return impl(operand)
+
+
 def expr_to_z3(expr, z3_vars):
     """Delegate to :func:`pyfcstm.solver.expr.expr_to_z3`."""
     from pyfcstm.solver.expr import expr_to_z3 as impl
@@ -477,7 +484,7 @@ def _ufunc_z3_or_result(
                 f"sqrt requires Real or Int operand, got {operand.sort()}.",
             )
         if func == "round":
-            return _python_round_z3(operand), None
+            return python_round_to_z3(operand), None
         return None, _skip_result(
             "undecidable_skip",
             "Mathematical function {func!r} is not supported in Z3 conversion.".format(
@@ -491,31 +498,6 @@ def _ufunc_z3_or_result(
     except z3.Z3Exception as err:
         # Z3Exception: Z3 rejects sort/operator-domain mismatches.
         return None, _skip_result("undecidable_skip", str(err))
-
-
-def _python_round_z3(operand: _Z3Expr) -> z3.ArithRef:
-    """Return a Z3 expression matching Python's single-argument ``round``.
-
-    :param operand: Integer or real operand.
-    :type operand: Union[z3.ArithRef, z3.BoolRef]
-    :return: Rounded integer expression.
-    :rtype: z3.ArithRef
-    """
-    if z3.is_int(operand):
-        return operand
-    real_operand = operand if z3.is_real(operand) else z3.ToReal(operand)
-    floor_value = z3.ToInt(real_operand)
-    fraction = real_operand - z3.ToReal(floor_value)
-    half = z3.RealVal("1/2")
-    return z3.If(
-        fraction < half,
-        floor_value,
-        z3.If(
-            fraction > half,
-            floor_value + 1,
-            z3.If(floor_value % 2 == 0, floor_value, floor_value + 1),
-        ),
-    )
 
 
 def _expr_conditions_and_z3_or_result(
@@ -1466,6 +1448,105 @@ def forced_guard_unsat_under_init(
     return AlgorithmResult(kind=sat_result.kind)
 
 
+def _effect_guard_context_or_result(
+    transition: Transition,
+    variables: Sequence[VarDefine],
+    z3_vars: _Z3Vars,
+    *,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[
+    Optional[_Z3Expr], Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]
+]:
+    """Build a feasible guard context for transition-effect algorithms.
+
+    :param transition: Transition whose effect context is analyzed.
+    :type transition: Transition
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param z3_vars: Initial Z3 variable environment.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Guard expression, type constraints, or an algorithm result.
+    :rtype: Tuple[Optional[Union[z3.ArithRef, z3.BoolRef]], Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]
+    """
+    if transition.guard is None:
+        guard_z3 = z3.BoolVal(True)
+    else:
+        guard_z3, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+        if result is not None:
+            return None, None, result
+
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    guard_feasible = is_sat(
+        [guard_z3, *type_constraints],
+        timeout_ms=smt_timeout_ms,
+    )
+    if guard_feasible.kind == "unsat":
+        return None, None, AlgorithmResult(kind="sat")
+    if guard_feasible.kind != "sat":
+        return None, None, AlgorithmResult(kind=guard_feasible.kind)
+    return guard_z3, type_constraints, None
+
+
+def _execute_effects_under_guard_or_result(
+    transition: Transition,
+    z3_vars: _Z3Vars,
+    guard_z3: _Z3Expr,
+    type_constraints: Sequence[z3.ExprRef],
+    *,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[
+    Optional[_Z3Vars], Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]
+]:
+    """Execute transition effects with guard-pruned ternary semantics.
+
+    Transition effects run only when the transition trigger is enabled.  This
+    helper passes that guard context into the raw path-sensitive operation
+    executor so expression-level ternary value branches that the guard makes
+    unreachable are not translated.
+
+    :param transition: Transition whose effects should be executed.
+    :type transition: Transition
+    :param z3_vars: Initial Z3 variable environment.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param guard_z3: Z3 guard expression for the transition.
+    :type guard_z3: Union[z3.ArithRef, z3.BoolRef]
+    :param type_constraints: Type/domain constraints for model variables.
+    :type type_constraints: Sequence[z3.ExprRef]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Post-effect variables, runtime definedness constraints, or an
+        algorithm result when execution cannot be expressed.
+    :rtype: Tuple[Optional[Dict[str, Union[z3.ArithRef, z3.BoolRef]]], Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]
+    """
+    _, after_vars, effect_domain_constraints, result = (
+        _execute_operation_prefix_conditions_and_vars_or_result(
+            transition.effects,
+            z3_vars,
+            context_constraints=[guard_z3, *type_constraints],
+            smt_timeout_ms=smt_timeout_ms,
+        )
+    )
+    if result is not None:
+        return None, None, result
+
+    defined_effect_context = [
+        guard_z3,
+        *type_constraints,
+        *(effect_domain_constraints or ()),
+    ]
+    defined_effect_feasible = is_sat(
+        defined_effect_context,
+        timeout_ms=smt_timeout_ms,
+    )
+    if defined_effect_feasible.kind == "unsat":
+        return None, None, AlgorithmResult(kind="sat")
+    if defined_effect_feasible.kind != "sat":
+        return None, None, AlgorithmResult(kind=defined_effect_feasible.kind)
+    return after_vars, tuple(effect_domain_constraints or ()), None
+
+
 def effect_no_op_under_guard(
     transition: Transition,
     variables: Sequence[VarDefine],
@@ -1473,6 +1554,10 @@ def effect_no_op_under_guard(
     smt_timeout_ms: Optional[int] = None,
 ) -> AlgorithmResult:
     """Detect transition effects that never change model variables.
+
+    Pure syntactic self-assignment blocks such as ``x = x`` are deliberately
+    ignored as a presentation-level no-op rather than reported as SMT no-op
+    diagnostics.
 
     :param transition: Transition to check.
     :type transition: Transition
@@ -1489,37 +1574,43 @@ def effect_no_op_under_guard(
         return AlgorithmResult(kind="sat")
 
     z3_vars = _z3_vars(variables)
-    after_vars, result = _execute_operations_or_result(transition.effects, z3_vars)
+    guard_z3, type_constraints, result = _effect_guard_context_or_result(
+        transition,
+        variables,
+        z3_vars,
+        smt_timeout_ms=smt_timeout_ms,
+    )
+    if result is not None:
+        return result
+    after_vars, effect_domain_constraints, result = (
+        _execute_effects_under_guard_or_result(
+            transition,
+            z3_vars,
+            guard_z3,
+            type_constraints or (),
+            smt_timeout_ms=smt_timeout_ms,
+        )
+    )
     if result is not None:
         return result
 
-    if transition.guard is None:
-        guard_z3 = z3.BoolVal(True)
-    else:
-        guard_z3, result = _expr_to_z3_or_result(transition.guard, z3_vars)
-        if result is not None:
-            return result
-
-    type_constraints = _build_type_constraints(variables, z3_vars)
-    guard_feasible = is_sat(
-        [guard_z3, *type_constraints],
-        timeout_ms=smt_timeout_ms,
-    )
-    if guard_feasible.kind == "unsat":
-        return AlgorithmResult(kind="sat")
-    if guard_feasible.kind != "sat":
-        return AlgorithmResult(kind=guard_feasible.kind)
-
-    changed_disjuncts = [
-        after_vars[variable.name] != z3_vars[variable.name] for variable in variables
-    ]
+    try:
+        changed_disjuncts = [
+            after_vars[variable.name] != z3_vars[variable.name]
+            for variable in variables
+        ]
+    except KeyError as err:
+        # KeyError: the symbolic executor should preserve all model variables;
+        # a missing variable means the effect state cannot be compared.
+        return _skip_result("undecidable_skip", str(err))
     if not changed_disjuncts:
         return AlgorithmResult(kind="sat")
 
     formula = z3.And(
         guard_z3,
         z3.Or(*changed_disjuncts),
-        *type_constraints,
+        *(type_constraints or ()),
+        *(effect_domain_constraints or ()),
     )
     sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
     if sat_result.kind == "unsat":
@@ -1558,31 +1649,35 @@ def effect_contradicts_guard(
         return AlgorithmResult(kind="sat")
 
     z3_vars = _z3_vars(variables)
-    guard_before, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+    guard_before, type_constraints, result = _effect_guard_context_or_result(
+        transition,
+        variables,
+        z3_vars,
+        smt_timeout_ms=smt_timeout_ms,
+    )
     if result is not None:
         return result
-    after_vars, result = _execute_operations_or_result(transition.effects, z3_vars)
+    after_vars, effect_domain_constraints, result = (
+        _execute_effects_under_guard_or_result(
+            transition,
+            z3_vars,
+            guard_before,
+            type_constraints or (),
+            smt_timeout_ms=smt_timeout_ms,
+        )
+    )
     if result is not None:
         return result
     guard_after, result = _expr_to_z3_or_result(transition.guard, after_vars)
     if result is not None:
         return result
-    type_constraints = _build_type_constraints(variables, z3_vars)
-
-    guard_feasible = is_sat(
-        [guard_before, *type_constraints],
-        timeout_ms=smt_timeout_ms,
-    )
-    if guard_feasible.kind == "unsat":
-        return AlgorithmResult(kind="sat")
-    if guard_feasible.kind != "sat":
-        return AlgorithmResult(kind=guard_feasible.kind)
 
     sat_result = is_sat(
         [
             guard_before,
             guard_after,
-            *type_constraints,
+            *(type_constraints or ()),
+            *(effect_domain_constraints or ()),
         ],
         timeout_ms=smt_timeout_ms,
     )
@@ -1678,44 +1773,44 @@ def transition_shadowed_by_predecessor(
                 )
                 sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
                 if sat_result.kind == "unsat":
+                    trigger_sat = is_sat(
+                        [trigger, *_build_type_constraints(variables, z3_vars)],
+                        timeout_ms=smt_timeout_ms,
+                    )
+                    if trigger_sat.kind == "unsat":
+                        # A transition whose own trigger is unsatisfiable
+                        # belongs to dead_guard, not predecessor shadowing.
+                        continue
+                    if trigger_sat.kind != "sat":
+                        first_indeterminate_result = _first_indeterminate(
+                            first_indeterminate_result,
+                            trigger_sat.kind,
+                        )
+                        continue
+
                     has_unconditional_catchall = any(
                         item["event"] is None and item["guard"] is None
                         for item in prior_payloads
                     )
                     if has_unconditional_catchall:
                         reason = "unconditional_catchall"
-                    else:
-                        trigger_sat = is_sat(
-                            [trigger, *_build_type_constraints(variables, z3_vars)],
-                            timeout_ms=smt_timeout_ms,
-                        )
-                        if trigger_sat.kind == "unsat":
-                            # A transition whose own trigger is unsatisfiable
-                            # belongs to dead_guard, not predecessor shadowing.
-                            continue
-                        if trigger_sat.kind != "sat":
-                            first_indeterminate_result = _first_indeterminate(
-                                first_indeterminate_result,
-                                trigger_sat.kind,
-                            )
-                            continue
-                        if (
-                            current_payload["event"] is not None
-                            and current_payload["guard"] is None
-                            and any(
-                                item["event"] == current_payload["event"]
-                                and item["guard"] is None
-                                for item in prior_payloads
-                            )
-                        ):
-                            reason = "duplicate_event"
-                        elif current_payload["guard"] is not None and all(
-                            item["event"] is None and item["guard"] is not None
+                    elif (
+                        current_payload["event"] is not None
+                        and current_payload["guard"] is None
+                        and any(
+                            item["event"] == current_payload["event"]
+                            and item["guard"] is None
                             for item in prior_payloads
-                        ):
-                            reason = "guard_shadow"
-                        else:
-                            reason = "prior_trigger_cover"
+                        )
+                    ):
+                        reason = "duplicate_event"
+                    elif current_payload["guard"] is not None and all(
+                        item["event"] is None and item["guard"] is not None
+                        for item in prior_payloads
+                    ):
+                        reason = "guard_shadow"
+                    else:
+                        reason = "prior_trigger_cover"
                     diagnostics.append(
                         _make_diag(
                             "W_TRANSITION_SHADOWED",

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -42,6 +42,15 @@ _Z3Expr = Union[z3.ArithRef, z3.BoolRef]
 _Z3Vars = Dict[str, _Z3Expr]
 
 
+@dataclass(frozen=True)
+class _ConditionPoint:
+    """Condition expression with its symbolic store and path predicates."""
+
+    condition: "Expr"
+    z3_vars: _Z3Vars
+    path_conditions: Tuple[z3.ExprRef, ...] = ()
+
+
 def _dsl_nodes():
     """Import DSL node sentinels lazily to keep registry import lightweight."""
     from pyfcstm.dsl import node as dsl_nodes
@@ -315,24 +324,35 @@ def _execute_operations_or_result(
 def _execute_operation_prefix_conditions_or_result(
     operations: Sequence[OperationStatement],
     z3_vars: _Z3Vars,
-) -> Tuple[Optional[Tuple[Tuple[Expr, _Z3Vars], ...]], Optional[AlgorithmResult]]:
-    """Collect condition expressions with the symbolic environment at each point.
+    path_conditions: Sequence[z3.ExprRef] = (),
+) -> Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[AlgorithmResult]]:
+    """Collect condition expressions with point-in-time path predicates.
+
+    The collected path predicates model the branch-selection predicates needed
+    to reach the condition point.  They let callers skip diagnostics for
+    syntactic conditions inside branches that are unreachable in the surrounding
+    first-cycle context.
 
     :param operations: Operation statements to scan in execution order.
     :type operations: Sequence[OperationStatement]
     :param z3_vars: Starting symbolic environment before the operation block.
     :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
-    :return: Pairs of condition expression and point-in-time symbolic store, or
-        an algorithm result when symbolic prefix execution cannot be expressed.
-    :rtype: Tuple[Optional[Tuple[Tuple[Expr, Dict[str, Union[z3.ArithRef, z3.BoolRef]]], ...]], Optional[AlgorithmResult]]
+    :param path_conditions: Predicates that must hold before this block is run.
+    :type path_conditions: Sequence[z3.ExprRef]
+    :return: Condition points, or an algorithm result when symbolic prefix
+        execution cannot be expressed.
+    :rtype: Tuple[Optional[Tuple[_ConditionPoint, ...]], Optional[AlgorithmResult]]
     """
-    pairs: List[Tuple[Expr, _Z3Vars]] = []
+    points: List[_ConditionPoint] = []
     current_vars = dict(z3_vars)
+    current_path = tuple(path_conditions)
 
     for statement in operations:
         if isinstance(statement, _operation_type()):
             for condition in _conditional_conditions_from_expr(statement.expr):
-                pairs.append((condition, dict(current_vars)))
+                points.append(
+                    _ConditionPoint(condition, dict(current_vars), current_path)
+                )
             current_vars, result = _execute_operations_or_result(
                 [statement], current_vars
             )
@@ -341,16 +361,33 @@ def _execute_operation_prefix_conditions_or_result(
             continue
 
         if isinstance(statement, _if_block_type()):
+            prior_not_taken: List[z3.ExprRef] = []
             for branch in statement.branches:
+                branch_path = [*current_path, *prior_not_taken]
                 if branch.condition is not None:
-                    pairs.append((branch.condition, dict(current_vars)))
-                branch_pairs, result = _execute_operation_prefix_conditions_or_result(
+                    branch_condition, result = _expr_to_z3_or_result(
+                        branch.condition,
+                        current_vars,
+                    )
+                    if result is not None:
+                        return None, result
+                    points.append(
+                        _ConditionPoint(
+                            branch.condition,
+                            dict(current_vars),
+                            tuple(branch_path),
+                        )
+                    )
+                    branch_path.append(branch_condition)
+                    prior_not_taken.append(z3.Not(branch_condition))
+                branch_points, result = _execute_operation_prefix_conditions_or_result(
                     branch.statements,
                     current_vars,
+                    branch_path,
                 )
                 if result is not None:
                     return None, result
-                pairs.extend(branch_pairs or ())
+                points.extend(branch_points or ())
 
             current_vars, result = _execute_operations_or_result(
                 [statement], current_vars
@@ -364,7 +401,7 @@ def _execute_operation_prefix_conditions_or_result(
             f"Unknown operation statement type {type(statement)!r}.",
         )
 
-    return tuple(pairs), None
+    return tuple(points), None
 
 
 def _transition_trigger_or_result(
@@ -887,20 +924,6 @@ def effect_contradicts_guard(
     return AlgorithmResult(kind=sat_result.kind)
 
 
-def _domain_key(transition: Transition):
-    """Return the transition trigger domain key.
-
-    :param transition: Transition to inspect.
-    :type transition: Transition
-    :return: Domain key.
-    """
-    if transition.guard is not None:
-        return "guard"
-    if transition.event is not None:
-        return ("event", transition.event.path_name)
-    return "unconditional"
-
-
 def _iter_ordered_outgoing(
     machine: StateMachine,
 ) -> Iterable[Tuple[State, List[Transition]]]:
@@ -950,109 +973,75 @@ def transition_shadowed_by_predecessor(
     first_indeterminate_result: Optional[AlgorithmResult] = None
 
     for source, outgoing in _iter_ordered_outgoing(machine):
-        prior_events: Dict[str, Transition] = {}
-        prior_guards: List[Transition] = []
-        prior_unconditional: Optional[Transition] = None
+        z3_vars = _z3_vars(variables)
+        event_vars: Dict[str, z3.BoolRef] = {}
+        prior_triggers: List[z3.ExprRef] = []
+        prior_payloads: List[dict] = []
 
         for transition in outgoing:
-            key = _domain_key(transition)
-            if key == "unconditional":
-                if prior_unconditional is not None:
-                    diagnostics.append(
-                        _make_diag(
-                            "W_TRANSITION_SHADOWED",
-                            "transition_shadowed_by_predecessor",
-                            transition=_transition_payload(transition),
-                            shadowed_by=(_transition_payload(prior_unconditional),),
-                            reason="unconditional_catchall",
-                            source=_state_path(source),
-                            verification_scope="topological_only",
-                        )
-                    )
-                    continue
-
-                prior_unconditional = transition
+            trigger, result = _transition_trigger_or_result(
+                transition,
+                z3_vars,
+                event_vars,
+            )
+            if result is not None:
+                first_indeterminate_result = _first_indeterminate(
+                    first_indeterminate_result,
+                    result.kind,
+                    result.reason,
+                )
                 continue
 
-            if isinstance(key, tuple) and key[0] == "event":
-                event_name = key[1]
-                if event_name in prior_events:
+            current_payload = _transition_payload(transition)
+            if prior_triggers:
+                formula = z3.And(
+                    trigger,
+                    *(z3.Not(prior_trigger) for prior_trigger in prior_triggers),
+                    *_build_type_constraints(variables, z3_vars),
+                )
+                sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
+                if sat_result.kind == "unsat":
+                    if any(
+                        item["event"] is None and item["guard"] is None
+                        for item in prior_payloads
+                    ):
+                        reason = "unconditional_catchall"
+                    elif (
+                        current_payload["event"] is not None
+                        and current_payload["guard"] is None
+                        and any(
+                            item["event"] == current_payload["event"]
+                            and item["guard"] is None
+                            for item in prior_payloads
+                        )
+                    ):
+                        reason = "duplicate_event"
+                    elif current_payload["guard"] is not None and all(
+                        item["event"] is None and item["guard"] is not None
+                        for item in prior_payloads
+                    ):
+                        reason = "guard_shadow"
+                    else:
+                        reason = "prior_trigger_cover"
                     diagnostics.append(
                         _make_diag(
                             "W_TRANSITION_SHADOWED",
                             "transition_shadowed_by_predecessor",
-                            transition=_transition_payload(transition),
-                            shadowed_by=(
-                                _transition_payload(prior_events[event_name]),
-                            ),
-                            reason="duplicate_event",
+                            transition=current_payload,
+                            shadowed_by=tuple(prior_payloads),
+                            reason=reason,
                             source=_state_path(source),
-                            verification_scope="topological_only",
+                            verification_scope="smt_local",
                         )
                     )
                 else:
-                    prior_events[event_name] = transition
-                continue
-
-            if key == "guard":
-                z3_vars = _z3_vars(variables)
-                current_guard, result = _expr_to_z3_or_result(transition.guard, z3_vars)
-                if result is not None:
                     first_indeterminate_result = _first_indeterminate(
                         first_indeterminate_result,
-                        result.kind,
-                        result.reason,
-                    )
-                    prior_guards.append(transition)
-                    continue
-
-                predecessor_guards: List[z3.ExprRef] = []
-                predecessor_payloads = []
-                predecessor_failed = False
-                for prior_guard_transition in prior_guards:
-                    prior_guard, result = _expr_to_z3_or_result(
-                        prior_guard_transition.guard,
-                        z3_vars,
-                    )
-                    if result is not None:
-                        first_indeterminate_result = _first_indeterminate(
-                            first_indeterminate_result,
-                            result.kind,
-                            result.reason,
-                        )
-                        predecessor_failed = True
-                        break
-                    predecessor_guards.append(z3.Not(prior_guard))
-                    predecessor_payloads.append(
-                        _transition_payload(prior_guard_transition)
+                        sat_result.kind,
                     )
 
-                if not predecessor_failed and predecessor_guards:
-                    formula = z3.And(
-                        current_guard,
-                        *predecessor_guards,
-                        *_build_type_constraints(variables, z3_vars),
-                    )
-                    sat_result = is_sat([formula], timeout_ms=smt_timeout_ms)
-                    if sat_result.kind == "unsat":
-                        diagnostics.append(
-                            _make_diag(
-                                "W_TRANSITION_SHADOWED",
-                                "transition_shadowed_by_predecessor",
-                                transition=_transition_payload(transition),
-                                shadowed_by=tuple(predecessor_payloads),
-                                reason="guard_shadow",
-                                source=_state_path(source),
-                                verification_scope="smt_local",
-                            )
-                        )
-                    else:
-                        first_indeterminate_result = _first_indeterminate(
-                            first_indeterminate_result,
-                            sat_result.kind,
-                        )
-
-                prior_guards.append(transition)
+            prior_triggers.append(trigger)
+            prior_payloads.append(current_payload)
 
     if diagnostics:
         return AlgorithmResult(kind="unsat", diagnostics=tuple(diagnostics))
@@ -1225,24 +1214,20 @@ def enter_postcondition_implies_during_precondition(
     if init_transitions is None:
         return AlgorithmResult(kind="sat")
 
-    before_aspect_operations = _concrete_before_aspect_operations(state)
-    during_operations = _action_operations(state.on_durings)
-    if not during_operations:
+    first_cycle_operations = [
+        *_concrete_before_aspect_operations(state),
+        *_action_operations(state.on_durings),
+    ]
+    if not first_cycle_operations:
         return AlgorithmResult(kind="sat")
 
     entry_vars, result = _execute_operations_or_result(entry_operations or (), z3_vars)
     if result is not None:
         return result
-    first_cycle_vars, result = _execute_operations_or_result(
-        before_aspect_operations,
-        entry_vars,
-    )
-    if result is not None:
-        return result
 
     condition_points, result = _execute_operation_prefix_conditions_or_result(
-        during_operations,
-        first_cycle_vars,
+        first_cycle_operations,
+        entry_vars,
     )
     if result is not None:
         return result
@@ -1266,8 +1251,32 @@ def enter_postcondition_implies_during_precondition(
     if context_check.kind == "unsat":
         return AlgorithmResult(kind="sat")
 
-    for condition, condition_vars in condition_points:
-        condition_z3, result = _expr_to_z3_or_result(condition, condition_vars)
+    for condition_point in condition_points:
+        condition = condition_point.condition
+        point_context = [
+            *init_constraints,
+            *(entry_constraints or ()),
+            *condition_point.path_conditions,
+            *type_constraints,
+        ]
+        reachability_check = is_sat(
+            point_context,
+            timeout_ms=smt_timeout_ms,
+        )
+        if reachability_check.kind == "unsat":
+            continue
+        if reachability_check.kind in {"unknown", "timeout"}:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                reachability_check.kind,
+                getattr(reachability_check, "reason", None),
+            )
+            continue
+
+        condition_z3, result = _expr_to_z3_or_result(
+            condition,
+            condition_point.z3_vars,
+        )
         if result is not None:
             first_indeterminate_result = _first_indeterminate(
                 first_indeterminate_result,
@@ -1277,21 +1286,11 @@ def enter_postcondition_implies_during_precondition(
             continue
 
         true_check = is_sat(
-            [
-                condition_z3,
-                *init_constraints,
-                *(entry_constraints or ()),
-                *type_constraints,
-            ],
+            [condition_z3, *point_context],
             timeout_ms=smt_timeout_ms,
         )
         false_check = is_sat(
-            [
-                z3.Not(condition_z3),
-                *init_constraints,
-                *(entry_constraints or ()),
-                *type_constraints,
-            ],
+            [z3.Not(condition_z3), *point_context],
             timeout_ms=smt_timeout_ms,
         )
 

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -15,7 +15,17 @@ algorithm results to the diagnostics layer.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 try:
     from typing import Literal
@@ -57,6 +67,26 @@ class _ConditionPoint:
     path_conditions: Tuple[z3.ExprRef, ...] = ()
     source: str = "expression"
     z3_condition: Optional[z3.ExprRef] = None
+
+
+@dataclass(frozen=True)
+class _InitialPathContext:
+    """One feasible root-to-leaf initial path symbolic context."""
+
+    transitions: Tuple["Transition", ...]
+    constraints: Tuple[z3.ExprRef, ...]
+    operations: Tuple["OperationStatement", ...]
+
+
+@dataclass(frozen=True)
+class _InitialPathSearchContext:
+    """Search state used while enumerating root initial path alternatives."""
+
+    transitions: Tuple["Transition", ...]
+    constraints: Tuple[z3.ExprRef, ...]
+    operations: Tuple["OperationStatement", ...]
+    z3_vars: _Z3Vars
+    domain_constraints: Tuple[z3.ExprRef, ...]
 
 
 def _dsl_nodes():
@@ -1190,6 +1220,223 @@ def _transition_trigger_or_result(
     return z3.And(*parts), trigger_domains, None
 
 
+def _root_initial_path_contexts(
+    state: State,
+    variables: Sequence[VarDefine],
+    z3_vars: _Z3Vars,
+    base_constraints: Sequence[z3.ExprRef],
+    *,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[Optional[Tuple[_InitialPathContext, ...]], Optional[AlgorithmResult]]:
+    """Enumerate feasible runtime first-enabled initial path contexts.
+
+    Evented and guarded initial transitions can offer multiple feasible paths to
+    the same leaf in one cycle.  A raw SMT diagnostic is deterministic only when
+    it holds for every feasible first-enabled path, so this helper enumerates the
+    full path set instead of committing to the first satisfiable transition.
+
+    :param state: Candidate root-initial leaf state.
+    :type state: State
+    :param variables: FCSTM variable definitions.
+    :type variables: Sequence[VarDefine]
+    :param z3_vars: Root symbolic variables.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param base_constraints: Constraints that hold before root entry, usually
+        DSL declaration initializers.
+    :type base_constraints: Sequence[z3.ExprRef]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Feasible path contexts or an indeterminate algorithm result.  A
+        ``None`` context tuple without a result means ``state`` is not selected
+        by any feasible root first-enabled initial path.
+    :rtype: Tuple[Optional[Tuple[_InitialPathContext, ...]], Optional[AlgorithmResult]]
+    """
+    path = _state_path_from_root(state)
+    if len(path) <= 1:
+        return (
+            (
+                _InitialPathContext(
+                    transitions=(),
+                    constraints=(),
+                    operations=tuple(_action_operations(state.on_enters)),
+                ),
+            ),
+            None,
+        )
+
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    search_contexts = [
+        _InitialPathSearchContext(
+            transitions=(),
+            constraints=(),
+            operations=(),
+            z3_vars=dict(z3_vars),
+            domain_constraints=(),
+        )
+    ]
+
+    for index, path_state in enumerate(path[:-1]):
+        child = path[index + 1]
+        next_contexts: List[_InitialPathSearchContext] = []
+
+        for context in search_contexts:
+            current_vars = dict(context.z3_vars)
+            context_constraints = [
+                *base_constraints,
+                *context.constraints,
+                *context.domain_constraints,
+                *type_constraints,
+            ]
+            current_operations = list(context.operations)
+            current_domains = list(context.domain_constraints)
+
+            enter_ops = _action_operations(path_state.on_enters)
+            current_operations.extend(enter_ops)
+            _, current_vars, new_domains, result = (
+                _execute_operation_prefix_conditions_and_vars_or_result(
+                    enter_ops,
+                    current_vars,
+                    context_constraints=context_constraints,
+                    smt_timeout_ms=smt_timeout_ms,
+                    domain_constraints=current_domains,
+                )
+            )
+            if result is not None:
+                return None, result
+            current_domains = list(new_domains or ())
+
+            if not path_state.is_leaf_state:
+                during_before_ops = _action_operations(
+                    path_state.list_on_durings(aspect="before")
+                )
+                current_operations.extend(during_before_ops)
+                _, current_vars, new_domains, result = (
+                    _execute_operation_prefix_conditions_and_vars_or_result(
+                        during_before_ops,
+                        current_vars,
+                        context_constraints=[
+                            *base_constraints,
+                            *context.constraints,
+                            *current_domains,
+                            *type_constraints,
+                        ],
+                        smt_timeout_ms=smt_timeout_ms,
+                        domain_constraints=current_domains,
+                    )
+                )
+                if result is not None:
+                    return None, result
+                current_domains = list(new_domains or ())
+
+            prior_triggers: List[z3.ExprRef] = []
+            prior_guard_domains: List[z3.ExprRef] = []
+            for transition in path_state.init_transitions:
+                trigger, guard_domains, result = _transition_trigger_or_result(
+                    transition,
+                    current_vars,
+                    context_constraints=[
+                        *base_constraints,
+                        *context.constraints,
+                        *current_domains,
+                        *prior_guard_domains,
+                        *type_constraints,
+                    ],
+                    smt_timeout_ms=smt_timeout_ms,
+                )
+                if result is not None:
+                    return None, result
+                if guard_domains:
+                    result = _definedness_feasibility_or_result(
+                        [
+                            *base_constraints,
+                            *context.constraints,
+                            *current_domains,
+                            *prior_guard_domains,
+                            *guard_domains,
+                            *type_constraints,
+                        ],
+                        reason=(
+                            "Initial transition guard runtime definedness "
+                            "constraints are unsatisfiable in context."
+                        ),
+                        smt_timeout_ms=smt_timeout_ms,
+                    )
+                    if result is not None:
+                        return None, result
+
+                if transition.to_state == child.name:
+                    candidate_constraints = [
+                        *context.constraints,
+                        *prior_guard_domains,
+                        *(z3.Not(prior_trigger) for prior_trigger in prior_triggers),
+                        *(guard_domains or ()),
+                        trigger,
+                    ]
+                    candidate_context = [
+                        *base_constraints,
+                        *candidate_constraints,
+                        *current_domains,
+                        *type_constraints,
+                    ]
+                    context_check = is_sat(
+                        candidate_context,
+                        timeout_ms=smt_timeout_ms,
+                    )
+                    if context_check.kind in {"unknown", "timeout"}:
+                        return (
+                            None,
+                            _skip_result(
+                                context_check.kind,
+                                getattr(context_check, "reason", None),
+                            ),
+                        )
+                    if context_check.kind == "sat":
+                        effect_operations = [*current_operations, *transition.effects]
+                        _, effect_vars, effect_domains, result = (
+                            _execute_operation_prefix_conditions_and_vars_or_result(
+                                transition.effects,
+                                current_vars,
+                                context_constraints=candidate_context,
+                                smt_timeout_ms=smt_timeout_ms,
+                                domain_constraints=current_domains,
+                            )
+                        )
+                        if result is not None:
+                            return None, result
+                        next_contexts.append(
+                            _InitialPathSearchContext(
+                                transitions=(
+                                    *context.transitions,
+                                    transition,
+                                ),
+                                constraints=tuple(candidate_constraints),
+                                operations=tuple(effect_operations),
+                                z3_vars=effect_vars or current_vars,
+                                domain_constraints=tuple(effect_domains or ()),
+                            )
+                        )
+
+                prior_guard_domains.extend(guard_domains or ())
+                prior_triggers.append(trigger)
+
+        if not next_contexts:
+            return None, None
+        search_contexts = next_contexts
+
+    leaf_enter_ops = tuple(_action_operations(state.on_enters))
+    return (
+        tuple(
+            _InitialPathContext(
+                transitions=context.transitions,
+                constraints=context.constraints,
+                operations=(*context.operations, *leaf_enter_ops),
+            )
+            for context in search_contexts
+        ),
+        None,
+    )
+
+
 def _root_initial_path_context(
     state: State,
     variables: Sequence[VarDefine],
@@ -1221,167 +1468,24 @@ def _root_initial_path_context(
         means the state is not selected by the root first-enabled initial path.
     :rtype: Tuple[Optional[Tuple[Transition, ...]], Optional[Tuple[z3.ExprRef, ...]], Optional[List[OperationStatement]], Optional[AlgorithmResult]]
     """
-    path = _state_path_from_root(state)
-    if len(path) <= 1:
-        return (), (), _action_operations(state.on_enters), None
-
-    selected: List[Transition] = []
-    constraints: List[z3.ExprRef] = []
-    domain_constraints: List[z3.ExprRef] = []
-    operations: List[OperationStatement] = []
-    current_vars: _Z3Vars = dict(z3_vars)
-    type_constraints = _build_type_constraints(variables, z3_vars)
-
-    for index, path_state in enumerate(path[:-1]):
-        child = path[index + 1]
-        enter_ops = _action_operations(path_state.on_enters)
-        operations.extend(enter_ops)
-        _, current_vars, new_domains, result = (
-            _execute_operation_prefix_conditions_and_vars_or_result(
-                enter_ops,
-                current_vars,
-                context_constraints=[
-                    *base_constraints,
-                    *constraints,
-                    *domain_constraints,
-                    *type_constraints,
-                ],
-                smt_timeout_ms=smt_timeout_ms,
-                domain_constraints=domain_constraints,
-            )
-        )
-        if result is not None:
-            return None, None, None, result
-        domain_constraints = list(new_domains or ())
-
-        if not path_state.is_leaf_state:
-            during_before_ops = _action_operations(
-                path_state.list_on_durings(aspect="before")
-            )
-            operations.extend(during_before_ops)
-            _, current_vars, new_domains, result = (
-                _execute_operation_prefix_conditions_and_vars_or_result(
-                    during_before_ops,
-                    current_vars,
-                    context_constraints=[
-                        *base_constraints,
-                        *constraints,
-                        *domain_constraints,
-                        *type_constraints,
-                    ],
-                    smt_timeout_ms=smt_timeout_ms,
-                    domain_constraints=domain_constraints,
-                )
-            )
-            if result is not None:
-                return None, None, None, result
-            domain_constraints = list(new_domains or ())
-
-        target_transition = None
-        selected_constraints = None
-        selected_guard_domains = None
-        prior_triggers: List[z3.ExprRef] = []
-        prior_guard_domains: List[z3.ExprRef] = []
-        for transition in path_state.init_transitions:
-            trigger, guard_domains, result = _transition_trigger_or_result(
-                transition,
-                current_vars,
-                context_constraints=[
-                    *base_constraints,
-                    *constraints,
-                    *domain_constraints,
-                    *prior_guard_domains,
-                    *type_constraints,
-                ],
-                smt_timeout_ms=smt_timeout_ms,
-            )
-            if result is not None:
-                return None, None, None, result
-            if guard_domains:
-                result = _definedness_feasibility_or_result(
-                    [
-                        *base_constraints,
-                        *constraints,
-                        *domain_constraints,
-                        *prior_guard_domains,
-                        *guard_domains,
-                        *type_constraints,
-                    ],
-                    reason=(
-                        "Initial transition guard runtime definedness "
-                        "constraints are unsatisfiable in context."
-                    ),
-                    smt_timeout_ms=smt_timeout_ms,
-                )
-                if result is not None:
-                    return None, None, None, result
-            if transition.to_state == child.name:
-                candidate_constraints = [
-                    *constraints,
-                    *prior_guard_domains,
-                    *(z3.Not(prior_trigger) for prior_trigger in prior_triggers),
-                    *(guard_domains or ()),
-                    trigger,
-                ]
-                context_check = is_sat(
-                    [
-                        *base_constraints,
-                        *candidate_constraints,
-                        *domain_constraints,
-                        *type_constraints,
-                    ],
-                    timeout_ms=smt_timeout_ms,
-                )
-                if context_check.kind in {"unknown", "timeout"}:
-                    return (
-                        None,
-                        None,
-                        None,
-                        _skip_result(
-                            context_check.kind,
-                            getattr(context_check, "reason", None),
-                        ),
-                    )
-                if context_check.kind == "sat":
-                    target_transition = transition
-                    selected_constraints = candidate_constraints
-                    selected_guard_domains = guard_domains
-                    break
-            prior_guard_domains.extend(guard_domains or ())
-            prior_triggers.append(trigger)
-
-        if (
-            target_transition is None
-            or selected_constraints is None
-            or selected_guard_domains is None
-        ):
-            return None, None, None, None
-        constraints = selected_constraints
-
-        selected.append(target_transition)
-        operations.extend(target_transition.effects)
-        _, current_vars, new_domains, result = (
-            _execute_operation_prefix_conditions_and_vars_or_result(
-                target_transition.effects,
-                current_vars,
-                context_constraints=[
-                    *base_constraints,
-                    *constraints,
-                    *domain_constraints,
-                    *type_constraints,
-                ],
-                smt_timeout_ms=smt_timeout_ms,
-                domain_constraints=domain_constraints,
-            )
-        )
-        if result is not None:
-            return None, None, None, result
-        domain_constraints = list(new_domains or ())
-
-    leaf_enter_ops = _action_operations(state.on_enters)
-    operations.extend(leaf_enter_ops)
-
-    return tuple(selected), tuple(constraints), operations, None
+    contexts, result = _root_initial_path_contexts(
+        state,
+        variables,
+        z3_vars,
+        base_constraints,
+        smt_timeout_ms=smt_timeout_ms,
+    )
+    if result is not None:
+        return None, None, None, result
+    if contexts is None:
+        return None, None, None, None
+    context = contexts[0]
+    return (
+        context.transitions,
+        context.constraints,
+        list(context.operations),
+        None,
+    )
 
 
 def _build_init_constraints_or_result(
@@ -2040,6 +2144,64 @@ def _iter_ordered_outgoing(
                 yield source, transitions
 
 
+def _state_has_definite_stable_entry(state: State) -> bool:
+    """Return whether entering ``state`` definitely reaches a stable leaf.
+
+    This helper is intentionally conservative: it proves only unconditional
+    initial chains whose first transition at each composite is eventless,
+    guardless, and leads recursively to a stoppable leaf.  Other cases may still
+    be valid at runtime, but transition shadowing must not emit a deterministic
+    diagnostic when validation viability depends on events, guards, or deeper
+    continuation semantics.
+
+    :param state: State entered by a transition.
+    :type state: State
+    :return: Whether entry is definitely validation-stable.
+    :rtype: bool
+    """
+    if state.is_stoppable:
+        return True
+    if state.is_leaf_state:
+        return False
+    if not state.init_transitions:
+        return False
+
+    transition = state.init_transitions[0]
+    if transition.event is not None or transition.guard is not None:
+        return False
+    if not isinstance(transition.to_state, str):
+        return False
+    target = state.substates.get(transition.to_state)
+    if target is None:
+        return False
+    return _state_has_definite_stable_entry(target)
+
+
+def _transition_has_definite_stable_continuation(
+    source: State,
+    transition: Transition,
+) -> bool:
+    """Return whether ``transition`` definitely passes stoppable validation.
+
+    :param source: Source state whose runtime selection validates outgoing
+        transitions.
+    :type source: State
+    :param transition: Candidate predecessor transition.
+    :type transition: Transition
+    :return: Whether the transition has a locally proven stable continuation.
+    :rtype: bool
+    """
+    parent = source.parent
+    if transition.to_state is _dsl_nodes().EXIT_STATE:
+        return parent is not None and parent.is_root_state
+    if parent is None or not isinstance(transition.to_state, str):
+        return False
+    target = parent.substates.get(transition.to_state)
+    if target is None:
+        return False
+    return _state_has_definite_stable_entry(target)
+
+
 def transition_shadowed_by_predecessor(
     machine: StateMachine,
     variables: Sequence[VarDefine],
@@ -2066,6 +2228,7 @@ def transition_shadowed_by_predecessor(
         prior_triggers: List[z3.ExprRef] = []
         prior_domain_constraints: List[z3.ExprRef] = []
         prior_payloads: List[dict] = []
+        prior_transitions: List[Transition] = []
         type_constraints = _build_type_constraints(variables, z3_vars)
 
         for transition in outgoing:
@@ -2135,6 +2298,7 @@ def transition_shadowed_by_predecessor(
                         prior_triggers.append(trigger)
                         prior_domain_constraints.extend(trigger_domains or ())
                         prior_payloads.append(current_payload)
+                        prior_transitions.append(transition)
                         continue
                     if loose_result.kind != "unsat":
                         first_indeterminate_result = _first_indeterminate(
@@ -2159,40 +2323,61 @@ def transition_shadowed_by_predecessor(
                         )
                         continue
 
-                    has_unconditional_catchall = any(
-                        item["event"] is None and item["guard"] is None
-                        for item in prior_payloads
+                    unstable_predecessor = (
+                        source.is_stoppable
+                        and not all(
+                            _transition_has_definite_stable_continuation(
+                                source, item
+                            )
+                            for item in prior_transitions
+                        )
                     )
-                    if has_unconditional_catchall:
-                        reason = "unconditional_catchall"
-                    elif (
-                        current_payload["event"] is not None
-                        and current_payload["guard"] is None
-                        and any(
-                            item["event"] == current_payload["event"]
-                            and item["guard"] is None
+                    if unstable_predecessor:
+                        first_indeterminate_result = _first_indeterminate(
+                            first_indeterminate_result,
+                            "undecidable_skip",
+                            (
+                                "Prior transition trigger coverage does not "
+                                "prove runtime shadowing because a predecessor "
+                                "transition lacks a locally proven stable "
+                                "continuation."
+                            ),
+                        )
+                    else:
+                        has_unconditional_catchall = any(
+                            item["event"] is None and item["guard"] is None
                             for item in prior_payloads
                         )
-                    ):
-                        reason = "duplicate_event"
-                    elif current_payload["guard"] is not None and all(
-                        item["event"] is None and item["guard"] is not None
-                        for item in prior_payloads
-                    ):
-                        reason = "guard_shadow"
-                    else:
-                        reason = "prior_trigger_cover"
-                    diagnostics.append(
-                        _make_diag(
-                            "W_TRANSITION_SHADOWED",
-                            "transition_shadowed_by_predecessor",
-                            transition=current_payload,
-                            shadowed_by=tuple(prior_payloads),
-                            reason=reason,
-                            source=_state_path(source),
-                            verification_scope="smt_local",
+                        if has_unconditional_catchall:
+                            reason = "unconditional_catchall"
+                        elif (
+                            current_payload["event"] is not None
+                            and current_payload["guard"] is None
+                            and any(
+                                item["event"] == current_payload["event"]
+                                and item["guard"] is None
+                                for item in prior_payloads
+                            )
+                        ):
+                            reason = "duplicate_event"
+                        elif current_payload["guard"] is not None and all(
+                            item["event"] is None and item["guard"] is not None
+                            for item in prior_payloads
+                        ):
+                            reason = "guard_shadow"
+                        else:
+                            reason = "prior_trigger_cover"
+                        diagnostics.append(
+                            _make_diag(
+                                "W_TRANSITION_SHADOWED",
+                                "transition_shadowed_by_predecessor",
+                                transition=current_payload,
+                                shadowed_by=tuple(prior_payloads),
+                                reason=reason,
+                                source=_state_path(source),
+                                verification_scope="smt_local",
+                            )
                         )
-                    )
                 else:
                     first_indeterminate_result = _first_indeterminate(
                         first_indeterminate_result,
@@ -2202,6 +2387,7 @@ def transition_shadowed_by_predecessor(
             prior_triggers.append(trigger)
             prior_domain_constraints.extend(trigger_domains or ())
             prior_payloads.append(current_payload)
+            prior_transitions.append(transition)
 
     if diagnostics:
         return AlgorithmResult(kind="unsat", diagnostics=tuple(diagnostics))
@@ -2340,65 +2526,55 @@ def _is_root_initial_leaf(state: State) -> bool:
     return _root_initial_path_transitions(state) is not None
 
 
-def enter_postcondition_implies_during_precondition(
+def _enter_condition_descriptors_for_context(
     state: State,
     variables: Sequence[VarDefine],
+    z3_vars: _Z3Vars,
+    init_constraints: Sequence[z3.ExprRef],
+    type_constraints: Sequence[z3.ExprRef],
+    first_cycle_operations: Sequence[OperationStatement],
+    context: _InitialPathContext,
     *,
     smt_timeout_ms: Optional[int] = None,
-) -> AlgorithmResult:
-    """Detect first-cycle during conditions determined by enter-time values.
+) -> Tuple[Optional[Set[Tuple[str, str, str]]], Optional[AlgorithmResult]]:
+    """Return branch descriptors determined in one initial-path context.
 
-    :param state: State to inspect.
+    :param state: Leaf state whose first-cycle during block is inspected.
     :type state: State
     :param variables: Variable definitions available to the model.
     :type variables: Sequence[VarDefine]
+    :param z3_vars: Root symbolic variables.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param init_constraints: DSL initializer constraints.
+    :type init_constraints: Sequence[z3.ExprRef]
+    :param type_constraints: Type-domain constraints.
+    :type type_constraints: Sequence[z3.ExprRef]
+    :param first_cycle_operations: Concrete first-cycle during operations.
+    :type first_cycle_operations: Sequence[OperationStatement]
+    :param context: One feasible root initial path context.
+    :type context: _InitialPathContext
     :param smt_timeout_ms: Optional solver timeout in milliseconds.
     :type smt_timeout_ms: Optional[int], optional
-    :return: Algorithm result.
-    :rtype: AlgorithmResult
+    :return: Determined ``(condition, source, branch_taken)`` descriptors or an
+        indeterminate algorithm result.
+    :rtype: Tuple[Optional[Set[Tuple[str, str, str]]], Optional[AlgorithmResult]]
     """
-    if not state.is_leaf_state or state.is_pseudo:
-        return AlgorithmResult(kind="sat")
-
-    z3_vars = _z3_vars(variables)
-    init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
-    if result is not None:
-        return result
-
-    init_transitions, entry_constraints, entry_operations, result = (
-        _root_initial_path_context(
-            state,
-            variables,
-            z3_vars,
-            init_constraints,
-            smt_timeout_ms=smt_timeout_ms,
-        )
-    )
-    if result is not None:
-        return result
-    if init_transitions is None:
-        return AlgorithmResult(kind="sat")
-
-    first_cycle_operations = _concrete_during_operations(state)
-    if not first_cycle_operations:
-        return AlgorithmResult(kind="sat")
-
-    type_constraints = _build_type_constraints(variables, z3_vars)
+    _ = variables, state
     context_constraints = [
         *init_constraints,
-        *(entry_constraints or ()),
+        *context.constraints,
         *type_constraints,
     ]
     _, entry_vars, entry_domain_constraints, result = (
         _execute_operation_prefix_conditions_and_vars_or_result(
-            entry_operations or (),
+            context.operations,
             z3_vars,
             context_constraints=context_constraints,
             smt_timeout_ms=smt_timeout_ms,
         )
     )
     if result is not None:
-        return result
+        return None, result
     context_constraints.extend(entry_domain_constraints or ())
 
     condition_points, _, _, result = (
@@ -2410,11 +2586,10 @@ def enter_postcondition_implies_during_precondition(
         )
     )
     if result is not None:
-        return result
+        return None, result
     if not condition_points:
-        return AlgorithmResult(kind="sat")
+        return set(), None
 
-    diagnostics: List[dict] = []
     first_indeterminate_result: Optional[AlgorithmResult] = None
 
     context_check = is_sat(
@@ -2428,7 +2603,9 @@ def enter_postcondition_implies_during_precondition(
             getattr(context_check, "reason", None),
         )
     if context_check.kind == "unsat":
-        return AlgorithmResult(kind="sat")
+        return set(), None
+
+    descriptors: Set[Tuple[str, str, str]] = set()
 
     for condition_point in condition_points:
         condition = condition_point.condition
@@ -2448,7 +2625,8 @@ def enter_postcondition_implies_during_precondition(
 
         point_context = [
             *init_constraints,
-            *(entry_constraints or ()),
+            *context.constraints,
+            *(entry_domain_constraints or ()),
             *condition_point.path_conditions,
             *type_constraints,
         ]
@@ -2476,29 +2654,9 @@ def enter_postcondition_implies_during_precondition(
         )
 
         if true_check.kind == "unsat":
-            diagnostics.append(
-                _make_diag(
-                    "I_ENTER_DURING_CONTRADICT",
-                    "enter_postcondition_implies_during_precondition",
-                    state=_state_path(state),
-                    condition=str(condition),
-                    condition_source=condition_point.source,
-                    branch_taken="false",
-                    verification_scope="smt_local",
-                )
-            )
+            descriptors.add((str(condition), condition_point.source, "false"))
         elif false_check.kind == "unsat":
-            diagnostics.append(
-                _make_diag(
-                    "I_ENTER_DURING_CONTRADICT",
-                    "enter_postcondition_implies_during_precondition",
-                    state=_state_path(state),
-                    condition=str(condition),
-                    condition_source=condition_point.source,
-                    branch_taken="true",
-                    verification_scope="smt_local",
-                )
-            )
+            descriptors.add((str(condition), condition_point.source, "true"))
         else:
             first_indeterminate_result = _first_indeterminate(
                 first_indeterminate_result,
@@ -2508,6 +2666,98 @@ def enter_postcondition_implies_during_precondition(
                 first_indeterminate_result,
                 false_check.kind,
             )
+
+    if first_indeterminate_result is not None and not descriptors:
+        return None, first_indeterminate_result
+    return descriptors, None
+
+
+def enter_postcondition_implies_during_precondition(
+    state: State,
+    variables: Sequence[VarDefine],
+    *,
+    smt_timeout_ms: Optional[int] = None,
+) -> AlgorithmResult:
+    """Detect first-cycle during conditions determined by enter-time values.
+
+    :param state: State to inspect.
+    :type state: State
+    :param variables: Variable definitions available to the model.
+    :type variables: Sequence[VarDefine]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Algorithm result.
+    :rtype: AlgorithmResult
+    """
+    if not state.is_leaf_state or state.is_pseudo:
+        return AlgorithmResult(kind="sat")
+
+    z3_vars = _z3_vars(variables)
+    init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
+    if result is not None:
+        return result
+
+    contexts, result = (
+        _root_initial_path_contexts(
+            state,
+            variables,
+            z3_vars,
+            init_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+    )
+    if result is not None:
+        return result
+    if contexts is None:
+        return AlgorithmResult(kind="sat")
+
+    first_cycle_operations = _concrete_during_operations(state)
+    if not first_cycle_operations:
+        return AlgorithmResult(kind="sat")
+
+    type_constraints = _build_type_constraints(variables, z3_vars)
+    first_indeterminate_result: Optional[AlgorithmResult] = None
+    common_descriptors: Optional[Set[Tuple[str, str, str]]] = None
+
+    for context in contexts:
+        descriptors, result = _enter_condition_descriptors_for_context(
+            state,
+            variables,
+            z3_vars,
+            init_constraints,
+            type_constraints,
+            first_cycle_operations,
+            context,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                result.kind,
+                result.reason,
+            )
+            common_descriptors = set()
+            continue
+        if common_descriptors is None:
+            common_descriptors = set(descriptors or ())
+        else:
+            common_descriptors &= set(descriptors or ())
+
+    diagnostics: List[dict] = []
+    for condition, condition_source, branch_taken in sorted(
+        common_descriptors or ()
+    ):
+        diagnostics.append(
+            _make_diag(
+                "I_ENTER_DURING_CONTRADICT",
+                "enter_postcondition_implies_during_precondition",
+                state=_state_path(state),
+                condition=condition,
+                condition_source=condition_source,
+                branch_taken=branch_taken,
+                verification_scope="smt_local",
+            )
+        )
 
     if diagnostics:
         return AlgorithmResult(kind="unsat", diagnostics=tuple(diagnostics))

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -312,6 +312,212 @@ def _execute_operations_or_result(
         return None, _skip_result("undecidable_skip", str(err))
 
 
+def _execute_operation_prefix_conditions_or_result(
+    operations: Sequence[OperationStatement],
+    z3_vars: _Z3Vars,
+) -> Tuple[Optional[Tuple[Tuple[Expr, _Z3Vars], ...]], Optional[AlgorithmResult]]:
+    """Collect condition expressions with the symbolic environment at each point.
+
+    :param operations: Operation statements to scan in execution order.
+    :type operations: Sequence[OperationStatement]
+    :param z3_vars: Starting symbolic environment before the operation block.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :return: Pairs of condition expression and point-in-time symbolic store, or
+        an algorithm result when symbolic prefix execution cannot be expressed.
+    :rtype: Tuple[Optional[Tuple[Tuple[Expr, Dict[str, Union[z3.ArithRef, z3.BoolRef]]], ...]], Optional[AlgorithmResult]]
+    """
+    pairs: List[Tuple[Expr, _Z3Vars]] = []
+    current_vars = dict(z3_vars)
+
+    for statement in operations:
+        if isinstance(statement, _operation_type()):
+            for condition in _conditional_conditions_from_expr(statement.expr):
+                pairs.append((condition, dict(current_vars)))
+            current_vars, result = _execute_operations_or_result(
+                [statement], current_vars
+            )
+            if result is not None:
+                return None, result
+            continue
+
+        if isinstance(statement, _if_block_type()):
+            for branch in statement.branches:
+                if branch.condition is not None:
+                    pairs.append((branch.condition, dict(current_vars)))
+                branch_pairs, result = _execute_operation_prefix_conditions_or_result(
+                    branch.statements,
+                    current_vars,
+                )
+                if result is not None:
+                    return None, result
+                pairs.extend(branch_pairs or ())
+
+            current_vars, result = _execute_operations_or_result(
+                [statement], current_vars
+            )
+            if result is not None:
+                return None, result
+            continue
+
+        return None, _skip_result(
+            "undecidable_skip",
+            f"Unknown operation statement type {type(statement)!r}.",
+        )
+
+    return tuple(pairs), None
+
+
+def _transition_trigger_or_result(
+    transition: Transition,
+    z3_vars: _Z3Vars,
+    event_vars: Optional[Dict[str, z3.BoolRef]] = None,
+) -> Tuple[Optional[z3.ExprRef], Optional[AlgorithmResult]]:
+    """Build a transition trigger expression in the supplied environment.
+
+    :param transition: Transition whose event and guard should be encoded.
+    :type transition: Transition
+    :param z3_vars: Symbolic variable environment at the trigger point.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param event_vars: Optional shared event boolean variable mapping.
+    :type event_vars: Optional[Dict[str, z3.BoolRef]], optional
+    :return: Trigger expression and optional failure result.
+    :rtype: Tuple[Optional[z3.ExprRef], Optional[AlgorithmResult]]
+    """
+    parts: List[z3.ExprRef] = []
+    if transition.event is not None:
+        event_key = _event_bool_name(transition)
+        if event_vars is None:
+            event_expr = z3.Bool(event_key)
+        else:
+            event_expr = event_vars.setdefault(event_key, z3.Bool(event_key))
+        parts.append(event_expr)
+
+    if transition.guard is not None:
+        guard_expr, result = _expr_to_z3_or_result(transition.guard, z3_vars)
+        if result is not None:
+            return None, result
+        parts.append(guard_expr)
+
+    if not parts:
+        return z3.BoolVal(True), None
+    if len(parts) == 1:
+        return parts[0], None
+    return z3.And(*parts), None
+
+
+def _root_initial_path_context(
+    state: State,
+    variables: Sequence[VarDefine],
+    z3_vars: _Z3Vars,
+    base_constraints: Sequence[z3.ExprRef],
+    *,
+    smt_timeout_ms: Optional[int] = None,
+) -> Tuple[
+    Optional[Tuple[Transition, ...]],
+    Optional[Tuple[z3.ExprRef, ...]],
+    Optional[List[OperationStatement]],
+    Optional[AlgorithmResult],
+]:
+    """Build the runtime first-enabled initial path context for a leaf.
+
+    :param state: Candidate root-initial leaf state.
+    :type state: State
+    :param variables: FCSTM variable definitions.
+    :type variables: Sequence[VarDefine]
+    :param z3_vars: Root symbolic variables.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param base_constraints: Constraints that hold before root entry, usually
+        DSL declaration initializers.
+    :type base_constraints: Sequence[z3.ExprRef]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
+    :return: Initial transitions, path constraints, entry operation stream, and
+        optional algorithm result.  A ``None`` transition tuple without a result
+        means the state is not selected by the root first-enabled initial path.
+    :rtype: Tuple[Optional[Tuple[Transition, ...]], Optional[Tuple[z3.ExprRef, ...]], Optional[List[OperationStatement]], Optional[AlgorithmResult]]
+    """
+    path = _state_path_from_root(state)
+    if len(path) <= 1:
+        return (), (), [], None
+
+    selected: List[Transition] = []
+    constraints: List[z3.ExprRef] = []
+    operations: List[OperationStatement] = []
+    current_vars: _Z3Vars = dict(z3_vars)
+    type_constraints = _build_type_constraints(variables, z3_vars)
+
+    for index, path_state in enumerate(path[:-1]):
+        child = path[index + 1]
+        enter_ops = _action_operations(path_state.on_enters)
+        operations.extend(enter_ops)
+        current_vars, result = _execute_operations_or_result(enter_ops, current_vars)
+        if result is not None:
+            return None, None, None, result
+
+        if not path_state.is_leaf_state:
+            during_before_ops = _action_operations(
+                path_state.list_on_durings(aspect="before")
+            )
+            operations.extend(during_before_ops)
+            current_vars, result = _execute_operations_or_result(
+                during_before_ops,
+                current_vars,
+            )
+            if result is not None:
+                return None, None, None, result
+
+        target_transition = None
+        selected_constraints = None
+        prior_triggers: List[z3.ExprRef] = []
+        for transition in path_state.init_transitions:
+            trigger, result = _transition_trigger_or_result(transition, current_vars)
+            if result is not None:
+                return None, None, None, result
+            if transition.to_state == child.name:
+                candidate_constraints = [
+                    *constraints,
+                    *(z3.Not(prior_trigger) for prior_trigger in prior_triggers),
+                    trigger,
+                ]
+                context_check = is_sat(
+                    [*base_constraints, *candidate_constraints, *type_constraints],
+                    timeout_ms=smt_timeout_ms,
+                )
+                if context_check.kind in {"unknown", "timeout"}:
+                    return (
+                        None,
+                        None,
+                        None,
+                        _skip_result(
+                            context_check.kind,
+                            getattr(context_check, "reason", None),
+                        ),
+                    )
+                if context_check.kind == "sat":
+                    target_transition = transition
+                    selected_constraints = candidate_constraints
+                    break
+            prior_triggers.append(trigger)
+
+        if target_transition is None or selected_constraints is None:
+            return None, None, None, None
+        constraints = selected_constraints
+
+        selected.append(target_transition)
+        operations.extend(target_transition.effects)
+        current_vars, result = _execute_operations_or_result(
+            target_transition.effects,
+            current_vars,
+        )
+        if result is not None:
+            return None, None, None, result
+
+    leaf_enter_ops = _action_operations(state.on_enters)
+    operations.extend(leaf_enter_ops)
+
+    return tuple(selected), tuple(constraints), operations, None
+
+
 def _build_init_constraints_or_result(
     variables: Sequence[VarDefine],
     z3_vars: _Z3Vars,
@@ -764,6 +970,7 @@ def transition_shadowed_by_predecessor(
                         )
                     )
                     continue
+
                 prior_unconditional = transition
                 continue
 
@@ -959,11 +1166,7 @@ def _root_initial_path_transitions(state: State) -> Optional[Tuple[Transition, .
     transitions: List[Transition] = []
     for parent, child in zip(path, path[1:]):
         transition = next(
-            (
-                item
-                for item in parent.init_transitions
-                if item.to_state == child.name
-            ),
+            (item for item in parent.init_transitions if item.to_state == child.name),
             None,
         )
         if transition is None:
@@ -981,40 +1184,6 @@ def _is_root_initial_leaf(state: State) -> bool:
     :rtype: bool
     """
     return _root_initial_path_transitions(state) is not None
-
-
-def _root_initial_entry_operations(
-    state: State,
-    init_transitions: Sequence[Transition],
-) -> List[OperationStatement]:
-    """Collect first-entry operations from the root through ``state``.
-
-    The order mirrors :class:`pyfcstm.simulate.runtime.SimulationRuntime` for a
-    root initial entry: each entered state executes its ``enter`` actions, a
-    composite then executes local ``during before`` actions, then the selected
-    initial transition effect runs before entering the child.  Leaf ``during``
-    and cross-cutting ``>> during before`` aspect actions are intentionally left
-    to the caller because they form the first-cycle condition being inspected.
-
-    :param state: Leaf state reached by the initial chain.
-    :type state: State
-    :param init_transitions: Initial transition chain returned by
-        :func:`_root_initial_path_transitions`.
-    :type init_transitions: Sequence[Transition]
-    :return: Flattened operation stream before first leaf during.
-    :rtype: List[OperationStatement]
-    """
-    path = _state_path_from_root(state)
-    operations: List[OperationStatement] = []
-    for index, path_state in enumerate(path):
-        operations.extend(_action_operations(path_state.on_enters))
-        if not path_state.is_leaf_state:
-            operations.extend(
-                _action_operations(path_state.list_on_durings(aspect="before"))
-            )
-        if index < len(init_transitions):
-            operations.extend(init_transitions[index].effects)
-    return operations
 
 
 def enter_postcondition_implies_during_precondition(
@@ -1036,35 +1205,32 @@ def enter_postcondition_implies_during_precondition(
     """
     if not state.is_leaf_state or state.is_pseudo:
         return AlgorithmResult(kind="sat")
-    init_transitions = _root_initial_path_transitions(state)
-    if init_transitions is None:
-        return AlgorithmResult(kind="sat")
-
-    entry_operations = _root_initial_entry_operations(state, init_transitions)
-    before_aspect_operations = _concrete_before_aspect_operations(state)
-    during_operations = _action_operations(state.on_durings)
-    if not during_operations:
-        return AlgorithmResult(kind="sat")
-
-    conditions = tuple(_conditional_conditions_from_operations(during_operations))
-    if not conditions:
-        return AlgorithmResult(kind="sat")
 
     z3_vars = _z3_vars(variables)
     init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
     if result is not None:
         return result
-    entry_constraints: List[z3.ExprRef] = []
-    for transition in init_transitions:
-        if transition.event is not None:
-            entry_constraints.append(z3.Bool(_event_bool_name(transition)))
-        if transition.guard is not None:
-            guard_z3, result = _expr_to_z3_or_result(transition.guard, z3_vars)
-            if result is not None:
-                return result
-            entry_constraints.append(guard_z3)
 
-    entry_vars, result = _execute_operations_or_result(entry_operations, z3_vars)
+    init_transitions, entry_constraints, entry_operations, result = (
+        _root_initial_path_context(
+            state,
+            variables,
+            z3_vars,
+            init_constraints,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+    )
+    if result is not None:
+        return result
+    if init_transitions is None:
+        return AlgorithmResult(kind="sat")
+
+    before_aspect_operations = _concrete_before_aspect_operations(state)
+    during_operations = _action_operations(state.on_durings)
+    if not during_operations:
+        return AlgorithmResult(kind="sat")
+
+    entry_vars, result = _execute_operations_or_result(entry_operations or (), z3_vars)
     if result is not None:
         return result
     first_cycle_vars, result = _execute_operations_or_result(
@@ -1074,12 +1240,21 @@ def enter_postcondition_implies_during_precondition(
     if result is not None:
         return result
 
+    condition_points, result = _execute_operation_prefix_conditions_or_result(
+        during_operations,
+        first_cycle_vars,
+    )
+    if result is not None:
+        return result
+    if not condition_points:
+        return AlgorithmResult(kind="sat")
+
     type_constraints = _build_type_constraints(variables, z3_vars)
     diagnostics: List[dict] = []
     first_indeterminate_result: Optional[AlgorithmResult] = None
 
     context_check = is_sat(
-        [*init_constraints, *entry_constraints, *type_constraints],
+        [*init_constraints, *(entry_constraints or ()), *type_constraints],
         timeout_ms=smt_timeout_ms,
     )
     if context_check.kind in {"unknown", "timeout"}:
@@ -1091,8 +1266,8 @@ def enter_postcondition_implies_during_precondition(
     if context_check.kind == "unsat":
         return AlgorithmResult(kind="sat")
 
-    for condition in conditions:
-        condition_z3, result = _expr_to_z3_or_result(condition, first_cycle_vars)
+    for condition, condition_vars in condition_points:
+        condition_z3, result = _expr_to_z3_or_result(condition, condition_vars)
         if result is not None:
             first_indeterminate_result = _first_indeterminate(
                 first_indeterminate_result,
@@ -1105,7 +1280,7 @@ def enter_postcondition_implies_during_precondition(
             [
                 condition_z3,
                 *init_constraints,
-                *entry_constraints,
+                *(entry_constraints or ()),
                 *type_constraints,
             ],
             timeout_ms=smt_timeout_ms,
@@ -1114,7 +1289,7 @@ def enter_postcondition_implies_during_precondition(
             [
                 z3.Not(condition_z3),
                 *init_constraints,
-                *entry_constraints,
+                *(entry_constraints or ()),
                 *type_constraints,
             ],
             timeout_ms=smt_timeout_ms,
@@ -1213,22 +1388,20 @@ def composite_init_guards_incomplete(
         triggers: List[z3.ExprRef] = []
         per_composite_failed = False
         for transition in init_transitions:
-            if transition.guard is not None:
-                guard_expr, result = _expr_to_z3_or_result(transition.guard, z3_vars)
-                if result is not None:
-                    first_indeterminate_result = _first_indeterminate(
-                        first_indeterminate_result,
-                        result.kind,
-                        result.reason,
-                    )
-                    per_composite_failed = True
-                    break
-                triggers.append(guard_expr)
-                continue
-
-            event_key = _event_bool_name(transition)
-            event_vars.setdefault(event_key, z3.Bool(event_key))
-            triggers.append(event_vars[event_key])
+            trigger, result = _transition_trigger_or_result(
+                transition,
+                z3_vars,
+                event_vars,
+            )
+            if result is not None:
+                first_indeterminate_result = _first_indeterminate(
+                    first_indeterminate_result,
+                    result.kind,
+                    result.reason,
+                )
+                per_composite_failed = True
+                break
+            triggers.append(trigger)
 
         if per_composite_failed or not triggers:
             continue

--- a/test/solver/test_expr.py
+++ b/test/solver/test_expr.py
@@ -11,14 +11,15 @@ import z3
 
 from pyfcstm.model.expr import (
     Integer, Float, Boolean, Variable,
-    BinaryOp, UnaryOp, ConditionalOp, UFunc, parse_expr
+    BinaryOp, UnaryOp, ConditionalOp, UFunc
 )
 from pyfcstm.model.model import VarDefine
 from pyfcstm.dsl.parse import parse_with_grammar_entry
 from pyfcstm.model.model import parse_dsl_node_to_state_machine
 from pyfcstm.solver.expr import (
     expr_to_z3,
-    create_z3_vars_from_models
+    create_z3_vars_from_models,
+    python_round_to_z3,
 )
 
 
@@ -284,6 +285,38 @@ class TestExprToZ3:
         solver.add(result_round == 4)
         solver.add(z3_vars['x'] == z3.RealVal(3.6))
         assert solver.check() == z3.sat
+
+    def test_rounding_functions_accept_boolean_operands(self):
+        """Legacy expression conversion coerces booleans for rounding helpers."""
+        for func in ("floor", "ceil", "trunc"):
+            result = expr_to_z3(UFunc(func=func, x=Boolean(True)), {})
+
+            assert result is not None
+
+    def test_sqrt_rejects_boolean_operand(self):
+        """sqrt reports unsupported Bool operands explicitly."""
+        with pytest.raises(NotImplementedError, match="sqrt requires Real or Int"):
+            expr_to_z3(UFunc(func="sqrt", x=Boolean(True)), {})
+
+    def test_python_round_to_z3_matches_half_even_for_int_and_real(self):
+        """Shared round helper follows Python half-even semantics."""
+        int_operand = z3.Int("round_int_operand")
+        real_operand = z3.Real("round_real_operand")
+
+        assert python_round_to_z3(int_operand) is int_operand
+
+        rounded = python_round_to_z3(real_operand)
+        for raw_value, expected in [
+            ("-2.5", -2),
+            ("-1.5", -2),
+            ("1.5", 2),
+            ("2.5", 2),
+            ("3.6", 4),
+        ]:
+            solver = z3.Solver()
+            solver.add(real_operand == z3.RealVal(raw_value), rounded != expected)
+
+            assert solver.check() == z3.unsat
 
     def test_math_function_sqrt(self):
         """Test square root function."""
@@ -701,7 +734,7 @@ class TestExprToZ3EdgeCases:
         expr_exp = BinaryOp(x=Integer(2), op='**', y=x_var)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result_exp = expr_to_z3(expr_exp, z3_vars)
+            assert expr_to_z3(expr_exp, z3_vars) is not None
             assert len(w) == 1
             assert "variable exponent" in str(w[0].message).lower()
 
@@ -709,7 +742,7 @@ class TestExprToZ3EdgeCases:
         expr_both = BinaryOp(x=x_var, op='**', y=y_var)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result_both = expr_to_z3(expr_both, z3_vars)
+            assert expr_to_z3(expr_both, z3_vars) is not None
             assert len(w) == 1
             assert "two variables" in str(w[0].message).lower()
 

--- a/test/solver/test_safety.py
+++ b/test/solver/test_safety.py
@@ -128,6 +128,31 @@ class TestPowerSafety:
 
 
 @pytest.mark.unittest
+class TestLinearArithmeticSafety:
+    """Test rejection of arithmetic outside the linear SMT envelope."""
+
+    def test_variable_multiplication_is_rejected(self):
+        """Variable-variable multiplication is nonlinear."""
+        expr = BinaryOp(Variable("x"), "*", Variable("y"))
+
+        assert assert_unsafe(expr, "nonlinear") is expr
+
+    def test_variable_denominator_is_rejected(self):
+        """Division and modulo by symbolic values leave linear arithmetic."""
+        div_expr = BinaryOp(Variable("x"), "/", Variable("y"))
+        mod_expr = BinaryOp(Variable("x"), "%", Variable("y"))
+
+        assert assert_unsafe(div_expr, "nonlinear") is div_expr
+        assert assert_unsafe(mod_expr, "nonlinear") is mod_expr
+
+    def test_constant_scaled_variable_is_accepted(self):
+        """Linear scalar multiplication and constant division stay accepted."""
+        assert_safe(BinaryOp(Variable("x"), "*", Integer(2)))
+        assert_safe(BinaryOp(Integer(2), "*", Variable("x")))
+        assert_safe(BinaryOp(Variable("x"), "/", Integer(2)))
+
+
+@pytest.mark.unittest
 class TestTraversalAndEffects:
     """Test traversal ordering and operation-block safety."""
 

--- a/test/solver/test_safety.py
+++ b/test/solver/test_safety.py
@@ -1,4 +1,4 @@
-"""Tests for solver expression safety classification."""
+"""Tests for optional solver expression policy classification."""
 
 from dataclasses import FrozenInstanceError
 

--- a/test/verify/test_registry.py
+++ b/test/verify/test_registry.py
@@ -42,14 +42,14 @@ def test_registry_contains_exactly_all_pr_a_algorithms_in_stable_order():
     assert len(REGISTRY) == 19
 
 
-def test_registry_keys_match_meta_names_and_pr_a3_impl_state():
+def test_registry_keys_match_meta_names_and_pr_a4_impl_state():
     assert not hasattr(REGISTRY, "__setitem__")
     assert len(set(REGISTRY)) == len(REGISTRY)
     for name, meta in REGISTRY.items():
         assert meta.name == name
         assert meta.description
         assert meta.quantifier_alternation_depth == 0
-        if name in GROUP1_TOPOLOGY:
+        if name in GROUP1_TOPOLOGY or name in GROUP2_SMT_LOCAL:
             assert meta.impl is not None
         else:
             assert meta.impl is None
@@ -310,6 +310,5 @@ def test_verify_package_does_not_create_later_algorithm_modules():
     forbidden_paths = (
         "pyfcstm/verify/search.py",
         "pyfcstm/verify/reachability.py",
-        "pyfcstm/verify/smt_local.py",
     )
     assert [path for path in forbidden_paths if pathlib.Path(path).exists()] == []

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -2233,6 +2233,41 @@ class TestEffectContradictsGuard:
         assert result.kind == "undecidable_skip"
         assert "runtime definedness" in result.reason
 
+    def test_post_guard_runtime_undefined_after_effect_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 1;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [1 / x > 0] effect { x = 0; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
+    def test_post_guard_runtime_defined_after_effect_is_not_contradiction(self):
+        machine = parse_machine(
+            """
+            def int x = 1;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [1 / x > 0] effect { x = 1; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
     def test_guard_prunes_unselected_ternary_value_for_guard_contradiction(self):
         machine = parse_machine(
             """
@@ -2495,6 +2530,27 @@ class TestTransitionShadowedByPredecessor:
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
         assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
+    def test_prior_guard_undefined_in_candidate_space_is_not_shadow(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [1 / x > 0];
+                A -> C : if [x == 0];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert result.diagnostics == ()
         assert "runtime definedness" in result.reason
 
     def test_current_guard_translation_failure_propagates(self, monkeypatch):

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -19,7 +19,14 @@ from pyfcstm.verify.smt_local import (
     transition_shadowed_by_predecessor,
 )
 from pyfcstm.model.expr import BinaryOp, Boolean, Integer, Variable
-from pyfcstm.model.model import IfBlock, IfBlockBranch, Operation, Transition, VarDefine
+from pyfcstm.model.model import (
+    Event,
+    IfBlock,
+    IfBlockBranch,
+    Operation,
+    Transition,
+    VarDefine,
+)
 
 
 pytestmark = pytest.mark.unittest
@@ -76,6 +83,13 @@ def sat_timeout_result(*args, **kwargs):
     from pyfcstm.solver.logical import SatResult
 
     return SatResult(kind="timeout")
+
+
+def sat_unknown_result(*args, **kwargs):
+    """Deterministic unknown-shaped logical helper result."""
+    from pyfcstm.solver.logical import SatResult
+
+    return SatResult(kind="unknown")
 
 
 def assert_single_diag(result, code):
@@ -375,6 +389,149 @@ def test_conditional_collection_includes_if_block_conditions():
     )
 
 
+def test_operation_prefix_collection_updates_after_if_block():
+    """Prefix condition collection uses the merged store after operation ifs."""
+    condition = BinaryOp(Variable("mode"), "==", Integer(0))
+    ternary_condition = BinaryOp(Variable("mode"), "==", Integer(1))
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=condition,
+                    statements=[Operation(var_name="mode", expr=Integer(1))],
+                ),
+                IfBlockBranch(
+                    condition=None,
+                    statements=[Operation(var_name="mode", expr=Integer(2))],
+                ),
+            ]
+        ),
+        Operation(
+            var_name="x",
+            expr=ternary_condition.select(Integer(10), Integer(20)),
+        ),
+    ]
+    z3_vars = smt_local._z3_vars(
+        [
+            VarDefine("mode", "int", Integer(0)),
+            VarDefine("x", "int", Integer(0)),
+        ]
+    )
+
+    condition_points, result = smt_local._execute_operation_prefix_conditions_or_result(
+        operations,
+        z3_vars,
+    )
+
+    assert result is None
+    assert condition_points is not None
+    assert [condition for condition, _ in condition_points] == [
+        condition,
+        ternary_condition,
+    ]
+    assert str(condition_points[1][1]["mode"]) in {
+        "If(mode == 0, 1, 2)",
+        "If(0 == mode, 1, 2)",
+    }
+
+
+def test_operation_prefix_collection_propagates_branch_body_failure():
+    """Nested branch symbolic failures stop prefix condition collection."""
+    condition = BinaryOp(Variable("x"), ">", Integer(0))
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=condition,
+                    statements=[Operation(var_name="x", expr=Variable("missing"))],
+                )
+            ]
+        )
+    ]
+
+    condition_points, result = smt_local._execute_operation_prefix_conditions_or_result(
+        operations,
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert condition_points is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_operation_prefix_collection_propagates_if_merge_failure():
+    """The final symbolic if merge can fail after branch scanning succeeds."""
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=Variable("missing"),
+                    statements=[],
+                )
+            ]
+        )
+    ]
+
+    condition_points, result = smt_local._execute_operation_prefix_conditions_or_result(
+        operations,
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert condition_points is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_operation_prefix_collection_rejects_unknown_statement_type():
+    """Unknown operation statement objects are normalized as undecidable."""
+    condition_points, result = smt_local._execute_operation_prefix_conditions_or_result(
+        [object()],
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert condition_points is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_transition_trigger_builds_private_event_bool_when_no_mapping_given():
+    """Trigger construction can create standalone event predicates."""
+    transition = Transition(
+        from_state="A",
+        to_state="B",
+        event=Event("Tick", ("System",)),
+        guard=None,
+        effects=[],
+    )
+
+    trigger, result = smt_local._transition_trigger_or_result(transition, {})
+
+    assert result is None
+    assert str(trigger) == "__event__System__Tick"
+
+
+def test_root_initial_context_handles_root_state_directly():
+    """A root-only helper call has an empty initial path context."""
+    machine = parse_machine(
+        """
+        state System {
+            state Idle;
+            [*] -> Idle;
+        }
+        """
+    )
+
+    z3_vars = smt_local._z3_vars(variables(machine))
+    transitions, constraints, operations, result = smt_local._root_initial_path_context(
+        machine.root_state,
+        variables(machine),
+        z3_vars,
+        (),
+    )
+
+    assert result is None
+    assert transitions == ()
+    assert constraints == ()
+    assert operations == []
+
+
 def test_root_initial_leaf_helper_identifies_global_initial_path():
     """Lifecycle first-cycle analysis only pins the global initial leaf."""
     machine = parse_machine(
@@ -428,6 +585,15 @@ def test_group2_algorithms_default_to_unbounded_solver_timeout():
         )
 
         assert default is None
+
+
+def test_first_indeterminate_keeps_first_relevant_outcome():
+    """Aggregate helper ignores definite results after first indeterminate."""
+    current = smt_local._first_indeterminate(None, "sat")
+    current = smt_local._first_indeterminate(current, "unknown", "first")
+
+    assert current == AlgorithmResult(kind="unknown", reason="first")
+    assert smt_local._first_indeterminate(current, "timeout", "later") is current
 
 
 class TestDeadGuard:
@@ -942,6 +1108,49 @@ class TestEffectNoOpUnderGuard:
 
         assert result.kind == "undecidable_skip"
 
+    def test_guard_translation_failure_propagates(self):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=BinaryOp(Variable("missing"), ">", Integer(0)),
+            effects=[
+                Operation(var_name="x", expr=BinaryOp(Variable("x"), "+", Integer(1)))
+            ],
+        )
+
+        result = effect_no_op_under_guard(
+            transition,
+            [VarDefine("x", "int", Integer(0))],
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_guard_feasibility_unknown_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0] effect { x = x + 1; };
+            }
+            """
+        )
+        calls = []
+
+        def feasible_unknown(*args, **kwargs):
+            calls.append(args)
+            return sat_unknown_result(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", feasible_unknown)
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="unknown")
+        assert len(calls) == 1
+
     def test_effect_translation_failure_propagates(self):
         transition = Transition(
             from_state="A",
@@ -1093,6 +1302,107 @@ class TestEffectContradictsGuard:
         result = effect_contradicts_guard(root_transition(machine), variables(machine))
 
         assert result == AlgorithmResult(kind="sat")
+
+    def test_guard_before_translation_failure_propagates(self):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=BinaryOp(Variable("missing"), ">", Integer(0)),
+            effects=[Operation(var_name="x", expr=Integer(0))],
+        )
+
+        result = effect_contradicts_guard(
+            transition,
+            [VarDefine("x", "int", Integer(0))],
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_guard_after_translation_failure_propagates(self):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=BinaryOp(Variable("tmp"), ">", Integer(0)),
+            effects=[Operation(var_name="x", expr=Integer(0))],
+        )
+
+        result = effect_contradicts_guard(
+            transition,
+            [VarDefine("x", "int", Integer(0))],
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_guard_after_retranslation_failure_propagates(self):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=BinaryOp(Variable("tmp"), ">", Integer(0)),
+            effects=[Operation(var_name="tmp", expr=Integer(1))],
+        )
+
+        result = effect_contradicts_guard(
+            transition,
+            [VarDefine("x", "int", Integer(0))],
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_guard_after_translation_failure_after_symbolic_execution_propagates(
+        self,
+        monkeypatch,
+    ):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=BinaryOp(Variable("x"), ">", Integer(0)),
+            effects=[Operation(var_name="x", expr=Integer(1))],
+        )
+
+        def drop_guard_variable(*args, **kwargs):
+            return {}, None
+
+        monkeypatch.setattr(
+            smt_local,
+            "_execute_operations_or_result",
+            drop_guard_variable,
+        )
+
+        result = effect_contradicts_guard(
+            transition,
+            [VarDefine("x", "int", Integer(0))],
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_guard_feasibility_unknown_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [counter > 0] effect { counter = counter + 1; };
+            }
+            """
+        )
+        calls = []
+
+        def feasible_unknown(*args, **kwargs):
+            calls.append(args)
+            return sat_unknown_result(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", feasible_unknown)
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="unknown")
+        assert len(calls) == 1
 
     def test_effect_translation_failure_propagates(self):
         transition = Transition(
@@ -1331,6 +1641,26 @@ class TestTransitionShadowedByPredecessor:
 
         assert result == AlgorithmResult(kind="sat")
 
+    def test_second_unconditional_transition_is_shadowed(self):
+        machine = parse_machine(
+            """
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B;
+                A -> C;
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+        assert diag["data"]["reason"] == "unconditional_catchall"
+
 
 class TestEnterPostconditionImpliesDuringPrecondition:
     """Test first-cycle lifecycle coupling checks."""
@@ -1498,6 +1828,398 @@ class TestEnterPostconditionImpliesDuringPrecondition:
 
         assert result.kind == "undecidable_skip"
 
+    def test_no_during_operations_returns_sat(self):
+        machine = parse_machine(
+            """
+            state System {
+                state Idle;
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_init_context_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle : if [mode == 1];
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_init_path_entry_translation_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                enter { mode = 1; }
+                state Idle {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        machine.root_state.on_enters[0].operations = [
+            Operation(var_name="mode", expr=Variable("missing"))
+        ]
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_init_path_during_before_translation_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Parent {
+                    during before { mode = 1; }
+                    state Child {
+                        during { x = (mode == 1) ? 10 : 20; }
+                    }
+                    [*] -> Child;
+                }
+                [*] -> Parent;
+            }
+            """
+        )
+        parent = machine.root_state.substates["Parent"]
+        parent.on_durings[0].operations = [
+            Operation(var_name="mode", expr=Variable("missing"))
+        ]
+        state = parent.substates["Child"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_init_transition_guard_translation_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle : if [mode == 1];
+            }
+            """
+        )
+        machine.root_state.init_transitions[0].guard = BinaryOp(
+            Variable("missing"), "==", Integer(1)
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_init_transition_effect_translation_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle effect { mode = 1; };
+            }
+            """
+        )
+        machine.root_state.init_transitions[0].effects = [
+            Operation(var_name="mode", expr=Variable("missing"))
+        ]
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_context_unknown_without_diagnostic_is_returned(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int external = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (external > mode) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        monkeypatch.setattr(smt_local, "is_sat", sat_unknown_result)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="unknown")
+
+    def test_context_unknown_takes_precedence_when_no_diagnostic(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def context_unknown_then_sat(*args, **kwargs):
+            calls.append(args)
+            if len(calls) == 2:
+                return sat_unknown_result(*args, **kwargs)
+            from pyfcstm.solver.logical import SatResult
+
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", context_unknown_then_sat)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="unknown")
+        assert len(calls) == 4
+
+    def test_unsatisfiable_entry_context_short_circuits_before_conditions(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle : if [mode == 1];
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_entry_context_unsat_short_circuits_after_condition_collection(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def context_unsat_then_sat(*args, **kwargs):
+            calls.append(args)
+            from pyfcstm.solver.logical import SatResult
+
+            return SatResult(kind="unsat" if len(calls) == 2 else "sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", context_unsat_then_sat)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+        assert len(calls) == 2
+
+    def test_during_condition_translation_failure_after_prefix_execution(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        x = (mode == 1) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        state.on_durings[0].operations[0].expr.cond = BinaryOp(
+            Variable("temp"),
+            "==",
+            Integer(1),
+        )
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_condition_translation_failure_inside_condition_loop_is_aggregated(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        def missing_condition_point(*args, **kwargs):
+            return (
+                (
+                    (
+                        BinaryOp(Variable("missing"), "==", Integer(1)),
+                        smt_local._z3_vars(variables(machine)),
+                    ),
+                ),
+                None,
+            )
+
+        monkeypatch.setattr(
+            smt_local,
+            "_execute_operation_prefix_conditions_or_result",
+            missing_condition_point,
+        )
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_condition_translation_failure_returns_first_prior_indeterminate(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        x = (mode == 0) ? 10 : 20;
+                        x = (mode == 1) ? 30 : 40;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        state.on_durings[0].operations[1].expr.cond = BinaryOp(
+            Variable("missing"),
+            "==",
+            Integer(1),
+        )
+
+        def always_unknown(*args, **kwargs):
+            return sat_unknown_result(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", always_unknown)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="unknown")
+
+    def test_during_if_block_prefix_feeds_following_condition(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 0] {
+                            mode = 1;
+                        } else {
+                            mode = 2;
+                        }
+                        x = (mode == 1) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        assert any(
+            diag["code"] == "I_ENTER_DURING_CONTRADICT"
+            and diag["data"]["condition"] == "mode == 1"
+            and diag["data"]["branch_taken"] == "true"
+            for diag in result.diagnostics
+        )
+
     def test_enter_translation_failure_propagates(self):
         machine = parse_machine(
             """
@@ -1599,7 +2321,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
 
         def both_branches_feasible(constraints, **kwargs):
             calls.append(tuple(constraints))
-            if len(calls) in {1, 2}:
+            if len(calls) in {1, 2, 3}:
                 return SatResult(kind="sat")
             return real_is_sat(constraints, **kwargs)
 
@@ -1610,7 +2332,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="sat")
-        assert len(calls) == 3
+        assert len(calls) == 4
 
     def test_ancestor_before_aspect_feeds_first_during_condition(self):
         machine = parse_machine(
@@ -1700,6 +2422,106 @@ class TestEnterPostconditionImpliesDuringPrecondition:
                     enter { x = 0; }
                     during { x = (mode == 1) ? 10 : 20; }
                 }
+                [*] -> Idle effect { mode = 1; };
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_during_prefix_assignment_feeds_following_condition(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        mode = 1;
+                        x = (mode == 1) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_nested_init_guard_uses_parent_entry_context(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                enter { mode = 1; }
+                state Parent {
+                    state Child {
+                        during { x = (mode == 1) ? 10 : 20; }
+                    }
+                    [*] -> Child : if [mode == 1];
+                }
+                [*] -> Parent;
+            }
+            """
+        )
+        state = machine.root_state.substates["Parent"].substates["Child"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_later_shadowed_init_transition_target_is_not_root_initial(self):
+        machine = parse_machine(
+            """
+            def int mode = 1;
+            def int x = 0;
+            state System {
+                state A;
+                state B {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> A;
+                [*] -> B;
+            }
+            """
+        )
+        state = machine.root_state.substates["B"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_second_same_target_init_transition_can_be_selected(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle : if [mode == 1] effect { mode = 0; };
                 [*] -> Idle effect { mode = 1; };
             }
             """
@@ -1880,6 +2702,78 @@ class TestCompositeInitGuardsIncomplete:
 
         assert result == AlgorithmResult(kind="unsat")
 
+    def test_ignores_composites_without_init_transitions(self):
+        machine = parse_machine(
+            """
+            state System {
+                state Parent {
+                    state Child;
+                    [*] -> Child;
+                }
+                [*] -> Parent;
+            }
+            """
+        )
+        machine.root_state.substates["Parent"].init_transitions.clear()
+        machine.root_state.substates["Parent"].transitions.clear()
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="unsat")
+
+    def test_ignores_composite_without_init_transitions_with_prior_timeout(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state Parent {
+                    state Child;
+                    [*] -> Child;
+                }
+                [*] -> A : if [x > 0];
+                [*] -> B : if [x < 0];
+            }
+            """
+        )
+        machine.root_state.substates["Parent"].init_transitions.clear()
+        machine.root_state.substates["Parent"].transitions.clear()
+        calls = []
+
+        def timeout_once(*args, **kwargs):
+            calls.append(args)
+            return sat_timeout_result(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", timeout_once)
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="timeout")
+        assert len(calls) == 1
+
+    def test_event_only_transition_uses_fresh_event_boolean(self):
+        machine = parse_machine(
+            """
+            state System {
+                event Tick;
+                state A;
+                state B;
+                [*] -> A : Tick;
+                [*] -> B : Tick;
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        diag = assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+        assert diag["data"]["state"] == "System"
+
     def test_does_not_trigger_for_complete_guard_coverage(self):
         machine = parse_machine(
             """
@@ -1914,6 +2808,27 @@ class TestCompositeInitGuardsIncomplete:
         result = composite_init_guards_incomplete(machine, variables(machine))
 
         assert result == AlgorithmResult(kind="timeout")
+
+    def test_internal_guarded_event_init_transition_requires_both_triggers(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A : if [x >= 0];
+                [*] -> B : if [x < 0];
+            }
+            """
+        )
+        transition = machine.root_state.init_transitions[0]
+        transition.event = Event("E", machine.root_state.path)
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        diag = assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+        assert diag["data"]["state"] == "System"
 
     def test_bitwise_init_guard_translation_failure_is_undecidable(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -3,7 +3,6 @@
 from textwrap import dedent
 
 import pytest
-
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.verify import smt_local
@@ -19,8 +18,8 @@ from pyfcstm.verify.smt_local import (
     guard_tautology,
     transition_shadowed_by_predecessor,
 )
-from pyfcstm.model.expr import BinaryOp, Integer, Variable
-from pyfcstm.model.model import IfBlock, IfBlockBranch, Operation, Transition
+from pyfcstm.model.expr import BinaryOp, Boolean, Integer, Variable
+from pyfcstm.model.model import IfBlock, IfBlockBranch, Operation, Transition, VarDefine
 
 
 pytestmark = pytest.mark.unittest
@@ -51,6 +50,11 @@ def variables(machine):
 def root_transition(machine, index=-1):
     """Return one root-scope transition."""
     return machine.root_state.transitions[index]
+
+
+def init_transition(machine):
+    """Return the first root-scope initial transition."""
+    return machine.root_state.init_transitions[0]
 
 
 def transition_by_guard(machine, text):
@@ -97,6 +101,21 @@ def test_raw_transition_payload_covers_root_transition_without_event():
     assert payload["from_state"] == "System"
     assert payload["to_state"] == "[*]"
     assert payload["event"] is None
+
+
+def test_raw_transition_payload_includes_guard_text():
+    """Guarded transition payloads preserve a readable guard string."""
+    transition = Transition(
+        from_state="A",
+        to_state="B",
+        event=None,
+        guard=BinaryOp(Variable("x"), "&&", Boolean(True)),
+        effects=[],
+    )
+
+    payload = smt_local._transition_payload(transition)
+
+    assert payload["guard"] == "x && True"
 
 
 def test_expected_expression_translation_failures_are_normalized():
@@ -182,6 +201,23 @@ def test_operation_translation_z3_exception_is_undecidable_skip(monkeypatch):
     assert result.kind == "undecidable_skip"
 
 
+def test_expected_operation_type_failures_are_normalized(monkeypatch):
+    """Documented operation type failures become undecidable skips."""
+
+    def raise_type_error(*args, **kwargs):
+        raise TypeError("unsupported symbolic operation")
+
+    monkeypatch.setattr(smt_local, "execute_operations", raise_type_error)
+
+    value, result = smt_local._execute_operations_or_result(
+        [Operation(var_name="x", expr=Integer(1))],
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert value is None
+    assert result.kind == "undecidable_skip"
+
+
 def test_init_constraint_translation_failure_is_normalized():
     """Invalid variable initializers become an algorithm result."""
     machine = parse_machine(
@@ -203,6 +239,28 @@ def test_init_constraint_translation_failure_is_normalized():
 
     assert value is None
     assert result.kind == "undecidable_skip"
+
+
+def test_unsafe_initializers_skip_before_translation():
+    """Unsafe DSL initializers are reported instead of crashing in Z3."""
+    machine = parse_machine(
+        """
+        def int flags = 1 << 2;
+        state System {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+
+    constraints, result = smt_local._build_init_constraints_or_result(
+        variables(machine),
+        {"flags": smt_local.z3.Int("flags")},
+    )
+
+    assert constraints is None
+    assert result.kind == "unsafe_skip"
+    assert result.reason == "bitwise"
 
 
 def test_guard_translation_failure_is_normalized():
@@ -289,6 +347,23 @@ def test_conditional_collection_includes_if_block_conditions():
     )
 
 
+def test_root_initial_leaf_helper_identifies_global_initial_path():
+    """Lifecycle first-cycle analysis only pins the global initial leaf."""
+    machine = parse_machine(
+        """
+        state System {
+            state Idle;
+            state Active;
+            [*] -> Idle;
+            Idle -> Active;
+        }
+        """
+    )
+
+    assert smt_local._is_root_initial_leaf(machine.root_state.substates["Idle"])
+    assert not smt_local._is_root_initial_leaf(machine.root_state.substates["Active"])
+
+
 def test_event_bool_name_falls_back_for_anonymous_transition():
     """Internal event-bool naming has a deterministic anonymous fallback."""
     transition = Transition("A", "B", event=None, guard=None, effects=[])
@@ -315,8 +390,34 @@ def test_group2_registry_impls_are_real_function_pointers():
         assert REGISTRY[name].impl is expected_impls[name]
 
 
+def test_group2_algorithms_default_to_unbounded_solver_timeout():
+    """Raw PR-A4 functions follow the PR-A2 ``None`` timeout contract."""
+    import inspect
+
+    for name in GROUP2_SMT_LOCAL:
+        default = (
+            inspect.signature(REGISTRY[name].impl).parameters["smt_timeout_ms"].default
+        )
+
+        assert default is None
+
+
 class TestDeadGuard:
     """Test dead guard detection."""
+
+    def test_ignores_unguarded_transitions(self):
+        machine = parse_machine(
+            """
+            state System {
+                state A;
+                [*] -> A;
+            }
+            """
+        )
+
+        result = dead_guard(init_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_triggers_for_unsatisfiable_guard(self):
         machine = parse_machine(
@@ -391,9 +492,42 @@ class TestDeadGuard:
         assert result.kind == "unsafe_skip"
         assert result.reason == "bitwise"
 
+    def test_non_linear_variable_multiplication_is_unsafe_skip(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x * y > 1 && x * y < 0];
+            }
+            """
+        )
+
+        result = dead_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "nonlinear"
+
 
 class TestGuardTautology:
     """Test tautological guard detection."""
+
+    def test_ignores_unguarded_transitions(self):
+        machine = parse_machine(
+            """
+            state System {
+                state A;
+                [*] -> A;
+            }
+            """
+        )
+
+        result = guard_tautology(init_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_triggers_for_tautological_guard(self):
         machine = parse_machine(
@@ -472,6 +606,26 @@ class TestGuardTautology:
 class TestForcedGuardUnsatUnderInit:
     """Test forced transition guard checks under initial values."""
 
+    def test_ignores_non_forced_transition(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0];
+            }
+            """
+        )
+
+        result = forced_guard_unsat_under_init(
+            root_transition(machine),
+            variables(machine),
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
     def test_triggers_for_forced_guard_false_at_init(self):
         machine = parse_machine(
             """
@@ -495,7 +649,8 @@ class TestForcedGuardUnsatUnderInit:
         result = forced_guard_unsat_under_init(transition, variables(machine))
 
         assert result.kind == "unsat"
-        assert_single_diag(result, "W_FORCED_GUARD_UNSAT")
+        diag = assert_single_diag(result, "W_FORCED_GUARD_UNSAT")
+        assert diag["data"]["scope"] == "dsl_def_init_only"
 
     def test_does_not_trigger_when_forced_guard_true_at_init(self):
         machine = parse_machine(
@@ -575,9 +730,71 @@ class TestForcedGuardUnsatUnderInit:
         assert result.kind == "unsafe_skip"
         assert result.reason == "bitwise"
 
+    def test_forced_init_translation_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            def int threshold = 0;
+            state System {
+                state A {
+                    state Sub1;
+                    state Sub2;
+                    [*] -> Sub1;
+                    Sub1 -> Sub2;
+                }
+                state B;
+                [*] -> A;
+                !A -> B : if [counter > threshold];
+            }
+            """
+        )
+        var_def = machine.defines["threshold"]
+        var_def.init = Variable("missing")
+
+        result = forced_guard_unsat_under_init(
+            transition_by_guard(machine, "counter > threshold"),
+            variables(machine),
+        )
+
+        assert result.kind == "undecidable_skip"
+
 
 class TestEffectNoOpUnderGuard:
     """Test semantic no-op effect checks."""
+
+    def test_ignores_transitions_without_effects(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0];
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_ignores_syntactic_self_assignment(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0] effect { x = x; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_triggers_for_semantic_no_op_effect(self):
         machine = parse_machine(
@@ -598,6 +815,23 @@ class TestEffectNoOpUnderGuard:
         assert result.kind == "unsat"
         assert_single_diag(result, "W_EFFECT_SMT_NO_OP")
 
+    def test_dead_guard_case_does_not_emit_no_op_diagnostic(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0 && x < 0] effect { x = x + 1; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
     def test_does_not_trigger_when_effect_can_change_state(self):
         machine = parse_machine(
             """
@@ -612,6 +846,38 @@ class TestEffectNoOpUnderGuard:
         )
 
         result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_no_guard_semantic_no_op_triggers(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B effect { x = x + y - y; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "W_EFFECT_SMT_NO_OP")
+
+    def test_zero_variable_effect_block_does_not_report_no_op(self):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=None,
+            effects=[Operation(var_name="tmp", expr=Integer(1))],
+        )
+
+        result = effect_no_op_under_guard(transition, ())
 
         assert result == AlgorithmResult(kind="sat")
 
@@ -651,9 +917,59 @@ class TestEffectNoOpUnderGuard:
         assert result.kind == "unsafe_skip"
         assert result.reason == "bitwise"
 
+    def test_effect_translation_failure_propagates(self):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=None,
+            effects=[Operation(var_name="x", expr=Variable("missing"))],
+        )
+
+        result = effect_no_op_under_guard(
+            transition,
+            [VarDefine("x", "int", Integer(0))],
+        )
+
+        assert result.kind == "undecidable_skip"
+
 
 class TestEffectContradictsGuard:
     """Test effect/guard contradiction checks."""
+
+    def test_ignores_unguarded_transitions(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B effect { x = x + 1; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_ignores_transitions_without_effects(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0];
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_triggers_when_effect_makes_guard_false(self):
         machine = parse_machine(
@@ -754,9 +1070,39 @@ class TestEffectContradictsGuard:
         assert result.kind == "unsafe_skip"
         assert result.reason == "double_var_power"
 
+    def test_effect_translation_failure_propagates(self):
+        transition = Transition(
+            from_state="A",
+            to_state="B",
+            event=None,
+            guard=BinaryOp(Variable("x"), ">", Integer(0)),
+            effects=[Operation(var_name="x", expr=Variable("missing"))],
+        )
+
+        result = effect_contradicts_guard(
+            transition,
+            [VarDefine("x", "int", Integer(0))],
+        )
+
+        assert result.kind == "undecidable_skip"
+
 
 class TestTransitionShadowedByPredecessor:
     """Test transition shadowing detection."""
+
+    def test_empty_transition_sets_are_sat(self):
+        machine = parse_machine(
+            """
+            state System {
+                state A;
+                [*] -> A;
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_triggers_for_guard_shadowing(self):
         machine = parse_machine(
@@ -838,6 +1184,71 @@ class TestTransitionShadowedByPredecessor:
         assert result.kind == "unsafe_skip"
         assert result.reason == "bitwise"
 
+    def test_current_guard_translation_failure_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 0];
+                A -> C : if [x <= 5];
+            }
+            """
+        )
+        calls = []
+        real_expr_to_z3 = smt_local.expr_to_z3
+
+        def fail_on_second_guard(expr, z3_vars):
+            if str(expr) == "x <= 5":
+                calls.append(expr)
+                raise ValueError("synthetic current guard failure")
+            return real_expr_to_z3(expr, z3_vars)
+
+        monkeypatch.setattr(smt_local, "expr_to_z3", fail_on_second_guard)
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert calls
+        assert result.kind == "undecidable_skip"
+
+    def test_prior_guard_translation_failure_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 0];
+                A -> C : if [x <= 5];
+            }
+            """
+        )
+        calls = []
+        real_expr_to_z3 = smt_local.expr_to_z3
+
+        def fail_when_prior_guard_is_retranslated(expr, z3_vars):
+            if str(expr) == "x > 0":
+                calls.append(expr)
+                if len(calls) >= 2:
+                    raise ValueError("synthetic prior guard failure")
+            return real_expr_to_z3(expr, z3_vars)
+
+        monkeypatch.setattr(
+            smt_local,
+            "expr_to_z3",
+            fail_when_prior_guard_is_retranslated,
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert len(calls) >= 2
+        assert result.kind == "undecidable_skip"
+
     def test_event_duplicate_shadowing_is_structural(self):
         machine = parse_machine(
             """
@@ -859,9 +1270,92 @@ class TestTransitionShadowedByPredecessor:
         diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
         assert diag["data"]["reason"] == "duplicate_event"
 
+    def test_unconditional_transition_does_not_cross_shadow_event_domain(self):
+        machine = parse_machine(
+            """
+            state System {
+                event Tick;
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B;
+                A -> C : Tick;
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_unconditional_transition_does_not_cross_shadow_guard_domain(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B;
+                A -> C : if [x > 0];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
 
 class TestEnterPostconditionImpliesDuringPrecondition:
     """Test first-cycle lifecycle coupling checks."""
+
+    def test_ignores_composite_states(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state Parent {
+                    state Child {
+                        enter { x = 1; }
+                        during { x = (x > 0) ? 1 : 2; }
+                    }
+                    [*] -> Child;
+                }
+                [*] -> Parent;
+            }
+            """
+        )
+        state = machine.root_state.substates["Parent"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_ignores_states_without_enter_actions(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_triggers_when_enter_determines_during_ternary_true_branch(self):
         machine = parse_machine(
@@ -957,9 +1451,253 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         assert result.kind == "unsafe_skip"
         assert result.reason == "bitwise"
 
+    def test_init_constraint_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        machine.defines["mode"].init = Variable("missing")
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_enter_translation_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        state.on_enters[0].operations = [
+            Operation(var_name="x", expr=Variable("missing"))
+        ]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_aspect_translation_failure_propagates(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                >> during before { mode = mode + 1; }
+                state Idle {
+                    enter { x = 1; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        machine.root_state.on_during_aspects[0].operations = [
+            Operation(var_name="mode", expr=Variable("missing"))
+        ]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_condition_translation_failure_returns_aggregate_skip(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        state.on_durings[0].operations[0].expr.cond = BinaryOp(
+            Variable("missing"),
+            ">",
+            Integer(0),
+        )
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_no_determined_branch_returns_sat(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        from pyfcstm.solver.logical import SatResult
+
+        calls = []
+        real_is_sat = smt_local.is_sat
+
+        def both_branches_feasible(constraints, **kwargs):
+            calls.append(tuple(constraints))
+            if len(calls) in {1, 2}:
+                return SatResult(kind="sat")
+            return real_is_sat(constraints, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", both_branches_feasible)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+        assert len(calls) == 2
+
+    def test_ancestor_before_aspect_feeds_first_during_condition(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                >> during before { mode = 1; }
+                state Idle {
+                    enter { x = 0; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_uninitialized_leaf_entry_is_overapproximated(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { mode = 1; }
+                }
+                state Active {
+                    enter { x = 0; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+                Idle -> Active;
+            }
+            """
+        )
+        state = machine.root_state.substates["Active"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_child_to_child_transition_effect_is_overapproximated(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                event Go;
+                state A;
+                state B {
+                    enter { x = 1; }
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> A;
+                A -> B : Go effect { mode = 1; }
+            }
+            """
+        )
+        state = machine.root_state.substates["B"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
 
 class TestCompositeInitGuardsIncomplete:
     """Test composite initial-transition coverage checks."""
+
+    def test_ignores_models_without_composite_init_transitions(self):
+        machine = parse_machine(
+            """
+            state System;
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="unsat")
+
+    def test_skips_when_guard_translation_fails(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state Root {
+                state A;
+                [*] -> A : if [x > 0];
+            }
+            """
+        )
+
+        def fail_guard_translation(expr, z3_vars):
+            raise ValueError("synthetic init guard failure")
+
+        monkeypatch.setattr(smt_local, "expr_to_z3", fail_guard_translation)
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "undecidable_skip"
 
     def test_triggers_for_guard_coverage_gap(self):
         machine = parse_machine(
@@ -978,6 +1716,46 @@ class TestCompositeInitGuardsIncomplete:
 
         assert result.kind == "sat"
         assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+
+    def test_triggers_for_event_coverage_gap(self):
+        machine = parse_machine(
+            """
+            state Root {
+                event Tick;
+                event Reset;
+                state A;
+                state B;
+                [*] -> A : Tick;
+                [*] -> B : Reset;
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        diag = assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+        assert diag["data"]["state"] == "Root"
+        assert diag["data"]["witness"] is not None
+
+    def test_catchall_init_transition_short_circuits_to_complete(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state Root {
+                state A;
+                state B;
+                state Default;
+                [*] -> A : if [x > 0];
+                [*] -> B : if [x < 0];
+                [*] -> Default;
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="unsat")
 
     def test_does_not_trigger_for_complete_guard_coverage(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -1,0 +1,1116 @@
+"""Tests for SMT-local verification algorithms."""
+
+from textwrap import dedent
+
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.verify import smt_local
+from pyfcstm.verify.registry import REGISTRY
+from pyfcstm.verify.smt_local import (
+    AlgorithmResult,
+    composite_init_guards_incomplete,
+    dead_guard,
+    effect_contradicts_guard,
+    effect_no_op_under_guard,
+    enter_postcondition_implies_during_precondition,
+    forced_guard_unsat_under_init,
+    guard_tautology,
+    transition_shadowed_by_predecessor,
+)
+from pyfcstm.model.expr import BinaryOp, Integer, Variable
+from pyfcstm.model.model import IfBlock, IfBlockBranch, Operation, Transition
+
+
+pytestmark = pytest.mark.unittest
+
+GROUP2_SMT_LOCAL = (
+    "dead_guard",
+    "guard_tautology",
+    "forced_guard_unsat_under_init",
+    "effect_no_op_under_guard",
+    "effect_contradicts_guard",
+    "transition_shadowed_by_predecessor",
+    "enter_postcondition_implies_during_precondition",
+    "composite_init_guards_incomplete",
+)
+
+
+def parse_machine(code):
+    """Parse DSL through grammar and model validation before using fixtures."""
+    ast = parse_with_grammar_entry(dedent(code), "state_machine_dsl")
+    return parse_dsl_node_to_state_machine(ast)
+
+
+def variables(machine):
+    """Return model variable definitions in stable source order."""
+    return tuple(machine.defines.values())
+
+
+def root_transition(machine, index=-1):
+    """Return one root-scope transition."""
+    return machine.root_state.transitions[index]
+
+
+def transition_by_guard(machine, text):
+    """Find a transition whose guard text contains a fragment."""
+    for state in machine.walk_states():
+        for transition in state.transitions:
+            if transition.guard is not None and text in str(transition.guard):
+                return transition
+    raise AssertionError("transition not found")
+
+
+def timeout_result(*args, **kwargs):
+    """Deterministic timeout result for monkeypatched solver helpers."""
+    return smt_local.AlgorithmResult(kind="timeout")
+
+
+def sat_timeout_result(*args, **kwargs):
+    """Deterministic timeout-shaped logical helper result."""
+    from pyfcstm.solver.logical import SatResult
+
+    return SatResult(kind="timeout")
+
+
+def assert_single_diag(result, code):
+    """Assert that an algorithm emitted exactly one expected raw diagnostic."""
+    assert len(result.diagnostics) == 1
+    assert result.diagnostics[0]["code"] == code
+    return result.diagnostics[0]
+
+
+def test_raw_transition_payload_covers_root_transition_without_event():
+    """Synthetic root transitions have no parent and are still serializable."""
+    machine = parse_machine(
+        """
+        state System {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    payload = smt_local._transition_payload(machine.root_state.transitions_from[0])
+
+    assert payload["parent"] is None
+    assert payload["from_state"] == "System"
+    assert payload["to_state"] == "[*]"
+    assert payload["event"] is None
+
+
+def test_expected_expression_translation_failures_are_normalized():
+    """Known expression-to-Z3 failures become algorithm results, not crashes."""
+    x = Variable("x")
+    missing_value, missing_result = smt_local._expr_to_z3_or_result(x, {})
+    bad_op_value, bad_op_result = smt_local._expr_to_z3_or_result(
+        BinaryOp(x, "@", Integer(1)),
+        {"x": smt_local.z3.Int("x")},
+    )
+    real_mod_value, real_mod_result = smt_local._expr_to_z3_or_result(
+        BinaryOp(x, "%", Integer(2)),
+        {"x": smt_local.z3.Real("x")},
+    )
+
+    assert missing_value is None
+    assert missing_result.kind == "undecidable_skip"
+    assert bad_op_value is None
+    assert bad_op_result.kind == "undecidable_skip"
+    assert real_mod_value is None
+    assert real_mod_result.kind == "undecidable_skip"
+
+
+def test_expected_operation_translation_failures_are_normalized():
+    """Operation symbolic execution normalizes expression translation failures."""
+    value, result = smt_local._execute_operations_or_result(
+        [Operation(var_name="x", expr=Variable("missing"))],
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert value is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_expr_translation_not_implemented_is_unsafe_skip(monkeypatch):
+    """Unsupported function translation is normalized as unsafe skip."""
+
+    def raise_not_implemented(*args, **kwargs):
+        raise NotImplementedError("unsupported function")
+
+    monkeypatch.setattr(smt_local, "expr_to_z3", raise_not_implemented)
+
+    value, result = smt_local._expr_to_z3_or_result(
+        Variable("x"),
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert value is None
+    assert result.kind == "unsafe_skip"
+
+
+def test_operation_translation_not_implemented_is_unsafe_skip(monkeypatch):
+    """Operation execution preserves unsupported-function safety skips."""
+
+    def raise_not_implemented(*args, **kwargs):
+        raise NotImplementedError("unsupported function")
+
+    monkeypatch.setattr(smt_local, "execute_operations", raise_not_implemented)
+
+    value, result = smt_local._execute_operations_or_result(
+        [Operation(var_name="x", expr=Integer(1))],
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert value is None
+    assert result.kind == "unsafe_skip"
+
+
+def test_operation_translation_z3_exception_is_undecidable_skip(monkeypatch):
+    """Z3 operation-domain failures are normalized as undecidable skips."""
+
+    def raise_z3_exception(*args, **kwargs):
+        raise smt_local.z3.Z3Exception("bad sort")
+
+    monkeypatch.setattr(smt_local, "execute_operations", raise_z3_exception)
+
+    value, result = smt_local._execute_operations_or_result(
+        [Operation(var_name="x", expr=Integer(1))],
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert value is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_init_constraint_translation_failure_is_normalized():
+    """Invalid variable initializers become an algorithm result."""
+    machine = parse_machine(
+        """
+        def int x = 0;
+        state System {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    var_def = next(iter(machine.defines.values()))
+    var_def.init = Variable("missing")
+
+    value, result = smt_local._build_init_constraints_or_result(
+        variables(machine),
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert value is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_guard_translation_failure_is_normalized():
+    """Guard translation failure propagates through guard helper."""
+    transition = Transition(
+        from_state="A",
+        to_state="B",
+        event=None,
+        guard=Variable("missing"),
+        effects=[],
+    )
+
+    guard, z3_vars, result = smt_local._guard_z3_or_result(transition, ())
+
+    assert guard is None
+    assert z3_vars is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_transition_shadowing_helper_reports_unconditional_followers():
+    """Any transition after an unconditional catch-all is structurally shadowed."""
+    machine = parse_machine(
+        """
+        state System {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B;
+            A -> C;
+        }
+        """
+    )
+
+    result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+    assert result.kind == "unsat"
+    diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+    assert diag["data"]["reason"] == "unconditional_catchall"
+
+
+def test_transition_shadowing_helper_starts_unconditional_domain():
+    """The first unconditional transition is the catch-all baseline."""
+    transition = Transition("A", "B", event=None, guard=None, effects=[])
+
+    assert smt_local._domain_key(transition) == "unconditional"
+
+
+def test_lifecycle_action_collection_skips_abstract_actions():
+    """Abstract lifecycle actions do not contribute concrete operations."""
+    machine = parse_machine(
+        """
+        def int x = 0;
+        state System {
+            state A {
+                enter abstract Setup;
+                during { x = x + 1; }
+            }
+            [*] -> A;
+        }
+        """
+    )
+    state = machine.root_state.substates["A"]
+
+    assert smt_local._action_operations(state.on_enters) == []
+
+
+def test_conditional_collection_includes_if_block_conditions():
+    """Operation if-block conditions are first-cycle condition candidates."""
+    condition = BinaryOp(Variable("x"), ">", Integer(0))
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=condition,
+                    statements=[Operation(var_name="x", expr=Integer(1))],
+                )
+            ]
+        )
+    ]
+
+    assert tuple(smt_local._conditional_conditions_from_operations(operations)) == (
+        condition,
+    )
+
+
+def test_event_bool_name_falls_back_for_anonymous_transition():
+    """Internal event-bool naming has a deterministic anonymous fallback."""
+    transition = Transition("A", "B", event=None, guard=None, effects=[])
+
+    assert smt_local._event_bool_name(transition) == "__event__anonymous"
+
+
+def test_group2_registry_impls_are_real_function_pointers():
+    """Every PR-A4 registry entry points at its raw implementation."""
+    expected_impls = {
+        "dead_guard": dead_guard,
+        "guard_tautology": guard_tautology,
+        "forced_guard_unsat_under_init": forced_guard_unsat_under_init,
+        "effect_no_op_under_guard": effect_no_op_under_guard,
+        "effect_contradicts_guard": effect_contradicts_guard,
+        "transition_shadowed_by_predecessor": transition_shadowed_by_predecessor,
+        "enter_postcondition_implies_during_precondition": (
+            enter_postcondition_implies_during_precondition
+        ),
+        "composite_init_guards_incomplete": composite_init_guards_incomplete,
+    }
+
+    for name in GROUP2_SMT_LOCAL:
+        assert REGISTRY[name].impl is expected_impls[name]
+
+
+class TestDeadGuard:
+    """Test dead guard detection."""
+
+    def test_triggers_for_unsatisfiable_guard(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 5 && x < 3];
+            }
+            """
+        )
+
+        result = dead_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "W_DEAD_GUARD")
+
+    def test_does_not_trigger_for_satisfiable_guard(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 5];
+            }
+            """
+        )
+
+        result = dead_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0];
+            }
+            """
+        )
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = dead_guard(
+            root_transition(machine), variables(machine), smt_timeout_ms=1
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_unsafe_guard_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int flags = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [(flags & 1) == 1];
+            }
+            """
+        )
+
+        result = dead_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "bitwise"
+
+
+class TestGuardTautology:
+    """Test tautological guard detection."""
+
+    def test_triggers_for_tautological_guard(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x >= 0 || x < 0];
+            }
+            """
+        )
+
+        result = guard_tautology(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "W_GUARD_TAUTOLOGY")
+
+    def test_does_not_trigger_for_non_tautological_guard(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0];
+            }
+            """
+        )
+
+        result = guard_tautology(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0];
+            }
+            """
+        )
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = guard_tautology(
+            root_transition(machine), variables(machine), smt_timeout_ms=1
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_unsafe_guard_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int flags = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [(flags << 1) > 0];
+            }
+            """
+        )
+
+        result = guard_tautology(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "bitwise"
+
+
+class TestForcedGuardUnsatUnderInit:
+    """Test forced transition guard checks under initial values."""
+
+    def test_triggers_for_forced_guard_false_at_init(self):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            def int threshold = 0;
+            state System {
+                state A {
+                    state Sub1;
+                    state Sub2;
+                    [*] -> Sub1;
+                    Sub1 -> Sub2;
+                }
+                state B;
+                [*] -> A;
+                !A -> B : if [counter > threshold];
+            }
+            """
+        )
+        transition = transition_by_guard(machine, "counter > threshold")
+
+        result = forced_guard_unsat_under_init(transition, variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "W_FORCED_GUARD_UNSAT")
+
+    def test_does_not_trigger_when_forced_guard_true_at_init(self):
+        machine = parse_machine(
+            """
+            def int counter = 5;
+            def int threshold = 0;
+            state System {
+                state A {
+                    state Sub1;
+                    state Sub2;
+                    [*] -> Sub1;
+                    Sub1 -> Sub2;
+                }
+                state B;
+                [*] -> A;
+                !A -> B : if [counter > threshold];
+            }
+            """
+        )
+        transition = transition_by_guard(machine, "counter > threshold")
+
+        result = forced_guard_unsat_under_init(transition, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int counter = 5;
+            def int threshold = 0;
+            state System {
+                state A {
+                    state Sub1;
+                    state Sub2;
+                    [*] -> Sub1;
+                    Sub1 -> Sub2;
+                }
+                state B;
+                [*] -> A;
+                !A -> B : if [counter > threshold];
+            }
+            """
+        )
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = forced_guard_unsat_under_init(
+            transition_by_guard(machine, "counter > threshold"),
+            variables(machine),
+            smt_timeout_ms=1,
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_unsafe_guard_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int flags = 0;
+            state System {
+                state A {
+                    state Sub1;
+                    state Sub2;
+                    [*] -> Sub1;
+                    Sub1 -> Sub2;
+                }
+                state B;
+                [*] -> A;
+                !A -> B : if [(flags ^ 1) == 0];
+            }
+            """
+        )
+
+        result = forced_guard_unsat_under_init(
+            transition_by_guard(machine, "flags ^ 1"),
+            variables(machine),
+        )
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "bitwise"
+
+
+class TestEffectNoOpUnderGuard:
+    """Test semantic no-op effect checks."""
+
+    def test_triggers_for_semantic_no_op_effect(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0] effect { x = x + y - y; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "W_EFFECT_SMT_NO_OP")
+
+    def test_does_not_trigger_when_effect_can_change_state(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0] effect { x = x + 1; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0] effect { x = x + 1; };
+            }
+            """
+        )
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_unsafe_effect_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x > 0] effect { x = x << 1; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "bitwise"
+
+
+class TestEffectContradictsGuard:
+    """Test effect/guard contradiction checks."""
+
+    def test_triggers_when_effect_makes_guard_false(self):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [counter > 0] effect { counter = 0; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "I_EFFECT_GUARD_CONTRADICT")
+
+    def test_does_not_trigger_when_guard_can_still_hold_after_effect(self):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [counter > 0] effect { counter = counter + 1; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [counter > 0] effect { counter = counter + 1; };
+            }
+            """
+        )
+        calls = []
+
+        def feasible_then_timeout(*args, **kwargs):
+            from pyfcstm.solver.logical import SatResult
+
+            calls.append(args)
+            if len(calls) == 1:
+                return SatResult(kind="sat")
+            return SatResult(kind="timeout")
+
+        monkeypatch.setattr(smt_local, "is_sat", feasible_then_timeout)
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="timeout")
+        assert len(calls) == 2
+
+    def test_dead_guard_case_does_not_emit_effect_contradiction(self):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [counter > 0 && counter < 0] effect { counter = 0; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_unsafe_effect_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int counter = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [counter > 0] effect { counter = counter ** counter; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "double_var_power"
+
+
+class TestTransitionShadowedByPredecessor:
+    """Test transition shadowing detection."""
+
+    def test_triggers_for_guard_shadowing(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 0];
+                A -> C : if [x > 1];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+        assert diag["data"]["reason"] == "guard_shadow"
+
+    def test_does_not_trigger_for_complementary_guards(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 5];
+                A -> C : if [x <= 5];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_timeout_propagates_when_no_shadow_diagnostic_exists(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 5];
+                A -> C : if [x <= 5];
+            }
+            """
+        )
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_unsafe_guard_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int flags = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [flags > 0];
+                A -> C : if [(flags & 1) == 1];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "bitwise"
+
+    def test_event_duplicate_shadowing_is_structural(self):
+        machine = parse_machine(
+            """
+            state System {
+                event Tick;
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : Tick;
+                A -> C : Tick;
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+        assert diag["data"]["reason"] == "duplicate_event"
+
+
+class TestEnterPostconditionImpliesDuringPrecondition:
+    """Test first-cycle lifecycle coupling checks."""
+
+    def test_triggers_when_enter_determines_during_ternary_true_branch(self):
+        machine = parse_machine(
+            """
+            def int mode = 1;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { mode = 1; }
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_does_not_trigger_without_during_conditional(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { x = mode + 1; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_timeout_propagates_when_no_diagnostic_exists(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int external = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { x = (external > mode) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = enter_postcondition_implies_during_precondition(
+            state,
+            variables(machine),
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_unsafe_during_condition_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int flags = 1;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { x = ((flags & 1) == 1) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "bitwise"
+
+
+class TestCompositeInitGuardsIncomplete:
+    """Test composite initial-transition coverage checks."""
+
+    def test_triggers_for_guard_coverage_gap(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state Root {
+                state A;
+                state B;
+                [*] -> A : if [x > 0];
+                [*] -> B : if [x < 0];
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+
+    def test_does_not_trigger_for_complete_guard_coverage(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state Root {
+                state A;
+                state B;
+                [*] -> A : if [x >= 0];
+                [*] -> B : if [x < 0];
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="unsat")
+
+    def test_timeout_propagates_when_no_diagnostic_exists(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state Root {
+                state A;
+                state B;
+                [*] -> A : if [x >= 0];
+                [*] -> B : if [x < 0];
+            }
+            """
+        )
+        monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="timeout")
+
+    def test_unsafe_init_guard_skips_solver(self):
+        machine = parse_machine(
+            """
+            def int flags = 0;
+            state Root {
+                state A;
+                state B;
+                [*] -> A : if [(flags & 1) == 1];
+                [*] -> B : if [flags == 0];
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "unsafe_skip"
+        assert result.reason == "bitwise"
+
+    def test_nested_composite_reports_nested_state(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state Root {
+                state Outer {
+                    state Inner1;
+                    state Inner2;
+                    [*] -> Inner1 : if [x > 0];
+                    [*] -> Inner2 : if [x < 0];
+                }
+                [*] -> Outer;
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        diag = assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+        assert diag["data"]["state"] == "Root.Outer"
+
+
+def test_algorithms_complete_under_simple_performance_smoke(benchmark):
+    """All eight algorithms stay fast on representative tiny fixtures."""
+    guard_machine = parse_machine(
+        """
+        def int x = 1;
+        def int y = 0;
+        state System {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B : if [x > 0] effect { y = y + 1; };
+            A -> C : if [x <= 0];
+        }
+        """
+    )
+    lifecycle_machine = parse_machine(
+        """
+        def int mode = 1;
+        def int x = 0;
+        state System {
+            state Idle {
+                enter { mode = 1; }
+                during { x = (mode == 1) ? 10 : 20; }
+            }
+            [*] -> Idle;
+        }
+        """
+    )
+    composite_machine = parse_machine(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A : if [x >= 0];
+            [*] -> B : if [x < 0];
+        }
+        """
+    )
+    guard_transition = guard_machine.root_state.transitions[1]
+    lifecycle_state = lifecycle_machine.root_state.substates["Idle"]
+
+    def run_all():
+        dead_guard(guard_transition, variables(guard_machine))
+        guard_tautology(guard_transition, variables(guard_machine))
+        forced_guard_unsat_under_init(guard_transition, variables(guard_machine))
+        effect_no_op_under_guard(guard_transition, variables(guard_machine))
+        effect_contradicts_guard(guard_transition, variables(guard_machine))
+        transition_shadowed_by_predecessor(guard_machine, variables(guard_machine))
+        enter_postcondition_implies_during_precondition(
+            lifecycle_state,
+            variables(lifecycle_machine),
+        )
+        composite_init_guards_incomplete(
+            composite_machine, variables(composite_machine)
+        )
+
+    benchmark(run_all)

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -1098,6 +1098,159 @@ def test_root_initial_context_handles_root_state_directly():
     assert operations == []
 
 
+def test_root_initial_path_context_returns_empty_for_unselected_leaf():
+    """Legacy single-context helper reports no context for non-initial leaves."""
+    machine = parse_machine(
+        """
+        state System {
+            state Idle;
+            state Active;
+            [*] -> Idle;
+        }
+        """
+    )
+    z3_vars = smt_local._z3_vars(variables(machine))
+
+    transitions, constraints, operations, result = smt_local._root_initial_path_context(
+        machine.root_state.substates["Active"],
+        variables(machine),
+        z3_vars,
+        (),
+    )
+
+    assert result is None
+    assert transitions is None
+    assert constraints is None
+    assert operations is None
+
+
+def test_definite_stable_entry_helper_is_conservative_for_edge_shapes():
+    """Validation-stability proof rejects shapes it cannot prove locally."""
+    pseudo_machine = parse_machine(
+        """
+        state System {
+            pseudo state Jump;
+            [*] -> Jump;
+        }
+        """
+    )
+    missing_init_machine = parse_machine(
+        """
+        state System {
+            state Parent {
+                state Child;
+                [*] -> Child;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    stable_machine = parse_machine(
+        """
+        state System {
+            state Parent {
+                state Child;
+                [*] -> Child;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    exit_init_machine = parse_machine(
+        """
+        state System {
+            state Parent {
+                state Child;
+                [*] -> Child;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    missing_target_machine = parse_machine(
+        """
+        state System {
+            state Parent {
+                state Child;
+                [*] -> Child;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    pseudo = pseudo_machine.root_state.substates["Jump"]
+    parent_without_init = missing_init_machine.root_state.substates["Parent"]
+    parent_without_init.transitions = []
+    exit_parent = exit_init_machine.root_state.substates["Parent"]
+    missing_target_parent = missing_target_machine.root_state.substates["Parent"]
+    exit_parent.init_transitions[0].to_state = smt_local._dsl_nodes().EXIT_STATE
+    missing_target_parent.init_transitions[0].to_state = "Missing"
+
+    stable_parent = stable_machine.root_state.substates["Parent"]
+
+    assert smt_local._state_has_definite_stable_entry(stable_parent)
+    assert not smt_local._state_has_definite_stable_entry(pseudo)
+    assert not smt_local._state_has_definite_stable_entry(parent_without_init)
+    assert not smt_local._state_has_definite_stable_entry(exit_parent)
+    assert not smt_local._state_has_definite_stable_entry(missing_target_parent)
+
+
+def test_transition_stable_continuation_helper_covers_exit_and_bad_targets():
+    """Transition continuation proof handles root exits and malformed targets."""
+    machine = parse_machine(
+        """
+        state System {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+    )
+    state_a = machine.root_state.substates["A"]
+    exit_transition = Transition(
+        from_state="A",
+        to_state=smt_local._dsl_nodes().EXIT_STATE,
+        event=None,
+        guard=None,
+        effects=[],
+    )
+    root_exit_transition = Transition(
+        from_state="System",
+        to_state=smt_local._dsl_nodes().EXIT_STATE,
+        event=None,
+        guard=None,
+        effects=[],
+    )
+    bad_target_transition = Transition(
+        from_state="A",
+        to_state="Missing",
+        event=None,
+        guard=None,
+        effects=[],
+    )
+    non_string_transition = Transition(
+        from_state="A",
+        to_state=smt_local._dsl_nodes().INIT_STATE,
+        event=None,
+        guard=None,
+        effects=[],
+    )
+
+    assert smt_local._transition_has_definite_stable_continuation(
+        state_a, exit_transition
+    )
+    assert not smt_local._transition_has_definite_stable_continuation(
+        machine.root_state, root_exit_transition
+    )
+    assert not smt_local._transition_has_definite_stable_continuation(
+        state_a, bad_target_transition
+    )
+    assert not smt_local._transition_has_definite_stable_continuation(
+        state_a, non_string_transition
+    )
+
+
 def test_root_initial_leaf_helper_identifies_global_initial_path():
     """Lifecycle first-cycle analysis only pins the global initial leaf."""
     machine = parse_machine(
@@ -2382,6 +2535,31 @@ class TestTransitionShadowedByPredecessor:
         assert result.kind == "unsat"
         diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
         assert diag["data"]["reason"] == "guard_shadow"
+
+
+    def test_validation_rejected_predecessor_is_not_deterministic_shadow(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state S {
+                state A;
+                state Bad {
+                    state Sink;
+                    [*] -> Sink : if [false];
+                }
+                state Good;
+                [*] -> A;
+                A -> Bad;
+                A -> Good;
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert result.diagnostics == ()
+        assert "stable continuation" in result.reason
 
     def test_dead_candidate_guard_is_not_reported_as_shadowed(self):
         machine = parse_machine(
@@ -4618,6 +4796,31 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         assert result.kind == "unsat"
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
         assert diag["data"]["branch_taken"] == "true"
+
+
+    def test_event_dependent_same_target_init_paths_do_not_force_branch(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                event E1;
+                event E2;
+                state Idle {
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle : E1 effect { mode = 1; };
+                [*] -> Idle : E2 effect { mode = 2; };
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_unsatisfiable_init_transition_context_returns_sat(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -476,7 +476,7 @@ def test_operation_prefix_collection_propagates_if_merge_failure():
 def test_operation_prefix_collection_propagates_if_merge_failure_after_branch_scan(
     monkeypatch,
 ):
-    """If-block merge failures after collected branch points stay normalized."""
+    """Helper-level prefix collection merges if-blocks internally."""
     condition = BinaryOp(Variable("x"), ">", Integer(0))
     operations = [
         IfBlock(
@@ -504,8 +504,10 @@ def test_operation_prefix_collection_propagates_if_merge_failure_after_branch_sc
         {"x": smt_local.z3.Int("x")},
     )
 
-    assert condition_points is None
-    assert result.kind == "undecidable_skip"
+    assert result is None
+    assert condition_points is not None
+    assert [point.condition for point in condition_points] == [condition]
+    assert calls == []
 
 
 def test_operation_prefix_collection_rejects_unknown_statement_type():
@@ -2151,6 +2153,39 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         assert result == AlgorithmResult(kind="timeout")
         assert len(calls) == 3
 
+    def test_condition_path_reachability_unsat_skips_condition(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def path_unsat_after_context(*args, **kwargs):
+            calls.append(args)
+            from pyfcstm.solver.logical import SatResult
+
+            if len(calls) == 3:
+                return SatResult(kind="unsat")
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", path_unsat_after_context)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+        assert len(calls) == 3
+
     def test_unsatisfiable_entry_context_short_circuits_before_conditions(self):
         machine = parse_machine(
             """
@@ -2233,6 +2268,127 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result.kind == "undecidable_skip"
+
+    def test_unreachable_branch_unsupported_expression_does_not_mask_later_condition(
+        self,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 1] {
+                            x = ((flags & 1) == 1) ? 10 : 20;
+                        }
+                        x = (mode == 0) ? 30 : 40;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag_items = {
+            (
+                diag["data"]["condition"],
+                diag["data"]["condition_source"],
+                diag["data"]["branch_taken"],
+            )
+            for diag in result.diagnostics
+        }
+        assert diag_items == {
+            ("mode == 1", "branch", "false"),
+            ("mode == 0", "expression", "true"),
+        }
+
+    def test_condition_path_reachability_branch_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 1] { x = 1; }
+                        x = (mode == 0) ? 30 : 40;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def branch_timeout_after_context(*args, **kwargs):
+            calls.append(args)
+            from pyfcstm.solver.logical import SatResult
+
+            if len(calls) == 3:
+                return sat_timeout_result(*args, **kwargs)
+            if len(calls) > 3:
+                return SatResult(kind="unsat")
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", branch_timeout_after_context)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+        assert len(calls) == 3
+
+    def test_condition_path_reachability_before_branch_timeout_propagates(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 1] { x = 1; }
+                        else if [mode == 2] { x = 2; }
+                        x = (mode == 0) ? 30 : 40;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def second_branch_timeout_after_context(*args, **kwargs):
+            calls.append(args)
+            from pyfcstm.solver.logical import SatResult
+
+            if len(calls) == 4:
+                return sat_timeout_result(*args, **kwargs)
+            if len(calls) > 4:
+                return SatResult(kind="unsat")
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", second_branch_timeout_after_context)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+        assert len(calls) == 4
 
     def test_condition_translation_failure_inside_condition_loop_is_aggregated(
         self,
@@ -2346,7 +2502,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             for diag in result.diagnostics
         )
 
-    def test_unreachable_if_branch_condition_is_not_reported(self):
+    def test_unreachable_branch_body_condition_is_not_reported(self):
         machine = parse_machine(
             """
             def int mode = 0;
@@ -2370,9 +2526,9 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result.kind == "unsat"
-        conditions = {diag["data"]["condition"] for diag in result.diagnostics}
-        assert conditions == {"mode == 1"}
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 1"
+        assert diag["data"]["condition_source"] == "branch"
         assert diag["data"]["branch_taken"] == "false"
 
     def test_unreachable_else_branch_ternary_is_not_reported(self):
@@ -2405,6 +2561,48 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         assert conditions == {"mode == 0"}
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
         assert diag["data"]["branch_taken"] == "true"
+
+    def test_unreachable_else_if_body_is_not_reported(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 0] {
+                            mode = 1;
+                        } else if [mode == 2] {
+                            x = (mode == 2) ? 10 : 20;
+                        } else {
+                            mode = 3;
+                        }
+                        x = (mode == 1) ? 30 : 40;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag_items = [
+            (
+                diag["data"]["condition"],
+                diag["data"]["condition_source"],
+                diag["data"]["branch_taken"],
+            )
+            for diag in result.diagnostics
+        ]
+        assert diag_items == [
+            ("mode == 0", "branch", "true"),
+            ("mode == 1", "expression", "true"),
+        ]
 
     def test_aspect_condition_is_checked_before_leaf_during(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -286,10 +286,13 @@ def test_guard_translation_failure_is_normalized():
         effects=[],
     )
 
-    guard, z3_vars, result = smt_local._guard_z3_or_result(transition, ())
+    guard, z3_vars, guard_domains, result = smt_local._guard_z3_or_result(
+        transition, ()
+    )
 
     assert guard is None
     assert z3_vars is None
+    assert guard_domains is None
     assert result.kind == "undecidable_skip"
 
 
@@ -965,6 +968,54 @@ def test_operation_prefix_collection_qualifies_branch_condition_domains():
     ]
 
 
+def test_branch_condition_definedness_unsat_in_context_is_undecidable():
+    """Unrunnable branch conditions stop path-sensitive operation execution."""
+    z3_vars = {"x": smt_local.z3.Int("x")}
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=BinaryOp(
+                        BinaryOp(Variable("x"), "/", Variable("x")),
+                        ">",
+                        Integer(0),
+                    ),
+                    statements=[],
+                )
+            ]
+        )
+    ]
+
+    _, _, _, result = smt_local._execute_operation_prefix_conditions_and_vars_or_result(
+        operations,
+        z3_vars,
+        context_constraints=[z3_vars["x"] == 0],
+    )
+
+    assert result.kind == "undecidable_skip"
+    assert "runtime definedness" in result.reason
+
+
+def test_definedness_feasibility_helper_handles_sat_and_timeout(monkeypatch):
+    """The shared definedness helper preserves feasible and indeterminate cases."""
+    feasible = smt_local._definedness_feasibility_or_result(
+        [smt_local.z3.BoolVal(True)],
+        reason="unused",
+    )
+
+    assert feasible is None
+
+    monkeypatch.setattr(smt_local, "is_sat", sat_timeout_result)
+
+    timeout = smt_local._definedness_feasibility_or_result(
+        [smt_local.z3.BoolVal(True)],
+        reason="unused",
+        smt_timeout_ms=1,
+    )
+
+    assert timeout.kind == "timeout"
+
+
 def test_operation_prefix_collection_rejects_unknown_statement_type():
     """Unknown operation statement objects are normalized as undecidable."""
     condition_points, result = smt_local._execute_operation_prefix_conditions_or_result(
@@ -986,10 +1037,40 @@ def test_transition_trigger_builds_private_event_bool_when_no_mapping_given():
         effects=[],
     )
 
-    trigger, result = smt_local._transition_trigger_or_result(transition, {})
+    trigger, trigger_domains, result = smt_local._transition_trigger_or_result(
+        transition, {}
+    )
 
     assert result is None
+    assert trigger_domains == ()
     assert str(trigger) == "__event__6:System4:Tick"
+
+
+def test_initial_path_guard_definedness_unsat_is_undecidable():
+    """Root initial path selection rejects unrunnable init guards."""
+    machine = parse_machine(
+        """
+        def int x = 0;
+        state System {
+            state Idle { during { x = 1; } }
+            [*] -> Idle : if [1 / 0 == 1 || true];
+        }
+        """
+    )
+    z3_vars = smt_local._z3_vars(variables(machine))
+
+    transitions, constraints, operations, result = smt_local._root_initial_path_context(
+        machine.root_state.substates["Idle"],
+        variables(machine),
+        z3_vars,
+        (),
+    )
+
+    assert transitions is None
+    assert constraints is None
+    assert operations is None
+    assert result.kind == "undecidable_skip"
+    assert "runtime definedness" in result.reason
 
 
 def test_root_initial_context_handles_root_state_directly():
@@ -1192,6 +1273,24 @@ class TestDeadGuard:
 
         assert result.kind == "undecidable_skip"
 
+    def test_runtime_undefined_guard_is_undecidable_not_dead(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [1 / 0 == 1 || false];
+            }
+            """
+        )
+
+        result = dead_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
     def test_non_linear_variable_multiplication_runs_full_power(self):
         machine = parse_machine(
             """
@@ -1302,6 +1401,43 @@ class TestGuardTautology:
 
         assert result.kind == "undecidable_skip"
 
+    def test_runtime_undefined_guard_is_undecidable_not_tautological(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [1 / 0 == 1 || true];
+            }
+            """
+        )
+
+        result = guard_tautology(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
+    def test_unselected_guard_ternary_branch_is_pruned(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int flags = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [(x == x) ? true : ((flags & 1) == 1)];
+            }
+            """
+        )
+
+        result = guard_tautology(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "W_GUARD_TAUTOLOGY")
+
 
 class TestForcedGuardUnsatUnderInit:
     """Test forced transition guard checks under initial values."""
@@ -1351,6 +1487,25 @@ class TestForcedGuardUnsatUnderInit:
         assert result.kind == "unsat"
         diag = assert_single_diag(result, "W_FORCED_GUARD_UNSAT")
         assert diag["data"]["scope"] == "dsl_def_init_only"
+
+    def test_runtime_undefined_forced_guard_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                !A -> B : if [x == 0 && 1 / x == 1];
+            }
+            """
+        )
+        transition = transition_by_guard(machine, "1 / x")
+
+        result = forced_guard_unsat_under_init(transition, variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
 
     def test_does_not_trigger_when_forced_guard_true_at_init(self):
         machine = parse_machine(
@@ -1690,6 +1845,69 @@ class TestEffectNoOpUnderGuard:
 
         result = effect_no_op_under_guard(root_transition(machine), variables(machine))
 
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
+    def test_guard_definedness_unsat_for_effect_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x == 0 && 1 / x == 1] effect { y = y + 0; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
+    def test_effect_definedness_helper_reports_unsat_context(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x == 0] effect { y = 1 / x; };
+            }
+            """
+        )
+        transition = root_transition(machine)
+        z3_vars = smt_local._z3_vars(variables(machine))
+        guard_z3, type_constraints, result = smt_local._effect_guard_context_or_result(
+            transition,
+            variables(machine),
+            z3_vars,
+        )
+
+        assert result is None
+
+        def defer_effect_domains(*args, **kwargs):
+            return (), dict(z3_vars), (z3_vars["x"] != 0,), None
+
+        monkeypatch.setattr(
+            smt_local,
+            "_execute_operation_prefix_conditions_and_vars_or_result",
+            defer_effect_domains,
+        )
+
+        after_vars, domains, result = smt_local._execute_effects_under_guard_or_result(
+            transition,
+            z3_vars,
+            guard_z3,
+            type_constraints,
+        )
+
+        assert after_vars is None
+        assert domains is None
         assert result.kind == "undecidable_skip"
         assert "runtime definedness" in result.reason
 
@@ -2259,6 +2477,26 @@ class TestTransitionShadowedByPredecessor:
 
         assert result.kind == "undecidable_skip"
 
+    def test_runtime_undefined_guard_does_not_shadow_following_transition(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [1 / 0 == 1 || true];
+                A -> C : if [x == 0];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
     def test_current_guard_translation_failure_propagates(self, monkeypatch):
         machine = parse_machine(
             """
@@ -2274,15 +2512,26 @@ class TestTransitionShadowedByPredecessor:
             """
         )
         calls = []
-        real_expr_to_z3 = smt_local.expr_to_z3
+        real_translate = smt_local._expr_conditions_and_z3_or_result
 
-        def fail_on_second_guard(expr, z3_vars):
+        def fail_on_second_guard(expr, *args, **kwargs):
             if str(expr) == "x <= 5":
                 calls.append(expr)
-                raise ValueError("synthetic current guard failure")
-            return real_expr_to_z3(expr, z3_vars)
+                return (
+                    None,
+                    None,
+                    AlgorithmResult(
+                        kind="undecidable_skip",
+                        reason="synthetic current guard failure",
+                    ),
+                )
+            return real_translate(expr, *args, **kwargs)
 
-        monkeypatch.setattr(smt_local, "expr_to_z3", fail_on_second_guard)
+        monkeypatch.setattr(
+            smt_local,
+            "_expr_conditions_and_z3_or_result",
+            fail_on_second_guard,
+        )
 
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
@@ -2290,6 +2539,8 @@ class TestTransitionShadowedByPredecessor:
         assert result.kind == "undecidable_skip"
 
     def test_prior_guard_translation_failure_propagates(self, monkeypatch):
+        from pyfcstm.model.expr import BinaryOp
+
         machine = parse_machine(
             """
             def int x = 0;
@@ -2304,25 +2555,31 @@ class TestTransitionShadowedByPredecessor:
             """
         )
         calls = []
-        real_expr_to_z3 = smt_local.expr_to_z3
+        real_translate = smt_local._expr_conditions_and_z3_or_result
 
-        def fail_when_prior_guard_is_retranslated(expr, z3_vars):
-            if str(expr) == "x > 0":
+        def fail_when_prior_guard_is_translated(expr, *args, **kwargs):
+            if isinstance(expr, BinaryOp) and str(expr) == "x > 0":
                 calls.append(expr)
-                if len(calls) >= 2:
-                    raise ValueError("synthetic prior guard failure")
-            return real_expr_to_z3(expr, z3_vars)
+                return (
+                    None,
+                    None,
+                    AlgorithmResult(
+                        kind="undecidable_skip",
+                        reason="synthetic prior guard failure",
+                    ),
+                )
+            return real_translate(expr, *args, **kwargs)
 
         monkeypatch.setattr(
             smt_local,
-            "expr_to_z3",
-            fail_when_prior_guard_is_retranslated,
+            "_expr_conditions_and_z3_or_result",
+            fail_when_prior_guard_is_translated,
         )
 
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
         assert len(calls) == 1
-        assert result.kind == "sat"
+        assert result.kind == "undecidable_skip"
 
     def test_events_with_underscore_path_boundary_do_not_shadow_each_other(self):
         machine = parse_machine(
@@ -3472,6 +3729,34 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         assert result.kind == "undecidable_skip"
         assert result.diagnostics == ()
 
+    def test_selected_value_branch_definedness_failure_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def float y = 0.0;
+            def int z = 0;
+            state System {
+                state Idle {
+                    during {
+                        y = (x == 0) ? sqrt(-1.0) : 1.0;
+                        z = 1;
+                        if [z == 1] { z = 2; } else { z = 3; }
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+        assert result.diagnostics == ()
+
     def test_unreachable_enter_branch_unsupported_expr_does_not_mask_during_condition(
         self,
     ):
@@ -4554,6 +4839,24 @@ class TestCompositeInitGuardsIncomplete:
         result = composite_init_guards_incomplete(machine, variables(machine))
 
         assert result.kind == "undecidable_skip"
+
+    def test_runtime_undefined_init_guard_does_not_cover_composite_gap(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state Root {
+                state A;
+                state B;
+                [*] -> A : if [1 / 0 == 1 || true];
+                [*] -> B : if [x > 0];
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
 
     def test_nested_composite_reports_nested_state(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -657,9 +657,7 @@ def test_path_sensitive_expression_translator_wraps_reachable_branch_domains():
     assert points is not None
     assert z3_expr is not None
     assert result is None
-    assert [str(item) for item in domain_constraints] == [
-        "Implies(True, 2 != 0)"
-    ]
+    assert [str(item) for item in domain_constraints] == ["Implies(True, 2 != 0)"]
 
 
 def test_path_sensitive_expression_translator_wraps_false_branch_domains():
@@ -674,9 +672,7 @@ def test_path_sensitive_expression_translator_wraps_false_branch_domains():
     assert points is not None
     assert z3_expr is not None
     assert result is None
-    assert [str(item) for item in domain_constraints] == [
-        "Implies(Not(True), 2 != 0)"
-    ]
+    assert [str(item) for item in domain_constraints] == ["Implies(Not(True), 2 != 0)"]
 
 
 def test_path_sensitive_expression_translator_denominator_failure_is_normalized():
@@ -1656,6 +1652,28 @@ class TestEffectNoOpUnderGuard:
 
         assert result.kind == "undecidable_skip"
 
+    def test_guard_prunes_unselected_ternary_value_for_no_op_effect(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 7;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [mode == 0] effect {
+                    x = (mode == 0) ? x : (flags & 1);
+                };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "W_EFFECT_SMT_NO_OP")
+
 
 class TestEffectContradictsGuard:
     """Test effect/guard contradiction checks."""
@@ -1853,11 +1871,11 @@ class TestEffectContradictsGuard:
         )
 
         def drop_guard_variable(*args, **kwargs):
-            return {}, None
+            return {}, (), None
 
         monkeypatch.setattr(
             smt_local,
-            "_execute_operations_or_result",
+            "_execute_effects_under_guard_or_result",
             drop_guard_variable,
         )
 
@@ -1908,6 +1926,27 @@ class TestEffectContradictsGuard:
         )
 
         assert result.kind == "undecidable_skip"
+
+    def test_guard_prunes_unselected_ternary_value_for_guard_contradiction(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [mode == 0] effect {
+                    mode = (mode == 0) ? 1 : (flags & 1);
+                };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "I_EFFECT_GUARD_CONTRADICT")
 
 
 class TestTransitionShadowedByPredecessor:
@@ -2035,7 +2074,7 @@ class TestTransitionShadowedByPredecessor:
         assert result == AlgorithmResult(kind="timeout")
         assert len(calls) == 2
 
-    def test_unconditional_predecessor_shadows_unknown_candidate_trigger(self):
+    def test_unconditional_predecessor_does_not_force_unknown_candidate_shadow(self):
         machine = parse_machine(
             """
             def int x = 0;
@@ -2053,9 +2092,26 @@ class TestTransitionShadowedByPredecessor:
 
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
-        assert result.kind == "unsat"
-        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
-        assert diag["data"]["reason"] == "unconditional_catchall"
+        assert result == AlgorithmResult(kind="unknown")
+
+    def test_unconditional_predecessor_does_not_shadow_dead_candidate_guard(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B;
+                A -> C : if [x > 0 && x < 0];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_does_not_trigger_for_complementary_guards(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -2268,6 +2268,61 @@ class TestEffectContradictsGuard:
 
         assert result == AlgorithmResult(kind="sat")
 
+    def test_partially_undefined_post_guard_after_effect_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int d = -1;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [d != 0 && x >= 0 && 1 / d < 0] effect {
+                    d = x;
+                };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert result.diagnostics == ()
+        assert "runtime definedness" in result.reason
+
+    def test_post_guard_definedness_implication_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int d = -1;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [d != 0 && x >= 0 && 1 / d < 0] effect {
+                    d = x;
+                };
+            }
+            """
+        )
+        calls = []
+        real_is_sat = smt_local.is_sat
+
+        def timeout_on_definedness_implication(*args, **kwargs):
+            from pyfcstm.solver.logical import SatResult
+
+            calls.append(args)
+            if len(calls) == 4:
+                return SatResult(kind="timeout")
+            return real_is_sat(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", timeout_on_definedness_implication)
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="timeout")
+        assert len(calls) == 4
+
     def test_guard_prunes_unselected_ternary_value_for_guard_contradiction(self):
         machine = parse_machine(
             """

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -150,8 +150,8 @@ def test_expected_operation_translation_failures_are_normalized():
     assert result.kind == "undecidable_skip"
 
 
-def test_expr_translation_not_implemented_is_unsafe_skip(monkeypatch):
-    """Unsupported function translation is normalized as unsafe skip."""
+def test_expr_translation_not_implemented_is_undecidable_skip(monkeypatch):
+    """Unsupported function translation is normalized as undecidable."""
 
     def raise_not_implemented(*args, **kwargs):
         raise NotImplementedError("unsupported function")
@@ -164,11 +164,11 @@ def test_expr_translation_not_implemented_is_unsafe_skip(monkeypatch):
     )
 
     assert value is None
-    assert result.kind == "unsafe_skip"
+    assert result.kind == "undecidable_skip"
 
 
-def test_operation_translation_not_implemented_is_unsafe_skip(monkeypatch):
-    """Operation execution preserves unsupported-function safety skips."""
+def test_operation_translation_not_implemented_is_undecidable_skip(monkeypatch):
+    """Operation execution normalizes unsupported functions as undecidable."""
 
     def raise_not_implemented(*args, **kwargs):
         raise NotImplementedError("unsupported function")
@@ -181,7 +181,7 @@ def test_operation_translation_not_implemented_is_unsafe_skip(monkeypatch):
     )
 
     assert value is None
-    assert result.kind == "unsafe_skip"
+    assert result.kind == "undecidable_skip"
 
 
 def test_operation_translation_z3_exception_is_undecidable_skip(monkeypatch):
@@ -241,8 +241,8 @@ def test_init_constraint_translation_failure_is_normalized():
     assert result.kind == "undecidable_skip"
 
 
-def test_unsafe_initializers_skip_before_translation():
-    """Unsafe DSL initializers are reported instead of crashing in Z3."""
+def test_initializer_translation_failure_is_undecidable_skip():
+    """Initializer translation failures are reported after full-power translation."""
     machine = parse_machine(
         """
         def int flags = 1 << 2;
@@ -259,8 +259,7 @@ def test_unsafe_initializers_skip_before_translation():
     )
 
     assert constraints is None
-    assert result.kind == "unsafe_skip"
-    assert result.reason == "bitwise"
+    assert result.kind == "undecidable_skip"
 
 
 def test_guard_translation_failure_is_normalized():
@@ -278,6 +277,35 @@ def test_guard_translation_failure_is_normalized():
     assert guard is None
     assert z3_vars is None
     assert result.kind == "undecidable_skip"
+
+
+def test_verify_algorithms_do_not_import_solver_safety_by_default(monkeypatch):
+    """Direct verify calls run full-power instead of consulting safety gates."""
+    machine = parse_machine(
+        """
+        def int x = 0;
+        def int y = 0;
+        state System {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : if [x * y > 1 && x * y < 0];
+        }
+        """
+    )
+
+    def fail_import(name, *args, **kwargs):
+        if name == "pyfcstm.solver.safety":
+            raise AssertionError("verify must not consult solver.safety by default")
+        return real_import(name, *args, **kwargs)
+
+    real_import = __import__
+    monkeypatch.setattr("builtins.__import__", fail_import)
+
+    result = dead_guard(root_transition(machine), variables(machine))
+
+    assert result.kind == "unsat"
+    assert_single_diag(result, "W_DEAD_GUARD")
 
 
 def test_transition_shadowing_helper_reports_unconditional_followers():
@@ -474,7 +502,7 @@ class TestDeadGuard:
 
         assert result == AlgorithmResult(kind="timeout")
 
-    def test_unsafe_guard_skips_solver(self):
+    def test_bitwise_guard_translation_failure_is_undecidable(self):
         machine = parse_machine(
             """
             def int flags = 0;
@@ -489,10 +517,9 @@ class TestDeadGuard:
 
         result = dead_guard(root_transition(machine), variables(machine))
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "bitwise"
+        assert result.kind == "undecidable_skip"
 
-    def test_non_linear_variable_multiplication_is_unsafe_skip(self):
+    def test_non_linear_variable_multiplication_runs_full_power(self):
         machine = parse_machine(
             """
             def int x = 0;
@@ -508,8 +535,9 @@ class TestDeadGuard:
 
         result = dead_guard(root_transition(machine), variables(machine))
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "nonlinear"
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_DEAD_GUARD")
+        assert diag["data"]["verification_scope"] == "smt_local"
 
 
 class TestGuardTautology:
@@ -584,7 +612,7 @@ class TestGuardTautology:
 
         assert result == AlgorithmResult(kind="timeout")
 
-    def test_unsafe_guard_skips_solver(self):
+    def test_bitwise_guard_translation_failure_is_undecidable(self):
         machine = parse_machine(
             """
             def int flags = 0;
@@ -599,8 +627,7 @@ class TestGuardTautology:
 
         result = guard_tautology(root_transition(machine), variables(machine))
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "bitwise"
+        assert result.kind == "undecidable_skip"
 
 
 class TestForcedGuardUnsatUnderInit:
@@ -704,7 +731,7 @@ class TestForcedGuardUnsatUnderInit:
 
         assert result == AlgorithmResult(kind="timeout")
 
-    def test_unsafe_guard_skips_solver(self):
+    def test_bitwise_guard_translation_failure_is_undecidable(self):
         machine = parse_machine(
             """
             def int flags = 0;
@@ -727,8 +754,7 @@ class TestForcedGuardUnsatUnderInit:
             variables(machine),
         )
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "bitwise"
+        assert result.kind == "undecidable_skip"
 
     def test_forced_init_translation_failure_propagates(self):
         machine = parse_machine(
@@ -899,7 +925,7 @@ class TestEffectNoOpUnderGuard:
 
         assert result == AlgorithmResult(kind="timeout")
 
-    def test_unsafe_effect_skips_solver(self):
+    def test_bitwise_effect_translation_failure_is_undecidable(self):
         machine = parse_machine(
             """
             def int x = 0;
@@ -914,8 +940,7 @@ class TestEffectNoOpUnderGuard:
 
         result = effect_no_op_under_guard(root_transition(machine), variables(machine))
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "bitwise"
+        assert result.kind == "undecidable_skip"
 
     def test_effect_translation_failure_propagates(self):
         transition = Transition(
@@ -1052,7 +1077,7 @@ class TestEffectContradictsGuard:
 
         assert result == AlgorithmResult(kind="sat")
 
-    def test_unsafe_effect_skips_solver(self):
+    def test_nonlinear_effect_runs_full_power(self):
         machine = parse_machine(
             """
             def int counter = 0;
@@ -1067,8 +1092,7 @@ class TestEffectContradictsGuard:
 
         result = effect_contradicts_guard(root_transition(machine), variables(machine))
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "double_var_power"
+        assert result == AlgorithmResult(kind="sat")
 
     def test_effect_translation_failure_propagates(self):
         transition = Transition(
@@ -1164,7 +1188,7 @@ class TestTransitionShadowedByPredecessor:
 
         assert result == AlgorithmResult(kind="timeout")
 
-    def test_unsafe_guard_skips_solver(self):
+    def test_bitwise_guard_translation_failure_is_undecidable(self):
         machine = parse_machine(
             """
             def int flags = 0;
@@ -1181,8 +1205,7 @@ class TestTransitionShadowedByPredecessor:
 
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "bitwise"
+        assert result.kind == "undecidable_skip"
 
     def test_current_guard_translation_failure_propagates(self, monkeypatch):
         machine = parse_machine(
@@ -1336,7 +1359,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
 
         assert result == AlgorithmResult(kind="sat")
 
-    def test_ignores_states_without_enter_actions(self):
+    def test_def_initializer_can_determine_first_during_condition(self):
         machine = parse_machine(
             """
             def int mode = 0;
@@ -1355,7 +1378,9 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             state, variables(machine)
         )
 
-        assert result == AlgorithmResult(kind="sat")
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "false"
 
     def test_triggers_when_enter_determines_during_ternary_true_branch(self):
         machine = parse_machine(
@@ -1428,7 +1453,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
 
         assert result == AlgorithmResult(kind="timeout")
 
-    def test_unsafe_during_condition_skips_solver(self):
+    def test_bitwise_during_condition_translation_failure_is_undecidable(self):
         machine = parse_machine(
             """
             def int flags = 1;
@@ -1448,8 +1473,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             state, variables(machine)
         )
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "bitwise"
+        assert result.kind == "undecidable_skip"
 
     def test_init_constraint_failure_propagates(self):
         machine = parse_machine(
@@ -1586,7 +1610,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="sat")
-        assert len(calls) == 2
+        assert len(calls) == 3
 
     def test_ancestor_before_aspect_feeds_first_during_condition(self):
         machine = parse_machine(
@@ -1612,6 +1636,105 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         assert result.kind == "unsat"
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
         assert diag["data"]["branch_taken"] == "true"
+
+    def test_root_enter_feeds_first_during_condition(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                enter { mode = 1; }
+                state Idle {
+                    enter { x = 0; }
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_composite_during_before_feeds_first_during_condition(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Parent {
+                    during before { mode = 1; }
+                    state Child {
+                        enter { x = 0; }
+                        during { x = (mode > 0) ? 10 : 20; }
+                    }
+                    [*] -> Child;
+                }
+                [*] -> Parent;
+            }
+            """
+        )
+        state = machine.root_state.substates["Parent"].substates["Child"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_init_transition_effect_feeds_first_during_condition(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 0; }
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle effect { mode = 1; };
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_unsatisfiable_init_transition_context_returns_sat(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter { x = 0; }
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle : if [mode == 1];
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_uninitialized_leaf_entry_is_overapproximated(self):
         machine = parse_machine(
@@ -1792,7 +1915,7 @@ class TestCompositeInitGuardsIncomplete:
 
         assert result == AlgorithmResult(kind="timeout")
 
-    def test_unsafe_init_guard_skips_solver(self):
+    def test_bitwise_init_guard_translation_failure_is_undecidable(self):
         machine = parse_machine(
             """
             def int flags = 0;
@@ -1807,8 +1930,7 @@ class TestCompositeInitGuardsIncomplete:
 
         result = composite_init_guards_incomplete(machine, variables(machine))
 
-        assert result.kind == "unsafe_skip"
-        assert result.reason == "bitwise"
+        assert result.kind == "undecidable_skip"
 
     def test_nested_composite_reports_nested_state(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -989,7 +989,7 @@ def test_transition_trigger_builds_private_event_bool_when_no_mapping_given():
     trigger, result = smt_local._transition_trigger_or_result(transition, {})
 
     assert result is None
-    assert str(trigger) == "__event__System__Tick"
+    assert str(trigger) == "__event__6:System4:Tick"
 
 
 def test_root_initial_context_handles_root_state_directly():
@@ -1039,6 +1039,28 @@ def test_event_bool_name_falls_back_for_anonymous_transition():
     transition = Transition("A", "B", event=None, guard=None, effects=[])
 
     assert smt_local._event_bool_name(transition) == "__event__anonymous"
+
+
+def test_event_bool_name_is_injective_for_underscore_and_path_boundaries():
+    """Event Bool encoding keeps ``S.A__B`` distinct from ``S.A.B``."""
+    flat = Transition(
+        "X",
+        "Y",
+        event=Event("A__B", ("S",)),
+        guard=None,
+        effects=[],
+    )
+    nested = Transition(
+        "X",
+        "Z",
+        event=Event("B", ("S", "A")),
+        guard=None,
+        effects=[],
+    )
+
+    assert smt_local._event_bool_name(flat) == "__event__1:S4:A__B"
+    assert smt_local._event_bool_name(nested) == "__event__1:S1:A1:B"
+    assert smt_local._event_bool_name(flat) != smt_local._event_bool_name(nested)
 
 
 def test_group2_registry_impls_are_real_function_pointers():
@@ -1652,6 +1674,54 @@ class TestEffectNoOpUnderGuard:
 
         assert result.kind == "undecidable_skip"
 
+    def test_effect_definedness_unsat_under_guard_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x == 0] effect { y = 1 / x; };
+            }
+            """
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
+
+    def test_missing_effect_variable_after_symbolic_execution_is_undecidable(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B effect { x = 1; };
+            }
+            """
+        )
+
+        def drop_effect_variable(*args, **kwargs):
+            return {}, (), None
+
+        monkeypatch.setattr(
+            smt_local,
+            "_execute_effects_under_guard_or_result",
+            drop_effect_variable,
+        )
+
+        result = effect_no_op_under_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+
     def test_guard_prunes_unselected_ternary_value_for_no_op_effect(self):
         machine = parse_machine(
             """
@@ -1926,6 +1996,24 @@ class TestEffectContradictsGuard:
         )
 
         assert result.kind == "undecidable_skip"
+
+    def test_effect_definedness_unsat_under_guard_contradiction_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x == 0] effect { x = 1 / x; };
+            }
+            """
+        )
+
+        result = effect_contradicts_guard(root_transition(machine), variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert "runtime definedness" in result.reason
 
     def test_guard_prunes_unselected_ternary_value_for_guard_contradiction(self):
         machine = parse_machine(
@@ -2235,6 +2323,26 @@ class TestTransitionShadowedByPredecessor:
 
         assert len(calls) == 1
         assert result.kind == "sat"
+
+    def test_events_with_underscore_path_boundary_do_not_shadow_each_other(self):
+        machine = parse_machine(
+            """
+            state S {
+                event A__B;
+                state A { event B; }
+                state X;
+                state Y;
+                state Z;
+                [*] -> X;
+                X -> Y : A__B;
+                X -> Z : /A.B;
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
 
     def test_event_duplicate_shadowing_is_structural(self):
         machine = parse_machine(
@@ -4240,6 +4348,27 @@ class TestCompositeInitGuardsIncomplete:
 
         assert result.kind == "sat"
         assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+
+    def test_init_events_with_underscore_path_boundary_use_distinct_witness_bools(self):
+        machine = parse_machine(
+            """
+            state S {
+                event A__B;
+                state A { event B; }
+                state X;
+                state Y;
+                [*] -> X : A__B;
+                [*] -> Y : /A.B;
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        diag = assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+        assert "__event__1:S4:A__B" in diag["data"]["witness"]
+        assert "__event__1:S1:A1:B" in diag["data"]["witness"]
 
     def test_triggers_for_event_coverage_gap(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -344,13 +344,6 @@ def test_transition_shadowing_helper_reports_unconditional_followers():
     assert diag["data"]["reason"] == "unconditional_catchall"
 
 
-def test_transition_shadowing_helper_starts_unconditional_domain():
-    """The first unconditional transition is the catch-all baseline."""
-    transition = Transition("A", "B", event=None, guard=None, effects=[])
-
-    assert smt_local._domain_key(transition) == "unconditional"
-
-
 def test_lifecycle_action_collection_skips_abstract_actions():
     """Abstract lifecycle actions do not contribute concrete operations."""
     machine = parse_machine(
@@ -425,11 +418,11 @@ def test_operation_prefix_collection_updates_after_if_block():
 
     assert result is None
     assert condition_points is not None
-    assert [condition for condition, _ in condition_points] == [
+    assert [point.condition for point in condition_points] == [
         condition,
         ternary_condition,
     ]
-    assert str(condition_points[1][1]["mode"]) in {
+    assert str(condition_points[1].z3_vars["mode"]) in {
         "If(mode == 0, 1, 2)",
         "If(0 == mode, 1, 2)",
     }
@@ -470,6 +463,41 @@ def test_operation_prefix_collection_propagates_if_merge_failure():
             ]
         )
     ]
+
+    condition_points, result = smt_local._execute_operation_prefix_conditions_or_result(
+        operations,
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert condition_points is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_operation_prefix_collection_propagates_if_merge_failure_after_branch_scan(
+    monkeypatch,
+):
+    """If-block merge failures after collected branch points stay normalized."""
+    condition = BinaryOp(Variable("x"), ">", Integer(0))
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=condition,
+                    statements=[],
+                )
+            ]
+        )
+    ]
+    calls = []
+    real_execute = smt_local.execute_operations
+
+    def fail_only_during_final_merge(operations_arg, z3_vars):
+        calls.append(operations_arg)
+        if len(calls) == 1:
+            raise ValueError("synthetic merge failure")
+        return real_execute(operations_arg, z3_vars)
+
+    monkeypatch.setattr(smt_local, "execute_operations", fail_only_during_final_merge)
 
     condition_points, result = smt_local._execute_operation_prefix_conditions_or_result(
         operations,
@@ -1579,8 +1607,8 @@ class TestTransitionShadowedByPredecessor:
 
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
-        assert len(calls) >= 2
-        assert result.kind == "undecidable_skip"
+        assert len(calls) == 1
+        assert result.kind == "sat"
 
     def test_event_duplicate_shadowing_is_structural(self):
         machine = parse_machine(
@@ -1603,7 +1631,7 @@ class TestTransitionShadowedByPredecessor:
         diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
         assert diag["data"]["reason"] == "duplicate_event"
 
-    def test_unconditional_transition_does_not_cross_shadow_event_domain(self):
+    def test_unconditional_transition_shadows_later_event_transition(self):
         machine = parse_machine(
             """
             state System {
@@ -1620,9 +1648,11 @@ class TestTransitionShadowedByPredecessor:
 
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
-        assert result == AlgorithmResult(kind="sat")
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+        assert diag["data"]["reason"] == "unconditional_catchall"
 
-    def test_unconditional_transition_does_not_cross_shadow_guard_domain(self):
+    def test_unconditional_transition_shadows_later_guard_transition(self):
         machine = parse_machine(
             """
             def int x = 0;
@@ -1639,7 +1669,33 @@ class TestTransitionShadowedByPredecessor:
 
         result = transition_shadowed_by_predecessor(machine, variables(machine))
 
-        assert result == AlgorithmResult(kind="sat")
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+        assert diag["data"]["reason"] == "unconditional_catchall"
+
+    def test_event_guard_shadowing_reports_prior_trigger_cover(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                event Tick;
+                state A;
+                state B;
+                state C;
+                state D;
+                [*] -> A;
+                A -> B : Tick;
+                A -> D : if [x > 0];
+                A -> C : if [x > 1];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+        assert diag["data"]["reason"] == "prior_trigger_cover"
 
     def test_second_unconditional_transition_is_shadowed(self):
         machine = parse_machine(
@@ -2023,7 +2079,77 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="unknown")
-        assert len(calls) == 4
+        assert len(calls) == 5
+
+    def test_condition_path_reachability_unknown_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def path_unknown_after_context(*args, **kwargs):
+            calls.append(args)
+            from pyfcstm.solver.logical import SatResult
+
+            if len(calls) == 3:
+                return sat_unknown_result(*args, **kwargs)
+            if len(calls) > 3:
+                return SatResult(kind="unsat")
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", path_unknown_after_context)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="unknown")
+        assert len(calls) == 3
+
+    def test_condition_path_reachability_timeout_propagates(self, monkeypatch):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def path_timeout_after_context(*args, **kwargs):
+            calls.append(args)
+            from pyfcstm.solver.logical import SatResult
+
+            if len(calls) == 3:
+                return sat_timeout_result(*args, **kwargs)
+            if len(calls) > 3:
+                return SatResult(kind="unsat")
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", path_timeout_after_context)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="timeout")
+        assert len(calls) == 3
 
     def test_unsatisfiable_entry_context_short_circuits_before_conditions(self):
         machine = parse_machine(
@@ -2129,7 +2255,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         def missing_condition_point(*args, **kwargs):
             return (
                 (
-                    (
+                    smt_local._ConditionPoint(
                         BinaryOp(Variable("missing"), "==", Integer(1)),
                         smt_local._z3_vars(variables(machine)),
                     ),
@@ -2219,6 +2345,92 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             and diag["data"]["branch_taken"] == "true"
             for diag in result.diagnostics
         )
+
+    def test_unreachable_if_branch_condition_is_not_reported(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 1] {
+                            x = (mode == 0) ? 10 : 20;
+                        }
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        conditions = {diag["data"]["condition"] for diag in result.diagnostics}
+        assert conditions == {"mode == 1"}
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "false"
+
+    def test_unreachable_else_branch_ternary_is_not_reported(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 0] {
+                            x = 1;
+                        } else {
+                            x = (mode == 1) ? 10 : 20;
+                        }
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        conditions = {diag["data"]["condition"] for diag in result.diagnostics}
+        assert conditions == {"mode == 0"}
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_aspect_condition_is_checked_before_leaf_during(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Parent {
+                    >> during before { x = (mode == 0) ? 10 : 20; }
+                    state Child;
+                    [*] -> Child;
+                }
+                [*] -> Parent;
+            }
+            """
+        )
+        state = machine.root_state.substates["Parent"].substates["Child"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 0"
+        assert diag["data"]["branch_taken"] == "true"
 
     def test_enter_translation_failure_propagates(self):
         machine = parse_machine(
@@ -2321,7 +2533,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
 
         def both_branches_feasible(constraints, **kwargs):
             calls.append(tuple(constraints))
-            if len(calls) in {1, 2, 3}:
+            if len(calls) in {1, 2, 3, 4}:
                 return SatResult(kind="sat")
             return real_is_sat(constraints, **kwargs)
 
@@ -2332,7 +2544,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="sat")
-        assert len(calls) == 4
+        assert len(calls) == 5
 
     def test_ancestor_before_aspect_feeds_first_during_condition(self):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -382,6 +382,354 @@ def test_conditional_collection_includes_if_block_conditions():
     )
 
 
+def test_conditional_collection_includes_nested_ternary_conditions():
+    """Legacy condition iterator still reports ternary expression conditions."""
+    outer_condition = BinaryOp(Variable("x"), ">", Integer(0))
+    inner_condition = BinaryOp(Variable("y"), ">", Integer(0))
+    operations = [
+        Operation(
+            var_name="z",
+            expr=outer_condition.select(
+                inner_condition.select(Integer(1), Integer(2)),
+                Integer(3),
+            ),
+        )
+    ]
+
+    assert tuple(smt_local._conditional_conditions_from_operations(operations)) == (
+        outer_condition,
+        inner_condition,
+    )
+
+
+def test_path_sensitive_operator_helpers_normalize_z3_exceptions():
+    """Helper-level Z3 sort failures are normalized as undecidable skips."""
+
+    _, binary_result = smt_local._binary_z3_or_result(
+        "&&",
+        smt_local.z3.IntVal(1),
+        smt_local.z3.BoolVal(True),
+    )
+    _, unary_result = smt_local._unary_z3_or_result("!", smt_local.z3.IntVal(1))
+
+    class BadOperand:
+        def __ge__(self, other):
+            raise smt_local.z3.Z3Exception("synthetic Z3 ufunc failure")
+
+    _, ufunc_result = smt_local._ufunc_z3_or_result("abs", BadOperand())
+
+    assert binary_result.kind == "undecidable_skip"
+    assert unary_result.kind == "undecidable_skip"
+    assert ufunc_result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_ufunc_helper_covers_round_fallback_and_type_error():
+    """Synthetic ufunc edge cases stay normalized for private helper callers."""
+    round_value, round_result = smt_local._ufunc_z3_or_result(
+        "round",
+        smt_local.z3.BoolVal(True),
+    )
+    abs_value, abs_result = smt_local._ufunc_z3_or_result(
+        "abs",
+        smt_local.z3.BoolVal(True),
+    )
+
+    assert round_value is not None
+    assert round_result is None
+    assert abs_value is None
+    assert abs_result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_ufunc_helper_matches_python_round_half_even():
+    """The path-sensitive round helper matches Python's half-even semantics."""
+    operand = smt_local.z3.Real("x")
+    rounded, result = smt_local._ufunc_z3_or_result("round", operand)
+
+    assert result is None
+    for raw_value, expected in [
+        ("-2.5", -2),
+        ("-1.5", -2),
+        ("1.5", 2),
+        ("2.5", 2),
+        ("3.6", 4),
+        ("-3.6", -4),
+    ]:
+        solver = smt_local.z3.Solver()
+        solver.add(operand == smt_local.z3.RealVal(raw_value), rounded != expected)
+
+        assert solver.check() == smt_local.z3.unsat
+
+
+def test_path_sensitive_ufunc_helper_reports_bad_sqrt_sort():
+    """The ufunc helper covers direct unsupported sqrt operands."""
+    sqrt_value, sqrt_result = smt_local._ufunc_z3_or_result(
+        "sqrt",
+        smt_local.z3.BoolVal(True),
+    )
+
+    assert sqrt_value is None
+    assert sqrt_result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_supports_all_base_node_shapes():
+    """Path-sensitive expression conversion covers non-ternary expression forms."""
+    from pyfcstm.model.expr import Float, UFunc, UnaryOp
+
+    z3_vars = {
+        "x": smt_local.z3.Int("x"),
+        "y": smt_local.z3.Int("y"),
+    }
+    expressions = [
+        BinaryOp(Variable("x"), "+", Integer(1)),
+        BinaryOp(Variable("x"), "-", Integer(1)),
+        BinaryOp(Variable("x"), "*", Integer(2)),
+        BinaryOp(Variable("x"), "/", Integer(2)),
+        BinaryOp(Variable("x"), "%", Integer(2)),
+        BinaryOp(Variable("x"), "**", Integer(2)),
+        BinaryOp(Variable("x"), "<", Integer(2)),
+        BinaryOp(Variable("x"), "<=", Integer(2)),
+        BinaryOp(Variable("x"), ">", Integer(2)),
+        BinaryOp(Variable("x"), ">=", Integer(2)),
+        BinaryOp(Variable("x"), "==", Integer(2)),
+        BinaryOp(Variable("x"), "!=", Integer(2)),
+        BinaryOp(Boolean(True), "&&", Boolean(False)),
+        BinaryOp(Boolean(True), "||", Boolean(False)),
+        BinaryOp(Boolean(True), "&", Boolean(False)),
+        BinaryOp(Boolean(True), "|", Boolean(False)),
+        BinaryOp(Boolean(True), "^", Boolean(False)),
+        UnaryOp("-", Variable("x")),
+        UnaryOp("+", Variable("x")),
+        UnaryOp("!", Boolean(False)),
+        UFunc("abs", Variable("x")),
+        UFunc("sign", Variable("x")),
+        UFunc("floor", Float(1.5)),
+        UFunc("ceil", Float(1.5)),
+        UFunc("trunc", Float(-1.5)),
+        UFunc("trunc", Integer(-1)),
+        UFunc("sqrt", Float(4.0)),
+        UFunc("sqrt", Integer(4)),
+        UFunc("round", Float(1.2)),
+        UFunc("round", Integer(1)),
+    ]
+
+    for expr in expressions:
+        points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+            expr,
+            z3_vars,
+        )
+
+        assert points == ()
+        assert z3_expr is not None
+        assert result is None
+
+
+def test_path_sensitive_expression_translator_normalizes_unsupported_shapes():
+    """Unsupported path-sensitive conversion cases return undecidable skips."""
+    from pyfcstm.model.expr import UFunc, UnaryOp
+
+    z3_vars = {"x": smt_local.z3.Int("x")}
+    expressions = [
+        BinaryOp(Variable("x"), "@", Integer(1)),
+        BinaryOp(Variable("x"), "&", Integer(1)),
+        BinaryOp(Variable("x"), ">>", Integer(1)),
+        BinaryOp(Boolean(True), "<<", Boolean(False)),
+        Boolean(True).select(
+            Variable("x"), BinaryOp(Boolean(True), "<<", Boolean(False))
+        ),
+        Boolean(False).select(
+            BinaryOp(Boolean(True), "<<", Boolean(False)), Variable("x")
+        ),
+        Boolean(True).select(
+            BinaryOp(Boolean(True), "<<", Boolean(False)), Variable("x")
+        ),
+        Boolean(True)
+        .select(Variable("x"), BinaryOp(Boolean(True), "<<", Boolean(False)))
+        .select(Integer(1), Integer(2)),
+        BinaryOp(Variable("x"), "+", BinaryOp(Boolean(True), "<<", Boolean(False))),
+        UnaryOp("~", Variable("x")),
+        UnaryOp("?", Variable("x")),
+        UFunc("log", Variable("x")),
+        UFunc("abs", BinaryOp(Boolean(True), "<<", Boolean(False))),
+        UFunc("sqrt", Boolean(True)),
+    ]
+
+    for expr in expressions:
+        z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+            expr,
+            z3_vars,
+        )[1:]
+
+        assert z3_expr is None
+        assert result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_handles_empty_reachable_ternary(
+    monkeypatch,
+):
+    """A contradictory context that prunes both ternary branches is undecidable."""
+    from pyfcstm.solver.logical import SatResult
+
+    def always_unsat(*args, **kwargs):
+        return SatResult(kind="unsat")
+
+    monkeypatch.setattr(smt_local, "is_sat", always_unsat)
+
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        Boolean(True).select(Integer(1), Integer(2)),
+        {},
+        context_constraints=(),
+    )
+
+    assert points is None
+    assert z3_expr is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_propagates_false_path_unknown(
+    monkeypatch,
+):
+    """Ternary false-branch reachability uncertainty propagates to the caller."""
+    from pyfcstm.solver.logical import SatResult
+
+    calls = []
+
+    def sat_then_unknown(*args, **kwargs):
+        calls.append(args)
+        if len(calls) == 2:
+            return SatResult(kind="unknown")
+        return SatResult(kind="sat")
+
+    monkeypatch.setattr(smt_local, "is_sat", sat_then_unknown)
+
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        Boolean(True).select(Integer(1), Integer(2)),
+        {},
+        context_constraints=(),
+    )
+
+    assert points is None
+    assert z3_expr is None
+    assert result.kind == "unknown"
+    assert len(calls) == 2
+
+
+def test_path_sensitive_expression_translator_normalizes_if_merge_failure(
+    monkeypatch,
+):
+    """A Z3 failure while merging two reachable ternary branches is normalized."""
+
+    def raise_z3_exception(*args, **kwargs):
+        raise smt_local.z3.Z3Exception("synthetic if merge failure")
+
+    monkeypatch.setattr(smt_local.z3, "If", raise_z3_exception)
+
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        Boolean(True).select(Integer(1), Integer(2)),
+        {},
+    )
+
+    assert points is None
+    assert z3_expr is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_normalizes_non_boolean_logic_left():
+    """Malformed logical operands are normalized after both sides are translated."""
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        BinaryOp(Integer(1), "&&", Boolean(True)),
+        {},
+    )
+
+    assert points == ()
+    assert z3_expr is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_wraps_reachable_branch_domains():
+    """Reachable ternary value-branch domain constraints are path-qualified."""
+    domain_constraints = []
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        Boolean(True).select(BinaryOp(Variable("x"), "/", Integer(2)), Integer(0)),
+        {"x": smt_local.z3.Int("x")},
+        domain_constraints=domain_constraints,
+    )
+
+    assert points is not None
+    assert z3_expr is not None
+    assert result is None
+    assert [str(item) for item in domain_constraints] == [
+        "Implies(True, 2 != 0)"
+    ]
+
+
+def test_path_sensitive_expression_translator_wraps_false_branch_domains():
+    """False value-branch domain constraints are path-qualified too."""
+    domain_constraints = []
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        Boolean(True).select(Integer(0), BinaryOp(Variable("x"), "/", Integer(2))),
+        {"x": smt_local.z3.Int("x")},
+        domain_constraints=domain_constraints,
+    )
+
+    assert points is not None
+    assert z3_expr is not None
+    assert result is None
+    assert [str(item) for item in domain_constraints] == [
+        "Implies(Not(True), 2 != 0)"
+    ]
+
+
+def test_path_sensitive_expression_translator_denominator_failure_is_normalized():
+    """Malformed denominator domain checks are undecidable, not crashes."""
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        BinaryOp(Integer(1), "/", Boolean(True)),
+        {},
+    )
+
+    assert points is None
+    assert z3_expr is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_propagates_rhs_failure():
+    """Logical RHS translation is not skipped by symbolic short-circuit rules."""
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        BinaryOp(Boolean(True), "&&", BinaryOp(Boolean(True), "<<", Boolean(False))),
+        {},
+    )
+
+    assert points is None
+    assert z3_expr is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_propagates_unary_child_failure():
+    """Unary expressions propagate unsupported child translation results."""
+    from pyfcstm.model.expr import UnaryOp
+
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        UnaryOp("-", BinaryOp(Boolean(True), "<<", Boolean(False))),
+        {},
+    )
+
+    assert points is None
+    assert z3_expr is None
+    assert result.kind == "undecidable_skip"
+
+
+def test_path_sensitive_expression_translator_rejects_unknown_expr_type():
+    """Unknown expression objects are normalized as undecidable skips."""
+
+    points, z3_expr, result = smt_local._expr_conditions_and_z3_or_result(
+        object(),
+        {},
+    )
+
+    assert points is None
+    assert z3_expr is None
+    assert result.kind == "undecidable_skip"
+
+
 def test_operation_prefix_collection_updates_after_if_block():
     """Prefix condition collection uses the merged store after operation ifs."""
     condition = BinaryOp(Variable("mode"), "==", Integer(0))
@@ -508,6 +856,117 @@ def test_operation_prefix_collection_propagates_if_merge_failure_after_branch_sc
     assert condition_points is not None
     assert [point.condition for point in condition_points] == [condition]
     assert calls == []
+
+
+def test_operation_prefix_collection_records_else_domain_constraints():
+    """Else-branch runtime domain constraints are collected without implication."""
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=None,
+                    statements=[
+                        Operation(
+                            var_name="x",
+                            expr=BinaryOp(Variable("x"), "/", Integer(2)),
+                        )
+                    ],
+                )
+            ]
+        )
+    ]
+
+    _, _, domain_constraints, result = (
+        smt_local._execute_operation_prefix_conditions_and_vars_or_result(
+            operations,
+            {"x": smt_local.z3.Int("x")},
+        )
+    )
+
+    assert result is None
+    assert [str(item) for item in domain_constraints] == ["2 != 0"]
+
+
+def test_operation_prefix_collection_records_branch_domain_constraints():
+    """Guarded branch runtime domain constraints are path-qualified."""
+    condition = BinaryOp(Variable("x"), ">", Integer(0))
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=condition,
+                    statements=[
+                        Operation(
+                            var_name="x",
+                            expr=BinaryOp(Variable("x"), "/", Integer(2)),
+                        )
+                    ],
+                )
+            ]
+        )
+    ]
+
+    _, _, domain_constraints, result = (
+        smt_local._execute_operation_prefix_conditions_and_vars_or_result(
+            operations,
+            {"x": smt_local.z3.Int("x")},
+        )
+    )
+
+    assert result is None
+    assert [str(item) for item in domain_constraints] == ["Implies(0 < x, 2 != 0)"]
+
+
+def test_operation_prefix_collection_records_plain_assignment_domain_constraints():
+    """Plain operation expression domain constraints are collected."""
+    _, _, domain_constraints, result = (
+        smt_local._execute_operation_prefix_conditions_and_vars_or_result(
+            [Operation("x", BinaryOp(Variable("x"), "/", Integer(2)))],
+            {"x": smt_local.z3.Int("x")},
+        )
+    )
+
+    assert result is None
+    assert [str(item) for item in domain_constraints] == ["2 != 0"]
+
+
+def test_operation_prefix_collection_qualifies_branch_condition_domains():
+    """If-condition definedness constraints are qualified by branch selection."""
+    operations = [
+        IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=BinaryOp(
+                        BinaryOp(Variable("x"), "/", Integer(2)),
+                        ">",
+                        Integer(0),
+                    ),
+                    statements=[],
+                ),
+                IfBlockBranch(
+                    condition=BinaryOp(
+                        BinaryOp(Variable("x"), "/", Integer(3)),
+                        ">",
+                        Integer(0),
+                    ),
+                    statements=[],
+                ),
+            ]
+        )
+    ]
+
+    _, _, domain_constraints, result = (
+        smt_local._execute_operation_prefix_conditions_and_vars_or_result(
+            operations,
+            {"x": smt_local.z3.Int("x")},
+        )
+    )
+
+    assert result is None
+    assert [str(item) for item in domain_constraints] == [
+        "2 != 0",
+        "Implies(And(2 != 0, Not(0 < x/2)), 3 != 0)",
+    ]
 
 
 def test_operation_prefix_collection_rejects_unknown_statement_type():
@@ -1489,6 +1948,115 @@ class TestTransitionShadowedByPredecessor:
         diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
         assert diag["data"]["reason"] == "guard_shadow"
 
+    def test_dead_candidate_guard_is_not_reported_as_shadowed(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 0];
+                A -> C : if [x > 0 && x < 0];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_candidate_trigger_unknown_is_not_reported_as_shadowed(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 0];
+                A -> C : if [x > 1];
+            }
+            """
+        )
+        calls = []
+
+        def shadow_unsat_then_trigger_unknown(*args, **kwargs):
+            calls.append(args)
+            if len(calls) == 1:
+                from pyfcstm.solver.logical import SatResult
+
+                return SatResult(kind="unsat")
+            return sat_unknown_result(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", shadow_unsat_then_trigger_unknown)
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="unknown")
+        assert len(calls) == 2
+
+    def test_candidate_trigger_timeout_is_not_reported_as_shadowed(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B : if [x > 0];
+                A -> C : if [x > 1];
+            }
+            """
+        )
+        calls = []
+
+        def shadow_unsat_then_trigger_timeout(*args, **kwargs):
+            calls.append(args)
+            if len(calls) == 1:
+                from pyfcstm.solver.logical import SatResult
+
+                return SatResult(kind="unsat")
+            return sat_timeout_result(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", shadow_unsat_then_trigger_timeout)
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result == AlgorithmResult(kind="timeout")
+        assert len(calls) == 2
+
+    def test_unconditional_predecessor_shadows_unknown_candidate_trigger(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state A;
+                state B;
+                state C;
+                [*] -> A;
+                A -> B;
+                A -> C : if [x ** y > 0];
+            }
+            """
+        )
+
+        result = transition_shadowed_by_predecessor(machine, variables(machine))
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "W_TRANSITION_SHADOWED")
+        assert diag["data"]["reason"] == "unconditional_catchall"
+
     def test_does_not_trigger_for_complementary_guards(self):
         machine = parse_machine(
             """
@@ -2042,13 +2610,20 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             """
         )
         state = machine.root_state.substates["Idle"]
-        monkeypatch.setattr(smt_local, "is_sat", sat_unknown_result)
+        calls = []
+
+        def context_unknown(*args, **kwargs):
+            calls.append(args)
+            return sat_unknown_result(*args, **kwargs)
+
+        monkeypatch.setattr(smt_local, "is_sat", context_unknown)
 
         result = enter_postcondition_implies_during_precondition(
             state, variables(machine)
         )
 
         assert result == AlgorithmResult(kind="unknown")
+        assert len(calls) == 1
 
     def test_context_unknown_takes_precedence_when_no_diagnostic(self, monkeypatch):
         machine = parse_machine(
@@ -2081,7 +2656,46 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="unknown")
-        assert len(calls) == 5
+        assert len(calls) == 2
+
+    def test_context_unknown_is_recorded_when_diagnostic_exists(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def context_unknown_then_sat(*args, **kwargs):
+            calls.append(args)
+            if len(calls) == 4:
+                return sat_unknown_result(*args, **kwargs)
+            from pyfcstm.solver.logical import SatResult
+
+            if len(calls) == 6:
+                return SatResult(kind="unsat")
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", context_unknown_then_sat)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert len(calls) == 7
 
     def test_condition_path_reachability_unknown_propagates(self, monkeypatch):
         machine = parse_machine(
@@ -2103,10 +2717,8 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             calls.append(args)
             from pyfcstm.solver.logical import SatResult
 
-            if len(calls) == 3:
+            if len(calls) == 5:
                 return sat_unknown_result(*args, **kwargs)
-            if len(calls) > 3:
-                return SatResult(kind="unsat")
             return SatResult(kind="sat")
 
         monkeypatch.setattr(smt_local, "is_sat", path_unknown_after_context)
@@ -2116,7 +2728,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="unknown")
-        assert len(calls) == 3
+        assert len(calls) == 5
 
     def test_condition_path_reachability_timeout_propagates(self, monkeypatch):
         machine = parse_machine(
@@ -2138,10 +2750,8 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             calls.append(args)
             from pyfcstm.solver.logical import SatResult
 
-            if len(calls) == 3:
+            if len(calls) == 5:
                 return sat_timeout_result(*args, **kwargs)
-            if len(calls) > 3:
-                return SatResult(kind="unsat")
             return SatResult(kind="sat")
 
         monkeypatch.setattr(smt_local, "is_sat", path_timeout_after_context)
@@ -2151,7 +2761,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="timeout")
-        assert len(calls) == 3
+        assert len(calls) == 5
 
     def test_condition_path_reachability_unsat_skips_condition(self, monkeypatch):
         machine = parse_machine(
@@ -2173,7 +2783,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             calls.append(args)
             from pyfcstm.solver.logical import SatResult
 
-            if len(calls) == 3:
+            if len(calls) == 4:
                 return SatResult(kind="unsat")
             return SatResult(kind="sat")
 
@@ -2184,7 +2794,43 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="sat")
-        assert len(calls) == 3
+        assert len(calls) == 4
+
+    def test_condition_path_reachability_unsat_after_context_skips_condition(
+        self,
+        monkeypatch,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+        calls = []
+
+        def path_unsat_after_context(*args, **kwargs):
+            calls.append(args)
+            from pyfcstm.solver.logical import SatResult
+
+            if len(calls) == 5:
+                return SatResult(kind="unsat")
+            return SatResult(kind="sat")
+
+        monkeypatch.setattr(smt_local, "is_sat", path_unsat_after_context)
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result == AlgorithmResult(kind="sat")
+        assert len(calls) == 5
 
     def test_unsatisfiable_entry_context_short_circuits_before_conditions(self):
         machine = parse_machine(
@@ -2230,7 +2876,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             calls.append(args)
             from pyfcstm.solver.logical import SatResult
 
-            return SatResult(kind="unsat" if len(calls) == 2 else "sat")
+            return SatResult(kind="unsat" if len(calls) == 4 else "sat")
 
         monkeypatch.setattr(smt_local, "is_sat", context_unsat_then_sat)
 
@@ -2239,7 +2885,7 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="sat")
-        assert len(calls) == 2
+        assert len(calls) == 4
 
     def test_during_condition_translation_failure_after_prefix_execution(self):
         machine = parse_machine(
@@ -2419,10 +3065,14 @@ class TestEnterPostconditionImpliesDuringPrecondition:
                 None,
             )
 
+        def missing_condition_point_with_vars(*args, **kwargs):
+            condition_points, result = missing_condition_point(*args, **kwargs)
+            return condition_points, smt_local._z3_vars(variables(machine)), (), result
+
         monkeypatch.setattr(
             smt_local,
-            "_execute_operation_prefix_conditions_or_result",
-            missing_condition_point,
+            "_execute_operation_prefix_conditions_and_vars_or_result",
+            missing_condition_point_with_vars,
         )
 
         result = enter_postcondition_implies_during_precondition(
@@ -2562,6 +3212,392 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
         assert diag["data"]["branch_taken"] == "true"
 
+    def test_logical_or_unsupported_rhs_is_not_short_circuit_pruned(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        x = (mode == 0 || (flags & 1) == 1) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_logical_and_unsupported_rhs_is_not_short_circuit_pruned(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        x = (mode == 1 && (flags & 1) == 1) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_logical_if_condition_unsupported_rhs_is_not_short_circuit_pruned(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 0 || (flags & 1) == 1] { x = 1; }
+                        else { x = 2; }
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+
+    def test_logical_or_division_rhs_is_not_short_circuit_pruned(self):
+        machine = parse_machine(
+            """
+            def int x = 0;
+            def int y = 0;
+            state System {
+                state Idle {
+                    enter { x = 1; }
+                    during { y = (x == 1 || (x / (x - 1)) == 1) ? 1 : 2; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+        assert result.diagnostics == ()
+
+    def test_unreachable_enter_branch_unsupported_expr_does_not_mask_during_condition(
+        self,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    enter {
+                        if [mode == 0] { mode = 1; }
+                        else { mode = flags & 1; }
+                    }
+                    during { x = (mode == 1) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 1"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_ancestor_enter_uses_path_sensitive_entry_execution(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                enter {
+                    if [false] { mode = flags & 1; }
+                    else { mode = 1; }
+                }
+                state Idle { during { x = (mode == 1) ? 10 : 20; } }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 1"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_ancestor_enter_with_guarded_branch_uses_path_sensitive_entry_execution(
+        self,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                enter {
+                    if [mode == 0] { mode = 1; }
+                    else { mode = flags & 1; }
+                }
+                state Idle { during { x = (mode == 1) ? 10 : 20; } }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 1"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_composite_during_before_uses_path_sensitive_entry_execution(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Parent {
+                    during before { mode = (false) ? (flags & 1) : 1; }
+                    state Child { during { x = (mode == 1) ? 10 : 20; } }
+                    [*] -> Child;
+                }
+                [*] -> Parent;
+            }
+            """
+        )
+        state = machine.root_state.substates["Parent"].substates["Child"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 1"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_init_transition_effect_uses_path_sensitive_entry_execution(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle { during { x = (mode == 1) ? 10 : 20; } }
+                [*] -> Idle effect { mode = (false) ? (flags & 1) : 1; };
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 1"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_prior_domain_failure_skips_later_during_conditions(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int y = 0;
+            def int x = 0;
+            state System {
+                during {
+                    y = 1 / 0;
+                    x = (mode == 0) ? 10 : 20;
+                }
+            }
+            """
+        )
+
+        result = enter_postcondition_implies_during_precondition(
+            machine.root_state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+        assert result.diagnostics == ()
+
+    def test_variable_denominator_failure_skips_later_during_conditions(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int y = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        y = 1 / mode;
+                        x = (mode == 0) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+        assert result.diagnostics == ()
+
+    def test_round_negative_half_matches_runtime_branch_direction(self):
+        machine = parse_machine(
+            """
+            def float value = -1.5;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        rounded = round(value);
+                        x = (rounded == -2) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "rounded == -2"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_unreachable_nested_ternary_branch_is_not_reported(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 0) ? 10 : ((mode == 1) ? 20 : 30); }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 0"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_unreachable_nested_ternary_unsupported_branch_does_not_mask_condition(
+        self,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 0) ? 10 : (((flags & 1) == 1) ? 20 : 30); }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 0"
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_unselected_ternary_value_translation_failure_does_not_mask_condition(
+        self,
+    ):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int flags = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode == 0) ? 30 : (flags & 1); }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 0"
+        assert diag["data"]["branch_taken"] == "true"
+
     def test_unreachable_else_if_body_is_not_reported(self):
         machine = parse_machine(
             """
@@ -2603,6 +3639,43 @@ class TestEnterPostconditionImpliesDuringPrecondition:
             ("mode == 0", "branch", "true"),
             ("mode == 1", "expression", "true"),
         ]
+
+    def test_elif_condition_uses_prior_branch_path_for_later_store(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during {
+                        if [mode == 0] { mode = 1; }
+                        else if [mode == 1] { mode = 2; }
+                        x = (mode == 2) ? 10 : 20;
+                    }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag_items = {
+            (
+                diag["data"]["condition"],
+                diag["data"]["condition_source"],
+                diag["data"]["branch_taken"],
+            )
+            for diag in result.diagnostics
+        }
+        assert diag_items == {
+            ("mode == 0", "branch", "true"),
+            ("mode == 2", "expression", "false"),
+        }
 
     def test_aspect_condition_is_checked_before_leaf_during(self):
         machine = parse_machine(
@@ -2726,14 +3799,8 @@ class TestEnterPostconditionImpliesDuringPrecondition:
 
         from pyfcstm.solver.logical import SatResult
 
-        calls = []
-        real_is_sat = smt_local.is_sat
-
         def both_branches_feasible(constraints, **kwargs):
-            calls.append(tuple(constraints))
-            if len(calls) in {1, 2, 3, 4}:
-                return SatResult(kind="sat")
-            return real_is_sat(constraints, **kwargs)
+            return SatResult(kind="sat")
 
         monkeypatch.setattr(smt_local, "is_sat", both_branches_feasible)
 
@@ -2742,7 +3809,6 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         )
 
         assert result == AlgorithmResult(kind="sat")
-        assert len(calls) == 5
 
     def test_ancestor_before_aspect_feeds_first_during_condition(self):
         machine = parse_machine(
@@ -2769,6 +3835,32 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
         assert diag["data"]["branch_taken"] == "true"
 
+    def test_ancestor_after_aspect_feeds_first_during_condition(self):
+        machine = parse_machine(
+            """
+            def int trace = 0;
+            def int x = 0;
+            state System {
+                >> during before { trace = trace * 10 + 1; }
+                >> during after { x = (trace == 12) ? 10 : 20; }
+                state Idle {
+                    during { trace = trace * 10 + 2; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "trace == 12"
+        assert diag["data"]["branch_taken"] == "true"
+
     def test_root_enter_feeds_first_during_condition(self):
         machine = parse_machine(
             """
@@ -2792,6 +3884,27 @@ class TestEnterPostconditionImpliesDuringPrecondition:
 
         assert result.kind == "unsat"
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["branch_taken"] == "true"
+
+    def test_root_leaf_enter_feeds_first_during_condition(self):
+        machine = parse_machine(
+            """
+            def int mode = 0;
+            def int x = 0;
+            state System {
+                enter { mode = 1; }
+                during { x = (mode == 1) ? 10 : 20; }
+            }
+            """
+        )
+
+        result = enter_postcondition_implies_during_precondition(
+            machine.root_state, variables(machine)
+        )
+
+        assert result.kind == "unsat"
+        diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
+        assert diag["data"]["condition"] == "mode == 1"
         assert diag["data"]["branch_taken"] == "true"
 
     def test_composite_during_before_feeds_first_during_condition(self):

--- a/test/verify/test_topology.py
+++ b/test/verify/test_topology.py
@@ -22,7 +22,7 @@ GROUP1_TOPOLOGY = (
     "event_emission_to_consumer_reachable",
 )
 
-GROUP2_AND_GROUP3 = (
+GROUP2_SMT_LOCAL = (
     "dead_guard",
     "guard_tautology",
     "forced_guard_unsat_under_init",
@@ -31,6 +31,9 @@ GROUP2_AND_GROUP3 = (
     "transition_shadowed_by_predecessor",
     "enter_postcondition_implies_during_precondition",
     "composite_init_guards_incomplete",
+)
+
+GROUP3_BMC_PLACEHOLDERS = (
     "bounded_reachability",
     "symbolic_bfs",
     "bounded_safety",
@@ -920,7 +923,10 @@ def test_registry_wires_group1_impls_and_preserves_later_placeholders():
     }
     for name in GROUP1_TOPOLOGY:
         assert REGISTRY[name].impl is expected_impls[name]
-    for name in GROUP2_AND_GROUP3:
+
+
+def test_registry_preserves_group3_placeholders_after_topology_and_smt_local():
+    for name in GROUP3_BMC_PLACEHOLDERS:
         assert REGISTRY[name].impl is None
 
 


### PR DESCRIPTION
## 总览

本 PR 是 Layer 3 / issue #114 的 **PR-A4：组 2 SMT 局部实装** 子 PR。

- Umbrella PR：#127（PR-A 总伞 PR）
- Base：`dev/issue114-pr-a-verify`
- Head：`dev/issue114-pr-a4-smt-local`
- 前置：PR-A1 + PR-A2 + PR-A3 已合入 umbrella 分支
- 当前状态：已完成 TDD + SMT-local 实装、多轮 5-agent adversarial review、C/I 修复与覆盖率迭代；最新 head `887765de` 已推送；本地 focused checks、`pyfcstm.verify.smt_local` 100% focused coverage、`test/verify` 与 `test/solver` 已通过，GitHub Actions / Codecov 正在刷新；等待 CI / Codecov 更新与最终 5-agent review，**本 PR 不自行 merge**。


---

## 架构原则：verify / solver 是算法核心库，不是 inspect/diagnostics 策略层

维护者裁定（2026-06-01）：本 PR 以及 issue #114 后续开发必须遵守以下优先级更高的边界。

- `pyfcstm.verify` 与 `pyfcstm.solver` 的定位是纯算法核心与基础设施层；它们服务的不只是 `inspect_model()` / diagnostics。
- verify 算法默认直接调用时必须是“满血”算法：调用方让它跑就跑，不因 diagnostics/inspect 的产品策略、复杂度档位或 safety 预筛而默认降级/拦截。
- solver/verify 可以提供 safety classifier、metadata、可选参数、reason、witness 等基础设施，让下游自行施加限制；但这些限制默认不得反向绑死 verify 算法本体。
- 下游是否启用某个算法、如何限制复杂度、如何把 `unknown` / `timeout` / 非线性 / 多路径结果解释成 warning/info/error，属于 `inspect` / diagnostics adapter 的策略责任。
- 因此 Track A / PR-A4 修复原则是：优先完善算法本身和基础设施；若算法确实有边界，应通过 raw result / reason / registry metadata / 可选参数暴露给调用方，而不是把 verify 层写成 diagnostics gate。
- 本 PR 仍保持与 `pyfcstm/diagnostics/**` / `codes.yaml` / `schema.json` / `editors/**` 解耦；PR-B1 再负责 adapter / diagnostic 策略。

---

## 当前实现与验收状态

- 已新增 `pyfcstm/verify/smt_local.py`，实装 8 条组 2 SMT-local 原始算法函数。
- 已将 registry 中 8 条组 2 算法从 `impl=None` 接到真实函数指针；组 3 BMC/search 仍保持 placeholder。
- 已新增 `test/verify/test_smt_local.py` 并扩展 registry/topology 契约测试。
- 本地 focused checks 已通过：
  - `ruff check pyfcstm/verify test/solver/test_safety.py test/verify --output-format=full`
  - `git diff --check`
  - `python -m compileall -q pyfcstm/verify test/verify pyfcstm/solver/safety.py test/solver/test_safety.py`
  - `pytest test/verify/ -q`（195 passed）
  - `pytest test/solver/ -q`（179 passed）
  - `pytest test/verify/test_smt_local.py --cov=pyfcstm.verify.smt_local --cov-report=term-missing:skip-covered -q`（130 passed，`smt_local.py` 100%）
- CI：最新 PR head `887765de` 的 GitHub Actions checks 正在重新跑。
- Codecov 当前 comment 仍可能滞后于最新 head；`887765de` 本地 focused coverage 已将 `pyfcstm.verify.smt_local` 保持在 100%，等待 Codecov 新 comment/更新。

## 本 PR 范围

### 新建文件

- `pyfcstm/verify/smt_local.py` —— 实装 8 个 SMT 局部算法
- `test/verify/test_smt_local.py` —— 黑盒契约测试

### 修改文件

- `pyfcstm/verify/registry.py` —— 将 8 条组 2 SMT-local 算法的 `impl=None` 改为真实函数指针

### 明确禁止修改

- `pyfcstm/diagnostics/**`
- `pyfcstm/model/**`
- `codes.yaml`
- `schema.json`
- `editors/**`（尤其 `editors/jsfcstm/**`）
- PR-A3 / 组 1 拓扑相关实现文件
- 组 3 / dev/verify 预留文件：`pyfcstm/verify/search.py`、`pyfcstm/verify/reachability.py`

---

## 待实装算法

| 算法 | 入参形式 | smt_logic | 触发诊断 | spec / 备注 |
|---|---|---|---|---|
| `dead_guard` | `(transition, variables)` | `QF_LIRA` | `W_DEAD_GUARD` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4585868161)；合并自原 guard_sat + dead_transition |
| `guard_tautology` | `(transition, variables)` | `QF_LIRA` | `W_GUARD_TAUTOLOGY` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4585868215)；guard 恒真检测 |
| `forced_guard_unsat_under_init` | `(transition, variables)` | `QF_LIRA` | `W_FORCED_GUARD_UNSAT` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4585868294)；forced/init 语境下 guard 不可满足 |
| `effect_no_op_under_guard` | `(transition, variables)` | `QF_LIRA` | `W_EFFECT_SMT_NO_OP` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4585871764)；guard 下 effect 不改变状态 |
| `effect_contradicts_guard` | `(transition, variables)` | `QF_LIRA` | `I_EFFECT_GUARD_CONTRADICT` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4585871860)；info 级，effect 与 guard 后续条件矛盾 |
| `transition_shadowed_by_predecessor` | `(machine, variables)` | `QF_LIRA` | `W_TRANSITION_SHADOWED` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4585981921)；覆盖 guard/event/unconditional 三个 domain |
| `enter_postcondition_implies_during_precondition` | `(state, variables)` | `QF_LIRA` | `I_ENTER_DURING_CONTRADICT` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4585880134)；info 级，仅首次 cycle 推理 |
| `composite_init_guards_incomplete` | `(machine, variables)` | `QF_LIRA` | `W_COMPOSITE_INIT_INCOMPLETE` | [spec](https://github.com/HansBug/pyfcstm/issues/114#issuecomment-4586576881)；v9 新增；任意 composite 的 `[*] -> X_i` trigger 联合覆盖性 |

⚠️ 8 条函数签名不同：5 条接 `Transition`，2 条接 `StateMachine`，1 条接 `State`。本 PR 只在 registry 中保存原始函数指针；统一 `(machine, *, ...)` 适配 wrapper 留给 PR-B1。

---

## API 草案

```python
from dataclasses import dataclass
from typing import Optional, Sequence, Tuple
from typing_extensions import Literal

from pyfcstm.model import State, StateMachine, Transition, VarDefine

ResultKind = Literal['sat', 'unsat', 'unknown', 'timeout', 'undecidable_skip']

@dataclass(frozen=True)
class AlgorithmResult:
    kind: ResultKind
    diagnostics: Tuple[dict, ...]
    reason: Optional[str] = None


def dead_guard(transition: Transition, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
def guard_tautology(transition: Transition, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
def forced_guard_unsat_under_init(transition: Transition, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
def effect_no_op_under_guard(transition: Transition, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
def effect_contradicts_guard(transition: Transition, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
def transition_shadowed_by_predecessor(machine: StateMachine, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
def enter_postcondition_implies_during_precondition(state: State, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
def composite_init_guards_incomplete(machine: StateMachine, variables: Sequence[VarDefine], *, smt_timeout_ms: Optional[int] = None) -> AlgorithmResult: ...
```

说明：PR-A2 已确认 solver helper 的 timeout 契约是 `Optional[int] = None`；本 PR raw 算法层也沿用该默认值。`None` 表示不设置 solver timeout，非 `None` 原样传给 PR-A2 helper；有限预算策略由调用方、CLI 或后续 wrapper 层负责。

Python 兼容性要求：API 草案表达类型契约；实际实现必须保持仓库 Python 3.7-3.14 支持，`Literal` 不得直接依赖 Python 3.8+ 的 `typing.Literal`。若需要运行期导入，应使用仓库既有兼容路径或 `typing_extensions.Literal`。

---

## 实现要点

- verify raw 算法默认不调用 `pyfcstm.solver.safety`，直接把可翻译表达式交给 Z3；直接调用 verify 时必须是“满血”算法，调用方让它跑就跑。
- `pyfcstm.solver.safety` 仅作为可选 downstream policy classifier 保留，供 `inspect` / diagnostics adapter 或其他调用方在调用 raw verify 前自行使用；命中后如何限流、降级或解释不属于本 PR raw 算法默认行为。
- 使用 PR-A2 的 `pyfcstm.solver.logical.is_sat()` / `is_valid()` / `is_overlap()`：
  - `unknown` / `timeout` 原样映射到 `AlgorithmResult.kind`
  - 不抛出为诊断失败
- Z3 翻译以 `pyfcstm.solver.expr` 现有表达式翻译能力为基础；如遇当前 solver 翻译或 operation 执行无法表达的结构，归一化为 `undecidable_skip`。verify 层不再默认把非线性/位运算/超越函数作为 policy unsafe 拦截。
- 本 PR 产出的 `diagnostics` 暂为 `Tuple[dict, ...]`；PR-B1 再接入 `ModelDiagnostic`。

---

## TDD / 测试验收

- `pytest test/verify/test_smt_local.py -v` 全绿
- 所有 FCSTM fixture 必须经过 `parse_with_grammar_entry` + `parse_dsl_node_to_state_machine`（即 parse + semantic/model validation）后再喂给算法测试；不得用跳过解析/语义验证的裸 mock 替代契约样本。
- 至少 32 个测试用例：8 个算法 × 至少 4 case
  - normal 触发
  - normal 不触发
  - timeout / unknown 传播（例如 monkeypatch helper）
  - 当前 solver 翻译 / operation 执行失败归一化为 `undecidable_skip`
- 8 个算法在 registry 中 `impl is not None`，以完整 8-name 列表为准（issue #114 旧 checklist 曾漏列 v9 新增 `composite_init_guards_incomplete`，不得照抄遗漏）：

  ```python
  from pyfcstm.verify.registry import REGISTRY

  names = [
      'dead_guard',
      'guard_tautology',
      'forced_guard_unsat_under_init',
      'effect_no_op_under_guard',
      'effect_contradicts_guard',
      'transition_shadowed_by_predecessor',
      'enter_postcondition_implies_during_precondition',
      'composite_init_guards_incomplete',
  ]
  assert all(REGISTRY[name].impl is not None for name in names)
  ```

- 单条算法 p95 < 50ms（pytest-benchmark 简单基准）。若本地环境不适合稳定判定，可补充轻量性能 smoke，但不能替代该验收项。
- Track A 边界保护：
  - `git diff main -- pyfcstm/diagnostics pyfcstm/model codes.yaml schema.json editors/` 返空
  - 不创建 `pyfcstm/verify/search.py` / `pyfcstm/verify/reachability.py`

---

## 当前一致性 review 要求

请 reviewer 对比本 PR-A4 title/body、umbrella PR #127 的 PR-A4 部分、issue #114 的 PR-A4 卡片与 v9 变更，检查范围、文件边界、算法清单、签名、timeout 语义、测试验收是否一致。

问题分级：

- `C` / Critical：会导致实现方向错误、破坏 Track A 边界、或与 issue/umbrella 明显冲突。
- `I` / Important：不立即修会显著增加返工或测试/验收不可执行。
- `M` / Minor：措辞、文档、非阻塞增强建议。

若存在 C/I 级问题，需要先修 PR title/body 再进入开发；M 级不阻塞。





---


## 最新修复迭代（head `6f006f75`）

多轮 5-agent code review 后，本 PR 已处理 C/I 阻塞项，并按维护者最新架构裁定重申 verify/solver 边界：

- `pyfcstm.verify` / `pyfcstm.solver` 保持算法核心库定位；直接调用 raw verify 时默认“满血”运行，不因 inspect/diagnostics policy、复杂度档位或 `solver.safety` 预筛而自动拦截。
- `pyfcstm.solver.safety` 保留为可选 downstream policy classifier，并更新 docstring 说明它不是 raw verify 默认 gate。
- raw `AlgorithmResult.kind` 已移除 `unsafe_skip`；solver 翻译、operation 执行、Z3 类型等无法表达/无法判断的路径统一归一化为 `undecidable_skip`，`unknown` / `timeout` 继续原样传播。
- `effect_no_op_under_guard` 增加 guard feasibility gate，dead guard 不再真空真误报 no-op。
- `transition_shadowed_by_predecessor` 按 issue spec 只在同 domain 内做 shadow 判定，不再让 unconditional 跨 domain 遮蔽 event/guard。
- `enter_postcondition_implies_during_precondition` 的 first-cycle 语义已补齐 root/ancestor `enter`、composite local `during before`、init transition effect、init guard/event feasibility context；不可达 init context 返回无诊断 `sat`。
- 8 个 raw SMT-local 函数的 `smt_timeout_ms` 默认值统一为 `None`，与 PR-A2 / umbrella 契约一致。
- focused coverage：`pyfcstm.verify.smt_local` 本地为 100%；`SKIP_SLOW_TESTS=1 make unittest` 本地通过（9094 passed / 164 skipped / 63 deselected）；GitHub Actions 最新 head `aa5d2cf8` 正在重新跑。



### head `6f006f75` 增量说明（已被 `d65ed251` 继承）

本次增量专门处理第二轮 review / Codecov 暴露的问题：

- 为 `enter_postcondition_implies_during_precondition` 补齐 root/ancestor enter、composite local `during before`、init transition guard/effect/event first-enabled context，以及 during block 内 prefix condition store。
- 不可达 initial path / unsat entry context 不再产生确定性 first-cycle 诊断。
- 保持 verify raw algorithms 默认“满血”：未引入 `solver.safety` 默认 gate；非线性/变量幂等可翻译表达式继续直接交给 Z3，是否限制由下游 adapter / caller 决定。
- focused tests：`pytest test/verify/test_smt_local.py --cov=pyfcstm.verify.smt_local --cov-report=term-missing:skip-covered -q` → `130 passed`，`smt_local.py` 100%。
- fast full suite：`SKIP_SLOW_TESTS=1 make unittest` → `9094 passed, 164 skipped, 63 deselected`。


### head `f34d6c22` 增量说明

本次增量专门处理 head `d65ed251` 第三轮 codex-alpha/beta/gamma review 暴露的 `enter_postcondition_implies_during_precondition` path-sensitive 收集问题，同时继续遵守 verify raw 默认“满血”的架构原则：

- first-cycle condition collector 改为在 caller 提供的 context 下做 branch reachability 剪枝；不可达 branch body 不再被翻译/执行，因此不可达分支里的 unsupported expression 不会把整条算法提前降级成 `undecidable_skip` 并吞掉后续可判定诊断。
- if/else-if branch selection condition 与 ternary/expression condition 在 raw payload 中通过 `condition_source` 区分，降低下游 adapter 面对同文本 condition 时的歧义。
- 保持 raw verify 默认满血：8 个 raw API 的 `smt_timeout_ms` 默认仍为 `None`，`pyfcstm.verify.smt_local` 仍不默认导入或调用 `pyfcstm.solver.safety`，不因为 inspect/diagnostics policy 自动拦截。
- 本地验证：
  - `ruff check pyfcstm/verify test/verify test/solver/test_safety.py --output-format=full` → passed。
  - `git diff --check` / `python -m compileall -q pyfcstm/verify test/verify pyfcstm/solver/safety.py test/solver/test_safety.py` → passed。
  - `pytest test/verify/test_smt_local.py -q` → `141 passed`。
  - `pytest test/verify/ -q` → `206 passed`。
  - `pytest test/solver/ -q` → `179 passed`。
  - `pytest test/verify/test_smt_local.py --cov=pyfcstm.verify.smt_local --cov-report=term-missing:skip-covered -q` → `141 passed`，`smt_local.py` 100%。
  - `SKIP_SLOW_TESTS=1 make unittest` → `9105 passed, 164 skipped, 63 deselected`。

### head `d65ed251` 增量说明

本次增量专门处理最新 review 暴露的 SMT-local 语义边界，同时再次固化维护者关于 verify 默认“满血”的原则：

- `transition_shadowed_by_predecessor` 改为按 declaration-order 的 prior trigger coverage 判定遮蔽；无条件前驱现在会遮蔽后续 event / guard transition，混合 event+guard 覆盖会返回 `prior_trigger_cover`。
- `enter_postcondition_implies_during_precondition` 的 condition collection 现在携带 `_ConditionPoint.path_conditions`，对 during `if` / `else if` / `else` 内部 ternary 做 path-sensitive reachability 检查，不再报告不可达 branch 内的条件。
- first-cycle stream 现在统一扫描 ancestor `>> during before` aspect 与 leaf `during` 的条件，避免遗漏 aspect 中的 deterministic branch。
- raw verify 默认参数仍保持满血：`smt_timeout_ms=None`，不默认导入或调用 `pyfcstm.solver.safety`，不因为 inspect/diagnostics policy 自动拦截；下游若要限制必须在 adapter / caller 层显式施加。
- 本地验证：
  - `pytest test/verify/test_smt_local.py --cov=pyfcstm.verify.smt_local --cov-report=term-missing:skip-covered -q` → `136 passed`，`smt_local.py` 100%。
  - `pytest test/verify/ -q` → `201 passed`。
  - `pytest test/solver/ -q` → `179 passed`。
  - `ruff check pyfcstm/verify test/verify test/solver/test_logical.py test/solver/test_safety.py --output-format=full` → passed。
  - `git diff --check` / `python -m compileall -q ...` → passed。
  - `SKIP_SLOW_TESTS=1 make unittest` → `9100 passed, 164 skipped, 63 deselected`。


### head `aa5d2cf8` 增量说明

本次增量处理 final review 中剩余的 I 级 soundness 反例，并继续固化维护者要求的 verify raw 默认“满血”原则：

- root 本身为 leaf 时，first-cycle context 现在包含 root `enter` 动作；直接调用 `enter_postcondition_implies_during_precondition()` 不再把 root leaf 的 during branch 方向报反。
- expression-level ternary 现在按 first-cycle symbolic context 做 path-sensitive value-branch pruning；运行时不可达的 ternary 分支不会被翻译/执行，也不会因为未选分支中的 unsupported expression 把算法降级成 `undecidable_skip`。
- `transition_shadowed_by_predecessor()` 在报告 predecessor shadow 前会先确认 candidate trigger 自身可满足；candidate 自己的 dead guard 不再被误归因为前驱遮蔽。
- `round()` 的 path-sensitive Z3 helper 对齐 Python single-argument half-even 语义，并补齐负数 half case regression。
- raw verify 默认仍保持满血：8 个 raw API 的 `smt_timeout_ms` 默认均为 `None`；`pyfcstm.verify.smt_local` 仍不默认导入或调用 `pyfcstm.solver.safety`；非线性/变量幂等可翻译表达式继续直接交给 Z3，是否限制由 downstream adapter / caller 决定。
- 本地验证：
  - `ruff check pyfcstm/verify test/verify test/solver/test_safety.py --output-format=full` → passed。
  - `git diff --check` / `python -m compileall -q pyfcstm/verify test/verify pyfcstm/solver/safety.py test/solver/test_safety.py` → passed。
  - `pytest test/verify/test_smt_local.py --cov=pyfcstm.verify.smt_local --cov-report=term-missing:skip-covered -q` → `186 passed`，`smt_local.py` 100%。
- 最新 head `aa5d2cf8` 已推送；GitHub Actions 正在重新跑。提交消息包含 `[skip-slow]`，按仓库 CI 约定跳过 native C/C++ slow tests。



### head `887765de` 增量说明

本次增量处理 head `220ffe8c` final review 暴露的 mixed post-effect guard runtime-definedness soundness 边界，并继续遵守 verify / solver raw 算法默认“满血”的架构原则：

- `effect_contradicts_guard()` 现在只有在 post-effect context 蕴含全部 post-guard runtime-definedness constraints 时，才允许发确定性 `I_EFFECT_GUARD_CONTRADICT`。
- 如果存在可行 effect 后路径使 post-guard runtime-undefined（即使另一路径 runtime-defined 但 guard false），raw algorithm 返回 `undecidable_skip`，不再误报确定性 contradiction。
- raw verify 默认仍保持满血：8 个 raw API 的 `smt_timeout_ms` 默认均为 `None`；`pyfcstm.verify.smt_local` 仍不默认导入或调用 `pyfcstm.solver.safety`；限制策略继续留给 downstream adapter / caller。
- 本地验证：
  - `ruff check pyfcstm/solver/expr.py pyfcstm/solver/safety.py pyfcstm/verify/registry.py pyfcstm/verify/smt_local.py test/solver/test_expr.py test/solver/test_safety.py test/verify/test_registry.py test/verify/test_smt_local.py test/verify/test_topology.py --output-format=full` → passed。
  - `python -m compileall -q ...` / `git diff --check` → passed。
  - `pytest test/verify/test_smt_local.py -q` → `212 passed`。
  - `pytest test/verify/test_smt_local.py --cov=pyfcstm.verify.smt_local --cov-report=term-missing:skip-covered -q` → `212 passed`，`smt_local.py` 100%。
  - `pytest test/verify/ -q` → `277 passed`。
  - `pytest test/solver/ -q` → `182 passed`。
- 最新 head `887765de` 已推送；GitHub Actions / Codecov 正在刷新。提交消息包含 `[skip-slow]`，按仓库 CI 约定跳过 native C/C++ slow tests。


### head `220ffe8c` 增量说明

本次增量处理 head `1641ad5f` final review 暴露的 runtime-definedness soundness 边界，并继续遵守 verify / solver raw 算法默认“满血”的架构原则：

- `effect_contradicts_guard()` 在 effect 后重新检查 guard 时，现在收集 post-state guard runtime-definedness constraints；若这些 constraints 在 pre-guard + effect context 下不可满足，返回 `undecidable_skip` 而不是发确定性 `I_EFFECT_GUARD_CONTRADICT`。
- `transition_shadowed_by_predecessor()` 不再把 prior guard definedness 当作候选 transition 的全局裁剪依据；如果 prior runtime-definedness 排除了 candidate 剩余空间，返回 `undecidable_skip` 而不是 `W_TRANSITION_SHADOWED`。
- raw verify 默认仍保持满血：8 个 raw API 的 `smt_timeout_ms` 默认均为 `None`；`pyfcstm.verify.smt_local` 仍不默认导入或调用 `pyfcstm.solver.safety`；限制策略继续留给 downstream adapter / caller。
- 本地验证：
  - `ruff check pyfcstm/solver/expr.py pyfcstm/solver/safety.py pyfcstm/verify/registry.py pyfcstm/verify/smt_local.py test/solver/test_expr.py test/solver/test_safety.py test/verify/test_registry.py test/verify/test_smt_local.py test/verify/test_topology.py --output-format=full` → passed。
  - `python -m compileall -q ...` / `git diff --check` → passed。
  - `pytest test/verify/test_smt_local.py -q` → `210 passed`。
  - `pytest test/verify/test_smt_local.py --cov=pyfcstm.verify.smt_local --cov-report=term-missing:skip-covered -q` → `210 passed`，`smt_local.py` 100%。
  - `pytest test/verify/ -q` → `275 passed`。
  - `pytest test/solver/ -q` → `182 passed`。
- 最新 head `220ffe8c` 已推送；GitHub Actions / Codecov 正在刷新。提交消息包含 `[skip-slow]`，按仓库 CI 约定跳过 native C/C++ slow tests。

