### PR TITLE
PR-D1：为 pyfcstm model 保留 DSL source span 基础设施 (#133)

### DIFF
--- a/pyfcstm/dsl/listener.py
+++ b/pyfcstm/dsl/listener.py
@@ -803,6 +803,9 @@ class GrammarParseListener(GrammarListener):
                 condition=self.nodes[condition],
                 statements=self.nodes[block],
             )
+            # Branch spans intentionally cover the executable operation block.
+            # The condition text remains covered by the parent OperationIf span;
+            # expression-level guard spans are a separate diagnostic contract.
             branch._span = _ctx_span(block)
             branches.append(branch)
 
@@ -811,6 +814,8 @@ class GrammarParseListener(GrammarListener):
                 condition=None,
                 statements=self.nodes[blocks[-1]],
             )
+            # Keep else-branch semantics aligned with condition branches: the
+            # branch span points at the executable block, not the ``else`` token.
             branch._span = _ctx_span(blocks[-1])
             branches.append(branch)
 

--- a/pyfcstm/dsl/listener.py
+++ b/pyfcstm/dsl/listener.py
@@ -797,23 +797,26 @@ class GrammarParseListener(GrammarListener):
         conditions = list(ctx.cond_expression())
         blocks = list(ctx.operation_block())
 
-        branches = [
-            OperationIfBranch(
+        branches = []
+        for condition, block in zip(conditions, blocks[: len(conditions)]):
+            branch = OperationIfBranch(
                 condition=self.nodes[condition],
                 statements=self.nodes[block],
             )
-            for condition, block in zip(conditions, blocks[: len(conditions)])
-        ]
+            branch._span = _ctx_span(block)
+            branches.append(branch)
 
         if len(blocks) > len(conditions):
-            branches.append(
-                OperationIfBranch(
-                    condition=None,
-                    statements=self.nodes[blocks[-1]],
-                )
+            branch = OperationIfBranch(
+                condition=None,
+                statements=self.nodes[blocks[-1]],
             )
+            branch._span = _ctx_span(blocks[-1])
+            branches.append(branch)
 
-        self.nodes[ctx] = OperationIf(branches=branches)
+        node = OperationIf(branches=branches)
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitOperational_statement_set(
         self, ctx: GrammarParser.Operational_statement_setContext
@@ -870,10 +873,12 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.Operation_assignmentContext
         """
         super().exitOperation_assignment(ctx)
-        self.nodes[ctx] = OperationAssignment(
+        node = OperationAssignment(
             name=str(ctx.ID()),
             expr=self.nodes[ctx.num_expression()],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitEnterOperations(self, ctx: GrammarParser.EnterOperationsContext) -> None:
         """
@@ -883,12 +888,14 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.EnterOperationsContext
         """
         super().exitEnterOperations(ctx)
-        self.nodes[ctx] = EnterOperations(
+        node = EnterOperations(
             name=ctx.func_name.text if ctx.func_name else None,
             operations=self.nodes[ctx.operational_statement_set()]
             if ctx.operational_statement_set()
             else [],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitEnterAbstractFunc(
         self, ctx: GrammarParser.EnterAbstractFuncContext
@@ -900,10 +907,12 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.EnterAbstractFuncContext
         """
         super().exitEnterAbstractFunc(ctx)
-        self.nodes[ctx] = EnterAbstractFunction(
+        node = EnterAbstractFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             doc=format_multiline_comment(ctx.raw_doc.text) if ctx.raw_doc else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitEnterRefFunc(self, ctx: GrammarParser.EnterRefFuncContext) -> None:
         """
@@ -913,10 +922,12 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.EnterRefFuncContext
         """
         super().exitEnterRefFunc(ctx)
-        self.nodes[ctx] = EnterRefFunction(
+        node = EnterRefFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             ref=self.nodes[ctx.chain_id()],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitExitOperations(self, ctx: GrammarParser.ExitOperationsContext) -> None:
         """
@@ -926,12 +937,14 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.ExitOperationsContext
         """
         super().exitExitOperations(ctx)
-        self.nodes[ctx] = ExitOperations(
+        node = ExitOperations(
             name=ctx.func_name.text if ctx.func_name else None,
             operations=self.nodes[ctx.operational_statement_set()]
             if ctx.operational_statement_set()
             else [],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitExitAbstractFunc(self, ctx: GrammarParser.ExitAbstractFuncContext) -> None:
         """
@@ -941,10 +954,12 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.ExitAbstractFuncContext
         """
         super().exitExitAbstractFunc(ctx)
-        self.nodes[ctx] = ExitAbstractFunction(
+        node = ExitAbstractFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             doc=format_multiline_comment(ctx.raw_doc.text) if ctx.raw_doc else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitExitRefFunc(self, ctx: GrammarParser.ExitRefFuncContext) -> None:
         """
@@ -954,10 +969,12 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.ExitRefFuncContext
         """
         super().exitExitRefFunc(ctx)
-        self.nodes[ctx] = ExitRefFunction(
+        node = ExitRefFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             ref=self.nodes[ctx.chain_id()],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitDuringOperations(self, ctx: GrammarParser.DuringOperationsContext) -> None:
         """
@@ -967,13 +984,15 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.DuringOperationsContext
         """
         super().exitDuringOperations(ctx)
-        self.nodes[ctx] = DuringOperations(
+        node = DuringOperations(
             name=ctx.func_name.text if ctx.func_name else None,
             aspect=ctx.aspect.text if ctx.aspect else None,
             operations=self.nodes[ctx.operational_statement_set()]
             if ctx.operational_statement_set()
             else [],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitDuringAbstractFunc(
         self, ctx: GrammarParser.DuringAbstractFuncContext
@@ -985,11 +1004,13 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.DuringAbstractFuncContext
         """
         super().exitDuringAbstractFunc(ctx)
-        self.nodes[ctx] = DuringAbstractFunction(
+        node = DuringAbstractFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             aspect=ctx.aspect.text if ctx.aspect else None,
             doc=format_multiline_comment(ctx.raw_doc.text) if ctx.raw_doc else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitDuringRefFunc(self, ctx: GrammarParser.DuringRefFuncContext) -> None:
         """
@@ -999,11 +1020,13 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.DuringRefFuncContext
         """
         super().exitDuringRefFunc(ctx)
-        self.nodes[ctx] = DuringRefFunction(
+        node = DuringRefFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             aspect=ctx.aspect.text if ctx.aspect else None,
             ref=self.nodes[ctx.chain_id()],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitGeneric_expression(
         self, ctx: GrammarParser.Generic_expressionContext
@@ -1029,13 +1052,15 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.DuringAspectOperationsContext
         """
         super().exitDuringAspectOperations(ctx)
-        self.nodes[ctx] = DuringAspectOperations(
+        node = DuringAspectOperations(
             name=ctx.func_name.text if ctx.func_name else None,
             aspect=ctx.aspect.text if ctx.aspect else None,
             operations=self.nodes[ctx.operational_statement_set()]
             if ctx.operational_statement_set()
             else [],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitDuringAspectAbstractFunc(
         self, ctx: GrammarParser.DuringAspectAbstractFuncContext
@@ -1047,11 +1072,13 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.DuringAspectAbstractFuncContext
         """
         super().exitDuringAspectAbstractFunc(ctx)
-        self.nodes[ctx] = DuringAspectAbstractFunction(
+        node = DuringAspectAbstractFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             aspect=ctx.aspect.text if ctx.aspect else None,
             doc=format_multiline_comment(ctx.raw_doc.text) if ctx.raw_doc else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitDuringAspectRefFunc(
         self, ctx: GrammarParser.DuringAspectRefFuncContext
@@ -1063,11 +1090,13 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.DuringAspectRefFuncContext
         """
         super().exitDuringAspectRefFunc(ctx)
-        self.nodes[ctx] = DuringAspectRefFunction(
+        node = DuringAspectRefFunction(
             name=ctx.func_name.text if ctx.func_name else None,
             aspect=ctx.aspect.text if ctx.aspect else None,
             ref=self.nodes[ctx.chain_id()],
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitNormalForceTransitionDefinition(
         self, ctx: GrammarParser.NormalForceTransitionDefinitionContext
@@ -1191,12 +1220,14 @@ class GrammarParseListener(GrammarListener):
         :type ctx: GrammarParser.Event_definitionContext
         """
         super().exitEvent_definition(ctx)
-        self.nodes[ctx] = EventDefinition(
+        node = EventDefinition(
             name=ctx.event_name.text,
             extra_name=_parse_string_literal(ctx.extra_name.text)
             if ctx.extra_name
             else None,
         )
+        node._span = _ctx_span(ctx)
+        self.nodes[ctx] = node
 
     def exitImport_mapping_statement(
         self, ctx: GrammarParser.Import_mapping_statementContext

--- a/pyfcstm/dsl/node.py
+++ b/pyfcstm/dsl/node.py
@@ -1547,6 +1547,7 @@ class OperationAssignment(OperationalStatement):
 
     name: str
     expr: Expr
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1573,6 +1574,7 @@ class OperationIfBranch(ASTNode):
 
     condition: Optional[Expr]
     statements: List[OperationalStatement]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
 
 @dataclass
@@ -1588,6 +1590,7 @@ class OperationIf(OperationalStatement):
     """
 
     branches: List[OperationIfBranch]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1644,6 +1647,7 @@ class EventDefinition(ASTNode):
 
     name: str
     extra_name: Optional[str] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1739,6 +1743,7 @@ class EnterOperations(EnterStatement):
 
     operations: List[OperationalStatement]
     name: Optional[str] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1782,6 +1787,7 @@ class EnterAbstractFunction(EnterStatement):
 
     name: Optional[str]
     doc: Optional[str]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1829,6 +1835,7 @@ class EnterRefFunction(EnterStatement):
 
     name: Optional[str]
     ref: ChainID
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1880,6 +1887,7 @@ class ExitOperations(ExitStatement):
 
     operations: List[OperationalStatement]
     name: Optional[str] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1924,6 +1932,7 @@ class ExitAbstractFunction(ExitStatement):
 
     name: Optional[str]
     doc: Optional[str]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -1971,6 +1980,7 @@ class ExitRefFunction(ExitStatement):
 
     name: Optional[str]
     ref: ChainID
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -2025,6 +2035,7 @@ class DuringOperations(DuringStatement):
     aspect: Optional[str]
     operations: List[OperationalStatement]
     name: Optional[str] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -2077,6 +2088,7 @@ class DuringAbstractFunction(DuringStatement):
     name: Optional[str]
     aspect: Optional[str]
     doc: Optional[str]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -2133,6 +2145,7 @@ class DuringRefFunction(DuringStatement):
     name: Optional[str]
     aspect: Optional[str]
     ref: ChainID
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -2193,6 +2206,7 @@ class DuringAspectOperations(DuringAspectStatement):
     aspect: str
     operations: List[OperationalStatement]
     name: Optional[str] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -2241,6 +2255,7 @@ class DuringAspectAbstractFunction(DuringAspectStatement):
     name: Optional[str]
     aspect: str
     doc: Optional[str]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """
@@ -2293,6 +2308,7 @@ class DuringAspectRefFunction(DuringAspectStatement):
     name: Optional[str]
     aspect: str
     ref: ChainID
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __str__(self) -> str:
         """

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -82,6 +82,11 @@ from ..utils import sequence_safe
 
 def _node_span(node) -> Optional[Span]:
     """Return an AST node span when the parser attached one."""
+    # PR-D1 span propagation is deliberately tolerant of AST nodes that do not
+    # carry parser spans yet: older synthetic/export-created nodes can still
+    # pass through this path, and PR-D2 will decide which missing spans are
+    # diagnostic-contract gaps. Keep the missing-span case observable as
+    # ``None`` instead of manufacturing an imprecise fallback.
     return getattr(node, '_span', None)
 
 
@@ -146,6 +151,9 @@ class Operation(OperationStatement):
         """
         Convert this operation to an AST node.
 
+        The private ``_span`` metadata is intentionally not copied. Exported
+        AST nodes are for DSL serialization, not source-span round-tripping.
+
         :return: An operation assignment AST node
         :rtype: dsl_nodes.OperationAssignment
         """
@@ -183,6 +191,9 @@ class IfBlockBranch(AstExportable):
         """
         Convert this branch back to a DSL AST node.
 
+        The private ``_span`` metadata is intentionally not copied. Exported
+        AST nodes are for DSL serialization, not source-span round-tripping.
+
         :return: Operation-if branch AST node
         :rtype: dsl_nodes.OperationIfBranch
         """
@@ -209,6 +220,9 @@ class IfBlock(OperationStatement):
     def to_ast_node(self) -> dsl_nodes.OperationIf:
         """
         Convert this if-block back to a DSL AST node.
+
+        The private ``_span`` metadata is intentionally not copied. Exported
+        AST nodes are for DSL serialization, not source-span round-tripping.
 
         :return: Operation-if AST node
         :rtype: dsl_nodes.OperationIf

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -80,6 +80,11 @@ __all__ = [
 from ..utils import sequence_safe
 
 
+def _node_span(node) -> Optional[Span]:
+    """Return an AST node span when the parser attached one."""
+    return getattr(node, '_span', None)
+
+
 def _event_origin_from_id(
         event_id: dsl_nodes.ChainID,
         event_scope: Optional[str] = None,
@@ -135,6 +140,7 @@ class Operation(OperationStatement):
 
     var_name: str
     expr: Expr
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def to_ast_node(self) -> dsl_nodes.OperationAssignment:
         """
@@ -171,6 +177,7 @@ class IfBlockBranch(AstExportable):
 
     condition: Optional[Expr]
     statements: List[OperationStatement]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def to_ast_node(self) -> dsl_nodes.OperationIfBranch:
         """
@@ -197,6 +204,7 @@ class IfBlock(OperationStatement):
     """
 
     branches: List[IfBlockBranch]
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def to_ast_node(self) -> dsl_nodes.OperationIf:
         """
@@ -237,6 +245,7 @@ class Event:
     extra_name: Optional[str] = None
     declared: bool = field(default=False, compare=False)
     origins: List[str] = field(default_factory=list, compare=False)
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         self.origins = list(self.origins or (['declared'] if self.declared else []))
@@ -344,6 +353,7 @@ class Transition(AstExportable):
     is_forced: bool = field(default=False, compare=False)
     forced_origin: Optional[str] = field(default=None, compare=False)
     parent_ref: Optional[weakref.ReferenceType] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     @property
     def parent(self) -> Optional["State"]:
@@ -433,6 +443,7 @@ class OnStage(AstExportable):
     ref: Union["OnStage", "OnAspect", None] = None
     ref_state_path: Optional[Tuple[str, ...]] = None
     parent_ref: Optional[weakref.ReferenceType] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     @property
     def parent(self) -> Optional["State"]:
@@ -649,6 +660,7 @@ class OnAspect(AstExportable):
     ref: Union["OnStage", "OnAspect", None] = None
     ref_state_path: Optional[Tuple[str, ...]] = None
     parent_ref: Optional[weakref.ReferenceType] = None
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     @property
     def parent(self) -> Optional["State"]:
@@ -826,6 +838,7 @@ class State(AstExportable, PlantUMLExportable):
     substate_name_to_id: Dict[str, int] = None
     extra_name: Optional[str] = None
     is_pseudo: bool = False
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         """
@@ -1933,6 +1946,7 @@ class VarDefine(AstExportable):
     name: str
     type: str
     init: Expr
+    _span: Optional[Span] = field(default=None, repr=False, compare=False)
 
     def to_ast_node(self) -> dsl_nodes.DefAssignment:
         """
@@ -2313,8 +2327,9 @@ def parse_dsl_node_to_state_machine(
                 name=def_item.name,
                 type=def_item.type,
                 init=parse_expr_node_to_expr(def_item.expr),
+                _span=_node_span(def_item),
             )
-            d_define_spans[def_item.name] = getattr(def_item, '_span', None)
+            d_define_spans[def_item.name] = _node_span(def_item)
         else:
             sink.emit(ModelDiagnostic(
                 code='E_DUPLICATE_VAR',
@@ -2429,7 +2444,11 @@ def parse_dsl_node_to_state_machine(
                     },
                 ))
 
-            operation = Operation(var_name=op_item.name, expr=operation_val)
+            operation = Operation(
+                var_name=op_item.name,
+                expr=operation_val,
+                _span=_node_span(op_item),
+            )
             available_vars.add(op_item.name)
             return operation
         elif isinstance(op_item, dsl_nodes.OperationIf):
@@ -2503,10 +2522,14 @@ def parse_dsl_node_to_state_machine(
                 block_local_names=block_local_names,
             )
             branches.append(
-                IfBlockBranch(condition=condition, statements=branch_statements)
+                IfBlockBranch(
+                    condition=condition,
+                    statements=branch_statements,
+                    _span=_node_span(branch),
+                )
             )
 
-        return IfBlock(branches=branches)
+        return IfBlock(branches=branches, _span=_node_span(if_node))
 
     def _recursive_build_states(
         node: dsl_nodes.StateDefinition, current_path: Tuple[str, ...]
@@ -2559,6 +2582,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, enter_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(enter_item),
                 )
             elif isinstance(enter_item, dsl_nodes.EnterAbstractFunction):
                 on_stage = OnStage(
@@ -2571,6 +2595,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, enter_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(enter_item),
                 )
             elif isinstance(enter_item, dsl_nodes.EnterRefFunction):
                 on_stage = OnStage(
@@ -2590,6 +2615,7 @@ def parse_dsl_node_to_state_machine(
                         ),
                         *enter_item.ref.path,
                     ),
+                    _span=_node_span(enter_item),
                 )
 
             if on_stage is not None:
@@ -2670,6 +2696,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, during_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(during_item),
                 )
             elif isinstance(during_item, dsl_nodes.DuringAbstractFunction):
                 on_stage = OnStage(
@@ -2682,6 +2709,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, during_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(during_item),
                 )
             elif isinstance(during_item, dsl_nodes.DuringRefFunction):
                 on_stage = OnStage(
@@ -2701,6 +2729,7 @@ def parse_dsl_node_to_state_machine(
                         ),
                         *during_item.ref.path,
                     ),
+                    _span=_node_span(during_item),
                 )
 
             if on_stage is not None:
@@ -2745,6 +2774,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, exit_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(exit_item),
                 )
             elif isinstance(exit_item, dsl_nodes.ExitAbstractFunction):
                 on_stage = OnStage(
@@ -2757,6 +2787,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, exit_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(exit_item),
                 )
             elif isinstance(exit_item, dsl_nodes.ExitRefFunction):
                 on_stage = OnStage(
@@ -2776,6 +2807,7 @@ def parse_dsl_node_to_state_machine(
                         ),
                         *exit_item.ref.path,
                     ),
+                    _span=_node_span(exit_item),
                 )
 
             if on_stage is not None:
@@ -2841,6 +2873,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, during_aspect_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(during_aspect_item),
                 )
             elif isinstance(during_aspect_item, dsl_nodes.DuringAspectAbstractFunction):
                 on_aspect = OnAspect(
@@ -2853,6 +2886,7 @@ def parse_dsl_node_to_state_machine(
                     state_path=(*current_path, during_aspect_item.name),
                     ref=None,
                     ref_state_path=None,
+                    _span=_node_span(during_aspect_item),
                 )
             elif isinstance(during_aspect_item, dsl_nodes.DuringAspectRefFunction):
                 on_aspect = OnAspect(
@@ -2872,6 +2906,7 @@ def parse_dsl_node_to_state_machine(
                         ),
                         *during_aspect_item.ref.path,
                     ),
+                    _span=_node_span(during_aspect_item),
                 )
 
             if on_aspect is not None:
@@ -2903,6 +2938,7 @@ def parse_dsl_node_to_state_machine(
                 state_path=current_path,
                 declared=True,
                 origins=['declared'],
+                _span=_node_span(event),
             )
 
         my_state = State(
@@ -2917,6 +2953,7 @@ def parse_dsl_node_to_state_machine(
             on_exits=on_exits,
             on_during_aspects=on_during_aspects,
             named_functions=named_functions,
+            _span=_node_span(node),
         )
         if my_state.is_pseudo and not my_state.is_leaf_state:
             sink.emit(ModelDiagnostic(
@@ -3062,6 +3099,7 @@ def parse_dsl_node_to_state_machine(
                             name=suffix_name,
                             state_path=start_state.path,
                             origins=[origin],
+                            _span=_node_span(f_transnode),
                         )
                     else:
                         if origin not in start_state.events[suffix_name].origins:
@@ -3126,6 +3164,7 @@ def parse_dsl_node_to_state_machine(
                     guard,
                     f_transnode.event_scope,
                     getattr(f_transnode, 'source_raw', None) or str(f_transnode),
+                    _node_span(f_transnode),
                 )
             )
 
@@ -3141,6 +3180,7 @@ def parse_dsl_node_to_state_machine(
                 guard,
                 event_scope,
                 forced_origin,
+                forced_span,
             ) in force_transition_tuples_to_inherit:
                 if from_state is dsl_nodes.ALL or from_state == subnode.name:
                     transitions.append(
@@ -3153,6 +3193,7 @@ def parse_dsl_node_to_state_machine(
                             event_scope=event_scope,
                             is_forced=True,
                             forced_origin=forced_origin,
+                            _span=forced_span,
                         )
                     )
                     _inner_force_transitions.append(
@@ -3163,6 +3204,7 @@ def parse_dsl_node_to_state_machine(
                             condition_expr=condition_expr,
                             event_scope=event_scope,
                             source_raw=forced_origin,
+                            _span=forced_span,
                         )
                     )
 
@@ -3314,6 +3356,7 @@ def parse_dsl_node_to_state_machine(
                             name=suffix_name,
                             state_path=start_state.path,
                             origins=[origin],
+                            _span=_node_span(transnode),
                         )
                     else:
                         if origin not in start_state.events[suffix_name].origins:
@@ -3359,6 +3402,7 @@ def parse_dsl_node_to_state_machine(
                 guard=guard,
                 effects=post_operations,
                 event_scope=event_scope,
+                _span=_node_span(transnode),
             )
             transitions.append(transition)
 

--- a/test/dsl/test_listener_spans.py
+++ b/test/dsl/test_listener_spans.py
@@ -451,3 +451,88 @@ class TestSpanInvariants:
         # Slice should start with "state Root" and end with "}"
         assert sliced.startswith("state Root")
         assert sliced.endswith("}")
+
+
+@pytest.mark.unittest
+class TestActionAndOperationSpan:
+    def test_event_and_lifecycle_action_spans(self):
+        src = (
+            "def int x = 0;\n"
+            "state Root {\n"
+            "    event Go named \"Go Event\";\n"
+            "    enter Init { x = 1; }\n"
+            "    during before Tick { x = x + 1; }\n"
+            "    exit abstract Cleanup;\n"
+            "    >> during after Monitor { x = x + 2; }\n"
+            "    state A;\n"
+            "    [*] -> A;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        root = ast.root_state
+
+        assert (
+            _slice_by_span(src, root.events[0]._span)
+            == 'event Go named "Go Event";'
+        )
+        assert _slice_by_span(src, root.enters[0]._span) == "enter Init { x = 1; }"
+        assert _slice_by_span(src, root.enters[0].operations[0]._span) == "x = 1;"
+        assert (
+            _slice_by_span(src, root.durings[0]._span)
+            == "during before Tick { x = x + 1; }"
+        )
+        assert _slice_by_span(src, root.durings[0].operations[0]._span) == "x = x + 1;"
+        assert _slice_by_span(src, root.exits[0]._span) == "exit abstract Cleanup;"
+        assert (
+            _slice_by_span(src, root.during_aspects[0]._span)
+            == ">> during after Monitor { x = x + 2; }"
+        )
+        assert (
+            _slice_by_span(src, root.during_aspects[0].operations[0]._span)
+            == "x = x + 2;"
+        )
+
+    def test_operation_if_span(self):
+        src = (
+            "def int x = 0;\n"
+            "state Root {\n"
+            "    state A {\n"
+            "        during {\n"
+            "            if [x > 0] {\n"
+            "                x = x + 1;\n"
+            "            } else {\n"
+            "                x = x + 2;\n"
+            "            }\n"
+            "        }\n"
+            "    }\n"
+            "    [*] -> A;\n"
+            "}"
+        )
+        ast = parse_with_grammar_entry(src, 'state_machine_dsl')
+        if_statement = ast.root_state.substates[0].durings[0].operations[0]
+
+        assert _slice_by_span(src, if_statement._span) == (
+            "if [x > 0] {\n"
+            "                x = x + 1;\n"
+            "            } else {\n"
+            "                x = x + 2;\n"
+            "            }"
+        )
+        assert _slice_by_span(src, if_statement.branches[0]._span) == (
+            "{\n"
+            "                x = x + 1;\n"
+            "            }"
+        )
+        assert (
+            _slice_by_span(src, if_statement.branches[0].statements[0]._span)
+            == "x = x + 1;"
+        )
+        assert _slice_by_span(src, if_statement.branches[1]._span) == (
+            "{\n"
+            "                x = x + 2;\n"
+            "            }"
+        )
+        assert (
+            _slice_by_span(src, if_statement.branches[1].statements[0]._span)
+            == "x = x + 2;"
+        )

--- a/test/model/test_span_propagation.py
+++ b/test/model/test_span_propagation.py
@@ -1,0 +1,185 @@
+"""
+Model-layer source span propagation tests.
+
+PR-D1 of issue #133 keeps diagnostic emit sites unchanged, but requires
+model objects created from DSL AST nodes to retain the AST source span so
+PR-D2 can anchor diagnostics without re-parsing source text.
+"""
+
+import pytest
+
+from pyfcstm.diagnostics.inspect import inspect_model
+from pyfcstm.model import load_state_machine_from_text
+from pyfcstm.utils.validate import Span
+
+
+MODEL_SPAN_DSL = """def int x = 0;
+def float y = 1.0;
+
+state Root {
+    event Go named "Go Event";
+
+    enter Init { x = 1; }
+    during before Tick { x = x + 1; }
+    exit abstract Cleanup;
+    >> during after Monitor { x = x + 2; }
+
+    state A {
+        enter { x = x + 3; }
+    }
+    state B;
+
+    [*] -> A;
+    A -> B : Go effect {
+        x = x + 4;
+    };
+}
+"""
+
+
+def _slice_by_span(source: str, span: Span) -> str:
+    """Return the source slice covered by a 1-based listener span."""
+    assert span is not None, "span must not be None"
+    lines = source.split("\n")
+    end_line = span.end_line or span.line
+    end_column = span.end_column or (span.column + 1)
+    if end_line == span.line:
+        return lines[span.line - 1][span.column - 1 : end_column - 1]
+
+    pieces = [lines[span.line - 1][span.column - 1 :]]
+    for index in range(span.line, end_line - 1):
+        pieces.append(lines[index])
+    pieces.append(lines[end_line - 1][: end_column - 1])
+    return "\n".join(pieces)
+
+
+def _assert_source_slice(source: str, obj, expected: str) -> None:
+    span = getattr(obj, "_span", None)
+    assert span is not None, f"{obj!r} does not carry _span"
+    assert _slice_by_span(source, span) == expected
+
+
+@pytest.mark.unittest
+class TestModelSpanPropagation:
+    def test_core_model_objects_keep_ast_source_spans(self):
+        machine = load_state_machine_from_text(MODEL_SPAN_DSL)
+        root = machine.root_state
+
+        _assert_source_slice(MODEL_SPAN_DSL, machine.defines["x"], "def int x = 0;")
+        _assert_source_slice(
+            MODEL_SPAN_DSL, root, MODEL_SPAN_DSL.split("\n", 3)[3].rstrip("\n")
+        )
+        _assert_source_slice(
+            MODEL_SPAN_DSL, root.events["Go"], 'event Go named "Go Event";'
+        )
+        _assert_source_slice(
+            MODEL_SPAN_DSL,
+            root.substates["A"],
+            "state A {\n        enter { x = x + 3; }\n    }",
+        )
+
+        user_transition = next(
+            transition
+            for transition in root.transitions
+            if transition.from_state == "A" and transition.to_state == "B"
+        )
+        _assert_source_slice(
+            MODEL_SPAN_DSL,
+            user_transition,
+            "A -> B : Go effect {\n        x = x + 4;\n    }",
+        )
+
+    def test_lifecycle_actions_and_operations_keep_ast_source_spans(self):
+        machine = load_state_machine_from_text(MODEL_SPAN_DSL)
+        root = machine.root_state
+
+        enter_action = root.on_enters[0]
+        during_action = root.on_durings[0]
+        exit_action = root.on_exits[0]
+        aspect_action = root.on_during_aspects[0]
+        user_transition = next(
+            transition
+            for transition in root.transitions
+            if transition.from_state == "A" and transition.to_state == "B"
+        )
+
+        _assert_source_slice(MODEL_SPAN_DSL, enter_action, "enter Init { x = 1; }")
+        _assert_source_slice(MODEL_SPAN_DSL, enter_action.operations[0], "x = 1;")
+        _assert_source_slice(
+            MODEL_SPAN_DSL, during_action, "during before Tick { x = x + 1; }"
+        )
+        _assert_source_slice(MODEL_SPAN_DSL, during_action.operations[0], "x = x + 1;")
+        _assert_source_slice(MODEL_SPAN_DSL, exit_action, "exit abstract Cleanup;")
+        _assert_source_slice(
+            MODEL_SPAN_DSL, aspect_action, ">> during after Monitor { x = x + 2; }"
+        )
+        _assert_source_slice(MODEL_SPAN_DSL, aspect_action.operations[0], "x = x + 2;")
+        _assert_source_slice(MODEL_SPAN_DSL, user_transition.effects[0], "x = x + 4;")
+
+    def test_inspect_json_does_not_leak_model_private_span_fields(self):
+        machine = load_state_machine_from_text(MODEL_SPAN_DSL)
+        payload = inspect_model(machine).to_json()
+
+        def _walk(value):
+            if isinstance(value, dict):
+                assert "_span" not in value
+                for item in value.values():
+                    _walk(item)
+            elif isinstance(value, list):
+                for item in value:
+                    _walk(item)
+
+        _walk(payload)
+
+    def test_if_block_statements_keep_ast_source_spans(self):
+        source = """def int x = 0;
+
+state Root {
+    state A {
+        during {
+            if [x > 0] {
+                x = x + 1;
+            } else {
+                x = x + 2;
+            }
+        }
+    }
+    [*] -> A;
+}
+"""
+        machine = load_state_machine_from_text(source)
+        if_block = machine.root_state.substates["A"].on_durings[0].operations[0]
+
+        _assert_source_slice(
+            source,
+            if_block,
+            (
+                "if [x > 0] {\n"
+                "                x = x + 1;\n"
+                "            } else {\n"
+                "                x = x + 2;\n"
+                "            }"
+            ),
+        )
+        _assert_source_slice(source, if_block.branches[0].statements[0], "x = x + 1;")
+        _assert_source_slice(source, if_block.branches[1].statements[0], "x = x + 2;")
+
+    def test_forced_transition_expansions_keep_declaring_ast_source_span(self):
+        source = """def int x = 0;
+
+state Root {
+    state A;
+    state B;
+
+    [*] -> A;
+    !A -> B : if [x > 0];
+}
+"""
+        machine = load_state_machine_from_text(source)
+        transition = next(
+            transition
+            for transition in machine.root_state.transitions
+            if transition.is_forced
+        )
+
+        _assert_source_slice(source, transition, "!A -> B : if [x > 0];")

--- a/test/model/test_span_propagation.py
+++ b/test/model/test_span_propagation.py
@@ -116,6 +116,35 @@ class TestModelSpanPropagation:
         _assert_source_slice(MODEL_SPAN_DSL, aspect_action.operations[0], "x = x + 2;")
         _assert_source_slice(MODEL_SPAN_DSL, user_transition.effects[0], "x = x + 4;")
 
+    def test_lifecycle_ref_actions_keep_their_own_ast_source_spans(self):
+        source = """def int x = 0;
+
+state Root {
+    enter SharedEnter { x = 1; }
+    enter ref SharedEnter;
+    during before SharedDuring { x = x + 1; }
+    during before ref SharedDuring;
+    exit SharedExit { x = x + 2; }
+    exit ref SharedExit;
+    >> during after SharedAspect { x = x + 3; }
+    >> during after ref SharedAspect;
+
+    state A;
+    [*] -> A;
+}
+"""
+        machine = load_state_machine_from_text(source)
+        root = machine.root_state
+
+        _assert_source_slice(source, root.on_enters[1], "enter ref SharedEnter;")
+        _assert_source_slice(
+            source, root.on_durings[1], "during before ref SharedDuring;"
+        )
+        _assert_source_slice(source, root.on_exits[1], "exit ref SharedExit;")
+        _assert_source_slice(
+            source, root.on_during_aspects[1], ">> during after ref SharedAspect;"
+        )
+
     def test_inspect_json_does_not_leak_model_private_span_fields(self):
         machine = load_state_machine_from_text(MODEL_SPAN_DSL)
         payload = inspect_model(machine).to_json()


### PR DESCRIPTION
## PR-D1 范围

本 PR 实现 issue #133 的 **PR-D1：pyfcstm model `_span` propagation infra**。

本 PR 做了：

- 在从 DSL AST 构建 pyfcstm model 对象时保留源码 span 元数据。
- 给后续 analyzer 使用的核心 model 实体补充 `_span` 基础设施，但本 PR **不填 27 个 analyzer emit-site**。
- 保持 Python-only 改动，不依赖 jsfcstm 测试夹具，也不触碰 jsfcstm 编辑器 range fallback。
- 按 TDD 增加覆盖，证明由 DSL 构建出的 model 对象能保留可回切源码的 span。

改动点：

- `pyfcstm/dsl/node.py` / `pyfcstm/dsl/listener.py`：为 event、lifecycle action、operation、if block 等 AST 节点补齐 `_span`，并在 listener 里从 parse context 写入。
- `pyfcstm/model/model.py`：给 `State`、`Transition`、`Event`、`VarDefine`、`Operation`、`IfBlock`、`IfBlockBranch`、`OnStage`、`OnAspect` 增加 private `_span: Optional[Span] = field(default=None, repr=False, compare=False)`，并在 AST → model 构造路径上转抄 span。
- forced transition expansion 会把声明处 span 继续带到展开出来的 `Transition`，便于 PR-D2 后续按原始声明定位。
- `pyfcstm/utils/validate.py` 中已有 `Span`，本 PR 沿用现有 1-based line / column 且 `end_column` exclusive 的约定，不改坐标系。

明确不在本 PR 范围内：

- PR-D2 的 analyzer emit-site `span=` 填充。
- jsfcstm editor diagnostic range fallback / quick-fix range 改动。
- PR-E 的 schema / `codes.yaml` 契约文档化和 cross-end parity source-slice 升级。
- 修改 `inspect_model()` 输出 JSON 契约；PR-D1 只做 model plumbing。

测试：

- 新增 `test/model/test_span_propagation.py`。
- 扩展 `test/dsl/test_listener_spans.py` 覆盖 event / lifecycle action / operation / if block AST span。
- 对 state / transition / event / var / operation / if block / lifecycle action / forced transition expansion 等 model 对象断言 `_span is not None`，并按 span 回切源文本命中对应对象。
- 额外断言 `inspect_model(machine).to_json()` 不泄漏 private `_span` 字段。
- 不测试 `inspect_model()` 诊断输出 span；那是 PR-D2 范围。

本地验证：

- `python -m py_compile pyfcstm/dsl/node.py pyfcstm/dsl/listener.py pyfcstm/model/model.py test/dsl/test_listener_spans.py test/model/test_span_propagation.py`
- `pytest test/dsl/test_listener_spans.py test/model/test_span_propagation.py -q`
- `pytest test/model/test_diagnostic_emit.py test/model/test_load.py test/diagnostics/test_inspect_model.py -q`
- `SKIP_SLOW_TESTS=1 make unittest`：8971 passed, 164 skipped, 63 deselected, 699 warnings, coverage 94%

依赖关系：无；PR-D1 可直接基于 `main` 合入，后续 PR-D2 依赖本 PR。

Closes none. Part of #133.
