### PR TITLE
修复 simulate hot start 与 CLI init 边界语义

### DIFF
--- a/pyfcstm/entry/simulate/commands.py
+++ b/pyfcstm/entry/simulate/commands.py
@@ -390,13 +390,12 @@ class CommandProcessor:
             initial_vars[var_name] = var_value
 
         # Validate that all variables are provided
-        if initial_vars:
-            missing_vars = set(self.runtime.vars.keys()) - set(initial_vars.keys())
-            if missing_vars:
-                return CommandResult(
-                    f"Error: All variables must be provided. Missing: {sorted(missing_vars)}\n"
-                    f"Available variables: {sorted(self.runtime.vars.keys())}"
-                )
+        missing_vars = set(self.runtime.vars.keys()) - set(initial_vars.keys())
+        if missing_vars:
+            return CommandResult(
+                f"Error: All variables must be provided. Missing: {sorted(missing_vars)}\n"
+                f"Available variables: {sorted(self.runtime.vars.keys())}"
+            )
 
         # Create new runtime with hot start
         try:
@@ -406,7 +405,7 @@ class CommandProcessor:
             new_runtime = SimulationRuntime(
                 self.state_machine,
                 initial_state=state_path,
-                initial_vars=initial_vars if initial_vars else None,
+                initial_vars=initial_vars,
                 abstract_error_mode=self.runtime.abstract_error_mode,
                 history_size=self.runtime.history_size
             )

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -742,11 +742,13 @@ class SimulationRuntime:
         """
         Validate that a hot-start target can reach a stable boundary.
 
-        The runtime constructs hot-start stacks without executing enter actions.
-        This preflight clones the constructed stack and current variables, then
-        advances that clone with no events in validation mode. The real runtime
-        therefore remains at the requested target state and no lifecycle or
-        abstract-handler side effects from the preflight are committed.
+        A non-pseudo leaf target is already a stable boundary, so validation
+        succeeds without executing the leaf's first-cycle ``during`` actions.
+        Other targets are checked by cloning the constructed stack and current
+        variables, then advancing that clone with no events in validation mode.
+        The real runtime therefore remains at the requested target state and no
+        lifecycle or abstract-handler side effects from the preflight are
+        committed.
 
         :param target_state: Target state selected by the user.
         :type target_state: State
@@ -754,6 +756,9 @@ class SimulationRuntime:
         :rtype: None
         :raises ValueError: If the target cannot reach a stoppable state or end.
         """
