### PR TITLE
fix(jsfcstm): 过滤 parse recovery 后的零宽语义诊断

### DIFF
--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -699,6 +699,9 @@ function pushIdentifierDiagnostic(
     severity: 'error' | 'warning' | 'info' = 'error',
     data?: Record<string, unknown>
 ): void {
+    if (identifier.name.length === 0 || rangeIsEmptyOrInvalid(identifier.range)) {
+        return;
+    }
     // M2 (PR #115 final review): inject ``var_name`` from the
     // identifier itself so every E_UNDEFINED_VAR / E_DUPLICATE_VAR
     // emit carries the schema-required field without each caller
@@ -713,6 +716,11 @@ function pushIdentifierDiagnostic(
         code,
         data: mergedData,
     });
+}
+
+function rangeIsEmptyOrInvalid(range: import('../utils/text').TextRange): boolean {
+    if (range.end.line < range.start.line) return true;
+    return range.end.line === range.start.line && range.end.character <= range.start.character;
 }
 
 /**
@@ -1341,16 +1349,20 @@ function emitTypeMismatch(
     expected: TypeCategory,
     actual: TypeCategory,
 ): void {
+    const exprText = (expr as {text?: string}).text ?? '';
+    if (exprText.length === 0 || rangeIsEmptyOrInvalid(expr.range)) {
+        return;
+    }
     diagnostics.push({
         range: expr.range,
-        message: `Type mismatch: expected ${expected} expression, got ${actual} (${JSON.stringify((expr as {text?: string}).text ?? '')}).`,
+        message: `Type mismatch: expected ${expected} expression, got ${actual} (${JSON.stringify(exprText)}).`,
         severity: 'error',
         source: 'fcstm',
         code: FCSTM_DIAGNOSTIC_CODES.typeMismatch,
         data: {
             expected,
             actual,
-            expr_text: (expr as {text?: string}).text ?? '',
+            expr_text: exprText,
         },
     });
 }

--- a/editors/jsfcstm/src/editor/analyzers.ts
+++ b/editors/jsfcstm/src/editor/analyzers.ts
@@ -17,7 +17,7 @@ import type {
     FcstmAstUnaryExpression,
 } from '../ast';
 import type {FcstmSemanticDocument, FcstmSemanticImport, FcstmSemanticTransition} from '../semantics';
-import {FcstmDiagnostic, TextDocumentLike} from '../utils/text';
+import {FcstmDiagnostic, rangeIsEmptyOrInvalid, TextDocumentLike} from '../utils/text';
 import {getWorkspaceGraph} from '../workspace';
 import {findIdentifierRange} from './ranges';
 
@@ -716,11 +716,6 @@ function pushIdentifierDiagnostic(
         code,
         data: mergedData,
     });
-}
-
-function rangeIsEmptyOrInvalid(range: import('../utils/text').TextRange): boolean {
-    if (range.end.line < range.start.line) return true;
-    return range.end.line === range.start.line && range.end.character <= range.start.character;
 }
 
 /**

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -8,6 +8,7 @@ import {collectSemanticAnalysisDiagnosticsFromSemantic} from './analyzers';
 import {
     createRange,
     FcstmDiagnostic,
+    rangeIsEmptyOrInvalid,
     TextDocumentLike,
     TextRange,
 } from '../utils/text';
@@ -69,11 +70,6 @@ function rangeEquals(left: TextRange, right: TextRange): boolean {
         left.start.character === right.start.character &&
         left.end.line === right.end.line &&
         left.end.character === right.end.character;
-}
-
-function rangeIsEmptyOrInvalid(range: TextRange): boolean {
-    if (range.end.line < range.start.line) return true;
-    return range.end.line === range.start.line && range.end.character <= range.start.character;
 }
 
 function isDslIdentifier(value: string): boolean {
@@ -257,7 +253,13 @@ export function convertParseErrorToDiagnostic(
     };
 }
 
-function shouldSuppressParseRecoveryDiagnostic(
+/**
+ * Return whether a semantic diagnostic should be hidden after parser recovery.
+ *
+ * The collector only calls this when parse diagnostics already exist, keeping
+ * normal semantic diagnostics untouched for syntactically valid documents.
+ */
+export function shouldSuppressParseRecoveryDiagnostic(
     diagnostic: FcstmDiagnostic,
     parseDiagnostics: readonly FcstmDiagnostic[],
 ): boolean {

--- a/editors/jsfcstm/src/editor/diagnostics.ts
+++ b/editors/jsfcstm/src/editor/diagnostics.ts
@@ -71,6 +71,15 @@ function rangeEquals(left: TextRange, right: TextRange): boolean {
         left.end.character === right.end.character;
 }
 
+function rangeIsEmptyOrInvalid(range: TextRange): boolean {
+    if (range.end.line < range.start.line) return true;
+    return range.end.line === range.start.line && range.end.character <= range.start.character;
+}
+
+function isDslIdentifier(value: string): boolean {
+    return /^[A-Za-z_][A-Za-z0-9_]*$/.test(value);
+}
+
 function documentUri(document: TextDocumentLike): string {
     const filePath = document.filePath || document.uri?.fsPath;
     return filePath ? pathToFileURL(filePath).toString() : 'untitled:fcstm';
@@ -248,11 +257,32 @@ export function convertParseErrorToDiagnostic(
     };
 }
 
+function shouldSuppressParseRecoveryDiagnostic(
+    diagnostic: FcstmDiagnostic,
+    parseDiagnostics: readonly FcstmDiagnostic[],
+): boolean {
+    if (!diagnostic.code || parseDiagnostics.length === 0) return false;
+    if (diagnostic.code === 'E_UNDEFINED_VAR') {
+        const varName = typeof diagnostic.data?.var_name === 'string' ? diagnostic.data.var_name : '';
+        if (varName.length === 0 || !isDslIdentifier(varName)) return true;
+    }
+    if (diagnostic.code === 'E_TYPE_MISMATCH') {
+        const exprText = typeof diagnostic.data?.expr_text === 'string' ? diagnostic.data.expr_text : '';
+        if (exprText.length === 0) return true;
+    }
+    if (diagnostic.code === 'W_UNREFERENCED_VAR') {
+        const varName = typeof diagnostic.data?.var_name === 'string' ? diagnostic.data.var_name : '';
+        if (varName.length === 0 || !isDslIdentifier(varName)) return true;
+    }
+    return rangeIsEmptyOrInvalid(diagnostic.range);
+}
+
 export async function collectDocumentDiagnostics(
     document: TextDocumentLike
 ): Promise<FcstmDiagnostic[]> {
     const parseResult = await getParser().parse(document.getText());
-    const diagnostics = parseResult.errors.map(error => convertParseErrorToDiagnostic(error, document));
+    const parseDiagnostics = parseResult.errors.map(error => convertParseErrorToDiagnostic(error, document));
+    const diagnostics = [...parseDiagnostics];
     diagnostics.push(...await getImportWorkspaceIndex().collectImportDiagnostics(document));
     const snapshot = await getWorkspaceGraph().buildSnapshotForDocument(document);
     const node = snapshot.nodes[snapshot.rootFile];
@@ -263,5 +293,5 @@ export async function collectDocumentDiagnostics(
             diagnostics.push(...collectInspectModelDiagnostics(document, node.semantic, localModel, diagnostics));
         }
     }
-    return diagnostics;
+    return diagnostics.filter(diagnostic => !shouldSuppressParseRecoveryDiagnostic(diagnostic, parseDiagnostics));
 }

