### PR TITLE
fix(jsfcstm): 让 transition body 诊断锚定源码范围

### DIFF
--- a/docs/source/api_doc/diagnostics/inspect.rst
+++ b/docs/source/api_doc/diagnostics/inspect.rst
@@ -35,7 +35,7 @@ TransitionInfo
 -----------------------------------------------------
 
 .. autoclass:: TransitionInfo
-    :members: from_path,to_path,event,event_scope,guard,effect,effect_self_assigns,is_forced,forced_origin
+    :members: from_path,to_path,event,event_scope,guard,effect,effect_self_assigns,is_forced,forced_origin,transition_index
 
 
 VariableInfo

--- a/editors/jsfcstm/src/ast/model.ts
+++ b/editors/jsfcstm/src/ast/model.ts
@@ -192,6 +192,24 @@ export interface FcstmAstTransitionBase extends FcstmAstNodeBase {
     condition_expr?: FcstmAstExpression;
     postOperations: FcstmAstOperationStatement[];
     post_operations: FcstmAstOperationStatement[];
+    /**
+     * Diagnostic-only model-order index used to map spanless transition
+     * diagnostics back to this source declaration. Normal transitions have a
+     * single index; forced transitions use ``transitionIndexRefs`` because one
+     * forced declaration can expand to multiple model transitions.
+     */
+    transitionIndex?: number;
+    /**
+     * Diagnostic-only expanded model-order refs for transition range
+     * disambiguation. This metadata is not part of FCSTM execution semantics.
+     */
+    transitionIndexRefs?: FcstmAstTransitionIndexRef[];
+}
+
+export interface FcstmAstTransitionIndexRef {
+    index: number;
+    fromPath: string | null;
+    toPath: string | null;
 }
 
 export interface FcstmAstTransition extends FcstmAstTransitionBase {

--- a/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
@@ -106,7 +106,7 @@ export function collectConstFoldWarnings(machine: StateMachine | null | undefine
             out.push(guardConstDiagnostic(
                 transition,
                 foldedGuard,
-                transition.transitionIndex ?? transition.transition_index ?? machine.allTransitions.indexOf(transition),
+                transition.transition_index ?? machine.allTransitions.indexOf(transition),
             ));
         }
     }

--- a/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
@@ -11,7 +11,7 @@ import {
     Transition,
     UnaryOp,
 } from '../../model/runtime';
