### PR TITLE
fix(jsfcstm): 修复 inspect 诊断展示 range 与 quick fix 插入点混用

### DIFF
--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -6,7 +6,7 @@ import {FcstmDiagnostic, TextDocumentLike, TextRange, createRange} from '../util
 import {getWorkspaceGraph} from '../workspace';
 import {FCSTM_DIAGNOSTIC_CODES} from './analyzers';
 import {collectInspectDiagnosticsFromItems, diagnosticKey} from './diagnostics';
-import {rangeIntersects} from './ranges';
+import {findIdentifierRange, rangeIntersects} from './ranges';
 import type {FcstmWorkspaceEdit} from './references';
 import {planSuggestedFixEdit, suggestedFixFromDiagnostic} from './suggested-fixes';
 
@@ -138,26 +138,60 @@ export async function collectCodeActions(
         const existing = new Set<string>();
         const inspectDiagnostics = inspectModel(node.model).diagnostics;
         const serverSuggestedKeysAtRange = new Set(
-            collectInspectDiagnosticsFromItems(document, semantic, inspectDiagnostics)
+            collectInspectDiagnosticsFromItems(document, semantic, inspectDiagnostics, [], {rangeMode: 'fix-edit'})
                 .filter(diagnostic => (
                     suggestedFixFromDiagnostic(diagnostic) &&
                     rangeIntersects(diagnostic.range, range)
                 ))
                 .map(diagnosticKey),
         );
+        for (const item of inspectDiagnostics) {
+            const suggestedFix = item.refs?.suggested_fix;
+            if (
+                item.code !== 'W_INITIAL_UNCONDITIONAL_MISSING' ||
+                typeof item.refs?.composite_path !== 'string' ||
+                typeof suggestedFix !== 'object' ||
+                suggestedFix === null
+            ) {
+                continue;
+            }
+            const composite = semantic.states.find(state => (
+                state.identity.qualifiedName === item.refs.composite_path
+            ));
+            if (!composite) continue;
+            const transitionHit = semantic.transitions.some(transition => {
+                if (transition.sourceKind !== 'init' || transition.ownerStateId !== composite.identity.id) {
+                    return false;
+                }
+                return rangeIntersects(transition.range, range) || rangeIntersects(
+                    findIdentifierRange(document, transition.targetStateName, transition.range, {preferLast: true}),
+                    range,
+                );
+            });
+            if (transitionHit) {
+                serverSuggestedKeysAtRange.add(diagnosticKey({
+                    range: composite.range,
+                    message: item.message,
+                    severity: item.severity,
+                    source: 'fcstm',
+                    code: item.code,
+                    data: item.refs,
+                }));
+            }
+        }
         for (const diagnostic of collectInspectDiagnosticsFromItems(
             document,
             semantic,
             inspectDiagnostics,
             [],
-            {rangeMode: 'issue'},
+            {rangeMode: 'problem'},
         )) {
             if (!suggestedFixFromDiagnostic(diagnostic)) continue;
             const key = diagnosticKey(diagnostic);
             // Suggested-fix diagnostics can have two useful server-derived
-            // ranges: an edit-oriented published range and a broader issue
-            // range for cursor discovery. Never use client-supplied
-            // suggested_fix payloads as authorization for either range.
+            // ranges: the problem-object range and the fix-edit range. Never
+            // use client-supplied suggested_fix payloads as authorization
+            // for either range.
             if (!rangeIntersects(diagnostic.range, range) && !serverSuggestedKeysAtRange.has(key)) continue;
             if (existing.has(key)) continue;
             existing.add(key);

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -10,7 +10,7 @@ import {
 } from '../utils/text';
 import {getImportWorkspaceIndex} from '../workspace/imports';
 import {getWorkspaceGraph} from '../workspace';
-import {resolveRangeFromRefs} from './inspect-ranges';
+import {resolveRangeFromRefsDetailed} from './inspect-ranges';
 import {suggestedFixDiagnosticRange, suggestedFixIssueRange} from './suggested-fixes';
 
 // Only suppress inspect codes that the semantic analyzer already reports with
@@ -32,7 +32,7 @@ function canonicalDiagnosticData(value: unknown): unknown {
     const out: Record<string, unknown> = {};
     const item = value as Record<string, unknown>;
     for (const key of Object.keys(item).sort()) {
-        if (key === 'suggested_fix') continue;
+        if (key === 'suggested_fix' || key === '__rangeFallback') continue;
         out[key] = canonicalDiagnosticData(item[key]);
     }
     return out;
@@ -69,7 +69,7 @@ function rangeEquals(left: TextRange, right: TextRange): boolean {
 }
 
 export interface CollectInspectModelDiagnosticsOptions {
-    rangeMode?: 'diagnostic' | 'issue';
+    rangeMode?: 'problem' | 'fix-edit';
 }
 
 export function collectInspectDiagnosticsFromItems(
@@ -98,12 +98,23 @@ export function collectInspectDiagnosticsFromItems(
             code: item.code,
             data: item.refs,
         };
-        const suggestedRange = options.rangeMode === 'issue'
-            ? suggestedFixIssueRange(document, semantic, diagnostic)
-            : suggestedFixDiagnosticRange(document, semantic, diagnostic);
-        diagnostic.range = rangeEquals(suggestedRange, fullRange)
-            ? resolveRangeFromRefs(document, semantic, item.refs) ?? fullRange
-            : suggestedRange;
+        const refResolution = resolveRangeFromRefsDetailed(document, semantic, item.refs);
+        const problemRange = refResolution.range
+            ?? suggestedFixIssueRange(document, semantic, diagnostic);
+        if (options.rangeMode === 'fix-edit') {
+            const suggestedRange = suggestedFixDiagnosticRange(document, semantic, diagnostic);
+            diagnostic.range = rangeEquals(suggestedRange, fullRange)
+                ? problemRange
+                : suggestedRange;
+        } else {
+            diagnostic.range = problemRange;
+            if (rangeEquals(diagnostic.range, fullRange)) {
+                diagnostic.data = {...(diagnostic.data ?? {}), __rangeFallback: 'full_document'};
+            }
+        }
+        if (refResolution.fallback) {
+            diagnostic.data = {...(diagnostic.data ?? {}), __rangeFallback: refResolution.fallback};
+        }
         if (consumeDiagnosticCount(existingCounts, diagnosticKey(diagnostic))) continue;
         diagnostics.push(diagnostic);
     }

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -87,6 +87,7 @@ export function collectInspectDiagnosticsFromItems(
     }
     const fullRange = fullDocumentRange(document);
     const diagnostics: FcstmDiagnostic[] = [];
+    const seenEffectSelfAssigns = new Map<string, number>();
 
     for (const item of items) {
         if (SUPPRESSED_FROM_INSPECT_SURFACE.has(item.code)) continue;
@@ -98,7 +99,7 @@ export function collectInspectDiagnosticsFromItems(
             code: item.code,
             data: item.refs,
         };
-        const refResolution = resolveRangeFromRefsDetailed(document, semantic, item.refs);
+        const refResolution = resolveRangeFromRefsDetailed(document, semantic, item.refs, seenEffectSelfAssigns);
         const problemRange = refResolution.range
             ?? suggestedFixIssueRange(document, semantic, diagnostic);
         if (options.rangeMode === 'fix-edit') {

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -1,7 +1,13 @@
 import type {FcstmSemanticDocument} from '../semantics';
 import type {TextDocumentLike, TextRange} from '../utils/text';
 import {findIdentifierRange} from './ranges';
-import {resolveStatePath, spanLikeToRange, variableDefinitionRange} from './suggested-fixes';
+import {
+    effectSelfAssignRange,
+    firstVariableDefinitionRange,
+    resolveStatePath,
+    spanLikeToRange,
+    variableDefinitionRange,
+} from './suggested-fixes';
 
 function stringRef(refs: Record<string, unknown>, key: string): string | null {
     const value = refs[key];
@@ -29,6 +35,13 @@ function eventRange(
     return findIdentifierRange(document, event.name, event.declarationAst?.range ?? event.range);
 }
 
+export type InspectRangeFallback = 'full_document' | 'first_of_ambiguous';
+
+export interface InspectRangeResolution {
+    range: TextRange | null;
+    fallback?: InspectRangeFallback;
+}
+
 function arrayFirstRange(value: unknown): TextRange | null {
     if (!Array.isArray(value)) return null;
     for (const item of value) {
@@ -43,32 +56,49 @@ function arrayFirstRange(value: unknown): TextRange | null {
  * editor semantic document. Returning null lets callers fall back to a full
  * document range, which keeps anchor-less inspect diagnostics visible.
  */
+export function resolveRangeFromRefsDetailed(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    refs: unknown,
+): InspectRangeResolution {
+    if (typeof refs !== 'object' || refs === null) return {range: null};
+    const refMap = refs as Record<string, unknown>;
+
+    for (const key of ['guard_span', 'transition_span', 'forced_span', 'normal_span']) {
+        const range = spanLikeToRange(refMap[key]);
+        if (range) return {range};
+    }
+
+    const variableName = stringRef(refMap, 'var_name');
+    const statePath = stringRef(refMap, 'state_path');
+    if (variableName && refMap.effect_self_assign_anchor !== undefined && statePath) {
+        const range = effectSelfAssignRange(document, semantic, statePath, variableName);
+        if (range) return {range};
+    }
+
+    for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path', 'deepest_path']) {
+        const range = statePathRange(document, semantic, stringRef(refMap, key));
+        if (range) return {range};
+    }
+
+    if (variableName) {
+        const range = variableDefinitionRange(document, semantic, variableName);
+        if (range) return {range};
+        const firstRange = firstVariableDefinitionRange(document, semantic, variableName);
+        if (firstRange) return {range: firstRange, fallback: 'first_of_ambiguous'};
+    }
+
+    const resolvedEventRange = eventRange(document, semantic, stringRef(refMap, 'event_qualified_name'));
+    if (resolvedEventRange) return {range: resolvedEventRange};
+
+    const duplicateRange = arrayFirstRange(refMap.duplicate_spans);
+    return {range: duplicateRange};
+}
+
 export function resolveRangeFromRefs(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
     refs: unknown,
 ): TextRange | null {
-    if (typeof refs !== 'object' || refs === null) return null;
-    const refMap = refs as Record<string, unknown>;
-
-    for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path']) {
-        const range = statePathRange(document, semantic, stringRef(refMap, key));
-        if (range) return range;
-    }
-
-    const variableName = stringRef(refMap, 'var_name');
-    if (variableName) {
-        const range = variableDefinitionRange(document, semantic, variableName);
-        if (range) return range;
-    }
-
-    const resolvedEventRange = eventRange(document, semantic, stringRef(refMap, 'event_qualified_name'));
-    if (resolvedEventRange) return resolvedEventRange;
-
-    for (const key of ['transition_span', 'guard_span']) {
-        const range = spanLikeToRange(refMap[key]);
-        if (range) return range;
-    }
-
-    return arrayFirstRange(refMap.duplicate_spans);
+    return resolveRangeFromRefsDetailed(document, semantic, refs).range;
 }

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -51,6 +51,30 @@ function arrayFirstRange(value: unknown): TextRange | null {
     return null;
 }
 
+function effectSelfAssignGroupKey(refMap: Record<string, unknown>): string | null {
+    const variableName = stringRef(refMap, 'var_name');
+    const statePath = stringRef(refMap, 'state_path');
+    if (!variableName || !statePath) return null;
+    if (
+        typeof refMap.effect_self_assign_anchor !== 'string' &&
+        !Object.prototype.hasOwnProperty.call(refMap, 'transition_span')
+    ) {
+        return null;
+    }
+    return JSON.stringify([statePath, variableName]);
+}
+
+function effectSelfAssignOccurrenceIndex(
+    seen: Map<string, number> | undefined,
+    refMap: Record<string, unknown>,
+): number | undefined {
+    const key = effectSelfAssignGroupKey(refMap);
+    if (!key || !seen) return undefined;
+    const index = seen.get(key) ?? 0;
+    seen.set(key, index + 1);
+    return index;
+}
+
 /**
  * Resolve inspect diagnostic refs into the best source range available in the
  * editor semantic document. Returning null lets callers fall back to a full
@@ -60,6 +84,7 @@ export function resolveRangeFromRefsDetailed(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
     refs: unknown,
+    seenEffectSelfAssigns?: Map<string, number>,
 ): InspectRangeResolution {
     if (typeof refs !== 'object' || refs === null) return {range: null};
     const refMap = refs as Record<string, unknown>;
@@ -72,13 +97,19 @@ export function resolveRangeFromRefsDetailed(
     const variableName = stringRef(refMap, 'var_name');
     const statePath = stringRef(refMap, 'state_path');
     const looksLikeEffectSelfAssign = variableName && statePath && (
-        refMap.effect_self_assign_anchor !== undefined ||
+        typeof refMap.effect_self_assign_anchor === 'string' ||
         Object.prototype.hasOwnProperty.call(refMap, 'transition_span')
     );
     if (looksLikeEffectSelfAssign) {
-        const range = effectSelfAssignRange(document, semantic, statePath, variableName);
+        const range = effectSelfAssignRange(
+            document,
+            semantic,
+            statePath,
+            variableName,
+            effectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap),
+        );
         if (range) return {range};
-        if (statePath === '[*]') return {range: null};
+        return {range: null};
     }
 
     for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path', 'deepest_path']) {

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -64,15 +64,24 @@ function effectSelfAssignGroupKey(refMap: Record<string, unknown>): string | nul
     return JSON.stringify([statePath, variableName]);
 }
 
-function effectSelfAssignOccurrenceIndex(
+function consumeEffectSelfAssignOccurrenceIndex(
+    seen: Map<string, number> | undefined,
+    refMap: Record<string, unknown>,
+    matched: boolean,
+): void {
+    if (!matched) return;
+    const key = effectSelfAssignGroupKey(refMap);
+    if (!key || !seen) return;
+    seen.set(key, (seen.get(key) ?? 0) + 1);
+}
+
+function peekEffectSelfAssignOccurrenceIndex(
     seen: Map<string, number> | undefined,
     refMap: Record<string, unknown>,
 ): number | undefined {
     const key = effectSelfAssignGroupKey(refMap);
     if (!key || !seen) return undefined;
-    const index = seen.get(key) ?? 0;
-    seen.set(key, index + 1);
-    return index;
+    return seen.get(key) ?? 0;
 }
 
 /**
@@ -89,11 +98,6 @@ export function resolveRangeFromRefsDetailed(
     if (typeof refs !== 'object' || refs === null) return {range: null};
     const refMap = refs as Record<string, unknown>;
 
-    for (const key of ['guard_span', 'transition_span', 'forced_span', 'normal_span']) {
-        const range = spanLikeToRange(refMap[key]);
-        if (range) return {range};
-    }
-
     const variableName = stringRef(refMap, 'var_name');
     const statePath = stringRef(refMap, 'state_path');
     const looksLikeEffectSelfAssign = variableName && statePath && (
@@ -106,10 +110,16 @@ export function resolveRangeFromRefsDetailed(
             semantic,
             statePath,
             variableName,
-            effectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap),
+            peekEffectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap),
         );
+        consumeEffectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap, Boolean(range));
         if (range) return {range};
         return {range: null};
+    }
+
+    for (const key of ['guard_span', 'transition_span', 'forced_span', 'normal_span']) {
+        const range = spanLikeToRange(refMap[key]);
+        if (range) return {range};
     }
 
     for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path', 'deepest_path']) {

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -71,9 +71,14 @@ export function resolveRangeFromRefsDetailed(
 
     const variableName = stringRef(refMap, 'var_name');
     const statePath = stringRef(refMap, 'state_path');
-    if (variableName && refMap.effect_self_assign_anchor !== undefined && statePath) {
+    const looksLikeEffectSelfAssign = variableName && statePath && (
+        refMap.effect_self_assign_anchor !== undefined ||
+        Object.prototype.hasOwnProperty.call(refMap, 'transition_span')
+    );
+    if (looksLikeEffectSelfAssign) {
         const range = effectSelfAssignRange(document, semantic, statePath, variableName);
         if (range) return {range};
+        if (statePath === '[*]') return {range: null};
     }
 
     for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path', 'deepest_path']) {

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -275,6 +275,7 @@ export function effectSelfAssignRange(
     semantic: FcstmSemanticDocument,
     statePath: string | undefined,
     varName: string,
+    occurrenceIndex?: number,
 ): TextRange | null {
     const matches: TextRange[] = [];
     for (const transition of semantic.transitions) {
@@ -288,6 +289,9 @@ export function effectSelfAssignRange(
         for (const statement of statements) {
             matches.push(statementDeleteRange(document, statement));
         }
+    }
+    if (occurrenceIndex !== undefined) {
+        return matches[occurrenceIndex] ?? null;
     }
     return matches.length === 1 ? matches[0] : null;
 }

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -81,6 +81,18 @@ function statementDeleteRange(document: TextDocumentLike, statement: FcstmAstAss
     return statement.range;
 }
 
+function variableDeclarationRange(
+    document: TextDocumentLike,
+    range: TextRange,
+    text: string,
+): TextRange {
+    const line = document.lineAt(range.start.line).text;
+    if (trimComparable(line) === trimComparable(text)) {
+        return fullLineRange(document, range);
+    }
+    return range;
+}
+
 export function variableDefinitionRange(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
@@ -89,11 +101,23 @@ export function variableDefinitionRange(
     const variables = semantic.variables.filter(item => item.name === varName);
     if (variables.length !== 1) return null;
     const variable = variables[0];
-    const line = document.lineAt(variable.range.start.line).text;
-    if (trimComparable(line) === trimComparable(variable.ast.text)) {
-        return fullLineRange(document, variable.range);
-    }
-    return variable.range;
+    return variableDeclarationRange(document, variable.range, variable.ast.text);
+}
+
+export function firstVariableDefinitionRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    varName: string,
+): TextRange | null {
+    const variables = semantic.variables.filter(item => item.name === varName);
+    if (variables.length === 0) return null;
+    const variable = variables
+        .slice()
+        .sort((left, right) => (
+            left.range.start.line - right.range.start.line ||
+            left.range.start.character - right.range.start.character
+        ))[0];
+    return variableDeclarationRange(document, variable.range, variable.ast.text);
 }
 
 export function resolveStatePath(semantic: FcstmSemanticDocument, statePath: string) {
@@ -246,7 +270,7 @@ function collectSelfAssignsInIf(
     }
 }
 
-function effectSelfAssignRange(
+export function effectSelfAssignRange(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
     statePath: string | undefined,

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -278,7 +278,11 @@ export function effectSelfAssignRange(
 ): TextRange | null {
     const matches: TextRange[] = [];
     for (const transition of semantic.transitions) {
-        if (statePath && transition.sourceStatePath?.join('.') !== statePath) continue;
+        if (statePath === '[*]') {
+            if (transition.sourceKind !== 'init') continue;
+        } else if (statePath && transition.sourceStatePath?.join('.') !== statePath) {
+            continue;
+        }
         const statements: FcstmAstAssignmentStatement[] = [];
         collectSelfAssignStatements(transition.ast.effect?.statements ?? [], varName, statements);
         for (const statement of statements) {

--- a/editors/jsfcstm/test/diagnostics-published-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-published-range.test.ts
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict';
+
+import {createDocument, packageModule, sliceByRange} from './support';
+
+function fullDocumentSlice(text: string): string {
+    const lines = text.split('\n');
+    return sliceByRange(text, packageModule.createRange(
+        0,
+        0,
+        lines.length - 1,
+        lines[lines.length - 1]?.length ?? 0,
+    ));
+}
+
+describe('diagnostics published ranges', () => {
+    afterEach(() => {
+        packageModule.getWorkspaceGraph().clearOverlays();
+    });
+
+    it('anchors deadlock leaf diagnostics on the leaf states instead of fix insertion points', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    pseudo state C;',
+            '    state D;',
+            '    state F;',
+            '',
+            '    [*] -> A;',
+            '',
+            '    A -> B : if [x >= 48 && x % 7 == 1] effect {',
+            '        x = x + 10;',
+            '    };',
+            '    B -> D : if [x % 4 == 0];',
+            '',
+            '    A -> C : if [x % 7 != 1];',
+            '    C -> F : if [x % 4 != 1];',
+            '    C -> A effect {',
+            '        x = x + 1;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-deadlock.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const deadlocks = diagnostics
+            .filter(item => item.code === 'W_DEADLOCK_LEAF')
+            .sort((a, b) => String(a.data?.state_path).localeCompare(String(b.data?.state_path)));
+
+        assert.equal(deadlocks.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(deadlocks.map(item => item.data?.state_path), ['Root.D', 'Root.F']);
+        assert.equal(sliceByRange(text, deadlocks[0].range), 'D');
+        assert.equal(sliceByRange(text, deadlocks[1].range), 'F');
+        assert.notDeepEqual(deadlocks[0].range, packageModule.createRange(6, 0, 6, 0));
+        assert.notDeepEqual(deadlocks[1].range, packageModule.createRange(7, 0, 7, 0));
+
+        const fixEditDiagnostics = packageModule.collectInspectDiagnosticsFromItems(
+            document,
+            await packageModule.getWorkspaceGraph().getSemanticDocument(document),
+            deadlocks.map(item => ({
+                code: item.code,
+                severity: item.severity,
+                message: item.message,
+                span: null,
+                refs: item.data,
+            })),
+            [],
+            {rangeMode: 'fix-edit'},
+        );
+        const fixEditRanges = fixEditDiagnostics
+            .sort((a, b) => String(a.data?.state_path).localeCompare(String(b.data?.state_path)))
+            .map(item => item.range);
+        assert.deepEqual(fixEditRanges[0], packageModule.createRange(6, 0, 6, 0));
+        assert.deepEqual(fixEditRanges[1], packageModule.createRange(7, 0, 7, 0));
+    });
+
+    it('anchors missing unconditional initial diagnostics on the composite state', async () => {
+        const text = [
+            'def int ready = 0;',
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle : if [ready > 0];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-initial.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING');
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range), 'Root');
+        assert.notDeepEqual(diagnostic.range, packageModule.createRange(4, 0, 4, 0));
+    });
+
+    it('keeps delete-style suggested diagnostics on the concrete problem statement', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-self-assign.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), 'x = x;');
+        assert.notEqual(sliceByRange(text, diagnostic.range), 'A');
+    });
+
+    it('keeps quick-fix edit ranges separate from published problem ranges', async () => {
+        const text = [
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-deadlock-action-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_DEADLOCK_LEAF');
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range), 'Idle');
+
+        const actions = await packageModule.collectCodeActions(document, diagnostic.range, [diagnostic]);
+        const action = actions.find(item => /exit transition/.test(item.title));
+        assert.ok(action, `expected exit-transition quick fix, got ${JSON.stringify(actions)}`);
+        const edit = Object.values(action.edit?.changes || {}).flat()[0];
+        assert.ok(edit, 'expected quick-fix edit');
+        assert.deepEqual(edit.range, packageModule.createRange(2, 0, 2, 0));
+        assert.notDeepEqual(edit.range, diagnostic.range);
+        assert.match(edit.newText, /Idle -> \[\*\];\n/);
+    });
+
+
+    it('does not unlock missing-initial quick fixes from unrelated initial transitions', async () => {
+        const text = [
+            'def int ready = 0;',
+            'state Root {',
+            '    state Idle;',
+            '    state Standby;',
+            '    [*] -> Idle : if [ready > 0];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-initial-unrelated-transition.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_INITIAL_UNCONDITIONAL_MISSING');
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        const actions = await packageModule.collectCodeActions(
+            document,
+            diagnostics.find(item => item.code === 'W_DEADLOCK_LEAF' && item.data?.state_path === 'Root.Standby')!.range,
+            diagnostics,
+        );
+        assert.equal(
+            actions.some(item => /fallback entry transition/.test(item.title)),
+            false,
+            `unrelated sibling range must not unlock missing-initial quick fix: ${JSON.stringify(actions)}`,
+        );
+    });
+
+    it('keeps full-document fallback observable when refs cannot identify a problem range', async () => {
+        const text = 'state Root;\n';
+        const document = createDocument(text, '/tmp/published-full-fallback.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        assert.ok(semantic);
+
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(
+            document,
+            semantic,
+            [{
+                code: 'W_HIGH_VAR_TO_LEAF_RATIO',
+                severity: 'warning' as const,
+                message: 'Variable count is high compared with leaf states.',
+                span: null,
+                refs: {actual: 3, threshold: 2},
+            }],
+        );
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(sliceByRange(text, diagnostics[0].range), fullDocumentSlice(text));
+        assert.equal(diagnostics[0].data?.__rangeFallback, 'full_document');
+    });
+
+    it('marks duplicate-variable inspect fallback as first-of-ambiguous instead of full document', async () => {
+        const text = [
+            'def int x = 0;',
+            'def float x = 1.0;',
+            'state Root {',
+            '    state Idle;',
+            '    [*] -> Idle;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-duplicate-var.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_UNREFERENCED_VAR');
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range), 'def int x = 0;');
+        assert.equal(diagnostic.data?.__rangeFallback, 'first_of_ambiguous');
+        assert.notEqual(sliceByRange(text, diagnostic.range), fullDocumentSlice(text));
+    });
+});

--- a/editors/jsfcstm/test/diagnostics-published-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-published-range.test.ts
@@ -131,6 +131,76 @@ describe('diagnostics published ranges', () => {
         assert.notEqual(sliceByRange(text, diagnostic.range), 'def int x = 0;');
     });
 
+    it('anchors ambiguous self-assignment diagnostics on each matching transition statement', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    state C;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '    };',
+            '    A -> C effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-ambiguous-self-assign.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const selfAssignments = diagnostics.filter(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+
+        assert.equal(selfAssignments.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            selfAssignments.map(item => item.range.start.line),
+            [7, 10],
+        );
+        assert.deepEqual(
+            selfAssignments.map(item => sliceByRange(text, item.range).trim()),
+            ['x = x;', 'x = x;'],
+        );
+        assert.deepEqual(
+            selfAssignments.map(item => item.data?.__rangeFallback ?? null),
+            [null, null],
+        );
+        assert.notDeepEqual(
+            selfAssignments.map(item => sliceByRange(text, item.range)),
+            ['A', 'A'],
+        );
+    });
+
+    it('anchors repeated initial self-assignment diagnostics on each matching statement', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    [*] -> A effect {',
+            '        x = x;',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-repeated-initial-self-assign.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const selfAssignments = diagnostics.filter(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+
+        assert.equal(selfAssignments.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            selfAssignments.map(item => item.range.start.line),
+            [4, 5],
+        );
+        assert.deepEqual(
+            selfAssignments.map(item => sliceByRange(text, item.range).trim()),
+            ['x = x;', 'x = x;'],
+        );
+        assert.deepEqual(
+            selfAssignments.map(item => item.data?.__rangeFallback ?? null),
+            [null, null],
+        );
+        assert.notEqual(sliceByRange(text, selfAssignments[0].range), fullDocumentSlice(text));
+    });
+
     it('keeps quick-fix edit ranges separate from published problem ranges', async () => {
         const text = [
             'state Root {',

--- a/editors/jsfcstm/test/diagnostics-published-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-published-range.test.ts
@@ -170,6 +170,73 @@ describe('diagnostics published ranges', () => {
         );
     });
 
+    it('keeps self-assignment problem ranges ahead of later transition spans', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-self-assign-with-span.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(
+            document,
+            semantic,
+            [{
+                code: 'W_EFFECT_SELF_ASSIGN',
+                severity: 'warning' as const,
+                message: 'Transition effect assigns "x" to itself.',
+                span: null,
+                refs: {
+                    state_path: 'Root.A',
+                    transition_span: packageModule.createRange(5, 4, 7, 6),
+                    var_name: 'x',
+                    effect_self_assign_anchor: 'x',
+                },
+            }],
+        );
+
+        assert.equal(diagnostics.length, 1);
+        const slice = sliceByRange(text, diagnostics[0].range).trim();
+        assert.equal(slice, 'x = x;');
+        assert.notEqual(slice, 'A -> B effect {\n        x = x;\n    };');
+    });
+
+    it('only consumes self-assignment occurrence counters after a range is matched', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-self-assign-counter.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const refs = {
+            state_path: 'Root.A',
+            transition_span: null,
+            var_name: 'x',
+        };
+        const seen = new Map<string, number>();
+
+        const first = packageModule.resolveRangeFromRefsDetailed(document, semantic, refs, seen);
+        assert.equal(sliceByRange(text, first.range!).trim(), 'x = x;');
+        assert.equal(seen.get(JSON.stringify(['Root.A', 'x'])), 1);
+
+        const missing = packageModule.resolveRangeFromRefsDetailed(document, semantic, refs, seen);
+        assert.equal(missing.range, null);
+        assert.equal(seen.get(JSON.stringify(['Root.A', 'x'])), 1);
+    });
+
     it('anchors repeated initial self-assignment diagnostics on each matching statement', async () => {
         const text = [
             'def int x = 0;',

--- a/editors/jsfcstm/test/diagnostics-published-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-published-range.test.ts
@@ -112,6 +112,25 @@ describe('diagnostics published ranges', () => {
         assert.notEqual(sliceByRange(text, diagnostic.range), 'A');
     });
 
+    it('anchors initial-transition self-assignment diagnostics on the effect statement', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    [*] -> A effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/published-initial-self-assign.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_EFFECT_SELF_ASSIGN');
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), 'x = x;');
+        assert.notEqual(sliceByRange(text, diagnostic.range), 'def int x = 0;');
+    });
+
     it('keeps quick-fix edit ranges separate from published problem ranges', async () => {
         const text = [
             'state Root {',

--- a/editors/jsfcstm/test/support.ts
+++ b/editors/jsfcstm/test/support.ts
@@ -131,3 +131,18 @@ export async function withPatchedProperty<T extends object, K extends keyof T, R
         }
     }
 }
+
+export function sliceByRange(
+    text: string,
+    range: {start: {line: number; character: number}; end: {line: number; character: number}}
+): string {
+    const lines = text.split('\n');
+    if (range.start.line === range.end.line) {
+        return (lines[range.start.line] ?? '').slice(range.start.character, range.end.character);
+    }
+    return [
+        (lines[range.start.line] ?? '').slice(range.start.character),
+        ...lines.slice(range.start.line + 1, range.end.line),
+        (lines[range.end.line] ?? '').slice(0, range.end.character),
+    ].join('\n');
+}


### PR DESCRIPTION
> ✅ **状态：PR-A 已实现，正在等待 CI 与强对抗 review。** 本 PR 已完成 TDD 开发、本地验证和 push；当前 PR 不关闭 #133。

## 背景

本 PR 是 #133 的拆分执行入口，专注处理 **PR-A：jsfcstm 诊断 range 止血 + ambiguous fallback 策略**。#133 已确认问题不是单个 `W_DEADLOCK_LEAF` 的 off-by-one，而是一整类 diagnostic range/source-slice 契约失真。本 PR 只先修最影响 VSCode 用户体验、且能独立收敛的一层：发布到 editor 的 diagnostic range 不能再默认使用 quick-fix 的 edit/insertion range。

## 本 PR 的目标

1. 修复 inspect-backed diagnostics 在 VSCode / jsfcstm 中的 published diagnostic range 映射策略，让诊断波浪线优先指向问题对象本身。
2. 明确区分三类 range：
   - problem range：诊断展示位置，必须指向 message/refs 描述的对象；
   - fix edit range：quick fix 实际插入/删除/替换位置，只供 code action 使用；
   - related range：后续用于 duplicate / forced / shadow 等辅助定位。
3. 先止血 `W_DEADLOCK_LEAF`、`W_INITIAL_UNCONDITIONAL_MISSING` 等会被 suggested fix 插入点污染的诊断。
4. 收紧 duplicate / ambiguous 变量声明场景下的 fallback，不再静默退到 full document，而是给出可观测 fallback 标记。
5. 新增 TDD 覆盖：最终 `collectDocumentDiagnostics()` 输出必须能按 range 回切源文本并命中诊断对象。

## 范围边界

本 PR 只处理 #133 执行计划里的 PR-A，不在本 PR 中一次性解决全部 span 契约问题。

### 本 PR 内

- `editors/jsfcstm/src/editor/diagnostics.ts`：调整 inspect diagnostic published range 的选择顺序。
- `editors/jsfcstm/src/editor/code-actions.ts`：确保 code action 仍然使用 fix edit range，不被 published diagnostic range 改动破坏。
- `editors/jsfcstm/src/editor/inspect-ranges.ts` / `editors/jsfcstm/src/editor/suggested-fixes.ts`：补足 problem/object range 与 fallback 策略。
- `editors/jsfcstm/test/`：新增 source-slice 精确性测试，直接校验最终 diagnostics 的 range。

### 本 PR 外

- transition / guard / effect 类诊断补真实 transition span：留给 PR-B1。
- forced override related ranges：留给 PR-B2。
- action / event shadow / dead named action 的 declaration signature 定位：留给 PR-B3。
- parse recovery 后空 identifier / zero-width semantic diagnostics：留给 PR-C。
- pyfcstm `inspect_model()` span propagation：留给 PR-D1 / PR-D2。
- schema/codes.yaml 契约文档化与跨端 parity source-slice 升级：留给 PR-E。

## TDD 验收点

- ✅ `W_DEADLOCK_LEAF` 在 `state D;` / `state F;` 上的诊断 range 回切结果命中 `D` / `F`，不再是空字符串、下一行行首或 quick-fix 插入点。
- ✅ `W_INITIAL_UNCONDITIONAL_MISSING` 的诊断 range 命中 composite state 对象，而不是 transition 插入点。
- ✅ code action 的实际 edit range 仍落在插入点，没有因为 diagnostic range 改为 problem range 而失效。
- ✅ 对 refs 不足且确实无法定位的诊断，fallback 到 full document 时会在 diagnostic data 中记录 `__rangeFallback = full_document`。
- ✅ duplicate var 下的 `W_UNREFERENCED_VAR` 不再直接 fallback 到 full document，而是命中第一个声明并记录 `__rangeFallback = first_of_ambiguous`。


## 已完成实现摘要

- published inspect diagnostic 默认使用 problem/object range，不再默认使用 quick-fix edit/insertion range。
- `rangeMode` 拆成 `problem` 与 `fix-edit`，code action 内部仍通过服务端重算的 fix-edit/problem range 授权 quick fix，不信任客户端伪造 payload。
- `resolveRangeFromRefsDetailed()` 返回 range + fallback marker，支持 `full_document` 与 `first_of_ambiguous` 可观测标记。
- `W_EFFECT_SELF_ASSIGN` 这类 delete-style suggested diagnostic 优先锚到具体 self-assignment statement，避免重新退回 source state identifier。
- 新增 `editors/jsfcstm/test/diagnostics-published-range.test.ts`，直接对最终 `collectDocumentDiagnostics()` 输出做 source-slice 断言。

## 本地验证

- `npm run test`：575 passing，jsfcstm coverage summary `Statements 96.04% / Branches 86.64% / Functions 96.47% / Lines 96.04%`。
- `SKIP_SLOW_TESTS=1 make unittest`：8964 passed，164 skipped，63 deselected。
- `make rst_auto`：已执行；本 PR 未引入 Python API 文档变更。

## 一致性核查状态

已完成 5 路一致性核查评论（codex-alpha / codex-beta / codex-gamma / claude / deepseek）。共同结论是：PR-A 的 title/body 与 #133 的 PR-A 范围一致，但空 PR 阶段尚未满足实现验收；因此后续必须按 TDD 补齐代码和测试后再进入 ready-to-merge 评审。

## 与 issue #133 的关系

本 PR 对应 #133 执行计划中的 **PR-A：C1 止血 + M1 ambiguous fallback policy**。合入后应满足 #133 的第一阶段止血目标，但不会关闭 #133；后续仍需继续 PR-B/C/D/E 完成 transition span、pyfcstm span、parse recovery 和统一契约文档化。

Refs: #133（部分修复，issue 不应因本 PR 自动关闭）