--- a/editors/jsfcstm/src/utils/text.ts
+++ b/editors/jsfcstm/src/utils/text.ts
@@ -95,6 +95,11 @@ export function createRange(
     };
 }
 
+export function rangeIsEmptyOrInvalid(range: TextRange): boolean {
+    if (range.end.line < range.start.line) return true;
+    return range.end.line === range.start.line && range.end.character <= range.start.character;
+}
+
 export function cloneRange(range: TextRange): TextRange {
     return createRange(
         range.start.line,

--- a/editors/jsfcstm/test/diagnostics-parse-recovery.test.ts
+++ b/editors/jsfcstm/test/diagnostics-parse-recovery.test.ts
@@ -1,15 +1,9 @@
 import assert from 'node:assert/strict';
 
-import {createDocument, packageModule, sliceByRange} from './support';
+import {createDocument, editorModule, packageModule, sliceByRange} from './support';
 
 const SEMANTIC_RECOVERY_CODES = new Set(['E_UNDEFINED_VAR', 'E_TYPE_MISMATCH']);
 const DSL_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
-
-function rangeIsEmptyOrInvalid(range: {start: {line: number; character: number}; end: {line: number; character: number}}): boolean {
-    if (range.end.line < range.start.line) return true;
-    if (range.end.line === range.start.line && range.end.character <= range.start.character) return true;
-    return false;
-}
 
 function rangeKey(range: {start: {line: number; character: number}; end: {line: number; character: number}}): string {
     return `${range.start.line}:${range.start.character}-${range.end.line}:${range.end.character}`;
@@ -70,7 +64,7 @@ describe('diagnostics parse recovery', () => {
             const semanticDiagnostics = diagnostics.filter(item => item.code !== undefined);
             const semanticRecoveryDiagnostics = semanticDiagnostics.filter(item => SEMANTIC_RECOVERY_CODES.has(String(item.code)));
             const invalidSemanticDiagnostics = semanticRecoveryDiagnostics.filter(item => (
-                rangeIsEmptyOrInvalid(item.range)
+                packageModule.rangeIsEmptyOrInvalid(item.range)
                 || sliceByRange(testCase.text, item.range).length === 0
                 || item.data?.var_name === ''
                 || item.data?.expr_text === ''
@@ -88,7 +82,7 @@ describe('diagnostics parse recovery', () => {
                 [],
             );
 
-            const zeroWidthSemanticDiagnostics = semanticDiagnostics.filter(item => rangeIsEmptyOrInvalid(item.range));
+            const zeroWidthSemanticDiagnostics = semanticDiagnostics.filter(item => packageModule.rangeIsEmptyOrInvalid(item.range));
             assert.deepEqual(
                 zeroWidthSemanticDiagnostics.map(item => ({
                     code: item.code,
@@ -116,4 +110,114 @@ describe('diagnostics parse recovery', () => {
             );
         });
     }
+
+    it('suppresses final recovery diagnostics with empty data or zero-width ranges', () => {
+        const parseDiagnostic = {
+            range: packageModule.createRange(0, 8, 0, 9),
+            message: 'parse error',
+            severity: 'error' as const,
+            source: 'fcstm',
+        };
+        const parseDiagnostics = [parseDiagnostic];
+        const makeDiagnostic = (
+            code: string,
+            data: Record<string, unknown>,
+            range = packageModule.createRange(0, 4, 0, 5),
+        ) => ({
+            range,
+            message: code,
+            severity: 'error' as const,
+            source: 'fcstm',
+            code,
+            data,
+        });
+
+        assert.equal(packageModule.shouldSuppressParseRecoveryDiagnostic(parseDiagnostic, parseDiagnostics), false);
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('E_UNDEFINED_VAR', {var_name: ''}),
+                parseDiagnostics,
+            ),
+            true,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('E_UNDEFINED_VAR', {var_name: '1bad'}),
+                parseDiagnostics,
+            ),
+            true,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('E_UNDEFINED_VAR', {var_name: 'valid_name'}),
+                parseDiagnostics,
+            ),
+            false,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('E_TYPE_MISMATCH', {expr_text: ''}),
+                parseDiagnostics,
+            ),
+            true,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('E_TYPE_MISMATCH', {expr_text: 'x'}),
+                parseDiagnostics,
+            ),
+            false,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('W_UNREFERENCED_VAR', {var_name: 'not-a-name'}),
+                parseDiagnostics,
+            ),
+            true,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('W_UNREFERENCED_VAR', {var_name: 'unused'}),
+                parseDiagnostics,
+            ),
+            false,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('W_SOME_FUTURE_RECOVERY', {}, packageModule.createRange(1, 2, 1, 2)),
+                parseDiagnostics,
+            ),
+            true,
+        );
+        assert.equal(
+            packageModule.shouldSuppressParseRecoveryDiagnostic(
+                makeDiagnostic('E_UNDEFINED_VAR', {var_name: ''}),
+                [],
+            ),
+            false,
+        );
+    });
+
+    it('shares the range emptiness predicate across analyzer and final-filter guards', () => {
+        assert.equal(packageModule.rangeIsEmptyOrInvalid(packageModule.createRange(1, 2, 0, 9)), true);
+        assert.equal(packageModule.rangeIsEmptyOrInvalid(packageModule.createRange(1, 2, 1, 2)), true);
+        assert.equal(packageModule.rangeIsEmptyOrInvalid(packageModule.createRange(1, 2, 1, 3)), false);
+    });
+
+    it('does not emit type mismatches for recovered empty expressions', () => {
+        const diagnostics: unknown[] = [];
+        editorModule.checkExpression({
+            expressionKind: 'identifier',
+            name: '',
+            range: packageModule.createRange(0, 0, 0, 0),
+        }, 'boolean', diagnostics);
+        editorModule.checkExpression({
+            expressionKind: 'identifier',
+            name: 'x',
+            text: 'x',
+            range: packageModule.createRange(0, 3, 0, 3),
+        }, 'boolean', diagnostics);
+
+        assert.deepEqual(diagnostics, []);
+    });
 });