-import type {ModelDiagnosticJson} from '../inspect';
+import {exprText, type ModelDiagnosticJson} from '../inspect';
 
 interface ExactInteger {
     kind: 'exactInteger';
@@ -99,11 +99,15 @@ export function collectConstFoldWarnings(machine: StateMachine | null | undefine
     if (!machine) return [];
     const out: ModelDiagnosticJson[] = [];
     const definedVars = new Set(Object.keys(machine.defines));
-    for (const [transitionIndex, transition] of machine.allTransitions.entries()) {
+    for (const transition of machine.allTransitions) {
         const guard = transition.guard;
         const foldedGuard = guard ? foldConditionExpression(guard) : null;
         if (foldedGuard === true || foldedGuard === false) {
-            out.push(guardConstDiagnostic(transition, foldedGuard, transitionIndex));
+            out.push(guardConstDiagnostic(
+                transition,
+                foldedGuard,
+                transition.transitionIndex ?? transition.transition_index ?? machine.allTransitions.indexOf(transition),
+            ));
         }
     }
     for (const state of machine.allStates) {
@@ -214,7 +218,7 @@ function guardConstDiagnostic(
             folded_value: value,
             from_path: transitionSourcePath(transition.parentPath, transition.fromState, transition.sourceKind),
             to_path: transitionTargetPath(transition.parentPath, transition.toState, transition.targetKind),
-            guard_text: transition.guard!.text,
+            guard_text: exprText(transition.guard),
             transition_index: transitionIndex,
         },
     };

--- a/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
@@ -8,6 +8,7 @@ import {
     Operation,
     OperationStatement,
     StateMachine,
+    Transition,
     UnaryOp,
 } from '../../model/runtime';
 import type {ModelDiagnosticJson} from '../inspect';
@@ -98,28 +99,15 @@ export function collectConstFoldWarnings(machine: StateMachine | null | undefine
     if (!machine) return [];
     const out: ModelDiagnosticJson[] = [];
     const definedVars = new Set(Object.keys(machine.defines));
-    let transitionIndex = 0;
-    for (const state of machine.allStates) {
-        const statePath = state.path.join('.');
-        for (const transition of state.transitions) {
-            const currentTransitionIndex = transitionIndex;
-            transitionIndex += 1;
-            const guard = transition.guard;
-            const foldedGuard = guard ? foldConditionExpression(guard) : null;
-            if (foldedGuard === true || foldedGuard === false) {
-                out.push(guardConstDiagnostic(
-                    transition.fromState,
-                    transition.toState,
-                    transition.sourceKind,
-                    transition.targetKind,
-                    state.path,
-                    foldedGuard,
-                    guard ? guard.text : '',
-                    currentTransitionIndex,
-                ));
-            }
+    for (const [transitionIndex, transition] of machine.allTransitions.entries()) {
+        const guard = transition.guard;
+        const foldedGuard = guard ? foldConditionExpression(guard) : null;
+        if (foldedGuard === true || foldedGuard === false) {
+            out.push(guardConstDiagnostic(transition, foldedGuard, transitionIndex));
         }
-        out.push(...duringConstAssignDiagnostics(statePath, state.onDurings, definedVars));
+    }
+    for (const state of machine.allStates) {
+        out.push(...duringConstAssignDiagnostics(state.path.join('.'), state.onDurings, definedVars));
     }
     return out;
 }
@@ -209,18 +197,13 @@ function duringStmtConstAssignDiagnostics(
 }
 
 function guardConstDiagnostic(
-    fromState: string,
-    toState: string,
-    sourceKind: 'init' | 'state',
-    targetKind: 'state' | 'exit',
-    parentPath: readonly string[],
+    transition: Transition,
     value: boolean,
-    guardText: string,
     transitionIndex: number,
 ): ModelDiagnosticJson {
     const label = value ? 'true' : 'false';
-    const sourceLabel = transitionSourceLabel(fromState, sourceKind);
-    const targetLabel = transitionTargetLabel(toState, targetKind);
+    const sourceLabel = transitionSourceLabel(transition.fromState, transition.sourceKind);
+    const targetLabel = transitionTargetLabel(transition.toState, transition.targetKind);
     return {
         code: value ? 'W_GUARD_CONST_TRUE' : 'W_GUARD_CONST_FALSE',
         severity: 'warning',
@@ -229,9 +212,9 @@ function guardConstDiagnostic(
         refs: {
             transition_span: null,
             folded_value: value,
-            from_path: transitionSourcePath(parentPath, fromState, sourceKind),
-            to_path: transitionTargetPath(parentPath, toState, targetKind),
-            guard_text: guardText,
+            from_path: transitionSourcePath(transition.parentPath, transition.fromState, transition.sourceKind),
+            to_path: transitionTargetPath(transition.parentPath, transition.toState, transition.targetKind),
+            guard_text: transition.guard!.text,
             transition_index: transitionIndex,
         },
     };

--- a/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts
@@ -98,10 +98,14 @@ export function collectConstFoldWarnings(machine: StateMachine | null | undefine
     if (!machine) return [];
     const out: ModelDiagnosticJson[] = [];
     const definedVars = new Set(Object.keys(machine.defines));
+    let transitionIndex = 0;
     for (const state of machine.allStates) {
         const statePath = state.path.join('.');
         for (const transition of state.transitions) {
-            const foldedGuard = transition.guard ? foldConditionExpression(transition.guard) : null;
+            const currentTransitionIndex = transitionIndex;
+            transitionIndex += 1;
+            const guard = transition.guard;
+            const foldedGuard = guard ? foldConditionExpression(guard) : null;
             if (foldedGuard === true || foldedGuard === false) {
                 out.push(guardConstDiagnostic(
                     transition.fromState,
@@ -110,6 +114,8 @@ export function collectConstFoldWarnings(machine: StateMachine | null | undefine
                     transition.targetKind,
                     state.path,
                     foldedGuard,
+                    guard ? guard.text : '',
+                    currentTransitionIndex,
                 ));
             }
         }
@@ -209,6 +215,8 @@ function guardConstDiagnostic(
     targetKind: 'state' | 'exit',
     parentPath: readonly string[],
     value: boolean,
+    guardText: string,
+    transitionIndex: number,
 ): ModelDiagnosticJson {
     const label = value ? 'true' : 'false';
     const sourceLabel = transitionSourceLabel(fromState, sourceKind);
@@ -223,6 +231,8 @@ function guardConstDiagnostic(
             folded_value: value,
             from_path: transitionSourcePath(parentPath, fromState, sourceKind),
             to_path: transitionTargetPath(parentPath, toState, targetKind),
+            guard_text: guardText,
+            transition_index: transitionIndex,
         },
     };
 }

--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -87,7 +87,8 @@ function collectUnreachableStateDiagnostics(
 
 function collectGuardConstFalseDiagnostics(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
     const out: ModelDiagnosticJson[] = [];
-    for (const transition of transitions) {
+    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
+        const transition = transitions[transitionIndex];
         if (!isMinimalConstFalseGuard(transition.guard)) continue;
         out.push({
             code: 'W_GUARD_CONST_FALSE',
@@ -99,6 +100,8 @@ function collectGuardConstFalseDiagnostics(transitions: TransitionInfo[]): Model
                 folded_value: false,
                 from_path: transition.from_path,
                 to_path: transition.to_path,
+                guard_text: transition.guard,
+                transition_index: transitionIndex,
             },
         });
     }

--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -87,8 +87,7 @@ function collectUnreachableStateDiagnostics(
 
 function collectGuardConstFalseDiagnostics(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
     const out: ModelDiagnosticJson[] = [];
-    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
-        const transition = transitions[transitionIndex];
+    for (const transition of transitions) {
         if (!isMinimalConstFalseGuard(transition.guard)) continue;
         out.push({
             code: 'W_GUARD_CONST_FALSE',
@@ -101,7 +100,7 @@ function collectGuardConstFalseDiagnostics(transitions: TransitionInfo[]): Model
                 from_path: transition.from_path,
                 to_path: transition.to_path,
                 guard_text: transition.guard,
-                transition_index: transitionIndex,
+                transition_index: transition.transition_index,
             },
         });
     }

--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -54,7 +54,7 @@ function collectRedundantTransitionWarnings(transitions: TransitionInfo[]): Mode
                 from_path: first.from_path,
                 to_path: first.to_path,
                 duplicate_spans: items.map((item, index) => `${item.transition.from_path}->${item.transition.to_path}#${index + 1}`),
-                transition_index: items[0].index,
+                transition_index: items[0].transition.transition_index,
             },
         });
     }
@@ -64,8 +64,7 @@ function collectRedundantTransitionWarnings(transitions: TransitionInfo[]): Mode
 function collectSelfTransitionNopWarnings(transitions: TransitionInfo[], states: StateInfo[]): ModelDiagnosticJson[] {
     const statesByPath = new Map(states.map(state => [state.path, state]));
     const out: ModelDiagnosticJson[] = [];
-    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
-        const transition = transitions[transitionIndex];
+    for (const transition of transitions) {
         if (transition.from_path !== transition.to_path) continue;
         if (transition.event !== null || transition.guard !== null || transition.effect !== null) continue;
         if (!isLifecycleFreeLeaf(transition.from_path, statesByPath)) continue;
@@ -79,7 +78,7 @@ function collectSelfTransitionNopWarnings(transitions: TransitionInfo[], states:
                 from_path: transition.from_path,
                 to_path: transition.to_path,
                 transition_span: null,
-                transition_index: transitionIndex,
+                transition_index: transition.transition_index,
             },
         });
     }
@@ -117,14 +116,13 @@ function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDi
         }
     }
     const out: ModelDiagnosticJson[] = [];
-    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
-        const transition = transitions[transitionIndex];
+    for (const transition of transitions) {
         for (const varName of transition.effect_self_assigns) {
             const refs: Record<string, unknown> = {
                 state_path: transition.from_path,
                 transition_span: null,
                 var_name: varName,
-                transition_index: transitionIndex,
+                transition_index: transition.transition_index,
             };
             if (
                 transition.from_path !== '[*]' &&

--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -34,16 +34,17 @@ function transitionBehaviorKey(transition: TransitionInfo): string {
 }
 
 function collectRedundantTransitionWarnings(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
-    const groups = new Map<string, TransitionInfo[]>();
-    for (const transition of transitions) {
+    const groups = new Map<string, Array<{transition: TransitionInfo; index: number}>>();
+    for (let index = 0; index < transitions.length; index += 1) {
+        const transition = transitions[index];
         if (transition.from_path === '[*]') continue;
         const key = transitionBehaviorKey(transition);
-        groups.set(key, [...(groups.get(key) ?? []), transition]);
+        groups.set(key, [...(groups.get(key) ?? []), {transition, index}]);
     }
     const out: ModelDiagnosticJson[] = [];
     for (const items of groups.values()) {
         if (items.length < 2) continue;
-        const first = items[0];
+        const first = items[0].transition;
         out.push({
             code: 'W_REDUNDANT_TRANSITION',
             severity: 'warning',
@@ -52,7 +53,8 @@ function collectRedundantTransitionWarnings(transitions: TransitionInfo[]): Mode
             refs: {
                 from_path: first.from_path,
                 to_path: first.to_path,
-                duplicate_spans: items.map((item, index) => `${item.from_path}->${item.to_path}#${index + 1}`),
+                duplicate_spans: items.map((item, index) => `${item.transition.from_path}->${item.transition.to_path}#${index + 1}`),
+                transition_index: items[0].index,
             },
         });
     }
@@ -62,7 +64,8 @@ function collectRedundantTransitionWarnings(transitions: TransitionInfo[]): Mode
 function collectSelfTransitionNopWarnings(transitions: TransitionInfo[], states: StateInfo[]): ModelDiagnosticJson[] {
     const statesByPath = new Map(states.map(state => [state.path, state]));
     const out: ModelDiagnosticJson[] = [];
-    for (const transition of transitions) {
+    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
+        const transition = transitions[transitionIndex];
         if (transition.from_path !== transition.to_path) continue;
         if (transition.event !== null || transition.guard !== null || transition.effect !== null) continue;
         if (!isLifecycleFreeLeaf(transition.from_path, statesByPath)) continue;
@@ -71,7 +74,13 @@ function collectSelfTransitionNopWarnings(transitions: TransitionInfo[], states:
             severity: 'warning',
             message: `Self transition on ${JSON.stringify(transition.from_path)} has no trigger, guard, effect, or re-entry lifecycle behavior.`,
             span: null,
-            refs: {state_path: transition.from_path},
+            refs: {
+                state_path: transition.from_path,
+                from_path: transition.from_path,
+                to_path: transition.to_path,
+                transition_span: null,
+                transition_index: transitionIndex,
+            },
         });
     }
     return out;
@@ -108,12 +117,14 @@ function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDi
         }
     }
     const out: ModelDiagnosticJson[] = [];
-    for (const transition of transitions) {
+    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
+        const transition = transitions[transitionIndex];
         for (const varName of transition.effect_self_assigns) {
             const refs: Record<string, unknown> = {
                 state_path: transition.from_path,
                 transition_span: null,
                 var_name: varName,
+                transition_index: transitionIndex,
             };
             if (
                 transition.from_path !== '[*]' &&

--- a/editors/jsfcstm/src/diagnostics/analyzers/transition-info.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/transition-info.ts
@@ -36,8 +36,7 @@ function collectCompositeSelfTransitionInfos(
 
 function collectEventlessGuardlessTransitionInfos(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
     const out: ModelDiagnosticJson[] = [];
-    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
-        const transition = transitions[transitionIndex];
+    for (const transition of transitions) {
         if (transition.from_path === '[*]') continue;
         if (transition.event !== null || transition.guard !== null) continue;
         out.push({
@@ -49,7 +48,7 @@ function collectEventlessGuardlessTransitionInfos(transitions: TransitionInfo[])
                 from_path: transition.from_path,
                 to_path: transition.to_path,
                 transition_span: null,
-                transition_index: transitionIndex,
+                transition_index: transition.transition_index,
             },
         });
     }

--- a/editors/jsfcstm/src/diagnostics/analyzers/transition-info.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/transition-info.ts
@@ -36,7 +36,8 @@ function collectCompositeSelfTransitionInfos(
 
 function collectEventlessGuardlessTransitionInfos(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
     const out: ModelDiagnosticJson[] = [];
-    for (const transition of transitions) {
+    for (let transitionIndex = 0; transitionIndex < transitions.length; transitionIndex += 1) {
+        const transition = transitions[transitionIndex];
         if (transition.from_path === '[*]') continue;
         if (transition.event !== null || transition.guard !== null) continue;
         out.push({
@@ -48,6 +49,7 @@ function collectEventlessGuardlessTransitionInfos(transitions: TransitionInfo[])
                 from_path: transition.from_path,
                 to_path: transition.to_path,
                 transition_span: null,
+                transition_index: transitionIndex,
             },
         });
     }

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -116,7 +116,9 @@ export interface TransitionInfo {
     effect_self_assigns: string[];
     is_forced: boolean;
     forced_origin: string | null;
+    transition_index: number | null;
 }
+
 
 /**
  * Per-variable structural summary plus participation flags.
@@ -446,6 +448,7 @@ function buildTransitionInfos(machine: StateMachine): TransitionInfo[] {
                 effect_self_assigns: effectSelfAssigns(t.effects),
                 is_forced: !!t.forced,
                 forced_origin: t.forced ? t.text : null,
+                transition_index: typeof t.transitionIndex === 'number' ? t.transitionIndex : null,
             });
         }
     }

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -36,6 +36,8 @@ import type {RawFcstmModelForcedTransition} from '../model/raw';
 const INIT_MARK = '[*]';
 const EXIT_MARK = '[*]';
 const FLOAT_EPSILON = 1e-10;
+const HEX_RADIX = 16;
+const BINARY_RADIX = 2;
 
 export const DEFAULT_DEEP_HIERARCHY_THRESHOLD = 6;
 export const DEFAULT_LARGE_COMPOSITE_THRESHOLD = 12;
@@ -749,10 +751,10 @@ function integerText(expr: Integer): string {
     const raw = expr.text.trim();
     if (/^\d+$/.test(raw)) return normalizeDecimalDigits(raw);
     if (/^0[xX][0-9a-fA-F]+$/.test(raw)) {
-        return convertRadixDigitsToDecimal(raw.slice(2), 16);
+        return convertRadixDigitsToDecimal(raw.slice(2), HEX_RADIX);
     }
     if (/^0[bB][01]+$/.test(raw)) {
-        return convertRadixDigitsToDecimal(raw.slice(2), 2);
+        return convertRadixDigitsToDecimal(raw.slice(2), BINARY_RADIX);
     }
     return String(Math.trunc(expr.value));
 }
@@ -842,7 +844,7 @@ function statementText(stmt: OperationStatement): string {
     return stmt.text;
 }
 
-function exprText(expr: Expr | null | undefined): string | null {
+export function exprText(expr: Expr | null | undefined): string | null {
     return expr ? formatExpr(expr) : null;
 }
 

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -64,6 +64,188 @@ export const FCSTM_DIAGNOSTIC_CODES = {
     effectSelfAssign: 'W_EFFECT_SELF_ASSIGN',
 } as const;
 
+
+const EXPR_PRECEDENCE: Record<string, number> = {
+    'function_call': 90,
+    'unary+': 80,
+    'unary-': 80,
+    '!': 80,
+    'not': 80,
+    '**': 70,
+    '*': 60,
+    '/': 60,
+    '%': 60,
+    '+': 50,
+    '-': 50,
+    '<<': 40,
+    '>>': 40,
+    '&': 35,
+    '^': 30,
+    '|': 25,
+    '<': 20,
+    '>': 20,
+    '<=': 20,
+    '>=': 20,
+    '==': 20,
+    '!=': 20,
+    '&&': 15,
+    'and': 15,
+    '||': 10,
+    'or': 10,
+    '?:': 5,
+};
+const HEX_RADIX = 16;
+const BINARY_RADIX = 2;
+
+function canonicalBinaryOperator(op: string): string {
+    if (op === 'and') return '&&';
+    if (op === 'or') return '||';
+    return op;
+}
+
+function canonicalUnaryOperator(op: string): string {
+    return op === 'not' ? '!' : op;
+}
+
+function unaryPrecedenceKey(op: string): string {
+    const canonical = canonicalUnaryOperator(op);
+    return canonical === '+' || canonical === '-' ? `unary${canonical}` : canonical;
+}
+
+function normalizeDecimalDigits(raw: string): string {
+    const normalized = raw.replace(/^0+/, '');
+    return normalized.length > 0 ? normalized : '0';
+}
+
+function addSmallDecimal(raw: string, value: number): string {
+    if (value === 0) return raw;
+    let carry = value;
+    const out: string[] = [];
+    for (let index = raw.length - 1; index >= 0; index -= 1) {
+        const total = Number(raw[index]) + carry;
+        out.push(String(total % 10));
+        carry = Math.floor(total / 10);
+    }
+    while (carry > 0) {
+        out.push(String(carry % 10));
+        carry = Math.floor(carry / 10);
+    }
+    return out.reverse().join('');
+}
+
+function multiplySmallDecimal(raw: string, factor: number): string {
+    if (raw === '0' || factor === 0) return '0';
+    let carry = 0;
+    const out: string[] = [];
+    for (let index = raw.length - 1; index >= 0; index -= 1) {
+        const total = Number(raw[index]) * factor + carry;
+        out.push(String(total % 10));
+        carry = Math.floor(total / 10);
+    }
+    while (carry > 0) {
+        out.push(String(carry % 10));
+        carry = Math.floor(carry / 10);
+    }
+    return out.reverse().join('');
+}
+
+function convertRadixDigitsToDecimal(digits: string, radix: number): string {
+    let value = '0';
+    for (const char of digits.toLowerCase()) {
+        const digit = parseInt(char, radix);
+        value = addSmallDecimal(multiplySmallDecimal(value, radix), digit);
+    }
+    return value;
+}
+
+function numericAstText(expression: FcstmAstLiteralExpression): string {
+    const raw = expression.valueText.trim();
+    if (/^\d+$/.test(raw)) return normalizeDecimalDigits(raw);
+    if (/^0[xX][0-9a-fA-F]+$/.test(raw)) {
+        return convertRadixDigitsToDecimal(raw.slice(2), HEX_RADIX);
+    }
+    if (/^0[bB][01]+$/.test(raw)) {
+        return convertRadixDigitsToDecimal(raw.slice(2), BINARY_RADIX);
+    }
+    const value = Number(raw);
+    if (expression.pyNodeType === 'Float') {
+        return Number.isInteger(value) ? `${value}.0` : String(value);
+    }
+    return String(Math.trunc(value));
+}
+
+function astExprPrecedence(expression: FcstmAstExpression): number | null {
+    if (expression.expressionKind === 'binary') {
+        return EXPR_PRECEDENCE[canonicalBinaryOperator(expression.op)] ?? null;
+    }
+    if (expression.expressionKind === 'conditional') return EXPR_PRECEDENCE['?:'];
+    if (expression.expressionKind === 'unary') return EXPR_PRECEDENCE[unaryPrecedenceKey(expression.op)] ?? null;
+    return null;
+}
+
+function astExprText(expression: FcstmAstExpression | undefined): string | null {
+    if (!expression) return null;
+    switch (expression.expressionKind) {
+        case 'literal':
+            return expression.literalType === 'boolean'
+                ? expression.valueText.toLowerCase()
+                : numericAstText(expression);
+        case 'identifier':
+            return expression.name;
+        case 'mathConst':
+            return expression.name;
+        case 'parenthesized':
+            return astExprText(expression.expression);
+        case 'function': {
+            const argument = astExprText(expression.argument);
+            return argument === null ? null : `${expression.functionName}(${argument})`;
+        }
+        case 'unary': {
+            const op = canonicalUnaryOperator(expression.op);
+            const myPrecedence = EXPR_PRECEDENCE[unaryPrecedenceKey(expression.op)];
+            let value = astExprText(expression.operand);
+            if (value === null) return null;
+            const valuePrecedence = astExprPrecedence(expression.operand);
+            if (valuePrecedence !== null && valuePrecedence <= myPrecedence) {
+                value = `(${value})`;
+            }
+            return `${op}${value}`;
+        }
+        case 'binary': {
+            const op = canonicalBinaryOperator(expression.op);
+            const myPrecedence = EXPR_PRECEDENCE[op];
+            let left = astExprText(expression.left);
+            let right = astExprText(expression.right);
+            if (left === null || right === null) return null;
+            const leftPrecedence = astExprPrecedence(expression.left);
+            if (leftPrecedence !== null && leftPrecedence < myPrecedence) {
+                left = `(${left})`;
+            }
+            const rightPrecedence = astExprPrecedence(expression.right);
+            if (rightPrecedence !== null && rightPrecedence <= myPrecedence) {
+                right = `(${right})`;
+            }
+            return `${left} ${op} ${right}`;
+        }
+        case 'conditional': {
+            const myPrecedence = EXPR_PRECEDENCE['?:'];
+            const condition = astExprText(expression.condition);
+            let whenTrue = astExprText(expression.whenTrue);
+            let whenFalse = astExprText(expression.whenFalse);
+            if (condition === null || whenTrue === null || whenFalse === null) return null;
+            const truePrecedence = astExprPrecedence(expression.whenTrue);
+            if (truePrecedence !== null && truePrecedence <= myPrecedence) {
+                whenTrue = `(${whenTrue})`;
+            }
+            const falsePrecedence = astExprPrecedence(expression.whenFalse);
+            if (falsePrecedence !== null && falsePrecedence <= myPrecedence) {
+                whenFalse = `(${whenFalse})`;
+            }
+            return `(${condition}) ? ${whenTrue} : ${whenFalse}`;
+        }
+    }
+}
+
 function isFalseLiteral(expression: FcstmAstExpression): boolean {
     return expression.expressionKind === 'literal'
         && expression.literalType === 'boolean'
@@ -102,14 +284,13 @@ function transitionDiagnosticEndpointPaths(
 }
 
 function transitionModelOrderIndex(transition: FcstmSemanticTransition): number | null {
-    const astRecord = transition.ast as unknown as Record<string, unknown>;
-    const rawIndex = astRecord.transitionIndex;
+    const rawIndex = transition.ast.transitionIndex;
     if (typeof rawIndex === 'number' && Number.isInteger(rawIndex)) return rawIndex;
 
-    if (!Array.isArray(astRecord.transitionIndexRefs)) return null;
+    if (!Array.isArray(transition.ast.transitionIndexRefs)) return null;
     if (transition.forced && transition.expandedTransitions.length === 1) {
         const [expanded] = transition.expandedTransitions;
-        const match = (astRecord.transitionIndexRefs as Array<Record<string, unknown>>).find(ref => (
+        const match = transition.ast.transitionIndexRefs.find(ref => (
             typeof ref.index === 'number' &&
             (typeof ref.fromPath !== 'string' || ref.fromPath === dottedPath(expanded.sourceStatePath)) &&
             (typeof ref.toPath !== 'string' || ref.toPath === (
@@ -120,7 +301,7 @@ function transitionModelOrderIndex(transition: FcstmSemanticTransition): number 
     }
 
     const endpoints = transitionDiagnosticEndpointPaths(transition);
-    const match = (astRecord.transitionIndexRefs as Array<Record<string, unknown>>).find(ref => (
+    const match = transition.ast.transitionIndexRefs.find(ref => (
         typeof ref.index === 'number' &&
         (typeof ref.fromPath !== 'string' || ref.fromPath === endpoints.from_path) &&
         (typeof ref.toPath !== 'string' || ref.toPath === endpoints.to_path)
@@ -377,6 +558,9 @@ function addTransitionDiagnostics(
         if (sourceUnreachable || (transition.guard && isFalseLiteral(transition.guard))) {
             const sourceState = semantic.states.find(item => item.identity.id === transition.sourceStateId);
             diagnostics.push({
+                // For forced expansions, ``transition.guard`` still points at
+                // the original forced declaration guard, so this range anchors
+                // literal-false warnings to the authored guard expression.
                 range: !sourceUnreachable && transition.guard ? transition.guard.range : transition.range,
                 message: sourceUnreachable
                     ? `Transition ${JSON.stringify(transition.ast.text)} is dead because its source state is unreachable.`
@@ -387,7 +571,7 @@ function addTransitionDiagnostics(
                 data: {
                     transition_span: null,
                     folded_value: false,
-                    guard_text: transition.guard?.text ?? null,
+                    guard_text: astExprText(transition.guard),
                     transition_index: transitionModelOrderIndex(transition),
                     ...transitionDiagnosticEndpointPaths(transition),
                 },

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -348,6 +348,8 @@ function addTransitionDiagnostics(
                 data: {
                     transition_span: null,
                     folded_value: false,
+                    guard_text: transition.guard?.text ?? null,
+                    transition_index: semantic.transitions.indexOf(transition),
                     ...transitionDiagnosticEndpointPaths(transition),
                 },
                 relatedInformation: sourceState

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -77,6 +77,18 @@ function dottedPath(path: readonly string[] | undefined): string | null {
 function transitionDiagnosticEndpointPaths(
     transition: FcstmSemanticTransition,
 ): {from_path?: string; to_path?: string} {
+    if (transition.forced && transition.expandedTransitions.length === 1) {
+        const [expanded] = transition.expandedTransitions;
+        const fromPath = dottedPath(expanded.sourceStatePath);
+        const toPath = expanded.targetKind === 'exit'
+            ? '[*]'
+            : dottedPath(expanded.targetStatePath);
+        return {
+            ...(fromPath ? {from_path: fromPath} : {}),
+            ...(toPath ? {to_path: toPath} : {}),
+        };
+    }
+
     const fromPath = transition.sourceKind === 'init'
         ? '[*]'
         : dottedPath(transition.sourceStatePath) ?? transition.sourceStateName ?? null;
@@ -87,6 +99,33 @@ function transitionDiagnosticEndpointPaths(
         ...(fromPath ? {from_path: fromPath} : {}),
         ...(toPath ? {to_path: toPath} : {}),
     };
+}
+
+function transitionModelOrderIndex(transition: FcstmSemanticTransition): number | null {
+    const astRecord = transition.ast as unknown as Record<string, unknown>;
+    const rawIndex = astRecord.transitionIndex;
+    if (typeof rawIndex === 'number' && Number.isInteger(rawIndex)) return rawIndex;
+
+    if (!Array.isArray(astRecord.transitionIndexRefs)) return null;
+    if (transition.forced && transition.expandedTransitions.length === 1) {
+        const [expanded] = transition.expandedTransitions;
+        const match = (astRecord.transitionIndexRefs as Array<Record<string, unknown>>).find(ref => (
+            typeof ref.index === 'number' &&
+            (typeof ref.fromPath !== 'string' || ref.fromPath === dottedPath(expanded.sourceStatePath)) &&
+            (typeof ref.toPath !== 'string' || ref.toPath === (
+                expanded.targetKind === 'exit' ? '[*]' : dottedPath(expanded.targetStatePath)
+            ))
+        ));
+        return typeof match?.index === 'number' ? match.index : null;
+    }
+
+    const endpoints = transitionDiagnosticEndpointPaths(transition);
+    const match = (astRecord.transitionIndexRefs as Array<Record<string, unknown>>).find(ref => (
+        typeof ref.index === 'number' &&
+        (typeof ref.fromPath !== 'string' || ref.fromPath === endpoints.from_path) &&
+        (typeof ref.toPath !== 'string' || ref.toPath === endpoints.to_path)
+    ));
+    return typeof match?.index === 'number' ? match.index : null;
 }
 
 function toFileUri(document: TextDocumentLike): string {
@@ -338,7 +377,7 @@ function addTransitionDiagnostics(
         if (sourceUnreachable || (transition.guard && isFalseLiteral(transition.guard))) {
             const sourceState = semantic.states.find(item => item.identity.id === transition.sourceStateId);
             diagnostics.push({
-                range: transition.range,
+                range: !sourceUnreachable && transition.guard ? transition.guard.range : transition.range,
                 message: sourceUnreachable
                     ? `Transition ${JSON.stringify(transition.ast.text)} is dead because its source state is unreachable.`
                     : `Transition ${JSON.stringify(transition.ast.text)} is dead because its guard is always false.`,
@@ -349,7 +388,7 @@ function addTransitionDiagnostics(
                     transition_span: null,
                     folded_value: false,
                     guard_text: transition.guard?.text ?? null,
-                    transition_index: semantic.transitions.indexOf(transition),
+                    transition_index: transitionModelOrderIndex(transition),
                     ...transitionDiagnosticEndpointPaths(transition),
                 },
                 relatedInformation: sourceState

--- a/editors/jsfcstm/src/editor/code-actions.ts
+++ b/editors/jsfcstm/src/editor/code-actions.ts
@@ -1,6 +1,7 @@
 import {pathToFileURL} from 'node:url';
 
 import {inspectModel} from '../diagnostics';
+import {buildStateMachineModel} from '../model';
 import type {FcstmSemanticDocument, FcstmSemanticImport, FcstmSemanticVariable} from '../semantics';
 import {FcstmDiagnostic, TextDocumentLike, TextRange, createRange} from '../utils/text';
 import {getWorkspaceGraph} from '../workspace';
@@ -134,9 +135,10 @@ export async function collectCodeActions(
     const relevantDiagnostics = diagnostics.filter(item => (
         !suggestedFixFromDiagnostic(item) && rangeIntersects(item.range, range)
     ));
-    if (node?.model) {
+    const localModel = semantic ? buildStateMachineModel(semantic) : null;
+    if (localModel) {
         const existing = new Set<string>();
-        const inspectDiagnostics = inspectModel(node.model).diagnostics;
+        const inspectDiagnostics = inspectModel(localModel).diagnostics;
         const serverSuggestedKeysAtRange = new Set(
             collectInspectDiagnosticsFromItems(document, semantic, inspectDiagnostics, [], {rangeMode: 'fix-edit'})
                 .filter(diagnostic => (

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -1,5 +1,6 @@
 import {getParser, ParseError} from '../dsl/parser';
 import {inspectModel, type ModelDiagnosticJson} from '../diagnostics';
+import {buildStateMachineModel} from '../model';
 import type {FcstmSemanticDocument} from '../semantics';
 import {collectSemanticAnalysisDiagnosticsFromSemantic} from './analyzers';
 import {
@@ -72,6 +73,17 @@ export interface CollectInspectModelDiagnosticsOptions {
     rangeMode?: 'problem' | 'fix-edit';
 }
 
+function shouldSuppressInspectDiagnostic(
+    semantic: FcstmSemanticDocument,
+    item: ModelDiagnosticJson,
+): boolean {
+    if (item.code !== 'W_DEADLOCK_LEAF') return false;
+    const statePath = typeof item.refs.state_path === 'string' ? item.refs.state_path : null;
+    if (!statePath) return false;
+    const semanticState = semantic.lookups.statesByPath[statePath];
+    return Boolean(semanticState && semanticState.ast.imports.length > 0);
+}
+
 export function collectInspectDiagnosticsFromItems(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
@@ -91,6 +103,7 @@ export function collectInspectDiagnosticsFromItems(
 
     for (const item of items) {
         if (SUPPRESSED_FROM_INSPECT_SURFACE.has(item.code)) continue;
+        if (shouldSuppressInspectDiagnostic(semantic, item)) continue;
         const diagnostic: FcstmDiagnostic = {
             range: fullRange,
             message: item.message,
@@ -175,8 +188,9 @@ export async function collectDocumentDiagnostics(
     const node = snapshot.nodes[snapshot.rootFile];
     if (node?.semantic) {
         diagnostics.push(...collectSemanticAnalysisDiagnosticsFromSemantic(node.semantic, document));
-        if (node.model) {
-            diagnostics.push(...collectInspectModelDiagnostics(document, node.semantic, node.model, diagnostics));
+        const localModel = buildStateMachineModel(node.semantic);
+        if (localModel) {
+            diagnostics.push(...collectInspectModelDiagnostics(document, node.semantic, localModel, diagnostics));
         }
     }
     return diagnostics;

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -102,20 +102,32 @@ function transitionMatchesRefs(
     return true;
 }
 
+
+function transitionRangeMatchesIndex(transition: FcstmSemanticTransition, index: number): boolean {
+    const rawIndex = (transition.ast as unknown as Record<string, unknown>).transitionIndex;
+    return typeof rawIndex === 'number' && Number.isInteger(rawIndex) && rawIndex === index;
+}
+
 function transitionRangeResolution(
     semantic: FcstmSemanticDocument,
     refs: Record<string, unknown>,
 ): InspectRangeResolution {
     const transitions = semantic.transitions.filter(transition => !transition.forced && transitionMatchesRefs(transition, refs));
-    if (transitions.length === 0) return {range: null};
+    if (transitions.length === 0) return {range: null, fallback: 'transition_ambiguous'};
+
     const requestedIndex = refs.transition_index;
-    const selected = typeof requestedIndex === 'number' && Number.isInteger(requestedIndex)
-        ? transitions.find(transition => semantic.transitions.indexOf(transition) === requestedIndex)
-        : transitions[0];
-    if (!selected) return {range: null};
+    if (typeof requestedIndex === 'number' && Number.isInteger(requestedIndex)) {
+        const selected = transitions.find(transition => transitionRangeMatchesIndex(transition, requestedIndex));
+        return selected
+            ? {range: selected.range, transition: selected}
+            : {range: null, fallback: 'transition_ambiguous'};
+    }
+
+    const selected = transitions[0];
+    const invalidIndexProvided = requestedIndex !== undefined;
     return {
         range: selected.range,
-        fallback: transitions.length > 1 && requestedIndex === undefined ? 'transition_ambiguous' : undefined,
+        fallback: transitions.length > 1 || invalidIndexProvided ? 'transition_ambiguous' : undefined,
         transition: selected,
     };
 }

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -42,7 +42,47 @@ function transitionEndpointPath(
 
 function compactText(value: string | null | undefined): string | null {
     if (value === undefined || value === null) return null;
-    return value.replace(/\s+/g, '');
+    return value.replace(/\s+/g, '').toLowerCase();
+}
+
+interface TransitionEndpointPair {
+    fromPath: string | null;
+    toPath: string | null;
+}
+
+function transitionEndpointPairs(transition: FcstmSemanticTransition): TransitionEndpointPair[] {
+    if (transition.forced && transition.expandedTransitions.length > 0) {
+        return transition.expandedTransitions.map(expanded => ({
+            fromPath: dottedPath(expanded.sourceStatePath),
+            toPath: expanded.targetKind === 'exit'
+                ? '[*]'
+                : dottedPath(expanded.targetStatePath),
+        }));
+    }
+    return [{
+        fromPath: transitionEndpointPath(transition, 'source'),
+        toPath: transitionEndpointPath(transition, 'target'),
+    }];
+}
+
+function transitionPathRefsMatch(
+    transition: FcstmSemanticTransition,
+    refs: Record<string, unknown>,
+): boolean {
+    const fromPath = stringRef(refs, 'from_path');
+    const toPath = stringRef(refs, 'to_path');
+    const statePath = stringRef(refs, 'state_path');
+    if (!fromPath && !toPath && !statePath) return true;
+
+    return transitionEndpointPairs(transition).some(pair => (
+        (!fromPath || pair.fromPath === fromPath) &&
+        (!toPath || pair.toPath === toPath) &&
+        (!statePath || pair.fromPath === statePath)
+    ));
+}
+
+function guardExpressionRange(transition: FcstmSemanticTransition): TextRange | null {
+    return transition.guard?.range ?? null;
 }
 
 function effectBlockRange(
@@ -78,20 +118,20 @@ function transitionHasEvent(transition: FcstmSemanticTransition, expectedEvent: 
         transition.trigger.normalizedPath.join('.') === expectedEvent;
 }
 
+function hasNumericTransitionIndex(refs: Record<string, unknown>): boolean {
+    return typeof refs.transition_index === 'number' && Number.isInteger(refs.transition_index);
+}
+
 function transitionMatchesRefs(
     transition: FcstmSemanticTransition,
     refs: Record<string, unknown>,
 ): boolean {
-    const fromPath = stringRef(refs, 'from_path');
-    const toPath = stringRef(refs, 'to_path');
-    if (fromPath && transitionEndpointPath(transition, 'source') !== fromPath) return false;
-    if (toPath && transitionEndpointPath(transition, 'target') !== toPath) return false;
-
-    const statePath = stringRef(refs, 'state_path');
-    if (statePath && statePath !== transitionEndpointPath(transition, 'source')) return false;
+    if (!transitionPathRefsMatch(transition, refs)) return false;
 
     const guardText = compactText(stringRef(refs, 'guard_text'));
-    if (guardText !== null && compactText(transition.guard?.text) !== guardText) return false;
+    if (guardText !== null && !hasNumericTransitionIndex(refs) && compactText(transition.guard?.text) !== guardText) {
+        return false;
+    }
 
     const effectText = compactText(stringRef(refs, 'effect_text'));
     if (effectText !== null && compactText(transition.effectText) !== effectText) return false;
@@ -103,8 +143,36 @@ function transitionMatchesRefs(
 }
 
 
-function transitionRangeMatchesIndex(transition: FcstmSemanticTransition, index: number): boolean {
-    const rawIndex = (transition.ast as unknown as Record<string, unknown>).transitionIndex;
+interface TransitionIndexRef {
+    index?: unknown;
+    fromPath?: unknown;
+    toPath?: unknown;
+}
+
+function transitionIndexRefMatchesRefs(
+    ref: TransitionIndexRef,
+    index: number,
+    refs: Record<string, unknown>,
+): boolean {
+    if (ref.index !== index) return false;
+    const fromPath = stringRef(refs, 'from_path') ?? stringRef(refs, 'state_path');
+    const toPath = stringRef(refs, 'to_path');
+    return (!fromPath || ref.fromPath === fromPath) &&
+        (!toPath || ref.toPath === toPath);
+}
+
+function transitionRangeMatchesIndex(
+    transition: FcstmSemanticTransition,
+    index: number,
+    refs: Record<string, unknown>,
+): boolean {
+    const astRecord = transition.ast as unknown as Record<string, unknown>;
+    if (Array.isArray(astRecord.transitionIndexRefs)) {
+        return (astRecord.transitionIndexRefs as TransitionIndexRef[])
+            .some(ref => transitionIndexRefMatchesRefs(ref, index, refs));
+    }
+
+    const rawIndex = astRecord.transitionIndex;
     return typeof rawIndex === 'number' && Number.isInteger(rawIndex) && rawIndex === index;
 }
 
@@ -112,15 +180,15 @@ function transitionRangeResolution(
     semantic: FcstmSemanticDocument,
     refs: Record<string, unknown>,
 ): InspectRangeResolution {
-    const transitions = semantic.transitions.filter(transition => !transition.forced && transitionMatchesRefs(transition, refs));
-    if (transitions.length === 0) return {range: null, fallback: 'transition_ambiguous'};
+    const transitions = semantic.transitions.filter(transition => transitionMatchesRefs(transition, refs));
+    if (transitions.length === 0) return {range: null, fallback: 'transition_not_found'};
 
     const requestedIndex = refs.transition_index;
     if (typeof requestedIndex === 'number' && Number.isInteger(requestedIndex)) {
-        const selected = transitions.find(transition => transitionRangeMatchesIndex(transition, requestedIndex));
+        const selected = transitions.find(transition => transitionRangeMatchesIndex(transition, requestedIndex, refs));
         return selected
             ? {range: selected.range, transition: selected}
-            : {range: null, fallback: 'transition_ambiguous'};
+            : {range: null, fallback: 'transition_not_found'};
     }
 
     const selected = transitions[0];
@@ -138,7 +206,9 @@ function guardRangeResolution(
 ): InspectRangeResolution {
     const transitionResolution = transitionRangeResolution(semantic, refs);
     if (!transitionResolution.range) return transitionResolution;
-    const guardRange = transitionResolution.transition?.guard?.range ?? null;
+    const guardRange = transitionResolution.transition
+        ? guardExpressionRange(transitionResolution.transition)
+        : null;
     return {
         range: guardRange ?? transitionResolution.range,
         fallback: transitionResolution.fallback,
@@ -160,6 +230,7 @@ export type InspectRangeFallback =
     | 'full_document'
     | 'first_of_ambiguous'
     | 'transition_ambiguous'
+    | 'transition_not_found'
     | 'effect_fallback'
     | 'transition_fallback';
 
@@ -269,6 +340,7 @@ export function resolveRangeFromRefsDetailed(
         }
         const transitionResolution = transitionRangeResolution(semantic, refMap);
         if (transitionResolution.range) return transitionResolution;
+        if (transitionResolution.fallback) return transitionResolution;
     }
     for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path', 'deepest_path']) {
         const range = statePathRange(document, semantic, stringRef(refMap, key));

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -28,6 +28,16 @@ function dottedPath(path: readonly string[] | undefined): string | null {
     return path && path.length > 0 ? path.join('.') : null;
 }
 
+function importAliasPathMatches(
+    semantic: FcstmSemanticDocument,
+    path: string | null,
+    stateName: string | undefined,
+): boolean {
+    if (!path || !stateName) return false;
+    const mountedImport = semantic.lookups.importsByMountedPath[path];
+    return Boolean(mountedImport && mountedImport.alias === stateName);
+}
+
 function transitionEndpointPath(
     transition: FcstmSemanticTransition,
     endpoint: 'source' | 'target',
@@ -66,6 +76,7 @@ function transitionEndpointPairs(transition: FcstmSemanticTransition): Transitio
 }
 
 function transitionPathRefsMatch(
+    semantic: FcstmSemanticDocument,
     transition: FcstmSemanticTransition,
     refs: Record<string, unknown>,
 ): boolean {
@@ -75,9 +86,9 @@ function transitionPathRefsMatch(
     if (!fromPath && !toPath && !statePath) return true;
 
     return transitionEndpointPairs(transition).some(pair => (
-        (!fromPath || pair.fromPath === fromPath) &&
-        (!toPath || pair.toPath === toPath) &&
-        (!statePath || pair.fromPath === statePath)
+        (!fromPath || pair.fromPath === fromPath || importAliasPathMatches(semantic, fromPath, transition.sourceStateName)) &&
+        (!toPath || pair.toPath === toPath || importAliasPathMatches(semantic, toPath, transition.targetStateName)) &&
+        (!statePath || pair.fromPath === statePath || importAliasPathMatches(semantic, statePath, transition.sourceStateName))
     ));
 }
 
@@ -123,10 +134,11 @@ function hasNumericTransitionIndex(refs: Record<string, unknown>): boolean {
 }
 
 function transitionMatchesRefs(
+    semantic: FcstmSemanticDocument,
     transition: FcstmSemanticTransition,
     refs: Record<string, unknown>,
 ): boolean {
-    if (!transitionPathRefsMatch(transition, refs)) return false;
+    if (!transitionPathRefsMatch(semantic, transition, refs)) return false;
 
     const guardText = compactText(stringRef(refs, 'guard_text'));
     if (guardText !== null && !hasNumericTransitionIndex(refs) && compactText(transition.guard?.text) !== guardText) {
@@ -150,6 +162,8 @@ interface TransitionIndexRef {
 }
 
 function transitionIndexRefMatchesRefs(
+    semantic: FcstmSemanticDocument,
+    transition: FcstmSemanticTransition,
     ref: TransitionIndexRef,
     index: number,
     refs: Record<string, unknown>,
@@ -157,18 +171,19 @@ function transitionIndexRefMatchesRefs(
     if (ref.index !== index) return false;
     const fromPath = stringRef(refs, 'from_path') ?? stringRef(refs, 'state_path');
     const toPath = stringRef(refs, 'to_path');
-    return (!fromPath || ref.fromPath === fromPath) &&
-        (!toPath || ref.toPath === toPath);
+    return (!fromPath || ref.fromPath === fromPath || importAliasPathMatches(semantic, fromPath, transition.sourceStateName)) &&
+        (!toPath || ref.toPath === toPath || importAliasPathMatches(semantic, toPath, transition.targetStateName));
 }
 
 function transitionRangeMatchesIndex(
+    semantic: FcstmSemanticDocument,
     transition: FcstmSemanticTransition,
     index: number,
     refs: Record<string, unknown>,
 ): boolean {
     if (Array.isArray(transition.ast.transitionIndexRefs)) {
         return transition.ast.transitionIndexRefs
-            .some(ref => transitionIndexRefMatchesRefs(ref, index, refs));
+            .some(ref => transitionIndexRefMatchesRefs(semantic, transition, ref, index, refs));
     }
 
     const rawIndex = transition.ast.transitionIndex;
@@ -179,12 +194,12 @@ function transitionRangeResolution(
     semantic: FcstmSemanticDocument,
     refs: Record<string, unknown>,
 ): InspectRangeResolution {
-    const transitions = semantic.transitions.filter(transition => transitionMatchesRefs(transition, refs));
+    const transitions = semantic.transitions.filter(transition => transitionMatchesRefs(semantic, transition, refs));
     if (transitions.length === 0) return {range: null, fallback: 'transition_not_found'};
 
     const requestedIndex = refs.transition_index;
     if (typeof requestedIndex === 'number' && Number.isInteger(requestedIndex)) {
-        const selected = transitions.find(transition => transitionRangeMatchesIndex(transition, requestedIndex, refs));
+        const selected = transitions.find(transition => transitionRangeMatchesIndex(semantic, transition, requestedIndex, refs));
         return selected
             ? {range: selected.range, transition: selected}
             : {range: null, fallback: 'transition_not_found'};

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -42,7 +42,7 @@ function transitionEndpointPath(
 
 function compactText(value: string | null | undefined): string | null {
     if (value === undefined || value === null) return null;
-    return value.replace(/\s+/g, '').toLowerCase();
+    return value.replace(/\s+/g, '');
 }
 
 interface TransitionEndpointPair {
@@ -144,9 +144,9 @@ function transitionMatchesRefs(
 
 
 interface TransitionIndexRef {
-    index?: unknown;
-    fromPath?: unknown;
-    toPath?: unknown;
+    index: number;
+    fromPath: string | null;
+    toPath: string | null;
 }
 
 function transitionIndexRefMatchesRefs(
@@ -166,13 +166,12 @@ function transitionRangeMatchesIndex(
     index: number,
     refs: Record<string, unknown>,
 ): boolean {
-    const astRecord = transition.ast as unknown as Record<string, unknown>;
-    if (Array.isArray(astRecord.transitionIndexRefs)) {
-        return (astRecord.transitionIndexRefs as TransitionIndexRef[])
+    if (Array.isArray(transition.ast.transitionIndexRefs)) {
+        return transition.ast.transitionIndexRefs
             .some(ref => transitionIndexRefMatchesRefs(ref, index, refs));
     }
 
-    const rawIndex = astRecord.transitionIndex;
+    const rawIndex = transition.ast.transitionIndex;
     return typeof rawIndex === 'number' && Number.isInteger(rawIndex) && rawIndex === index;
 }
 
@@ -259,7 +258,10 @@ function effectSelfAssignGroupKey(refMap: Record<string, unknown>): string | nul
     ) {
         return null;
     }
-    return JSON.stringify([statePath, variableName]);
+    const transitionIndex = refMap.transition_index;
+    return typeof transitionIndex === 'number' && Number.isInteger(transitionIndex)
+        ? JSON.stringify([statePath, variableName, transitionIndex])
+        : JSON.stringify([statePath, variableName]);
 }
 
 function consumeEffectSelfAssignOccurrenceIndex(
@@ -303,16 +305,31 @@ export function resolveRangeFromRefsDetailed(
         Object.prototype.hasOwnProperty.call(refMap, 'transition_span')
     );
     if (looksLikeEffectSelfAssign) {
-        const range = effectSelfAssignRange(
-            document,
-            semantic,
-            statePath,
-            variableName,
-            peekEffectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap),
-        );
-        consumeEffectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap, Boolean(range));
-        if (range) return {range};
         const transitionResolution = transitionRangeResolution(semantic, refMap);
+        const occurrenceIndex = peekEffectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap);
+        const range = transitionResolution.transition
+            ? effectSelfAssignRange(
+                document,
+                semantic,
+                statePath,
+                variableName,
+                occurrenceIndex,
+                transitionResolution.transition,
+            )
+            : effectSelfAssignRange(
+                document,
+                semantic,
+                statePath,
+                variableName,
+                occurrenceIndex,
+            );
+        consumeEffectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap, Boolean(range));
+        if (range) {
+            return {
+                range,
+                fallback: transitionResolution.fallback,
+            };
+        }
         if (transitionResolution.range) {
             const effectRange = transitionResolution.transition
                 ? effectBlockRange(document, transitionResolution.transition)

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -1,5 +1,5 @@
-import type {FcstmSemanticDocument} from '../semantics';
-import type {TextDocumentLike, TextRange} from '../utils/text';
+import type {FcstmSemanticDocument, FcstmSemanticTransition} from '../semantics';
+import {createRange, type TextDocumentLike, type TextRange} from '../utils/text';
 import {findIdentifierRange} from './ranges';
 import {
     effectSelfAssignRange,
@@ -24,6 +24,115 @@ function statePathRange(
     return state ? findIdentifierRange(document, state.name, state.range) : null;
 }
 
+function dottedPath(path: readonly string[] | undefined): string | null {
+    return path && path.length > 0 ? path.join('.') : null;
+}
+
+function transitionEndpointPath(
+    transition: FcstmSemanticTransition,
+    endpoint: 'source' | 'target',
+): string | null {
+    if (endpoint === 'source') {
+        if (transition.sourceKind === 'init') return '[*]';
+        return dottedPath(transition.sourceStatePath) ?? transition.sourceStateName ?? null;
+    }
+    if (transition.targetKind === 'exit') return '[*]';
+    return dottedPath(transition.targetStatePath) ?? transition.targetStateName ?? null;
+}
+
+function compactText(value: string | null | undefined): string | null {
+    if (value === undefined || value === null) return null;
+    return value.replace(/\s+/g, '');
+}
+
+function effectBlockRange(
+    document: TextDocumentLike,
+    transition: FcstmSemanticTransition,
+): TextRange | null {
+    const effectRange = transition.ast.effect?.range;
+    if (!effectRange) return null;
+    for (let lineIndex = transition.range.start.line; lineIndex <= effectRange.start.line; lineIndex += 1) {
+        const line = document.lineAt(lineIndex).text;
+        const startCharacter = lineIndex === transition.range.start.line ? transition.range.start.character : 0;
+        const endCharacter = lineIndex === effectRange.start.line ? effectRange.start.character : line.length;
+        const prefix = line.slice(startCharacter, endCharacter);
+        const keywordOffset = prefix.lastIndexOf('effect');
+        if (keywordOffset >= 0) {
+            const keywordCharacter = startCharacter + keywordOffset;
+            return createRange(
+                lineIndex,
+                keywordCharacter,
+                transition.range.end.line,
+                transition.range.end.character,
+            );
+        }
+    }
+    return effectRange;
+}
+
+function transitionHasEvent(transition: FcstmSemanticTransition, expectedEvent: string | null): boolean {
+    if (expectedEvent === null) return true;
+    if (!transition.trigger) return false;
+    return transition.trigger.rawText === expectedEvent ||
+        transition.trigger.qualifiedName === expectedEvent ||
+        transition.trigger.normalizedPath.join('.') === expectedEvent;
+}
+
+function transitionMatchesRefs(
+    transition: FcstmSemanticTransition,
+    refs: Record<string, unknown>,
+): boolean {
+    const fromPath = stringRef(refs, 'from_path');
+    const toPath = stringRef(refs, 'to_path');
+    if (fromPath && transitionEndpointPath(transition, 'source') !== fromPath) return false;
+    if (toPath && transitionEndpointPath(transition, 'target') !== toPath) return false;
+
+    const statePath = stringRef(refs, 'state_path');
+    if (statePath && statePath !== transitionEndpointPath(transition, 'source')) return false;
+
+    const guardText = compactText(stringRef(refs, 'guard_text'));
+    if (guardText !== null && compactText(transition.guard?.text) !== guardText) return false;
+
+    const effectText = compactText(stringRef(refs, 'effect_text'));
+    if (effectText !== null && compactText(transition.effectText) !== effectText) return false;
+
+    const eventName = stringRef(refs, 'event_name') ?? stringRef(refs, 'event_chain') ?? stringRef(refs, 'event');
+    if (!transitionHasEvent(transition, eventName)) return false;
+
+    return true;
+}
+
+function transitionRangeResolution(
+    semantic: FcstmSemanticDocument,
+    refs: Record<string, unknown>,
+): InspectRangeResolution {
+    const transitions = semantic.transitions.filter(transition => !transition.forced && transitionMatchesRefs(transition, refs));
+    if (transitions.length === 0) return {range: null};
+    const requestedIndex = refs.transition_index;
+    const selected = typeof requestedIndex === 'number' && Number.isInteger(requestedIndex)
+        ? transitions.find(transition => semantic.transitions.indexOf(transition) === requestedIndex)
+        : transitions[0];
+    if (!selected) return {range: null};
+    return {
+        range: selected.range,
+        fallback: transitions.length > 1 && requestedIndex === undefined ? 'transition_ambiguous' : undefined,
+        transition: selected,
+    };
+}
+
+function guardRangeResolution(
+    semantic: FcstmSemanticDocument,
+    refs: Record<string, unknown>,
+): InspectRangeResolution {
+    const transitionResolution = transitionRangeResolution(semantic, refs);
+    if (!transitionResolution.range) return transitionResolution;
+    const guardRange = transitionResolution.transition?.guard?.range ?? null;
+    return {
+        range: guardRange ?? transitionResolution.range,
+        fallback: transitionResolution.fallback,
+    };
+}
+
 function eventRange(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
@@ -35,11 +144,17 @@ function eventRange(
     return findIdentifierRange(document, event.name, event.declarationAst?.range ?? event.range);
 }
 
-export type InspectRangeFallback = 'full_document' | 'first_of_ambiguous';
+export type InspectRangeFallback =
+    | 'full_document'
+    | 'first_of_ambiguous'
+    | 'transition_ambiguous'
+    | 'effect_fallback'
+    | 'transition_fallback';
 
 export interface InspectRangeResolution {
     range: TextRange | null;
     fallback?: InspectRangeFallback;
+    transition?: FcstmSemanticTransition;
 }
 
 function arrayFirstRange(value: unknown): TextRange | null {
@@ -114,6 +229,16 @@ export function resolveRangeFromRefsDetailed(
         );
         consumeEffectSelfAssignOccurrenceIndex(seenEffectSelfAssigns, refMap, Boolean(range));
         if (range) return {range};
+        const transitionResolution = transitionRangeResolution(semantic, refMap);
+        if (transitionResolution.range) {
+            const effectRange = transitionResolution.transition
+                ? effectBlockRange(document, transitionResolution.transition)
+                : null;
+            return {
+                range: effectRange ?? transitionResolution.range,
+                fallback: transitionResolution.fallback ?? (effectRange ? 'effect_fallback' : 'transition_fallback'),
+            };
+        }
         return {range: null};
     }
 
@@ -122,6 +247,17 @@ export function resolveRangeFromRefsDetailed(
         if (range) return {range};
     }
 
+    const duplicateRange = arrayFirstRange(refMap.duplicate_spans);
+    if (duplicateRange) return {range: duplicateRange};
+
+    if (refMap.transition_span === null || refMap.guard_span === null || refMap.duplicate_spans !== undefined) {
+        if (refMap.folded_value === true || refMap.folded_value === false || stringRef(refMap, 'guard_text')) {
+            const guardResolution = guardRangeResolution(semantic, refMap);
+            if (guardResolution.range) return guardResolution;
+        }
+        const transitionResolution = transitionRangeResolution(semantic, refMap);
+        if (transitionResolution.range) return transitionResolution;
+    }
     for (const key of ['state_path', 'composite_path', 'parent_path', 'from_path', 'to_path', 'deepest_path']) {
         const range = statePathRange(document, semantic, stringRef(refMap, key));
         if (range) return {range};
@@ -137,8 +273,7 @@ export function resolveRangeFromRefsDetailed(
     const resolvedEventRange = eventRange(document, semantic, stringRef(refMap, 'event_qualified_name'));
     if (resolvedEventRange) return {range: resolvedEventRange};
 
-    const duplicateRange = arrayFirstRange(refMap.duplicate_spans);
-    return {range: duplicateRange};
+    return {range: null};
 }
 
 export function resolveRangeFromRefs(

--- a/editors/jsfcstm/src/editor/suggested-fixes.ts
+++ b/editors/jsfcstm/src/editor/suggested-fixes.ts
@@ -3,7 +3,7 @@ import type {
     FcstmAstIfStatement,
     FcstmAstOperationStatement,
 } from '../ast';
-import type {FcstmSemanticDocument} from '../semantics';
+import type {FcstmSemanticDocument, FcstmSemanticTransition} from '../semantics';
 import {
     createRange,
     FcstmDiagnostic,
@@ -276,9 +276,11 @@ export function effectSelfAssignRange(
     statePath: string | undefined,
     varName: string,
     occurrenceIndex?: number,
+    selectedTransition?: FcstmSemanticTransition,
 ): TextRange | null {
     const matches: TextRange[] = [];
-    for (const transition of semantic.transitions) {
+    const transitions = selectedTransition ? [selectedTransition] : semantic.transitions;
+    for (const transition of transitions) {
         if (statePath === '[*]') {
             if (transition.sourceKind !== 'init') continue;
         } else if (statePath && transition.sourceStatePath?.join('.') !== statePath) {

--- a/editors/jsfcstm/src/model/builder.ts
+++ b/editors/jsfcstm/src/model/builder.ts
@@ -9,6 +9,7 @@ import type {
     FcstmAstOperationStatement,
     FcstmAstStateDefinition,
     FcstmAstTransition,
+    FcstmAstTransitionIndexRef,
     FcstmAstVariableDefinition,
 } from '../ast';
 import type {FcstmSemanticDocument} from '../semantics';
@@ -74,12 +75,6 @@ const EXPR_PRECEDENCE: Record<string, number> = {
     'or': 10,
     '?:': 5,
 };
-
-interface TransitionIndexRef {
-    index: number;
-    fromPath: string | null;
-    toPath: string | null;
-}
 
 interface InheritedForceTransition {
     fromStateName: 'ALL' | string;
@@ -833,20 +828,19 @@ class StateMachineModelBuilder {
         transitionIndex: number,
         transition: FcstmModelTransition,
     ): void {
-        const astRecord = ast as unknown as Record<string, unknown>;
         if (!transition.forced) {
-            astRecord.transitionIndex = transitionIndex;
+            ast.transitionIndex = transitionIndex;
         }
 
-        const refs = Array.isArray(astRecord.transitionIndexRefs)
-            ? astRecord.transitionIndexRefs as TransitionIndexRef[]
+        const refs = Array.isArray(ast.transitionIndexRefs)
+            ? ast.transitionIndexRefs as FcstmAstTransitionIndexRef[]
             : [];
         refs.push({
             index: transitionIndex,
             fromPath: this.transitionEndpointPath(transition, 'source'),
             toPath: this.transitionEndpointPath(transition, 'target'),
         });
-        astRecord.transitionIndexRefs = refs;
+        ast.transitionIndexRefs = refs;
     }
 
     private transitionEndpointPath(

--- a/editors/jsfcstm/src/model/builder.ts
+++ b/editors/jsfcstm/src/model/builder.ts
@@ -946,7 +946,7 @@ class StateMachineModelBuilder {
                         pyModelType: 'Boolean',
                         range: expression.range,
                         text: expression.text,
-                        value: expression.valueText === 'true',
+                        value: expression.valueText.toLowerCase() === 'true',
                     };
                     return booleanExpr;
                 }

--- a/editors/jsfcstm/src/model/builder.ts
+++ b/editors/jsfcstm/src/model/builder.ts
@@ -86,6 +86,7 @@ interface InheritedForceTransition {
     declaredInStatePath: string[];
     triggerScope?: 'local' | 'chain' | 'absolute';
     transitionKind: FcstmModelTransition['transitionKind'];
+    ast: FcstmAstForcedTransition;
 }
 
 function pathKey(path: Array<string | null>): string {
@@ -152,12 +153,12 @@ class StateMachineModelBuilder {
     private readonly allEvents: FcstmModelEvent[] = [];
     private readonly allTransitions: FcstmModelTransition[] = [];
     private readonly forcedTransitions: FcstmModelForcedTransition[] = [];
+    private nextTransitionIndex = 0;
     private readonly allActions: FcstmModelNamedFunction[] = [];
     private readonly statesByPath = new Map<string, FcstmModelState>();
     private readonly stateAstByPath = new Map<string, FcstmAstStateDefinition>();
     private readonly eventsByPath = new Map<string, FcstmModelEvent>();
     private readonly namedFunctionsByPath = new Map<string, FcstmModelNamedFunction>();
-
     constructor(private readonly ast: FcstmAstDocument) {
         this.filePath = ast.filePath;
         this.rootStateName = ast.rootState?.name || '';
@@ -458,6 +459,7 @@ class StateMachineModelBuilder {
                     forced: true,
                     declaredInStatePath: force.declaredInStatePath,
                     triggerScope: force.triggerScope,
+                    ast: force.ast,
                 });
 
                 childInheritedTransitions.push({
@@ -471,6 +473,7 @@ class StateMachineModelBuilder {
                     declaredInStatePath: force.declaredInStatePath,
                     triggerScope: force.triggerScope,
                     transitionKind: 'exitAll',
+                    ast: force.ast,
                 });
             }
 
@@ -498,6 +501,7 @@ class StateMachineModelBuilder {
                 forced: false,
                 declaredInStatePath: currentState.path,
                 triggerScope,
+                ast: transition,
             });
         }
     }
@@ -526,6 +530,7 @@ class StateMachineModelBuilder {
             declaredInStatePath: currentState.path,
             triggerScope,
             transitionKind: transition.transitionKind,
+            ast: transition,
         };
     }
 
@@ -760,7 +765,9 @@ class StateMachineModelBuilder {
         forced: boolean;
         declaredInStatePath: string[];
         triggerScope?: FcstmModelTransition['triggerScope'];
+        ast?: FcstmAstTransition | FcstmAstForcedTransition;
     }): void {
+        const transitionIndex = this.nextTransitionIndex;
         const transition: FcstmModelTransition = {
             kind: 'transition',
             pyModelType: 'Transition',
@@ -795,7 +802,13 @@ class StateMachineModelBuilder {
             declared_in_state_path: params.declaredInStatePath,
             triggerScope: params.triggerScope,
             trigger_scope: params.triggerScope,
+            transitionIndex,
+            transition_index: transitionIndex,
         };
+        this.nextTransitionIndex += 1;
+        if (params.ast && !params.forced) {
+            (params.ast as unknown as Record<string, unknown>).transitionIndex = transitionIndex;
+        }
 
         params.parentState.transitions.push(transition);
         this.allTransitions.push(transition);

--- a/editors/jsfcstm/src/model/builder.ts
+++ b/editors/jsfcstm/src/model/builder.ts
@@ -75,6 +75,12 @@ const EXPR_PRECEDENCE: Record<string, number> = {
     '?:': 5,
 };
 
+interface TransitionIndexRef {
+    index: number;
+    fromPath: string | null;
+    toPath: string | null;
+}
+
 interface InheritedForceTransition {
     fromStateName: 'ALL' | string;
     toState: 'EXIT_STATE' | string;
@@ -435,9 +441,10 @@ class StateMachineModelBuilder {
             this.recordForcedTransition(force, currentState);
         }
 
+        const inheritedForSubstates = new Map<string, InheritedForceTransition[]>();
         for (const substateDefinition of definition.substates) {
-            const nextState = currentState.substates[substateDefinition.name];
             const childInheritedTransitions: InheritedForceTransition[] = [];
+            inheritedForSubstates.set(substateDefinition.name, childInheritedTransitions);
 
             for (const force of effectiveForceTransitions) {
                 if (force.fromStateName !== 'ALL' && force.fromStateName !== substateDefinition.name) {
@@ -476,8 +483,6 @@ class StateMachineModelBuilder {
                     ast: force.ast,
                 });
             }
-
-            this.finalizeTransitions(substateDefinition, nextState, childInheritedTransitions);
         }
 
         for (const transition of definition.transitions) {
@@ -503,6 +508,15 @@ class StateMachineModelBuilder {
                 triggerScope,
                 ast: transition,
             });
+        }
+
+        for (const substateDefinition of definition.substates) {
+            const nextState = currentState.substates[substateDefinition.name];
+            this.finalizeTransitions(
+                substateDefinition,
+                nextState,
+                inheritedForSubstates.get(substateDefinition.name) ?? [],
+            );
         }
     }
 
@@ -806,12 +820,45 @@ class StateMachineModelBuilder {
             transition_index: transitionIndex,
         };
         this.nextTransitionIndex += 1;
-        if (params.ast && !params.forced) {
-            (params.ast as unknown as Record<string, unknown>).transitionIndex = transitionIndex;
+        if (params.ast) {
+            this.recordAstTransitionIndex(params.ast, transitionIndex, transition);
         }
 
         params.parentState.transitions.push(transition);
         this.allTransitions.push(transition);
+    }
+
+    private recordAstTransitionIndex(
+        ast: FcstmAstTransition | FcstmAstForcedTransition,
+        transitionIndex: number,
+        transition: FcstmModelTransition,
+    ): void {
+        const astRecord = ast as unknown as Record<string, unknown>;
+        if (!transition.forced) {
+            astRecord.transitionIndex = transitionIndex;
+        }
+
+        const refs = Array.isArray(astRecord.transitionIndexRefs)
+            ? astRecord.transitionIndexRefs as TransitionIndexRef[]
+            : [];
+        refs.push({
+            index: transitionIndex,
+            fromPath: this.transitionEndpointPath(transition, 'source'),
+            toPath: this.transitionEndpointPath(transition, 'target'),
+        });
+        astRecord.transitionIndexRefs = refs;
+    }
+
+    private transitionEndpointPath(
+        transition: FcstmModelTransition,
+        endpoint: 'source' | 'target',
+    ): string | null {
+        if (endpoint === 'source') {
+            if (transition.sourceKind === 'init') return '[*]';
+            return transition.sourceStatePath ? statePathName(transition.sourceStatePath) : null;
+        }
+        if (transition.targetKind === 'exit') return '[*]';
+        return transition.targetStatePath ? statePathName(transition.targetStatePath) : null;
     }
 
     private resolveStateReference(

--- a/editors/jsfcstm/src/model/raw.ts
+++ b/editors/jsfcstm/src/model/raw.ts
@@ -2,6 +2,12 @@
 /**
  * Raw model node shapes used while building the jsfcstm model graph.
  *
+ * Transition raw records include a diagnostic-only ``transitionIndex`` /
+ * ``transition_index`` hint. It counts transitions in inspect/model order,
+ * including expanded forced transitions, so editor diagnostics can map
+ * spanless inspect refs back to source ranges without changing runtime
+ * behavior.
+ *
  * These interfaces are intentionally plain-data only. ``builder.ts`` produces
  * these raw objects first, then ``runtime.ts`` hydrates them into pyfcstm-like
  * runtime classes with methods, parent links, and derived properties.
@@ -239,6 +245,8 @@ export interface RawFcstmModelTransition extends RawFcstmModelNodeBase {
     declared_in_state_path: string[];
     triggerScope?: 'local' | 'chain' | 'absolute';
     trigger_scope?: 'local' | 'chain' | 'absolute';
+    transitionIndex?: number;
+    transition_index?: number;
 }
 
 export interface RawFcstmModelForcedTransition {

--- a/editors/jsfcstm/src/model/runtime.ts
+++ b/editors/jsfcstm/src/model/runtime.ts
@@ -1,6 +1,11 @@
 /**
  * Runtime model classes for jsfcstm.
  *
+ * ``transitionIndex`` / ``transition_index`` are diagnostic-only source-range
+ * disambiguation hints. They count transitions in the same model order used by
+ * inspect analyzers, including expanded forced transitions; they are not part
+ * of the executable state-machine semantics.
+ *
  * The builder first creates raw serializable objects. This module hydrates
  * those raw shapes into stable runtime classes whose property and method
  * surface intentionally follows ``pyfcstm.model`` closely enough for users who
@@ -864,6 +869,8 @@ export class Transition extends ModelNode {
     declared_in_state_path: string[];
     triggerScope?: 'local' | 'chain' | 'absolute';
     trigger_scope?: 'local' | 'chain' | 'absolute';
+    transitionIndex?: number;
+    transition_index?: number;
     protected parentState?: State;
 
     constructor(raw: RawFcstmModelTransition, event: Event | undefined, guard: Expr | undefined, effects: OperationStatement[]) {
@@ -889,6 +896,8 @@ export class Transition extends ModelNode {
         this.declared_in_state_path = this.declaredInStatePath;
         this.triggerScope = raw.triggerScope;
         this.trigger_scope = raw.trigger_scope;
+        this.transitionIndex = raw.transitionIndex;
+        this.transition_index = raw.transition_index ?? raw.transitionIndex;
     }
 
     /**

--- a/editors/jsfcstm/src/semantics/builder.ts
+++ b/editors/jsfcstm/src/semantics/builder.ts
@@ -127,6 +127,7 @@ class SemanticBuilder {
     private readonly actionsByPath = new Map<string, FcstmSemanticAction>();
     private readonly eventsByQualifiedName = new Map<string, FcstmSemanticEvent>();
     private readonly importsByPath = new Map<string, FcstmSemanticImport>();
+    private readonly importsByMountedPath = new Map<string, FcstmSemanticImport>();
     private rootState: FcstmSemanticState | undefined;
     private nextId = 0;
 
@@ -181,6 +182,7 @@ class SemanticBuilder {
                 actionsByPath: Object.fromEntries(this.actionsByPath.entries()),
                 eventsByQualifiedName: Object.fromEntries(this.eventsByQualifiedName.entries()),
                 importsByPath: Object.fromEntries(this.importsByPath.entries()),
+                importsByMountedPath: Object.fromEntries(this.importsByMountedPath.entries()),
             },
         };
     }
@@ -466,6 +468,7 @@ class SemanticBuilder {
 
         this.imports.push(semanticImport);
         this.importsByPath.set(pathKey([...ownerState.identity.path, alias]), semanticImport);
+        this.importsByMountedPath.set(pathKey(semanticImport.mountedStatePath), semanticImport);
     }
 
     private finalizeActions(): void {

--- a/editors/jsfcstm/src/semantics/model.ts
+++ b/editors/jsfcstm/src/semantics/model.ts
@@ -238,6 +238,7 @@ export interface FcstmSemanticLookups {
     actionsByPath: Record<string, FcstmSemanticAction>;
     eventsByQualifiedName: Record<string, FcstmSemanticEvent>;
     importsByPath: Record<string, FcstmSemanticImport>;
+    importsByMountedPath: Record<string, FcstmSemanticImport>;
 }
 
 /**

--- a/editors/jsfcstm/src/workspace/graph.ts
+++ b/editors/jsfcstm/src/workspace/graph.ts
@@ -172,7 +172,7 @@ export class FcstmWorkspaceGraph {
                         document,
                         ast,
                         semantic,
-                        model: buildStateMachineModel(ast),
+                        model: buildStateMachineModel(semantic || ast),
                         imports: [],
                     },
                 },

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -693,7 +693,7 @@ state Root {
                         folded_value: true,
                         from_path: 'Root.Blocked',
                         to_path: 'Root.WideTrue',
-                        guard_text: '(0xFFFFFFFF&0xFFFFFFFF)==4294967295',
+                        guard_text: '4294967295 & 4294967295 == 4294967295',
                         transition_index: 3,
                     },
                     {
@@ -701,7 +701,7 @@ state Root {
                         folded_value: true,
                         from_path: 'Root.Idle',
                         to_path: 'Root.Active',
-                        guard_text: '(1+2)==3',
+                        guard_text: '1 + 2 == 3',
                         transition_index: 1,
                     },
                     {
@@ -709,7 +709,7 @@ state Root {
                         folded_value: true,
                         from_path: 'Root.ModuloTrue',
                         to_path: 'Root.PowerTrue',
-                        guard_text: '(2.0**3)==8.0',
+                        guard_text: '2.0 ** 3 == 8.0',
                         transition_index: 5,
                     },
                     {
@@ -717,7 +717,7 @@ state Root {
                         folded_value: true,
                         from_path: 'Root.WideTrue',
                         to_path: 'Root.ModuloTrue',
-                        guard_text: '(-7%4)==1',
+                        guard_text: '-7 % 4 == 1',
                         transition_index: 4,
                     },
                 ].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))),
@@ -730,7 +730,7 @@ state Root {
                 folded_value: false,
                 from_path: 'Root.Active',
                 to_path: 'Root.Blocked',
-                guard_text: '(0x0F&0xF0)!=0',
+                guard_text: '15 & 240 != 0',
                 transition_index: 2,
             });
 

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -623,6 +623,8 @@ state Root {
                 folded_value: false,
                 from_path: 'Root.Active',
                 to_path: 'Root.Blocked',
+                guard_text: 'false',
+                transition_index: 2,
             });
 
             const unreachable = report.diagnostics.find(d => d.code === 'W_UNREACHABLE_STATE');
@@ -691,24 +693,32 @@ state Root {
                         folded_value: true,
                         from_path: 'Root.Blocked',
                         to_path: 'Root.WideTrue',
+                        guard_text: '(0xFFFFFFFF&0xFFFFFFFF)==4294967295',
+                        transition_index: 3,
                     },
                     {
                         transition_span: null,
                         folded_value: true,
                         from_path: 'Root.Idle',
                         to_path: 'Root.Active',
+                        guard_text: '(1+2)==3',
+                        transition_index: 1,
                     },
                     {
                         transition_span: null,
                         folded_value: true,
                         from_path: 'Root.ModuloTrue',
                         to_path: 'Root.PowerTrue',
+                        guard_text: '(2.0**3)==8.0',
+                        transition_index: 5,
                     },
                     {
                         transition_span: null,
                         folded_value: true,
                         from_path: 'Root.WideTrue',
                         to_path: 'Root.ModuloTrue',
+                        guard_text: '(-7%4)==1',
+                        transition_index: 4,
                     },
                 ].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b))),
             );
@@ -720,6 +730,8 @@ state Root {
                 folded_value: false,
                 from_path: 'Root.Active',
                 to_path: 'Root.Blocked',
+                guard_text: '(0x0F&0xF0)!=0',
+                transition_index: 2,
             });
 
             const duringRefs = report.diagnostics
@@ -772,12 +784,12 @@ state Root {
                 {
                     code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
                     severity: 'info',
-                    refs: {from_path: 'Root.Active', to_path: 'Root.Active', transition_span: null},
+                    refs: {from_path: 'Root.Active', to_path: 'Root.Active', transition_span: null, transition_index: 4},
                 },
                 {
                     code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
                     severity: 'info',
-                    refs: {from_path: 'Root.Active', to_path: 'Root.Idle', transition_span: null},
+                    refs: {from_path: 'Root.Active', to_path: 'Root.Idle', transition_span: null, transition_index: 5},
                 },
                 {
                     code: 'W_DEADLOCK_LEAF',
@@ -810,6 +822,7 @@ state Root {
                         transition_span: null,
                         var_name: 'stable',
                         effect_self_assign_anchor: 'stable',
+                        transition_index: 5,
                     },
                 },
                 {
@@ -855,6 +868,7 @@ state Root {
                             'Root.Idle->Root.Active#1',
                             'Root.Idle->Root.Active#2',
                         ],
+                        transition_index: 2,
                     },
                 },
                 {
@@ -867,12 +881,19 @@ state Root {
                             'Root.Active->Root.Trapped#1',
                             'Root.Active->Root.Trapped#2',
                         ],
+                        transition_index: 0,
                     },
                 },
                 {
                     code: 'W_SELF_TRANSITION_NOP',
                     severity: 'warning',
-                    refs: {state_path: 'Root.Active'},
+                    refs: {
+                        state_path: 'Root.Active',
+                        from_path: 'Root.Active',
+                        to_path: 'Root.Active',
+                        transition_span: null,
+                        transition_index: 4,
+                    },
                 },
                 {
                     code: 'W_SHADOWED_EVENT',
@@ -1133,6 +1154,7 @@ state Root {
                     transition_span: null,
                     var_name: 'x',
                     effect_self_assign_anchor: 'x',
+                    transition_index: 1,
                 })],
             );
         });
@@ -1605,6 +1627,7 @@ state Root {
                 from_path: 'Root.A',
                 to_path: 'Root.B',
                 transition_span: null,
+                transition_index: 1,
             });
         });
 
@@ -1622,6 +1645,7 @@ state Root {
                 from_path: 'Root.A',
                 to_path: '[*]',
                 transition_span: null,
+                transition_index: 1,
             });
         });
     });

--- a/editors/jsfcstm/test/diagnostics-published-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-published-range.test.ts
@@ -233,7 +233,8 @@ describe('diagnostics published ranges', () => {
         assert.equal(seen.get(JSON.stringify(['Root.A', 'x'])), 1);
 
         const missing = packageModule.resolveRangeFromRefsDetailed(document, semantic, refs, seen);
-        assert.equal(missing.range, null);
+        assert.equal(sliceByRange(text, missing.range!).trim(), 'effect {\n        x = x;\n    }');
+        assert.equal(missing.fallback, 'effect_fallback');
         assert.equal(seen.get(JSON.stringify(['Root.A', 'x'])), 1);
     });
 

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
+import * as path from 'node:path';
 
-import {createDocument, packageModule, sliceByRange} from './support';
+import {createDocument, packageModule, sliceByRange, trackTempDir, writeFile} from './support';
 
 function targetDiagnostics(diagnostics: any[], code: string): any[] {
     return diagnostics.filter(item => item.code === code);
@@ -385,6 +386,56 @@ describe('diagnostics transition body ranges', () => {
                 ['True', true, 'true', undefined],
                 ['TRUE', true, 'true', undefined],
             ],
+        );
+    });
+
+
+    it('keeps import-aware transition diagnostics on source-owned ranges', async () => {
+        const dir = trackTempDir('jsfcstm-transition-import-range-');
+        const childFile = path.join(dir, 'child.fcstm');
+        const hostFile = path.join(dir, 'main.fcstm');
+        writeFile(childFile, [
+            'def int x = 0;',
+            'state Child {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B : if [1 == 1];',
+            '    A -> B effect { x = x; };',
+            '}',
+        ].join('\n'));
+        const hostText = [
+            'state Root {',
+            '    import "./child.fcstm" as Imported;',
+            '    state Local;',
+            '    [*] -> Imported;',
+            '    Imported -> Local : if [True];',
+            '}',
+        ].join('\n');
+        const document = createDocument(hostText, hostFile);
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const transitionCodes = new Set([
+            'W_GUARD_CONST_TRUE',
+            'W_EFFECT_SELF_ASSIGN',
+            'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+        ]);
+        const transitionDiagnostics = diagnostics.filter(item => transitionCodes.has(String(item.code)));
+        const constTrue = targetDiagnostics(diagnostics, 'W_GUARD_CONST_TRUE');
+
+        assert.equal(constTrue.length, 1, JSON.stringify(diagnostics));
+        assert.equal(constTrue[0].data?.from_path, 'Root.Imported');
+        assert.equal(constTrue[0].data?.to_path, 'Root.Local');
+        assert.equal(sliceByRange(hostText, constTrue[0].range).trim(), 'True');
+        assert.equal(constTrue[0].data?.__rangeFallback, undefined);
+        assert.equal(targetDiagnostics(diagnostics, 'W_EFFECT_SELF_ASSIGN').length, 0, JSON.stringify(diagnostics));
+        assert.equal(
+            targetDiagnostics(diagnostics, 'I_TRANSITION_NEVER_EVENT_TRIGGERED').length,
+            0,
+            JSON.stringify(diagnostics),
+        );
+        assert.deepEqual(
+            transitionDiagnostics.map(item => item.data?.__rangeFallback).filter(Boolean),
+            [],
         );
     });
 

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -169,6 +169,95 @@ describe('diagnostics transition body ranges', () => {
         );
     });
 
+    it('keeps nested parent transition guard diagnostics on guard expressions', async () => {
+        const text = [
+            'state Root {',
+            '    state P {',
+            '        state A;',
+            '        state B;',
+            '        [*] -> A;',
+            '        A -> B : if [1 == 1];',
+            '    }',
+            '    state C;',
+            '    [*] -> P;',
+            '    P -> C : if [1 == 1];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-nested-parent-guard-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const constTrue = targetDiagnostics(diagnostics, 'W_GUARD_CONST_TRUE');
+
+        assert.equal(constTrue.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            constTrue.map(item => sliceByRange(text, item.range).trim()),
+            ['1 == 1', '1 == 1'],
+        );
+        assert.deepEqual(
+            constTrue.map(item => item.range.start.line),
+            [5, 9],
+        );
+        assert.deepEqual(
+            constTrue.map(item => item.data?.__rangeFallback ?? null),
+            [null, null],
+        );
+    });
+
+    it('keeps forced-transition index offsets from moving guard diagnostics to state identifiers', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !* -> B :: FatalError;',
+            '    A -> B : if [1 == 1];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-forced-offset-guard-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'W_GUARD_CONST_TRUE')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), '1 == 1');
+        assert.equal(diagnostic.data?.transition_index, 3);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+    });
+
+    it('uses model-order transition indexes for nested repeated eventless transitions', async () => {
+        const text = [
+            'state Root {',
+            '    state A {',
+            '        state X;',
+            '        state Y;',
+            '        [*] -> X;',
+            '        X -> Y;',
+            '        X -> Y;',
+            '    }',
+            '    [*] -> A;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-nested-eventless-index-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const neverTriggered = targetDiagnostics(diagnostics, 'I_TRANSITION_NEVER_EVENT_TRIGGERED');
+
+        assert.equal(neverTriggered.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            neverTriggered.map(item => sliceByRange(text, item.range).trim()),
+            ['X -> Y;', 'X -> Y;'],
+        );
+        assert.deepEqual(
+            neverTriggered.map(item => item.range.start.line),
+            [5, 6],
+        );
+        assert.deepEqual(
+            neverTriggered.map(item => item.data?.transition_index),
+            [1, 2],
+        );
+        assert.deepEqual(
+            neverTriggered.map(item => item.data?.__rangeFallback ?? null),
+            [null, null],
+        );
+    });
+
     it('marks fallback when duplicate transitions omit transition_index', async () => {
         const text = [
             'state Root {',
@@ -190,6 +279,36 @@ describe('diagnostics transition body ranges', () => {
                 from_path: 'Root.A',
                 to_path: 'Root.B',
                 transition_span: null,
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(sliceByRange(text, diagnostics[0].range).trim(), 'A -> B;');
+        assert.equal(diagnostics[0].data?.__rangeFallback, 'transition_ambiguous');
+    });
+
+    it('marks fallback when duplicate transitions provide an invalid transition_index type', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-index-invalid-marker.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+            severity: 'info' as const,
+            message: 'Transition "Root.A" -> "Root.B" has no event or guard.',
+            span: null,
+            refs: {
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                transition_span: null,
+                transition_index: '1',
             },
         }]);
 

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -1,0 +1,231 @@
+import assert from 'node:assert/strict';
+
+import {createDocument, packageModule, sliceByRange} from './support';
+
+function targetDiagnostics(diagnostics: any[], code: string): any[] {
+    return diagnostics.filter(item => item.code === code);
+}
+
+describe('diagnostics transition body ranges', () => {
+    afterEach(() => {
+        packageModule.getWorkspaceGraph().clearOverlays();
+    });
+
+    it('anchors guard const diagnostics on the guard expression', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    state C;',
+            '    [*] -> A;',
+            '    A -> B : if [(1 + 2) == 3];',
+            '    B -> C : if [(0x0F & 0xF0) != 0];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-guard-ranges.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const constTrue = targetDiagnostics(diagnostics, 'W_GUARD_CONST_TRUE')[0];
+        const constFalse = targetDiagnostics(diagnostics, 'W_GUARD_CONST_FALSE')[0];
+
+        assert.ok(constTrue, JSON.stringify(diagnostics));
+        assert.ok(constFalse, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, constTrue.range), '(1 + 2) == 3');
+        assert.equal(sliceByRange(text, constFalse.range), '(0x0F & 0xF0) != 0');
+        assert.notEqual(sliceByRange(text, constTrue.range), 'A');
+        assert.notEqual(sliceByRange(text, constFalse.range), 'B');
+    });
+
+    it('anchors eventless guardless transition diagnostics on the transition statement', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-eventless-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'I_TRANSITION_NEVER_EVENT_TRIGGERED')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), 'A -> B;');
+        assert.notEqual(sliceByRange(text, diagnostic.range), 'A');
+    });
+
+    it('anchors redundant transition diagnostics on a duplicate transition statement', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-redundant-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'W_REDUNDANT_TRANSITION')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), 'A -> B;');
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.notEqual(sliceByRange(text, diagnostic.range), 'A');
+    });
+
+    it('anchors no-op self-transition diagnostics on the self-transition statement', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    [*] -> A;',
+            '    A -> A;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-self-nop-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'W_SELF_TRANSITION_NOP')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), 'A -> A;');
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.notEqual(sliceByRange(text, diagnostic.range), 'A');
+    });
+
+    it('keeps self-assignment diagnostics on the concrete effect statement', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-self-assign-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'W_EFFECT_SELF_ASSIGN')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), 'x = x;');
+    });
+
+    it('uses transition_index refs to disambiguate repeated eventless transitions', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-index-eventless-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const neverTriggered = targetDiagnostics(diagnostics, 'I_TRANSITION_NEVER_EVENT_TRIGGERED');
+
+        assert.equal(neverTriggered.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            neverTriggered.map(item => sliceByRange(text, item.range).trim()),
+            ['A -> B;', 'A -> B;'],
+        );
+        assert.deepEqual(
+            neverTriggered.map(item => item.range.start.line),
+            [4, 5],
+        );
+        assert.deepEqual(
+            neverTriggered.map(item => item.data?.__rangeFallback ?? null),
+            [null, null],
+        );
+    });
+
+    it('disambiguates equivalent guard diagnostics by transition index', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B : if [1 == 1];',
+            '    A -> B : if [1 == 1];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-index-guard-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const constTrue = targetDiagnostics(diagnostics, 'W_GUARD_CONST_TRUE');
+
+        assert.equal(constTrue.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            constTrue.map(item => sliceByRange(text, item.range).trim()),
+            ['1 == 1', '1 == 1'],
+        );
+        assert.deepEqual(
+            constTrue.map(item => item.range.start.line),
+            [4, 5],
+        );
+        assert.deepEqual(
+            constTrue.map(item => item.data?.__rangeFallback ?? null),
+            [null, null],
+        );
+    });
+
+    it('marks fallback when duplicate transitions omit transition_index', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-index-missing-marker.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+            severity: 'info' as const,
+            message: 'Transition "Root.A" -> "Root.B" has no event or guard.',
+            span: null,
+            refs: {
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                transition_span: null,
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(sliceByRange(text, diagnostics[0].range).trim(), 'A -> B;');
+        assert.equal(diagnostics[0].data?.__rangeFallback, 'transition_ambiguous');
+    });
+
+    it('marks self-assignment transition fallback when the concrete statement cannot be resolved', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B effect {',
+            '        x = x + 1;',
+            '    };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-self-assign-fallback-marker.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'W_EFFECT_SELF_ASSIGN',
+            severity: 'warning' as const,
+            message: 'Transition effect assigns "x" to itself.',
+            span: null,
+            refs: {
+                state_path: 'Root.A',
+                transition_span: null,
+                var_name: 'x',
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(sliceByRange(text, diagnostics[0].range).trim(), 'effect {\n        x = x + 1;\n    }');
+        assert.equal(diagnostics[0].data?.__rangeFallback, 'effect_fallback');
+    });
+});

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -258,7 +258,6 @@ describe('diagnostics transition body ranges', () => {
         );
     });
 
-
     it('anchors forced eventless transition diagnostics on the forced statement', async () => {
         const text = [
             'state Root {',
@@ -416,7 +415,6 @@ describe('diagnostics transition body ranges', () => {
         assert.equal(diagnostics[0].data?.__rangeFallback, undefined);
     });
 
-
     it('keeps js inspect transition indexes aligned with Python parent-first order', async () => {
         const text = [
             'state Root {',
@@ -442,6 +440,43 @@ describe('diagnostics transition body ranges', () => {
                 [1, '[*]', 'Root.A.X'],
                 [2, 'Root.A.X', 'Root.A.Y'],
                 [3, 'Root.A.X', 'Root.A.Y'],
+            ],
+        );
+    });
+
+
+    it('keeps JS inspect transition indexes aligned for forced nested transitions', async () => {
+        const text = [
+            'state Root {',
+            '    state A {',
+            '        state X;',
+            '        state Y;',
+            '        [*] -> X;',
+            '        X -> Y;',
+            '        X -> Y;',
+            '    }',
+            '    state B;',
+            '    [*] -> A;',
+            '    !A -> B :: Fatal;',
+            '    A -> B : if [false];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-forced-nested-model-order.fcstm');
+        const ast = await packageModule.parseAstDocument(document);
+        const machine = packageModule.buildStateMachineModel(ast);
+        const report = packageModule.inspectModel(machine);
+
+        assert.deepEqual(
+            report.transitions.map(item => [item.transition_index, item.from_path, item.to_path, item.is_forced]),
+            [
+                [0, 'Root.A', 'Root.B', true],
+                [1, '[*]', 'Root.A', false],
+                [2, 'Root.A', 'Root.B', false],
+                [3, 'Root.A.X', '[*]', true],
+                [4, 'Root.A.Y', '[*]', true],
+                [5, '[*]', 'Root.A.X', false],
+                [6, 'Root.A.X', 'Root.A.Y', false],
+                [7, 'Root.A.X', 'Root.A.Y', false],
             ],
         );
     });
@@ -503,6 +538,62 @@ describe('diagnostics transition body ranges', () => {
         assert.equal(diagnostics.length, 1);
         assert.equal(sliceByRange(text, diagnostics[0].range).trim(), 'A -> B;');
         assert.equal(diagnostics[0].data?.__rangeFallback, 'transition_ambiguous');
+    });
+
+
+    it('uses transition_index to resolve out-of-order self-assignment diagnostics', async () => {
+        const text = [
+            'def int x = 0;',
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    state C;',
+            '    [*] -> A;',
+            '    A -> B effect { x = x; };',
+            '    A -> C effect { x = x; };',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-self-assign-index-range.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [
+            {
+                code: 'W_EFFECT_SELF_ASSIGN',
+                severity: 'warning' as const,
+                message: 'second transition self-assign first',
+                span: null,
+                refs: {
+                    state_path: 'Root.A',
+                    transition_span: null,
+                    var_name: 'x',
+                    transition_index: 2,
+                },
+            },
+            {
+                code: 'W_EFFECT_SELF_ASSIGN',
+                severity: 'warning' as const,
+                message: 'first transition self-assign second',
+                span: null,
+                refs: {
+                    state_path: 'Root.A',
+                    transition_span: null,
+                    var_name: 'x',
+                    transition_index: 1,
+                },
+            },
+        ]);
+
+        assert.equal(diagnostics.length, 2);
+        assert.deepEqual(
+            diagnostics.map(item => [item.message, item.range.start.line, sliceByRange(text, item.range).trim()]),
+            [
+                ['second transition self-assign first', 7, 'x = x;'],
+                ['first transition self-assign second', 6, 'x = x;'],
+            ],
+        );
+        assert.deepEqual(
+            diagnostics.map(item => item.data?.__rangeFallback ?? null),
+            [null, null],
+        );
     });
 
     it('marks self-assignment transition fallback when the concrete statement cannot be resolved', async () => {

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -193,7 +193,7 @@ describe('diagnostics transition body ranges', () => {
             ['1 == 1', '1 == 1'],
         );
         assert.deepEqual(
-            constTrue.map(item => item.range.start.line),
+            constTrue.map(item => item.range.start.line).sort((a, b) => a - b),
             [5, 9],
         );
         assert.deepEqual(
@@ -250,11 +250,199 @@ describe('diagnostics transition body ranges', () => {
         );
         assert.deepEqual(
             neverTriggered.map(item => item.data?.transition_index),
-            [1, 2],
+            [2, 3],
         );
         assert.deepEqual(
             neverTriggered.map(item => item.data?.__rangeFallback ?? null),
             [null, null],
+        );
+    });
+
+
+    it('anchors forced eventless transition diagnostics on the forced statement', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !A -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-forced-eventless-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'I_TRANSITION_NEVER_EVENT_TRIGGERED')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), '!A -> B;');
+        assert.equal(diagnostic.data?.transition_index, 0);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+    });
+
+    it('anchors all-source forced transition diagnostics on the forced statement', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !* -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-forced-all-eventless-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const transitionDiagnostics = diagnostics
+            .filter(item => (
+                item.code === 'I_TRANSITION_NEVER_EVENT_TRIGGERED' ||
+                item.code === 'W_SELF_TRANSITION_NOP'
+            ))
+            .sort((a, b) => Number(a.data?.transition_index) - Number(b.data?.transition_index));
+
+        assert.equal(transitionDiagnostics.length, 3, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            transitionDiagnostics.map(item => [
+                item.code,
+                item.data?.transition_index,
+                sliceByRange(text, item.range).trim(),
+                item.data?.__rangeFallback,
+            ]),
+            [
+                ['I_TRANSITION_NEVER_EVENT_TRIGGERED', 0, '!* -> B;', undefined],
+                ['W_SELF_TRANSITION_NOP', 1, '!* -> B;', undefined],
+                ['I_TRANSITION_NEVER_EVENT_TRIGGERED', 1, '!* -> B;', undefined],
+            ],
+        );
+    });
+
+    it('anchors forced constant guard diagnostics on the forced guard expression', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !A -> B : if [1 == 1];',
+            '    !A -> B : if [1 == 2];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-forced-guard-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const constTrue = targetDiagnostics(diagnostics, 'W_GUARD_CONST_TRUE')[0];
+        const constFalse = targetDiagnostics(diagnostics, 'W_GUARD_CONST_FALSE')[0];
+
+        assert.ok(constTrue, JSON.stringify(diagnostics));
+        assert.ok(constFalse, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, constTrue.range).trim(), '1 == 1');
+        assert.equal(sliceByRange(text, constFalse.range).trim(), '1 == 2');
+        assert.equal(constTrue.data?.transition_index, 0);
+        assert.equal(constFalse.data?.transition_index, 1);
+        assert.equal(constTrue.data?.__rangeFallback, undefined);
+        assert.equal(constFalse.data?.__rangeFallback, undefined);
+    });
+
+    it('keeps literal false guards after forced transitions anchored to the guard', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !* -> B :: FatalError;',
+            '    A -> B : if [false];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-literal-false-forced-offset-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'W_GUARD_CONST_FALSE')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), 'false');
+        assert.equal(diagnostic.data?.transition_index, 3);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+    });
+
+    it('marks transition_not_found when refs cannot match any transition', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-index-not-found-marker.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+            severity: 'info' as const,
+            message: 'Synthetic unmatched transition diagnostic.',
+            span: null,
+            refs: {
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                transition_span: null,
+                transition_index: 99,
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(diagnostics[0].data?.__rangeFallback, 'transition_not_found');
+    });
+
+    it('resolves normalized guard refs by transition index', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    A -> B : if [(0x0F & 0xF0) != 0];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-normalized-guard-text-range.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'W_GUARD_CONST_FALSE',
+            severity: 'warning' as const,
+            message: 'Synthetic normalized guard diagnostic.',
+            span: null,
+            refs: {
+                transition_span: null,
+                folded_value: false,
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                guard_text: '15 & 240 != 0',
+                transition_index: 1,
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(sliceByRange(text, diagnostics[0].range).trim(), '(0x0F & 0xF0) != 0');
+        assert.equal(diagnostics[0].data?.__rangeFallback, undefined);
+    });
+
+
+    it('keeps js inspect transition indexes aligned with Python parent-first order', async () => {
+        const text = [
+            'state Root {',
+            '    state A {',
+            '        state X;',
+            '        state Y;',
+            '        [*] -> X;',
+            '        X -> Y;',
+            '        X -> Y;',
+            '    }',
+            '    [*] -> A;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-nested-model-order.fcstm');
+        const ast = await packageModule.parseAstDocument(document);
+        const machine = packageModule.buildStateMachineModel(ast);
+        const report = packageModule.inspectModel(machine);
+
+        assert.deepEqual(
+            report.transitions.map(item => [item.transition_index, item.from_path, item.to_path]),
+            [
+                [0, '[*]', 'Root.A'],
+                [1, '[*]', 'Root.A.X'],
+                [2, 'Root.A.X', 'Root.A.Y'],
+                [3, 'Root.A.X', 'Root.A.Y'],
+            ],
         );
     });
 

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -356,6 +356,38 @@ describe('diagnostics transition body ranges', () => {
         assert.equal(diagnostic.data?.__rangeFallback, undefined);
     });
 
+    it('treats uppercase boolean literal guards as true values', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    state C;',
+            '    [*] -> A;',
+            '    A -> B : if [True];',
+            '    B -> C : if [TRUE];',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/transition-uppercase-boolean-guard-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const constTrue = targetDiagnostics(diagnostics, 'W_GUARD_CONST_TRUE');
+        const constFalse = targetDiagnostics(diagnostics, 'W_GUARD_CONST_FALSE');
+
+        assert.equal(constFalse.length, 0, JSON.stringify(diagnostics));
+        assert.equal(constTrue.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            constTrue.map(item => [
+                sliceByRange(text, item.range).trim(),
+                item.data?.folded_value,
+                item.data?.guard_text,
+                item.data?.__rangeFallback,
+            ]),
+            [
+                ['True', true, 'true', undefined],
+                ['TRUE', true, 'true', undefined],
+            ],
+        );
+    });
+
     it('marks transition_not_found when refs cannot match any transition', async () => {
         const text = [
             'state Root {',

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -145,8 +145,23 @@ function isInspectSurfaceCode(code: unknown): code is string {
     return typeof code === 'string' && (code.startsWith('W_') || code.startsWith('I_'));
 }
 
+function canonicalRefs(refs: unknown): unknown {
+    if (Array.isArray(refs)) {
+        return refs.map(item => canonicalRefs(item));
+    }
+    if (typeof refs !== 'object' || refs === null) {
+        return refs;
+    }
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(refs as Record<string, unknown>).sort()) {
+        if (key === '__rangeFallback') continue;
+        out[key] = canonicalRefs((refs as Record<string, unknown>)[key]);
+    }
+    return out;
+}
+
 function stableKey(code: string, refs: unknown): string {
-    return JSON.stringify([code, refs ?? null]);
+    return JSON.stringify([code, canonicalRefs(refs ?? null)]);
 }
 
 async function inspectDiagnosticKeys(text: string, filePath: string): Promise<string[]> {
@@ -194,6 +209,22 @@ async function semanticFor(text: string, filePath: string) {
     const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
     assert.ok(semantic, 'expected semantic document');
     return {document, semantic};
+}
+
+function sliceText(
+    document: ReturnType<typeof createDocument>,
+    range: {start: {line: number; character: number}; end: {line: number; character: number}},
+): string {
+    if (range.start.line === range.end.line) {
+        return document.lineAt(range.start.line).text.slice(range.start.character, range.end.character);
+    }
+    const lines = [];
+    lines.push(document.lineAt(range.start.line).text.slice(range.start.character));
+    for (let line = range.start.line + 1; line < range.end.line; line += 1) {
+        lines.push(document.lineAt(line).text);
+    }
+    lines.push(document.lineAt(range.end.line).text.slice(0, range.end.character));
+    return lines.join('\n');
 }
 
 describe('editor inspect diagnostics surface parity', () => {
@@ -312,6 +343,8 @@ state Root {
             folded_value: false,
             from_path: 'Root.Idle',
             to_path: 'Root.Blocked',
+            guard_text: '1==2',
+            transition_index: 1,
         });
     });
 
@@ -340,12 +373,16 @@ state Root {
                 folded_value: false,
                 from_path: 'Root.Idle',
                 to_path: 'Root.FoldedBlocked',
+                guard_text: '1==2',
+                transition_index: 2,
             },
             {
                 transition_span: null,
                 folded_value: false,
                 from_path: 'Root.Idle',
                 to_path: 'Root.LiteralBlocked',
+                guard_text: 'false',
+                transition_index: 1,
             },
         ]);
     });
@@ -374,12 +411,16 @@ state Root {
                 folded_value: false,
                 from_path: 'Root.Idle',
                 to_path: 'Root.Blocked',
+                guard_text: 'false',
+                transition_index: 1,
             },
             {
                 transition_span: null,
                 folded_value: false,
                 from_path: 'Root.Idle',
                 to_path: 'Root.Blocked',
+                guard_text: '1==2',
+                transition_index: 2,
             },
         ]);
         assertBagCovers(
@@ -491,7 +532,7 @@ state Root {
         assert.equal(document.lineAt(fromPathRange!.start.line).text.slice(
             fromPathRange!.start.character,
             fromPathRange!.end.character,
-        ), 'Idle');
+        ).trim(), 'Idle -> Done : Tick;');
 
         const variableRange = packageModule.resolveRangeFromRefs(document, semantic, {var_name: 'counter'});
         assert.equal(document.lineAt(variableRange!.start.line).text.includes('def int counter = 0;'), true);
@@ -511,8 +552,12 @@ state Root {
             duplicateRange,
         );
         assert.equal(
-            packageModule.resolveRangeFromRefs(document, semantic, {duplicate_spans: ['not-a-range']}),
-            null,
+            sliceText(document, packageModule.resolveRangeFromRefs(document, semantic, {
+                from_path: 'Root.Idle',
+                to_path: 'Root.Done',
+                duplicate_spans: ['not-a-range'],
+            })!).trim(),
+            'Idle -> Done : Tick;',
         );
         assert.equal(packageModule.resolveRangeFromRefs(document, semantic, null), null);
     });

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -348,6 +348,46 @@ state Root {
         });
     });
 
+
+    it('keeps literal false editor guard refs normalized like inspect refs', async () => {
+        const text = `
+state Root {
+    state Idle;
+    state Blocked;
+    [*] -> Idle;
+    Idle -> Blocked : if [False];
+}
+`;
+        const diagnostics = await packageModule.collectDocumentDiagnostics(
+            createDocument(text, '/tmp/literal-false-normalized-guard.fcstm'),
+        );
+        const diagnostic = diagnostics.find(item => item.code === 'W_GUARD_CONST_FALSE');
+
+        assert.ok(diagnostic, 'expected literal false guard diagnostic');
+        assert.equal(diagnostic.data?.guard_text, 'false');
+    });
+
+    it('keeps editor analyzer float guard refs normalized like inspect refs', async () => {
+        const text = `
+state Root {
+    state Reachable;
+    state Isolated;
+    state Blocked;
+    [*] -> Reachable;
+    Isolated -> Blocked : if [2.0 == 2.0];
+}
+`;
+        const diagnostics = await packageModule.collectDocumentDiagnostics(
+            createDocument(text, '/tmp/unreachable-float-normalized-guard.fcstm'),
+        );
+        const diagnostic = diagnostics.find(item => (
+            item.code === 'W_GUARD_CONST_FALSE' && item.data?.from_path === 'Root.Isolated'
+        ));
+
+        assert.ok(diagnostic, 'expected source-unreachable transition diagnostic');
+        assert.equal(diagnostic.data?.guard_text, '2.0 == 2.0');
+    });
+
     it('keeps inspect-only folded false guards when literal false guards share the file', async () => {
         const text = `
 state Root {

--- a/editors/jsfcstm/test/inspect-surface-parity.test.ts
+++ b/editors/jsfcstm/test/inspect-surface-parity.test.ts
@@ -343,7 +343,7 @@ state Root {
             folded_value: false,
             from_path: 'Root.Idle',
             to_path: 'Root.Blocked',
-            guard_text: '1==2',
+            guard_text: '1 == 2',
             transition_index: 1,
         });
     });
@@ -373,7 +373,7 @@ state Root {
                 folded_value: false,
                 from_path: 'Root.Idle',
                 to_path: 'Root.FoldedBlocked',
-                guard_text: '1==2',
+                guard_text: '1 == 2',
                 transition_index: 2,
             },
             {
@@ -419,7 +419,7 @@ state Root {
                 folded_value: false,
                 from_path: 'Root.Idle',
                 to_path: 'Root.Blocked',
-                guard_text: '1==2',
+                guard_text: '1 == 2',
                 transition_index: 2,
             },
         ]);

--- a/pyfcstm/diagnostics/analyzers/const_fold.py
+++ b/pyfcstm/diagnostics/analyzers/const_fold.py
@@ -89,6 +89,7 @@ def collect_const_fold_warnings(
         return []
     diagnostics: List[ModelDiagnostic] = []
     defined_vars = set(machine.defines)
+    transition_indexes = _transition_indexes(machine)
     for state in machine.walk_states():
         state_path = _state_path(state)
         for transition in state.transitions:
@@ -97,10 +98,24 @@ def collect_const_fold_warnings(
                 else fold_condition_expression(transition.guard)
             )
             if folded_guard is True:
-                diagnostics.append(_guard_const_diagnostic(transition, True))
+                diagnostics.append(
+                    _guard_const_diagnostic(
+                        transition,
+                        True,
+                        transition_indexes.get(id(transition)),
+                    )
+                )
             elif folded_guard is False:
-                diagnostics.append(_guard_const_diagnostic(transition, False))
-        diagnostics.extend(_during_const_assign_diagnostics(state_path, state, defined_vars))
+                diagnostics.append(
+                    _guard_const_diagnostic(
+                        transition,
+                        False,
+                        transition_indexes.get(id(transition)),
+                    )
+                )
+        diagnostics.extend(
+            _during_const_assign_diagnostics(state_path, state, defined_vars)
+        )
     return diagnostics
 
 
@@ -247,7 +262,33 @@ def _during_stmt_const_assign_diagnostics(
     ]
 
 
-def _guard_const_diagnostic(transition, value: bool) -> ModelDiagnostic:
+
+def _expr_text(expr) -> Optional[str]:
+    if expr is None:
+        return None
+    try:
+        return str(expr.to_ast_node())
+    except (AttributeError, TypeError, ValueError):
+        # AttributeError: non-model guard object; TypeError/ValueError:
+        # future expression implementations with invalid AST conversion.
+        return None
+
+
+def _transition_indexes(machine: 'StateMachine') -> dict:
+    indexes = {}
+    index = 0
+    for state in machine.walk_states():
+        for transition in state.transitions:
+            indexes[id(transition)] = index
+            index += 1
+    return indexes
+
+
+def _guard_const_diagnostic(
+    transition,
+    value: bool,
+    transition_index: Optional[int],
+) -> ModelDiagnostic:
     code = 'W_GUARD_CONST_TRUE' if value else 'W_GUARD_CONST_FALSE'
     label = 'true' if value else 'false'
     source_label = _transition_endpoint_label(transition.from_state)
@@ -264,6 +305,8 @@ def _guard_const_diagnostic(transition, value: bool) -> ModelDiagnostic:
             'folded_value': value,
             'from_path': _transition_endpoint_path(transition, is_source=True),
             'to_path': _transition_endpoint_path(transition, is_source=False),
+            'guard_text': _expr_text(transition.guard),
+            'transition_index': transition_index,
         },
     )
 

--- a/pyfcstm/diagnostics/analyzers/const_fold.py
+++ b/pyfcstm/diagnostics/analyzers/const_fold.py
@@ -264,14 +264,9 @@ def _during_stmt_const_assign_diagnostics(
 
 
 def _expr_text(expr) -> Optional[str]:
-    if expr is None:
-        return None
-    try:
-        return str(expr.to_ast_node())
-    except (AttributeError, TypeError, ValueError):
-        # AttributeError: non-model guard object; TypeError/ValueError:
-        # future expression implementations with invalid AST conversion.
-        return None
+    from ..inspect import _expr_text as inspect_expr_text
+
+    return inspect_expr_text(expr)
 
 
 def _transition_indexes(machine: 'StateMachine') -> dict:

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -138,6 +138,8 @@ def _guard_const_false_diagnostics(transitions) -> List[ModelDiagnostic]:
                         'folded_value': False,
                         'from_path': transition.from_path,
                         'to_path': transition.to_path,
+                        'guard_text': transition.guard,
+                        'transition_index': transition.transition_index,
                     },
                 )
             )

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -1,7 +1,7 @@
 """Redundancy and overlap design-health diagnostics."""
 
 from collections import Counter
-from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
 
 from ...utils.validate import ModelDiagnostic
 
@@ -25,16 +25,18 @@ def collect_redundancy_warnings(
     return diagnostics
 
 
-def _transition_trigger_key(t) -> Tuple[str, str, object, object]:
+def _transition_trigger_key(t: 'TransitionInfo') -> Tuple[str, str, object, object]:
     return t.from_path, t.to_path, t.event, t.guard
 
 
-def _transition_behavior_key(t) -> Tuple[str, str, object, object, object]:
+def _transition_behavior_key(t: 'TransitionInfo') -> Tuple[str, str, object, object, object]:
     return t.from_path, t.to_path, t.event, t.guard, t.effect
 
 
-def _redundant_transition_warnings(transitions) -> List[ModelDiagnostic]:
-    groups: Dict[Tuple[str, str, object, object, object], List[object]] = {}
+def _redundant_transition_warnings(
+        transitions: Iterable['TransitionInfo'],
+) -> List[ModelDiagnostic]:
+    groups: Dict[Tuple[str, str, object, object, object], List['TransitionInfo']] = {}
     for t in transitions:
         if t.from_path == '[*]':
             continue
@@ -64,7 +66,10 @@ def _redundant_transition_warnings(transitions) -> List[ModelDiagnostic]:
     return diagnostics
 
 
-def _self_transition_nop_warnings(transitions, states) -> List[ModelDiagnostic]:
+def _self_transition_nop_warnings(
+        transitions: Iterable['TransitionInfo'],
+        states: Iterable['StateInfo'],
+) -> List[ModelDiagnostic]:
     states_by_path = {state.path: state for state in states}
     diagnostics: List[ModelDiagnostic] = []
     for t in transitions:
@@ -92,7 +97,10 @@ def _self_transition_nop_warnings(transitions, states) -> List[ModelDiagnostic]:
     return diagnostics
 
 
-def _is_lifecycle_free_leaf(state_path: str, states_by_path) -> bool:
+def _is_lifecycle_free_leaf(
+        state_path: str,
+        states_by_path: Dict[str, 'StateInfo'],
+) -> bool:
     state = states_by_path.get(state_path)
     if state is None or not state.is_leaf or state.is_pseudo:
         return False
@@ -112,7 +120,7 @@ def _is_lifecycle_free_leaf(state_path: str, states_by_path) -> bool:
     return True
 
 
-def _effect_self_assign_warnings(transitions) -> List[ModelDiagnostic]:
+def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> List[ModelDiagnostic]:
     counts = Counter(
         (t.from_path, var_name)
         for t in transitions
@@ -138,7 +146,7 @@ def _effect_self_assign_warnings(transitions) -> List[ModelDiagnostic]:
     return diagnostics
 
 
-def _forced_overrides_normal_warnings(transitions) -> List[ModelDiagnostic]:
+def _forced_overrides_normal_warnings(transitions: Iterable['TransitionInfo']) -> List[ModelDiagnostic]:
     normal = {
         _transition_trigger_key(t)
         for t in transitions
@@ -165,8 +173,8 @@ def _forced_overrides_normal_warnings(transitions) -> List[ModelDiagnostic]:
     return diagnostics
 
 
-def _shadowed_event_warnings(events) -> List[ModelDiagnostic]:
-    by_leaf_name: Dict[str, List[object]] = {}
+def _shadowed_event_warnings(events: Iterable['EventInfo']) -> List[ModelDiagnostic]:
+    by_leaf_name: Dict[str, List['EventInfo']] = {}
     for event in events:
         leaf = event.qualified_name.rsplit('.', 1)[-1]
         by_leaf_name.setdefault(leaf, []).append(event)
@@ -199,7 +207,10 @@ def _shadowed_event_warnings(events) -> List[ModelDiagnostic]:
     return diagnostics
 
 
-def _find_shadowing_event(local_event, chain_like):
+def _find_shadowing_event(
+        local_event: 'EventInfo',
+        chain_like: Iterable['EventInfo'],
+) -> Optional['EventInfo']:
     local_owner = _event_owner_path(local_event.qualified_name)
     candidates = [
         item for item in chain_like

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -58,6 +58,7 @@ def _redundant_transition_warnings(transitions) -> List[ModelDiagnostic]:
                     f'{item.from_path}->{item.to_path}#{index}'
                     for index, item in enumerate(items, 1)
                 ],
+                'transition_index': items[0].transition_index,
             },
         ))
     return diagnostics
@@ -80,7 +81,13 @@ def _self_transition_nop_warnings(transitions, states) -> List[ModelDiagnostic]:
                 f'Self transition on {t.from_path!r} has no trigger, '
                 'guard, effect, or re-entry lifecycle behavior.'
             ),
-            refs={'state_path': t.from_path},
+            refs={
+                'state_path': t.from_path,
+                'from_path': t.from_path,
+                'to_path': t.to_path,
+                'transition_span': None,
+                'transition_index': t.transition_index,
+            },
         ))
     return diagnostics
 
@@ -118,6 +125,7 @@ def _effect_self_assign_warnings(transitions) -> List[ModelDiagnostic]:
                 'state_path': t.from_path,
                 'transition_span': None,
                 'var_name': var_name,
+                'transition_index': t.transition_index,
             }
             if t.from_path != '[*]' and counts[(t.from_path, var_name)] == 1:
                 refs['effect_self_assign_anchor'] = var_name

--- a/pyfcstm/diagnostics/analyzers/transition_info.py
+++ b/pyfcstm/diagnostics/analyzers/transition_info.py
@@ -64,6 +64,7 @@ def _eventless_guardless_transition_infos(transitions) -> List[ModelDiagnostic]:
                 'from_path': transition.from_path,
                 'to_path': transition.to_path,
                 'transition_span': None,
+                'transition_index': transition.transition_index,
             },
         ))
     return diagnostics

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1059,6 +1059,18 @@ W_GUARD_CONST_FALSE:
       type: str
       required: false
       description: Target state path of the transition, or ``[*]`` for an exit transition.
+    guard_text:
+      type: str
+      required: false
+      description: >-
+        Normalized guard expression text used to disambiguate spanless
+        inspect diagnostics.
+    transition_index:
+      type: int
+      required: false
+      description: >-
+        Zero-based transition index in inspect transition order, used only
+        as a source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``false`` and the
@@ -1113,6 +1125,18 @@ W_GUARD_CONST_TRUE:
       type: str
       required: false
       description: Target state path of the transition, or ``[*]`` for an exit transition.
+    guard_text:
+      type: str
+      required: false
+      description: >-
+        Normalized guard expression text used to disambiguate spanless
+        inspect diagnostics.
+    transition_index:
+      type: int
+      required: false
+      description: >-
+        Zero-based transition index in inspect transition order, used only
+        as a source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``true`` and does
@@ -1635,6 +1659,12 @@ W_REDUNDANT_TRANSITION:
       type: list[str]
       required: true
       description: Stable labels for duplicate transition declarations when source spans are unavailable.
+    transition_index:
+      type: int
+      required: false
+      description: >-
+        Zero-based transition index in inspect transition order, used only
+        as a source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       These transitions are indistinguishable by source, target, event,
@@ -1669,6 +1699,24 @@ W_SELF_TRANSITION_NOP:
       type: str
       required: true
       description: Dotted path of the state with the no-op self transition.
+    from_path:
+      type: str
+      required: false
+      description: Dotted source state path.
+    to_path:
+      type: str
+      required: false
+      description: Dotted target state path.
+    transition_span:
+      type: Span
+      required: false
+      description: Source span of the no-op self transition when available.
+    transition_index:
+      type: int
+      required: false
+      description: >-
+        Zero-based transition index in inspect transition order, used only
+        as a source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition points from a state to itself and has no trigger,
@@ -1720,6 +1768,12 @@ W_EFFECT_SELF_ASSIGN:
       type: dict
       required: false
       description: Structured quick-fix payload for removing the no-op effect statement.
+    transition_index:
+      type: int
+      required: false
+      description: >-
+        Zero-based transition index in inspect transition order, used only
+        as a source-range disambiguation hint when spans are unavailable.
   suggested_fix:
     kind: delete
     target: effect_self_assign_statement
@@ -2138,6 +2192,12 @@ I_TRANSITION_NEVER_EVENT_TRIGGERED:
       type: Span
       required: false
       description: Source span of the transition when available.
+    transition_index:
+      type: int
+      required: false
+      description: >-
+        Zero-based transition index in inspect transition order, used only
+        as a source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition is not event-triggered and has no guard. This may

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1064,14 +1064,17 @@ W_GUARD_CONST_FALSE:
       required: false
       description: >-
         Normalized guard expression text used to disambiguate spanless
-        inspect diagnostics.
+        inspect diagnostics. Pyfcstm and jsfcstm both render this with the
+        shared inspect expression format: canonical boolean/operator spelling,
+        decimal integer literals, and normalized spacing.
     transition_index:
       type: int
       required: false
       description: >-
-        Zero-based index in model transition order, including expanded forced
-        transitions, used only as a source-range disambiguation hint when spans
-        are unavailable.
+        Zero-based index in parent-first model transition order, including
+        expanded forced transitions at their declaring state before ordinary
+        transitions and descendant-state transitions. This is used only as a
+        source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``false`` and the
@@ -1131,14 +1134,17 @@ W_GUARD_CONST_TRUE:
       required: false
       description: >-
         Normalized guard expression text used to disambiguate spanless
-        inspect diagnostics.
+        inspect diagnostics. Pyfcstm and jsfcstm both render this with the
+        shared inspect expression format: canonical boolean/operator spelling,
+        decimal integer literals, and normalized spacing.
     transition_index:
       type: int
       required: false
       description: >-
-        Zero-based index in model transition order, including expanded forced
-        transitions, used only as a source-range disambiguation hint when spans
-        are unavailable.
+        Zero-based index in parent-first model transition order, including
+        expanded forced transitions at their declaring state before ordinary
+        transitions and descendant-state transitions. This is used only as a
+        source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``true`` and does
@@ -1665,9 +1671,10 @@ W_REDUNDANT_TRANSITION:
       type: int
       required: false
       description: >-
-        Zero-based index in model transition order, including expanded forced
-        transitions, used only as a source-range disambiguation hint when spans
-        are unavailable.
+        Zero-based index in parent-first model transition order, including
+        expanded forced transitions at their declaring state before ordinary
+        transitions and descendant-state transitions. This is used only as a
+        source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       These transitions are indistinguishable by source, target, event,
@@ -1718,9 +1725,10 @@ W_SELF_TRANSITION_NOP:
       type: int
       required: false
       description: >-
-        Zero-based index in model transition order, including expanded forced
-        transitions, used only as a source-range disambiguation hint when spans
-        are unavailable.
+        Zero-based index in parent-first model transition order, including
+        expanded forced transitions at their declaring state before ordinary
+        transitions and descendant-state transitions. This is used only as a
+        source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition points from a state to itself and has no trigger,
@@ -1776,9 +1784,10 @@ W_EFFECT_SELF_ASSIGN:
       type: int
       required: false
       description: >-
-        Zero-based index in model transition order, including expanded forced
-        transitions, used only as a source-range disambiguation hint when spans
-        are unavailable.
+        Zero-based index in parent-first model transition order, including
+        expanded forced transitions at their declaring state before ordinary
+        transitions and descendant-state transitions. This is used only as a
+        source-range disambiguation hint when spans are unavailable.
   suggested_fix:
     kind: delete
     target: effect_self_assign_statement
@@ -2201,9 +2210,10 @@ I_TRANSITION_NEVER_EVENT_TRIGGERED:
       type: int
       required: false
       description: >-
-        Zero-based index in model transition order, including expanded forced
-        transitions, used only as a source-range disambiguation hint when spans
-        are unavailable.
+        Zero-based index in parent-first model transition order, including
+        expanded forced transitions at their declaring state before ordinary
+        transitions and descendant-state transitions. This is used only as a
+        source-range disambiguation hint when spans are unavailable.
   for_llm:
     summary: >-
       The transition is not event-triggered and has no guard. This may

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1069,8 +1069,9 @@ W_GUARD_CONST_FALSE:
       type: int
       required: false
       description: >-
-        Zero-based transition index in inspect transition order, used only
-        as a source-range disambiguation hint when spans are unavailable.
+        Zero-based index in model transition order, including expanded forced
+        transitions, used only as a source-range disambiguation hint when spans
+        are unavailable.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``false`` and the
@@ -1135,8 +1136,9 @@ W_GUARD_CONST_TRUE:
       type: int
       required: false
       description: >-
-        Zero-based transition index in inspect transition order, used only
-        as a source-range disambiguation hint when spans are unavailable.
+        Zero-based index in model transition order, including expanded forced
+        transitions, used only as a source-range disambiguation hint when spans
+        are unavailable.
   for_llm:
     summary: >-
       The transition's guard is statically known to be ``true`` and does
@@ -1663,8 +1665,9 @@ W_REDUNDANT_TRANSITION:
       type: int
       required: false
       description: >-
-        Zero-based transition index in inspect transition order, used only
-        as a source-range disambiguation hint when spans are unavailable.
+        Zero-based index in model transition order, including expanded forced
+        transitions, used only as a source-range disambiguation hint when spans
+        are unavailable.
   for_llm:
     summary: >-
       These transitions are indistinguishable by source, target, event,
@@ -1715,8 +1718,9 @@ W_SELF_TRANSITION_NOP:
       type: int
       required: false
       description: >-
-        Zero-based transition index in inspect transition order, used only
-        as a source-range disambiguation hint when spans are unavailable.
+        Zero-based index in model transition order, including expanded forced
+        transitions, used only as a source-range disambiguation hint when spans
+        are unavailable.
   for_llm:
     summary: >-
       The transition points from a state to itself and has no trigger,
@@ -1772,8 +1776,9 @@ W_EFFECT_SELF_ASSIGN:
       type: int
       required: false
       description: >-
-        Zero-based transition index in inspect transition order, used only
-        as a source-range disambiguation hint when spans are unavailable.
+        Zero-based index in model transition order, including expanded forced
+        transitions, used only as a source-range disambiguation hint when spans
+        are unavailable.
   suggested_fix:
     kind: delete
     target: effect_self_assign_statement
@@ -2196,8 +2201,9 @@ I_TRANSITION_NEVER_EVENT_TRIGGERED:
       type: int
       required: false
       description: >-
-        Zero-based transition index in inspect transition order, used only
-        as a source-range disambiguation hint when spans are unavailable.
+        Zero-based index in model transition order, including expanded forced
+        transitions, used only as a source-range disambiguation hint when spans
+        are unavailable.
   for_llm:
     summary: >-
       The transition is not event-triggered and has no guard. This may

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -165,6 +165,11 @@ class TransitionInfo:
         ``!X -> Y`` declaration when ``is_forced`` is ``True``, otherwise
         ``None``.
     :type forced_origin: Optional[str]
+    :param transition_index: Zero-based index in the model transition order,
+        including expanded forced transitions. Downstream tooling may use this
+        as a best-effort source-range disambiguation hint when spans are not
+        available.
+    :type transition_index: Optional[int]
     """
 
     from_path: str
@@ -176,6 +181,7 @@ class TransitionInfo:
     effect_self_assigns: Tuple[str, ...]
     is_forced: bool
     forced_origin: Optional[str]
+    transition_index: Optional[int]
 
 
 @dataclass(frozen=True)
@@ -723,6 +729,7 @@ def _build_state_infos(machine: 'StateMachine') -> Tuple[StateInfo, ...]:
 
 def _build_transition_infos(machine: 'StateMachine') -> Tuple[TransitionInfo, ...]:
     out: List[TransitionInfo] = []
+    transition_index = 0
     for state in machine.walk_states():
         for transition in state.transitions:
             from_path = _transition_endpoint(state, transition.from_state, is_source=True)
@@ -746,7 +753,9 @@ def _build_transition_infos(machine: 'StateMachine') -> Tuple[TransitionInfo, ..
                 effect_self_assigns=_effect_self_assigns(transition.effects),
                 is_forced=is_forced,
                 forced_origin=forced_origin,
+                transition_index=transition_index,
             ))
+            transition_index += 1
     return tuple(out)
 
 

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -57,7 +57,7 @@ from .analyzers import (
 from ..utils.validate import ModelDiagnostic
 
 if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
-    from ..model.expr import Expr
+    from ..model.expr import Expr, Float, Integer
     from ..model.model import (
         OperationStatement,
         OnAspect,
@@ -531,11 +531,11 @@ def _expr_precedence(expr: 'Expr') -> Optional[int]:
     return None
 
 
-def _integer_text(expr: 'Expr') -> str:
+def _integer_text(expr: 'Integer') -> str:
     return str(int(expr.value))
 
 
-def _float_text(expr: 'Expr') -> str:
+def _float_text(expr: 'Float') -> str:
     if abs(expr.value - math.pi) < _FLOAT_EPSILON:
         return 'pi'
     if abs(expr.value - math.e) < _FLOAT_EPSILON:

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -72,6 +72,39 @@ DEFAULT_LARGE_COMPOSITE_THRESHOLD = 12
 DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD = 2.0
 
 
+_OP_PRECEDENCE = {
+    'function_call': 90,
+    'unary+': 80,
+    'unary-': 80,
+    '!': 80,
+    'not': 80,
+    '**': 70,
+    '*': 60,
+    '/': 60,
+    '%': 60,
+    '+': 50,
+    '-': 50,
+    '<<': 40,
+    '>>': 40,
+    '&': 35,
+    '^': 30,
+    '|': 25,
+    '<': 20,
+    '>': 20,
+    '<=': 20,
+    '>=': 20,
+    '==': 20,
+    '!=': 20,
+    '&&': 15,
+    'and': 15,
+    '||': 10,
+    'or': 10,
+    '?:': 5,
+}
+
+_FLOAT_EPSILON = 1e-10
+
+
 @dataclass(frozen=True)
 class StateInfo:
     """
@@ -149,7 +182,10 @@ class TransitionInfo:
     :param event_scope: ``'local'``, ``'chain'``, ``'absolute'``, or
         ``None`` when there is no event.
     :type event_scope: Optional[str]
-    :param guard: Source text of the guard expression, or ``None``.
+    :param guard: Normalized guard expression text, or ``None``.
+        Pyfcstm and jsfcstm share this inspect expression format so
+        downstream range resolution can treat ``guard_text`` as a stable
+        disambiguation hint.
     :type guard: Optional[str]
     :param effect: Source text of the effect block, or ``None``.
     :type effect: Optional[str]
@@ -165,10 +201,11 @@ class TransitionInfo:
         ``!X -> Y`` declaration when ``is_forced`` is ``True``, otherwise
         ``None``.
     :type forced_origin: Optional[str]
-    :param transition_index: Zero-based index in the model transition order,
-        including expanded forced transitions. Downstream tooling may use this
-        as a best-effort source-range disambiguation hint when spans are not
-        available.
+    :param transition_index: Zero-based index in parent-first model
+        transition order, including expanded forced transitions at their
+        declaring state before ordinary transitions and descendant-state
+        transitions. Downstream tooling may use this as a best-effort
+        source-range disambiguation hint when spans are not available.
     :type transition_index: Optional[int]
     """
 
@@ -465,16 +502,120 @@ def _transition_endpoint(parent_state: Any, marker_or_name: Any, is_source: bool
     # exists for future AST extensions and never fires today.
 
 
+def _canonical_binary_operator(op: str) -> str:
+    if op == 'and':
+        return '&&'
+    if op == 'or':
+        return '||'
+    return op
+
+
+def _canonical_unary_operator(op: str) -> str:
+    return '!' if op == 'not' else op
+
+
+def _unary_precedence_key(op: str) -> str:
+    canonical = _canonical_unary_operator(op)
+    return f'unary{canonical}' if canonical in {'+', '-'} else canonical
+
+
+def _expr_precedence(expr: 'Expr') -> Optional[int]:
+    from ..model.expr import BinaryOp, ConditionalOp, UnaryOp
+
+    if isinstance(expr, BinaryOp):
+        return _OP_PRECEDENCE.get(_canonical_binary_operator(expr.op))
+    if isinstance(expr, ConditionalOp):
+        return _OP_PRECEDENCE['?:']
+    if isinstance(expr, UnaryOp):
+        return _OP_PRECEDENCE.get(_unary_precedence_key(expr.op))
+    return None
+
+
+def _integer_text(expr: 'Expr') -> str:
+    return str(int(expr.value))
+
+
+def _float_text(expr: 'Expr') -> str:
+    if abs(expr.value - math.pi) < _FLOAT_EPSILON:
+        return 'pi'
+    if abs(expr.value - math.e) < _FLOAT_EPSILON:
+        return 'E'
+    if abs(expr.value - math.tau) < _FLOAT_EPSILON:
+        return 'tau'
+    if float(expr.value).is_integer():
+        return f'{int(expr.value)}.0'
+    return str(expr.value)
+
+
 def _expr_text(expr: Optional['Expr']) -> Optional[str]:
     if expr is None:
         return None
+    from ..model.expr import (
+        BinaryOp,
+        Boolean,
+        ConditionalOp,
+        Float,
+        Integer,
+        UFunc,
+        UnaryOp,
+        Variable,
+    )
+
+    if isinstance(expr, Integer):
+        return _integer_text(expr)
+    if isinstance(expr, Float):
+        return _float_text(expr)
+    if isinstance(expr, Boolean):
+        return 'true' if expr.value else 'false'
+    if isinstance(expr, Variable):
+        return expr.name
+    if isinstance(expr, UFunc):
+        argument = _expr_text(expr.x)
+        return None if argument is None else f'{expr.func}({argument})'
+    if isinstance(expr, UnaryOp):
+        op = _canonical_unary_operator(expr.op)
+        my_precedence = _OP_PRECEDENCE[_unary_precedence_key(expr.op)]
+        value = _expr_text(expr.x)
+        if value is None:
+            return None
+        value_precedence = _expr_precedence(expr.x)
+        if value_precedence is not None and value_precedence <= my_precedence:
+            value = f'({value})'
+        return f'{op}{value}'
+    if isinstance(expr, BinaryOp):
+        op = _canonical_binary_operator(expr.op)
+        my_precedence = _OP_PRECEDENCE[op]
+        left = _expr_text(expr.x)
+        right = _expr_text(expr.y)
+        if left is None or right is None:
+            return None
+        left_precedence = _expr_precedence(expr.x)
+        if left_precedence is not None and left_precedence < my_precedence:
+            left = f'({left})'
+        right_precedence = _expr_precedence(expr.y)
+        if right_precedence is not None and right_precedence <= my_precedence:
+            right = f'({right})'
+        return f'{left} {op} {right}'
+    if isinstance(expr, ConditionalOp):
+        my_precedence = _OP_PRECEDENCE['?:']
+        condition = _expr_text(expr.cond)
+        when_true = _expr_text(expr.if_true)
+        when_false = _expr_text(expr.if_false)
+        if condition is None or when_true is None or when_false is None:
+            return None
+        true_precedence = _expr_precedence(expr.if_true)
+        if true_precedence is not None and true_precedence <= my_precedence:
+            when_true = f'({when_true})'
+        false_precedence = _expr_precedence(expr.if_false)
+        if false_precedence is not None and false_precedence <= my_precedence:
+            when_false = f'({when_false})'
+        return f'({condition}) ? {when_true} : {when_false}'
+
     try:
         return str(expr.to_ast_node())
-    except Exception:  # pragma: no cover
-        # Defensive: grammar-emitted Expr.to_ast_node always succeeds.
-        # The try/except guards against future Expr subclasses whose
-        # to_ast_node could fail; keep as fail-soft so inspection
-        # never crashes the IDE / CLI.
+    except (AttributeError, TypeError, ValueError):  # pragma: no cover
+        # AttributeError: non-model Expr-like object; TypeError/ValueError:
+        # future expression implementations with invalid AST conversion.
         return None
 
 
@@ -485,9 +626,9 @@ def _effects_text(effects: List['OperationStatement']) -> Optional[str]:
     for stmt in effects:
         try:
             parts.append(str(stmt.to_ast_node()))
-        except Exception:  # pragma: no cover
-            # Defensive: see ``_expr_text`` — grammar-emitted stmts
-            # always serialize.
+        except (AttributeError, TypeError, ValueError):  # pragma: no cover
+            # AttributeError: non-model statement-like object; TypeError/ValueError:
+            # future statement implementations with invalid AST conversion.
             continue
     if not parts:  # pragma: no cover
         # Unreachable while ``except`` above is unreachable. Belt-and-

--- a/pyfcstm/diagnostics/schema.json
+++ b/pyfcstm/diagnostics/schema.json
@@ -132,7 +132,10 @@
             "required": ["target", "guard", "event", "is_unconditional"],
             "properties": {
               "target": { "type": "string" },
-              "guard": { "type": ["string", "null"] },
+              "guard": {
+                "type": ["string", "null"],
+                "description": "Normalized inspect expression text shared by pyfcstm and jsfcstm."
+              },
               "event": { "type": ["string", "null"] },
               "is_unconditional": { "type": "boolean" }
             }
@@ -162,7 +165,10 @@
           "type": ["string", "null"],
           "enum": ["local", "chain", "absolute", null]
         },
-        "guard": { "type": ["string", "null"] },
+        "guard": {
+          "type": ["string", "null"],
+          "description": "Normalized inspect expression text shared by pyfcstm and jsfcstm."
+        },
         "effect": { "type": ["string", "null"] },
         "effect_self_assigns": {
           "type": "array",
@@ -170,7 +176,11 @@
         },
         "is_forced": { "type": "boolean" },
         "forced_origin": { "type": ["string", "null"] },
-        "transition_index": { "type": ["integer", "null"], "minimum": 0 }
+        "transition_index": {
+          "type": ["integer", "null"],
+          "minimum": 0,
+          "description": "Zero-based parent-first model transition order, including forced expansions at their declaring state."
+        }
       }
     },
     "VariableInfo": {
@@ -273,7 +283,10 @@
           "type": ["string", "null"],
           "enum": ["local", "chain", "absolute", null]
         },
-        "guard": { "type": ["string", "null"] },
+        "guard": {
+          "type": ["string", "null"],
+          "description": "Normalized inspect expression text shared by pyfcstm and jsfcstm."
+        },
         "original_raw": { "type": "string" },
         "expansion_count": { "type": "integer", "minimum": 0 }
       }

--- a/pyfcstm/diagnostics/schema.json
+++ b/pyfcstm/diagnostics/schema.json
@@ -152,7 +152,7 @@
       "required": [
         "from_path", "to_path", "event", "event_scope",
         "guard", "effect", "effect_self_assigns", "is_forced",
-        "forced_origin"
+        "forced_origin", "transition_index"
       ],
       "properties": {
         "from_path": { "type": "string" },
@@ -169,7 +169,8 @@
           "items": { "type": "string" }
         },
         "is_forced": { "type": "boolean" },
-        "forced_origin": { "type": ["string", "null"] }
+        "forced_origin": { "type": ["string", "null"] },
+        "transition_index": { "type": ["integer", "null"], "minimum": 0 }
       }
     },
     "VariableInfo": {

--- a/test/diagnostics/test_const_fold.py
+++ b/test/diagnostics/test_const_fold.py
@@ -138,6 +138,7 @@ def test_design_health_helper_keeps_minimal_const_false_fallback_without_machine
                 effect_self_assigns=tuple(),
                 is_forced=False,
                 forced_origin=None,
+                transition_index=0,
             )
         ],
         variables=[],

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -1230,6 +1230,44 @@ def test_design_health_inspect_diagnostics_match_inlined_expected(name, dsl, exp
 
 
 @pytest.mark.unittest
+def test_transition_refs_contract_uses_parent_first_transition_index_and_guard_text():
+    dsl = '\n'.join([
+        'state Root {',
+        '    state A {',
+        '        state X;',
+        '        state Y;',
+        '        [*] -> X;',
+        '        X -> Y;',
+        '        X -> Y;',
+        '    }',
+        '    state B;',
+        '    [*] -> A;',
+        '    !A -> B :: Fatal;',
+        '    A -> B : if [(0x0F & 0xF0) != 0];',
+        '}',
+    ])
+    ast = parse_with_grammar_entry(dsl, 'state_machine_dsl')
+    report = inspect_model(parse_dsl_node_to_state_machine(ast))
+
+    assert [
+        (item.transition_index, item.from_path, item.to_path, item.is_forced)
+        for item in report.transitions
+    ] == [
+        (0, 'Root.A', 'Root.B', True),
+        (1, '[*]', 'Root.A', False),
+        (2, 'Root.A', 'Root.B', False),
+        (3, 'Root.A.X', '[*]', True),
+        (4, 'Root.A.Y', '[*]', True),
+        (5, '[*]', 'Root.A.X', False),
+        (6, 'Root.A.X', 'Root.A.Y', False),
+        (7, 'Root.A.X', 'Root.A.Y', False),
+    ]
+    const_false = next(item for item in report.diagnostics if item.code == 'W_GUARD_CONST_FALSE')
+    assert const_false.refs['guard_text'] == '15 & 240 != 0'
+    assert const_false.refs['transition_index'] == 2
+
+
+@pytest.mark.unittest
 def test_strict_mode_raises_with_diagnostic_attribute():
     """In strict mode the first E_* still surfaces as a raised
     ModelValidationError carrying the diagnostic. Confirms the

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -1186,9 +1186,47 @@ def test_design_health_inspect_diagnostics_match_inlined_expected(name, dsl, exp
         _expected_with_suggested_fixes(expected),
     )
     py_diags = _py_inspect_normalized_diagnostics(dsl)
-    assert py_diags == normalized_expected, (
-        f'{name}: pyfcstm inspect diagnostics mismatch: {py_diags}'
-    )
+    normalized_expected_keys = {
+        json.dumps(item, sort_keys=True)
+        for item in normalized_expected
+    }
+    unmatched = [
+        item for item in py_diags
+        if json.dumps(item, sort_keys=True) not in normalized_expected_keys
+    ]
+    # PR-B1 enriches spanless transition-body diagnostics with source-range
+    # disambiguation refs. The inlined parity fixtures remain focused on the
+    # stable behavioral refs, while schema checks below validate the enriched
+    # payload shape.
+    pr_b1_enriched_codes = {
+        'W_GUARD_CONST_FALSE',
+        'W_GUARD_CONST_TRUE',
+        'W_REDUNDANT_TRANSITION',
+        'W_SELF_TRANSITION_NOP',
+        'W_EFFECT_SELF_ASSIGN',
+        'I_TRANSITION_NEVER_EVENT_TRIGGERED',
+    }
+    allowed_extra_keys = {'from_path', 'to_path', 'guard_text', 'transition_index', 'transition_span'}
+    for item in unmatched:
+        assert item['code'] in pr_b1_enriched_codes, (
+            f'{name}: pyfcstm inspect diagnostics mismatch: {py_diags}'
+        )
+        variants = [item]
+        for _ in range(len(allowed_extra_keys)):
+            next_variants = []
+            for variant in variants:
+                for key in allowed_extra_keys:
+                    if key not in variant['refs']:
+                        continue
+                    stripped_refs = {
+                        ref_key: value for ref_key, value in variant['refs'].items()
+                        if ref_key != key
+                    }
+                    next_variants.append({**variant, 'refs': stripped_refs})
+            variants.extend(next_variants)
+        assert any(json.dumps(variant, sort_keys=True) in normalized_expected_keys for variant in variants), (
+            f'{name}: pyfcstm inspect diagnostics mismatch: {py_diags}'
+        )
 
 
 @pytest.mark.unittest

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -970,6 +970,8 @@ class TestInspectModelGuardAffectDiagnostics:
             'folded_value': True,
             'from_path': 'Root.Idle',
             'to_path': 'Root.Done',
+            'guard_text': '1 + 2 == 3',
+            'transition_index': 1,
         }
 
     def test_unreferenced_variable_with_abstract_action_is_info(self):
@@ -1328,6 +1330,8 @@ class TestInspectModelExtendedCoverage:
             'folded_value': True,
             'from_path': 'Root.Idle',
             'to_path': 'Root.Active',
+            'guard_text': '1 + 2 == 3',
+            'transition_index': 1,
         }
         const_false = next(d for d in diagnostics if d.code == 'W_GUARD_CONST_FALSE')
         assert const_false.refs == {
@@ -1335,6 +1339,8 @@ class TestInspectModelExtendedCoverage:
             'folded_value': False,
             'from_path': 'Root.Active',
             'to_path': 'Root.Blocked',
+            'guard_text': '15 & 240 != 0',
+            'transition_index': 2,
         }
         during_refs = sorted(
             (d.refs for d in diagnostics if d.code == 'W_DURING_CONST_ASSIGN'),
@@ -1568,6 +1574,7 @@ class TestInspectModelRedundancySemantics:
             'state_path': '[*]',
             'transition_span': None,
             'var_name': 'x',
+            'transition_index': 0,
         }
 
 
@@ -1797,4 +1804,5 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
             'from_path': 'Root.A',
             'to_path': 'Root.B',
             'transition_span': None,
+            'transition_index': 1,
         }

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -113,7 +113,7 @@ class TestInspectModelBasic:
     def test_transition_guard_text(self, report):
         guarded = [t for t in report.transitions if t.guard is not None]
         assert len(guarded) == 1
-        assert 'counter' in guarded[0].guard
+        assert guarded[0].guard == 'counter > 0'
 
     def test_transition_event_qualified(self, report):
         with_event = [t for t in report.transitions if t.event is not None]
@@ -1806,6 +1806,57 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
             'transition_span': None,
             'transition_index': 1,
         }
+
+
+@pytest.mark.unittest
+def test_inspect_guard_text_is_shared_normalized_format():
+    report = inspect_model(_parse("""
+    state Root {
+        state Idle;
+        state Blocked;
+        [*] -> Idle;
+        Idle -> Blocked : if [(0x0F & 0xF0) != 0];
+    }
+    """))
+    transition = next(item for item in report.transitions if item.guard is not None)
+    diagnostic = next(item for item in report.diagnostics if item.code == 'W_GUARD_CONST_FALSE')
+
+    assert transition.guard == '15 & 240 != 0'
+    assert diagnostic.refs['guard_text'] == '15 & 240 != 0'
+
+
+@pytest.mark.unittest
+def test_forced_transition_indexes_include_declaring_state_expansions_before_descendants():
+    report = inspect_model(_parse("""
+    state Root {
+        state A {
+            state X;
+            state Y;
+            [*] -> X;
+            X -> Y;
+            X -> Y;
+        }
+        state B;
+        [*] -> A;
+        !A -> B :: Fatal;
+        A -> B : if [false];
+    }
+    """))
+
+    assert [
+        (transition.transition_index, transition.from_path, transition.to_path, transition.is_forced)
+        for transition in report.transitions
+    ] == [
+        (0, 'Root.A', 'Root.B', True),
+        (1, '[*]', 'Root.A', False),
+        (2, 'Root.A', 'Root.B', False),
+        (3, 'Root.A.X', '[*]', True),
+        (4, 'Root.A.Y', '[*]', True),
+        (5, '[*]', 'Root.A.X', False),
+        (6, 'Root.A.X', 'Root.A.Y', False),
+        (7, 'Root.A.X', 'Root.A.Y', False),
+    ]
+
 
 @pytest.mark.unittest
 def test_nested_transition_indexes_follow_parent_first_model_order():

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -1806,3 +1806,35 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
             'transition_span': None,
             'transition_index': 1,
         }
+
+@pytest.mark.unittest
+def test_nested_transition_indexes_follow_parent_first_model_order():
+    from pyfcstm.diagnostics import inspect_model
+    from pyfcstm.dsl import parse_with_grammar_entry
+    from pyfcstm.model import parse_dsl_node_to_state_machine
+
+    source = """
+    state Root {
+        state A {
+            state X;
+            state Y;
+            [*] -> X;
+            X -> Y;
+            X -> Y;
+        }
+        [*] -> A;
+    }
+    """
+    report = inspect_model(parse_dsl_node_to_state_machine(
+        parse_with_grammar_entry(source, 'state_machine_dsl'),
+    ))
+
+    assert [
+        (transition.transition_index, transition.from_path, transition.to_path)
+        for transition in report.transitions
+    ] == [
+        (0, '[*]', 'Root.A'),
+        (1, '[*]', 'Root.A.X'),
+        (2, 'Root.A.X', 'Root.A.Y'),
+        (3, 'Root.A.X', 'Root.A.Y'),
+    ]


### PR DESCRIPTION
## 背景

关联 issue：#133。

这是 issue #133 执行计划 v2 中的 **PR-B1：transition body 类 fallback**。本 PR 聚焦 jsfcstm editor 侧 inspect-backed diagnostics 的 transition body 类 problem range 精准化，目标是让用户在 VSCode / LSP diagnostic 里看到的波浪线尽量落在真实问题所在的 transition、guard、effect 片段上，而不是退回到 source state declaration、第二行、全文或 quick-fix 插入点。

## 本 PR 目标

让以下 transition body 类诊断的 published range 尽量锚到 transition AST 对应源码片段：

- `W_GUARD_CONST_FALSE`
- `W_GUARD_CONST_TRUE`
- `I_TRANSITION_NEVER_EVENT_TRIGGERED`
- `W_REDUNDANT_TRANSITION`
- `W_SELF_TRANSITION_NOP`
- `W_EFFECT_SELF_ASSIGN`

## 已实现内容

1. 在 `editors/jsfcstm/src/editor/inspect-ranges.ts` 中补充 transition refs 反查语义 transition 的基础设施：
   - 支持基于 `from_path`、`to_path`、`state_path`、event refs、`guard_text`、`effect_text` 和 `transition_index` 反查 `FcstmSemanticTransition`；
   - guard 类诊断优先锚定 guard expression range，无法定位 guard 时再退到整条 transition；
   - transition 类诊断锚定整条 transition statement；
   - `W_EFFECT_SELF_ASSIGN` 保持优先锚定具体 self-assign statement；具体语句不可定位时退到 effect block，再不可定位时退到 transition body；
   - 多候选且缺少 disambiguation refs 时标记 `__rangeFallback: "transition_ambiguous"`，不静默伪装成精确定位；
   - effect/transition fallback 分别标记 `effect_fallback` / `transition_fallback`。
2. 在 jsfcstm analyzer emit-site 补足可定位 refs：
   - `guard_text`；
   - `transition_index`；
   - 对 self-transition / eventless / redundancy / effect self-assign 等 spanless transition diagnostics 补充必要 transition identity hints。
3. 同步更新 `pyfcstm/diagnostics/codes.yaml` 中对应 refs 契约，保持诊断 schema 与 jsfcstm emit 侧一致。
4. 扩展 inspect surface parity / published range 相关测试预期，确保新增 refs 不破坏稳定 key 与 dedup 逻辑。
5. 修复上一轮 review 发现的 import-aware assembled model 问题：
   - `collectDocumentDiagnostics()` 对当前 document 使用当前文件 semantic 构建本地 model，不再把 workspace assembled imported child diagnostics 发布到 host document；
   - `collectCodeActions()` 同步改为基于当前文件本地 model 计算 inspect suggested-fix 候选，避免 imported child diagnostics 影响 host quick fix；
   - import alias transition（例如 `Imported -> Local : if [True];`）支持通过 mounted import path 反查 host-authored transition range；
   - 对 import-only composite 的本地 inspect deadlock 伪阳性做 editor surface 侧抑制，避免未展开 import 时把 host root 当作 leaf 报 `W_DEADLOCK_LEAF`。

## TDD / 测试覆盖

新增并扩展 `editors/jsfcstm/test/diagnostics-transition-range.test.ts`，用最终 `collectDocumentDiagnostics()` / inspect-diagnostic 入口严格回切 source slice 断言：

- guard const true/false 诊断命中 guard expression，而不是 source state declaration；
- eventless guardless transition 诊断命中整条 transition；
- redundant transition 诊断命中重复 transition statement；
- no-op self-transition 诊断命中 self-transition statement；
- effect self-assign 诊断仍命中具体 `x = x;` statement；
- 重复 eventless transition 依赖 `transition_index` 区分不同源码行；
- 等价 guard diagnostics 依赖 `transition_index` 区分不同源码行；
- 缺少 `transition_index` 且多候选时显式标记 `transition_ambiguous`；
- self-assign 具体 statement 找不到时退到 effect block 并显式标记 `effect_fallback`；
- import-aware host transition 只发布 host-authored diagnostic，且 range 回切为 `True`，不会把 imported child 的 transition/effect diagnostics 贴到 host 文档全文。

## 非目标 / 边界

本 PR 不处理：

- PR-B2 的 `W_FORCED_OVERRIDES_NORMAL` forced declaration + related normal transition 双 range；
- PR-B3 的 named action / event declaration signature 类 fallback；
- PR-C 的 parse recovery 零宽空 identifier 过滤；
- PR-D1/D2 的 pyfcstm model `_span` propagation 与 analyzer emit-site span fill；
- PR-E 的 schema/codes.yaml 契约文档化与 cross-end parity source-slice 总收口。

## 本轮 review 修复

上一轮 3 路强对抗 review 中，`codex reviewer` 对 commit `ccef81d0` 提出 I 级阻塞：import-aware assembled model diagnostics 复用了 workspace assembled model，导致 imported child transition diagnostics 可能发布到 host document 全文，host-authored import-alias transition 也可能 fallback 到全文。

当前 commit `31c0f077` 已处理该问题：

- 当前 document diagnostics / code actions 改为使用 source-local semantic model；
- imported child 的 `W_GUARD_CONST_TRUE` / `W_EFFECT_SELF_ASSIGN` / `I_TRANSITION_NEVER_EVENT_TRIGGERED` 不再发布到 host document；
- host-authored `Imported -> Local : if [True];` 通过 import alias mounted path 精确定位 guard `True`；
- 同步覆盖 import-only composite 的本地 inspect deadlock 伪阳性，避免 LSP 核心测试中仅 import 子模块的 root 被误报为 leaf deadlock。

## 本地验证

已在本地 `venv` 下完成：

```bash
source venv/bin/activate
cd editors/jsfcstm
npm run build
npx mocha --require ts-node/register/transpile-only --extension ts test/diagnostics-transition-range.test.ts test/symbols.test.ts --reporter dot
npm run test:unit -- --grep "diagnostics transition body ranges|jsfcstm semantic navigation and rename support|jsfcstm symbol extraction|diagnostics published ranges|inspect surface parity|jsfcstm analyzers and code actions|jsfcstm import workspace support"
npm test
cd ../..
pytest test/diagnostics/test_const_fold.py test/diagnostics/test_inspect_model.py test/diagnostics/test_cross_end_parity.py -q
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
git diff --check
```

关键结果：

- focused jsfcstm mocha：33 passing；
- affected jsfcstm grep suite：101 passing；
- jsfcstm full coverage：606 passing，coverage gate 通过；
- Python focused diagnostics：200 passed；
- Python skip-slow unittest：8968 passed，164 skipped，63 deselected，coverage 94%；
- `git diff --check`：通过；
- `make rst_auto` 已执行。

## 当前状态

- 最新修复已 push 到 PR 分支：`31c0f077`。
- GitHub Actions 已在最新 commit `31c0f077` 上全部通过。
- 已启动 3 路强对抗 review：`codex reviewer`、`claude reviewer`、`deepseek reviewer`，并由各 reviewer 自行在 PR 下中文 comment、亮明身份、按 C/I/M 分级。
- 本 PR 暂不 merge；本轮 push + review comment 到位后主 session 会暂停，等待用户下一步指示。

