### PR TITLE
修复 Python 生成运行时表达式错误包装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,9 @@ Mandatory completion rule for built-in template work:
 
 - Treat formatter convergence as part of correctness, not optional polish.
 - The generated target-language artifacts must be acceptable to the corresponding formatter defaults for that language.
+- For the built-in `python` template specifically, every emitted `machine.py` should be designed to pass both
+  `ruff check` and `ruff format --check` in the representative template tests. Do not treat "ruff can rewrite it" as
+  sufficient; generated Python should be lint-clean and formatter-stable without users editing the generated file.
 - Template-facing documentation artifacts that ship with the generated output, especially generated `README.md` / `README_zh.md` files and their embedded code snippets, must also be kept formatter-friendly for the relevant language and text formatter set.
 - For template changes, "done" means the generated outputs have converged under the intended formatter flow. If the formatter still wants to rewrite the emitted code or the generated usage examples materially, the template work is not complete yet.
 - When adding or changing a multi-language built-in template, explicitly design the generated code shape and README examples so they stabilize under the formatter set listed above instead of relying on hand-aligned formatting.
@@ -1169,6 +1172,9 @@ For built-in template work, the current design bar is defined by the `python` te
 - Preserve naming clarity for generated extension points so DSL authors can map states, actions, and abstract behavior back to code quickly, ideally with IDE completion support.
 - Keep generated code readable and inspectable. Generated runtimes are product artifacts, not opaque intermediate blobs.
 - Ensure the final generated code, generated support files, and generated README examples are written so the corresponding formatter flow reaches a stable end state. Template work that has not reached formatter convergence is not complete.
+- For changes to `templates/python/`, verify representative generated `machine.py` outputs with both `ruff check` and
+  `ruff format --check`; if ruff reports lint diagnostics or would reformat the generated Python, the template change
+  is not ready.
 - When adding a new built-in template, update all of the following together: `templates/<name>/`, packaged template assets, CLI/template metadata, maintainer docs, generated docs if applicable, and the corresponding tests.
 
 ### Testing Strategy

--- a/pyfcstm/render/statement.py
+++ b/pyfcstm/render/statement.py
@@ -351,7 +351,7 @@ def _indent_rendered_text(text: str, indent: str, level: int) -> str:
     :rtype: str
     """
     prefix = indent * level
-    return '\n'.join(prefix + line if line else prefix for line in text.splitlines())
+    return '\n'.join(prefix + line if line else line for line in text.splitlines())
 
 
 def _merge_numeric_types(type_a: Optional[str], type_b: Optional[str]) -> Optional[str]:

--- a/pyfcstm/render/statement.py
+++ b/pyfcstm/render/statement.py
@@ -332,6 +332,28 @@ def _render_template_string(
     return env.from_string(template_str).render(**kwargs)
 
 
+def _indent_rendered_text(text: str, indent: str, level: int) -> str:
+    """
+    Prefix each rendered line with the requested indentation level.
+
+    Statement-style templates may render either a single line or a multi-line
+    language fragment. Applying indentation to each line lets custom templates
+    emit formatter-friendly wrapped expressions without hard-coding the caller's
+    nesting level.
+
+    :param text: Rendered statement text.
+    :type text: str
+    :param indent: Indentation unit.
+    :type indent: str
+    :param level: Indentation level.
+    :type level: int
+    :return: Indented rendered text.
+    :rtype: str
+    """
+    prefix = indent * level
+    return '\n'.join(prefix + line if line else prefix for line in text.splitlines())
+
+
 def _merge_numeric_types(type_a: Optional[str], type_b: Optional[str]) -> Optional[str]:
     """
     Merge two inferred numeric types conservatively.
@@ -650,7 +672,13 @@ def _render_statement_impl(
                 env,
                 name=node.name,
             )
-            text = _render_template_string(templates['assign'], env, target=target, expr=expr)
+            text = _render_template_string(
+                templates['assign'],
+                env,
+                target=target,
+                expr=expr,
+                name=node.name,
+            )
             new_visible = set(visible_names)
             new_visible_types = dict(visible_var_types)
             lines = []
@@ -668,10 +696,10 @@ def _render_statement_impl(
                         inferred_type=inferred_type,
                     )
                     if declaration:
-                        lines.append('{indent}{text}'.format(indent=indent * level, text=declaration))
+                        lines.append(_indent_rendered_text(declaration, indent, level))
                 if inferred_type is not None:
                     new_visible_types[node.name] = inferred_type
-            lines.append('{indent}{text}'.format(indent=indent * level, text=text))
+            lines.append(_indent_rendered_text(text, indent, level))
             return '\n'.join(lines), new_visible, new_visible_types
 
         if isinstance(node, dsl_nodes.OperationIf):