--- a/editors/jsfcstm/test/diagnostics-parse-recovery.test.ts
+++ b/editors/jsfcstm/test/diagnostics-parse-recovery.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+
+import {createDocument, packageModule, sliceByRange} from './support';
+
+const SEMANTIC_RECOVERY_CODES = new Set(['E_UNDEFINED_VAR', 'E_TYPE_MISMATCH']);
+const DSL_IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function rangeIsEmptyOrInvalid(range: {start: {line: number; character: number}; end: {line: number; character: number}}): boolean {
+    if (range.end.line < range.start.line) return true;
+    if (range.end.line === range.start.line && range.end.character <= range.start.character) return true;
+    return false;
+}
+
+function rangeKey(range: {start: {line: number; character: number}; end: {line: number; character: number}}): string {
+    return `${range.start.line}:${range.start.character}-${range.end.line}:${range.end.character}`;
+}
+
+describe('diagnostics parse recovery', () => {
+    const cases = [
+        {
+            name: 'integer identifier used as a guard condition',
+            text: [
+                'def int x = 0;',
+                'state Root {',
+                '    state A;',
+                '    state B;',
+                '    [*] -> A;',
+                '    A -> B : if [x];',
+                '}',
+            ].join('\n'),
+        },
+        {
+            name: 'missing variable name in a definition',
+            text: [
+                'def int = 0;',
+                'state Root;',
+            ].join('\n'),
+        },
+        {
+            name: 'empty transition guard',
+            text: [
+                'state Root {',
+                '    state A;',
+                '    state B;',
+                '    [*] -> A;',
+                '    A -> B : if [];',
+                '}',
+            ].join('\n'),
+        },
+        {
+            name: 'empty assignment RHS in an action block',
+            text: [
+                'def int x = 0;',
+                'state Root {',
+                '    state A { enter { y = ; } }',
+                '    [*] -> A;',
+                '}',
+            ].join('\n'),
+        },
+    ];
+
+    for (const testCase of cases) {
+        it(`keeps parse diagnostics but suppresses empty semantic diagnostics for ${testCase.name}`, async () => {
+            const document = createDocument(testCase.text, `/tmp/parse-recovery-${testCase.name}.fcstm`);
+            const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+            const parseDiagnostics = diagnostics.filter(item => item.code === undefined);
+            assert.ok(parseDiagnostics.length > 0, `expected parse diagnostic for ${testCase.name}: ${JSON.stringify(diagnostics)}`);
+
+            const parseRanges = new Set(parseDiagnostics.map(item => rangeKey(item.range)));
+            const semanticDiagnostics = diagnostics.filter(item => item.code !== undefined);
+            const semanticRecoveryDiagnostics = semanticDiagnostics.filter(item => SEMANTIC_RECOVERY_CODES.has(String(item.code)));
+            const invalidSemanticDiagnostics = semanticRecoveryDiagnostics.filter(item => (
+                rangeIsEmptyOrInvalid(item.range)
+                || sliceByRange(testCase.text, item.range).length === 0
+                || item.data?.var_name === ''
+                || item.data?.expr_text === ''
+                || parseRanges.has(rangeKey(item.range))
+            ));
+
+            assert.deepEqual(
+                invalidSemanticDiagnostics.map(item => ({
+                    code: item.code,
+                    message: item.message,
+                    range: item.range,
+                    slice: sliceByRange(testCase.text, item.range),
+                    data: item.data,
+                })),
+                [],
+            );
+
+            const zeroWidthSemanticDiagnostics = semanticDiagnostics.filter(item => rangeIsEmptyOrInvalid(item.range));
+            assert.deepEqual(
+                zeroWidthSemanticDiagnostics.map(item => ({
+                    code: item.code,
+                    message: item.message,
+                    range: item.range,
+                    slice: sliceByRange(testCase.text, item.range),
+                    data: item.data,
+                })),
+                [],
+            );
+
+            const invalidVariableNameDiagnostics = diagnostics.filter(item => (
+                typeof item.data?.var_name === 'string'
+                && !DSL_IDENTIFIER_PATTERN.test(item.data.var_name)
+            ));
+            assert.deepEqual(
+                invalidVariableNameDiagnostics.map(item => ({
+                    code: item.code,
+                    message: item.message,
+                    range: item.range,
+                    slice: sliceByRange(testCase.text, item.range),
+                    data: item.data,
+                })),
+                [],
+            );
+        });
+    }
+});