+        if target_state.is_stoppable:
+            return
+
         validation_stack = self._clone_stack(self.stack)
         validation_vars = copy.deepcopy(self.vars)
         success, _ = self._run_cycle_on_context(

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -543,7 +543,14 @@ class SimulationRuntime:
 
                 # Type checking and conversion
                 define = self.state_machine.defines[name]
-                if define.type == "int" and isinstance(value, float):
+                if type(value) is bool:
+                    raise ValueError(f"initial_vars[{name!r}] must not be bool")
+                if type(value) not in (int, float):
+                    raise ValueError(
+                        f"initial_vars[{name!r}] must be int or float, "
+                        f"got {type(value).__name__}"
+                    )
+                if define.type == "int" and type(value) is float:
                     if value != int(value):
                         raise ValueError(
                             f"Variable '{name}' is int type, cannot assign float {value}"
@@ -564,6 +571,7 @@ class SimulationRuntime:
 
             # Build hot start stack
             self.stack = self._build_hot_start_stack(target_state)
+            self._validate_hot_start_stack(target_state)
             self._initialized = True
         else:
             # Default mode: start from root state
@@ -729,6 +737,36 @@ class SimulationRuntime:
                     stack.append(_Frame(state, "active"))
 
         return stack
+
+    def _validate_hot_start_stack(self, target_state: State) -> None:
+        """
+        Validate that a hot-start target can reach a stable boundary.
+
+        The runtime constructs hot-start stacks without executing enter actions.
+        This preflight clones the constructed stack and current variables, then
+        advances that clone with no events in validation mode. The real runtime
+        therefore remains at the requested target state and no lifecycle or
+        abstract-handler side effects from the preflight are committed.
+
+        :param target_state: Target state selected by the user.
+        :type target_state: State
+        :return: ``None``.
+        :rtype: None
+        :raises ValueError: If the target cannot reach a stoppable state or end.
+        """
+        validation_stack = self._clone_stack(self.stack)
+        validation_vars = copy.deepcopy(self.vars)
+        success, _ = self._run_cycle_on_context(
+            validation_stack,
+            validation_vars,
+            {},
+            is_validation_mode=True,
+        )
+        if not success:
+            target_path = ".".join(target_state.path)
+            raise ValueError(
+                f"Hot start target '{target_path}' cannot reach a stoppable state"
+            )
 
     def _parse_event(self, event: Any) -> Event:
         """

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -343,7 +343,14 @@ class {{ machine_class_name(model) }}:
                     "initial_vars contains unknown variables: %s" % sorted(extra_vars)
                 )
             for name, value in initial_vars.items():
-                if self._VAR_TYPES[name] == "int" and isinstance(value, float):
+                if type(value) is bool:
+                    raise ValueError("initial_vars[%r] must not be bool" % (name,))
+                if type(value) not in (int, float):
+                    raise ValueError(
+                        "initial_vars[%r] must be int or float, got %s"
+                        % (name, type(value).__name__)
+                    )
+                if self._VAR_TYPES[name] == "int" and type(value) is float:
                     if value != int(value):
                         raise ValueError(
                             "Variable %r is int type, cannot assign float %r"
@@ -364,6 +371,7 @@ class {{ machine_class_name(model) }}:
             self._stack = self._build_hot_start_stack(
                 self._normalize_state_path(initial_state)
             )
+            self._validate_hot_start_stack(self._normalize_state_path(initial_state))
 
     @property
     def vars(self):
@@ -455,6 +463,21 @@ class {{ machine_class_name(model) }}:
             else:
                 stack.append({"state": state_path, "mode": "active"})
         return stack
+
+    def _validate_hot_start_stack(self, target_path):
+        validation_stack = self._clone_stack(self._stack)
+        validation_vars = dict(self._vars)
+        success, _ = self._run_cycle_on_context(
+            validation_stack,
+            validation_vars,
+            set(),
+            is_validation_mode=True,
+        )
+        if not success:
+            target_display = ".".join(self._STATE_INFO[target_path]["path"])
+            raise ValueError(
+                "Hot start target %r cannot reach a stoppable state" % (target_display,)
+            )
 
     @staticmethod
     def _clone_stack(stack):

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -465,6 +465,9 @@ class {{ machine_class_name(model) }}:
         return stack
 
     def _validate_hot_start_stack(self, target_path):
+        if self._is_stoppable_state(target_path):
+            return
+
         validation_stack = self._clone_stack(self._stack)
         validation_vars = dict(self._vars)
         success, _ = self._run_cycle_on_context(

--- a/test/fixtures/simulate_semantics/cases/cli_init_zero_variable_state.fcstm
+++ b/test/fixtures/simulate_semantics/cases/cli_init_zero_variable_state.fcstm
@@ -1,0 +1,4 @@
+state Root {
+    state A;
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/cli_init_zero_variable_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/cli_init_zero_variable_state.yaml
@@ -1,0 +1,39 @@
+schema_version: 1
+id: cli_init_zero_variable_state
+title: CLI init treats an empty variable snapshot as complete
+source:
+  fcstm: cli_init_zero_variable_state.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_cli_command_semantic_fixture
+  assertion_types:
+  - cli_output
+  - state
+  - vars_exact
+  - ended
+  notes:
+  - Covers zero-variable hot start through the command processor.
+categories:
+- runtime
+- hot_start
+- cli
+runners:
+- cli_command
+initial:
+  state: null
+  vars: null
+commands:
+- input: init Root.A
+  expect:
+    output_contains:
+    - 'Initialized from state: Root.A'
+    - Root.A
+    output_not_contains:
+    - Initialization failed
+    - Error
+    runtime:
+      state:
+      - Root
+      - A
+      vars_exact: {}
+      ended: false

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.fcstm
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.fcstm
@@ -1,0 +1,8 @@
+def int counter = 0;
+def float temp = 1.5;
+state Root {
+    state A {
+        during { counter = counter + 1; temp = temp + 0.5; }
+    }
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+id: hot_start_initial_vars_reject_bool_values
+title: Hot start rejects bool initial variable values at construction
+source:
+  fcstm: hot_start_initial_vars_reject_bool_values.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
+  assertion_types:
+  - constructor_exception
+  notes:
+  - Guards against Python bool being accepted as an int subclass.
+categories:
+- runtime
+- hot_start
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: Root.A
+  vars:
+    counter: true
+    temp: 1.0
+  expect:
+    raises:
+      type: ValueError
+      match: "initial_vars['counter'] must not be bool"
+      match_kind: substring
+steps: []

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.fcstm
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.fcstm
@@ -1,0 +1,8 @@
+def int counter = 0;
+def float temp = 1.5;
+state Root {
+    state A {
+        during { counter = counter + 1; temp = temp + 0.5; }
+    }
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+id: hot_start_initial_vars_reject_string_values
+title: Hot start rejects string initial variable values at construction
+source:
+  fcstm: hot_start_initial_vars_reject_string_values.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
+  assertion_types:
+  - constructor_exception
+  notes:
+  - Covers non-DSL numeric objects before the first cycle.
+categories:
+- runtime
+- hot_start
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: Root.A
+  vars:
+    counter: '0'
+    temp: '1.0'
+  expect:
+    raises:
+      type: ValueError
+      match: "initial_vars['counter'] must be int or float"
+      match_kind: substring
+steps: []

--- a/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.fcstm
+++ b/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.fcstm
@@ -1,0 +1,7 @@
+def int x = 0;
+state Root {
+    state A {
+        during { x = 1 / x; }
+    }
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.yaml
@@ -1,0 +1,34 @@
+schema_version: 1
+id: hot_start_leaf_defers_during_expression_error
+title: Hot start leaf defers during expression errors until the first cycle
+source:
+  fcstm: hot_start_leaf_defers_during_expression_error.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/pull/153#issuecomment-4627323375
+  assertion_types:
+  - exception
+  notes:
+  - A non-pseudo leaf target is already stoppable, so construction must not run its first-cycle during action.
+categories:
+- runtime
+- hot_start
+- validation
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: Root.A
+  vars:
+    x: 0
+steps:
+- cycle: {}
+  expect:
+    raises:
+      type: SimulationRuntimeExpressionError
+      match: "operation assignment to 'x' evaluation failed: division by zero"
+      match_kind: substring
+      cause_type: ZeroDivisionError
+      cause_match: 'division by zero'
+      cause_match_kind: substring

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.fcstm
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.fcstm
@@ -1,0 +1,8 @@
+def int x = 0;
+state Root {
+    state C {
+        state A { during { x = x + 1; } }
+        [*] -> A : if [x > 0];
+    }
+    [*] -> C;
+}

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.yaml
@@ -1,0 +1,31 @@
+schema_version: 1
+id: hot_start_rejects_blocked_composite_initial
+title: Hot start rejects a composite target whose initial transition is blocked
+source:
+  fcstm: hot_start_rejects_blocked_composite_initial.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
+  assertion_types:
+  - constructor_exception
+  notes:
+  - The target composite remains in init_wait because its guarded initial transition is false.
+categories:
+- runtime
+- hot_start
+- validation
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: Root.C
+  vars:
+    x: 0
+  expect:
+    raises:
+      type: ValueError
+      match: "Hot start target 'Root.C' cannot reach a stoppable state"
+      match_kind: substring
+steps: []

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.fcstm
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.fcstm
@@ -1,0 +1,6 @@
+def int x = 0;
+state Root {
+    pseudo state P { during { x = x + 1; } }
+    state A;
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.yaml
@@ -1,0 +1,32 @@
+schema_version: 1
+id: hot_start_rejects_unstable_pseudo_leaf
+title: Hot start rejects a pseudo leaf that cannot stabilize
+source:
+  fcstm: hot_start_rejects_unstable_pseudo_leaf.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
+  assertion_types:
+  - constructor_exception
+  notes:
+  - The pseudo state's during action may run only in an isolated preflight clone.
+categories:
+- runtime
+- hot_start
+- validation
+- pseudo_chain
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: Root.P
+  vars:
+    x: 0
+  expect:
+    raises:
+      type: ValueError
+      match: "Hot start target 'Root.P' cannot reach a stoppable state"
+      match_kind: substring
+steps: []

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -66,6 +66,46 @@ They are rejected when `generated_python_alignment` is present, because the
 generated Python runtime runner intentionally covers the shared public runtime
 surface and does not install Python callback handlers.
 
+## Runtime construction diagnostics
+
+`initial` normally provides optional runtime construction inputs:
+
+```yaml
+initial:
+  state: Root.A
+  vars:
+    counter: 0
+```
+
+When construction itself is expected to fail, `initial.expect.raises` records
+the constructor-time diagnostic. This shape is supported by `simulation` and
+`generated_python_alignment` runners:
+
+```yaml
+runners: [simulation, generated_python_alignment]
+initial:
+  state: Root.A
+  vars:
+    counter: "0"
+  expect:
+    raises:
+      type: ValueError
+      match: "initial_vars['counter'] must be int or float"
+      match_kind: substring
+steps: []
+```
+
+Allowed fields:
+
+- `initial.state`: state path string or `null`.
+- `initial.vars`: full variable snapshot mapping or `null`.
+- `initial.expect.raises`: required constructor exception expectation.
+
+Construction-diagnostic cases must use `steps: []`; executable steps are
+rejected so that constructor failures cannot silently skip later assertions.
+`initial.expect` is rejected for `cli_command` cases because CLI diagnostics
+belong under `commands[].expect`.
+
 ## Runtime options
 
 ```yaml
@@ -356,6 +396,10 @@ alignment cases because the generated runtime does not expose it as a public
 contract. `runtime_options`, `handlers`, `warnings`, `handler_calls`,
 `abstract_handler_errors`, `error_state`, and `error_info` are also rejected for
 generated alignment cases in this schema version.
+
+For constructor diagnostics, the alignment runner builds both runtimes and
+requires matching exception class names and messages before applying the
+`initial.expect.raises` matcher.
 
 ## CLI command cases
 

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -101,6 +101,9 @@ Allowed fields:
 - `initial.vars`: full variable snapshot mapping or `null`.
 - `initial.expect.raises`: required constructor exception expectation.
 
+When `initial.expect` is present, `initial.state` and `initial.vars` must both
+be explicit non-null values. Use `initial.vars: {}` for zero-variable machines.
+
 Construction-diagnostic cases must use `steps: []`; executable steps are
 rejected so that constructor failures cannot silently skip later assertions.
 `initial.expect` is rejected for `cli_command` cases because CLI diagnostics

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -254,6 +254,41 @@ def _set_model_build_expectation(data, raises):
             "model_build.expect has unknown fields",
         ),
         (
+            lambda data: data["initial"].update({"unexpected": True}),
+            "initial has unknown fields",
+        ),
+        (
+            lambda data: data["initial"].update({"expect": {"return": None}}),
+            "initial.expect has unknown fields",
+        ),
+        (
+            lambda data: data["initial"].update(
+                {"expect": {"raises": {"type": "UnknownError"}}}
+            ),
+            "initial.expect.raises.type is unknown",
+        ),
+        (
+            lambda data: (
+                _set_cli_expectation(data, {"output_contains": ["Commands"]})
+                or data.update(
+                    {
+                        "initial": {
+                            "state": "Root.A",
+                            "vars": {},
+                            "expect": {"raises": {"type": "ValueError"}},
+                        }
+                    }
+                )
+            ),
+            "initial.expect is not supported for cli_command cases",
+        ),
+        (
+            lambda data: data["initial"].update(
+                {"expect": {"raises": {"type": "ValueError"}}}
+            ),
+            "initial.expect.raises cases require empty steps",
+        ),
+        (
             lambda data: data["steps"][0]["expect"].update({"unknown_expect": True}),
             "unknown fields",
         ),

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -258,12 +258,48 @@ def _set_model_build_expectation(data, raises):
             "initial has unknown fields",
         ),
         (
-            lambda data: data["initial"].update({"expect": {"return": None}}),
+            lambda data: data["initial"].update(
+                {
+                    "state": "Root.A",
+                    "vars": {},
+                    "expect": {"return": None},
+                }
+            ),
             "initial.expect has unknown fields",
         ),
         (
             lambda data: data["initial"].update(
+                {
+                    "state": None,
+                    "vars": {},
+                    "expect": {"raises": {"type": "ValueError"}},
+                }
+            ),
+            "initial.expect requires initial.state",
+        ),
+        (
+            lambda data: data["initial"].update(
+                {
+                    "state": "Root.A",
+                    "vars": None,
+                    "expect": {"raises": {"type": "ValueError"}},
+                }
+            ),
+            "initial.expect requires initial.vars",
+        ),
+        (
+            lambda data: data["initial"].update(
                 {"expect": {"raises": {"type": "UnknownError"}}}
+            ),
+            "initial.expect requires initial.state",
+        ),
+        (
+            lambda data: data["initial"].update(
+                {
+                    "state": "Root.A",
+                    "vars": {},
+                    "expect": {"raises": {"type": "UnknownError"}},
+                }
             ),
             "initial.expect.raises.type is unknown",
         ),
@@ -284,7 +320,11 @@ def _set_model_build_expectation(data, raises):
         ),
         (
             lambda data: data["initial"].update(
-                {"expect": {"raises": {"type": "ValueError"}}}
+                {
+                    "state": "Root.A",
+                    "vars": {},
+                    "expect": {"raises": {"type": "ValueError"}},
+                }
             ),
             "initial.expect.raises cases require empty steps",
         ),

--- a/test/testings/__init__.py
+++ b/test/testings/__init__.py
@@ -1,2 +1,6 @@
-from .compare import walk_files, dir_compare, file_compare
-from .testfile import get_testfile
+from .compare import dir_compare as dir_compare
+from .compare import file_compare as file_compare
+from .compare import walk_files as walk_files
+from .testfile import get_testfile as get_testfile
+
+__all__ = ["dir_compare", "file_compare", "get_testfile", "walk_files"]

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -109,6 +109,8 @@ _ALLOWED_CLI_RUNTIME_FIELDS = {
     "stack",
     "cycle_count",
 }
+_ALLOWED_INITIAL_FIELDS = {"state", "vars", "expect"}
+_ALLOWED_INITIAL_CONSTRUCTOR_EXPECT_FIELDS = {"raises"}
 _ALLOWED_CYCLE_FIELDS = {"events"}
 _ALLOWED_MODEL_BUILD_FIELDS = {"expect"}
 _ALLOWED_MODEL_BUILD_EXPECT_FIELDS = {"raises"}
@@ -146,6 +148,7 @@ _EXCEPTION_TYPES = {
     "SimulationRuntimeExpressionError": SimulationRuntimeExpressionError,
     "ValueError": ValueError,
 }
+_CONSTRUCTOR_EXCEPTION_TYPES = tuple(_EXCEPTION_TYPES.values())
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
@@ -850,6 +853,69 @@ def run_model_build_case(case: SemanticCase) -> None:
         )
 
 
+def _initial_constructor_expect(case: SemanticCase) -> Optional[Mapping[str, Any]]:
+    initial = case.data.get("initial") or {}
+    expect = initial.get("expect")
+    if expect is None:
+        return None
+    return expect
+
+
+def _initial_constructor_expect_data(initial: Any) -> bool:
+    return isinstance(initial, dict) and "expect" in initial
+
+
+def _capture_construction(build_runtime):
+    try:
+        return build_runtime(), None
+    except _CONSTRUCTOR_EXCEPTION_TYPES as err:
+        # Each class in _CONSTRUCTOR_EXCEPTION_TYPES is an allowed semantic
+        # diagnostic in fixture ``raises`` matchers. Unexpected exceptions
+        # propagate and fail the test as implementation bugs.
+        return None, err
+
+
+def _assert_constructor_failure(build_runtime, expect, case: SemanticCase) -> None:
+    runtime, err = _capture_construction(build_runtime)
+    assert runtime is None, "%s initial.expect.raises unexpectedly built runtime" % (
+        case.id,
+    )
+    assert err is not None, "%s initial.expect.raises expected exception %r" % (
+        case.id,
+        expect["raises"],
+    )
+    _assert_exception(err, expect, case, "initial.expect.raises")
+
+
+def _assert_aligned_constructor_failure(case: SemanticCase) -> None:
+    expect = _initial_constructor_expect(case)
+    _, simulation_err = _capture_construction(lambda: _build_simulation_runtime(case))
+    _, generated_err = _capture_construction(lambda: _build_generated_runtime(case))
+
+    assert simulation_err is not None, (
+        "%s initial.expect.raises expected SimulationRuntime construction failure %r"
+        % (case.id, expect["raises"])
+    )
+    assert generated_err is not None, (
+        "%s initial.expect.raises expected generated Python construction failure %r"
+        % (case.id, expect["raises"])
+    )
+    assert type(simulation_err).__name__ == type(generated_err).__name__, (
+        "%s constructor exception type mismatch: simulation=%s generated=%s"
+        % (
+            case.id,
+            type(simulation_err).__name__,
+            type(generated_err).__name__,
+        )
+    )
+    assert str(simulation_err) == str(generated_err), (
+        "%s constructor exception message mismatch: simulation=%s generated=%s"
+        % (case.id, simulation_err, generated_err)
+    )
+    _assert_exception(simulation_err, expect, case, "initial.expect.raises")
+    _assert_exception(generated_err, expect, case, "initial.expect.raises")
+
+
 def _initial_kwargs(case: SemanticCase) -> Dict[str, Any]:
     initial = case.data.get("initial") or {}
     kwargs = {}
@@ -1142,6 +1208,14 @@ def run_simulation_case(case: SemanticCase, caplog: Any = None) -> None:
     if "model_build" in case.data:
         run_model_build_case(case)
         return
+    initial_expect = _initial_constructor_expect(case)
+    if initial_expect is not None:
+        _assert_constructor_failure(
+            lambda: _build_simulation_runtime(case),
+            initial_expect,
+            case,
+        )
+        return
     runtime = _build_simulation_runtime(case)
     handler_calls = _register_fixture_handlers(runtime, case)
     for index, step in enumerate(case.data.get("steps") or []):
@@ -1157,6 +1231,9 @@ def run_simulation_case(case: SemanticCase, caplog: Any = None) -> None:
 
 def run_generated_python_alignment_case(case: SemanticCase, caplog: Any = None) -> None:
     """Run a semantic fixture against simulation and generated Python runtimes."""
+    if _initial_constructor_expect(case) is not None:
+        _assert_aligned_constructor_failure(case)
+        return
     simulation_runtime = _build_simulation_runtime(case)
     _register_fixture_handlers(simulation_runtime, case)
     generated_runtime = _build_generated_runtime(case)
@@ -1890,12 +1967,14 @@ def _validate_origin(origin: Any, case_id: str, yaml_path: str) -> None:
             )
 
 
-def _validate_initial(initial: Any, case_id: str, yaml_path: str) -> None:
+def _validate_initial(
+    initial: Any, case_id: str, yaml_path: str, runners: Sequence[str]
+) -> None:
     if initial is None:
         return
     if not isinstance(initial, dict):
         raise _case_error(case_id, yaml_path, "initial must be a mapping")
-    unknown_initial = set(initial.keys()) - {"state", "vars"}
+    unknown_initial = set(initial.keys()) - _ALLOWED_INITIAL_FIELDS
     if unknown_initial:
         raise _case_error(
             case_id,
@@ -1906,6 +1985,27 @@ def _validate_initial(initial: Any, case_id: str, yaml_path: str) -> None:
         raise _case_error(case_id, yaml_path, "initial.state must be a string or null")
     if initial.get("vars") is not None:
         _validate_vars_mapping(initial.get("vars"), case_id, yaml_path, "initial.vars")
+    if "expect" not in initial:
+        return
+    if "cli_command" in runners:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "initial.expect is not supported for cli_command cases",
+        )
+    expect = initial["expect"]
+    if not isinstance(expect, dict):
+        raise _case_error(case_id, yaml_path, "initial.expect must be a mapping")
+    _validate_expect(
+        expect,
+        case_id,
+        yaml_path,
+        "initial.expect",
+        runners,
+        allowed_fields=_ALLOWED_INITIAL_CONSTRUCTOR_EXPECT_FIELDS,
+    )
+    if "raises" not in expect:
+        raise _case_error(case_id, yaml_path, "initial.expect.raises is required")
 
 
 def _validate_runtime_options(
@@ -2147,7 +2247,6 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
         raise _case_error(case_id, yaml_path, "id must match YAML file name")
     _validate_source(data.get("source"), case_id, yaml_path)
     _validate_origin(data.get("origin"), case_id, yaml_path)
-    _validate_initial(data.get("initial"), case_id, yaml_path)
     categories = data.get("categories")
     if not isinstance(categories, list) or not categories:
         raise _case_error(case_id, yaml_path, "categories must be a non-empty list")
@@ -2168,6 +2267,7 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
         raise _case_error(
             case_id, yaml_path, "cli_command cannot be mixed with other runners"
         )
+    _validate_initial(data.get("initial"), case_id, yaml_path, runners)
     _validate_runtime_options(data.get("runtime_options"), case_id, yaml_path, runners)
     _validate_handlers(data.get("handlers"), case_id, yaml_path, runners)
     _validate_model_build(data.get("model_build"), case_id, yaml_path, runners)
@@ -2190,6 +2290,22 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
             yaml_path,
             "expected_failure is reserved for inactive regression fixtures",
         )
+    has_initial_constructor_expect = _initial_constructor_expect_data(
+        data.get("initial")
+    )
+    if has_initial_constructor_expect:
+        if not has_steps:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "initial.expect.raises cases require empty steps",
+            )
+        if data["steps"]:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "initial.expect.raises cases require empty steps",
+            )
     if has_steps:
         if not isinstance(data["steps"], list):
             raise _case_error(case_id, yaml_path, "steps must be a list")

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -1987,6 +1987,18 @@ def _validate_initial(
         _validate_vars_mapping(initial.get("vars"), case_id, yaml_path, "initial.vars")
     if "expect" not in initial:
         return
+    if initial.get("state") is None:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "initial.expect requires initial.state",
+        )
+    if initial.get("vars") is None:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "initial.expect requires initial.vars",
+        )
     if "cli_command" in runners:
         raise _case_error(
             case_id,


### PR DESCRIPTION
## 子 PR：修复 simulate hot start 与 CLI init 边界语义

本 PR 是 [伞 PR #144](https://github.com/HansBug/pyfcstm/pull/144) 的 PR-4，覆盖 [issue #143](https://github.com/HansBug/pyfcstm/issues/143) 中 [Worker C：hot start / init 指定状态与变量初始化语义](https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614019573) 的 3 个剩余问题：C-1、C-2、C-3。

本 PR 不处理已经由其他子 PR 合入并回填为 `🔍 已验证` 的问题：PR-0 fixture corpus、PR-1 rollback/speculative metadata、PR-2 lifecycle/transition fallback、PR-3 abstract context/error contracts、PR-5 CLI/REPL session state、PR-6 event input / ended no-op、PR-7 generated expression errors。

## 覆盖问题与目标语义

| 编号 | 问题 | 目标语义 | 计划状态 |
|---|---|---|---|
| C-1 | CLI `init` 对零变量状态机把 `{}` 当成未提供变量，无法 hot start | 零变量状态机的完整变量集就是空 dict；CLI `init Root.A` 应与 API `SimulationRuntime(..., initial_vars={})` 一致成功 | ✅ 已本地验证 |
| C-2 | API/generated runtime hot start 接受字符串、bool 等非 DSL 数值值，延迟到 `cycle()` 裸崩 | `initial_vars` 在构造边界拒绝非 `int`/`float`；`bool` 不属于 DSL 数值类型；int 变量只接受整数值 | ✅ 已本地验证 |
| C-3 | hot start 到不可稳定目标会构造出反复 rollback、`cycle_count` 不增长的卡住 runtime | hot start 构造时必须验证目标可在当前变量和空事件条件下到达 stoppable leaf 或结束；否则抛明确 `ValueError` | ✅ 已本地验证 |

## C-1：CLI `init` 无法 hot start 零变量状态机

### 最小 DSL

```fcstm
state Root {
    state A;
    [*] -> A;
}
```

### 最小复现

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime
from pyfcstm.entry.simulate.commands import CommandProcessor

DSL = '''
state Root {
    state A;
    [*] -> A;
}
'''

sm = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
processor = CommandProcessor(SimulationRuntime(sm), sm)
print(processor.process('init Root.A').output)

api_runtime = SimulationRuntime(sm, initial_state='Root.A', initial_vars={})
print(api_runtime.current_state.path, api_runtime.vars)
```

### 期望结果

CLI `init Root.A` 成功，当前状态为 `('Root', 'A')`，变量为 `{}`；API hot start 同样成功。

### 修复前实际结果

```text
Initialization failed: initial_vars must be provided when initial_state is specified
api_state= ('Root', 'A') vars= {}
```

### 原因与疑似根因

`initial_vars={}` 对零变量状态机是完整变量集，不应等价于未提供。当前 CLI 命令处理里使用 truthiness 判断：

- `if initial_vars:` 会跳过空 dict 的完整性逻辑。
- `initial_vars=initial_vars if initial_vars else None` 会把 `{}` 转为 `None`，导致 `SimulationRuntime` 构造阶段按 API 契约拒绝。

计划修复：CLI `init` 保留空 dict，并用变量定义集合是否为空来决定是否要求命令行变量，而不是用 `initial_vars` 的 truthiness。

## C-2：`initial_vars` 接受非数值对象，非法值延迟到 `cycle()` 裸崩

### 最小 DSL

```fcstm
def int counter = 0;
def float temp = 1.5;
state Root {
    state A {
        during { counter = counter + 1; temp = temp + 0.5; }
    }
    [*] -> A;
}
```

### 最小复现

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = '''
def int counter = 0;
def float temp = 1.5;
state Root {
    state A {
        during { counter = counter + 1; temp = temp + 0.5; }
    }
    [*] -> A;
}
'''

sm = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
runtime = SimulationRuntime(
    sm,
    initial_state="Root.A",
    initial_vars={"counter": "0", "temp": "1.0"},
)
print(runtime.current_state.path, runtime.vars)
runtime.cycle()
```

### 期望结果

`SimulationRuntime(...)` 构造阶段统一抛出明确 `ValueError`，指出 `counter` / `temp` 的初始值必须是 DSL 数值类型。`bool` 也应拒绝，因为 DSL 当前变量类型只有 `int` / `float`，没有 bool。fixture 与 generated Python alignment 都固定断言 `ValueError`，避免 `ValueError` / `TypeError` 漂移。

### 修复前实际结果

```text
(('Root', 'A'), {'counter': '0', 'temp': '1.0'})
TypeError can only concatenate str (not "int") to str
```

`bool` 也会被 Python 的 `bool`-is-`int` 关系误接受。

### 原因与疑似根因

`SimulationRuntime.__init__` 只检查缺失/未知变量，并只对 `int` 变量接收整数性 `float` 做特殊转换；其他值会原样写入 `self.vars`。内置 Python 模板生成的 runtime 也有同构逻辑。计划修复：

- `int` 变量：接受 `int`；接受整数性 `float` 并转为 `int`；拒绝非整数 `float`；拒绝 `bool` 和其他对象。
- `float` 变量：接受 `int` / `float`；拒绝 `bool` 和其他对象。
- 实现需用 `type(value) is int` / `type(value) is float` 或等价检查显式排除 `bool`，不能依赖 `isinstance(True, int)`。
- 统一抛 `ValueError` 并固定 message 子串，例如 `initial_vars['counter'] must be int or float` / `initial_vars['counter'] must not be bool`，fixture 使用 `match_kind: substring`。
- 必须同步 `templates/python/` 与 packaged built-in template assets，并通过 generated Python alignment 验证。

## C-3：hot start 到不可稳定目标会静默卡住

### 最小 DSL A：pseudo 无出边

```fcstm
def int x = 0;
state Root {
    pseudo state P { during { x = x + 1; } }
    state A;
    [*] -> A;
}
```

### 最小 DSL B：composite 初始转换 guard 当前为 false

```fcstm
def int x = 0;
state Root {
    state C {
        state A { during { x = x + 1; } }
        [*] -> A : if [x > 0];
    }
    [*] -> C;
}
```

### 最小复现

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = '''
def int x = 0;
state Root {
    pseudo state P { during { x = x + 1; } }
    state A;
    [*] -> A;
}
'''

sm = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
r = SimulationRuntime(sm, initial_state='Root.P', initial_vars={'x': 0})
print('constructed', r.current_state.path, r.brief_stack, r.vars, r.cycle_count)
for _ in range(2):
    r.cycle()
    print(r.current_state.path, r.brief_stack, r.vars, r.cycle_count, r.is_ended)
```

composite 版本的完整复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = '''
def int x = 0;
state Root {
    state C {
        state A { during { x = x + 1; } }
        [*] -> A : if [x > 0];
    }
    [*] -> C;
}
'''

sm = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
r = SimulationRuntime(sm, initial_state='Root.C', initial_vars={'x': 0})
print('constructed', r.current_state.path, r.brief_stack, r.vars, r.cycle_count)
for _ in range(2):
    r.cycle()
    print(r.current_state.path, r.brief_stack, r.vars, r.cycle_count, r.is_ended)
```


### 期望结果

hot start 指定的目标必须能在当前变量与空事件集合下到达 stoppable leaf 或结束；若不能稳定，构造阶段应抛出明确 `ValueError`，message 固定包含 `Hot start target '<path>' cannot reach a stoppable state`，其中 `<path>` 是目标状态路径（例如 `Root.P` / `Root.C`）。

### 修复前实际结果

pseudo 无出边：

```text
constructed ('Root', 'P') [(('Root',), 'active'), (('Root', 'P'), 'active')] {'x': 0} cycle_count 0
cycle 1 ('Root', 'P') [(('Root',), 'active'), (('Root', 'P'), 'active')] {'x': 0} cycle_count 0 ended False
cycle 2 ('Root', 'P') [(('Root',), 'active'), (('Root', 'P'), 'active')] {'x': 0} cycle_count 0 ended False
```

composite blocked init：

```text
constructed ('Root', 'C') [(('Root',), 'active'), (('Root', 'C'), 'init_wait')] {'x': 0} cycle_count 0
cycle 1 ('Root', 'C') [(('Root',), 'active'), (('Root', 'C'), 'init_wait')] {'x': 0} cycle_count 0 ended False
cycle 2 ('Root', 'C') [(('Root',), 'active'), (('Root', 'C'), 'init_wait')] {'x': 0} cycle_count 0 ended False
```

### 原因与疑似根因

`_build_hot_start_stack()` 只按路径设置 frame mode：leaf 设为 `active`，composite 设为 `init_wait`，但没有验证该 stack 是否能稳定。pseudo leaf 不是 stoppable；guard false 的 composite init 也不能推进。由于 hot start 已将 runtime 视为 initialized，后续每次 `cycle()` 失败都会 rollback 到同一个 hot-start snapshot，只发 warning 而不让调用方得到明确失败。

计划修复：构造 hot-start stack 后执行只读/clone 稳定性预检，复用 PR-2 已稳定的 candidate validation / stoppable 语义；若预检失败，在构造阶段抛 `ValueError`。该预检不得执行真实 enter actions，也不得污染真实 runtime 的 `vars`、stack、warnings、handler logs；如果 pseudo `during` 或 initial/pseudo 链上的 effect 在预检 clone 中执行，其副作用也必须只存在于 clone 中并在预检后丢弃。

## 测试承载计划

优先复用 PR-0 的 semantic fixture corpus，不为同类 runtime 语义私造平行框架：

| 问题 | Fixture / test 承载 | 说明 |
|---|---|---|
| C-1 | 新增 CLI command semantic fixture | 用零变量 `.fcstm` + `commands: init Root.A` 断言输出、state、`vars_exact: {}`、ended。 |
| C-2 | 新增 runtime hot-start constructor negative fixture；同步 generated Python alignment | 必须扩展 `initial.expect.raises` / constructor expectation schema，并补 schema negative tests；runtime 与 generated Python runtime 都断言构造阶段统一 `ValueError`。 |
| C-3 | 新增 runtime hot-start constructor negative fixtures；同步 generated Python alignment | 用 pseudo leaf 无出边与 composite init guard false 两个 fixture 断言构造阶段 `ValueError`；必须同步修复 `templates/python/` 中同构 hot-start stack 稳定性缺口。 |

### Constructor expectation schema 设计

当前 PR-0 semantic fixture schema 的 `initial` 只允许 `state` / `vars`，无法表达 constructor-time failure；因此本 PR 必须扩展 schema、loader、runner 与 schema-negative tests。新增字段形态固定为：

```yaml
initial:
  state: Root.A
  vars:
    counter: "0"
    temp: "1.0"
  expect:
    raises:
      type: ValueError
      match: "initial_vars['counter'] must be int or float"
      match_kind: substring
```

约束：

- `initial.expect.raises` 使用现有 `raises` matcher 形态（`type` / `match` / `match_kind` / optional cause fields），并复用 `_EXCEPTION_TYPES`；本 PR 不新增 `TypeError` 到 allowed exception set。
- `initial.expect` 只能包含 `raises`；构造失败 fixture 不再执行 `steps` 的 runtime assertions。
- 该字段必须兼容 `runners: [simulation]` 和 `runners: [simulation, generated_python_alignment]`；alignment runner 需要分别构造 simulation runtime 与 generated Python runtime，并断言二者构造期异常类型与 message matcher 一致。
- schema negative tests 必须覆盖：未知 `initial.*` 字段继续拒绝、`initial.expect` 只允许 `raises`、`initial.expect.raises.type` 未知时拒绝、constructor expectation 不能用于 `cli_command` runner、constructor failure case 不能与可执行 `steps` 混用导致 silently ignored。

示例 C-3 fixture 形态：

```yaml
runners:
- simulation
- generated_python_alignment
initial:
  state: Root.P
  vars:
    x: 0
  expect:
    raises:
      type: ValueError
      match: "Hot start target 'Root.P' cannot reach a stoppable state"
      match_kind: substring
steps: []
```

如果某个断言属于 fixture 目前无法合理表达的 Python API shape（例如直接实例化 generated `Machine(initial_state=..., initial_vars=...)` 的构造异常），允许保留小范围专门 pytest，但必须在实现后更新 PR body 说明原因，并保证不复制整套语义样例。

新增 fixture 是增补覆盖；已有 dedicated `test/simulate/test_cli_init.py`、`test/simulate/test_hot_start.py`、`test/simulate/test_hot_start_edge_cases.py` 不在本 PR 中删除，除非某个用例被逐条迁移并证明覆盖行不回退。


## 实现摘要

- CLI `init` 现在把零变量状态机的 `{}` 作为完整变量快照传入 hot start，不再用 truthiness 把空 dict 降级为 `None`。
- `SimulationRuntime` 与内置 Python 模板 runtime 均在构造阶段校验 `initial_vars`：拒绝 `bool`，拒绝非 `int` / `float` 对象，保留 int 变量对整数性 `float` 的转换。
- hot-start stack 构造后会用 clone stack / clone vars / 空事件做 validation-mode 稳定性预检；目标不能到达 stoppable leaf 或 ended 时，构造阶段抛 `ValueError`，真实 runtime 的 vars、stack、handler 与 warning 状态不被预检污染。
- PR-0 semantic fixture schema 已扩展 `initial.expect.raises`，并补齐 constructor-time failure 的 simulation / generated Python alignment runner 与 schema negative tests。
- 已新增 C-1/C-2/C-3 对应 semantic fixtures，并通过 generated Python alignment 覆盖内置模板 runtime。


## 第二轮 review 修复摘要

- 已处理 [codex reviewer 的 I-1](https://github.com/HansBug/pyfcstm/pull/153#issuecomment-4627323375)：stoppable non-pseudo leaf hot start 现在静态通过稳定性预检，不再在构造期执行首个 `during`。pseudo leaf 与 composite target 仍继续使用 clone preflight 验证是否能到达 stoppable / ended。
- 已新增 `hot_start_leaf_defers_during_expression_error` semantic fixture，固定“构造成功、首个 `cycle()` 才抛 `SimulationRuntimeExpressionError`”的 API 与 generated Python alignment 语义。
- 已同步 `templates/python/machine.py.j2` 并运行 `make tpl` 刷新本地 packaged assets；tracked diff 仍只提交模板源与 fixture/schema，ignored zip 不纳入 commit。
- 已处理 claude reviewer 的 M 级 schema 建议：`initial.expect` 现在要求 `initial.state` 与 `initial.vars` 显式非空，零变量构造失败场景需写 `initial.vars: {}`，避免不完整 constructor expectation 延迟到 runtime。

## 实施步骤

1. 红灯：先加入 C-1/C-2/C-3 最小回归 fixture / constructor negative schema，并确认当前实现失败。
2. 修复 CLI `init` 空 dict 保留逻辑。
3. 修复 `SimulationRuntime` hot-start `initial_vars` 数值类型校验与 bool 排除。
4. 为 hot-start stack 增加稳定性预检，确保目标可达 stoppable leaf / ended；失败抛明确 `ValueError`，message 含固定子串 `Hot start target '<path>' cannot reach a stoppable state`。
5. 必须更新 `templates/python/` 中的同构 initial-vars 校验与 hot-start 稳定性预检逻辑，运行 `make tpl` 刷新 `pyfcstm/template/` packaged assets，并补 generated Python alignment。
6. 跑本地范围化测试与 slow-skip 全量测试；push 后等待 CI / Codecov。
7. ready 前如果 [伞 PR #144](https://github.com/HansBug/pyfcstm/pull/144) 或 base 已前进，先合入或 rebase 最新 base、处理冲突，再重新跑 CI/Codecov 和三路复审。

## 本地验收命令

计划中的最小验收命令：

```bash
pytest test/simulate/test_semantic_fixtures.py -q
pytest test/template/python/test_semantic_fixture_alignment.py -q
pytest test/simulate/test_cli_init.py test/simulate/test_hot_start.py test/simulate/test_hot_start_edge_cases.py -q
ruff check pyfcstm/simulate pyfcstm/entry/simulate test/testings test/simulate test/template/python
SKIP_SLOW_TESTS=1 make unittest
```

若修改内置 Python 模板，还必须执行：

```bash
make tpl
pytest test/template/python/test_semantic_fixture_alignment.py -q
pytest test/template/python/test_runtime.py -q
```

并确认代表性 generated `machine.py` 继续满足 `ruff check` 与 `ruff format --check`。

## Review / CI / Codecov 记录

- plan-stage review：✅ 三路 reviewer 已评论；首轮 claude/deepseek 提出 I 级 PR body 收口问题，已更新：C-2 统一 `ValueError`、constructor expectation schema 形态、generated Python alignment 必做、C-3 message 子串与预检副作用边界。
- TDD 红灯：✅ 已补 semantic fixtures 并确认旧实现覆盖的失败边界：`cli_init_zero_variable_state`、`hot_start_initial_vars_reject_bool_values`、`hot_start_initial_vars_reject_string_values`、`hot_start_rejects_blocked_composite_initial`、`hot_start_rejects_unstable_pseudo_leaf`。
- 本地绿灯：✅ 首轮已通过 focused tests 与 slow-skip 全量；第二轮修复后已通过 `pytest test/template/python/test_runtime.py -q`（7 passed）、`pytest test/template/python/test_semantic_fixture_alignment.py -q`（84 passed）、`pytest test/simulate/test_semantic_fixtures.py -q`（180 passed）、`pytest test/simulate/test_cli_init.py test/simulate/test_hot_start.py test/simulate/test_hot_start_edge_cases.py -q`（52 passed）、`ruff check pyfcstm/simulate pyfcstm/entry/simulate test/testings test/simulate test/template/python`、`SKIP_SLOW_TESTS=1 make unittest`（9206 passed, 164 skipped, 63 deselected）。
- CI：✅ 第二轮修复 head `9e44bb15b8fdd8a4351659c802527dcd5a1d96de` 已通过 GitHub Actions 33 个 checks。
- Codecov：✅ Codecov comment 显示 `All modified and coverable lines are covered by tests.`；modified coverable lines 全覆盖，未见覆盖回退信号。
- post-code adversarial review：✅ 首轮 post-code review 已完成：claude READY（1 个 M 级 schema 建议，已处理）、deepseek READY、codex NEEDS CHANGES（I-1 已修复并补 fixture）；第二轮 focused re-review 已全部 READY：claude [comment](https://github.com/HansBug/pyfcstm/pull/153#issuecomment-4627419445)、deepseek [comment](https://github.com/HansBug/pyfcstm/pull/153#issuecomment-4627425520)、codex [comment](https://github.com/HansBug/pyfcstm/pull/153#issuecomment-4627442639)。

## Base 同步 / merge conflict 纪律

- 2026-06-05 已执行 `git fetch origin` 与 `git merge origin/dev/simulate-semantics-umbrella-143`，结果为 `已经是最新的。`。第二轮修复后 `mergeStateStatus: CLEAN`，当前无 merge conflict。
- ready 前如果 base 再次前进，必须再次合入或 rebase 最新 base、解决冲突、重新跑 CI/Codecov，并要求 post-code reviewer 重点检查 merge 引入问题。

## 命名与边界纪律

- 代码、fixture、test、pydoc/docstring 命名只使用客观功能/领域语义，不使用 PR/issue/stage/workflow 等临时流程要素。
- Markdown 如需引用 workflow 项，使用显式链接，例如 [伞 PR #144](https://github.com/HansBug/pyfcstm/pull/144) 和 [issue #143](https://github.com/HansBug/pyfcstm/issues/143)。
- Python 测试只使用 `test/` 内 fixture / helper，不依赖 jsfcstm 或 Node 侧测试树。






