### PR TITLE
fix(simulate): make speculative validation rollback complete

### DIFF
--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -1137,10 +1137,14 @@ class SimulationRuntime:
 
             # Check if this is an anonymous abstract (no name)
             if func.name is None:
+                if is_validation_mode:
+                    self.logger.debug(f'[VALIDATION] Skip anonymous abstract function {func_path}')
+                    return
+
                 # Generate a unique key for this anonymous abstract
                 anonymous_key = id(func)
 
-                # Warn only once per anonymous abstract
+                # Warn only once per anonymous abstract during committed execution.
                 if anonymous_key not in self._warned_anonymous_abstracts:
                     warnings.warn(
                         f'Abstract action at {func_path} has no name. '
@@ -1151,10 +1155,7 @@ class SimulationRuntime:
                     )
                     self._warned_anonymous_abstracts.add(anonymous_key)
 
-                if is_validation_mode:
-                    self.logger.debug(f'[VALIDATION] Skip anonymous abstract function {func_path}')
-                else:
-                    self.logger.info(f'Execute anonymous abstract function {func_path} (no handlers supported)')
+                self.logger.info(f'Execute anonymous abstract function {func_path} (no handlers supported)')
                 return
 
             # Named abstract - check for handlers
@@ -2089,17 +2090,42 @@ class SimulationRuntime:
         snapshot_vars = copy.deepcopy(self.vars)
         snapshot_initialized = self._initialized
         snapshot_ended = self._ended
+        snapshot_warned_anonymous = set(self._warned_anonymous_abstracts)
+        snapshot_handler_errors = list(self._abstract_handler_errors)
 
-        sim_stack = self._clone_stack(self.stack)
-        sim_vars = copy.deepcopy(self.vars)
-        sim_initialized = self._initialized
-        sim_ended = self._ended
+        validation_stack = self._clone_stack(snapshot_stack)
+        validation_vars = copy.deepcopy(snapshot_vars)
+        validation_initialized = snapshot_initialized
+        validation_ended = snapshot_ended
 
-        if not sim_initialized:
-            sim_ended = self._initialize_context(sim_stack, sim_vars, d_events)
-            sim_initialized = True
+        if not validation_initialized:
+            validation_ended = self._initialize_context(
+                validation_stack,
+                validation_vars,
+                d_events,
+                is_validation_mode=True,
+            )
+            validation_initialized = True
 
-        success, sim_ended = self._run_cycle_on_context(sim_stack, sim_vars, d_events, ended=sim_ended)
+        success, validation_ended = self._run_cycle_on_context(
+            validation_stack,
+            validation_vars,
+            d_events,
+            ended=validation_ended,
+            is_validation_mode=True,
+        )
+
+        if success:
+            sim_stack = self._clone_stack(snapshot_stack)
+            sim_vars = copy.deepcopy(snapshot_vars)
+            sim_initialized = snapshot_initialized
+            sim_ended = snapshot_ended
+
+            if not sim_initialized:
+                sim_ended = self._initialize_context(sim_stack, sim_vars, d_events)
+                sim_initialized = True
+
+            success, sim_ended = self._run_cycle_on_context(sim_stack, sim_vars, d_events, ended=sim_ended)
 
         if success:
             self.stack = [] if sim_ended else sim_stack
@@ -2139,12 +2165,13 @@ class SimulationRuntime:
         else:
             self.vars = snapshot_vars
             self._ended = snapshot_ended
+            self._warned_anonymous_abstracts = snapshot_warned_anonymous
+            self._abstract_handler_errors = snapshot_handler_errors
             if not snapshot_initialized and not snapshot_ended:
                 self.stack = self._create_root_rollback_stack()
-                self._initialized = True
             else:
                 self.stack = snapshot_stack
-                self._initialized = snapshot_initialized
+            self._initialized = snapshot_initialized
             self.logger.warning(
                 f'Cycle {self.cycle_count + 1} failed - Unable to reach a stoppable state, changes rolled back')
 

--- a/test/fixtures/simulate_semantics/README.md
+++ b/test/fixtures/simulate_semantics/README.md
@@ -45,7 +45,7 @@ Use this checklist before deleting or replacing any inline original test:
 - The YAML cycle/event sequence matches the original call sequence exactly.
 - Event input strings are not rewritten to a different path form.
 - Every helper assertion and every bare assertion has a YAML equivalent.
-- `caplog` warnings use `logs`.
+- Runtime log assertions use `logs`; Python warning assertions use `warnings`.
 - `brief_stack` assertions use `stack`.
 - `set(runtime.vars.keys())` and temporary-variable non-leakage use
   `vars_keys` and/or `vars_absent`.
@@ -53,6 +53,8 @@ Use this checklist before deleting or replacing any inline original test:
   rollback state/vars assertions when the original checked them.
 - CLI tests keep output assertions under `output_contains` /
   `output_not_contains` / `error_contains`.
+- Abstract-handler callbacks use `handlers` plus `handler_calls`; log-mode
+  handler error metadata uses `abstract_handler_errors`.
 - Python API shape tests that YAML cannot represent, such as tuple or State
   object hot-start inputs, stay as dedicated Python tests.
 
@@ -126,6 +128,9 @@ inline files are removed.
 | `event_path_mixed_formats_relative` | simulation, generated_python_alignment | ended, return, state, vars | `test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats`<br>`test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats` |
 | `event_path_parent_relative` | simulation, generated_python_alignment | ended, return, state, vars | `test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_201_flexible_path_parent_relative`<br>`test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_201_flexible_path_parent_relative` |
 | `expression_failure_raises_expression_error` | simulation | ended, exception, state, vars | `test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_200_dsl_expression_failure_raises_expression_error` |