### PR DESCRIPTION
## 背景

本 PR 是 issue #133 的 PR-C 分片，接在已合入的 PR-A / PR-B1 / PR-B2 / PR-B3 与 PR-D1 之后，继续收敛 jsfcstm/VSCode 诊断 range/source-slice 契约中的 parse-recovery 问题。

已完成的相关分片：

- PR-A #134：拆开 published diagnostic range 与 quick-fix edit range，修复 `W_DEADLOCK_LEAF` / `W_INITIAL_UNCONDITIONAL_MISSING` 等错行问题。
- PR-B1 #135：让 transition body 类诊断锚定 transition / guard / effect 等真实源码范围。
- PR-B2 #137：让 `W_FORCED_OVERRIDES_NORMAL` 主范围锚定 forced declaration，并将 normal transition 作为 relatedInformation 暴露。
- PR-B3 #139：让 declaration signature 类诊断锚定 named action / event declaration，并补 relatedInformation 与 source-local boundary。
- PR-D1 #136：为 pyfcstm model 保留 DSL source span 基础设施。

## 本 PR-C 范围

本 PR 只处理 jsfcstm 侧 parse recovery 后继续产生的空对象 / 零宽 semantic diagnostics，覆盖 issue #133 中的 **I3：parse recovery 后可能产生空 identifier / zero-width semantic diagnostics**。