@@ -710,7 +738,7 @@ def _render_statement_impl(
                         _restore_scoped_expr_render(env, previous_global, previous_filter, previous_resolver)
                     header = _render_template_string(templates['elif'], env, condition=condition)
 
-                lines.append('{indent}{header}'.format(indent=indent * level, header=header))
+                lines.append(_indent_rendered_text(header, indent, level))
                 body, _, _ = _render_statements_impl(
                     nodes=branch.statements,
                     templates=templates,
@@ -750,7 +778,13 @@ def _render_statement_impl(
                 env,
                 name=node.name,
             )
-            text = _render_template_string(templates['assign'], env, target=target, expr=expr)
+            text = _render_template_string(
+                templates['assign'],
+                env,
+                target=target,
+                expr=expr,
+                name=node.name,
+            )
             new_visible = set(visible_names)
             new_visible_types = dict(visible_var_types)
             lines = []
@@ -767,11 +801,11 @@ def _render_statement_impl(
                         inferred_type=inferred_type,
                     )
                     if declaration:
-                        lines.append('{indent}{text}'.format(indent=indent * level, text=declaration))
+                        lines.append(_indent_rendered_text(declaration, indent, level))
                 new_visible.add(node.name)
                 if inferred_type is not None:
                     new_visible_types[node.name] = inferred_type
-            lines.append('{indent}{text}'.format(indent=indent * level, text=text))
+            lines.append(_indent_rendered_text(text, indent, level))
             return '\n'.join(lines), new_visible, new_visible_types
 
         if isinstance(node, dsl_nodes.OperationIf):
@@ -799,7 +833,7 @@ def _render_statement_impl(
                     else:
                         header = _render_template_string(templates['elif'], env, condition=condition)
 
-                lines.append('{indent}{header}'.format(indent=indent * level, header=header))
+                lines.append(_indent_rendered_text(header, indent, level))
                 body, _, _ = _render_statements_impl(
                     nodes=branch.statements,
                     templates=templates,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -14,3 +14,4 @@ testtools>=2
 where>=1.0.2
 natsort
 cmake<4
+ruff

--- a/templates/python/README.md
+++ b/templates/python/README.md
@@ -19,5 +19,6 @@ Current properties:
 - emits `machine.py`, `README.md`, and `README_zh.md`
 - embeds state metadata, cycle logic, hot start handling, and subclass hook points for abstract actions
 - depends only on the Python standard library
-- keeps generated output close to `ruff format` defaults
+- keeps generated `machine.py` output lint-clean under `ruff check`
+- keeps generated `machine.py` output stable under `ruff format --check`
 - exposes abstract hook names that are easy to discover through IDE completion

--- a/templates/python/README.md.j2
+++ b/templates/python/README.md.j2
@@ -158,6 +158,32 @@ except SimulationRuntimeDfsError as err:
     print(err)
 ```
 
+### `SimulationRuntimeExpressionError`
+
+Raised when a DSL guard, action assignment, transition effect, or `if` block
+condition fails while evaluating a numeric DSL expression. The generated runtime
+keeps this exception local to `machine.py`; it has the same class name as the
+simulation runtime error so alignment tests and user diagnostics can compare the
+stable boundary without importing `pyfcstm`.
+
+The message includes the DSL usage, for example
+`operation assignment to 'counter' evaluation failed: division by zero`, and the
+original Python exception is preserved as `__cause__`.
+
+Example:
+
+```python
+from machine import SimulationRuntimeExpressionError, {{ machine_class_name(model) }}
+
+machine = {{ machine_class_name(model) }}()
+
+try:
+    machine.cycle()
+except SimulationRuntimeExpressionError as err:
+    print(err)
+    print(type(err.__cause__).__name__)
+```
+
 ### `ReadOnlyExecutionContext`
 
 This object is passed into every abstract hook.

--- a/templates/python/README_zh.md
+++ b/templates/python/README_zh.md
@@ -18,5 +18,6 @@
 - 默认输出 `machine.py`、`README.md`、`README_zh.md`
 - 内置状态元数据、cycle 逻辑、hot start、abstract hook 扩展点与抽象处理器注册
 - 仅依赖 Python 标准库
-- 生成代码默认风格尽量贴近 `ruff format`
+- 生成的 `machine.py` 默认应通过 `ruff check`
+- 生成的 `machine.py` 默认应在 `ruff format --check` 下保持稳定
 - abstract hook 的命名有利于 DSL 用户借助 IDE 补全快速定位

--- a/templates/python/README_zh.md.j2
+++ b/templates/python/README_zh.md.j2
@@ -152,6 +152,31 @@ except SimulationRuntimeDfsError as err:
     print(err)
 ```
 
+### `SimulationRuntimeExpressionError`
+
+当 DSL guard、action assignment、transition effect 或 `if` block condition
+在计算数值 DSL 表达式时失败，会抛出这个异常。生成运行时把该异常保留在
+`machine.py` 本地；它与 simulation runtime 的错误使用同一个类名，方便
+alignment 测试和用户诊断在不导入 `pyfcstm` 的情况下比较稳定边界。
+
+错误消息会包含 DSL usage，例如
+`operation assignment to 'counter' evaluation failed: division by zero`，原始
+Python 异常会保留在 `__cause__` 上。
+
+例如：
+
+```python
+from machine import SimulationRuntimeExpressionError, {{ machine_class_name(model) }}
+
+machine = {{ machine_class_name(model) }}()
+
+try:
+    machine.cycle()
+except SimulationRuntimeExpressionError as err:
+    print(err)
+    print(type(err.__cause__).__name__)
+```
+
 ### `ReadOnlyExecutionContext`
 
 这个对象会在每次 abstract hook 执行时传入。

--- a/templates/python/config.yaml
+++ b/templates/python/config.yaml
@@ -6,6 +6,28 @@ expr_styles:
     base_lang: python
     Name: "scope[{{ node.name | tojson }}]"
 
+stmt_styles:
+  python_runtime:
+    base_lang: python
+    expr_lang: python
+    state_var_target: "scope[{{ name | tojson }}]"
+    temp_var_target: "{{ name }}"
+    assign: |-
+      {{ target }} = self._evaluate_runtime_expr(
+          lambda: {{ expr }},
+          {{ ("operation assignment to '" ~ name ~ "'") | tojson }},
+      )
+    if: |-
+      if self._evaluate_runtime_expr(
+          lambda: {{ condition }},
+          "if-block condition",
+      ):
+    elif: |-
+      elif self._evaluate_runtime_expr(
+          lambda: {{ condition }},
+          "if-block condition",
+      ):
+
 globals:
   machine_class_name:
     type: template

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -99,9 +99,9 @@ Original DSL Source::
 {{ (model.to_ast_node() | string) | indent(4, true) }}
 """
 
-import math
+import math  # noqa: F401 - rendered DSL math expressions may use this module.
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Tuple, Union
 
 
 Number = Union[int, float]
@@ -187,6 +187,13 @@ _EVENT_PATH_SET = set(_EVENT_PATHS)
 
 class SimulationRuntimeDfsError(RuntimeError):
     """Raised when speculative validation exceeds the generated runtime safety limit."""
+
+    pass
+
+
+
+class SimulationRuntimeExpressionError(ValueError, ArithmeticError):
+    """Raised when a DSL guard or action expression fails during execution."""
 
     pass
 
@@ -607,6 +614,18 @@ class {{ machine_class_name(model) }}:
             return True
         return transition["event_path"] in event_names
 
+    def _evaluate_runtime_expr(self, fn, usage):
+        try:
+            return fn()
+        except (ValueError, ArithmeticError) as err:
+            # ValueError: math domain errors or invalid numeric operations
+            # raised while evaluating a user's DSL expression.
+            # ArithmeticError: division by zero, overflow, or other numeric
+            # runtime failure while evaluating a user's DSL expression.
+            raise SimulationRuntimeExpressionError(
+                "%s evaluation failed: %s" % (usage, err)
+            ) from err
+
     def _transition_matches_guard(self, transition, vars_):
         if transition["guard"] is None:
             return True
@@ -794,7 +813,8 @@ class {{ machine_class_name(model) }}:
             if len(self._create_structural_signature(stack)) > max_structural_depth:
                 raise SimulationRuntimeDfsError(
                     "Speculative DFS exceeded the structural stack-depth safety limit "
-                    "(%s) without reaching a stoppable state or pruning."
+                    "(%s) without reaching a stoppable state or pruning; "
+                    "the state machine likely contains an invalid unbounded nesting chain."
                     % (max_structural_depth,)
                 )
 
@@ -976,7 +996,7 @@ class {{ machine_class_name(model) }}:
         """
         scope = vars_ if vars_ is not None else self._vars
 {% if resolved.item.operations %}
-{{ resolved.item.operations | stmts_render(style='python', indent='    ', level=2) }}
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
 {% else %}
         pass
 {% endif %}
@@ -1029,7 +1049,7 @@ class {{ machine_class_name(model) }}:
         """
         scope = vars_ if vars_ is not None else self._vars
 {% if resolved.item.operations %}
-{{ resolved.item.operations | stmts_render(style='python', indent='    ', level=2) }}
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
 {% else %}
         pass
 {% endif %}
@@ -1082,7 +1102,7 @@ class {{ machine_class_name(model) }}:
         """
         scope = vars_ if vars_ is not None else self._vars
 {% if resolved.item.operations %}
-{{ resolved.item.operations | stmts_render(style='python', indent='    ', level=2) }}
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
 {% else %}
         pass
 {% endif %}
@@ -1137,7 +1157,7 @@ class {{ machine_class_name(model) }}:
         """
         scope = vars_ if vars_ is not None else self._vars
 {% if resolved.item.operations %}
-{{ resolved.item.operations | stmts_render(style='python', indent='    ', level=2) }}
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
 {% else %}
         pass
 {% endif %}
@@ -1192,7 +1212,7 @@ class {{ machine_class_name(model) }}:
         """
         scope = vars_ if vars_ is not None else self._vars
 {% if resolved.item.operations %}
-{{ resolved.item.operations | stmts_render(style='python', indent='    ', level=2) }}
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
 {% else %}
         pass
 {% endif %}
@@ -1247,7 +1267,7 @@ class {{ machine_class_name(model) }}:
         """
         scope = vars_ if vars_ is not None else self._vars
 {% if resolved.item.operations %}
-{{ resolved.item.operations | stmts_render(style='python', indent='    ', level=2) }}
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
 {% else %}
         pass
 {% endif %}
@@ -1302,7 +1322,7 @@ class {{ machine_class_name(model) }}:
         """
         scope = vars_ if vars_ is not None else self._vars
 {% if resolved.item.operations %}
-{{ resolved.item.operations | stmts_render(style='python', indent='    ', level=2) }}
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
 {% else %}
         pass
 {% endif %}
@@ -1320,7 +1340,12 @@ class {{ machine_class_name(model) }}:
 {{ (transition.to_ast_node() | string) | indent(12, true) }}
         """
         scope = vars_ if vars_ is not None else self._vars
-        return bool({{ transition.guard.to_ast_node() | expr_render(style='python_scope_expr') }})
+        return bool(
+            self._evaluate_runtime_expr(
+                lambda: {{ transition.guard.to_ast_node() | expr_render(style='python_scope_expr') }},
+                "transition guard",
+            )
+        )
 
 {% endif %}
 {% if transition.effects %}
@@ -1333,7 +1358,7 @@ class {{ machine_class_name(model) }}:
 {{ (transition.to_ast_node() | string) | indent(12, true) }}
         """
         scope = vars_ if vars_ is not None else self._vars
-{{ transition.effects | stmts_render(style='python', indent='    ', level=2) }}
+{{ transition.effects | stmts_render(style='python_runtime', indent='    ', level=2) }}
 
 {% endif %}
 {% endfor %}
@@ -1348,7 +1373,12 @@ class {{ machine_class_name(model) }}:
 {{ (transition.to_ast_node() | string) | indent(12, true) }}
         """
         scope = vars_ if vars_ is not None else self._vars
-        return bool({{ transition.guard.to_ast_node() | expr_render(style='python_scope_expr') }})
+        return bool(
+            self._evaluate_runtime_expr(
+                lambda: {{ transition.guard.to_ast_node() | expr_render(style='python_scope_expr') }},
+                "transition guard",
+            )
+        )
 
 {% endif %}
 {% if transition.effects %}
@@ -1361,7 +1391,7 @@ class {{ machine_class_name(model) }}:
 {{ (transition.to_ast_node() | string) | indent(12, true) }}
         """
         scope = vars_ if vars_ is not None else self._vars
-{{ transition.effects | stmts_render(style='python', indent='    ', level=2) }}
+{{ transition.effects | stmts_render(style='python_runtime', indent='    ', level=2) }}
 
 {% endif %}
 {% endfor %}

--- a/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.fcstm
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.fcstm
@@ -1,0 +1,12 @@
+def int counter = 0;
+def int divisor = 0;
+state Root {
+    state A {
+        during {
+            if [1 / divisor > 0] {
+                counter = 1;
+            }
+        }
+    }
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.yaml
@@ -1,17 +1,17 @@
 schema_version: 1
-id: expression_failure_raises_expression_error
-title: 4 200 dsl expression failure raises expression error
+id: expression_failure_if_condition_raises_expression_error
+title: if block condition expression failure raises expression error
 source:
-  fcstm: expression_failure_raises_expression_error.fcstm
+  fcstm: expression_failure_if_condition_raises_expression_error.fcstm
 origin:
   files:
-  - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_200_dsl_expression_failure_raises_expression_error
+  - test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.fcstm
   assertion_types:
   - exception
 categories:
 - runtime
-- scenario_example
 - template_alignment
+- if_blocks
 runners:
 - simulation
 - generated_python_alignment
@@ -23,7 +23,7 @@ steps:
   expect:
     raises:
       type: SimulationRuntimeExpressionError
-      match: "operation assignment to 'counter' evaluation failed: division by zero"
+      match: 'if-block condition evaluation failed: division by zero'
       match_kind: substring
       cause_type: ZeroDivisionError
       cause_match: 'division by zero'

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.fcstm
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.fcstm
@@ -1,0 +1,10 @@
+def int counter = 1;
+def int sink = 0;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B effect {
+        sink = counter / 0;
+    }
+}

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.yaml
@@ -1,0 +1,48 @@
+schema_version: 1
+id: expression_failure_transition_effect_raises_expression_error
+title: transition effect expression failure raises expression error
+source:
+  fcstm: expression_failure_transition_effect_raises_expression_error.fcstm
+origin:
+  files:
+  - test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.fcstm
+  assertion_types:
+  - exception
+  - state
+  - vars
+categories:
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      counter: 1
+      sink: 0
+    ended: false
+    return: null
+- cycle: {}
+  expect:
+    raises:
+      type: SimulationRuntimeExpressionError
+      match: "operation assignment to 'sink' evaluation failed: division by zero"
+      match_kind: substring
+      cause_type: ZeroDivisionError
+      cause_match: 'division by zero'
+      cause_match_kind: substring
+    state:
+    - Root
+    - A
+    vars:
+      counter: 1
+      sink: 0
+    ended: false

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.fcstm
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.fcstm
@@ -1,0 +1,8 @@
+def int counter = 0;
+def int divisor = 0;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B : if [1 / divisor > 0];
+}

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.yaml
@@ -1,0 +1,48 @@
+schema_version: 1
+id: expression_failure_transition_guard_raises_expression_error
+title: transition guard expression failure raises expression error
+source:
+  fcstm: expression_failure_transition_guard_raises_expression_error.fcstm
+origin:
+  files:
+  - test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.fcstm
+  assertion_types:
+  - exception
+  - state
+  - vars
+categories:
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      counter: 0
+      divisor: 0
+    ended: false
+    return: null
+- cycle: {}
+  expect:
+    raises:
+      type: SimulationRuntimeExpressionError
+      match: 'transition guard evaluation failed: division by zero'
+      match_kind: substring
+      cause_type: ZeroDivisionError
+      cause_match: 'division by zero'
+      cause_match_kind: substring
+    state:
+    - Root
+    - A
+    vars:
+      counter: 0
+      divisor: 0
+    ended: false

--- a/test/render/test_statement.py
+++ b/test/render/test_statement.py
@@ -160,6 +160,75 @@ class TestRenderOperationStatements:
             '    scope["counter"] = fallback'
         )
 
+    def test_stmts_render_python_style_indents_multiline_templates(self):
+        statements = parse_with_grammar_entry(
+            """
+        if [counter > 0] {
+            counter = counter + 1;
+        } else if [counter < 0] {
+            tmp = 1;
+            counter = tmp;
+        } else {
+            counter = 0;
+        }
+        """,
+            entry_name="operational_statement_set",
+        )
+
+        rendered = render_stmt_nodes(
+            statements,
+            lang_style='python',
+            state_vars=['counter'],
+            ext_configs={
+                'assign': (
+                    '{{ target }} = wrap(\n'
+                    '    lambda: {{ expr }},\n'
+                    '    "assignment: {{ name }}",\n'
+                    ')'
+                ),
+                'if': (
+                    'if wrap(\n'
+                    '    lambda: {{ condition }},\n'
+                    '    "if-block",\n'
+                    '):'
+                ),
+                'elif': (
+                    'elif wrap(\n'
+                    '    lambda: {{ condition }},\n'
+                    '    "elif-block",\n'
+                    '):'
+                ),
+            },
+        )
+
+        assert rendered == (
+            'if wrap(\n'
+            '    lambda: scope["counter"] > 0,\n'
+            '    "if-block",\n'
+            '):\n'
+            '    scope["counter"] = wrap(\n'
+            '        lambda: scope["counter"] + 1,\n'
+            '        "assignment: counter",\n'
+            '    )\n'
+            'elif wrap(\n'
+            '    lambda: scope["counter"] < 0,\n'
+            '    "elif-block",\n'
+            '):\n'
+            '    tmp = wrap(\n'
+            '        lambda: 1,\n'
+            '        "assignment: tmp",\n'
+            '    )\n'
+            '    scope["counter"] = wrap(\n'
+            '        lambda: tmp,\n'
+            '        "assignment: counter",\n'
+            '    )\n'
+            'else:\n'
+            '    scope["counter"] = wrap(\n'
+            '        lambda: 0,\n'
+            '        "assignment: counter",\n'
+            '    )'
+        )
+
     @pytest.mark.parametrize(
         ['lang_style', 'expected'],
         [

--- a/test/render/test_statement.py
+++ b/test/render/test_statement.py
@@ -229,6 +229,39 @@ class TestRenderOperationStatements:
             '    )'
         )
 
+    def test_stmts_render_python_style_keeps_blank_template_lines_empty(self):
+        statements = parse_with_grammar_entry(
+            """
+        if [counter > 0] {
+            counter = counter + 1;
+        }
+        """,
+            entry_name="operational_statement_set",
+        )
+
+        rendered = render_stmt_nodes(
+            statements,
+            lang_style='python',
+            state_vars=['counter'],
+            ext_configs={
+                'assign': (
+                    '{{ target }} = wrap(\n'
+                    '\n'
+                    '    lambda: {{ expr }},\n'
+                    ')'
+                ),
+            },
+        )
+
+        assert rendered == (
+            'if scope["counter"] > 0:\n'
+            '    scope["counter"] = wrap(\n'
+            '\n'
+            '        lambda: scope["counter"] + 1,\n'
+            '    )'
+        )
+        assert '\n    \n' not in rendered
+
     @pytest.mark.parametrize(
         ['lang_style', 'expected'],
         [

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -214,6 +214,42 @@ def _set_generated_alignment(data):
         ),
         (
             lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update(
+                    {"raises": {"type": "ValueError", "cause_type": 1}}
+                )
+            ),
+            "raises.cause_type must be a string",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update(
+                    {"raises": {"type": "ValueError", "cause_match": 1}}
+                )
+            ),
+            "raises.cause_match must be a string",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update(
+                    {"raises": {"type": "ValueError", "cause_match_kind": "bad"}}
+                )
+            ),
+            "raises.cause_match_kind is invalid",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update(
+                    {"raises": {"type": "ValueError", "cause_match_kind": "regex"}}
+                )
+            ),
+            "raises.cause_match_kind requires cause_match",
+        ),
+        (
+            lambda data: (
                 _set_generated_alignment(data)
                 or data["steps"][0]["expect"].update({"cycle_count": 1})
             ),

--- a/test/template/python/test_runtime.py
+++ b/test/template/python/test_runtime.py
@@ -1,7 +1,6 @@
 import ast
 import importlib.util
 import os.path
-import shutil
 import subprocess
 import sys
 import textwrap
@@ -454,10 +453,26 @@ class TestPythonBuiltinTemplate:
             assert 'subprocess' not in source
             assert 'pathlib' not in source
 
-            ruff_executable = shutil.which('ruff')
-            if ruff_executable is None:
+            try:
+                from ruff import find_ruff_bin
+            except ImportError:
+                # from ruff import find_ruff_bin: Ruff is absent from the
+                # active test environment, so formatter convergence cannot run.
                 pytest.skip('ruff is not installed in this test environment')
+            try:
+                ruff_executable = find_ruff_bin()
+            except FileNotFoundError:
+                # find_ruff_bin(): the installed Ruff wrapper package cannot
+                # locate its bundled CLI binary in this test environment.
+                pytest.skip('ruff binary is not available in this test environment')
 
+            subprocess.run(
+                [ruff_executable, 'check', artifacts['machine_file']],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
             subprocess.run(
                 [ruff_executable, 'format', '--check', artifacts['machine_file']],
                 check=True,

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -107,7 +107,14 @@ _ALLOWED_CLI_RUNTIME_FIELDS = {
 }
 _ALLOWED_CYCLE_FIELDS = {"events"}
 _ALLOWED_STACK_FIELDS = {"path", "mode"}
-_ALLOWED_RAISES_FIELDS = {"type", "match", "match_kind"}
+_ALLOWED_RAISES_FIELDS = {
+    "type",
+    "match",
+    "match_kind",
+    "cause_type",
+    "cause_match",
+    "cause_match_kind",
+}
 _ALLOWED_LOG_FIELDS = {"contains", "not_contains"}
 _ALLOWED_LOG_ITEM_FIELDS = {"level", "message", "match_kind"}
 _ALLOWED_RUNTIME_OPTION_FIELDS = {"abstract_error_mode"}
@@ -526,6 +533,33 @@ def _assert_warnings(
             )
 
 
+def _assert_text_matches(
+    text: str,
+    match_text: str,
+    match_kind: str,
+    case: SemanticCase,
+    field_path: str,
+    target: str,
+) -> None:
+    if match_kind == "substring":
+        matched = match_text in text
+    elif match_kind == "regex":
+        matched = re.search(match_text, text) is not None
+    else:
+        raise _case_error(
+            case.id,
+            case.yaml_path,
+            "%s.%s has invalid match_kind %r" % (field_path, target, match_kind),
+        )
+    assert matched, "%s %s %s %r did not match %r" % (
+        case.id,
+        field_path,
+        target,
+        text,
+        match_text,
+    )
+
+
 def _assert_exception(
     exc: BaseException, expect: Mapping[str, Any], case: SemanticCase, field_path: str
 ) -> None:
@@ -542,24 +576,45 @@ def _assert_exception(
         )
     )
     if "match" in raises:
-        text = str(exc)
-        match_text = str(raises["match"])
-        match_kind = raises.get("match_kind", "substring")
-        if match_kind == "substring":
-            matched = match_text in text
-        elif match_kind == "regex":
-            matched = re.search(match_text, text) is not None
-        else:
-            raise _case_error(
-                case.id,
-                case.yaml_path,
-                "%s.raises has invalid match_kind %r" % (field_path, match_kind),
-            )
-        assert matched, "%s %s exception message %r did not match %r" % (
+        _assert_text_matches(
+            str(exc),
+            str(raises["match"]),
+            raises.get("match_kind", "substring"),
+            case,
+            field_path,
+            "exception message",
+        )
+    if "cause_type" in raises:
+        cause = exc.__cause__
+        assert cause is not None, "%s %s expected exception cause %r" % (
             case.id,
             field_path,
-            text,
-            match_text,
+            raises["cause_type"],
+        )
+        assert type(cause).__name__ == raises["cause_type"], (
+            "%s %s exception cause type mismatch: %s != %s: %s"
+            % (
+                case.id,
+                field_path,
+                type(cause).__name__,
+                raises["cause_type"],
+                cause,
+            )
+        )
+    if "cause_match" in raises:
+        cause = exc.__cause__
+        assert cause is not None, "%s %s expected exception cause message %r" % (
+            case.id,
+            field_path,
+            raises["cause_match"],
+        )
+        _assert_text_matches(
+            str(cause),
+            str(raises["cause_match"]),
+            raises.get("cause_match_kind", "substring"),
+            case,
+            field_path,
+            "exception cause message",
         )
 
 
@@ -892,6 +947,46 @@ class _GeneratedPythonAlignmentRuntime:
                     gen_exc,
                 )
             )
+            assert str(sim_exc) == str(gen_exc), (
+                "cycle(events=%r) exception message mismatch for DSL:\n%s\nsimulation=%s: %s\ngenerated=%s: %s"
+                % (
+                    events,
+                    self._dsl_code,
+                    type(sim_exc).__name__,
+                    sim_exc,
+                    type(gen_exc).__name__,
+                    gen_exc,
+                )
+            )
+            sim_cause = sim_exc.__cause__
+            gen_cause = gen_exc.__cause__
+            assert (sim_cause is None) == (gen_cause is None), (
+                "cycle(events=%r) exception cause presence mismatch for DSL:\n%s\nsimulation=%r\ngenerated=%r"
+                % (events, self._dsl_code, sim_cause, gen_cause)
+            )
+            if sim_cause is not None and gen_cause is not None:
+                assert type(sim_cause).__name__ == type(gen_cause).__name__, (
+                    "cycle(events=%r) exception cause type mismatch for DSL:\n%s\nsimulation=%s: %s\ngenerated=%s: %s"
+                    % (
+                        events,
+                        self._dsl_code,
+                        type(sim_cause).__name__,
+                        sim_cause,
+                        type(gen_cause).__name__,
+                        gen_cause,
+                    )
+                )
+                assert str(sim_cause) == str(gen_cause), (
+                    "cycle(events=%r) exception cause message mismatch for DSL:\n%s\nsimulation=%s: %s\ngenerated=%s: %s"
+                    % (
+                        events,
+                        self._dsl_code,
+                        type(sim_cause).__name__,
+                        sim_cause,
+                        type(gen_cause).__name__,
+                        gen_cause,
+                    )
+                )
             raise sim_exc
         assert sim_result == gen_result, (
             "cycle(events=%r) return mismatch for DSL:\n%s\nsimulation=%r, generated=%r"
@@ -1114,6 +1209,24 @@ def _validate_raises(
     if raises.get("match_kind", "substring") not in {"substring", "regex"}:
         raise _case_error(
             case_id, yaml_path, "%s.raises.match_kind is invalid" % field_path
+        )
+    if "cause_type" in raises and not isinstance(raises["cause_type"], str):
+        raise _case_error(
+            case_id, yaml_path, "%s.raises.cause_type must be a string" % field_path
+        )
+    if "cause_match" in raises and not isinstance(raises["cause_match"], str):
+        raise _case_error(
+            case_id, yaml_path, "%s.raises.cause_match must be a string" % field_path
+        )
+    if raises.get("cause_match_kind", "substring") not in {"substring", "regex"}:
+        raise _case_error(
+            case_id, yaml_path, "%s.raises.cause_match_kind is invalid" % field_path
+        )
+    if "cause_match_kind" in raises and "cause_match" not in raises:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.raises.cause_match_kind requires cause_match" % field_path,
         )
 
 


### PR DESCRIPTION
## 范围

上游伞拉取请求：[拉取请求 #144](https://github.com/HansBug/pyfcstm/pull/144)  
跟踪议题：[议题 #143](https://github.com/HansBug/pyfcstm/issues/143)  
依赖：

- [拉取请求 #145](https://github.com/HansBug/pyfcstm/pull/145)：共享语义夹具语料库，已合入。
- [拉取请求 #147](https://github.com/HansBug/pyfcstm/pull/147)：事件输入 / ended no-op 对齐，已合入；本拉取请求复用其固定下来的 generated Python alignment 路径。

本拉取请求实现伞拉取请求计划中的第 7 个切片：让内置 Python 生成运行时把 DSL 表达式运行时错误包装成 generated-local 的表达式错误边界，而不是裸露底层 Python 异常。

覆盖的来源问题：

| 编号 | 当前状态 | 来源 | 本拉取请求的预期处理 |
|---|---|---|---|
| U-2 | 🐞 待修复 | [worker-u：表达式错误包装不一致](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614288612) | Python 生成运行时在 guard、enter / during / exit action、transition effect、if-block condition 等 DSL 表达式失败时抛出 generated-local 表达式错误，并携带与 `SimulationRuntimeExpressionError` 等价的 usage 诊断和 `__cause__` 链。 |

明确不处理的范围：

- U-1：`path_name` event-like object 输入；已由 [拉取请求 #147](https://github.com/HansBug/pyfcstm/pull/147) 修复并验证。
- D-1 / M-1：ended no-op 与裸字符串事件输入；已由 [拉取请求 #147](https://github.com/HansBug/pyfcstm/pull/147) 修复并验证。
- E-1 / E-2 / E-4 / E-5：抽象处理器上下文与错误状态契约；正在 [拉取请求 #148](https://github.com/HansBug/pyfcstm/pull/148) 中推进，本拉取请求不触碰该范围。
- B/S/W/V lifecycle fallback、C hot-start / CLI init、F/R CLI session state，仍按 [拉取请求 #144](https://github.com/HansBug/pyfcstm/pull/144) 的后续拆分推进。

## 计划复核修订记录

开发前计划复核已在本拉取请求评论区完成：

- `claude reviewer`：[READY](https://github.com/HansBug/pyfcstm/pull/149#issuecomment-4621463655)
- `codex reviewer`：[CHANGES_REQUESTED](https://github.com/HansBug/pyfcstm/pull/149#issuecomment-4621468298)
- `deepseek reviewer`：[READY，并提出重要测试补强建议](https://github.com/HansBug/pyfcstm/pull/149#issuecomment-4621480399)

本正文已按这些意见修订：

- 红灯步骤明确拆成“先把夹具加入 `generated_python_alignment` runner，再运行 pytest 命令”，避免出现 `0 selected` 的不可验收红灯。
- 验收增加 `__cause__` 检查：夹具 `raises` 区块将支持可选 `cause_type` / `cause_match` / `cause_match_kind`，并由测试 helper 校验。
- 语义夹具覆盖从单一 assignment 扩展到 operation assignment、if-block condition、transition guard、transition effect 四类 usage 边界。
- 已确认 `SimulationRuntime` 的 guard 路径经由 `_transition_matches_guard()` 调用 `_evaluate_runtime_expr(..., usage='transition guard')`，因此 guard 表达式失败应与 generated runtime 对齐到同名表达式错误。
- ruff 验证改为检查 Python 测试 / helper 与生成后的 `.py` 产物；`templates/python/*.j2` 本身不作为 ruff 输入。

## 自包含问题说明

### U-2：生成 Python 运行时裸抛 `ZeroDivisionError`

最小 DSL：

```fcstm
def int x = 0;
def int y = 0;
state Root {
    state A {
        during {
            x = x + 1;
            y = 1 / y;
        }
    }
    [*] -> A;
}
```

最小 simulation 复现代码：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r'''
def int x = 0;
def int y = 0;
state Root {
    state A {
        during {
            x = x + 1;
            y = 1 / y;
        }
    }
    [*] -> A;
}
'''

model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
runtime = SimulationRuntime(model)
runtime.cycle()
```

`SimulationRuntime` 期望并已实现的错误边界：

```text
SimulationRuntimeExpressionError: operation assignment to 'y' evaluation failed: division by zero
__cause__: ZeroDivisionError('division by zero')
```

生成 Python 运行时当前实际行为：

```text
ZeroDivisionError: division by zero
__cause__: None
```

语义原因：DSL 表达式失败是用户模型错误，不应暴露成目标语言底层异常。生成运行时应该提供稳定的 generated-local 表达式错误类型，并带上 usage 信息，例如 `operation assignment to 'y'`，使用户在 simulate runtime 与 generated runtime 之间可复用同一类诊断策略。

## 实现计划

1. 测试驱动红灯先改共享语义夹具，而不是直接改模板：
   - 让现有 `expression_failure_raises_expression_error` 进入 `generated_python_alignment` runner；
   - 为 if-block condition、transition guard、transition effect 新增等价领域命名夹具，并全部进入 `simulation` 与 `generated_python_alignment` runner；
   - 在 `raises` 断言中加入 `cause_type` / `cause_match` / `cause_match_kind`，确认 `__cause__` 链被保留。
2. 红灯确认：运行 `pytest test/template/python/test_semantic_fixture_alignment.py -k expression_failure -v`，预期当前生成运行时因裸抛 `ZeroDivisionError` 或缺少 `__cause__` 与 `SimulationRuntimeExpressionError` 不一致而失败。
3. 在 `templates/python/machine.py.j2` 中新增 generated-local 表达式错误类型 `SimulationRuntimeExpressionError`。该类保持 generated runtime 自包含，不 import `pyfcstm.simulate`，并继承 `ValueError, ArithmeticError` 以保持与 simulation 侧契约一致。
4. 在生成运行时中新增表达式求值 helper，用最小异常边界包装 `ValueError` / `ArithmeticError`：
   - `ValueError`：例如 `math.sqrt(-1)`、`math.log(-1)` 等 DSL numeric/domain failure；
   - `ArithmeticError`：例如除零、overflow 等 DSL numeric failure；
   - 其他异常继续传播，不把事件解析错误、DFS 错误、抽象处理器错误或内部 bug 混入表达式错误类型。
5. 用模板生成代码在以下 DSL usage 边界统一包装：
   - operation assignment：`operation assignment to '<var>'`；
   - if-block condition：`if-block condition`；
   - transition guard：`transition guard`；
   - transition effect 内的 assignment / if-block condition，经 operation block helper 自然继承上述 usage；
   - lifecycle action 中的 concrete operation，经 operation block helper 自然继承上述 usage。
6. 包装错误必须保留原异常为 `__cause__`，并输出可诊断 usage 文案，例如 `operation assignment to 'y' evaluation failed: division by zero`。
7. 更新 Python 内置模板文档（`README.md.j2` / `README_zh.md.j2`）说明生成运行时的表达式错误边界；如模板源发生变化，运行 `make tpl` 刷新 `pyfcstm/template/python.zip` 与 `index.json`。
8. 保持 Python 3.7 兼容：不使用 PEP 604、`dict[str, ...]`、walrus、exception groups 等新语法。
9. 保持命名纪律：新增类、helper、fixture id、测试名使用领域行为名，不把拉取请求编号、议题编号或切片标签放入代码 / API / docstring / fixture id。

## 测试计划

红灯阶段：

```bash
# 先提交/暂存 fixture runner 与 cause 断言扩展后再运行；当前空 PR 上直接运行会 0 selected，不构成红灯证据。
pytest test/template/python/test_semantic_fixture_alignment.py -k expression_failure -v
```

预期红灯：生成 Python 运行时裸抛 `ZeroDivisionError`，或生成异常缺少 `SimulationRuntimeExpressionError` 类名、usage 文案、`__cause__` 链，无法与 simulation 侧对齐。

绿灯阶段 / 本地验证：

```bash
pytest test/template/python/test_semantic_fixture_alignment.py -k expression_failure -v
pytest test/simulate/test_semantic_fixtures.py -k expression_failure -v
pytest test/template/python/test_semantic_fixture_alignment.py -v
make tpl
pytest test/template/python/test_semantic_fixture_alignment.py -k expression_failure -v
python -m ruff check test/template/python test/testings/simulate_semantics.py
SKIP_SLOW_TESTS=1 make unittest
```

如果实现过程中新增 template helper 或 fixture schema 形态，需要补充 / 更新 schema 负向测试，并重新运行：

```bash
pytest test/simulate/test_semantic_fixtures.py -k schema_rejects_invalid_yaml -v
```

模板 formatter / lint 验证：`templates/python/*.j2` 不是 ruff 直接输入；需要对生成后的 `machine.py` 产物运行 ruff，确认模板输出稳定且可被 Python formatter/linter 接受。

补充验收要求：本拉取请求已经把 Python 内置模板的 representative generated `machine.py` 纳入 `ruff check` 与 `ruff format --check` 单元测试；`ruff` 已加入 `requirements-test.txt`，确保 CI 的 unittest 环境会安装该依赖。已调研 Ruff 的 Python 包：当前可用的公开入口主要是 `ruff.find_ruff_bin()` 用于定位随包分发的 CLI binary，没有稳定公开的 Python lint / format API。因此测试内使用 `find_ruff_bin()` 定位 Ruff，再调用 Ruff CLI，避免依赖私有 `ruff.__main__` 实现。

## 计划复核 / 验收清单

- [ ] PR 正文与 [拉取请求 #144](https://github.com/HansBug/pyfcstm/pull/144) 中 PR-7 路由以及 [议题 #143](https://github.com/HansBug/pyfcstm/issues/143) 中 U-2 来源问题一致。
- [ ] 开发前已有三路计划复核评论：`codex reviewer`、`claude reviewer`、`deepseek reviewer`；严重 / 重要计划问题已修复或已在本正文中明确落地。
- [ ] U-2 由共享语义夹具和 generated Python alignment 测试承载，且红灯命令不再出现 `0 selected`。
- [ ] 语义夹具覆盖 operation assignment、if-block condition、transition guard、transition effect 四类表达式 usage 边界。
- [ ] 生成 Python 运行时对 assignment / guard / effect / if-block condition 中的 DSL 表达式错误提供 generated-local 表达式错误边界。
- [ ] 错误文案包含 usage 信息和底层异常消息，且原异常保留为 `__cause__`。
- [ ] 非表达式错误继续按现有路径传播。
- [ ] Python 内置模板源和 packaged template assets 已同步；如运行 `make tpl`，对应 zip / index 变更已提交。
- [ ] Python 内置模板 representative generated `machine.py` 已通过 `ruff check` 与 `ruff format --check`，且 `ruff` 已进入 `requirements-test.txt`。
- [ ] 本地跳过慢速项的测试通过。
- [ ] GitHub Actions 检查通过。
- [ ] Codecov 报告修改代码没有已覆盖行回退；新增 / 修改行有合理覆盖。
- [ ] 实现后已有三路复核评论：`codex reviewer`、`claude reviewer`、`deepseek reviewer`；严重 / 重要问题在就绪前全部修复。

