### PR TITLE
PR-D2：为 pyfcstm analyzer 填充 inspect 诊断 source span (#133)

### DIFF
--- a/pyfcstm/diagnostics/analyzers/const_fold.py
+++ b/pyfcstm/diagnostics/analyzers/const_fold.py
@@ -253,6 +253,7 @@ def _during_stmt_const_assign_diagnostics(
                 f'During action in {state_path!r} assigns {stmt.var_name!r} '
                 'to the same constant value every cycle.'
             ),
+            span=getattr(stmt, '_span', None),
             refs={
                 'state_path': state_path,
                 'var_name': stmt.var_name,
@@ -291,12 +292,13 @@ def _guard_const_diagnostic(
     return ModelDiagnostic(
         code=code,
         severity='warning',
+        span=getattr(transition, '_span', None),
         message=(
             f'Transition {source_label!r} -> {target_label!r} '
             f'has a guard that is statically {label}.'
         ),
         refs={
-            'transition_span': None,
+            'transition_span': getattr(transition, '_span', None),
             'folded_value': value,
             'from_path': _transition_endpoint_path(transition, is_source=True),
             'to_path': _transition_endpoint_path(transition, is_source=False),

--- a/pyfcstm/diagnostics/analyzers/data_flow.py
+++ b/pyfcstm/diagnostics/analyzers/data_flow.py
@@ -1,6 +1,6 @@
 """Variable data-flow design-health diagnostics."""
 
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
 from ...dsl import EXIT_STATE, INIT_STATE
 from ...utils.validate import ModelDiagnostic
@@ -20,6 +20,7 @@ def collect_data_flow_warnings(
 ) -> List[ModelDiagnostic]:
     diagnostics: List[ModelDiagnostic] = []
     variables = list(variables)
+    variable_spans = {variable.name: variable.span for variable in variables}
     for variable in variables:
         read_states = set(variable.read_in_states)
         read_states.update(src for src, _ in variable.read_in_guards)
@@ -29,6 +30,7 @@ def collect_data_flow_warnings(
             if variable.abstract_actions_in_scope:
                 diagnostics.append(ModelDiagnostic(
                     code='I_UNREFERENCED_VAR_MAYBE_ABSTRACT',
+                    span=variable.span,
                     severity='info',
                     message=(
                         f'Variable {variable.name!r} does not affect any '
@@ -48,6 +50,7 @@ def collect_data_flow_warnings(
                     refs['definition_delete_anchor'] = variable.name
                 diagnostics.append(ModelDiagnostic(
                     code='W_UNREFERENCED_VAR',
+                    span=variable.span,
                     severity='warning',
                     message=(
                         f'Variable {variable.name!r} does not affect any '
@@ -59,6 +62,7 @@ def collect_data_flow_warnings(
         if read_states and not write_states:
             diagnostics.append(ModelDiagnostic(
                 code='W_UNWRITTEN_READ_VAR',
+                span=variable.span,
                 severity='warning',
                 message=(
                     f'Variable {variable.name!r} is read but never written '
@@ -73,6 +77,7 @@ def collect_data_flow_warnings(
         if write_states and not read_states:
             diagnostics.append(ModelDiagnostic(
                 code='W_WRITE_ONLY_VAR',
+                span=variable.span,
                 severity='warning',
                 message=f'Variable {variable.name!r} is written but never read.',
                 refs={
@@ -80,13 +85,14 @@ def collect_data_flow_warnings(
                     'written_states': sorted(write_states),
                 },
             ))
-    diagnostics.extend(_guard_vars_never_change_diagnostics(variables, machine))
+    diagnostics.extend(_guard_vars_never_change_diagnostics(variables, machine, variable_spans))
     return diagnostics
 
 
 def _guard_vars_never_change_diagnostics(
         variables: List['VariableInfo'],
         machine: Optional['StateMachine'],
+        variable_spans: Dict[str, object],
 ) -> List[ModelDiagnostic]:
     if machine is None:
         return []
@@ -121,6 +127,7 @@ def _guard_vars_never_change_diagnostics(
             )
             diagnostics.append(ModelDiagnostic(
                 code='W_GUARD_VARS_NEVER_CHANGE',
+                span=getattr(transition, '_span', None) or (variable_spans.get(guard_vars[0]) if guard_vars else None),
                 severity='warning',
                 message=(
                     'Transition guard reads only variables that are never '

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -115,6 +115,7 @@ def _unreachable_state_diagnostics(states, reachability_graph, root_state_path) 
                 code='W_UNREACHABLE_STATE',
                 severity='warning',
                 message=f'State {state.path!r} is unreachable from the root entry path.',
+                span=state.span,
                 refs={'state_path': state.path},
             )
         )
@@ -133,8 +134,9 @@ def _guard_const_false_diagnostics(transitions) -> List[ModelDiagnostic]:
                         f'Transition {transition.from_path!r} -> {transition.to_path!r} '
                         'has a guard that is statically false.'
                     ),
+                    span=transition.span,
                     refs={
-                        'transition_span': None,
+                        'transition_span': transition.span,
                         'folded_value': False,
                         'from_path': transition.from_path,
                         'to_path': transition.to_path,
@@ -168,6 +170,7 @@ def _unused_event_diagnostics(events) -> List[ModelDiagnostic]:
                 code='W_UNUSED_EVENT',
                 severity='warning',
                 message=f'Event {event.qualified_name!r} is declared but never used.',
+                span=event.span,
                 refs={
                     'event_qualified_name': event.qualified_name,
                     'scope': event.scope,

--- a/pyfcstm/diagnostics/analyzers/naming.py
+++ b/pyfcstm/diagnostics/analyzers/naming.py
@@ -33,6 +33,7 @@ def _named_action_shadows_ancestor_warnings(actions) -> List[ModelDiagnostic]:
             outer = max(ancestors, key=lambda item: len(item.state_path))
             diagnostics.append(ModelDiagnostic(
                 code='W_NAMED_ACTION_SHADOWS_ANCESTOR',
+                span=inner.span,
                 severity='warning',
                 message=(
                     f'Named action {function_name!r} in {inner.state_path!r} '

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -48,6 +48,7 @@ def _redundant_transition_warnings(
         from_path, to_path, _, _, _ = key
         diagnostics.append(ModelDiagnostic(
             code='W_REDUNDANT_TRANSITION',
+            span=items[0].span,
             severity='warning',
             message=(
                 f'Transition {from_path!r} -> {to_path!r} is duplicated '
@@ -56,10 +57,7 @@ def _redundant_transition_warnings(
             refs={
                 'from_path': from_path,
                 'to_path': to_path,
-                'duplicate_spans': [
-                    f'{item.from_path}->{item.to_path}#{index}'
-                    for index, item in enumerate(items, 1)
-                ],
+                'duplicate_spans': [item.span for item in items],
                 'transition_index': items[0].transition_index,
             },
         ))
@@ -81,6 +79,7 @@ def _self_transition_nop_warnings(
             continue
         diagnostics.append(ModelDiagnostic(
             code='W_SELF_TRANSITION_NOP',
+            span=t.span,
             severity='warning',
             message=(
                 f'Self transition on {t.from_path!r} has no trigger, '
@@ -90,7 +89,7 @@ def _self_transition_nop_warnings(
                 'state_path': t.from_path,
                 'from_path': t.from_path,
                 'to_path': t.to_path,
-                'transition_span': None,
+                'transition_span': t.span,
                 'transition_index': t.transition_index,
             },
         ))
@@ -128,10 +127,12 @@ def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> Lis
     )
     diagnostics: List[ModelDiagnostic] = []
     for t in transitions:
-        for var_name in getattr(t, 'effect_self_assigns', ()):
+        effect_self_assigns = getattr(t, 'effect_self_assigns', ())
+        effect_self_assign_spans = getattr(t, 'effect_self_assign_spans', ())
+        for index, var_name in enumerate(effect_self_assigns):
             refs = {
                 'state_path': t.from_path,
-                'transition_span': None,
+                'transition_span': t.span,
                 'var_name': var_name,
                 'transition_index': t.transition_index,
             }
@@ -139,6 +140,12 @@ def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> Lis
                 refs['effect_self_assign_anchor'] = var_name
             diagnostics.append(ModelDiagnostic(
                 code='W_EFFECT_SELF_ASSIGN',
+                span=(
+                    effect_self_assign_spans[index]
+                    if index < len(effect_self_assign_spans)
+                    and effect_self_assign_spans[index] is not None
+                    else t.span
+                ),
                 severity='warning',
                 message=f'Transition effect assigns {var_name!r} to itself.',
                 refs=refs,
@@ -147,17 +154,19 @@ def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> Lis
 
 
 def _forced_overrides_normal_warnings(transitions: Iterable['TransitionInfo']) -> List[ModelDiagnostic]:
-    normal = {
-        _transition_trigger_key(t)
+    normal_by_key = {
+        _transition_trigger_key(t): t
         for t in transitions
         if not t.is_forced
     }
     diagnostics: List[ModelDiagnostic] = []
     for t in transitions:
-        if not t.is_forced or _transition_trigger_key(t) not in normal:
+        normal_transition = normal_by_key.get(_transition_trigger_key(t))
+        if not t.is_forced or normal_transition is None:
             continue
         diagnostics.append(ModelDiagnostic(
             code='W_FORCED_OVERRIDES_NORMAL',
+            span=t.span,
             severity='warning',
             message=(
                 f'Forced transition {t.from_path!r} -> {t.to_path!r} '
@@ -166,8 +175,8 @@ def _forced_overrides_normal_warnings(transitions: Iterable['TransitionInfo']) -
             refs={
                 'from_path': t.from_path,
                 'to_path': t.to_path,
-                'forced_declaration_span': None,
-                'normal_transition_span': None,
+                'forced_declaration_span': t.span,
+                'normal_transition_span': normal_transition.span,
             },
         ))
     return diagnostics
@@ -193,6 +202,7 @@ def _shadowed_event_warnings(events: Iterable['EventInfo']) -> List[ModelDiagnos
                 continue
             diagnostics.append(ModelDiagnostic(
                 code='W_SHADOWED_EVENT',
+                span=local_event.span,
                 severity='warning',
                 message=(
                     f'Local event {local_event.qualified_name!r} shadows '

--- a/pyfcstm/diagnostics/analyzers/structural.py
+++ b/pyfcstm/diagnostics/analyzers/structural.py
@@ -50,22 +50,23 @@ def _aspect_no_descendant_leaf_warnings(states) -> List[ModelDiagnostic]:
         if descendant_leaf_count > 0:
             continue
         if state.aspect_before:
-            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, 'before'))
+            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state, 'before'))
         if state.aspect_after:
-            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state.path, 'after'))
+            diagnostics.append(_aspect_no_descendant_leaf_diagnostic(state, 'after'))
     return diagnostics
 
 
-def _aspect_no_descendant_leaf_diagnostic(state_path, aspect) -> ModelDiagnostic:
+def _aspect_no_descendant_leaf_diagnostic(state, aspect) -> ModelDiagnostic:
     return ModelDiagnostic(
         code='W_ASPECT_NO_DESCENDANT_LEAF',
         severity='warning',
         message=(
-            f'Composite state {state_path!r} declares >> during '
+            f'Composite state {state.path!r} declares >> during '
             f'{aspect} but has no descendant non-pseudo leaf state.'
         ),
+        span=state.span,
         refs={
-            'composite_path': state_path,
+            'composite_path': state.path,
             'aspect': aspect,
         },
     )
@@ -84,6 +85,7 @@ def _deadlock_leaf_warnings(states, transitions) -> List[ModelDiagnostic]:
             continue
         diagnostics.append(ModelDiagnostic(
             code='W_DEADLOCK_LEAF',
+            span=state.span,
             severity='warning',
             message=f'Leaf state {state.path!r} has no outgoing transition.',
             refs=_deadlock_leaf_refs(state),
@@ -122,6 +124,7 @@ def _initial_unconditional_missing_warnings(states) -> List[ModelDiagnostic]:
             refs['first_child_name'] = first_child_name
         diagnostics.append(ModelDiagnostic(
             code='W_INITIAL_UNCONDITIONAL_MISSING',
+            span=state.span,
             severity='warning',
             message=(
                 f'Composite state {state.path!r} has no unconditional '
@@ -147,6 +150,7 @@ def _forced_never_expands_warnings(forced_transitions) -> List[ModelDiagnostic]:
             continue
         diagnostics.append(ModelDiagnostic(
             code='W_FORCED_NEVER_EXPANDS',
+            span=item.span,
             severity='warning',
             message=(
                 f'Forced transition {item.original_raw!r} declares no '
@@ -186,6 +190,7 @@ def _dead_named_action_warnings(
             continue
         diagnostics.append(ModelDiagnostic(
             code='W_DEAD_NAMED_ACTION',
+            span=action.span,
             severity='warning',
             message=f'Named action {action.signature!r} is unreachable and unreferenced.',
             refs={

--- a/pyfcstm/diagnostics/analyzers/thresholds.py
+++ b/pyfcstm/diagnostics/analyzers/thresholds.py
@@ -22,6 +22,7 @@ def collect_threshold_warnings(
     diagnostics.extend(_high_var_to_leaf_ratio_warnings(
         metrics,
         var_to_leaf_ratio_threshold,
+        states,
     ))
     diagnostics.extend(_deep_hierarchy_warnings(
         states,
@@ -35,12 +36,14 @@ def collect_threshold_warnings(
     return diagnostics
 
 
-def _high_var_to_leaf_ratio_warnings(metrics, threshold) -> List[ModelDiagnostic]:
+def _high_var_to_leaf_ratio_warnings(metrics, threshold, states) -> List[ModelDiagnostic]:
     actual = metrics.var_to_leaf_ratio
     if actual <= threshold:
         return []
+    anchor_state = states[0] if states else None
     return [ModelDiagnostic(
         code='W_HIGH_VAR_TO_LEAF_RATIO',
+        span=getattr(anchor_state, 'span', None),
         severity='warning',
         message=(
             f'Variable-to-leaf ratio {actual!r} exceeds threshold '
@@ -64,8 +67,10 @@ def _deep_hierarchy_warnings(states, metrics, threshold) -> List[ModelDiagnostic
         if state.path.count('.') == actual
     ]
     deepest_path = sorted(deepest)[0] if deepest else ''
+    deepest_state = next((state for state in states if state.path == deepest_path), None)
     return [ModelDiagnostic(
         code='W_DEEP_HIERARCHY',
+        span=getattr(deepest_state, 'span', None),
         severity='warning',
         message=(
             f'Hierarchy depth {actual!r} exceeds threshold '
@@ -90,6 +95,7 @@ def _large_composite_warnings(states, threshold) -> List[ModelDiagnostic]:
             continue
         diagnostics.append(ModelDiagnostic(
             code='W_LARGE_COMPOSITE',
+            span=state.span,
             severity='warning',
             message=(
                 f'Composite state {state.path!r} has {actual!r} direct '

--- a/pyfcstm/diagnostics/analyzers/transition_info.py
+++ b/pyfcstm/diagnostics/analyzers/transition_info.py
@@ -33,6 +33,7 @@ def _composite_self_transition_infos(states_by_path, transitions) -> List[ModelD
             continue
         diagnostics.append(ModelDiagnostic(
             code='I_TRANSITION_TO_SELF_VIA_PARENT',
+            span=transition.span,
             severity='info',
             message=(
                 f'Composite state {transition.from_path!r} transitions '
@@ -55,6 +56,7 @@ def _eventless_guardless_transition_infos(transitions) -> List[ModelDiagnostic]:
             continue
         diagnostics.append(ModelDiagnostic(
             code='I_TRANSITION_NEVER_EVENT_TRIGGERED',
+            span=transition.span,
             severity='info',
             message=(
                 f'Transition {transition.from_path!r} -> '
@@ -63,7 +65,7 @@ def _eventless_guardless_transition_infos(transitions) -> List[ModelDiagnostic]:
             refs={
                 'from_path': transition.from_path,
                 'to_path': transition.to_path,
-                'transition_span': None,
+                'transition_span': transition.span,
                 'transition_index': transition.transition_index,
             },
         ))

--- a/pyfcstm/diagnostics/analyzers/type_shape.py
+++ b/pyfcstm/diagnostics/analyzers/type_shape.py
@@ -27,6 +27,7 @@ def _literal_init_narrowing_warnings(variables) -> List[ModelDiagnostic]:
         diagnostics.append(_narrowing_diagnostic(
             variable.name,
             variable.init_value,
+            variable.span,
         ))
     return diagnostics
 
@@ -36,14 +37,21 @@ def _literal_assignment_narrowing_warnings(variables) -> List[ModelDiagnostic]:
     for variable in variables:
         if variable.type != 'int':
             continue
-        for source_expr in variable.float_literal_assignments:
-            diagnostics.append(_narrowing_diagnostic(variable.name, source_expr))
+        for index, source_expr in enumerate(variable.float_literal_assignments):
+            span = (
+                variable.float_literal_assignment_spans[index]
+                if index < len(variable.float_literal_assignment_spans)
+                and variable.float_literal_assignment_spans[index] is not None
+                else variable.span
+            )
+            diagnostics.append(_narrowing_diagnostic(variable.name, source_expr, span))
     return diagnostics
 
 
-def _narrowing_diagnostic(var_name: str, source_expr: str) -> ModelDiagnostic:
+def _narrowing_diagnostic(var_name: str, source_expr: str, span) -> ModelDiagnostic:
     return ModelDiagnostic(
         code='W_LITERAL_TYPE_NARROWING',
+        span=span,
         severity='warning',
         message=(
             f'Integer variable {var_name!r} receives float literal '

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -130,6 +130,7 @@ _ALLOWED_REF_TYPES = (
     'dict',
     'Span',
     'list[str]',
+    'list[Span]',
 )
 
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -17,7 +17,7 @@
 # Allowed `refs.*.type` tokens (must mirror `_ALLOWED_REF_TYPES` in
 # codes.py — that tuple is the single source of truth, this comment block
 # is documentation; a test asserts the two stay aligned):
-#   str | str_or_null | int | int_or_null | float | number | bool | dict | Span | list[str]
+#   str | str_or_null | int | int_or_null | float | number | bool | dict | Span | list[str] | list[Span]
 #
 # Adding a new code: append a new top-level entry here AND add a fixture
 # test that triggers it from a real DSL snippet. The loader in `codes.py`
@@ -1664,9 +1664,9 @@ W_REDUNDANT_TRANSITION:
       required: true
       description: Dotted target state path.
     duplicate_spans:
-      type: list[str]
+      type: list[Span]
       required: true
-      description: Stable labels for duplicate transition declarations when source spans are unavailable.
+      description: Source spans for the duplicate transition declarations, using null for declarations whose span is unavailable.
     transition_index:
       type: int
       required: false

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -54,7 +54,7 @@ from .analyzers import (
     collect_design_health_warnings,
     collect_expr_variables,
 )
-from ..utils.validate import ModelDiagnostic
+from ..utils.validate import ModelDiagnostic, Span
 
 if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
     from ..model.expr import Expr, Float, Integer
@@ -70,6 +70,12 @@ if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
 DEFAULT_DEEP_HIERARCHY_THRESHOLD = 6
 DEFAULT_LARGE_COMPOSITE_THRESHOLD = 12
 DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD = 2.0
+
+# PR-D2 span contract guard: analyzer diagnostics should carry a real
+# source span by default. Any future code that intentionally cannot point to
+# one source object must be listed here and covered by
+# test/diagnostics/test_inspect_span_contract.py.
+KNOWN_SPANLESS_CODES = frozenset()
 
 
 _OP_PRECEDENCE = {
@@ -163,6 +169,7 @@ class StateInfo:
     aspect_before: Tuple[str, ...]
     aspect_after: Tuple[str, ...]
     has_abstract_action: bool
+    span: Optional['Span'] = None
 
 
 @dataclass(frozen=True)
@@ -194,6 +201,11 @@ class TransitionInfo:
         ``if`` branches. Duplicate names are preserved so quick-fix
         emitters can detect ambiguous occurrences.
     :type effect_self_assigns: Tuple[str, ...]
+    :param effect_self_assign_spans: Source spans for the self-assign
+        statements listed in ``effect_self_assigns``. The order matches
+        ``effect_self_assigns`` and uses ``None`` when a statement has no
+        source span, preventing later spans from shifting to earlier names.
+    :type effect_self_assign_spans: Tuple[Optional[pyfcstm.utils.validate.Span], ...]
     :param is_forced: ``True`` when the transition was expanded from a
         ``!``-prefixed forced transition.
     :type is_forced: bool
@@ -219,6 +231,9 @@ class TransitionInfo:
     is_forced: bool
     forced_origin: Optional[str]
     transition_index: Optional[int]
+    span: Optional['Span'] = None
+    effect_spans: Tuple['Span', ...] = field(default_factory=tuple)
+    effect_self_assign_spans: Tuple[Optional['Span'], ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -278,6 +293,8 @@ class VariableInfo:
     affects_guard_indirectly: bool
     abstract_actions_in_scope: Tuple[str, ...]
     float_literal_assignments: Tuple[str, ...] = field(default_factory=tuple)
+    span: Optional['Span'] = None
+    float_literal_assignment_spans: Tuple[Optional['Span'], ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -306,6 +323,7 @@ class EventInfo:
     used_by: Tuple[Tuple[str, str], ...]
     is_declared: bool
     is_used: bool
+    span: Optional['Span'] = None
 
 
 @dataclass(frozen=True)
@@ -320,6 +338,7 @@ class ActionInfo:
     is_ref: bool
     ref_target: Optional[str]
     is_attached: bool
+    span: Optional['Span'] = None
 
 
 @dataclass(frozen=True)
@@ -334,6 +353,7 @@ class ForcedTransitionInfo:
     guard: Optional[str]
     original_raw: str
     expansion_count: int
+    span: Optional['Span'] = None
 
 
 @dataclass(frozen=True)
@@ -673,6 +693,13 @@ def _effect_self_assigns(effects: List['OperationStatement']) -> Tuple[str, ...]
     return tuple(out)
 
 
+def _effect_self_assign_spans(effects: List['OperationStatement']) -> Tuple[Optional['Span'], ...]:
+    out: List[Optional['Span']] = []
+    for stmt in effects:
+        _walk_stmt_self_assign_spans(stmt, out)
+    return tuple(out)
+
+
 def _walk_stmt_self_assigns(stmt: 'OperationStatement', out: List[str]) -> None:
     from ..model.expr import Variable
     from ..model.model import IfBlock, Operation
@@ -686,20 +713,36 @@ def _walk_stmt_self_assigns(stmt: 'OperationStatement', out: List[str]) -> None:
                 _walk_stmt_self_assigns(inner, out)
 
 
+def _walk_stmt_self_assign_spans(stmt: 'OperationStatement', out: List[Optional['Span']]) -> None:
+    from ..model.expr import Variable
+    from ..model.model import IfBlock, Operation
+    if isinstance(stmt, Operation):
+        if isinstance(stmt.expr, Variable) and stmt.expr.name == stmt.var_name:
+            out.append(getattr(stmt, '_span', None))
+        return
+    if isinstance(stmt, IfBlock):
+        for branch in stmt.branches:
+            for inner in branch.statements:
+                _walk_stmt_self_assign_spans(inner, out)
+
+
 def _walk_stmt_float_literal_assignments(
         stmt: 'OperationStatement',
         out: Dict[str, List[str]],
+        spans: Optional[Dict[str, List[Optional[Span]]]] = None,
 ) -> None:
     from ..model.expr import Float
     from ..model.model import IfBlock, Operation
     if isinstance(stmt, Operation):
         if isinstance(stmt.expr, Float):
             out.setdefault(stmt.var_name, []).append(_expr_text(stmt.expr) or '')
+            if spans is not None:
+                spans.setdefault(stmt.var_name, []).append(getattr(stmt, '_span', None))
         return
     if isinstance(stmt, IfBlock):
         for branch in stmt.branches:
             for inner in branch.statements:
-                _walk_stmt_float_literal_assignments(inner, out)
+                _walk_stmt_float_literal_assignments(inner, out, spans)
 
 
 def _stage_function_label(stage_item: 'OnStage') -> str:
@@ -864,6 +907,7 @@ def _build_state_infos(machine: 'StateMachine') -> Tuple[StateInfo, ...]:
             aspect_before=asp_before,
             aspect_after=asp_after,
             has_abstract_action=has_abstract,
+            span=getattr(state, '_span', None),
         ))
     return tuple(out)
 
@@ -895,6 +939,13 @@ def _build_transition_infos(machine: 'StateMachine') -> Tuple[TransitionInfo, ..
                 is_forced=is_forced,
                 forced_origin=forced_origin,
                 transition_index=transition_index,
+                span=getattr(transition, '_span', None),
+                effect_spans=tuple(
+                    span
+                    for span in (getattr(effect, '_span', None) for effect in transition.effects)
+                    if span is not None
+                ),
+                effect_self_assign_spans=_effect_self_assign_spans(transition.effects),
             ))
             transition_index += 1
     return tuple(out)
@@ -935,12 +986,16 @@ def _build_variable_infos(
     var_float_literal_assignments: Dict[str, List[str]] = {
         name: [] for name in machine.defines
     }
+    var_float_literal_assignment_spans: Dict[str, List[Optional[Span]]] = {
+        name: [] for name in machine.defines
+    }
     state_lookup: Dict[str, StateInfo] = {s.path: s for s in states}
 
     for state in machine.walk_states():
         path = _state_path(state)
         reads, writes = _collect_action_reads_writes(state)
         float_assigns: Dict[str, List[str]] = {}
+        float_assign_spans: Dict[str, List[Optional[Span]]] = {}
         for collection in (
                 state.on_enters,
                 state.on_durings,
@@ -949,7 +1004,7 @@ def _build_variable_infos(
         ):
             for action in collection:
                 for stmt in action.operations:
-                    _walk_stmt_float_literal_assignments(stmt, float_assigns)
+                    _walk_stmt_float_literal_assignments(stmt, float_assigns, float_assign_spans)
         for var_name in reads:
             if var_name in var_reads_by_state:
                 var_reads_by_state[var_name].append(path)
@@ -959,6 +1014,7 @@ def _build_variable_infos(
         for var_name, assignments in float_assigns.items():
             if var_name in var_float_literal_assignments:
                 var_float_literal_assignments[var_name].extend(assignments)
+                var_float_literal_assignment_spans[var_name].extend(float_assign_spans.get(var_name, []))
 
         for transition in state.transitions:
             from_path = _transition_endpoint(state, transition.from_state, is_source=True)
@@ -971,7 +1027,8 @@ def _build_variable_infos(
                 lwrites: List[str] = []
                 _walk_stmt_reads_writes(stmt, lreads, lwrites)
                 lfloat_assigns: Dict[str, List[str]] = {}
-                _walk_stmt_float_literal_assignments(stmt, lfloat_assigns)
+                lfloat_assign_spans: Dict[str, List[Optional[Span]]] = {}
+                _walk_stmt_float_literal_assignments(stmt, lfloat_assigns, lfloat_assign_spans)
                 for v in lreads:
                     if v in var_reads_by_state:
                         var_reads_by_state[v].append(from_path)
@@ -981,6 +1038,7 @@ def _build_variable_infos(
                 for v, assignments in lfloat_assigns.items():
                     if v in var_float_literal_assignments:
                         var_float_literal_assignments[v].extend(assignments)
+                        var_float_literal_assignment_spans[v].extend(lfloat_assign_spans.get(v, []))
 
     # Stable, deduped sequences for the public payload.
     def _dedupe_ordered(seq: List[str]) -> Tuple[str, ...]:
@@ -1001,6 +1059,21 @@ def _build_variable_infos(
                 out.append(x)
         return tuple(out)
 
+    def _dedupe_float_assignment_pairs(
+            exprs: List[str],
+            spans: List[Optional[Span]],
+    ) -> Tuple[Tuple[str, ...], Tuple[Optional[Span], ...]]:
+        seen = set()
+        out_exprs: List[str] = []
+        out_spans: List[Optional[Span]] = []
+        for index, expr in enumerate(exprs):
+            if expr in seen:
+                continue
+            seen.add(expr)
+            out_exprs.append(expr)
+            out_spans.append(spans[index] if index < len(spans) else None)
+        return tuple(out_exprs), tuple(out_spans)
+
     use_def_graph = build_use_def_graph(machine)
     direct_guard_vars = {
         name for name, entries in var_read_guards.items()
@@ -1015,7 +1088,10 @@ def _build_variable_infos(
         read_guards = _dedupe_pairs(var_read_guards[name])
         written_effects = _dedupe_pairs(var_written_effects[name])
         abstract_actions = _abstract_actions_in_scope(state_lookup)
-        float_assignments = _dedupe_ordered(var_float_literal_assignments[name])
+        float_assignments, float_assignment_spans = _dedupe_float_assignment_pairs(
+            var_float_literal_assignments[name],
+            var_float_literal_assignment_spans[name],
+        )
         out.append(VariableInfo(
             name=name,
             type=var_define.type,
@@ -1030,6 +1106,8 @@ def _build_variable_infos(
             ),
             abstract_actions_in_scope=abstract_actions,
             float_literal_assignments=float_assignments,
+            span=getattr(var_define, '_span', None),
+            float_literal_assignment_spans=float_assignment_spans,
         ))
     return tuple(out)
 
@@ -1078,14 +1156,24 @@ def _build_event_infos(machine: 'StateMachine', transitions: Tuple[TransitionInf
     out: List[EventInfo] = []
     for qn in sorted(set(event_users.keys()) | set(event_declared.keys())):
         used_by = tuple(event_users.get(qn, []))
+        event_obj = _find_event_by_qualified_name(machine, qn)
         out.append(EventInfo(
             qualified_name=qn,
             scope=event_scope.get(qn, 'absolute'),
             used_by=used_by,
             is_declared=event_declared.get(qn, False),
             is_used=bool(used_by),
+            span=getattr(event_obj, '_span', None) if event_obj is not None else None,
         ))
     return tuple(out)
+
+
+def _find_event_by_qualified_name(machine: 'StateMachine', qualified_name: str):
+    for state in machine.walk_states():
+        for event in state.events.values():
+            if event.path_name == qualified_name:
+                return event
+    return None
 
 
 def _scope_from_event_origins(origins: List[str]) -> str:
@@ -1123,6 +1211,7 @@ def _build_action_infos(machine: 'StateMachine') -> Tuple[ActionInfo, ...]:
                     is_ref=action.is_ref,
                     ref_target=ref_target,
                     is_attached=True,
+                    span=getattr(action, '_span', None),
                 ))
     return tuple(out)
 
@@ -1148,6 +1237,7 @@ def _build_forced_transition_infos(machine: 'StateMachine') -> Tuple[ForcedTrans
             ),
             original_raw=str(item.get('original_raw', '')),
             expansion_count=int(item.get('expansion_count', 0)),
+            span=item.get('span'),
         ))
     return tuple(out)
 
@@ -1436,6 +1526,12 @@ def _to_json_dataclass(obj: Any) -> Any:
         return {
             name: _to_json_dataclass(getattr(obj, name))
             for name in obj.__dataclass_fields__
+            if name not in {
+                'span',
+                'effect_spans',
+                'effect_self_assign_spans',
+                'float_literal_assignment_spans',
+            }
         }
     if isinstance(obj, tuple):
         return [_to_json_dataclass(x) for x in obj]
@@ -1479,10 +1575,7 @@ def _to_json_inspect(report: ModelInspect) -> Dict[str, Any]:
 
 def _diagnostic_to_json(d: ModelDiagnostic) -> Dict[str, Any]:
     span = None
-    if d.span is not None:  # pragma: no cover
-        # Current design-health diagnostics are spanless, but the JSON
-        # contract already supports spans for diagnostics that can be
-        # anchored precisely.
+    if d.span is not None:
         span = {
             'line': d.span.line,
             'column': d.span.column,
@@ -1494,5 +1587,5 @@ def _diagnostic_to_json(d: ModelDiagnostic) -> Dict[str, Any]:
         'severity': d.severity,
         'message': d.message,
         'span': span,
-        'refs': dict(d.refs),
+        'refs': _to_json_dataclass(d.refs),
     }

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -3166,6 +3166,7 @@ def parse_dsl_node_to_state_machine(
                     'guard': str(condition_expr) if condition_expr is not None else None,
                     'original_raw': str(f_transnode),
                     'expansion_count': expansion_count,
+                    'span': _node_span(f_transnode),
                 })
 
             force_transition_tuples_to_inherit.append(

--- a/test/diagnostics/_schema_check.py
+++ b/test/diagnostics/_schema_check.py
@@ -29,6 +29,9 @@ _TYPE_PREDICATES = {
     'bool': lambda v: isinstance(v, bool),
     'dict': lambda v: isinstance(v, dict),
     'list[str]': lambda v: isinstance(v, list) and all(isinstance(item, str) for item in v),
+    'list[Span]': lambda v: isinstance(v, list) and all(
+        item is None or hasattr(item, 'line') for item in v
+    ),
     'Span': lambda v: v is None or hasattr(v, 'line'),
     'str_or_null': lambda v: v is None or isinstance(v, str),
     'int_or_null': lambda v: v is None or (isinstance(v, int) and not isinstance(v, bool)),

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -7,6 +7,7 @@ read resources outside the Python test runtime.
 """
 
 import json
+from dataclasses import is_dataclass
 
 import pytest
 
@@ -50,7 +51,7 @@ def _normalize_inspect_diagnostics(diags):
         normalized.append({
             'code': diag.code if isinstance(diag, ModelDiagnostic) else diag['code'],
             'severity': diag.severity if isinstance(diag, ModelDiagnostic) else diag['severity'],
-            'refs': json.loads(json.dumps(refs, sort_keys=True)),
+            'refs': json.loads(json.dumps(_stable_refs_for_parity(refs), sort_keys=True)),
         })
     return sorted(
         normalized,
@@ -60,6 +61,28 @@ def _normalize_inspect_diagnostics(diags):
             json.dumps(item['refs'], sort_keys=True),
         ),
     )
+
+
+def _stable_refs_for_parity(value):
+    if _is_span_like(value):
+        return None
+    if isinstance(value, dict):
+        return {
+            str(k): _stable_refs_for_parity(v)
+            for k, v in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_stable_refs_for_parity(item) for item in value]
+    if is_dataclass(value):  # pragma: no cover - defensive for future refs payloads
+        return {
+            name: _stable_refs_for_parity(getattr(value, name))
+            for name in value.__dataclass_fields__
+        }
+    return value
+
+
+def _is_span_like(value):
+    return all(hasattr(value, attr) for attr in ('line', 'column', 'end_line', 'end_column'))
 
 
 def _expected_with_suggested_fixes(expected):
@@ -832,8 +855,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                     'from_path': 'Root.Idle',
                     'to_path': 'Root.Active',
                     'duplicate_spans': [
-                        'Root.Idle->Root.Active#1',
-                        'Root.Idle->Root.Active#2',
+                        None,
+                        None,
                     ],
                 },
             },
@@ -844,8 +867,8 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                     'from_path': 'Root.Active',
                     'to_path': 'Root.Trapped',
                     'duplicate_spans': [
-                        'Root.Active->Root.Trapped#1',
-                        'Root.Active->Root.Trapped#2',
+                        None,
+                        None,
                     ],
                 },
             },

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -13,6 +13,7 @@ import os
 
 import pytest
 
+import pyfcstm.diagnostics.inspect as inspect_module
 from pyfcstm.diagnostics import (
     ActionInfo,
     DEFAULT_DEEP_HIERARCHY_THRESHOLD,
@@ -33,9 +34,29 @@ from pyfcstm.model import parse_dsl_node_to_state_machine
 from ._schema_check import assert_all_diags_match_schema
 
 
+def _assert_has_span(value):
+    assert value is not None
+    assert value.line >= 1
+    assert value.column >= 1
+
+
 def _parse(src):
     ast = parse_with_grammar_entry(src, 'state_machine_dsl')
     return parse_dsl_node_to_state_machine(ast)
+
+
+def _slice_by_span(source, span):
+    lines = source.split('\n')
+    end_line = span.end_line or span.line
+    end_column = span.end_column or span.column
+    if end_line == span.line:
+        return lines[span.line - 1][span.column - 1:end_column - 1]
+
+    pieces = [lines[span.line - 1][span.column - 1:]]
+    for index in range(span.line, end_line - 1):
+        pieces.append(lines[index])
+    pieces.append(lines[end_line - 1][:end_column - 1])
+    return '\n'.join(pieces)
 
 
 def _by_path(infos):
@@ -954,7 +975,7 @@ class TestInspectModelGuardAffectDiagnostics:
             'reason': 'no_outgoing_transition',
         }
 
-    def test_const_true_fix_is_omitted_when_transition_span_is_unavailable(self):
+    def test_const_true_transition_refs_include_source_span(self):
         by_code = self._diagnostics_by_code("""
         state Root {
             state Idle;
@@ -965,8 +986,9 @@ class TestInspectModelGuardAffectDiagnostics:
         """)
 
         const_true_refs = by_code['W_GUARD_CONST_TRUE'][0].refs
+        _assert_has_span(const_true_refs['transition_span'])
         assert const_true_refs == {
-            'transition_span': None,
+            'transition_span': const_true_refs['transition_span'],
             'folded_value': True,
             'from_path': 'Root.Idle',
             'to_path': 'Root.Done',
@@ -1276,7 +1298,7 @@ class TestInspectModelExtendedCoverage:
         }
         const_false = next(d for d in diagnostics if d.code == 'W_GUARD_CONST_FALSE')
         assert const_false.refs['folded_value'] is False
-        assert const_false.refs['transition_span'] is None
+        _assert_has_span(const_false.refs['transition_span'])
         assert const_false.refs['from_path'] == 'Root.Active'
         assert const_false.refs['to_path'] == 'Root.Blocked'
         unreachable = next(d for d in diagnostics if d.code == 'W_UNREACHABLE_STATE')
@@ -1291,6 +1313,35 @@ class TestInspectModelExtendedCoverage:
         )
         assert unused_payload['is_declared'] is True
         assert unused_payload['is_used'] is False
+
+    def test_implicit_event_info_uses_transition_span(self):
+        dsl = """
+        state Root {
+            state Idle;
+            state Active;
+            [*] -> Idle;
+            Idle -> Active : Go;
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        event = next(e for e in report.events if e.qualified_name == 'Root.Go')
+
+        assert event.is_declared is False
+        assert event.is_used is True
+        _assert_has_span(event.span)
+        assert 'Idle -> Active : Go' in _slice_by_span(dsl, event.span)
+
+    def test_event_lookup_returns_none_for_unknown_qualified_name(self):
+        machine = _parse("""
+        state Root {
+            state Idle;
+            [*] -> Idle;
+        }
+        """)
+
+        assert inspect_module._find_event_by_qualified_name(
+            machine, 'Root.MissingEvent'
+        ) is None
 
     def test_const_fold_guard_true_and_false_and_during_assign(self):
         dsl = """
@@ -1325,8 +1376,9 @@ class TestInspectModelExtendedCoverage:
         assert codes.count('W_DURING_CONST_ASSIGN') == 3
 
         const_true = next(d for d in diagnostics if d.code == 'W_GUARD_CONST_TRUE')
+        _assert_has_span(const_true.refs['transition_span'])
         assert const_true.refs == {
-            'transition_span': None,
+            'transition_span': const_true.refs['transition_span'],
             'folded_value': True,
             'from_path': 'Root.Idle',
             'to_path': 'Root.Active',
@@ -1334,8 +1386,9 @@ class TestInspectModelExtendedCoverage:
             'transition_index': 1,
         }
         const_false = next(d for d in diagnostics if d.code == 'W_GUARD_CONST_FALSE')
+        _assert_has_span(const_false.refs['transition_span'])
         assert const_false.refs == {
-            'transition_span': None,
+            'transition_span': const_false.refs['transition_span'],
             'folded_value': False,
             'from_path': 'Root.Active',
             'to_path': 'Root.Blocked',
@@ -1444,6 +1497,28 @@ class TestInspectModelRedundancySemantics:
             if d.code == 'W_REDUNDANT_TRANSITION'
         ] == []
 
+    def test_redundant_transition_refs_include_each_duplicate_span(self):
+        dsl = """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+            A -> B;
+            A -> B;
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        assert_all_diags_match_schema(report.diagnostics, context='redundant-transition-spans')
+        diag = next(d for d in report.diagnostics if d.code == 'W_REDUNDANT_TRANSITION')
+
+        duplicate_spans = diag.refs['duplicate_spans']
+        assert len(duplicate_spans) == 3
+        assert diag.span == duplicate_spans[0]
+        sliced = [_slice_by_span(dsl, span) for span in duplicate_spans]
+        assert sliced == ['A -> B;', 'A -> B;', 'A -> B;']
+        assert [span.line for span in duplicate_spans] == [6, 7, 8]
+
     def test_self_transition_with_lifecycle_action_is_not_noop(self):
         dsl = """
         def int counter = 0;
@@ -1498,7 +1573,7 @@ class TestInspectModelRedundancySemantics:
         ]
         assert len(refs) == 1
         assert refs[0]['state_path'] == 'Root.A'
-        assert refs[0]['transition_span'] is None
+        _assert_has_span(refs[0]['transition_span'])
         assert refs[0]['var_name'] == 'x'
         assert refs[0]['effect_self_assign_anchor'] == 'x'
         assert refs[0]['suggested_fix'] == {
@@ -1570,9 +1645,10 @@ class TestInspectModelRedundancySemantics:
             if d.code == 'W_EFFECT_SELF_ASSIGN'
         ]
         assert len(refs) == 1
+        _assert_has_span(refs[0]['transition_span'])
         assert refs[0] == {
             'state_path': '[*]',
-            'transition_span': None,
+            'transition_span': refs[0]['transition_span'],
             'var_name': 'x',
             'transition_index': 0,
         }
@@ -1663,8 +1739,12 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
             [*] -> A;
         }
         """
+        with pytest.raises(TypeError, match='deep_hierarchy_threshold'):
+            inspect_model(_parse(dsl), deep_hierarchy_threshold=True)
         with pytest.raises(ValueError, match='deep_hierarchy_threshold'):
             inspect_model(_parse(dsl), deep_hierarchy_threshold=0.5)
+        with pytest.raises(TypeError, match='large_composite_threshold'):
+            inspect_model(_parse(dsl), large_composite_threshold='bad')
         with pytest.raises(ValueError, match='large_composite_threshold'):
             inspect_model(_parse(dsl), large_composite_threshold=2.5)
 
@@ -1679,6 +1759,8 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
             inspect_model(_parse(dsl), var_to_leaf_ratio_threshold=True)
         with pytest.raises(ValueError, match='var_to_leaf_ratio_threshold'):
             inspect_model(_parse(dsl), var_to_leaf_ratio_threshold=float('nan'))
+        with pytest.raises(TypeError, match='var_to_leaf_ratio_threshold'):
+            inspect_model(_parse(dsl), var_to_leaf_ratio_threshold='bad')
 
     def test_integer_threshold_options_accept_integer_valued_float(self):
         dsl = """
@@ -1757,6 +1839,46 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
             'source_expr': '2.25',
         }
 
+    def test_literal_type_narrowing_keeps_deduped_assignment_spans_aligned(self):
+        dsl = """
+        def int truncated = 0;
+        state Root {
+            state A {
+                during {
+                    truncated = 2.25;
+                    truncated = 2.25;
+                    truncated = 3.5;
+                }
+            }
+            [*] -> A;
+        }
+        """
+        diagnostics = self._diagnostics_by_code(dsl)['W_LITERAL_TYPE_NARROWING']
+        by_expr = {diag.refs['source_expr']: diag for diag in diagnostics}
+
+        assert set(by_expr) == {'2.25', '3.5'}
+        assert 'truncated = 2.25;' in _slice_by_span(dsl, by_expr['2.25'].span)
+        assert 'truncated = 3.5;' in _slice_by_span(dsl, by_expr['3.5'].span)
+
+    def test_literal_type_narrowing_for_int_transition_effect_assignment(self):
+        dsl = """
+        def int truncated = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { truncated = 2.25; };
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['W_LITERAL_TYPE_NARROWING'][0]
+        assert diag.refs == {
+            'var_name': 'truncated',
+            'target_type': 'int',
+            'source_expr': '2.25',
+        }
+        _assert_has_span(diag.span)
+        assert 'truncated = 2.25' in _slice_by_span(dsl, diag.span)
+
     def test_aspect_no_descendant_leaf(self):
         dsl = """
         state Root {
@@ -1769,6 +1891,20 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
         assert diag.refs == {
             'composite_path': 'Root',
             'aspect': 'before',
+        }
+
+    def test_after_aspect_no_descendant_leaf(self):
+        dsl = """
+        state Root {
+            pseudo state Marker;
+            [*] -> Marker;
+            >> during after { }
+        }
+        """
+        diag = self._diagnostics_by_code(dsl)['W_ASPECT_NO_DESCENDANT_LEAF'][0]
+        assert diag.refs == {
+            'composite_path': 'Root',
+            'aspect': 'after',
         }
 
     def test_transition_to_self_via_parent_info(self):
@@ -1800,10 +1936,11 @@ class TestInspectModelThresholdNamingTypeDiagnostics:
         """
         diag = self._diagnostics_by_code(dsl)['I_TRANSITION_NEVER_EVENT_TRIGGERED'][0]
         assert diag.severity == 'info'
+        _assert_has_span(diag.refs['transition_span'])
         assert diag.refs == {
             'from_path': 'Root.A',
             'to_path': 'Root.B',
-            'transition_span': None,
+            'transition_span': diag.refs['transition_span'],
             'transition_index': 1,
         }
 

--- a/test/diagnostics/test_inspect_span_contract.py
+++ b/test/diagnostics/test_inspect_span_contract.py
@@ -1,0 +1,183 @@
+"""Contract tests for inspect diagnostics source spans."""
+
+from collections import defaultdict
+
+import pytest
+
+from pyfcstm.diagnostics import CODE_REGISTRY, VariableInfo, inspect_model
+from pyfcstm.diagnostics.analyzers.data_flow import collect_data_flow_warnings
+import pyfcstm.diagnostics.inspect as inspect_module
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.utils.validate import Span
+
+
+def _parse(source):
+    ast = parse_with_grammar_entry(source, "state_machine_dsl")
+    return parse_dsl_node_to_state_machine(ast)
+
+
+def _diagnostics_for_code(code, spec):
+    if code == "W_WRITE_ONLY_VAR":
+        source = spec.example_dsl
+        variable = next(
+            v for v in inspect_model(_parse(source)).variables if v.name == "counter"
+        )
+        diagnostics = collect_data_flow_warnings(
+            [
+                VariableInfo(
+                    name=variable.name,
+                    type=variable.type,
+                    init_value=variable.init_value,
+                    read_in_states=tuple(),
+                    written_in_states=variable.written_in_states,
+                    read_in_guards=tuple(),
+                    written_in_effects=tuple(),
+                    affects_guard_directly=True,
+                    affects_guard_indirectly=False,
+                    abstract_actions_in_scope=tuple(),
+                    span=variable.span,
+                ),
+            ]
+        )
+        return source, diagnostics
+    source = spec.example_dsl
+    report = inspect_model(
+        _parse(source),
+        deep_hierarchy_threshold=0,
+        large_composite_threshold=2,
+        var_to_leaf_ratio_threshold=0,
+    )
+    return source, report.diagnostics
+
+
+def _slice_by_span(source: str, span: Span) -> str:
+    """Return the source slice covered by a 1-based listener span."""
+    assert span is not None
+    lines = source.split("\n")
+    end_line = span.end_line or span.line
+    end_column = span.end_column or span.column
+    assert 1 <= span.line <= len(lines)
+    assert 1 <= end_line <= len(lines)
+    assert span.line <= end_line
+    assert span.column >= 1
+    assert end_column >= 1
+    if end_line == span.line:
+        assert span.column <= end_column
+        return lines[span.line - 1][span.column - 1 : end_column - 1]
+    pieces = [lines[span.line - 1][span.column - 1 :]]
+    for index in range(span.line, end_line - 1):
+        pieces.append(lines[index])
+    pieces.append(lines[end_line - 1][: end_column - 1])
+    return "\n".join(pieces)
+
+
+@pytest.mark.unittest
+def test_known_spanless_codes_are_registered_codes():
+    assert inspect_module.KNOWN_SPANLESS_CODES <= set(CODE_REGISTRY)
+
+
+@pytest.mark.unittest
+def test_registry_static_warning_info_examples_have_source_spans():
+    codes_seen = defaultdict(int)
+    spanless_hits = defaultdict(int)
+    for code, spec in CODE_REGISTRY.items():
+        if spec.emit_tier != "static_pipeline" or spec.severity not in {
+            "warning",
+            "info",
+        }:
+            continue
+        example_dsl = spec.example_dsl
+        assert example_dsl, (
+            f"{code} must provide an example_dsl for span contract coverage"
+        )
+        example_dsl, diagnostics = _diagnostics_for_code(code, spec)
+        matching = [diag for diag in diagnostics if diag.code == code]
+        assert matching, (
+            f"{code} example_dsl did not emit its code; emitted "
+            f"{[diag.code for diag in diagnostics]}"
+        )
+        for diag in matching:
+            codes_seen[code] += 1
+            if code in inspect_module.KNOWN_SPANLESS_CODES:
+                if diag.span is None:
+                    spanless_hits[code] += 1
+                continue
+            assert diag.span is not None, (code, diag.refs)
+            assert _slice_by_span(example_dsl, diag.span).strip(), (
+                code,
+                diag.refs,
+                diag.span,
+            )
+
+    expected = {
+        code
+        for code, spec in CODE_REGISTRY.items()
+        if spec.emit_tier == "static_pipeline" and spec.severity in {"warning", "info"}
+    }
+    assert set(codes_seen) == expected
+    assert set(spanless_hits) == inspect_module.KNOWN_SPANLESS_CODES
+
+
+@pytest.mark.unittest
+def test_all_static_inspect_diagnostics_have_source_spans():
+    source = """def int counter = 0;
+def int read_only = 0;
+def int stable = 0;
+def int assigned = 3.5;
+def int extra = 0;
+def int a = 0;
+def int b = 0;
+def int c = 0;
+def int d = 0;
+def int e = 0;
+def int f = 0;
+
+state Root {
+    event Tick;
+    event Unused;
+    enter Sync { }
+
+    state Active {
+        enter Sync { }
+        state Leaf;
+        [*] -> Leaf;
+    }
+    state Sparse {
+        pseudo state Marker;
+        [*] -> Marker;
+        >> during before { }
+    }
+    state Idle {
+        during { counter = 5; assigned = 2.25; }
+    }
+    state Blocked;
+    state Done;
+    state Orphan { enter Cleanup {} }
+    state LeafForced { !* -> [*] :: Never; }
+
+    [*] -> Idle : if [true];
+    Idle -> Active : if [read_only > 0];
+    Idle -> Active : if [read_only > 0];
+    Active -> Active;
+    Active -> Blocked : if [(0x0F & 0xF0) != 0];
+    Blocked -> Done effect { stable = stable; };
+    Done -> Idle : Tick;
+    !Done -> Idle : Tick;
+}
+"""
+    report = inspect_model(_parse(source), large_composite_threshold=2)
+    diagnostics = [diag for diag in report.diagnostics if diag.code in CODE_REGISTRY]
+    assert diagnostics
+    seen = {diag.code for diag in diagnostics}
+    assert seen - inspect_module.KNOWN_SPANLESS_CODES
+    for diag in diagnostics:
+        if diag.code in inspect_module.KNOWN_SPANLESS_CODES:
+            assert diag.span is None
+            continue
+        assert diag.span is not None, (diag.code, diag.refs)
+        assert _slice_by_span(source, diag.span).strip(), (
+            diag.code,
+            diag.refs,
+            diag.span,
+        )


### PR DESCRIPTION
## PR-D2：pyfcstm analyzer emit-site span 填充

关联 issue：#133

### 依赖关系

- depends on #136，PR-D1 已合入 main。
- 当前实现基于 PR-D1 提供的 model `_span` plumbing：本 PR 只消费已有 `_span` 并补 analyzer emit-site，不再改 AST/listener 基础设施。
- `schema.json` 仍不在本 PR 修改；`codes.yaml` 中 `W_REDUNDANT_TRANSITION.refs.duplicate_spans` 已根据 final review 的 I 级反馈从 `list[str]` 收紧为 `list[Span]`，避免 redundancy pair 的 secondary source span 继续停留在字符串占位。

### Issue #133 / PR-D2 验收映射

- [x] 仅处理 **PR-D2：pyfcstm analyzer emit-site span fill**。
- [x] 为 `pyfcstm/diagnostics/analyzers/*.py` 中 static inspect pipeline 的 `ModelDiagnostic(...)` emit-site 补 `span=`。
- [x] 多对象诊断按语义补充 auxiliary refs：`transition_span`、`forced_declaration_span`、`normal_transition_span`、`duplicate_spans` 等现在使用真实 `Span` 对象或 Span 列表。
- [x] 在 `pyfcstm/diagnostics/inspect.py` 增加 `KNOWN_SPANLESS_CODES = frozenset()`；当前确认不需要 whitelist，保持空集合。
- [x] 新增 `test/diagnostics/test_inspect_span_contract.py`，参数化覆盖 `CODE_REGISTRY` 中所有 `static_pipeline` warning/info code；非 whitelist code 必须有非空 span 且 source slice 有效。
- [x] 保持 `inspect_model(...).to_json()` structural payload 不泄漏内部 inspect-info span 字段，同时 diagnostic `span` / `refs` 内 Span 可 JSON 化。
- [x] 不处理 jsfcstm / VSCode diagnostic range；该 lane 已由 PR-A / PR-B 系列覆盖。
- [x] 不引入 byte offset 或新的坐标模型。

### 实现摘要

- `StateInfo` / `TransitionInfo` / `VariableInfo` / `EventInfo` / `ActionInfo` / `ForcedTransitionInfo` 内部携带源 span，供 analyzer 使用。
- transition / guard / redundancy / forced / event / action / threshold / type-shape / data-flow 等诊断 emit-site 改为携带 `ModelDiagnostic.span`。
- `W_EFFECT_SELF_ASSIGN`、`W_LITERAL_TYPE_NARROWING` 等语句级诊断优先锚定具体 operation statement；没有语句 span 时退到 transition / variable declaration span。
- 修复 review 发现的 `W_LITERAL_TYPE_NARROWING` 并行数组错位风险：float literal 文本去重时同步保留对应 span，避免重复 `2.25` 后的 `3.5` 诊断锚到错误语句。
- 修复 review 发现的 `W_REDUNDANT_TRANSITION.refs['duplicate_spans']` 字符串占位：现在直接输出重复 transition declaration 的 `Span` 列表，并用 schema-check 测试验证 `list[Span]`。
- forced transition declaration metadata 增加声明 span，使 `W_FORCED_NEVER_EXPANDS` 和 forced-vs-normal 场景有源码锚点。
- cross-end parity 测试继续聚焦 code/refs 行为结构；Span-like refs 在 parity normalize 时稳定归一，避免 PR-D2 在 PR-E 前提前改变跨端 source-slice 比较口径。

### TDD / 验证证据

- main 上红：`origin/main` 不存在 `pyfcstm.diagnostics.inspect.KNOWN_SPANLESS_CODES`；新增 span contract 测试导入/断言该符号时会失败，证明 PR-D2 前没有“spanless whitelist + 全 code span contract”护栏。
- PR 上绿，本地已跑（head `d9313684`）：
  - `python -m compileall -q pyfcstm/diagnostics pyfcstm/model test/diagnostics/test_inspect_model.py test/diagnostics/test_cross_end_parity.py test/diagnostics/test_inspect_span_contract.py`
  - `pytest test/diagnostics/test_inspect_span_contract.py test/diagnostics/test_inspect_model.py test/diagnostics/test_cross_end_parity.py -q` → `151 passed`
  - `pytest test/diagnostics -q` → `477 passed`
  - `SKIP_SLOW_TESTS=1 make unittest` → `8985 passed, 164 skipped, 63 deselected, 699 warnings`，coverage `94%`
- 针对 review I 级问题新增/更新的复现测试：
  - `test_redundant_transition_refs_include_each_duplicate_span`：断言三条 `A -> B;` 的 `duplicate_spans` 均可回切到各自源码行。
  - `test_literal_type_narrowing_keeps_deduped_assignment_spans_aligned`：断言重复 `2.25` 后的 `3.5` narrowing 诊断锚定 `truncated = 3.5;`。

### `KNOWN_SPANLESS_CODES`

当前为：

```python
KNOWN_SPANLESS_CODES = frozenset()
```

含义：本 PR 后 static inspect pipeline 的 warning/info diagnostics 默认都必须有可回切源码的 `span`；未来如果新增确实无法/不应锚定到单一源码对象的 code，必须显式加入该集合并补测试说明。

### CI / Review 状态

- 状态：**ready to merge**（等待人工指示；本 PR 不在此处合并）。
- CI：GitHub Actions 全部通过，head `d9313684`。
- Codecov：comment 已匹配 head `d9313684`，`All modified and coverable lines are covered by tests`，project coverage `93.65%`。
- 已处理 final review 中两个 I 级问题：
  - `W_LITERAL_TYPE_NARROWING` 重复 float literal 后 span/name 错位。
  - `W_REDUNDANT_TRANSITION.refs['duplicate_spans']` 字符串占位，现为 `list[Span]`。
- 三路最终复核均为中文 PR comment，均无 C/I：
  - codex reviewer：https://github.com/HansBug/pyfcstm/pull/138#issuecomment-4598877063
  - claude reviewer：https://github.com/HansBug/pyfcstm/pull/138#issuecomment-4598877590
  - deepseek reviewer：https://github.com/HansBug/pyfcstm/pull/138#issuecomment-4598889314

### 回滚策略

- 删除 analyzer `span=` 补充、inspect-info 内部 span 字段、`KNOWN_SPANLESS_CODES` 与新增 span contract 测试即可回滚；`schema.json` 未改变。`codes.yaml` 中 `duplicate_spans: list[Span]` 如需回滚，需同时恢复 redundancy analyzer 的字符串占位和 schema-check/parity 预期。