+| `failed_cycle_rolls_back_logged_abstract_handler_errors` | simulation | abstract_handler_errors, cycle_count, ended, handler_calls, return, stack, state, vars | [issue #143 comment](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614012639) |
+| `failed_initial_cycle_preserves_root_entry_lifecycle` | simulation | cycle_count, ended, return, stack, state, vars | [issue #143 comment](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134) |
+| `failed_initial_cycle_skips_abstract_handler_callbacks` | simulation | cycle_count, ended, handler_calls, return, stack, state, vars | [issue #143 comment](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134) |
 | `hot_start_composite_state_with_init` | simulation | initial, state, vars, stack, return, ended | `test/simulate/test_hot_start.py::TestHotStartCompositeState::test_hot_start_from_composite_state_with_init` |
 | `hot_start_leaf_state` | simulation | initial, state, vars, stack, return, ended | `test/simulate/test_hot_start.py::TestHotStartLeafState::test_hot_start_from_leaf_state_string_path` |
 | `hot_start_skips_enter_actions` | simulation | initial, state, vars, return, ended | `test/simulate/test_hot_start.py::TestHotStartWithLifecycleActions::test_hot_start_skips_enter_actions` |
@@ -140,6 +145,7 @@ inline files are removed.
 | `if_blocks_during_temp_reassigned` | simulation, generated_python_alignment | state, vars, return, ended | `test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions`<br>`test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions` |
 | `if_blocks_during_then_without_else` | simulation, generated_python_alignment | state, vars, return, ended | `test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions`<br>`test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions` |
 | `if_blocks_exit_effect_enter_actions` | simulation, generated_python_alignment | state, vars, return, ended | `test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_exit_effect_and_enter_actions`<br>`test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_exit_effect_and_enter_actions` |
+| `rejected_transition_candidate_defers_anonymous_warning` | simulation | cycle_count, ended, return, stack, state, vars, warnings | [issue #143 comment](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614148256) |
 | `scenario_ac_charger_session_control_normal` | simulation, generated_python_alignment | ended, return, state, vars | `test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control`<br>`test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control` |
 | `scenario_ac_charger_session_control_unplug` | simulation, generated_python_alignment | ended, return, state, vars | `test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control`<br>`test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control` |
 | `scenario_ats_mains_generator_transfer_outage` | simulation, generated_python_alignment | ended, return, state, vars | `test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_104_ats_mains_generator_transfer`<br>`test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_104_ats_mains_generator_transfer` |

--- a/test/fixtures/simulate_semantics/cases/failed_cycle_rolls_back_logged_abstract_handler_errors.fcstm
+++ b/test/fixtures/simulate_semantics/cases/failed_cycle_rolls_back_logged_abstract_handler_errors.fcstm
@@ -1,0 +1,8 @@
+def int x = 0;
+state Root {
+    pseudo state A {
+        during abstract Boom;
+    }
+
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/failed_cycle_rolls_back_logged_abstract_handler_errors.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_cycle_rolls_back_logged_abstract_handler_errors.yaml
@@ -1,0 +1,52 @@
+schema_version: 1
+id: failed_cycle_rolls_back_logged_abstract_handler_errors
+title: Failed cycle rolls back logged abstract handler errors
+source:
+  fcstm: failed_cycle_rolls_back_logged_abstract_handler_errors.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614012639
+  assertion_types:
+  - abstract_handler_errors
+  - cycle_count
+  - ended
+  - handler_calls
+  - return
+  - stack
+  - state
+  - vars
+  notes:
+  - Tracks failed-cycle rollback of log-mode abstract-handler errors.
+categories:
+- runtime
+- validation
+- abstract
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+runtime_options:
+  abstract_error_mode: log
+handlers:
+- action: Root.A.Boom
+  behavior: raise_error
+  exception:
+    type: ValueError
+    message: boom
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    vars:
+      x: 0
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    cycle_count: 0
+    handler_calls: []
+    abstract_handler_errors: []
+    return: null

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.fcstm
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.fcstm
@@ -1,0 +1,14 @@
+def int x = 0;
+state Root {
+    enter {
+        x = x + 1;
+    }
+
+    state A {
+        during {
+            x = x + 10;
+        }
+    }
+
+    [*] -> A :: Start;
+}

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
@@ -1,0 +1,61 @@
+schema_version: 1
+id: failed_initial_cycle_preserves_root_entry_lifecycle
+title: Failed initial cycle preserves root entry lifecycle on later success
+source:
+  fcstm: failed_initial_cycle_preserves_root_entry_lifecycle.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134
+  assertion_types:
+  - cycle_count
+  - ended
+  - return
+  - stack
+  - state
+  - vars
+  notes:
+  - Tracks failed-initial-cycle rollback of root entry lifecycle state.
+categories:
+- runtime
+- validation
+- lifecycle
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+steps:
+- cycle:
+    events: []
+  expect:
+    state:
+    - Root
+    vars:
+      x: 0
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    cycle_count: 0
+    return: null
+- cycle:
+    events:
+    - Root.Start
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      x: 11
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    - path:
+      - Root
+      - A
+      mode: active
+    cycle_count: 1
+    return: null

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.fcstm
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.fcstm
@@ -1,0 +1,8 @@
+def int x = 0;
+state Root {
+    enter abstract RootInit;
+
+    state A;
+
+    [*] -> A :: Start;
+}

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.yaml
@@ -1,0 +1,46 @@
+schema_version: 1
+id: failed_initial_cycle_skips_abstract_handler_callbacks
+title: Failed initial cycle skips abstract handler callbacks
+source:
+  fcstm: failed_initial_cycle_skips_abstract_handler_callbacks.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134
+  assertion_types:
+  - cycle_count
+  - ended
+  - handler_calls
+  - return
+  - stack
+  - state
+  - vars
+  notes:
+  - Tracks speculative initial-cycle isolation for abstract handlers.
+categories:
+- runtime
+- validation
+- abstract
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+handlers:
+- action: Root.RootInit
+  behavior: record_call
+steps:
+- cycle:
+    events: []
+  expect:
+    state:
+    - Root
+    vars:
+      x: 0
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    cycle_count: 0
+    handler_calls: []
+    return: null

--- a/test/fixtures/simulate_semantics/cases/rejected_transition_candidate_defers_anonymous_warning.fcstm
+++ b/test/fixtures/simulate_semantics/cases/rejected_transition_candidate_defers_anonymous_warning.fcstm
@@ -1,0 +1,23 @@
+def int x = 0;
+state Root {
+    state A;
+
+    state Bad {
+        enter abstract /* anonymous action */;
+
+        state Done;
+
+        [*] -> Done : if [x < 0];
+    }
+
+    state Good {
+        during {
+            x = -1;
+        }
+    }
+
+    [*] -> A;
+    A -> Bad :: Go;
+    A -> Good :: Go;
+    Good -> Bad :: TryBad;
+}

--- a/test/fixtures/simulate_semantics/cases/rejected_transition_candidate_defers_anonymous_warning.yaml
+++ b/test/fixtures/simulate_semantics/cases/rejected_transition_candidate_defers_anonymous_warning.yaml
@@ -1,0 +1,100 @@
+schema_version: 1
+id: rejected_transition_candidate_defers_anonymous_warning
+title: Rejected transition candidate defers anonymous abstract warning
+source:
+  fcstm: rejected_transition_candidate_defers_anonymous_warning.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614148256
+  assertion_types:
+  - cycle_count
+  - ended
+  - return
+  - stack
+  - state
+  - vars
+  - warnings
+  notes:
+  - Tracks validation-only anonymous abstract warning isolation.
+categories:
+- runtime
+- validation
+- abstract
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      x: 0
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    - path:
+      - Root
+      - A
+      mode: active
+    cycle_count: 1
+    return: null
+- cycle:
+    events:
+    - Root.A.Go
+  expect:
+    state:
+    - Root
+    - Good
+    vars:
+      x: -1
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    - path:
+      - Root
+      - Good
+      mode: active
+    cycle_count: 2
+    warnings:
+      count: 0
+    return: null
+- cycle:
+    events:
+    - Root.Good.TryBad
+  expect:
+    state:
+    - Root
+    - Bad
+    - Done
+    vars:
+      x: -1
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    - path:
+      - Root
+      - Bad
+      mode: init_wait
+    - path:
+      - Root
+      - Bad
+      - Done
+      mode: active
+    cycle_count: 3
+    warnings:
+      count: 1
+      contains:
+      - category: UserWarning
+        message: Root.Bad.<unnamed>
+        match_kind: substring
+    return: null

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -27,9 +27,10 @@ with a diagnostic containing the case id and YAML path.
 | `categories` | yes | Non-empty list from the allowed category set. |
 | `runners` | yes | Non-empty list from the allowed runner set. |
 | `initial` | no | Runtime construction state and vars. |
+| `runtime_options` | no | Simulation-only runtime options such as abstract-handler error mode. |
 | `steps` | conditional | Required for runtime/alignment runners. Mutually exclusive with `commands`. |
 | `commands` | conditional | Required for CLI runner. Mutually exclusive with `steps`. |
-| `handlers` | reserved | Reserved for future abstract-handler fixture extensions. |
+| `handlers` | no | Simulation-only abstract-handler fixtures for recording calls or raising errors. |
 | `expected_failure` | reserved | Reserved for inactive regression fixtures that should not run in the main corpus. |
 
 Allowed categories:
@@ -56,6 +57,62 @@ Allowed runners:
 
 `cli_command` must be the only runner in a case. Runtime/alignment cases use
 `steps`; CLI cases use `commands`.
+
+`runtime_options` and `handlers` are accepted only for simulation-only cases.
+They are rejected when `generated_python_alignment` is present, because the
+generated Python runtime runner intentionally covers the shared public runtime
+surface and does not install Python callback handlers.
+
+## Runtime options
+
+```yaml
+runtime_options:
+  abstract_error_mode: log
+```
+
+Allowed fields:
+
+- `abstract_error_mode`: `raise` or `log`, passed to
+  `SimulationRuntime(..., abstract_error_mode=...)`.
+
+Unknown runtime option fields are rejected. Add new options deliberately in the
+schema and loader tests instead of silently accepting ignored data.
+
+## Abstract-handler fixtures
+
+Handlers let simulation-only cases express callback side effects in YAML:
+
+```yaml
+handlers:
+  - action: Root.RootInit
+    behavior: record_call
+  - action: Root.A.Boom
+    behavior: raise_error
+    exception:
+      type: ValueError
+      message: boom
+```
+
+Allowed handler behaviors:
+
+- `record_call`: registers a handler that appends a call record.
+- `raise_error`: registers a handler that appends a call record and then raises
+  the configured exception.
+
+Handler call records have this shape:
+
+```yaml
+action: Root.RootInit
+state: Root
+stage: enter
+vars:
+  x: 0
+```
+
+Only `ValueError` is currently supported for `raise_error`, because the fixture
+corpus only needs a deterministic user-handler exception class for simulator
+rollback semantics. If another exception family is needed, extend the allowed
+set together with schema-negative tests.
 
 ## Runtime steps
 
@@ -106,6 +163,9 @@ parent-relative paths (`.go`), and root-relative paths (`/go`).
 | `return` | Expected `cycle()` return value. |
 | `raises` | Expected exception class name and optional message match. |
 | `logs` | Step-local `caplog` assertions. |
+| `warnings` | Step-local Python warning assertions. Simulation-only. |
+| `handler_calls` | Exact accumulated fixture-handler call records. Simulation-only. |
+| `abstract_handler_errors` | Expected `runtime.abstract_handler_errors` records. Simulation-only. |
 
 Allowed stack modes are `active` and `init_wait`.
 
@@ -159,6 +219,54 @@ includes the case id, step index, expected message, level, and actual records in
 failure messages. `logs` only allows `contains` and `not_contains`; each log
 matcher only allows `level`, `message`, and `match_kind`.
 
+## Warnings
+
+```yaml
+expect:
+  warnings:
+    count: 1
+    contains:
+      - category: UserWarning
+        message: Root.Bad.<unnamed>
+        match_kind: substring
+    not_contains:
+      - category: UserWarning
+        message: validation-only
+        match_kind: substring
+```
+
+Warnings are captured per step only when `warnings` is present. `count`, when
+present, asserts the exact number of warning records emitted during that step.
+`contains` and `not_contains` use the same `substring` / `regex` match policy as
+logs. The only allowed category name in this schema version is `UserWarning`.
+
+## Handler calls and handler errors
+
+```yaml
+expect:
+  handler_calls:
+    - action: Root.RootInit
+      state: Root
+      stage: enter
+      vars:
+        x: 0
+  abstract_handler_errors:
+    - action: Root.A.Boom
+      type: ValueError
+      message: boom
+      match_kind: substring
+```
+
+`handler_calls` is an exact accumulated-list assertion over the fixture handlers
+registered by the top-level `handlers` field. Use `handler_calls: []` to prove a
+failed speculative execution did not invoke any handler.
+
+`abstract_handler_errors` matches the public
+`SimulationRuntime.abstract_handler_errors` list. Each item may assert `action`,
+`type`, and `message`; `message` supports `substring` or `regex` via
+`match_kind`. Use `abstract_handler_errors: []` to prove failed rollback did not
+leave committed error metadata.
+
 ## Generated Python alignment runner
 
 `generated_python_alignment` builds a `SimulationRuntime` and a generated Python
@@ -178,7 +286,9 @@ at construction time and after every step:
 Even when YAML does not contain an explicit `stack` assertion, the alignment
 runner compares both stacks internally. `cycle_count` is rejected for generated
 alignment cases because the generated runtime does not expose it as a public
-contract.
+contract. `runtime_options`, `handlers`, `warnings`, `handler_calls`, and
+`abstract_handler_errors` are also rejected for generated alignment cases in
+this schema version.
 
 ## CLI command cases
 
@@ -210,6 +320,6 @@ strings. `should_exit`, when present, must be a boolean.
 
 ## Reserved fields
 
-`handlers`, `expected_failure`, `error_state`, and `error_info` are intentionally
-not active in this schema version. Any extension that needs them must update this
-schema and the loader tests rather than silently accepting ignored data.
+`expected_failure`, `error_state`, and `error_info` are intentionally not active
+in this schema version. Any extension that needs them must update this schema
+and the loader tests rather than silently accepting ignored data.

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -16,7 +16,7 @@ from test.testings.simulate_semantics import (
 def test_all_semantic_fixtures_load():
     cases = iter_semantic_cases()
 
-    assert len(cases) >= 77
+    assert len(cases) >= 81
     assert {case.id for case in cases}
 
 
@@ -83,6 +83,10 @@ def _set_cli_expectation(data, expect):
     data["commands"] = [{"input": "help", "expect": expect}]
 
 
+def _set_generated_alignment(data):
+    data["runners"] = ["simulation", "generated_python_alignment"]
+
+
 @pytest.mark.unittest
 @pytest.mark.parametrize(
     ["mutate", "message"],
@@ -94,8 +98,72 @@ def _set_cli_expectation(data, expect):
             "exactly one of steps or commands is required",
         ),
         (
-            lambda data: data.update({"handlers": []}),
-            "handlers is reserved",
+            lambda data: data.update({"handlers": "Root.Init"}),
+            "handlers must be a list",
+        ),
+        (
+            lambda data: data.update({"handlers": [{"action": "Root.Init"}]}),
+            "handlers\\[0\\].behavior is required",
+        ),
+        (
+            lambda data: data.update(
+                {"handlers": [{"action": "Root.Init", "behavior": "unknown_behavior"}]}
+            ),
+            "handlers\\[0\\].behavior is invalid",
+        ),
+        (
+            lambda data: data.update(
+                {
+                    "handlers": [
+                        {
+                            "action": "Root.Init",
+                            "behavior": "record_call",
+                            "exception": {"type": "ValueError"},
+                        }
+                    ]
+                }
+            ),
+            "handlers\\[0\\].exception is only allowed for raise_error",
+        ),
+        (
+            lambda data: data.update(
+                {
+                    "handlers": [
+                        {
+                            "action": "Root.Init",
+                            "behavior": "raise_error",
+                            "exception": {"type": "KeyError"},
+                        }
+                    ]
+                }
+            ),
+            "handlers\\[0\\].exception.type is invalid",
+        ),
+        (
+            lambda data: (
+                _set_generated_alignment(data)
+                or data.update(
+                    {"handlers": [{"action": "Root.Init", "behavior": "record_call"}]}
+                )
+            ),
+            "handlers are only supported by simulation-only cases",
+        ),
+        (
+            lambda data: data.update({"runtime_options": {"unknown": "value"}}),
+            "runtime_options has unknown fields",
+        ),
+        (
+            lambda data: data.update(
+                {"runtime_options": {"abstract_error_mode": "unknown"}}
+            ),
+            "runtime_options.abstract_error_mode is invalid",
+        ),
+        (
+            lambda data: (
+                _set_generated_alignment(data)
+                or data.update({"runtime_options": {"abstract_error_mode": "log"}})
+            ),
+            "runtime_options are only supported by simulation-only cases",
         ),
         (
             lambda data: data.update({"expected_failure": {"reason": "known bug"}}),
@@ -146,10 +214,63 @@ def _set_cli_expectation(data, expect):
         ),
         (
             lambda data: (
-                data.update({"runners": ["simulation", "generated_python_alignment"]})
+                _set_generated_alignment(data)
                 or data["steps"][0]["expect"].update({"cycle_count": 1})
             ),
             "cycle_count is not allowed for generated alignment",
+        ),
+        (
+            lambda data: (
+                _set_generated_alignment(data)
+                or data["steps"][0]["expect"].update({"warnings": {"count": 0}})
+            ),
+            "fields are not allowed for generated alignment",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"warnings": {"count": -1}}),
+            "warnings.count must be a non-negative integer",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"warnings": {"contains": {"message": "x"}}}
+            ),
+            "warnings.contains must be a list",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"warnings": {"contains": [{"category": "UserWarning"}]}}
+            ),
+            "warnings.contains\\[0\\].message is required",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"warnings": {"contains": [{"message": "x", "category": "Warning"}]}}
+            ),
+            "warnings.contains\\[0\\].category is invalid",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"handler_calls": {"action": "Root.Init"}}
+            ),
+            "handler_calls must be a list",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"handler_calls": [{"action": "Root.Init"}]}
+            ),
+            "handler_calls\\[0\\] missing fields",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"abstract_handler_errors": [{"message": "boom", "match_kind": "glob"}]}
+            ),
+            "abstract_handler_errors\\[0\\].match_kind is invalid",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"abstract_handler_errors": [{"match_kind": "regex"}]}
+            ),
+            "abstract_handler_errors\\[0\\].match_kind requires message",
         ),
         (
             lambda data: data["steps"][0]["expect"].update(

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -4,6 +4,7 @@ import importlib.util
 import logging
 import os
 import re
+import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from tempfile import TemporaryDirectory
@@ -37,6 +38,7 @@ _ALLOWED_TOP_LEVEL_FIELDS = {
     "categories",
     "runners",
     "initial",
+    "runtime_options",
     "steps",
     "commands",
     "handlers",
@@ -73,6 +75,9 @@ _ALLOWED_EXPECT_FIELDS = {
     "return",
     "raises",
     "logs",
+    "warnings",
+    "handler_calls",
+    "abstract_handler_errors",
 }
 _ALLOWED_INITIAL_EXPECT_FIELDS = {
     "state",
@@ -105,6 +110,17 @@ _ALLOWED_STACK_FIELDS = {"path", "mode"}
 _ALLOWED_RAISES_FIELDS = {"type", "match", "match_kind"}
 _ALLOWED_LOG_FIELDS = {"contains", "not_contains"}
 _ALLOWED_LOG_ITEM_FIELDS = {"level", "message", "match_kind"}
+_ALLOWED_RUNTIME_OPTION_FIELDS = {"abstract_error_mode"}
+_ALLOWED_ABSTRACT_ERROR_MODES = {"raise", "log"}
+_ALLOWED_HANDLER_FIELDS = {"action", "behavior", "exception"}
+_ALLOWED_HANDLER_BEHAVIORS = {"record_call", "raise_error"}
+_ALLOWED_HANDLER_EXCEPTION_FIELDS = {"type", "message"}
+_ALLOWED_HANDLER_EXCEPTION_TYPES = {"ValueError"}
+_ALLOWED_WARNING_FIELDS = {"contains", "not_contains", "count"}
+_ALLOWED_WARNING_ITEM_FIELDS = {"category", "message", "match_kind"}
+_ALLOWED_WARNING_CATEGORIES = {"UserWarning"}
+_ALLOWED_HANDLER_CALL_FIELDS = {"action", "state", "stage", "vars"}
+_ALLOWED_ABSTRACT_HANDLER_ERROR_FIELDS = {"action", "type", "message", "match_kind"}
 _CLI_OUTPUT_FIELDS = ("output_contains", "output_not_contains", "error_contains")
 _EXCEPTION_TYPES = {
     "SimulationRuntimeDfsError": SimulationRuntimeDfsError,
@@ -203,8 +219,108 @@ def _runtime_stack(runtime: Any) -> List[Tuple[Tuple[str, ...], str]]:
     return [(tuple(path), mode) for path, mode in runtime.brief_stack]
 
 
-def _assert_runtime_expectation(
+def _assert_handler_calls(
+    expect: Mapping[str, Any],
+    handler_calls: Optional[Sequence[Mapping[str, Any]]],
+    case: SemanticCase,
+    field_path: str,
+) -> None:
+    if "handler_calls" not in expect:
+        return
+    if handler_calls is None:
+        raise _case_error(
+            case.id,
+            case.yaml_path,
+            "%s.handler_calls requires registered fixture handlers" % field_path,
+        )
+    expected_calls = [dict(item) for item in expect["handler_calls"]]
+    actual_calls = [dict(item) for item in handler_calls]
+    assert actual_calls == expected_calls, "%s %s handler_calls mismatch: %r != %r" % (
+        case.id,
+        field_path,
+        actual_calls,
+        expected_calls,
+    )
+
+
+def _assert_abstract_handler_errors(
     runtime: Any, expect: Mapping[str, Any], case: SemanticCase, field_path: str
+) -> None:
+    if "abstract_handler_errors" not in expect:
+        return
+    expected_errors = expect["abstract_handler_errors"]
+    actual_errors = [
+        {
+            "action": action_path,
+            "type": type(error).__name__,
+            "message": str(error),
+        }
+        for action_path, error in runtime.abstract_handler_errors
+    ]
+    assert len(actual_errors) == len(expected_errors), (
+        "%s %s abstract_handler_errors length mismatch: %r != %r"
+        % (
+            case.id,
+            field_path,
+            actual_errors,
+            expected_errors,
+        )
+    )
+    for index, expected in enumerate(expected_errors):
+        actual = actual_errors[index]
+        if "action" in expected:
+            assert actual["action"] == expected["action"], (
+                "%s %s abstract_handler_errors[%d].action mismatch: %r != %r"
+                % (
+                    case.id,
+                    field_path,
+                    index,
+                    actual["action"],
+                    expected["action"],
+                )
+            )
+        if "type" in expected:
+            assert actual["type"] == expected["type"], (
+                "%s %s abstract_handler_errors[%d].type mismatch: %r != %r"
+                % (
+                    case.id,
+                    field_path,
+                    index,
+                    actual["type"],
+                    expected["type"],
+                )
+            )
+        if "message" in expected:
+            match_kind = expected.get("match_kind", "substring")
+            if match_kind == "substring":
+                matched = expected["message"] in actual["message"]
+            elif match_kind == "regex":
+                matched = re.search(expected["message"], actual["message"]) is not None
+            else:
+                raise _case_error(
+                    case.id,
+                    case.yaml_path,
+                    "%s.abstract_handler_errors[%d].match_kind is invalid"
+                    % (field_path, index),
+                )
+            assert matched, (
+                "%s %s abstract_handler_errors[%d].message mismatch: %r did not match %r"
+                % (
+                    case.id,
+                    field_path,
+                    index,
+                    actual["message"],
+                    expected["message"],
+                )
+            )
+
+
+def _assert_runtime_expectation(
+    runtime: Any,
+    expect: Mapping[str, Any],
+    case: SemanticCase,
+    field_path: str,
+    handler_calls: Optional[Sequence[Mapping[str, Any]]] = None,
 ) -> None:
     if "ended" in expect:
         actual_ended = bool(getattr(runtime, "is_ended"))
@@ -291,6 +407,9 @@ def _assert_runtime_expectation(
             )
         )
 
+    _assert_handler_calls(expect, handler_calls, case, field_path)
+    _assert_abstract_handler_errors(runtime, expect, case, field_path)
+
 
 def _assert_logs(
     expect: Mapping[str, Any], caplog: Any, case: SemanticCase, field_path: str
@@ -344,6 +463,62 @@ def _assert_logs(
             )
 
 
+def _warning_matches(item: Mapping[str, Any], warning_item: Any) -> bool:
+    category = item.get("category")
+    if category is not None and warning_item.category.__name__ != category:
+        return False
+    message = str(item["message"])
+    warning_message = str(warning_item.message)
+    match_kind = item.get("match_kind", "substring")
+    if match_kind == "substring":
+        return message in warning_message
+    if match_kind == "regex":
+        return re.search(message, warning_message) is not None
+    return False
+
+
+def _assert_warnings(
+    expect: Mapping[str, Any],
+    warning_records: Optional[Sequence[Any]],
+    case: SemanticCase,
+    field_path: str,
+) -> None:
+    warning_expect = expect.get("warnings")
+    if warning_expect is None:
+        return
+    if warning_records is None:
+        raise _case_error(
+            case.id,
+            case.yaml_path,
+            "%s.warnings requires warning capture" % field_path,
+        )
+    rendered = [
+        "%s:%s" % (record.category.__name__, record.message)
+        for record in warning_records
+    ]
+    if "count" in warning_expect:
+        assert len(warning_records) == warning_expect["count"], (
+            "%s %s warnings count mismatch: %r != %r; records=%r"
+            % (
+                case.id,
+                field_path,
+                len(warning_records),
+                warning_expect["count"],
+                rendered,
+            )
+        )
+    for group_name, should_exist in (("contains", True), ("not_contains", False)):
+        for item in warning_expect.get(group_name, []) or []:
+            found = any(_warning_matches(item, record) for record in warning_records)
+            assert found is should_exist, "%s %s warning %s %r failed; records=%r" % (
+                case.id,
+                field_path,
+                group_name,
+                item,
+                rendered,
+            )
+
+
 def _assert_exception(
     exc: BaseException, expect: Mapping[str, Any], case: SemanticCase, field_path: str
 ) -> None:
@@ -393,6 +568,16 @@ def _capture_logs_if_needed(expect: Mapping[str, Any], caplog: Any):
         yield
 
 
+@contextmanager
+def _capture_warnings_if_needed(expect: Mapping[str, Any]):
+    if "warnings" in expect:
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            yield records
+    else:
+        yield None
+
+
 def _step_events(
     cycle_data: Any, case: SemanticCase, field_path: str
 ) -> Optional[List[Any]]:
@@ -422,41 +607,57 @@ def _run_step(
     case: SemanticCase,
     index: int,
     caplog: Any = None,
+    handler_calls: Optional[Sequence[Mapping[str, Any]]] = None,
 ) -> None:
     field_path = "steps[%d]" % index
     if "expect_initial" in step:
         expect = step["expect_initial"]
         _assert_runtime_expectation(
-            runtime, expect, case, field_path + ".expect_initial"
+            runtime,
+            expect,
+            case,
+            field_path + ".expect_initial",
+            handler_calls=handler_calls,
         )
         return
 
     expect = step.get("expect") or {}
     events = _step_events(step.get("cycle", {}), case, field_path)
     with _capture_logs_if_needed(expect, caplog):
-        if "raises" in expect:
-            try:
-                runtime.cycle(events)
-            except Exception as err:
-                # Runtime/generator errors intentionally propagate through the
-                # fixture contract; expected semantic errors are matched here.
-                _assert_exception(err, expect, case, field_path + ".expect.raises")
+        with _capture_warnings_if_needed(expect) as warning_records:
+            if "raises" in expect:
+                try:
+                    runtime.cycle(events)
+                except Exception as err:
+                    # Runtime/generator errors intentionally propagate through the
+                    # fixture contract; expected semantic errors are matched here.
+                    _assert_exception(err, expect, case, field_path + ".expect.raises")
+                else:
+                    raise AssertionError(
+                        "%s %s expected exception %r"
+                        % (case.id, field_path, expect["raises"])
+                    )
             else:
-                raise AssertionError(
-                    "%s %s expected exception %r"
-                    % (case.id, field_path, expect["raises"])
-                )
-        else:
-            result = runtime.cycle(events)
-            if "return" in expect:
-                assert result == expect["return"], "%s %s return mismatch: %r != %r" % (
-                    case.id,
-                    field_path,
-                    result,
-                    expect["return"],
-                )
-    _assert_runtime_expectation(runtime, expect, case, field_path + ".expect")
+                result = runtime.cycle(events)
+                if "return" in expect:
+                    assert result == expect["return"], (
+                        "%s %s return mismatch: %r != %r"
+                        % (
+                            case.id,
+                            field_path,
+                            result,
+                            expect["return"],
+                        )
+                    )
+    _assert_runtime_expectation(
+        runtime,
+        expect,
+        case,
+        field_path + ".expect",
+        handler_calls=handler_calls,
+    )
     _assert_logs(expect, caplog, case, field_path + ".expect")
+    _assert_warnings(expect, warning_records, case, field_path + ".expect")
 
 
 def _strip_ansi(text: str) -> str:
@@ -481,6 +682,52 @@ def _initial_kwargs(case: SemanticCase) -> Dict[str, Any]:
     if initial.get("vars") is not None:
         kwargs["initial_vars"] = dict(initial["vars"])
     return kwargs
+
+
+def _simulation_kwargs(case: SemanticCase) -> Dict[str, Any]:
+    kwargs = _initial_kwargs(case)
+    kwargs.update(dict(case.data.get("runtime_options") or {}))
+    return kwargs
+
+
+def _handler_call_record(ctx: Any) -> Dict[str, Any]:
+    return {
+        "action": ctx.action_name,
+        "state": ctx.get_full_state_path(),
+        "stage": ctx.action_stage,
+        "vars": dict(ctx.vars),
+    }
+
+
+def _register_fixture_handlers(
+    runtime: SimulationRuntime, case: SemanticCase
+) -> List[Mapping[str, Any]]:
+    calls = []
+    for handler_data in case.data.get("handlers") or []:
+        action_path = handler_data["action"]
+        behavior = handler_data["behavior"]
+        if behavior == "record_call":
+
+            def record_handler(ctx, handler_calls=calls):
+                handler_calls.append(_handler_call_record(ctx))
+
+            runtime.register_abstract_handler(action_path, record_handler)
+        elif behavior == "raise_error":
+            exception_data = handler_data.get("exception") or {}
+            message = exception_data.get("message", "fixture handler error")
+
+            def raising_handler(ctx, handler_calls=calls, error_message=message):
+                handler_calls.append(_handler_call_record(ctx))
+                raise ValueError(error_message)
+
+            runtime.register_abstract_handler(action_path, raising_handler)
+        else:
+            raise _case_error(
+                case.id,
+                case.yaml_path,
+                "handlers behavior is invalid: %r" % behavior,
+            )
+    return calls
 
 
 class _GeneratedPythonAlignmentRuntime:
@@ -636,20 +883,29 @@ def _build_generated_runtime(case: SemanticCase) -> Any:
 
 def _build_simulation_runtime(case: SemanticCase) -> SimulationRuntime:
     return SimulationRuntime(
-        build_state_machine_from_case(case), **_initial_kwargs(case)
+        build_state_machine_from_case(case), **_simulation_kwargs(case)
     )
 
 
 def run_simulation_case(case: SemanticCase, caplog: Any = None) -> None:
     """Run a semantic fixture against :class:`SimulationRuntime`."""
     runtime = _build_simulation_runtime(case)
+    handler_calls = _register_fixture_handlers(runtime, case)
     for index, step in enumerate(case.data.get("steps") or []):
-        _run_step(runtime, step, case, index, caplog=caplog)
+        _run_step(
+            runtime,
+            step,
+            case,
+            index,
+            caplog=caplog,
+            handler_calls=handler_calls,
+        )
 
 
 def run_generated_python_alignment_case(case: SemanticCase, caplog: Any = None) -> None:
     """Run a semantic fixture against simulation and generated Python runtimes."""
     simulation_runtime = _build_simulation_runtime(case)
+    _register_fixture_handlers(simulation_runtime, case)
     generated_runtime = _build_generated_runtime(case)
     runtime = _GeneratedPythonAlignmentRuntime(
         simulation_runtime, generated_runtime, case.dsl_code
@@ -929,6 +1185,187 @@ def _validate_logs(
                 )
 
 
+def _validate_warnings(
+    expect: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> None:
+    warning_expect = expect.get("warnings")
+    if warning_expect is None:
+        return
+    if not isinstance(warning_expect, dict):
+        raise _case_error(
+            case_id, yaml_path, "%s.warnings must be a mapping" % field_path
+        )
+    unknown = set(warning_expect.keys()) - _ALLOWED_WARNING_FIELDS
+    if unknown:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.warnings has unknown fields: %r" % (field_path, sorted(unknown)),
+        )
+    if "count" in warning_expect:
+        count = warning_expect["count"]
+        if not isinstance(count, int) or count < 0:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.warnings.count must be a non-negative integer" % field_path,
+            )
+    for group_name in ("contains", "not_contains"):
+        group_items = warning_expect.get(group_name, []) or []
+        if not isinstance(group_items, list):
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.warnings.%s must be a list" % (field_path, group_name),
+            )
+        for index, item in enumerate(group_items):
+            if not isinstance(item, dict):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.warnings.%s[%d] must be a mapping"
+                    % (field_path, group_name, index),
+                )
+            unknown_item = set(item.keys()) - _ALLOWED_WARNING_ITEM_FIELDS
+            if unknown_item:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.warnings.%s[%d] has unknown fields: %r"
+                    % (field_path, group_name, index, sorted(unknown_item)),
+                )
+            if "message" not in item:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.warnings.%s[%d].message is required"
+                    % (field_path, group_name, index),
+                )
+            if not isinstance(item["message"], str):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.warnings.%s[%d].message must be a string"
+                    % (field_path, group_name, index),
+                )
+            if item.get("match_kind", "substring") not in {"substring", "regex"}:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.warnings.%s[%d].match_kind is invalid"
+                    % (field_path, group_name, index),
+                )
+            category = item.get("category")
+            if category is not None and category not in _ALLOWED_WARNING_CATEGORIES:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.warnings.%s[%d].category is invalid: %r"
+                    % (field_path, group_name, index, category),
+                )
+
+
+def _validate_handler_calls(
+    expect: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if "handler_calls" not in expect:
+        return
+    calls = expect["handler_calls"]
+    if not isinstance(calls, list):
+        raise _case_error(
+            case_id, yaml_path, "%s.handler_calls must be a list" % field_path
+        )
+    for index, item in enumerate(calls):
+        if not isinstance(item, dict):
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.handler_calls[%d] must be a mapping" % (field_path, index),
+            )
+        unknown = set(item.keys()) - _ALLOWED_HANDLER_CALL_FIELDS
+        if unknown:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.handler_calls[%d] has unknown fields: %r"
+                % (field_path, index, sorted(unknown)),
+            )
+        missing = _ALLOWED_HANDLER_CALL_FIELDS - set(item.keys())
+        if missing:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.handler_calls[%d] missing fields: %r"
+                % (field_path, index, sorted(missing)),
+            )
+        for field_name in ("action", "state", "stage"):
+            if not isinstance(item[field_name], str):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.handler_calls[%d].%s must be a string"
+                    % (field_path, index, field_name),
+                )
+        _validate_vars_mapping(
+            item["vars"],
+            case_id,
+            yaml_path,
+            "%s.handler_calls[%d].vars" % (field_path, index),
+        )
+
+
+def _validate_abstract_handler_errors(
+    expect: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if "abstract_handler_errors" not in expect:
+        return
+    errors = expect["abstract_handler_errors"]
+    if not isinstance(errors, list):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.abstract_handler_errors must be a list" % field_path,
+        )
+    for index, item in enumerate(errors):
+        if not isinstance(item, dict):
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.abstract_handler_errors[%d] must be a mapping"
+                % (field_path, index),
+            )
+        unknown = set(item.keys()) - _ALLOWED_ABSTRACT_HANDLER_ERROR_FIELDS
+        if unknown:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.abstract_handler_errors[%d] has unknown fields: %r"
+                % (field_path, index, sorted(unknown)),
+            )
+        for field_name in ("action", "type", "message"):
+            if field_name in item and not isinstance(item[field_name], str):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.abstract_handler_errors[%d].%s must be a string"
+                    % (field_path, index, field_name),
+                )
+        if item.get("match_kind", "substring") not in {"substring", "regex"}:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.abstract_handler_errors[%d].match_kind is invalid"
+                % (field_path, index),
+            )
+        if "match_kind" in item and "message" not in item:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.abstract_handler_errors[%d].match_kind requires message"
+                % (field_path, index),
+            )
+
+
 def _validate_path_segments(
     value: Any, case_id: str, yaml_path: str, field_path: str
 ) -> None:
