### PR TITLE
fix(jsfcstm): 让 forced override 诊断关联声明与被覆盖转换

### DIFF
--- a/docs/source/api_doc/dsl/node.rst
+++ b/docs/source/api_doc/dsl/node.rst
@@ -278,7 +278,7 @@ ForceTransitionDefinition
 -----------------------------------------------------
 
 .. autoclass:: ForceTransitionDefinition
-    :members: __str__,from_state,to_state,event_id,condition_expr,event_scope
+    :members: __str__,from_state,to_state,event_id,condition_expr,event_scope,source_raw
 
 
 StateDefinition

--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -1,4 +1,5 @@
 import type {EventInfo, ModelDiagnosticJson, StateInfo, TransitionInfo} from '../inspect';
+import type {TextRange} from '../../utils/text';
 
 export function collectRedundancyWarnings(
     transitions: TransitionInfo[],
@@ -143,10 +144,19 @@ function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDi
 }
 
 function collectForcedOverridesNormalWarnings(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
-    const normal = new Set(transitions.filter(t => !t.is_forced).map(transitionTriggerKey));
+    const normal = new Map<string, TransitionInfo>();
+    for (const transition of transitions) {
+        if (transition.is_forced) continue;
+        const key = transitionTriggerKey(transition);
+        if (!normal.has(key)) {
+            normal.set(key, transition);
+        }
+    }
     const out: ModelDiagnosticJson[] = [];
     for (const transition of transitions) {
-        if (!transition.is_forced || !normal.has(transitionTriggerKey(transition))) continue;
+        if (!transition.is_forced) continue;
+        const normalTransition = normal.get(transitionTriggerKey(transition));
+        if (!normalTransition) continue;
         out.push({
             code: 'W_FORCED_OVERRIDES_NORMAL',
             severity: 'warning',
@@ -155,12 +165,16 @@ function collectForcedOverridesNormalWarnings(transitions: TransitionInfo[]): Mo
             refs: {
                 from_path: transition.from_path,
                 to_path: transition.to_path,
-                forced_span: null,
-                normal_span: null,
+                forced_declaration_span: sourceRange(transition),
+                normal_transition_span: sourceRange(normalTransition),
             },
         });
     }
     return out;
+}
+
+function sourceRange(transition: TransitionInfo): TextRange | null {
+    return transition.__sourceRange ?? null;
 }
 
 function collectShadowedEventWarnings(events: EventInfo[]): ModelDiagnosticJson[] {

--- a/editors/jsfcstm/src/diagnostics/inspect.ts
+++ b/editors/jsfcstm/src/diagnostics/inspect.ts
@@ -32,6 +32,7 @@ import {
 import {collectDesignHealthWarnings} from './analyzers';
 import {buildUseDefGraph, collectExprVariables} from './analyzers/use-def';
 import type {RawFcstmModelForcedTransition} from '../model/raw';
+import type {TextRange} from '../utils/text';
 
 const INIT_MARK = '[*]';
 const EXIT_MARK = '[*]';
@@ -119,6 +120,12 @@ export interface TransitionInfo {
     is_forced: boolean;
     forced_origin: string | null;
     transition_index: number | null;
+    /**
+     * Non-enumerable editor-only source range for analyzer-to-editor
+     * handoff. It is intentionally omitted from ``toJson()`` output and from
+     * the shared schema; PR-E will formalize public span fields separately.
+     */
+    __sourceRange?: TextRange;
 }
 
 
@@ -440,7 +447,7 @@ function buildTransitionInfos(machine: StateMachine): TransitionInfo[] {
     const out: TransitionInfo[] = [];
     for (const state of machine.allStates) {
         for (const t of state.transitions) {
-            out.push({
+            const info: TransitionInfo = {
                 from_path: transitionEndpoint(state.path, t.fromState, true),
                 to_path: transitionEndpoint(state.path, t.toState, false),
                 event: t.event ? t.event.pathName : null,
@@ -451,7 +458,14 @@ function buildTransitionInfos(machine: StateMachine): TransitionInfo[] {
                 is_forced: !!t.forced,
                 forced_origin: t.forced ? t.text : null,
                 transition_index: typeof t.transitionIndex === 'number' ? t.transitionIndex : null,
+            };
+            Object.defineProperty(info, '__sourceRange', {
+                value: t.range,
+                enumerable: false,
+                configurable: false,
+                writable: false,
             });
+            out.push(info);
         }
     }
     return out;

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -1,3 +1,5 @@
+import {pathToFileURL} from 'node:url';
+
 import {getParser, ParseError} from '../dsl/parser';
 import {inspectModel, type ModelDiagnosticJson} from '../diagnostics';
 import {buildStateMachineModel} from '../model';
@@ -12,7 +14,7 @@ import {
 import {getImportWorkspaceIndex} from '../workspace/imports';
 import {getWorkspaceGraph} from '../workspace';
 import {resolveRangeFromRefsDetailed} from './inspect-ranges';
-import {suggestedFixDiagnosticRange, suggestedFixIssueRange} from './suggested-fixes';
+import {spanLikeToRange, suggestedFixDiagnosticRange, suggestedFixIssueRange} from './suggested-fixes';
 
 // Only suppress inspect codes that the semantic analyzer already reports with
 // equivalent coverage. Const-folded false guards stay inspect-backed because
@@ -67,6 +69,27 @@ function rangeEquals(left: TextRange, right: TextRange): boolean {
         left.start.character === right.start.character &&
         left.end.line === right.end.line &&
         left.end.character === right.end.character;
+}
+
+function documentUri(document: TextDocumentLike): string {
+    const filePath = document.filePath || document.uri?.fsPath;
+    return filePath ? pathToFileURL(filePath).toString() : 'untitled:fcstm';
+}
+
+function relatedInformationFromRefs(
+    document: TextDocumentLike,
+    item: ModelDiagnosticJson,
+): FcstmDiagnostic['relatedInformation'] {
+    if (item.code !== 'W_FORCED_OVERRIDES_NORMAL') return undefined;
+    const normalRange = spanLikeToRange(item.refs.normal_transition_span);
+    if (!normalRange) return undefined;
+    return [{
+        location: {
+            uri: documentUri(document),
+            range: normalRange,
+        },
+        message: 'Normal transition duplicated by this forced transition.',
+    }];
 }
 
 export interface CollectInspectModelDiagnosticsOptions {
@@ -129,6 +152,7 @@ export function collectInspectDiagnosticsFromItems(
         if (refResolution.fallback) {
             diagnostic.data = {...(diagnostic.data ?? {}), __rangeFallback: refResolution.fallback};
         }
+        diagnostic.relatedInformation = relatedInformationFromRefs(document, item);
         if (consumeDiagnosticCount(existingCounts, diagnosticKey(diagnostic))) continue;
         diagnostics.push(diagnostic);
     }

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -357,7 +357,7 @@ export function resolveRangeFromRefsDetailed(
         return {range: null};
     }
 
-    for (const key of ['guard_span', 'transition_span', 'forced_span', 'normal_span']) {
+    for (const key of ['guard_span', 'transition_span', 'forced_declaration_span', 'forced_span', 'normal_span']) {
         const range = spanLikeToRange(refMap[key]);
         if (range) return {range};
     }

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -357,7 +357,7 @@ export function resolveRangeFromRefsDetailed(
         return {range: null};
     }
 
-    for (const key of ['guard_span', 'transition_span', 'forced_declaration_span', 'forced_span', 'normal_span']) {
+    for (const key of ['guard_span', 'transition_span', 'forced_declaration_span', 'forced_span']) {
         const range = spanLikeToRange(refMap[key]);
         if (range) return {range};
     }

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -833,7 +833,18 @@ state Root {
                 {
                     code: 'W_FORCED_OVERRIDES_NORMAL',
                     severity: 'warning',
-                    refs: {from_path: 'Root.Active', to_path: 'Root.Trapped', forced_span: null, normal_span: null},
+                    refs: {
+                        from_path: 'Root.Active',
+                        to_path: 'Root.Trapped',
+                        forced_declaration_span: {
+                            start: {line: 18, character: 4},
+                            end: {line: 18, character: 31},
+                        },
+                        normal_transition_span: {
+                            start: {line: 16, character: 4},
+                            end: {line: 16, character: 30},
+                        },
+                    },
                 },
                 {
                     code: 'W_GUARD_VARS_NEVER_CHANGE',

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -439,6 +439,64 @@ describe('diagnostics transition body ranges', () => {
         );
     });
 
+    it('anchors forced override diagnostics on the forced declaration with related normal transition', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !A -> B :: Go;',
+            '    A -> B :: Go;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/forced-override-related-normal-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = targetDiagnostics(diagnostics, 'W_FORCED_OVERRIDES_NORMAL')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(sliceByRange(text, diagnostic.range).trim(), '!A -> B :: Go;');
+        assert.equal(diagnostic.data?.forced_declaration_span !== undefined, true);
+        assert.equal(diagnostic.data?.normal_transition_span !== undefined, true);
+        assert.equal(diagnostic.data?.forced_span, undefined);
+        assert.equal(diagnostic.data?.normal_span, undefined);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.ok(diagnostic.relatedInformation?.length, JSON.stringify(diagnostic));
+        assert.equal(sliceByRange(text, diagnostic.relatedInformation[0].location.range).trim(), 'A -> B :: Go;');
+    });
+
+    it('uses the wildcard forced declaration range for each forced override expansion', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    state C;',
+            '    [*] -> A;',
+            '    !* -> C : Reset;',
+            '    A -> C : Reset;',
+            '    B -> C : Reset;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/forced-override-wildcard-related-range.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const forcedOverrides = targetDiagnostics(diagnostics, 'W_FORCED_OVERRIDES_NORMAL')
+            .sort((left, right) => String(left.data?.from_path).localeCompare(String(right.data?.from_path)));
+
+        assert.equal(forcedOverrides.length, 2, JSON.stringify(diagnostics));
+        assert.deepEqual(
+            forcedOverrides.map(item => [
+                item.data?.from_path,
+                item.data?.to_path,
+                sliceByRange(text, item.range).trim(),
+                item.relatedInformation?.map((info: any) => sliceByRange(text, info.location.range).trim()),
+                item.data?.__rangeFallback,
+            ]),
+            [
+                ['Root.A', 'Root.C', '!* -> C : Reset;', ['A -> C : Reset;'], undefined],
+                ['Root.B', 'Root.C', '!* -> C : Reset;', ['B -> C : Reset;'], undefined],
+            ],
+        );
+    });
+
     it('marks transition_not_found when refs cannot match any transition', async () => {
         const text = [
             'state Root {',

--- a/editors/jsfcstm/test/diagnostics-transition-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-transition-range.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import * as path from 'node:path';
 
+import {collectRedundancyWarnings} from '../src/diagnostics/analyzers/redundancy';
 import {createDocument, packageModule, sliceByRange, trackTempDir, writeFile} from './support';
 
 function targetDiagnostics(diagnostics: any[], code: string): any[] {
@@ -495,6 +496,133 @@ describe('diagnostics transition body ranges', () => {
                 ['Root.B', 'Root.C', '!* -> C : Reset;', ['B -> C : Reset;'], undefined],
             ],
         );
+    });
+
+    it('keeps normal transition spans out of primary range fallback', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !A -> B :: Go;',
+            '    A -> B :: Go;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/forced-override-normal-span-fallback.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        const forcedRange = packageModule.createRange(4, 4, 4, 20);
+        const normalRange = packageModule.createRange(5, 4, 5, 19);
+
+        assert.deepEqual(
+            packageModule.resolveRangeFromRefsDetailed(document, semantic, {forced_span: forcedRange}).range,
+            forcedRange,
+        );
+        assert.equal(
+            packageModule.resolveRangeFromRefsDetailed(document, semantic, {normal_span: normalRange}).range,
+            null,
+        );
+    });
+
+    it('omits forced override related information when the normal span is unavailable', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !A -> B :: Go;',
+            '    A -> B :: Go;',
+            '}',
+        ].join('\n');
+        const semanticDocument = createDocument(text, '/tmp/forced-override-null-related-semantic.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(semanticDocument);
+        const document = {
+            getText() {
+                return text;
+            },
+            lineCount: text.split('\n').length,
+            lineAt(line: number) {
+                return {text: text.split('\n')[line] || ''};
+            },
+        };
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'W_FORCED_OVERRIDES_NORMAL',
+            severity: 'warning' as const,
+            message: 'Synthetic forced override without a normal span.',
+            span: null,
+            refs: {
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                forced_declaration_span: packageModule.createRange(4, 4, 4, 20),
+                normal_transition_span: null,
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(sliceByRange(text, diagnostics[0].range).trim(), '!A -> B :: Go;');
+        assert.equal(diagnostics[0].relatedInformation, undefined);
+    });
+
+    it('uses an untitled URI for forced override related information without a document file path', async () => {
+        const text = [
+            'state Root {',
+            '    state A;',
+            '    state B;',
+            '    [*] -> A;',
+            '    !A -> B :: Go;',
+            '    A -> B :: Go;',
+            '}',
+        ].join('\n');
+        const semanticDocument = createDocument(text, '/tmp/forced-override-untitled-related-semantic.fcstm');
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(semanticDocument);
+        const document = {
+            getText() {
+                return text;
+            },
+            lineCount: text.split('\n').length,
+            lineAt(line: number) {
+                return {text: text.split('\n')[line] || ''};
+            },
+        };
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'W_FORCED_OVERRIDES_NORMAL',
+            severity: 'warning' as const,
+            message: 'Synthetic forced override with an untitled document.',
+            span: null,
+            refs: {
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                forced_declaration_span: packageModule.createRange(4, 4, 4, 20),
+                normal_transition_span: packageModule.createRange(5, 4, 5, 19),
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(diagnostics[0].relatedInformation?.[0]?.location.uri, 'untitled:fcstm');
+        assert.equal(
+            sliceByRange(text, diagnostics[0].relatedInformation![0].location.range).trim(),
+            'A -> B :: Go;',
+        );
+    });
+
+    it('skips forced override analyzer warnings when no normal trigger matches', () => {
+        const diagnostics = collectRedundancyWarnings(
+            [{
+                from_path: 'Root.A',
+                to_path: 'Root.B',
+                event: 'Root.A.Go',
+                event_scope: 'local',
+                guard: null,
+                effect: null,
+                effect_self_assigns: [],
+                is_forced: true,
+                forced_origin: 'Root.A',
+                transition_index: 1,
+            }],
+            [],
+            [],
+        );
+
+        assert.deepEqual(targetDiagnostics(diagnostics, 'W_FORCED_OVERRIDES_NORMAL'), []);
     });
 
     it('marks transition_not_found when refs cannot match any transition', async () => {

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -166,8 +166,8 @@ def _forced_overrides_normal_warnings(transitions: Iterable['TransitionInfo']) -
             refs={
                 'from_path': t.from_path,
                 'to_path': t.to_path,
-                'forced_span': None,
-                'normal_span': None,
+                'forced_declaration_span': None,
+                'normal_transition_span': None,
             },
         ))
     return diagnostics

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -1831,11 +1831,11 @@ W_FORCED_OVERRIDES_NORMAL:
       type: str
       required: true
       description: Dotted target state path.
-    forced_span:
+    forced_declaration_span:
       type: Span
       required: false
       description: Source span of the forced transition when available.
-    normal_span:
+    normal_transition_span:
       type: Span
       required: false
       description: Source span of the normal transition when available.

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -872,8 +872,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 'refs': {
                     'from_path': 'Root.Active',
                     'to_path': 'Root.Trapped',
-                    'forced_span': None,
-                    'normal_span': None,
+                    'forced_declaration_span': None,
+                    'normal_transition_span': None,
                 },
             },
             {


### PR DESCRIPTION
## 背景

本 PR 是 issue #133 的 **PR-B2：forced override + related ranges** 分片。PR-A (#134) 已完成 inspect diagnostic 展示 range 与 quick-fix edit range 分层；PR-B1 (#135) 已完成 transition body 类诊断的 AST source-slice 定位，并解锁本分片。

issue #133 的核心问题是 jsfcstm / pyfcstm inspect-backed diagnostics 的 range/source-slice 契约不稳定：诊断波浪线有时不指向 message/refs 描述的真实对象，尤其 transition / forced transition 相关诊断容易退回到 source state、全文或不精确位置。

## 本 PR 范围

本 PR 只处理 `W_FORCED_OVERRIDES_NORMAL`，目标是把 forced override 诊断拆成清晰的 problem range 与 related range：

- primary diagnostic range 指向 forced declaration（例如 `!* -> ...` 或 `!StateA -> ...` 的 forced declaration）；
- normal transition range 通过 diagnostic related information 暴露；
- analyzer refs 固定增加 `forced_declaration_span` / `normal_transition_span` 两个字段，便于 editor 端稳定定位，并与 PR-D2 / PR-E 的 `<object>_span` 命名收口保持一致；
- 复用 PR-B1 已合入的 transition range infra，不扩张到 PR-B3 的 named action / event declaration signature 诊断；
- 不承诺 VSCode UI 是否最终展示 relatedInformation，本 PR 只保证数据与 LSP diagnostic 对象层面正确，UI 投递可后续单独跟进。

## 非范围

- 不处理 `W_DEAD_NAMED_ACTION`、`W_NAMED_ACTION_SHADOWS_ANCESTOR`、`W_SHADOWED_EVENT`（这些属于 PR-B3）；
- 不处理 parse-recovery 零宽空 identifier（属于 PR-C）；
- 不处理 pyfcstm analyzer emit-site span fill（属于 PR-D2）；
- 不做 schema/codes.yaml 契约收口与 cross-end source-slice parity 总收口（属于 PR-E）。

## 计划中的 TDD 验证

- 在 main / 当前 empty PR 基线先新增 failing test：构造 normal transition 与 forced transition override，断言 `W_FORCED_OVERRIDES_NORMAL` 当前不能同时满足 forced declaration primary range 与 normal transition related range；
- 实现后断言：
  - `sliceByRange(text, diagnostic.range)` 命中 forced declaration（`!*` / `!StateA` 或对应 forced transition statement）；
  - `diagnostic.relatedInformation` 至少包含 normal transition 的 range，回切源码命中被覆盖的 normal transition；
  - 复杂场景覆盖嵌套 state、`!StateA -> ...` 直接 forced declaration、`!* -> ...` wildcard forced declaration、`!*` 展开后多条派生 transition 共享同一 declaration span、同 source/target 多 transition 的消歧；
  - 不回退到全文、不落到 source state declaration、不产生零宽误导 range。

## 本地验证计划

开发完成前后会按风险运行：

```bash
cd editors/jsfcstm
npm run build
npx mocha --require ts-node/register/transpile-only --extension ts test/diagnostics-transition-range.test.ts --reporter spec
npm test

cd ../..
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
git diff --check
```

## Review 要点

请重点审查：

1. PR-B2 与 issue #133 中 `W_FORCED_OVERRIDES_NORMAL` 分片是否一致，有无越界到 B3/C/D2/E；
2. forced declaration 与 normal transition 的范围语义是否清晰且可由 downstream 消费；
3. relatedInformation 是否只作为数据契约，未错误承诺 VSCode UI 展示；
4. TDD 测试是否真实按最终 diagnostic range / related range 回切源码，而不是只测 helper。

Closes: none。Refs: #133。