目标行为：

- parse diagnostic 仍然保留，用户需要看到语法错误本身；
- parse recovery 后派生出来的空 `var_name`、空 `expr_text` 或零宽 range 的 semantic diagnostic 不再发布到最终 diagnostics；
- analyzer emit-site 对空 identifier、空 expression text 和零宽/非法 range 做防御性早返；
- final collector 在存在 parse diagnostic 的情况下，对空/非法 `var_name`、空 `expr_text` 和零宽 semantic range 做最终过滤；
- 最终 `collectDocumentDiagnostics()` 输出中不应出现无意义的 zero-width semantic diagnostic。

目标示例：

- `if [x]` 这类非法 guard recovery 场景；
- `def int = 0;` 这类缺变量名场景；
- `A -> B : if [];` 这类空 guard 场景；
- `enter { y = ; }` 这类空 assignment RHS 场景。

## 非目标

- 不修改 grammar / parser / ANTLR 生成文件。
- 不改变 verify / inspect 算法语义。
- 不处理 PR-D2 的 pyfcstm analyzer emit-site span 填充。
- 不做 PR-E 的 schema/codes.yaml 契约文档和 cross-end parity source-slice 收口。
- 不扩大到 transition body、forced override 或 declaration signature range；这些已经分别由 PR-B1 / PR-B2 / PR-B3 处理。