@@ -982,6 +1419,20 @@ def _validate_expect(
             yaml_path,
             "%s.cycle_count is not allowed for generated alignment" % field_path,
         )
+    if "generated_python_alignment" in runners:
+        generated_only_fields = {
+            "abstract_handler_errors",
+            "handler_calls",
+            "warnings",
+        }
+        overlap = generated_only_fields & set(expect.keys())
+        if overlap:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s fields are not allowed for generated alignment: %r"
+                % (field_path, sorted(overlap)),
+            )
     if "state" in expect:
         _validate_path_segments(
             expect["state"], case_id, yaml_path, field_path + ".state"
@@ -1000,6 +1451,9 @@ def _validate_expect(
     _validate_stack(expect, case_id, yaml_path, field_path)
     _validate_raises(expect, case_id, yaml_path, field_path)
     _validate_logs(expect, case_id, yaml_path, field_path)
+    _validate_warnings(expect, case_id, yaml_path, field_path)
+    _validate_handler_calls(expect, case_id, yaml_path, field_path)
+    _validate_abstract_handler_errors(expect, case_id, yaml_path, field_path)
 
 
 def _validate_source(source: Any, case_id: str, yaml_path: str) -> None:
@@ -1058,6 +1512,128 @@ def _validate_initial(initial: Any, case_id: str, yaml_path: str) -> None:
         _validate_vars_mapping(initial.get("vars"), case_id, yaml_path, "initial.vars")
 
 
+def _validate_runtime_options(
+    options: Any, case_id: str, yaml_path: str, runners: Sequence[str]
+) -> None:
+    if options is None:
+        return
+    if "simulation" not in runners or "generated_python_alignment" in runners:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "runtime_options are only supported by simulation-only cases",
+        )
+    if not isinstance(options, dict):
+        raise _case_error(case_id, yaml_path, "runtime_options must be a mapping")
+    unknown = set(options.keys()) - _ALLOWED_RUNTIME_OPTION_FIELDS
+    if unknown:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "runtime_options has unknown fields: %r" % sorted(unknown),
+        )
+    if (
+        "abstract_error_mode" in options
+        and options["abstract_error_mode"] not in _ALLOWED_ABSTRACT_ERROR_MODES
+    ):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "runtime_options.abstract_error_mode is invalid: %r"
+            % options["abstract_error_mode"],
+        )
+
+
+def _validate_handlers(
+    handlers: Any, case_id: str, yaml_path: str, runners: Sequence[str]
+) -> None:
+    if handlers is None:
+        return
+    if "simulation" not in runners or "generated_python_alignment" in runners:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "handlers are only supported by simulation-only cases",
+        )
+    if not isinstance(handlers, list):
+        raise _case_error(case_id, yaml_path, "handlers must be a list")
+    for index, item in enumerate(handlers):
+        if not isinstance(item, dict):
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "handlers[%d] must be a mapping" % index,
+            )
+        unknown = set(item.keys()) - _ALLOWED_HANDLER_FIELDS
+        if unknown:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "handlers[%d] has unknown fields: %r" % (index, sorted(unknown)),
+            )
+        for field_name in ("action", "behavior"):
+            if field_name not in item:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "handlers[%d].%s is required" % (index, field_name),
+                )
+            if not isinstance(item[field_name], str):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "handlers[%d].%s must be a string" % (index, field_name),
+                )
+        if item["behavior"] not in _ALLOWED_HANDLER_BEHAVIORS:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "handlers[%d].behavior is invalid: %r" % (index, item["behavior"]),
+            )
+        if item["behavior"] == "record_call" and "exception" in item:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "handlers[%d].exception is only allowed for raise_error" % index,
+            )
+        exception_data = item.get("exception")
+        if item["behavior"] == "raise_error":
+            if exception_data is None:
+                exception_data = {}
+            if not isinstance(exception_data, dict):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "handlers[%d].exception must be a mapping" % index,
+                )
+            unknown_exception = (
+                set(exception_data.keys()) - _ALLOWED_HANDLER_EXCEPTION_FIELDS
+            )
+            if unknown_exception:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "handlers[%d].exception has unknown fields: %r"
+                    % (index, sorted(unknown_exception)),
+                )
+            exception_type = exception_data.get("type", "ValueError")
+            if exception_type not in _ALLOWED_HANDLER_EXCEPTION_TYPES:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "handlers[%d].exception.type is invalid: %r"
+                    % (index, exception_type),
+                )
+            if "message" in exception_data and not isinstance(
+                exception_data["message"], str
+            ):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "handlers[%d].exception.message must be a string" % index,
+                )
+
+
 def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
     case_id = str(data.get("id", "<unknown>"))
     unknown = set(data.keys()) - _ALLOWED_TOP_LEVEL_FIELDS
