### PR TITLE
修复模拟器事件输入归一化与结束后空操作语义

### DIFF
--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -704,14 +704,17 @@ class SimulationRuntime:
 
         return stack
 
-    def _parse_event(self, event: Union[str, Event]) -> Event:
+    def _parse_event(self, event: Any) -> Event:
         """
         Resolve an event reference into a concrete event object.
 
-        This method accepts either an event object (returned as-is) or a
-        dot-separated event path string. String paths are resolved using
-        intelligent resolution that supports both StateMachine and State
-        resolve_event methods for maximum flexibility.
+        This method accepts an event object (returned as-is), a dot-separated
+        event path string, or an event-like object exposing a ``path_name``
+        attribute. Event-like inputs are resolved by passing their ``path_name``
+        value through the same string path resolver used for direct string
+        inputs. String paths are resolved using intelligent resolution that
+        supports both StateMachine and State resolve_event methods for maximum
+        flexibility.
 
         **Path Resolution Strategy**:
 
@@ -731,11 +734,13 @@ class SimulationRuntime:
         - **Parent-relative**: ``.error`` or ``..system.error`` (State.resolve_event)
         - **Absolute**: ``/global.shutdown`` (State.resolve_event from root)
 
-        :param event: Event object or dot-separated event path string.
-        :type event: Union[str, Event]
+        :param event: Event object, dot-separated event path string, or
+            event-like object exposing ``path_name``.
+        :type event: Any
         :return: The resolved event instance.
         :rtype: Event
-        :raises TypeError: If ``event`` is neither a string nor an :class:`Event`.
+        :raises TypeError: If ``event`` is neither a string, an :class:`Event`,
+            nor an event-like object exposing a string ``path_name``.
         :raises SimulationRuntimeEventError: If the user-supplied event path
             cannot be resolved by any supported method.
 
@@ -784,7 +789,15 @@ class SimulationRuntime:
         """
         if isinstance(event, Event):
             return event
-        elif isinstance(event, str):
+        if not isinstance(event, str) and hasattr(event, 'path_name'):
+            path_name = getattr(event, 'path_name')
+            if not isinstance(path_name, str):
+                raise TypeError(
+                    'Event-like object path_name must be str, got '
+                    f'{type(path_name)!r} - {path_name!r}.'
+                )
+            event = path_name
+        if isinstance(event, str):
             from .utils import is_state_resolve_event_path
 
             # Check if runtime has ended (no current state)
@@ -829,8 +842,7 @@ class SimulationRuntime:
                             f"failed with both StateMachine.resolve_event and State.resolve_event. "
                             f"Last error: {e}"
                         ) from e
-        else:
-            raise TypeError(f'Unknown event type {type(event)!r} - {event!r}.')
+        raise TypeError(f'Unknown event type {type(event)!r} - {event!r}.')
 
     @staticmethod
     def _clone_stack(stack: List[_Frame]) -> List[_Frame]:
@@ -849,21 +861,48 @@ class SimulationRuntime:
         """
         return [_Frame(frame.state, frame.mode) for frame in stack]
 
-    def _normalize_events(self, events: Optional[List[Union[str, Event]]]) -> Tuple[List[Event], Dict[str, Event]]:
+    @staticmethod
+    def _is_single_event_input(events: Any) -> bool:
+        """Return whether ``events`` is one event value rather than a collection."""
+        return isinstance(events, (str, Event))
+
+    def _iter_event_inputs(self, events: Any) -> List[Any]:
+        """Normalize the public ``cycle(events=...)`` shape into event items."""
+        if events is None:
+            return []
+        if self._is_single_event_input(events):
+            return [events]
+        try:
+            return list(events)
+        except TypeError as e:
+            # TypeError: list(events) raises when the caller supplied a
+            # non-iterable object that is not one of the supported single-event
+            # shapes. Surface the same public unsupported-event diagnostic that
+            # item-level parsing uses.
+            raise TypeError(
+                f'Unknown event type {type(events)!r} - {events!r}.'
+            ) from e
+
+    def _normalize_events(self, events: Any) -> Tuple[List[Event], Dict[str, Event]]:
         """
         Normalize user-provided events into object and lookup forms.
 
