### PR TITLE
fix(jsfcstm): 让声明类诊断锚定 action 与 event 声明

### DIFF
--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -76,20 +76,66 @@ function documentUri(document: TextDocumentLike): string {
     return filePath ? pathToFileURL(filePath).toString() : 'untitled:fcstm';
 }
 
-function relatedInformationFromRefs(
+function actionShadowRelatedInformation(
     document: TextDocumentLike,
-    item: ModelDiagnosticJson,
+    semantic: FcstmSemanticDocument,
+    refs: Record<string, unknown>,
 ): FcstmDiagnostic['relatedInformation'] {
-    if (item.code !== 'W_FORCED_OVERRIDES_NORMAL') return undefined;
-    const normalRange = spanLikeToRange(item.refs.normal_transition_span);
-    if (!normalRange) return undefined;
+    const range = resolveRangeFromRefsDetailed(document, semantic, {
+        function_name: refs.function_name,
+        defined_in: refs.outer_state_path,
+    }).range;
+    if (!range) return undefined;
     return [{
         location: {
             uri: documentUri(document),
-            range: normalRange,
+            range,
         },
-        message: 'Normal transition duplicated by this forced transition.',
+        message: 'Ancestor named action shadowed by this declaration.',
     }];
+}
+
+function shadowedEventRelatedInformation(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    refs: Record<string, unknown>,
+): FcstmDiagnostic['relatedInformation'] {
+    const range = resolveRangeFromRefsDetailed(document, semantic, {
+        event_qualified_name: refs.chain_path,
+    }).range;
+    if (!range) return undefined;
+    return [{
+        location: {
+            uri: documentUri(document),
+            range,
+        },
+        message: 'Broader event shadowed by this local event.',
+    }];
+}
+
+function relatedInformationFromRefs(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    item: ModelDiagnosticJson,
+): FcstmDiagnostic['relatedInformation'] {
+    if (item.code === 'W_FORCED_OVERRIDES_NORMAL') {
+        const normalRange = spanLikeToRange(item.refs.normal_transition_span);
+        if (!normalRange) return undefined;
+        return [{
+            location: {
+                uri: documentUri(document),
+                range: normalRange,
+            },
+            message: 'Normal transition duplicated by this forced transition.',
+        }];
+    }
+    if (item.code === 'W_NAMED_ACTION_SHADOWS_ANCESTOR') {
+        return actionShadowRelatedInformation(document, semantic, item.refs);
+    }
+    if (item.code === 'W_SHADOWED_EVENT') {
+        return shadowedEventRelatedInformation(document, semantic, item.refs);
+    }
+    return undefined;
 }
 
 export interface CollectInspectModelDiagnosticsOptions {
@@ -152,7 +198,7 @@ export function collectInspectDiagnosticsFromItems(
         if (refResolution.fallback) {
             diagnostic.data = {...(diagnostic.data ?? {}), __rangeFallback: refResolution.fallback};
         }
-        diagnostic.relatedInformation = relatedInformationFromRefs(document, item);
+        diagnostic.relatedInformation = relatedInformationFromRefs(document, semantic, item);
         if (consumeDiagnosticCount(existingCounts, diagnosticKey(diagnostic))) continue;
         diagnostics.push(diagnostic);
     }

--- a/editors/jsfcstm/src/editor/inspect-ranges.ts
+++ b/editors/jsfcstm/src/editor/inspect-ranges.ts
@@ -1,5 +1,5 @@
 import type {FcstmSemanticDocument, FcstmSemanticTransition} from '../semantics';
-import {createRange, type TextDocumentLike, type TextRange} from '../utils/text';
+import {createRange, getDocumentFilePath, type TextDocumentLike, type TextRange} from '../utils/text';
 import {findIdentifierRange} from './ranges';
 import {
     effectSelfAssignRange,
@@ -229,15 +229,62 @@ function guardRangeResolution(
     };
 }
 
+function importedBoundaryFileForStatePath(
+    semantic: FcstmSemanticDocument,
+    statePath: string | null,
+): string | null {
+    if (!statePath) return null;
+    const segments = statePath.split('.');
+    for (let length = segments.length; length >= 1; length -= 1) {
+        const candidatePath = segments.slice(0, length).join('.');
+        const state = semantic.lookups.statesByPath[candidatePath];
+        const importedFromFile = state?.ast.importedFromFile;
+        if (importedFromFile) return importedFromFile;
+    }
+    return null;
+}
+
+function statePathIsLocalToDocument(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    statePath: string | null,
+): boolean {
+    const importedFromFile = importedBoundaryFileForStatePath(semantic, statePath);
+    if (!importedFromFile) return true;
+    const documentFilePath = getDocumentFilePath(document);
+    return documentFilePath.length > 0 && importedFromFile === documentFilePath;
+}
+
+function actionDeclarationRange(
+    document: TextDocumentLike,
+    semantic: FcstmSemanticDocument,
+    statePath: string | null,
+    functionName: string | null,
+): TextRange | null {
+    if (!statePath || !functionName) return null;
+    if (!statePathIsLocalToDocument(document, semantic, statePath)) return null;
+
+    const matches = semantic.actions.filter(action => (
+        action.name === functionName && dottedPath(action.ownerStatePath) === statePath
+    ));
+    if (matches.length !== 1) return null;
+
+    const action = matches[0];
+    return action.ast.nameRange ?? findIdentifierRange(document, functionName, action.range);
+}
+
 function eventRange(
     document: TextDocumentLike,
     semantic: FcstmSemanticDocument,
     qualifiedName: string | null,
 ): TextRange | null {
     if (!qualifiedName) return null;
-    const event = semantic.events.find(item => item.identity.qualifiedName === qualifiedName);
+    const event = semantic.lookups.eventsByQualifiedName[qualifiedName]
+        ?? semantic.events.find(item => item.identity.qualifiedName === qualifiedName);
     if (!event) return null;
-    return findIdentifierRange(document, event.name, event.declarationAst?.range ?? event.range);
+    if (!statePathIsLocalToDocument(document, semantic, dottedPath(event.statePath))) return null;
+    return event.declarationAst?.nameRange
+        ?? findIdentifierRange(document, event.name, event.declarationAst?.range ?? event.range);
 }
 
 export type InspectRangeFallback =
@@ -364,6 +411,15 @@ export function resolveRangeFromRefsDetailed(
 
     const duplicateRange = arrayFirstRange(refMap.duplicate_spans);
     if (duplicateRange) return {range: duplicateRange};
+
+    const functionName = stringRef(refMap, 'function_name');
+    for (const key of ['defined_in', 'defined_in_path', 'inner_state_path']) {
+        const range = actionDeclarationRange(document, semantic, stringRef(refMap, key), functionName);
+        if (range) return {range};
+    }
+
+    const localEventRange = eventRange(document, semantic, stringRef(refMap, 'local_path'));
+    if (localEventRange) return {range: localEventRange};
 
     if (refMap.transition_span === null || refMap.guard_span === null || refMap.duplicate_spans !== undefined) {
         if (refMap.folded_value === true || refMap.folded_value === false || stringRef(refMap, 'guard_text')) {

--- a/editors/jsfcstm/test/diagnostics-declaration-range.test.ts
+++ b/editors/jsfcstm/test/diagnostics-declaration-range.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import * as path from 'node:path';
+
+import {createDocument, packageModule, sliceByRange, trackTempDir} from './support';
+
+function diagnosticsByCode(diagnostics: any[], code: string): any[] {
+    return diagnostics.filter(item => item.code === code);
+}
+
+function fullDocumentSlice(text: string): string {
+    const lines = text.split('\n');
+    return sliceByRange(text, packageModule.createRange(
+        0,
+        0,
+        lines.length - 1,
+        lines[lines.length - 1]?.length ?? 0,
+    ));
+}
+
+describe('diagnostics declaration ranges', () => {
+    afterEach(() => {
+        packageModule.getWorkspaceGraph().clearOverlays();
+    });
+
+    it('anchors dead named action diagnostics on the action declaration name', async () => {
+        const text = [
+            'state Root {',
+            '    state Live;',
+            '    state Orphan {',
+            '        enter Dead { }',
+            '    }',
+            '    [*] -> Live;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/declaration-dead-action.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnosticsByCode(diagnostics, 'W_DEAD_NAMED_ACTION')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(diagnostic.data?.defined_in, 'Root.Orphan');
+        assert.equal(sliceByRange(text, diagnostic.range), 'Dead');
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.notEqual(sliceByRange(text, diagnostic.range), 'Orphan');
+        assert.notEqual(sliceByRange(text, diagnostic.range), fullDocumentSlice(text));
+    });
+
+    it('anchors named action shadow diagnostics on the inner action and relates the outer action', async () => {
+        const text = [
+            'state Root {',
+            '    enter Sync { }',
+            '    state Child {',
+            '        enter Sync { }',
+            '    }',
+            '    [*] -> Child;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/declaration-action-shadow.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnosticsByCode(diagnostics, 'W_NAMED_ACTION_SHADOWS_ANCESTOR')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(diagnostic.data?.inner_state_path, 'Root.Child');
+        assert.equal(diagnostic.data?.outer_state_path, 'Root');
+        assert.equal(sliceByRange(text, diagnostic.range), 'Sync');
+        assert.equal(diagnostic.range.start.line, 3);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.ok(diagnostic.relatedInformation?.length, JSON.stringify(diagnostic));
+        assert.equal(sliceByRange(text, diagnostic.relatedInformation[0].location.range), 'Sync');
+        assert.equal(diagnostic.relatedInformation[0].location.range.start.line, 1);
+    });
+
+    it('uses the nearest ancestor action as related information in deep shadow chains', async () => {
+        const text = [
+            'state Root {',
+            '    enter Sync { }',
+            '    state A {',
+            '        enter Sync { }',
+            '        state B { enter Sync { } }',
+            '        [*] -> B;',
+            '    }',
+            '    [*] -> A;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/declaration-action-shadow-deep.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnosticsByCode(diagnostics, 'W_NAMED_ACTION_SHADOWS_ANCESTOR')
+            .find(item => item.data?.inner_state_path === 'Root.A.B');
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(diagnostic.data?.outer_state_path, 'Root.A');
+        assert.equal(sliceByRange(text, diagnostic.range), 'Sync');
+        assert.equal(diagnostic.range.start.line, 4);
+        assert.ok(diagnostic.relatedInformation?.length, JSON.stringify(diagnostic));
+        assert.equal(sliceByRange(text, diagnostic.relatedInformation[0].location.range), 'Sync');
+        assert.equal(diagnostic.relatedInformation[0].location.range.start.line, 3);
+    });
+
+    it('anchors shadowed event diagnostics on the local event and relates the broader event', async () => {
+        const text = [
+            'state Root {',
+            '    event Tick;',
+            '    state Active;',
+            '    state Idle;',
+            '    [*] -> Active;',
+            '    Active -> Idle : Tick;',
+            '    Active -> Idle :: Tick;',
+            '}',
+        ].join('\n');
+        const document = createDocument(text, '/tmp/declaration-shadowed-event.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnosticsByCode(diagnostics, 'W_SHADOWED_EVENT')[0];
+
+        assert.ok(diagnostic, JSON.stringify(diagnostics));
+        assert.equal(diagnostic.data?.local_path, 'Root.Active.Tick');
+        assert.equal(diagnostic.data?.chain_path, 'Root.Tick');
+        assert.equal(sliceByRange(text, diagnostic.range), 'Tick');
+        assert.equal(diagnostic.range.start.line, 6);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.ok(diagnostic.relatedInformation?.length, JSON.stringify(diagnostic));
+        assert.equal(sliceByRange(text, diagnostic.relatedInformation[0].location.range), 'Tick');
+        assert.equal(diagnostic.relatedInformation[0].location.range.start.line, 1);
+    });
+
+    it('does not map imported declaration diagnostics onto unrelated host-document ranges', async () => {
+        const dir = trackTempDir('jsfcstm-declaration-import-range-');
+        const childFile = path.join(dir, 'child.fcstm');
+        const hostText = [
+            'state Root {',
+            '    state Imported {',
+            '        state Orphan {',
+            '            enter Dead { }',
+            '        }',
+            '    }',
+            '    [*] -> Imported;',
+            '}',
+        ].join('\n');
+        const document = createDocument(hostText, path.join(dir, 'main.fcstm'));
+        const semantic = await packageModule.getWorkspaceGraph().getSemanticDocument(document);
+        assert.ok(semantic);
+        semantic.lookups.statesByPath['Root.Imported'].ast.importedFromFile = childFile;
+
+        const diagnostics = packageModule.collectInspectDiagnosticsFromItems(document, semantic, [{
+            code: 'W_DEAD_NAMED_ACTION',
+            severity: 'warning' as const,
+            message: 'Synthetic imported dead action.',
+            span: null,
+            refs: {
+                function_name: 'Dead',
+                defined_in: 'Root.Imported.Orphan',
+            },
+        }]);
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(sliceByRange(hostText, diagnostics[0].range), fullDocumentSlice(hostText));
+        assert.equal(diagnostics[0].data?.__rangeFallback, 'full_document');
+        assert.notEqual(sliceByRange(hostText, diagnostics[0].range), 'Dead');
+    });
+});


### PR DESCRIPTION
## 背景

本 PR 是 issue #133 的 PR-B3 分片，接在已合入的 PR-A / PR-B1 / PR-B2 之后继续收敛 jsfcstm/VSCode 诊断 range/source-slice 契约。

已完成的前置分片：

- PR-A #134：拆开 published diagnostic range 与 quick-fix edit range，修复 `W_DEADLOCK_LEAF` / `W_INITIAL_UNCONDITIONAL_MISSING` 等错行问题。
- PR-B1 #135：让 transition body 类诊断锚定 transition / guard / effect 等真实源码范围。
- PR-B2 #137：让 `W_FORCED_OVERRIDES_NORMAL` 主范围锚定 forced declaration，并将 normal transition 作为 relatedInformation 暴露。

## 本 PR-B3 范围

本 PR 只处理 declaration signature 类 inspect 诊断的 jsfcstm/editor range 定位，不扩大到 pyfcstm emit-site span、不处理 parse-recovery 零宽对象，也不做最终 schema/codes.yaml 契约收口。

目标诊断码：

- `W_DEAD_NAMED_ACTION`
- `W_NAMED_ACTION_SHADOWS_ANCESTOR`
- `W_SHADOWED_EVENT`

这些诊断和 PR-B1 的 transition body 类不同：它们不是按 transition index / guard / effect 反查，而是按 declaration signature/name 反查 named action 或 event declaration。因此单独切 PR-B3，避免把两套定位策略混在一起。

## 当前实现

- `resolveRangeFromRefsDetailed` 新增声明类定位：
  - `defined_in` / `defined_in_path` + `function_name` → named action declaration name。
  - `inner_state_path` + `function_name` → shadowing named action declaration name。
  - `local_path` → shadowing/local event declaration 或触发点 name。
- `relatedInformationFromRefs` 新增：
  - `W_NAMED_ACTION_SHADOWS_ANCESTOR`：relatedInformation 指向 ancestor action declaration。
  - `W_SHADOWED_EVENT`：relatedInformation 指向被 shadow 的 broader chain/absolute event。
  - 保留 PR-B2 的 `W_FORCED_OVERRIDES_NORMAL` relatedInformation 行为。
- source-local 边界：如果 semantic state 位于 imported subtree，且 imported source file 与当前 document 不同，则不把 imported declaration range 套到 host document 上；这种情况下保持可观察的 full-document fallback，由后续契约化分片继续收口。

## TDD 覆盖

新增 `editors/jsfcstm/test/diagnostics-declaration-range.test.ts`，覆盖：

- dead named action：published diagnostic range 精确命中 `Dead` action name，不再是全文或 state name。
- named action shadow：primary range 命中 inner `Sync`；relatedInformation 命中 outer `Sync`。
- 多层 shadow chain：`Root.A.B.Sync` 的 relatedInformation 命中最近 ancestor `Root.A.Sync`，不是更外层 `Root.Sync`。
- shadowed event：primary range 命中 local `:: Tick`；relatedInformation 命中 broader `event Tick;`。
- import/source-local：模拟 imported subtree 后，跨文件 declaration 不会被映射到 host document 中看似同名但 source 不同的 range。

## 本地验证

已在本地完成：

- RED：新增 declaration-range 测试在实现前失败，核心失败表现为 `W_DEAD_NAMED_ACTION` / `W_NAMED_ACTION_SHADOWS_ANCESTOR` / `W_SHADOWED_EVENT` 仍回落到全文 range。
- GREEN：`npm run build && npx mocha --require ts-node/register/transpile-only --extension ts "test/diagnostics-declaration-range.test.ts" --reporter spec` → 5 passing。
- `npm run test:unit` → 617 passing。
- `npm run test:coverage` → 617 passing；Statements 95.65%，Branches 85.94%，Functions 95.99%，Lines 95.65%。
- `source venv/bin/activate && SKIP_SLOW_TESTS=1 make unittest` → 8976 passed，164 skipped，63 deselected；Python coverage TOTAL 94%。
- `source venv/bin/activate && make rst_auto` 已执行；本 PR 没有需要保留的生成文档 diff。

## 非目标

- 不处理 PR-C 的 parse-recovery 空 identifier / zero-width semantic diagnostics。
- 不处理 PR-D2 的 pyfcstm analyzer emit-site span 填充。
- 不做 PR-E 的 schema/codes.yaml 全量契约文档和 cross-end parity source-slice 收口。
- 不改变 verify/inspect 算法语义，只补足 jsfcstm editor diagnostic range 基础设施。