@@ -1096,6 +1672,8 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
         raise _case_error(
             case_id, yaml_path, "cli_command cannot be mixed with other runners"
         )
+    _validate_runtime_options(data.get("runtime_options"), case_id, yaml_path, runners)
+    _validate_handlers(data.get("handlers"), case_id, yaml_path, runners)
     has_steps = "steps" in data
     has_commands = "commands" in data
     if has_steps == has_commands:
@@ -1106,12 +1684,6 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
         raise _case_error(case_id, yaml_path, "cli_command cases require commands")
     if "cli_command" not in runners and not has_steps:
         raise _case_error(case_id, yaml_path, "runtime cases require steps")
-    if "handlers" in data:
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "handlers is reserved for abstract-handler fixture extensions",
-        )
     if "expected_failure" in data:
         raise _case_error(
             case_id,


### PR DESCRIPTION
## 子 PR：speculative validation / rollback metadata 修复

Parent umbrella: [PR #144](https://github.com/HansBug/pyfcstm/pull/144)  
Tracking issue: [issue #143](https://github.com/HansBug/pyfcstm/issues/143)  
Depends on: PR-0 fixture corpus [PR #145](https://github.com/HansBug/pyfcstm/pull/145)（已合入）

这个 PR 修复 `SimulationRuntime.cycle()` 在 speculative validation / failed-cycle rollback 期间的控制状态与 metadata 半提交问题。按最新要求，A-1 / A-2 / N-1 / E-3 的回归测试**全部接入 PR-0 的 semantic fixture 系统**；本 PR 不保留独立 `test/simulate/test_speculative_rollback.py` 之类的专门测试文件。

| ID | 当前状态 | Fixture case | Issue comment | 本 PR 处理边界 |
|---|---|---|---|---|
| A-1 | 🧪 本地已验证，CI 待确认 | `failed_initial_cycle_preserves_root_entry_lifecycle` | [A-1](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134) | 初始 cycle 失败后 `_initialized` 不半提交；后续成功初始化必须执行 root lifecycle。 |
| A-2 | 🧪 本地已验证，CI 待确认 | `failed_initial_cycle_skips_abstract_handler_callbacks` | [A-2](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134) | failed speculative cycle 不调用用户 abstract handler 产生不可回滚副作用。 |
| N-1 | 🧪 本地已验证，CI 待确认 | `rejected_transition_candidate_defers_anonymous_warning` | [N-1](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614148256) | validation-only 路径不发 anonymous abstract warning，也不污染 `_warned_anonymous_abstracts`。 |
| E-3 | 🧪 本地已验证，CI 待确认 | `failed_cycle_rolls_back_logged_abstract_handler_errors` | [E-3](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614012639) | `abstract_error_mode='log'` 下 failed cycle 不污染 `abstract_handler_errors`，也不重复记录未提交执行错误。 |

> 本 PR 不处理 E-1/E-2/E-4/E-5（归 [PR #144](https://github.com/HansBug/pyfcstm/pull/144) 中后续 abstract context/error contract 子项），不处理 B/S/W/V 生命周期与候选 fallback，不处理 hot-start/CLI/event/template alignment 其他类别。

---

## 自包含 bug 说明与复现

### A-1：初始 cycle 失败后 `_initialized` 半提交，后续成功初始化跳过 root `enter`

#### 最小 DSL

```fcstm
def int x = 0;
state Root {
    enter { x = x + 1; }
    state A { during { x = x + 10; } }
    [*] -> A :: Start;
}
```

#### 最小复现代码

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r'''
def int x = 0;
state Root {
    enter { x = x + 1; }
    state A { during { x = x + 10; } }
    [*] -> A :: Start;
}
'''


def build_runtime():
    ast = parse_with_grammar_entry(DSL, 'state_machine_dsl')
    model = parse_dsl_node_to_state_machine(ast)
    return SimulationRuntime(model)


def state(rt):
    return '(ended)' if rt.is_ended else '.'.join(rt.current_state.path)

fresh = build_runtime()
fresh.cycle(['Root.Start'])
print('fresh_success', state(fresh), fresh.vars, fresh.cycle_count, fresh._initialized)

after_failure = build_runtime()
after_failure.cycle([])
print('after_failed_cycle', state(after_failure), after_failure.vars, after_failure.cycle_count, after_failure._initialized)
after_failure.cycle(['Root.Start'])
print('success_after_failure', state(after_failure), after_failure.vars, after_failure.cycle_count, after_failure._initialized)
```

运行方式：

```bash
PYTHONPATH=. python /tmp/repro_a1.py
```

#### 期望结果

第一次 `cycle([])` 无法进入带 event 的 initial transition，应整体 rollback。后续 `cycle(['Root.Start'])` 成功时应与 fresh 成功初始化一致，执行 `Root.enter` 和 `A.during`：

```text
success_after_failure Root.A {'x': 11} 1 True
```

失败后 public-observable state 应仍在 root boundary，`cycle_count == 0`，且初始化控制状态不应导致后续 root lifecycle 被跳过。

#### 修复前实际结果

```text
Cycle 1 failed - Unable to reach a stoppable state, changes rolled back
fresh_success Root.A {'x': 11} 1 True
after_failed_cycle Root {'x': 0} 0 True
success_after_failure Root.A {'x': 10} 1 True
```

`vars` / stack 看似 rollback，但 `_initialized=True` 泄漏；第二次成功初始化跳过 `Root.enter`，`x` 只有 `A.during` 的 `+10`。

#### 语义原因

失败 cycle 需要 rollback 的不仅是 `vars` / stack，也包括 runtime 控制状态。`_initialized` 决定 root lifecycle 是否已进入；失败路径把它半提交等价于声明“root 已进入”，与“失败时回滚到 root boundary”矛盾。

---

### A-2：failed speculative cycle 会执行 abstract handler 外部副作用

#### 最小 DSL

```fcstm
def int x = 0;
state Root {
    enter abstract RootInit;
    state A;
    [*] -> A :: Start;
}
```

#### 最小复现代码

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r'''
def int x = 0;
state Root {
    enter abstract RootInit;
    state A;
    [*] -> A :: Start;
}
'''

ast = parse_with_grammar_entry(DSL, 'state_machine_dsl')
model = parse_dsl_node_to_state_machine(ast)
runtime = SimulationRuntime(model)
calls = []
runtime.register_abstract_handler(
    'Root.RootInit',
    lambda ctx: calls.append((ctx.action_name, ctx.get_full_state_path())),
)

runtime.cycle([])
print('after_failed_initial', '.'.join(runtime.current_state.path), dict(runtime.vars), calls, runtime.cycle_count, runtime._initialized)
```

运行方式：

```bash
PYTHONPATH=. python /tmp/repro_a2.py
```

#### 期望结果

失败的 speculative 初始化不能对用户 handler 产生不可回滚外部副作用：

```text
after_failed_initial Root {'x': 0} [] 0 False
```

至少 `calls` 必须为空。

#### 修复前实际结果

```text
Cycle 1 failed - Unable to reach a stoppable state, changes rolled back
after_failed_initial Root {'x': 0} [('Root.RootInit', 'Root')] 0 True
```

`cycle_count` 未增加，但 handler 已执行，外部列表被污染。

#### 语义原因

`_validate_transition()` 已经规定 validation 期间跳过 abstract handlers，避免 speculative execution 副作用。顶层 `cycle()` 在 clone context 上先模拟、成功才提交；如果本轮最终失败，这段 clone 模拟也应视作 speculative，不应调用用户 handler。

---

### N-1：validation 提前消费 anonymous abstract warning，真实执行时静默

#### 最小 DSL

```fcstm
def int x = 0;
state Root {
    state A;
    state Bad {
        enter abstract /* anonymous action */;
        state Done;
        [*] -> Done : if [x < 0];
    }
    state Good { during { x = -1; } }

    [*] -> A;
    A -> Bad :: Go;
    A -> Good :: Go;
    Good -> Bad :: TryBad;
}
```

#### 最小复现代码

```python
import warnings

from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r'''
def int x = 0;
state Root {
    state A;
    state Bad {
        enter abstract /* anonymous action */;
        state Done;
        [*] -> Done : if [x < 0];
    }
    state Good { during { x = -1; } }

    [*] -> A;
    A -> Bad :: Go;
    A -> Good :: Go;
    Good -> Bad :: TryBad;
}
'''

model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
rt = SimulationRuntime(model)
rt.cycle()

with warnings.catch_warnings(record=True) as first:
    warnings.simplefilter('always')
    rt.cycle(['Root.A.Go'])
print('after Go', rt.current_state.path, [str(w.message) for w in first])

with warnings.catch_warnings(record=True) as second:
    warnings.simplefilter('always')
    rt.cycle(['Root.Good.TryBad'])
print('after TryBad', rt.current_state.path, [str(w.message) for w in second])
```

运行方式：

```bash
PYTHONPATH=. python /tmp/repro_n1.py
```

#### 期望结果

`A -> Bad :: Go` 是 validation 候选路径且最终被拒绝；实际提交的是 `A -> Good :: Go`。因此第一轮 `Root.A.Go` 不应产生 anonymous abstract warning，也不应把该 action 记为已 warning。下一轮真正进入 `Root.Bad.Done` 时，才应发 warning。

#### 修复前实际结果

```text
after Go ('Root', 'Good') ['Abstract action at Root.Bad.<unnamed> has no name. ...']
after TryBad ('Root', 'Bad', 'Done') []
```

warning 在未提交路径上提前出现；真实执行时反而静默。

#### 语义原因

这个复现依赖同名 local event 的候选 fallback：`A -> Bad :: Go` 和 `A -> Good :: Go` 都匹配 `Root.A.Go`，runtime 按声明顺序先尝试 `Bad`；`Bad` 内部 initial guard `[x < 0]` 不满足，因此该候选不可稳定并应被 rejection/fallback，随后提交 `A -> Good :: Go`。

anonymous abstract warning 是用户可见 abstract-action 表面，与 handler 副作用同属 validation 不应污染的 metadata。修复前 `_execute_func()` 在判断 `is_validation_mode` 前先 `warnings.warn(...)` 并写入 `_warned_anonymous_abstracts`，导致 validation-only 路径污染去重状态。

---

### E-3：`abstract_error_mode='log'` 下 failed cycle 污染 `abstract_handler_errors`

#### 最小 DSL

```fcstm
def int x = 0;
state Root {
    pseudo state A {
        during abstract Boom;
    }
    [*] -> A;
}
```

`A` 是 pseudo leaf，无法稳定；初始 cycle 会失败并 rollback 到 root boundary。

#### 最小复现代码

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r'''
def int x = 0;
state Root {
    pseudo state A {
        during abstract Boom;
    }
    [*] -> A;
}
'''

model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
rt = SimulationRuntime(model, abstract_error_mode='log')


def boom(ctx):
    raise ValueError('boom')

rt.register_abstract_handler('Root.A.Boom', boom)
print('before', 'cycle', rt.cycle_count, 'history', rt.history, 'errors', rt.abstract_handler_errors)
rt.cycle()
print('after', 'cycle', rt.cycle_count, 'history', rt.history,
      'errors', [(p, type(e).__name__, str(e)) for p, e in rt.abstract_handler_errors])
```

运行方式：

```bash
PYTHONPATH=. python /tmp/repro_e3.py
```

#### 期望结果

失败并 rollback 的 cycle 不产生 committed history；同属本轮执行尝试的 internal error metadata 也不应暴露为已提交错误。至少不应重复记录未提交执行错误。

```text
after cycle 0 history [] errors []
```

#### 修复前实际结果

```text
before cycle 0 history [] errors []
after cycle 0 history [] errors [('Root.A.Boom', 'ValueError', 'boom'), ('Root.A.Boom', 'ValueError', 'boom')]
```

`cycle_count == 0`、`history == []`，但 `abstract_handler_errors` 记录了 2 条未提交执行错误。

#### 语义原因

`abstract_handler_errors` 是 runtime public-observable metadata。若 failed cycle rollback 到“没有成功 cycle / 没有 history”，error metadata 也必须参与 snapshot/rollback，或者在 speculative 模拟中不执行 handler / 不记录 log-mode errors。修复前只 rollback `stack` / `vars` / `_initialized` / `_ended`，遗漏 `_abstract_handler_errors`。

---

## 测试承载方式：全部进入 PR-0 semantic fixture 系统

本 PR 按用户要求复用 [PR #145](https://github.com/HansBug/pyfcstm/pull/145) 已合入的 fixture runner，不新增独立回归测试文件。

| Fixture id | DSL file | YAML 覆盖点 |
|---|---|---|
| `failed_initial_cycle_preserves_root_entry_lifecycle` | `test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.fcstm` | A-1：failed initial cycle 后 root boundary / `cycle_count=0` / 后续 `x=11`。 |
| `failed_initial_cycle_skips_abstract_handler_callbacks` | `test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.fcstm` | A-2：`handlers` + `handler_calls: []` 证明 failed speculative cycle 不执行 handler。 |
| `rejected_transition_candidate_defers_anonymous_warning` | `test/fixtures/simulate_semantics/cases/rejected_transition_candidate_defers_anonymous_warning.fcstm` | N-1：`warnings.count` 断言 rejected candidate 不 warning，真实 committed path 才 warning。 |
| `failed_cycle_rolls_back_logged_abstract_handler_errors` | `test/fixtures/simulate_semantics/cases/failed_cycle_rolls_back_logged_abstract_handler_errors.fcstm` | E-3：`runtime_options.abstract_error_mode: log`、`handler_calls: []`、`abstract_handler_errors: []`。 |

Fixture schema / helper 扩展：

- top-level `runtime_options`：当前支持 `abstract_error_mode`，仅 simulation-only。
- top-level `handlers`：支持 `record_call` 和 `raise_error`，仅 simulation-only。
- expectation `warnings`：按 step 捕获 Python warnings。
- expectation `handler_calls`：精确断言 fixture handler 调用记录。
- expectation `abstract_handler_errors`：断言 `SimulationRuntime.abstract_handler_errors`。
- `generated_python_alignment` 会拒绝上述 simulation-only 字段，避免生成 runtime alignment 误装 Python callback 或漂移到非公共契约。
- `test/fixtures/simulate_semantics/schema.md` 和 `README.md` 已同步说明，schema negative tests 已覆盖无效 handler/runtime_options/warnings/handler metadata。

---

## 代码修复摘要

- `_execute_func()`：anonymous abstract 在 validation mode 下直接跳过，不再 warning，不再写 `_warned_anonymous_abstracts`。
- `cycle()`：先使用 validation-only context 验证本轮可稳定；只有 validation success 后，才从 snapshot 重新执行 committed pass。
- failed rollback 覆盖：
  - stack / vars / `_ended`
  - `_initialized`
  - `_warned_anonymous_abstracts`
  - `_abstract_handler_errors`
- failed initial cycle 不再把 `_initialized` 写死为 `True`；后续真正成功初始化仍会执行 root lifecycle。

---

## TDD / 验证记录

红灯验证：临时还原 `pyfcstm/simulate/runtime.py` 到修复前状态后，新增 fixture cases 失败，失败点与 A-1/A-2/N-1/E-3 对应：

```bash
python -m pytest test/simulate/test_semantic_fixtures.py -q --tb=short \
  -k 'failed_initial_cycle or rejected_transition_candidate or logged_abstract_handler_errors'
```

修复前结果：4 failed，分别表现为 `x: 10 != 11`、handler call 泄漏、anonymous warning 提前出现、log-mode handler error/call 泄漏。

绿灯验证（当前 commit `0250e0cf`）：

```bash
python -m py_compile pyfcstm/simulate/runtime.py test/testings/simulate_semantics.py test/simulate/test_semantic_fixtures.py
python -m pytest test/simulate/test_semantic_fixtures.py -q --tb=short
python -m pytest test/template/python/test_semantic_fixture_alignment.py -q --tb=short
python -m pytest test/simulate/test_abstract_handlers.py -q --tb=short
python -m pytest test/simulate/test_semantic_fixtures.py -q --tb=short \
  -k 'failed_initial_cycle or rejected_transition_candidate or logged_abstract_handler_errors'
SKIP_SLOW_TESTS=1 make unittest
```

本地结果：

- semantic fixture tests：`125 passed`
- generated Python alignment fixture tests：`68 passed`
- abstract handler tests：`19 passed`
- focused regression fixture selection：`4 passed`
- `SKIP_SLOW_TESTS=1 make unittest`：`9105 passed, 164 skipped, 63 deselected`

---

## 验收标准

- [x] PR body 自包含说明 A-1/A-2/N-1/E-3 的复现代码、运行方式、期望结果、修复前实际结果、语义原因，并与 [issue #143](https://github.com/HansBug/pyfcstm/issues/143) / [PR #144](https://github.com/HansBug/pyfcstm/pull/144) 一致。
- [x] A-1/A-2/N-1/E-3 回归测试均接入 [PR #145](https://github.com/HansBug/pyfcstm/pull/145) 的 semantic fixture corpus；不保留独立回归测试文件。
- [x] Fixture schema 支持当前回归所需的 simulation-only runtime options、handlers、warnings、handler call records、abstract handler error metadata，并拒绝 generated alignment 不支持的字段。
- [x] 新增 regression fixtures 已红灯失败、绿灯通过，覆盖 A-1/A-2/N-1/E-3。
- [x] failed cycle rollback 后不再半提交 `_initialized`、anonymous-warning 去重状态、log-mode handler error metadata。
- [x] failed speculative cycle 不调用用户 abstract handlers 产生外部副作用。
- [x] 不处理非本 PR row；若发现相邻问题，记录到 [issue #143](https://github.com/HansBug/pyfcstm/issues/143) 或后续子项，不在本 PR 膨胀范围。
- [x] 本地 fast/full-with-slow-skipped tests 通过。
- [ ] CI 全绿。
- [ ] Codecov comment 已作为 review 输入；若出现 covered-line 回退，需解释或补测试。
- [ ] Post-code 3-agent review 完成；C/I 全部解决，M 尽量处理但不阻塞。
- [ ] [PR #144](https://github.com/HansBug/pyfcstm/pull/144) 进展表已更新；本 PR 合入后再回填 [issue #143](https://github.com/HansBug/pyfcstm/issues/143) 对应 row status。
- [ ] Do not merge until maintainer explicitly instructs.

---

## Reviewer instructions

请 reviewer 用中文直接在本 PR comment，亮明身份，并按 C/I/M 分类：

- **C / Critical**：阻塞；PR body 与 [issue #143](https://github.com/HansBug/pyfcstm/issues/143) / [PR #144](https://github.com/HansBug/pyfcstm/pull/144) 不一致、缺少自包含复现、fixture 化测试没有真实覆盖、范围错误、引入新语义漂移。
- **I / Important**：应修；复现或期望不够精确、fixture schema/runner 边界不清、和 PR-0 fixture 复用不完整、CI/coverage gate 不充分、覆盖行较修改前回退。
- **M / Minor**：不阻塞；措辞、格式、额外建议。

Post-code reviewer 重点检查：

1. 本 PR 与 [PR #144](https://github.com/HansBug/pyfcstm/pull/144) row routing 是否一致。
2. A-1/A-2/N-1/E-3 是否都通过 PR-0 semantic fixture system 承载，且没有独立新测试文件。
3. 迁移后的测试语义是否与复现保持一致，是否出现测试漂移或断言弱化。
4. runtime 修复是否真的隔离 speculative validation 和 committed execution，是否有新的同质 metadata 半提交漏洞。
5. 是否符合 AGENTS：代码命名按功能/语义，不使用 PR stage / workflow label 作为代码命名；测试树独立；无不合规 broad catch。
6. Codecov comment / covered-line 变化是否显示本 PR 造成之前覆盖过的生产行不再覆盖。