-        The runtime accepts both event objects and string paths. This helper
-        resolves them into concrete :class:`Event` instances and also builds a
-        dictionary keyed by :attr:`Event.path_name` so transition
-        matching can perform constant-time membership checks.
+        The runtime accepts event objects, string paths, and iterables
+        containing event objects, string paths, or event-like objects exposing
+        ``path_name``. Bare strings and model event objects are treated as
+        single events, not as generic iterables. This helper resolves inputs
+        into concrete :class:`Event` instances and also builds a dictionary keyed
+        by :attr:`Event.path_name` so transition matching can perform
+        constant-time membership checks.
 
         :param events: Raw event inputs for the current execution attempt.
-        :type events: Optional[List[Union[str, Event]]]
+        :type events: Any
         :return: A pair containing the resolved event list and a name-indexed mapping.
         :rtype: Tuple[List[Event], Dict[str, Event]]
         """
-        event_objects = [self._parse_event(event) for event in list(events or [])]
+        event_objects = [
+            self._parse_event(event) for event in self._iter_event_inputs(events)
+        ]
         d_events = {event.path_name: event for event in event_objects}
         return event_objects, d_events
 
@@ -1852,7 +1891,7 @@ class SimulationRuntime:
 
         return True, True
 
-    def cycle(self, events: List[Union[str, Event]] = None):
+    def cycle(self, events: Any = None):
         """
         Execute a full runtime cycle until reaching a stable boundary.
 
@@ -1875,9 +1914,12 @@ class SimulationRuntime:
 
         **Event Handling**:
 
-        Events can be provided as either event objects or dot-separated path
-        strings. Multiple events can be active simultaneously, allowing complex
-        transition chains to execute in a single cycle.
+        Events can be provided as event objects, dot-separated path strings, or
+        iterables containing event objects, path strings, and event-like objects
+        exposing ``path_name``. A bare string is treated as one event path, not
+        as an iterable of characters. Multiple events can be active
+        simultaneously, allowing complex transition chains to execute in a
+        single cycle.
 
         **Flexible Event Path Formats**:
 
@@ -1912,9 +1954,11 @@ class SimulationRuntime:
         - For initial cycle: Pin runtime at root boundary in ``init_wait`` mode
         - All side effects from failed validation are discarded
 
-        :param events: Events available for the current cycle. Can be event
-            objects or dot-separated path strings.
-        :type events: List[Union[str, Event]], optional
+        :param events: Events available for the current cycle. Can be a single
+            event object, a dot-separated path string, or an iterable containing
+            event objects, path strings, and event-like objects exposing
+            ``path_name``.
+        :type events: Any, optional
         :return: ``None``.
         :rtype: None
 
@@ -1944,7 +1988,7 @@ class SimulationRuntime:
             ('System', 'Idle')
             >>> runtime.vars['counter']
             1
-            >>> runtime.cycle(['System.Idle.Start'])  # Transition to Active
+            >>> runtime.cycle('System.Idle.Start')  # Transition to Active
             >>> runtime.current_state.path
             ('System', 'Active')
 
