### PR TITLE
PR-157-B：model Expr 语义、优先级与 round-trip

### DIFF
--- a/pyfcstm/model/expr.py
+++ b/pyfcstm/model/expr.py
@@ -1176,15 +1176,22 @@ _OP_PRECEDENCE = {
     ">=": 20,
     "==": 20,
     "!=": 20,
+    "iff": 20,
 
     # Logical operators
     "&&": 15,
     "and": 15,
+    "xor": 12,
     "||": 10,
     "or": 10,
+    "=>": 7,
 
     # Conditional/ternary operator (C-style)
     "?:": 5
+}
+
+_RIGHT_ASSOCIATIVE_BINARY_OPS = {
+    "=>",
 }
 
 _OP_FUNCTIONS = {
@@ -1214,8 +1221,11 @@ _OP_FUNCTIONS = {
     "!=": operator.ne,
     "&&": lambda x, y: bool(x) and bool(y),
     "and": lambda x, y: bool(x) and bool(y),
+    "xor": lambda x, y: bool(x) != bool(y),
     "||": lambda x, y: bool(x) or bool(y),
     "or": lambda x, y: bool(x) or bool(y),
+    "=>": lambda x, y: (not bool(x)) or bool(y),
+    "iff": lambda x, y: bool(x) == bool(y),
 
     # Ternary operator
     "?:": lambda condition, true_value, false_value: true_value if condition else false_value
@@ -1257,6 +1267,7 @@ class BinaryOp(Op):
     __aliases__ = {
         'and': '&&',
         'or': '||',
+        'implies': '=>',
     }
 
     x: Expr
@@ -1312,13 +1323,17 @@ class BinaryOp(Op):
         left_need_paren = False
         if isinstance(self.x, Op):
             left_pre = _OP_PRECEDENCE[self.x.op_mark]
-            if left_pre < my_pre:
+            if self.op_mark in _RIGHT_ASSOCIATIVE_BINARY_OPS:
+                left_need_paren = left_pre <= my_pre
+            elif left_pre < my_pre:
                 left_need_paren = True
 
         right_need_paren = False
         if isinstance(self.y, Op):
             right_pre = _OP_PRECEDENCE[self.y.op_mark]
-            if right_pre <= my_pre:
+            if self.op_mark in _RIGHT_ASSOCIATIVE_BINARY_OPS:
+                right_need_paren = right_pre < my_pre
+            elif right_pre <= my_pre:
                 right_need_paren = True
 
         left_term = self.x.to_ast_node()

--- a/pyfcstm/model/expr.py
+++ b/pyfcstm/model/expr.py
@@ -1191,6 +1191,7 @@ _OP_PRECEDENCE = {
 }
 
 _RIGHT_ASSOCIATIVE_BINARY_OPS = {
+    "**",
     "=>",
 }
 

--- a/test/model/test_expr.py
+++ b/test/model/test_expr.py
@@ -2,6 +2,7 @@ import pytest
 import warnings
 
 from pyfcstm.dsl import parse_with_grammar_entry
+import pyfcstm.model.expr as model_expr
 from pyfcstm.model.expr import *
 
 
@@ -4600,3 +4601,103 @@ class TestModelExpr:
         assert isinstance(expr, ConditionalOp)
         assert expr(x=1) == 1
 
+    @pytest.mark.parametrize(
+        ["op", "left_value", "right_value", "expected_value", "expected_op"],
+        [
+            ("=>", True, True, True, "=>"),
+            ("=>", True, False, False, "=>"),
+            ("=>", False, True, True, "=>"),
+            ("=>", False, False, True, "=>"),
+            ("implies", True, True, True, "=>"),
+            ("implies", True, False, False, "=>"),
+            ("implies", False, True, True, "=>"),
+            ("implies", False, False, True, "=>"),
+            ("xor", True, True, False, "xor"),
+            ("xor", True, False, True, "xor"),
+            ("xor", False, True, True, "xor"),
+            ("xor", False, False, False, "xor"),
+            ("iff", True, True, True, "iff"),
+            ("iff", True, False, False, "iff"),
+            ("iff", False, True, False, "iff"),
+            ("iff", False, False, True, "iff"),
+        ],
+    )
+    def test_expr_new_logical_operator_truth_tables(
+        self, op, left_value, right_value, expected_value, expected_op
+    ):
+        """Test model-level truth tables for new logical binary operators."""
+        expr = BinaryOp(
+            x=Boolean(value=left_value),
+            op=op,
+            y=Boolean(value=right_value),
+        )
+        assert expr.op == expected_op
+        assert expr() is expected_value
+
+    def test_expr_new_logical_operator_precedence_and_aliases(self):
+        """Test precedence and alias boundaries for new logical operators."""
+        precedence = model_expr._OP_PRECEDENCE
+        assert precedence["=="] == precedence["!="] == precedence["iff"]
+        assert precedence["iff"] > precedence["&&"]
+        assert precedence["&&"] > precedence["xor"]
+        assert precedence["xor"] > precedence["||"]
+        assert precedence["||"] > precedence["=>"]
+        assert precedence["=>"] > precedence["?:"]
+
+        assert BinaryOp(Boolean(True), op="implies", y=Boolean(False)).op == "=>"
+        assert BinaryOp(Boolean(True), op="xor", y=Boolean(False)).op == "xor"
+        assert BinaryOp(Boolean(True), op="iff", y=Boolean(False)).op == "iff"
+        assert "^" not in BinaryOp.__aliases__
+
+        numeric_xor = BinaryOp(Integer(value=5), op="^", y=Integer(value=3))
+        assert numeric_xor.op == "^"
+        assert numeric_xor() == 6
+        assert str(numeric_xor.to_ast_node()) == "5 ^ 3"
+
+    @pytest.mark.parametrize(
+        ["expr_text", "expected_text"],
+        [
+            ("a > 0 => b > 0 => c > 0", "a > 0 => b > 0 => c > 0"),
+            ("a > 0 implies b > 0", "a > 0 => b > 0"),
+            ("(a > 0 => b > 0) => c > 0", "(a > 0 => b > 0) => c > 0"),
+            ("a > 0 => (b > 0 => c > 0)", "a > 0 => b > 0 => c > 0"),
+            ("a > 0 && b > 0 xor c > 0", "a > 0 && b > 0 xor c > 0"),
+            ("a > 0 xor b > 0 || c > 0", "a > 0 xor b > 0 || c > 0"),
+            ("a > 0 == b > 0 iff c > 0", "a > 0 == (b > 0) iff (c > 0)"),
+            ("a > 0 != b > 0 iff c > 0", "a > 0 != (b > 0) iff (c > 0)"),
+            ("a > 0 iff b > 0 == c > 0", "a > 0 iff (b > 0) == (c > 0)"),
+            ("a > 0 iff b > 0 != c > 0", "a > 0 iff (b > 0) != (c > 0)"),
+        ],
+    )
+    def test_expr_new_logical_operator_round_trip(self, expr_text, expected_text):
+        """Test model round-trip for new logical operator precedence."""
+        expr = parse_expr_from_string(expr_text, mode="logical")
+        assert str(expr.to_ast_node()) == expected_text
+
+        reparsed = parse_expr_from_string(str(expr.to_ast_node()), mode="logical")
+        assert pytest.approx(expr) == reparsed
+
+    def test_expr_implication_to_ast_node_associativity(self):
+        """Test right-associative implication parentheses in model exports."""
+        a = Variable(name="a") > 0
+        b = Variable(name="b") > 0
+        c = Variable(name="c") > 0
+
+        right_natural = BinaryOp(x=a, op="=>", y=BinaryOp(x=b, op="=>", y=c))
+        assert str(right_natural.to_ast_node()) == "a > 0 => b > 0 => c > 0"
+
+        left_grouped = BinaryOp(x=BinaryOp(x=a, op="=>", y=b), op="=>", y=c)
+        assert str(left_grouped.to_ast_node()) == "(a > 0 => b > 0) => c > 0"
+
+        right_reparsed = parse_expr_from_string(str(right_natural), mode="logical")
+        left_reparsed = parse_expr_from_string(str(left_grouped), mode="logical")
+        assert pytest.approx(right_natural) == right_reparsed
+        assert pytest.approx(left_grouped) == left_reparsed
+
+    def test_expr_new_logical_unknown_operator_still_fails(self):
+        """Test that unknown logical operators still fail at eval/export time."""
+        expr = BinaryOp(Boolean(True), op="<=>", y=Boolean(False))
+        with pytest.raises(KeyError):
+            expr()
+        with pytest.raises(KeyError):
+            expr.to_ast_node()

--- a/test/model/test_expr.py
+++ b/test/model/test_expr.py
@@ -4694,6 +4694,29 @@ class TestModelExpr:
         assert pytest.approx(right_natural) == right_reparsed
         assert pytest.approx(left_grouped) == left_reparsed
 
+    def test_expr_power_to_ast_node_associativity_round_trip(self):
+        """Test right-associative power parentheses in model exports."""
+        right_natural = BinaryOp(
+            x=Integer(value=2),
+            op="**",
+            y=BinaryOp(x=Integer(value=3), op="**", y=Integer(value=2)),
+        )
+        assert right_natural() == 512
+        assert str(right_natural.to_ast_node()) == "2 ** 3 ** 2"
+
+        left_grouped = BinaryOp(
+            x=BinaryOp(x=Integer(value=2), op="**", y=Integer(value=3)),
+            op="**",
+            y=Integer(value=2),
+        )
+        assert left_grouped() == 64
+        assert str(left_grouped.to_ast_node()) == "(2 ** 3) ** 2"
+
+        right_reparsed = parse_expr_from_string(str(right_natural), mode="numeric")
+        left_reparsed = parse_expr_from_string(str(left_grouped), mode="numeric")
+        assert pytest.approx(right_natural) == right_reparsed
+        assert pytest.approx(left_grouped) == left_reparsed
+
     def test_expr_new_logical_unknown_operator_still_fails(self):
         """Test that unknown logical operators still fail at eval/export time."""
         expr = BinaryOp(Boolean(True), op="<=>", y=Boolean(False))


### PR DESCRIPTION
## PR-157-B 定位

本 PR 是 [issue #157](https://github.com/HansBug/pyfcstm/issues/157) 的第二个子 PR，挂在 umbrella PR [#158](https://github.com/HansBug/pyfcstm/pull/158) 下。PR-157-A / [#159](https://github.com/HansBug/pyfcstm/pull/159) 已经合入本 PR 的 base 分支，完成共享 grammar、Python parser/listener、jsfcstm parser/AST/type 最小对齐。本 PR 只承接 model `Expr` 层，不再修改 grammar。

> 重要说明：issue #157 原文早期曾包含 condition 侧 `^` 作为 bool xor 的设想；该设想已经被 #158 与 #159 明确取消。后续实现必须以 #158 最新结论为准：condition bool xor 只支持 `xor`；numeric `^` 只表示 bitwise xor；不得加入任何 `^ -> xor` alias。

## 当前状态

| 项目 | 状态 | 说明 |
|---|---|---|
| PR 类型 | ✅ 实现已推送 | 当前实现 commit：`5b795b2f`、`44a1fe35` |
| 上游依赖 | ✅ 已满足 | PR-157-A 已合入，base 分支含 `=>` / `implies`、`xor`、`iff` 的 DSL AST 输入 |
| plan review | ✅ C/I 已清零 | 两轮 codex / claude / deepseek plan review 后进入实现 |
| TDD 与实现 | ✅ 已完成 | 已补 model 层 truth table、alias、precedence、round-trip、右结合、numeric `^` 回归和负例测试 |
| `**` 既有问题 | ✅ 已修复 | `**` 本来就是 grammar 层 `<assoc=right>`；旧 `to_ast_node()` 对 `(2 ** 3) ** 2` 会丢左括号，现已补回归测试 |
| 本地验证 | ✅ 已通过 | 见下方验证记录 |
| CI | ✅ 已通过 | 新 SHA `44a1fe35` 的 Code Test、Release Test、jsfcstm、CLI Build 全部通过 |
| 实现 review | ✅ C/I 已清零 | Codecov 已确认 modified coverable lines 全覆盖；codex、claude、deepseek 三路实现 review 均已到位，结论均为 C=0/I=0；剩余仅 M 级非阻塞建议 |
| 当前禁止项 | ✅ 已保持 | 不改 grammar、不改 listener、不改 render、不改 solver、不改 jsfcstm/editor、不引入 condition `^` |

## 目标

让 `pyfcstm/model/expr.py` 的模型表达式层完整支持 PR-157-A 已经产生的 canonical ops：

| op | 来源 | model 语义 | 说明 |
|---|---|---|---|
| `=>` | `A => B`、`A implies B` | `(not bool(A)) or bool(B)` | implication，右结合 |
| `xor` | `A xor B` | `bool(A) != bool(B)` | bool exclusive-or，不是 exactly-one |
| `iff` | `A iff B` | `bool(A) == bool(B)` | bool equivalence，等价于 condition equality 的可读写法 |

本 PR 同时修复 model 导出层已有的 `**` 右结合括号问题。这个修复与 `=>` 使用同一套右结合二元运算规则，避免引入只服务新 op 的半截抽象。

## 范围

### 本 PR 已修改

| 路径 | 目的 |
|---|---|
| `pyfcstm/model/expr.py` | 新增 model 层 operator precedence、eval function、alias/canonical 规则，并让右结合二元 op 的 `to_ast_node()` 保留语义 |
| `test/model/test_expr.py` | 新增真值表、优先级、round-trip、numeric `^` 回归、`**` 右结合回归和负例测试 |

### 本 PR 不应修改

| 路径 / 模块 | 原因 |
|---|---|
| `pyfcstm/dsl/grammar/*`、`pyfcstm/dsl/listener.py` | 已由 PR-157-A 完成；B 不重新打开 grammar 风险面 |
| `pyfcstm/render/expr.py`、`test/render/*` | 留给 PR-157-C |
| `pyfcstm/solver/expr.py`、`test/solver/*` | 留给 PR-157-C |
| `editors/jsfcstm/*`、`editors/vscode/*` | 最小 JS parity 已由 A 完成；editor polish 留给 D |
| `docs/*`、changelog / release note | 留给 PR-157-E |

## 设计要求

1. `BinaryOp` 必须能 eval `=>`、`xor`、`iff`，且结果按 Python bool 语义返回。
2. `BinaryOp.__aliases__` 可以包含 `implies -> =>`，但不得包含任何 `^ -> xor`。
3. numeric `^` 必须保持 bitwise xor，不受 `xor` bool op 影响。
4. precedence 必须与 #158 保持一致：`==/!=/iff` > `&&` > `xor` > `||` > `=>` > `?:`。
5. `=>` 必须作为右结合运算处理：`A => B => C` 的模型导出和再解析必须保持为 `A => (B => C)` 的语义。
6. `**` 也必须作为右结合运算处理：`(2 ** 3) ** 2` 必须导出为 `(2 ** 3) ** 2`，不能导出为会被 grammar 再解析成 `2 ** (3 ** 2)` 的 `2 ** 3 ** 2`。
7. `BinaryOp.to_ast_node()` 对右结合 op（当前 `**` 与 `=>`）使用专门括号规则：左侧子表达式与父节点同优先级时必须加括号；右侧子表达式与父节点同优先级时不加括号。
8. `iff` 在 model 层保留 canonical op `iff`，不降级成 `==`，避免 DSL round-trip 丢可读性。
9. 不新增 bool variable atom / bool `def` 类型；测试仍使用现有 bool literal、比较表达式和 model expression 构造方式。

## 测试覆盖

| 维度 | 覆盖情况 |
|---|---|
| 真值表 | `=>`、`implies`、`xor`、`iff` 对 `2**2=4` 个 bool 输入组合全部覆盖 |
| alias | 覆盖 `implies` canonical 到 `=>`；断言不存在 `^ -> xor` alias |
| numeric 回归 | 覆盖 `5 ^ 3` eval 仍为 `6`，且 AST 导出仍为 `5 ^ 3` |
| precedence | 覆盖 `iff`、`&&`、`xor`、`||`、`=>`、`?:` 的相对优先级边界 |
| `=>` 右结合 | 覆盖 `A => B => C`、`(A => B) => C`、`A => (B => C)` 的 `to_ast_node()` / string / 再解析语义 |
| `**` 右结合 | 覆盖 `2 ** (3 ** 2)` 自然导出和 `(2 ** 3) ** 2` 左括号保留；再解析后分别保持 512 与 64 |
| round-trip | 覆盖 `cond == cond iff cond`、`cond != cond iff cond`、`cond iff cond == cond`、`cond && cond xor cond`、`cond xor cond || cond` 等关键组合 |
| 负例 | 未知 op 仍在 eval/export 时失败；condition `^` 不在 model alias 层变成 `xor` |

## 本地验证记录

```bash
pytest test/model/test_expr.py::TestModelExpr::test_expr_implication_to_ast_node_associativity test/model/test_expr.py::TestModelExpr::test_expr_power_to_ast_node_associativity_round_trip test/model/test_expr.py::TestModelExpr::test_expr_new_logical_operator_round_trip -q --tb=short
# 通过：12 passed

pytest test/model/test_expr.py -q --tb=short
# 通过：751 passed

SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=model
# 通过：1777 passed

git diff --check
# 通过
```

新 SHA `44a1fe35` 上也执行过全量快速单测：

```bash
SKIP_SLOW_TESTS=1 make unittest
# 通过：40150 passed, 164 skipped, 63 deselected
```

Codecov 评论已确认：modified and coverable lines are covered by tests；project coverage 93.69%。

## Review challenge 清单

三路 reviewer 请重点挑战：

1. 本 PR 是否严格承接 #158 / #159 最新结论，而不是 issue #157 早期的 condition `^` 旧设想？
2. `BinaryOp.__aliases__` 是否存在误把 `^` alias 到 `xor` 的风险？
3. `=>` 右结合是否只靠字符串“看起来对”，还是有 round-trip / AST 结构测试保证？
4. `**` 的既有右结合导出 bug 是否已被真实回归测试锁住？
5. precedence 测试是否足以防止 `to_ast_node()` 多加括号或少加括号导致再解析语义变化？
6. `iff` 保留 distinct op 是否与后续 renderer / solver 计划一致？
7. 本 PR 是否越界修改 renderer、solver、grammar、jsfcstm 或 docs？
8. 测试命令是否能无脑执行，且不依赖 JS / editor 测试树？
9. 是否有应在 B 内解决的 C/I 问题，而不是推给 C/D/E？

## C/I/M 分级口径

- **C / Critical**：会引入错误语义、破坏 numeric `^`、重新支持 condition `^`、改变 grammar/parser、或让 model round-trip 无法可靠表达 `=>` / `**` 右结合。
- **I / Important**：实现不完整导致高概率漏测 precedence、alias、round-trip、truth table、unknown op、`**` 回归或 patch coverage。
- **M / Minor**：措辞、表格、测试命名、可后续优化的可读性建议；不阻塞进入下一步。

## 当前待办

- [x] 从 #158 最新 head 创建 PR-157-B 分支。
- [x] 创建 empty draft PR。
- [x] 三路第一轮 plan review：codex reviewer / claude reviewer / deepseek reviewer。
- [x] 修复第一轮所有 C/I 级 plan 问题。
- [x] 三路第二轮 plan 复核达到 `C=0/I=0`。
- [x] TDD：新增失败测试。
- [x] 实现 model `Expr` 支持。
- [x] 补 `**` 右结合 round-trip 回归测试。
- [x] 本地 skip-slow 验证。
- [x] push 实现 commit。
- [x] 等待新 SHA CI。
- [x] 三路实现 review + Codecov review。
- [x] 修复到 `C=0/I=0`。
- [x] ready 后等待用户是否 merge 的下一步指示。