## 实现说明

- 在 `editors/jsfcstm/src/editor/analyzers.ts` 中：
  - `pushIdentifierDiagnostic()` 对空 `identifier.name` 与零宽/非法 range 早返；
  - `emitTypeMismatch()` 对空 `expr.text` 与零宽/非法 range 早返。
- 在 `editors/jsfcstm/src/editor/diagnostics.ts` 中：
  - 新增并导出 `shouldSuppressParseRecoveryDiagnostic()`，只在 parse diagnostics 已存在时启用；
  - 对 `E_UNDEFINED_VAR` / `W_UNREFERENCED_VAR` 的空或非法 `var_name` 做最终过滤；
  - 对 `E_TYPE_MISMATCH` 的空 `expr_text` 做最终过滤；
  - 对其他 semantic diagnostic 的零宽/非法 range 做兜底过滤。
- 在 `editors/jsfcstm/src/utils/text.ts` 中：
  - 共享 `rangeIsEmptyOrInvalid()`，避免 analyzer 和 collector 的 range 判定漂移。
- 在 `editors/jsfcstm/test/diagnostics-parse-recovery.test.ts` 中：
  - 覆盖真实 parser recovery fixture；
  - 直接覆盖 final-filter helper 的 empty data / invalid identifier / zero-width / no-parse bypass 分支；
  - 覆盖 recovered empty expression 不再产生 type mismatch。

## 本地验证

已完成本地验证：

- `cd editors/jsfcstm && npm run build`
- `cd editors/jsfcstm && npx mocha --require ts-node/register/transpile-only --extension ts test/diagnostics-parse-recovery.test.ts --reporter spec`
  - 7 passing
- `cd editors/jsfcstm && npm run test:coverage`
  - 624 passing
  - statements/lines 95.66%，branches 85.95%，functions 96.00%
  - `src/editor/diagnostics.ts` 已提升到 99.33% lines
- `source venv/bin/activate && make rst_auto`
- `source venv/bin/activate && SKIP_SLOW_TESTS=1 make unittest`
  - 8976 passed, 164 skipped, 63 deselected

## 当前状态

实现 commit 已推送到本 PR，正在等待 GitHub Actions 与 Codecov 针对最新 head 更新。CI / Codecov 更新后会按 3 reviewer 模式进行中文强审查：

1. codex reviewer；
2. claude reviewer；
3. deepseek reviewer。

每个 reviewer 会独立在 PR comment 中亮明身份，并按 C/I/M（critical/important/minor）分级给出审查结论。