@@ -2077,14 +2121,18 @@ class SimulationRuntime:
            :class:`SimulationRuntimeDfsError` is raised. This indicates an
            invalid state machine with unbounded execution chains.
         """
-        _, d_events = self._normalize_events(events)
         if self._ended:
             self.logger.warning('Runtime already ended, cycle ignored.')
             return
 
+        event_objects, d_events = self._normalize_events(events)
+
         # Log cycle start
-        event_names = [e.path_name if isinstance(e, Event) else e for e in (events or [])]
-        self.logger.info(f'Cycle {self.cycle_count + 1} starting with events: {event_names if event_names else "none"}')
+        event_names = [event.path_name for event in event_objects]
+        self.logger.info(
+            f'Cycle {self.cycle_count + 1} starting with events: '
+            f'{event_names if event_names else "none"}'
+        )
 
         snapshot_stack = self._clone_stack(self.stack)
         snapshot_vars = copy.deepcopy(self.vars)

--- a/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.fcstm
+++ b/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.fcstm
@@ -1,0 +1,6 @@
+def int x = 0;
+state Root {
+    state A;
+    [*] -> A;
+    A -> [*] :: End;
+}

--- a/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.yaml
+++ b/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.yaml
@@ -1,0 +1,66 @@
+schema_version: 1
+id: ended_runtime_ignores_event_inputs
+title: ended runtime ignores event inputs
+source:
+  fcstm: ended_runtime_ignores_event_inputs.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614008879
+  assertion_types:
+  - ended
+  - return
+  - stack
+  - state
+  - vars
+  notes:
+  - Covers ended cycle no-op behavior before event parsing.
+categories:
+- event_paths
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      x: 0
+    ended: false
+    return: null
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    - path:
+      - Root
+      - A
+      mode: active
+- cycle:
+    events:
+    - Root.A.End
+  expect:
+    state: null
+    vars:
+      x: 0
+    ended: true
+    return: null
+    stack: []
+- cycle:
+    events:
+    - Missing
+  expect:
+    state: null
+    vars:
+      x: 0
+    ended: true
+    return: null
+    stack: []

--- a/test/fixtures/simulate_semantics/cases/event_input_bare_string_path.fcstm
+++ b/test/fixtures/simulate_semantics/cases/event_input_bare_string_path.fcstm
@@ -1,0 +1,7 @@
+def int x = 0;
+state Root {
+    state A { during { x = x + 1; } }
+    state B { during { x = x + 10; } }
+    [*] -> A;
+    A -> B :: Go;
+}

--- a/test/fixtures/simulate_semantics/cases/event_input_bare_string_path.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_input_bare_string_path.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+id: event_input_bare_string_path
+title: bare string event input is a single event path
+source:
+  fcstm: event_input_bare_string_path.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614133609
+  assertion_types:
+  - ended
+  - return
+  - state
+  - vars
+  notes:
+  - Covers a bare string passed directly to cycle(events=...).
+categories:
+- event_paths
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      x: 1
+    ended: false
+    return: null
+- cycle: Root.A.Go
+  expect:
+    state:
+    - Root
+    - B
+    vars:
+      x: 11
+    ended: false
+    return: null

--- a/test/fixtures/simulate_semantics/cases/event_input_path_name_object.fcstm
+++ b/test/fixtures/simulate_semantics/cases/event_input_path_name_object.fcstm
@@ -1,0 +1,7 @@
+def int x = 0;
+state Root {
+    state A { during { x = x + 1; } }
+    state B { during { x = x + 10; } }
+    [*] -> A;
+    A -> B :: Go;
+}

--- a/test/fixtures/simulate_semantics/cases/event_input_path_name_object.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_input_path_name_object.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+id: event_input_path_name_object
+title: path_name event-like object input is accepted
+source:
+  fcstm: event_input_path_name_object.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614288612
+  assertion_types:
+  - ended
+  - return
+  - state
+  - vars
+  notes:
+  - Covers event-like objects exposing path_name.
+categories:
+- event_paths
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      x: 1
+    ended: false
+    return: null
+- cycle:
+    events:
+    - event_like: Root.A.Go
+  expect:
+    state:
+    - Root
+    - B
+    vars:
+      x: 11
+    ended: false
+    return: null

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -140,9 +140,16 @@ steps:
       return: null
 ```
 
-`cycle` may be `{}`, `null`, or a mapping with only the `events` field.
-`events` may be `null` or a list. Bare string event input is deliberately not
-supported by this schema version, because string-vs-list cycle input is tracked separately.
+`cycle` may be `{}`, `null`, a bare event-path string, or a mapping with
+only the `events` field. A bare string such as `cycle: Root.A.Go` is passed
+unchanged as a single `runtime.cycle("Root.A.Go")` input so fixtures can cover
+string-vs-list API boundaries.
+
+`events` may be `null` or a list. Each list item may be either an event-path
+string or an event-like descriptor with exactly one `event_like` key, for
+example `{event_like: Root.A.Go}`. The runner converts that descriptor into a
+local object exposing `path_name = "Root.A.Go"` and passes the object to the
+runtime under test.
 
 Event strings are passed through unchanged. The corpus covers existing event
 path forms such as full paths (`Root.A.Go`), relative paths (`go`),

--- a/test/simulate/test_event_inputs.py
+++ b/test/simulate/test_event_inputs.py
@@ -1,0 +1,72 @@
+"""
+Unit tests for ``SimulationRuntime.cycle`` event input normalization.
+"""
+
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.simulate import SimulationRuntime
+
+
+def _build_runtime() -> SimulationRuntime:
+    """Build a minimal runtime with one evented transition."""
+    ast = parse_with_grammar_entry(
+        """
+def int x = 0;
+state Root {
+    state A { during { x = x + 1; } }
+    state B { during { x = x + 10; } }
+    [*] -> A;
+    A -> B :: Go;
+}
+""",
+        'state_machine_dsl',
+    )
+    return SimulationRuntime(parse_dsl_node_to_state_machine(ast))
+
+
+@pytest.mark.unittest
+def test_cycle_accepts_single_model_event_object():
+    """Model event objects can be passed directly as one event input."""
+    runtime = _build_runtime()
+    runtime.cycle()
+
+    event = runtime.state_machine.resolve_event('Root.A.Go')
+    runtime.cycle(event)
+
+    assert runtime.current_state.path == ('Root', 'B')
+    assert runtime.vars['x'] == 11
+
+
+@pytest.mark.unittest
+def test_cycle_rejects_event_like_item_with_non_string_path_name():
+    """Event-like collection items must expose a string ``path_name``."""
+    runtime = _build_runtime()
+    runtime.cycle()
+
+    class BadEvent:
+        path_name = 12
+
+    with pytest.raises(TypeError, match='path_name must be str'):
+        runtime.cycle([BadEvent()])
+
+
+@pytest.mark.unittest
+def test_cycle_rejects_unsupported_event_item_type():
+    """Unsupported collection item types fail before execution."""
+    runtime = _build_runtime()
+    runtime.cycle()
+
+    with pytest.raises(TypeError, match='Unknown event type'):
+        runtime.cycle([7])
+
+
+@pytest.mark.unittest
+def test_cycle_rejects_non_iterable_event_container():
+    """Unsupported non-iterable event containers fail before execution."""
+    runtime = _build_runtime()
+    runtime.cycle()
+
+    with pytest.raises(TypeError, match='Unknown event type'):
+        runtime.cycle(7)

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -299,6 +299,40 @@ def _set_generated_alignment(data):
             "cycle has unknown fields",
         ),
         (
+            lambda data: data["steps"][0].update({"cycle": 12}),
+            "cycle must be a mapping, string, or null",
+        ),
+        (
+            lambda data: data["steps"][0].update({"cycle": []}),
+            "cycle must be a mapping, string, or null",
+        ),
+        (
+            lambda data: data["steps"][0]["cycle"].update({"events": "Root.A.Go"}),
+            "cycle.events must be a list or null",
+        ),
+        (
+            lambda data: data["steps"][0]["cycle"].update({"events": [7]}),
+            r"cycle.events\[0\] must be a string or event-like descriptor",
+        ),
+        (
+            lambda data: data["steps"][0]["cycle"].update(
+                {"events": [{"event_like": "Root.A.Go", "extra": True}]}
+            ),
+            r"cycle.events\[0\] event descriptor must contain only event_like",
+        ),
+        (
+            lambda data: data["steps"][0]["cycle"].update(
+                {"events": [{"unknown": "Root.A.Go"}]}
+            ),
+            r"cycle.events\[0\] event descriptor must contain only event_like",
+        ),
+        (
+            lambda data: data["steps"][0]["cycle"].update(
+                {"events": [{"event_like": 12}]}
+            ),
+            r"cycle.events\[0\].event_like must be a string",
+        ),
+        (
             lambda data: data["steps"][0]["expect"].update({"logs": {"containz": []}}),
             "logs has unknown fields",
         ),

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -153,6 +153,13 @@ class SemanticCase:
         return tuple(self.data["runners"])
 
 
+@dataclass(frozen=True)
+class _FixtureEventLike:
+    """Event-like cycle input used by semantic fixture runners."""
+
+    path_name: str
+
+
 def _case_error(case_id: str, yaml_path: str, message: str) -> SemanticCaseError:
     return SemanticCaseError("%s (%s): %s" % (case_id, yaml_path, message))
 
@@ -578,16 +585,39 @@ def _capture_warnings_if_needed(expect: Mapping[str, Any]):
         yield None
 
 
-def _step_events(
-    cycle_data: Any, case: SemanticCase, field_path: str
-) -> Optional[List[Any]]:
+def _event_input_from_fixture_item(
+    item: Any, case: SemanticCase, field_path: str
+) -> Any:
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        if set(item.keys()) != {"event_like"}:
+            raise _case_error(
+                case.id,
+                case.yaml_path,
+                "%s event descriptor must contain only event_like" % field_path,
+            )
+        path_name = item["event_like"]
+        if not isinstance(path_name, str):
+            raise _case_error(
+                case.id,
+                case.yaml_path,
+                "%s.event_like must be a string" % field_path,
+            )
+        return _FixtureEventLike(path_name=path_name)
+    return item
+
+
+def _step_events(cycle_data: Any, case: SemanticCase, field_path: str) -> Any:
     if cycle_data in (None, {}):
         return None
+    if isinstance(cycle_data, str):
+        return cycle_data
     if not isinstance(cycle_data, dict):
         raise _case_error(
             case.id,
             case.yaml_path,
-            "%s.cycle must be a mapping, null, or omitted" % field_path,
+            "%s.cycle must be a mapping, string, null, or omitted" % field_path,
         )
     events = cycle_data.get("events")
     if events is None:
@@ -598,7 +628,14 @@ def _step_events(
             case.yaml_path,
             "%s.cycle.events must be a list or null" % field_path,
         )
-    return list(events)
+    return [
+        _event_input_from_fixture_item(
+            item,
+            case,
+            "%s.cycle.events[%d]" % (field_path, index),
+        )
+        for index, item in enumerate(events)
+    ]
 
 
 def _run_step(
@@ -1544,6 +1581,71 @@ def _validate_runtime_options(
         )
 
 
+def _validate_cycle_event_item(
+    item: Any, case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if isinstance(item, str):
+        return
+    if not isinstance(item, dict):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s must be a string or event-like descriptor" % field_path,
+        )
+    if set(item.keys()) != {"event_like"}:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s event descriptor must contain only event_like" % field_path,
+        )
+    if not isinstance(item["event_like"], str):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.event_like must be a string" % field_path,
+        )
+
+
+def _validate_cycle_data(
+    cycle_data: Any, case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if cycle_data in (None, {}):
+        return
+    if isinstance(cycle_data, str):
+        return
+    if not isinstance(cycle_data, dict):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.cycle must be a mapping, string, or null" % field_path,
+        )
+    unknown_cycle = set(cycle_data.keys()) - _ALLOWED_CYCLE_FIELDS
+    if unknown_cycle:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.cycle has unknown fields: %r" % (field_path, sorted(unknown_cycle)),
+        )
+    if "events" not in cycle_data:
+        return
+    events = cycle_data["events"]
+    if events is None:
+        return
+    if not isinstance(events, list):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.cycle.events must be a list or null" % field_path,
+        )
+    for event_index, item in enumerate(events):
+        _validate_cycle_event_item(
+            item,
+            case_id,
+            yaml_path,
+            "%s.cycle.events[%d]" % (field_path, event_index),
+        )
+
+
 def _validate_handlers(
     handlers: Any, case_id: str, yaml_path: str, runners: Sequence[str]
 ) -> None:
@@ -1741,30 +1843,9 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
                     raise _case_error(
                         case_id, yaml_path, "%s.expect is required" % field_path
                     )
-                cycle_data = step.get("cycle")
-                if cycle_data not in (None, {}) and not isinstance(cycle_data, dict):
-                    raise _case_error(
-                        case_id,
-                        yaml_path,
-                        "%s.cycle must be a mapping or null" % field_path,
-                    )
-                if isinstance(cycle_data, dict):
-                    unknown_cycle = set(cycle_data.keys()) - _ALLOWED_CYCLE_FIELDS
-                    if unknown_cycle:
-                        raise _case_error(
-                            case_id,
-                            yaml_path,
-                            "%s.cycle has unknown fields: %r"
-                            % (field_path, sorted(unknown_cycle)),
-                        )
-                    if "events" in cycle_data:
-                        events = cycle_data["events"]
-                        if events is not None and not isinstance(events, list):
-                            raise _case_error(
-                                case_id,
-                                yaml_path,
-                                "%s.cycle.events must be a list or null" % field_path,
-                            )
+                _validate_cycle_data(
+                    step.get("cycle"), case_id, yaml_path, field_path
+                )
                 _validate_expect(
                     step["expect"], case_id, yaml_path, field_path + ".expect", runners
                 )


### PR DESCRIPTION
## 范围

父级伞拉取请求：[拉取请求 #144](https://github.com/HansBug/pyfcstm/pull/144)  
跟踪议题：[议题 #143](https://github.com/HansBug/pyfcstm/issues/143)  
前置依赖：[拉取请求 #145](https://github.com/HansBug/pyfcstm/pull/145) 共享语义夹具语料库，以及 [拉取请求 #146](https://github.com/HansBug/pyfcstm/pull/146) 回滚与推测执行元数据基线。

本拉取请求实现伞拉取请求计划中的第 6 个切片：归一化 `SimulationRuntime.cycle()` 接受的公开事件输入，并让已经结束的运行时在解析事件前直接执行空操作。

覆盖的来源问题：

| 编号 | 来源 | 本拉取请求的预期处理 |
|---|---|---|
| D-1 | [worker-d：已结束运行时仍解析事件](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614008879) | 已结束的 `SimulationRuntime.cycle(events=...)` 在解析事件前直接空操作，即使传入的事件无效也不抛错。 |
| M-1 | [worker-m：裸字符串事件与生成运行时语义分叉](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614133609) | `SimulationRuntime.cycle("Root.A.Go")` 把字符串视为单个事件路径，与内置 Python 生成运行时行为一致。 |
| U-1 | [worker-u：`path_name` 类事件对象对齐问题](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614288612) | 暴露 `path_name` 的类事件对象在 `SimulationRuntime` 中按内置 Python 生成运行时的同一语义接受。 |

明确不处理的范围：

- U-2：Python 生成运行时的表达式错误包装；该项仍路由到第 7 个切片。
- 除本事件输入契约所需的对齐覆盖外，不做更广泛的生成运行时行为修改。
- 命令行界面 / 交互式模拟器的 `init` / `clear` 会话状态保留；该项仍路由到第 5 个切片。

## 自包含问题说明

### D-1：已结束运行时在空操作保护前解析事件

最小 DSL：

```fcstm
def int x = 0;
state Root {
    state A;
    [*] -> A;
    A -> [*] :: End;
}
```

复现代码：

```python
runtime = build_runtime(DSL)
runtime.cycle()
runtime.cycle(["Root.A.End"])
assert runtime.is_ended
runtime.cycle(["Missing"])
```

期望结果：最后一次 `cycle(["Missing"])` 因为运行时已结束而直接空操作；它不应解析或拒绝事件。

修复前实际结果：`"Missing"` 会在已结束空操作保护之前被解析，随后抛出 `SimulationRuntimeEventError`。

语义原因：运行时结束后已经没有活动的转换匹配上下文，因此传入事件不应再影响文档承诺的空操作行为。

### M-1：`SimulationRuntime` 把裸字符串事件拆成字符

最小 DSL：

```fcstm
def int x = 0;
state Root {
    state A { during { x = x + 1; } }
    state B { during { x = x + 10; } }
    [*] -> A;
    A -> B :: Go;
}
```

复现代码：

```python
runtime = build_runtime(DSL)
runtime.cycle()
runtime.cycle("Root.A.Go")
```

期望结果：`"Root.A.Go"` 被视为单个事件路径，运行时进入 `Root.B`，并且 `x == 11`。

修复前实际结果：字符串被当作可迭代对象拆成字符，运行时先尝试解析 `"R"`，然后抛出 `SimulationRuntimeEventError`。

语义原因：内置 Python 生成运行时和生成的 `README` 已经支持 `machine.cycle("<event-path>")`；`SimulationRuntime` 应提供同一公开输入边界。

### U-1：带 `path_name` 的类事件对象在生成运行时中成功，但在 `SimulationRuntime` 中失败

最小 DSL 与 M-1 相同。

复现代码：

```python
class EventLike:
    path_name = "Root.A.Go"

runtime = build_runtime(DSL)
runtime.cycle()
runtime.cycle([EventLike()])
```

期望结果：暴露 `path_name` 的对象被接受为类事件输入，运行时进入 `Root.B`，并且 `x == 11`。

修复前实际结果：`SimulationRuntime._parse_event()` 只接受模型 `Event` 实例和字符串，其他对象直接抛出 `TypeError`。

语义原因：Python 生成运行时已经把暴露 `path_name` 的对象视为公开事件输入形态，模板对齐也应包含 `SimulationRuntime`。

## 实现计划

1. 在 `test/fixtures/simulate_semantics/cases/` 下为 D-1、M-1、U-1 添加语义夹具用例，夹具使用客观领域命名，不使用拉取请求、议题、阶段等流程标签。
2. 本拉取请求必须扩展共享语义夹具的模式、文档、验证器和运行器：
   - M-1 必须能表达真正的裸字符串调用，例如 `cycle: Root.A.Go`，运行器需要把精确的 `"Root.A.Go"` 传给 `runtime.cycle()`，不能包成列表。
   - U-1 必须能表达明确的类事件描述符，例如 `events: [{event_like: Root.A.Go}]`，运行器需要构造一个本地对象，使其暴露 `path_name = "Root.A.Go"`，并把该对象同时传给 `SimulationRuntime` 和 Python 生成运行时对齐包装器。
   - 现有列表输入（例如 `events: [Root.A.Go]`）必须保持当前含义和覆盖。
   - 为格式错误的裸字符串 `cycle` 输入、格式错误的类事件描述符、不支持的事件项映射添加反向模式测试。
3. 使用扩展后的夹具语料库为 M-1 和 U-1 添加 Python 生成运行时对齐覆盖，保证 `SimulationRuntime` 与生成运行时共用同一份期望轨迹。
4. 把 `SimulationRuntime.cycle()` 中的已结束运行时空操作保护移到事件归一化之前。
5. 在 `SimulationRuntime` 中归一化 `events`：
   - `None` 表示无事件。
   - `str` 表示单个事件路径，而不是字符可迭代对象。
   - 模型 `Event` 对象表示单个事件。
   - 可迭代事件集合继续可用，集合项可混合字符串、模型事件、暴露 `path_name` 的类事件对象；类事件对象的 `path_name` 值通过与字符串相同的路径解析器解析。
6. 在运行时未结束时，保持不支持事件值的显式错误行为并加覆盖：
   - 空事件路径字符串仍然非法。
   - 不支持的事件项类型仍然在执行前抛错。
   - 夹具 YAML 中不支持的描述符映射在模式验证阶段失败，而不是进入运行时执行。
   - 已结束运行时仍然在任何事件解析前返回，即使传入无效或不支持的事件输入。
7. 更新 `SimulationRuntime.cycle()` / 事件归一化文档字符串，以及语义夹具模式文档，描述裸字符串和 `path_name` 类事件输入。生成的 `README` / 模板文档只有在源码或生成行为发生变化时才修改；本拉取请求预期是让 `SimulationRuntime` 对齐生成运行时已经文档化的行为。

## 测试计划

测试驱动开发红灯阶段：

- 添加由夹具驱动的测试，确认当前基线上的 D-1、M-1、U-1 会失败。
- 扩展第 0 个切片的语义夹具语料库，而不是为同类语义新增独立 pytest 文件。
- 在验证器接受新语法前，为新夹具语法添加模式验证反向测试。

绿灯阶段 / 本地验证：

```bash
pytest test/simulate/test_semantic_fixtures.py -v
pytest test/template/python/test_semantic_fixture_alignment.py -v
SKIP_SLOW_TESTS=1 make unittest
```

如果 Python 生成模板资产发生变化，还需要运行：

```bash
make tpl
pytest test/template/python/test_semantic_fixture_alignment.py -v
```

## 开发前计划复核状态

第一轮复核：

- [claude reviewer](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620379981)：结论：可继续；建议补充文档字符串 / `path_name` 解析路径说明。
- [deepseek reviewer](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620384523)：结论：要求修改；要求显式扩展模式 / 运行器来承载裸字符串和类事件夹具覆盖。
- [codex reviewer](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620389545)：结论：要求修改；要求把同一模式 / 运行器扩展明确列为测试驱动开发 / 验收任务。

本正文修订已把模式 / 运行器扩展、反向模式测试、文档字符串 / 模式文档更新列为必做验收项，以回应上述重要级计划意见。

第二轮计划复核：

- [claude reviewer](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620423807)：计划复核结论：可继续。
- [deepseek reviewer](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620432728)：计划复核结论：可继续。
- [codex reviewer](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620433949)：计划复核结论：可继续。

## 复核 / 验收清单

- [x] 拉取请求正文与 [拉取请求 #144](https://github.com/HansBug/pyfcstm/pull/144) 中第 6 个切片路由以及 [议题 #143](https://github.com/HansBug/pyfcstm/issues/143) 来源问题一致。
- [x] D-1、M-1、U-1 都在共享语义夹具语料库中拥有最小回归覆盖。
- [x] 夹具模式 / 运行器能表达裸字符串 `cycle(events=...)` 和带 `path_name` 的类事件对象输入，并为格式错误的形态提供反向模式覆盖。
- [x] 已结束运行时的 `cycle` 不解析无效事件输入。
- [x] 裸字符串事件路径和事件集合项中的 `path_name` 类事件对象在 `SimulationRuntime` 与 Python 生成运行时之间语义一致。
- [x] 运行时未结束时，不支持的事件值仍然在执行前以清晰诊断失败。
- [x] `SimulationRuntime.cycle()` / 事件归一化文档字符串与夹具模式文档描述支持的事件输入形态。
- [x] 本地跳过慢速项的测试通过。
- [x] GitHub Actions 检查通过。
- [x] Codecov 报告修改代码没有已覆盖行回退。
- [x] 实现后已有三路复核评论：`codex reviewer`、`claude reviewer`、`deepseek reviewer`；严重 / 重要问题在就绪前全部修复。

## 实现后状态

提交：[`1c2fa7323f7c089e8e2fad3ff5a92c742783445f`](https://github.com/HansBug/pyfcstm/commit/1c2fa7323f7c089e8e2fad3ff5a92c742783445f)

本轮实现内容：

- `SimulationRuntime.cycle()` 先检查 `_ended`，已结束运行时在任何事件解析前直接空操作。
- `SimulationRuntime` 的事件归一化现在把裸字符串视为单个事件路径，而不是字符序列。
- `SimulationRuntime._parse_event()` 接受事件集合项中的 `path_name` 类事件对象，并通过同一字符串路径解析器解析。
- 新增 `test/simulate/test_event_inputs.py`，覆盖模型 `Event` 单值输入、非法 `path_name`、非法事件项和非法非迭代容器。
- 扩展语义夹具模式 / 运行器，让共享语料库可表达 `cycle: Root.A.Go` 与 `events: [{event_like: Root.A.Go}]`，并为错误形态添加反向模式覆盖。
- 新增三组语义夹具：
  - `ended_runtime_ignores_event_inputs`
  - `event_input_bare_string_path`
  - `event_input_path_name_object`

### 测试驱动开发红灯证据

开发阶段先加入夹具 / 模式覆盖后确认旧实现失败：

- `ended_runtime_ignores_event_inputs`：已结束运行时仍解析 `Missing`，抛出 `SimulationRuntimeEventError`。
- `event_input_bare_string_path`：`runtime.cycle("Root.A.Go")` 被拆成字符，先解析 `"R"` 并失败。
- `event_input_path_name_object`：`runtime.cycle([EventLike(path_name="Root.A.Go")])` 抛出 `TypeError`。

### 本地绿灯验证

已通过：

```bash
python -m py_compile pyfcstm/simulate/runtime.py test/testings/simulate_semantics.py test/simulate/test_semantic_fixtures.py test/simulate/test_event_inputs.py
pytest test/simulate/test_event_inputs.py -v
pytest test/simulate/test_semantic_fixtures.py -k 'ended_runtime_ignores_event_inputs or event_input_bare_string_path or event_input_path_name_object or schema_rejects_invalid_yaml' -v
pytest test/template/python/test_semantic_fixture_alignment.py -k 'ended_runtime_ignores_event_inputs or event_input_bare_string_path or event_input_path_name_object' -v
pytest test/simulate/test_semantic_fixtures.py -v
pytest test/template/python/test_semantic_fixture_alignment.py -v
python -m ruff check pyfcstm/simulate/runtime.py test/testings/simulate_semantics.py test/simulate/test_semantic_fixtures.py test/simulate/test_event_inputs.py
git diff --check
SKIP_SLOW_TESTS=1 make unittest
```

`SKIP_SLOW_TESTS=1 make unittest` 结果：`9122 passed, 164 skipped, 63 deselected, 731 warnings`。本地覆盖率报告中 `pyfcstm/simulate/runtime.py` 为 `95%`，本拉取请求新增的可执行运行时代码行均被覆盖；未出现修改后可执行行缺失覆盖。

### 当前远端验收状态

- [x] 本地跳过慢速项的测试通过。
- [x] GitHub Actions 检查通过。
- [x] Codecov 报告修改代码没有已覆盖行回退。
- [x] 实现后三路复核评论到位：`codex reviewer`、`claude reviewer`、`deepseek reviewer`。
- [x] 严重 / 重要级实现后复核问题全部修复。

## 实现后复核汇总

三路实现后复核均已完成并给出“可继续”结论：

- [`claude reviewer`](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620974429)：未发现 C/I；记录裸 `path_name` 对象单值、dict 事件容器、docstring 示例风格等 M 级观察，均不阻塞。
- [`deepseek reviewer`](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4620999366)：未发现 C/I；记录 `_iter_event_inputs` 的 `TypeError` 误诊可能、私有 `_parse_event` 示例、`@staticmethod` 调用风格等 M 级观察，均不阻塞。
- [`codex reviewer`](https://github.com/HansBug/pyfcstm/pull/147#issuecomment-4621078522)：未发现 C/I/M；确认 D-1、M-1、U-1 均满足，且未吞 U-2 / 第 7 个切片 或命令行界面第 5 个切片范围。

主会话汇总结论：当前没有严重 / 重要级阻塞项；轻微项均为后续可选改进，不阻塞本拉取请求进入待合并状态。本拉取请求保持不合并，等待下一步指示。

