### PR TITLE
PR-157-C：renderer 与 solver 支持条件逻辑运算

### DIFF
--- a/pyfcstm/render/expr.py
+++ b/pyfcstm/render/expr.py
@@ -49,17 +49,28 @@ _DSL_STYLE = {
     'Name': '{{ node.name }}',
     'UnaryOp': '{{ node.op }}{{ node.expr | expr_render }}',
     'BinaryOp': '{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}',
+    'BinaryOp(=>)': '{{ node.expr1 | expr_render }} => {{ node.expr2 | expr_render }}',
+    'BinaryOp(xor)': '{{ node.expr1 | expr_render }} xor {{ node.expr2 | expr_render }}',
+    'BinaryOp(iff)': '{{ node.expr1 | expr_render }} iff {{ node.expr2 | expr_render }}',
     'ConditionalOp': '({{ node.cond | expr_render }}) ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}',
+}
+
+_C_LIKE_COND_STYLE = {
+    'BinaryOp(=>)': '((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))',
+    'BinaryOp(xor)': '(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))',
+    'BinaryOp(iff)': '(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))',
 }
 
 _C_STYLE = {
     **_DSL_STYLE,
+    **_C_LIKE_COND_STYLE,
     'Boolean': '{{ (1 if node.value else 0) | hex }}',
     'BinaryOp(**)': 'pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})',
 }
 
 _CPP_STYLE = {
     **_DSL_STYLE,
+    **_C_LIKE_COND_STYLE,
     'Boolean': '{{ "true" if node.value else "false" }}',
     'UFunc': 'std::{{ node.func }}({{ node.expr | expr_render }})',
     'BinaryOp(**)': 'std::pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})',
@@ -92,6 +103,9 @@ _PY_STYLE = {
     'UFunc(round)': 'round({{ node.expr | expr_render }})',
     'UFunc(trunc)': 'math.trunc({{ node.expr | expr_render }})',
     'UnaryOp(!)': 'not {{ node.expr | expr_render }}',
+    'BinaryOp(=>)': '((not ({{ node.expr1 | expr_render }})) or ({{ node.expr2 | expr_render }}))',
+    'BinaryOp(xor)': '(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))',
+    'BinaryOp(iff)': '(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))',
     'BinaryOp(&&)': '{{ node.expr1 | expr_render }} and {{ node.expr2 | expr_render }}',
     'BinaryOp(||)': '{{ node.expr1 | expr_render }} or {{ node.expr2 | expr_render }}',
     'ConditionalOp': '{{ node.value_true | expr_render }} if {{ node.cond | expr_render }} else {{ node.value_false | expr_render }}',
@@ -99,6 +113,7 @@ _PY_STYLE = {
 
 _JAVA_STYLE = {
     **_DSL_STYLE,
+    **_C_LIKE_COND_STYLE,
     'Boolean': '{{ "true" if node.value else "false" }}',
     'Constant': '{{ "Math.PI" if node.value == "pi" else ("Math.E" if node.value == "e" else ("(2.0 * Math.PI)" if node.value == "tau" else node.value | repr)) }}',
     'UFunc': 'Math.{{ node.func }}({{ node.expr | expr_render }})',
@@ -109,6 +124,7 @@ _JAVA_STYLE = {
 
 _JS_STYLE = {
     **_DSL_STYLE,
+    **_C_LIKE_COND_STYLE,
     'Boolean': '{{ "true" if node.value else "false" }}',
     'Constant': '{{ "Math.PI" if node.value == "pi" else ("Math.E" if node.value == "e" else ("(2 * Math.PI)" if node.value == "tau" else node.value | repr)) }}',
     'UFunc': 'Math.{{ node.func }}({{ node.expr | expr_render }})',
@@ -121,6 +137,7 @@ _TS_STYLE = {
 
 _RUST_STYLE = {
     **_DSL_STYLE,
+    **_C_LIKE_COND_STYLE,
     'Boolean': '{{ "true" if node.value else "false" }}',
     'Constant': '{{ "std::f64::consts::PI" if node.value == "pi" else ("std::f64::consts::E" if node.value == "e" else ("std::f64::consts::TAU" if node.value == "tau" else node.value | repr)) }}',
     'UFunc(abs)': '({{ node.expr | expr_render }}).abs()',
@@ -139,6 +156,7 @@ _RUST_STYLE = {
 
 _GO_STYLE = {
     **_DSL_STYLE,
+    **_C_LIKE_COND_STYLE,
     'Boolean': '{{ "true" if node.value else "false" }}',
     'Constant': '{{ "math.Pi" if node.value == "pi" else ("math.E" if node.value == "e" else ("(2 * math.Pi)" if node.value == "tau" else node.value | repr)) }}',
     'UFunc(abs)': '{{ go_abs_expr(node.expr | expr_render, node.expr) }}',
@@ -258,7 +276,7 @@ def _infer_expr_type(node: dsl_nodes.Expr) -> Optional[str]:
     if isinstance(node, dsl_nodes.BinaryOp):
         if node.op in {'<<', '>>', '&', '^', '|'}:
             return 'int'
-        if node.op in {'&&', '||', '==', '!=', '<', '<=', '>', '>='}:  # pragma: no cover
+        if node.op in {'&&', '||', '=>', 'xor', 'iff', '==', '!=', '<', '<=', '>', '>='}:  # pragma: no cover
             # These BinaryOp operators produce boolean results and only
             # appear in boolean contexts (guard / ConditionalOp cond) per
             # the grammar -- the same reason the ``!`` UnaryOp branch

--- a/pyfcstm/render/expr.py
+++ b/pyfcstm/render/expr.py
@@ -61,6 +61,11 @@ _C_LIKE_COND_STYLE = {
     'BinaryOp(iff)': '(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))',
 }
 
+_PY_CONDITION_OPS = {
+    '&&', 'and', '||', 'or', '=>', 'xor', 'iff',
+    '==', '!=', '<', '<=', '>', '>=',
+}
+
 _C_STYLE = {
     **_DSL_STYLE,
     **_C_LIKE_COND_STYLE,
@@ -103,6 +108,8 @@ _PY_STYLE = {
     'UFunc(round)': 'round({{ node.expr | expr_render }})',
     'UFunc(trunc)': 'math.trunc({{ node.expr | expr_render }})',
     'UnaryOp(!)': 'not {{ node.expr | expr_render }}',
+    'BinaryOp(==)': '{{ py_condition_operand(node.expr1 | expr_render, node.expr1) }} == {{ py_condition_operand(node.expr2 | expr_render, node.expr2) }}',
+    'BinaryOp(!=)': '{{ py_condition_operand(node.expr1 | expr_render, node.expr1) }} != {{ py_condition_operand(node.expr2 | expr_render, node.expr2) }}',
     'BinaryOp(=>)': '((not ({{ node.expr1 | expr_render }})) or ({{ node.expr2 | expr_render }}))',
     'BinaryOp(xor)': '(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))',
     'BinaryOp(iff)': '(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))',
@@ -234,6 +241,23 @@ def _merge_numeric_types(type_a: Optional[str], type_b: Optional[str]) -> Option
     return next(iter(known))  # pragma: no cover
 
 
+def _py_condition_operand(expr_text: str, node: dsl_nodes.Expr) -> str:
+    """
+    Wrap Python comparison operands that are themselves condition expressions.
+
+    Python chains adjacent comparisons (``a == b > c``), while the FCSTM AST
+    is already explicit. Parenthesizing condition-valued operands prevents a
+    rendered child comparison from being absorbed into the parent comparison.
+    """
+    if isinstance(node, dsl_nodes.BinaryOp) and node.op in _PY_CONDITION_OPS:
+        return f'({expr_text})'
+    if isinstance(node, dsl_nodes.UnaryOp) and node.op in {'!', 'not'}:
+        return f'({expr_text})'
+    if isinstance(node, dsl_nodes.ConditionalOp):
+        return f'({expr_text})'
+    return expr_text
+
+
 def _infer_expr_type(node: dsl_nodes.Expr) -> Optional[str]:
     """
     Infer a coarse DSL numeric type for one expression node.
@@ -276,7 +300,7 @@ def _infer_expr_type(node: dsl_nodes.Expr) -> Optional[str]:
     if isinstance(node, dsl_nodes.BinaryOp):
         if node.op in {'<<', '>>', '&', '^', '|'}:
             return 'int'
-        if node.op in {'&&', '||', '=>', 'xor', 'iff', '==', '!=', '<', '<=', '>', '>='}:  # pragma: no cover
+        if node.op in {'&&', '||', '=>', 'xor', 'iff', '==', '!=', '<', '<=', '>', '>='}:
             # These BinaryOp operators produce boolean results and only
             # appear in boolean contexts (guard / ConditionalOp cond) per
             # the grammar -- the same reason the ``!`` UnaryOp branch
@@ -309,6 +333,7 @@ def _create_base_env(env: Optional[jinja2.Environment] = None) -> jinja2.Environ
     """
     if env is not None:
         env.globals.setdefault('expr_infer_type', _infer_expr_type)
+        env.globals.setdefault('py_condition_operand', _py_condition_operand)
         env.globals.setdefault('go_expr_type', lambda node: 'float64' if _infer_expr_type(node) == 'float' else 'int')
         env.globals.setdefault(
             'go_abs_expr',
@@ -320,6 +345,7 @@ def _create_base_env(env: Optional[jinja2.Environment] = None) -> jinja2.Environ
         return env
     env = add_settings_for_env(jinja2.Environment())
     env.globals['expr_infer_type'] = _infer_expr_type
+    env.globals['py_condition_operand'] = _py_condition_operand
     env.globals['go_expr_type'] = lambda node: 'float64' if _infer_expr_type(node) == 'float' else 'int'
     env.globals['go_abs_expr'] = lambda expr_text, node: (
         f'int(math.Abs(float64({expr_text})))'
@@ -362,6 +388,7 @@ def fn_expr_render(node: Union[float, int, dict, dsl_nodes.Expr, Any],
         'True'
 
     """
+    env = _create_base_env(env)
     if isinstance(node, dsl_nodes.Expr):
         if isinstance(node, (dsl_nodes.Float, dsl_nodes.Integer, dsl_nodes.Boolean, dsl_nodes.Constant,
                              dsl_nodes.HexInt, dsl_nodes.Paren, dsl_nodes.Name, dsl_nodes.ConditionalOp)) \

--- a/pyfcstm/solver/expr.py
+++ b/pyfcstm/solver/expr.py
@@ -180,6 +180,11 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
             )
             return left | right
         elif expr.op == '^':
+            if z3.is_bool(left) or z3.is_bool(right):
+                raise ValueError(
+                    f"Bitwise XOR (^) requires non-boolean operands, "
+                    f"got {left.sort()} and {right.sort()}"
+                )
             warnings.warn(
                 f"Bitwise XOR (^) on Z3 Int types has limited support. "
                 f"For full bitwise operation support, consider using Z3 BitVec types. "

--- a/pyfcstm/solver/expr.py
+++ b/pyfcstm/solver/expr.py
@@ -44,6 +44,29 @@ from ..model.expr import (
 from ..model.model import StateMachine, VarDefine
 
 
+def _require_bool_operands(
+        op: str,
+        left: Union[z3.ArithRef, z3.BoolRef],
+        right: Union[z3.ArithRef, z3.BoolRef],
+) -> None:
+    """
+    Validate that a logical binary operator received boolean Z3 operands.
+
+    :param op: Binary operator mark.
+    :type op: str
+    :param left: Left Z3 operand.
+    :type left: Union[z3.ArithRef, z3.BoolRef]
+    :param right: Right Z3 operand.
+    :type right: Union[z3.ArithRef, z3.BoolRef]
+    :raises ValueError: If either operand is not a Z3 boolean expression.
+    """
+    if not z3.is_bool(left) or not z3.is_bool(right):
+        raise ValueError(
+            f"Boolean operands required for operator '{op}', "
+            f"got {left.sort()} and {right.sort()}"
+        )
+
+
 def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -> Union[z3.ArithRef, z3.BoolRef]:
     """
     Convert a pyfcstm expression to a Z3 solver expression.
@@ -201,6 +224,16 @@ def expr_to_z3(expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]) -
             return z3.And(left, right)
         elif expr.op in ('||', 'or'):
             return z3.Or(left, right)
+        elif expr.op == '=>':
+            _require_bool_operands(expr.op, left, right)
+            return z3.Implies(left, right)
+        elif expr.op == 'xor':
+            _require_bool_operands(expr.op, left, right)
+            return z3.Xor(left, right)
+        elif expr.op == 'iff':
+            _require_bool_operands(expr.op, left, right)
+            # For BoolRef operands, equality is boolean equivalence in Z3.
+            return left == right
 
         else:
             raise ValueError(f"Unsupported binary operator: {expr.op}")

--- a/test/render/test_expr.py
+++ b/test/render/test_expr.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model.expr import parse_expr_node_to_expr
 from pyfcstm.render import create_env, render_expr_node, create_expr_render_template
 
 
@@ -395,10 +396,12 @@ class TestRenderExprNode:
     @pytest.mark.parametrize(
         'expr_text, expected',
         [
-            ('true iff false == false', '((True) == (False)) == False'),
-            ('true iff false != true', '((True) == (False)) != True'),
+            ('true iff false == false', '(((True) == (False))) == False'),
+            ('true iff false != true', '(((True) == (False))) != True'),
             ('false => true && false', '((not (False)) or (True and False))'),
             ('(false => true) && false', '(((not (False)) or (True))) and False'),
+            ('!true == false', '(not True) == False'),
+            ('((true) ? false : true) == false', '(False if True else True) == False'),
         ],
     )
     def test_python_condition_logical_rendering_keeps_parent_expression_semantics(
@@ -410,12 +413,42 @@ class TestRenderExprNode:
         assert result == expected
         assert eval(result) == eval(expected)
 
+    @pytest.mark.parametrize(
+        'expr_text',
+        [
+            'a > 0 iff b > 0 == c > 0',
+            'a > 0 == b > 0 iff c > 0',
+            'a > 0 xor b > 0 == c > 0',
+            'a > 0 != b > 0 xor c > 0',
+        ],
+    )
+    def test_python_condition_logical_rendering_matches_model_for_comparison_chains(
+        self, expr_text, new_env
+    ):
+        ast_node = parse_with_grammar_entry(expr_text, entry_name='generic_expression')
+        result = render_expr_node(ast_node, lang_style='python', env=new_env)
+        model_expr = parse_expr_node_to_expr(ast_node)
+
+        for a in (-1, 1):
+            for b in (-1, 1):
+                for c in (-1, 1):
+                    scope = {'a': a, 'b': b, 'c': c}
+                    assert eval(result, {}, scope) == model_expr(**scope)
+
     @pytest.mark.parametrize('lang_style', ['dsl', 'c', 'cpp', 'java', 'js', 'ts', 'rust', 'go', 'python'])
     def test_numeric_caret_renderer_remains_bitwise_xor(self, lang_style, new_env):
         ast_node = parse_with_grammar_entry('x ^ y', entry_name='generic_expression')
         result = render_expr_node(ast_node, lang_style=lang_style, env=new_env)
 
         assert result == 'x ^ y'
+
+    @pytest.mark.parametrize('expr_text', ['true => false', 'true xor false', 'true iff false'])
+    def test_infer_expr_type_for_condition_logical_operators(self, expr_text):
+        from pyfcstm.render.expr import _infer_expr_type
+
+        ast_node = parse_with_grammar_entry(expr_text, entry_name='generic_expression')
+
+        assert _infer_expr_type(ast_node) == 'int'
 
 
 @pytest.mark.unittest

--- a/test/render/test_expr.py
+++ b/test/render/test_expr.py
@@ -1,5 +1,6 @@
 import pytest
 
+from pyfcstm.dsl import node as dsl_nodes
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model.expr import parse_expr_node_to_expr
 from pyfcstm.render import create_env, render_expr_node, create_expr_render_template
@@ -412,6 +413,21 @@ class TestRenderExprNode:
 
         assert result == expected
         assert eval(result) == eval(expected)
+
+    def test_python_condition_operand_wraps_direct_conditional_node(self, new_env):
+        ast_node = dsl_nodes.BinaryOp(
+            expr1=dsl_nodes.ConditionalOp(
+                cond=dsl_nodes.Boolean('true'),
+                value_true=dsl_nodes.Boolean('false'),
+                value_false=dsl_nodes.Boolean('true'),
+            ),
+            op='==',
+            expr2=dsl_nodes.Boolean('false'),
+        )
+        result = render_expr_node(ast_node, lang_style='python', env=new_env)
+
+        assert result == '(False if True else True) == False'
+        assert eval(result) is True
 
     @pytest.mark.parametrize(
         'expr_text',

--- a/test/render/test_expr.py
+++ b/test/render/test_expr.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pyfcstm.dsl import parse_with_grammar_entry
-from pyfcstm.render import create_env, render_expr_node
+from pyfcstm.render import create_env, render_expr_node, create_expr_render_template
 
 
 @pytest.fixture
@@ -326,6 +326,96 @@ class TestRenderExprNode:
             input_value, lang_style=lang_type, ext_configs=ext_configs, env=new_env
         )
         assert result == expected_result
+
+    @pytest.mark.parametrize(
+        'lang_style, expr_text, expected',
+        [
+            ('dsl', 'true => false', 'True => False'),
+            ('c', 'true => false', '((!(0x1)) || (0x0))'),
+            ('cpp', 'true => false', '((!(true)) || (false))'),
+            ('java', 'true => false', '((!(true)) || (false))'),
+            ('js', 'true => false', '((!(true)) || (false))'),
+            ('ts', 'true => false', '((!(true)) || (false))'),
+            ('rust', 'true => false', '((!(true)) || (false))'),
+            ('go', 'true => false', '((!(true)) || (false))'),
+            ('python', 'true => false', '((not (True)) or (False))'),
+            ('dsl', 'true xor false', 'True xor False'),
+            ('c', 'true xor false', '((0x1) != (0x0))'),
+            ('cpp', 'true xor false', '((true) != (false))'),
+            ('java', 'true xor false', '((true) != (false))'),
+            ('js', 'true xor false', '((true) != (false))'),
+            ('ts', 'true xor false', '((true) != (false))'),
+            ('rust', 'true xor false', '((true) != (false))'),
+            ('go', 'true xor false', '((true) != (false))'),
+            ('python', 'true xor false', '((True) != (False))'),
+            ('dsl', 'true iff false', 'True iff False'),
+            ('c', 'true iff false', '((0x1) == (0x0))'),
+            ('cpp', 'true iff false', '((true) == (false))'),
+            ('java', 'true iff false', '((true) == (false))'),
+            ('js', 'true iff false', '((true) == (false))'),
+            ('ts', 'true iff false', '((true) == (false))'),
+            ('rust', 'true iff false', '((true) == (false))'),
+            ('go', 'true iff false', '((true) == (false))'),
+            ('python', 'true iff false', '((True) == (False))'),
+        ],
+    )
+    def test_render_expr_node_for_condition_logical_operators(
+        self, lang_style, expr_text, expected, new_env
+    ):
+        ast_node = parse_with_grammar_entry(expr_text, entry_name='generic_expression')
+        result = render_expr_node(ast_node, lang_style=lang_style, env=new_env)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        'lang_style',
+        ['c', 'cpp', 'java', 'js', 'ts', 'rust', 'go', 'python'],
+    )
+    def test_non_dsl_styles_do_not_leak_condition_logical_operators(
+        self, lang_style, new_env
+    ):
+        ast_node = parse_with_grammar_entry(
+            '(true => false) xor (false iff true)',
+            entry_name='generic_expression',
+        )
+        result = render_expr_node(ast_node, lang_style=lang_style, env=new_env)
+
+        assert '=>' not in result
+        assert ' xor ' not in result
+        assert ' iff ' not in result
+
+    @pytest.mark.parametrize('lang_style', ['dsl', 'c', 'cpp', 'java', 'js', 'ts', 'rust', 'go', 'python'])
+    def test_condition_logical_operator_templates_are_operator_specific(self, lang_style):
+        templates = create_expr_render_template(lang_style)
+
+        assert 'BinaryOp(=>)' in templates
+        assert 'BinaryOp(xor)' in templates
+        assert 'BinaryOp(iff)' in templates
+        assert 'BinaryOp(^)' not in templates
+
+    @pytest.mark.parametrize(
+        'expr_text, expected',
+        [
+            ('true iff false == false', '((True) == (False)) == False'),
+            ('true iff false != true', '((True) == (False)) != True'),
+            ('false => true && false', '((not (False)) or (True and False))'),
+            ('(false => true) && false', '(((not (False)) or (True))) and False'),
+        ],
+    )
+    def test_python_condition_logical_rendering_keeps_parent_expression_semantics(
+        self, expr_text, expected, new_env
+    ):
+        ast_node = parse_with_grammar_entry(expr_text, entry_name='generic_expression')
+        result = render_expr_node(ast_node, lang_style='python', env=new_env)
+
+        assert result == expected
+        assert eval(result) == eval(expected)
+
+    @pytest.mark.parametrize('lang_style', ['dsl', 'c', 'cpp', 'java', 'js', 'ts', 'rust', 'go', 'python'])
+    def test_numeric_caret_renderer_remains_bitwise_xor(self, lang_style, new_env):
+        ast_node = parse_with_grammar_entry('x ^ y', entry_name='generic_expression')
+        result = render_expr_node(ast_node, lang_style=lang_style, env=new_env)
+
+        assert result == 'x ^ y'
 
 
 @pytest.mark.unittest

--- a/test/render/test_render.py
+++ b/test/render/test_render.py
@@ -200,6 +200,44 @@ class TestRenderRender:
 
         assert rendered == 'vars_["counter"] >= 1'
 
+    def test_renderer_expr_render_seeds_python_condition_helpers(self):
+        ast_node = parse_with_grammar_entry(
+            """
+        def int a = 0;
+        def int b = 0;
+        def int c = 0;
+        state Root {
+            state A;
+            [*] -> A : if [a > 0 iff b > 0 == c > 0];
+        }
+        """,
+            entry_name="state_machine_dsl",
+        )
+        model = parse_dsl_node_to_state_machine(ast_node)
+
+        with TemporaryDirectory() as template_dir:
+            with open(os.path.join(template_dir, 'config.yaml'), 'w') as f:
+                f.write(
+                    "expr_styles:\n"
+                    "  python_names:\n"
+                    "    base_lang: python\n"
+                    "    Name: \"{{ node.name }}\"\n"
+                )
+            with open(os.path.join(template_dir, 'expr.txt.j2'), 'w') as f:
+                f.write(
+                    "{{ model.root_state.init_transitions[0].guard.to_ast_node() "
+                    "| expr_render(style='python_names') }}"
+                )
+
+            renderer = StateMachineCodeRenderer(template_dir)
+
+            with TemporaryDirectory() as output_dir:
+                renderer.render(model=model, output_dir=output_dir)
+                with open(os.path.join(output_dir, 'expr.txt'), 'r') as f:
+                    rendered = f.read()
+
+        assert eval(rendered, {}, {'a': 1, 'b': -1, 'c': 0}) is True
+
     def test_renderer_injects_default_state_vars_and_var_types_for_default_cpp_stmt_rendering(self):
         ast_node = parse_with_grammar_entry(
             """

--- a/test/render/test_statement.py
+++ b/test/render/test_statement.py
@@ -160,12 +160,22 @@ class TestRenderOperationStatements:
             '    scope["counter"] = fallback'
         )
 
-    def test_stmts_render_python_style_supports_condition_logical_operators(self):
+    @pytest.mark.parametrize(
+        'condition, expected_condition',
+        [
+            ('(a > 0) => (b > 0)', '((not ((scope["a"] > 0))) or ((scope["b"] > 0)))'),
+            ('a > 0 xor b > 0', '((scope["a"] > 0) != (scope["b"] > 0))'),
+            ('a > 0 iff b > 0', '((scope["a"] > 0) == (scope["b"] > 0))'),
+        ],
+    )
+    def test_stmts_render_python_style_supports_condition_logical_operators(
+        self, condition, expected_condition
+    ):
         statements = parse_with_grammar_entry(
-            """
-        if [a > 0 iff b > 0] {
+            f"""
+        if [{condition}] {{
             a = 1;
-        }
+        }}
         """,
             entry_name="operational_statement_set",
         )
@@ -177,9 +187,11 @@ class TestRenderOperationStatements:
         )
 
         assert rendered == (
-            'if ((scope["a"] > 0) == (scope["b"] > 0)):\n'
+            f'if {expected_condition}:\n'
             '    scope["a"] = 1'
         )
+        assert '=>' not in rendered
+        assert ' xor ' not in rendered
         assert ' iff ' not in rendered
 
     def test_stmts_render_python_style_indents_multiline_templates(self):

--- a/test/render/test_statement.py
+++ b/test/render/test_statement.py
@@ -160,6 +160,28 @@ class TestRenderOperationStatements:
             '    scope["counter"] = fallback'
         )
 
+    def test_stmts_render_python_style_supports_condition_logical_operators(self):
+        statements = parse_with_grammar_entry(
+            """
+        if [a > 0 iff b > 0] {
+            a = 1;
+        }
+        """,
+            entry_name="operational_statement_set",
+        )
+
+        rendered = render_stmt_nodes(
+            statements,
+            lang_style='python',
+            state_vars=['a', 'b'],
+        )
+
+        assert rendered == (
+            'if ((scope["a"] > 0) == (scope["b"] > 0)):\n'
+            '    scope["a"] = 1'
+        )
+        assert ' iff ' not in rendered
+
     def test_stmts_render_python_style_indents_multiline_templates(self):
         statements = parse_with_grammar_entry(
             """

--- a/test/solver/test_expr.py
+++ b/test/solver/test_expr.py
@@ -239,6 +239,14 @@ class TestExprToZ3:
         with pytest.raises(ValueError, match='Boolean operands required'):
             expr_to_z3(expr, z3_vars)
 
+    def test_bitwise_caret_rejects_boolean_operands(self):
+        """Test solver does not treat bitwise caret as condition bool xor."""
+        expr = BinaryOp(x=Variable('a'), op='^', y=Variable('b'))
+        z3_vars = {'a': z3.Bool('a'), 'b': z3.Bool('b')}
+
+        with pytest.raises(ValueError, match=r'Bitwise XOR \(\^\) requires non-boolean operands'):
+            expr_to_z3(expr, z3_vars)
+
     # Note: Bitwise operators are not supported on Z3 Int types
     # They require BitVec types which is a different approach
     # Skipping bitwise operator tests

--- a/test/solver/test_expr.py
+++ b/test/solver/test_expr.py
@@ -176,6 +176,69 @@ class TestExprToZ3:
         solver.add(z3_vars['x'] == 150)
         assert solver.check() == z3.sat
 
+    @pytest.mark.parametrize(
+        'op, lhs, rhs',
+        [
+            ('=>', False, False),
+            ('=>', False, True),
+            ('=>', True, False),
+            ('=>', True, True),
+            ('xor', False, False),
+            ('xor', False, True),
+            ('xor', True, False),
+            ('xor', True, True),
+            ('iff', False, False),
+            ('iff', False, True),
+            ('iff', True, False),
+            ('iff', True, True),
+        ],
+    )
+    def test_condition_logical_operators_match_model_truth_table(self, op, lhs, rhs):
+        """Test new condition logical operators against model evaluation."""
+        expr = BinaryOp(x=Boolean(lhs), op=op, y=Boolean(rhs))
+        expected = expr()
+
+        result = expr_to_z3(expr, {})
+        simplified = z3.simplify(result)
+
+        assert z3.is_bool(simplified)
+        assert z3.is_true(simplified) if expected else z3.is_false(simplified)
+
+    @pytest.mark.parametrize(
+        'op, expected_true_assignments',
+        [
+            ('=>', [(False, False), (False, True), (True, True)]),
+            ('xor', [(False, True), (True, False)]),
+            ('iff', [(False, False), (True, True)]),
+        ],
+    )
+    def test_condition_logical_operators_are_satisfiable_as_expected(
+        self, op, expected_true_assignments
+    ):
+        """Test Z3 satisfiability for new condition logical operators."""
+        z3_vars = {'a': z3.Bool('a'), 'b': z3.Bool('b')}
+        expr = BinaryOp(x=Variable('a'), op=op, y=Variable('b'))
+        result = expr_to_z3(expr, z3_vars)
+
+        for lhs in (False, True):
+            for rhs in (False, True):
+                solver = z3.Solver()
+                solver.add(z3_vars['a'] == lhs)
+                solver.add(z3_vars['b'] == rhs)
+                solver.add(result)
+
+                expected = (lhs, rhs) in expected_true_assignments
+                assert solver.check() == (z3.sat if expected else z3.unsat)
+
+    @pytest.mark.parametrize('op', ['=>', 'xor', 'iff'])
+    def test_condition_logical_operators_reject_numeric_operands(self, op):
+        """Test new condition logical operators do not coerce numeric Z3 terms."""
+        z3_vars = {'x': z3.Int('x'), 'y': z3.Int('y')}
+        expr = BinaryOp(x=Variable('x'), op=op, y=Variable('y'))
+
+        with pytest.raises(ValueError, match='Boolean operands required'):
+            expr_to_z3(expr, z3_vars)
+
     # Note: Bitwise operators are not supported on Z3 Int types
     # They require BitVec types which is a different approach
     # Skipping bitwise operator tests

--- a/test/solver/test_operation.py
+++ b/test/solver/test_operation.py
@@ -438,6 +438,34 @@ class TestExecuteOperations:
         for name in var_names:
             assert_z3_expr_equal(new_exprs[name], expected_exprs[name])
 
+    def test_execute_if_block_supports_condition_logical_operators(self):
+        statements = parse_operations(
+            """
+            if [(x > 0) => (y > 0)] {
+                result = 1;
+            } else {
+                result = 0;
+            }
+            """,
+            allowed_vars=['x', 'y', 'result'],
+        )
+        var_exprs = {'x': z3.Int('x'), 'y': z3.Int('y'), 'result': z3.Int('result')}
+
+        new_exprs = execute_operations(statements, var_exprs)
+
+        assert_symbolic_outputs(
+            var_exprs,
+            new_exprs,
+            {'x': 1, 'y': 0},
+            {'result': 0},
+        )
+        assert_symbolic_outputs(
+            var_exprs,
+            new_exprs,
+            {'x': -1, 'y': 0},
+            {'result': 1},
+        )
+
     def test_execute_branch_local_temp_does_not_leak(self):
         """Test branch-local temporary expressions do not appear in final output."""
         statements = parse_operations("""

--- a/test/solver/test_operation.py
+++ b/test/solver/test_operation.py
@@ -438,14 +438,24 @@ class TestExecuteOperations:
         for name in var_names:
             assert_z3_expr_equal(new_exprs[name], expected_exprs[name])
 
-    def test_execute_if_block_supports_condition_logical_operators(self):
+    @pytest.mark.parametrize(
+        'condition, false_inputs, true_inputs',
+        [
+            ('(x > 0) => (y > 0)', {'x': 1, 'y': 0}, {'x': -1, 'y': 0}),
+            ('(x > 0) xor (y > 0)', {'x': 1, 'y': 1}, {'x': 1, 'y': 0}),
+            ('(x > 0) iff (y > 0)', {'x': 1, 'y': 0}, {'x': 1, 'y': 1}),
+        ],
+    )
+    def test_execute_if_block_supports_condition_logical_operators(
+        self, condition, false_inputs, true_inputs
+    ):
         statements = parse_operations(
-            """
-            if [(x > 0) => (y > 0)] {
+            f"""
+            if [{condition}] {{
                 result = 1;
-            } else {
+            }} else {{
                 result = 0;
-            }
+            }}
             """,
             allowed_vars=['x', 'y', 'result'],
         )
@@ -456,13 +466,13 @@ class TestExecuteOperations:
         assert_symbolic_outputs(
             var_exprs,
             new_exprs,
-            {'x': 1, 'y': 0},
+            false_inputs,
             {'result': 0},
         )
         assert_symbolic_outputs(
             var_exprs,
             new_exprs,
-            {'x': -1, 'y': 0},
+            true_inputs,
             {'result': 1},
         )
 


### PR DESCRIPTION
## PR-157-C 定位

本 PR 是 [issue #157](https://github.com/HansBug/pyfcstm/issues/157) 的第三个子 PR，挂在 umbrella PR [#158](https://github.com/HansBug/pyfcstm/pull/158) 下。

上游已完成：

- PR-157-A / [#159](https://github.com/HansBug/pyfcstm/pull/159)：共享 grammar、Python parser/listener、jsfcstm parser/AST/type 最小对齐。
- PR-157-B / [#160](https://github.com/HansBug/pyfcstm/pull/160)：model `Expr` 支持 `=>`、`xor`、`iff`，并修复既有 `**` 右结合导出问题。

本 PR 只承接 **renderer styles** 与 **Z3 solver backend**，不重新打开 grammar / parser / listener / model / editor / docs 范围。

> 重要约束：issue #157 早期曾写过 condition 侧 `^` 作为 bool xor 的设想，但该设想已经被 #158/#159/#160 收敛取消。当前有效设计是：condition bool xor 只支持 `xor` 关键字；numeric `^` 只表示 bitwise xor；不得在 renderer 或 solver 中复活任何 `^ -> xor` 逻辑。

## 当前状态

| 项目 | 状态 | 说明 |
|---|---|---|
| PR 类型 | ✅ 实现 PR | 当前 head 为 `36be6a3922ebb66c52276c5ba524684a7dcb030f`，共 4 个 commit |
| 改动范围 | ✅ 已收敛 | 只改 renderer、solver 与对应测试，共 7 个文件 |
| 上游依赖 | ✅ 已满足 | A/B 已合入 umbrella；base 已有 canonical ops 与 model truth table / round-trip 语义 |
| CI | ✅ 全绿 | Python matrix、CLI Build、jsfcstm test 全部通过 |
| Codecov | ✅ 已覆盖 | 最新 Codecov comment 确认所有新增可覆盖行已被测试覆盖 |
| 终审 | ✅ 无阻塞 | codex / claude / deepseek 终审代码侧均为 `C=0`；claude/deepseek 为 `I=0`；codex 提出的 PR body 状态不一致已由本次 body 更新修复 |
| 当前剩余 | 🟡 非阻塞 M | `_infer_expr_type` 对 condition op 仍沿用既有 `'int'` 粗分类；未来如引入 bool 类型可整体迁移 |
| 合并状态 | ⏸️ 等待人工指示 | 本 PR ready 后仍不由 agent merge |

## 实际改动

| 文件 | 改动 |
|---|---|
| `pyfcstm/render/expr.py` | 为 `=>`、`xor`、`iff` 增加 DSL 与非 DSL style 的 operator-specific templates；非 DSL lowering 全部整体加括号；Python style 增加 `py_condition_operand`，避免 condition-valued operand 触发 Python comparison-chain 语义漂移；`fn_expr_render()` 会给外部 env 注入新增 helper |
| `pyfcstm/solver/expr.py` | 增加 `z3.Implies`、`z3.Xor`、BoolRef equality 的映射；新增 bool operand 契约检查；明确拒绝 bool operand 的 numeric `^`，避免把 `^` 复活成 bool xor |
| `test/render/test_expr.py` | 覆盖 9 个 style 的 render matrix、非 DSL style 不泄漏 canonical op、Python comparison-chain 交叉验证、numeric `^` regression、direct conditional operand 覆盖 |
| `test/render/test_render.py` | 覆盖 `StateMachineCodeRenderer` 自定义 expr style 下的 Python helper 注入路径 |
| `test/render/test_statement.py` | 覆盖 statement renderer 中 `=>`、`xor`、`iff` guard 渲染连通性 |
| `test/solver/test_expr.py` | 覆盖三组 op 的 truth table、sat/unsat、numeric operand 拒绝、bool `^` 拒绝 |
| `test/solver/test_operation.py` | 覆盖 operation solver 中 `=>`、`xor`、`iff` if-block 连通性 |

## 语义约定

| DSL op | renderer canonical | 非 DSL lowering | solver 语义 |
|---|---|---|---|
| `A => B` / `A implies B` | `A => B` | Python: `((not (A)) or (B))`；C-like: `((!(A)) || (B))` | `z3.Implies(A, B)` |
| `A xor B` | `A xor B` | `((A) != (B))` | `z3.Xor(A, B)` |
| `A iff B` | `A iff B` | `((A) == (B))` | `A == B`，即 Z3 BoolRef equivalence |
| numeric `A ^ B` | 保持 `A ^ B` | 保持现有 numeric bitwise xor 路径 | bool operand 显式报错；不作为 condition xor |

## 验证结果

本地已通过：

```bash
pytest test/render/test_expr.py -q --tb=short
# 193 passed

pytest test/render/test_expr.py test/render/test_statement.py test/render/test_render.py test/solver/test_expr.py test/solver/test_operation.py -q --tb=short
# 379 passed, 68 warnings

SKIP_SLOW_TESTS=1 make unittest
# 40243 passed, 164 skipped, 63 deselected, 869 warnings
```

远端已通过：

- `gh pr checks 161`：全部 GitHub checks 通过。
- Codecov comment：`All modified and coverable lines are covered by tests.`

## 终审结论

| reviewer | 结论 | 说明 |
|---|---|---|
| codex reviewer | `C=0`，原 `I=1` 已处理 | 代码侧无阻塞；原 I 为 PR body 状态描述过期，本 body 已更新为实现状态 |
| claude reviewer | `C=0, I=0, M=1` | M 为 `_infer_expr_type` 对新增 condition op 仍沿用 `'int'` 粗分类 |
| deepseek reviewer | `C=0, I=0, M=1` | M 同上，不阻塞本 PR |
| Codecov | ✅ | 所有新增可覆盖行已覆盖 |

## 明确不做

| 不做项 | 原因 |
|---|---|
| 不改 grammar / listener | 已由 PR-157-A 完成，本 PR 不重开 ANTLR 风险面 |
| 不改 model `Expr` | 已由 PR-157-B 完成，本 PR 只消费 canonical op |
| 不改 jsfcstm / editor / docs | 留给后续子 PR |
| 不新增 `A ^ B` 作为 condition xor | 设计已收敛为 `xor` keyword only |
| 不引入 numeric truthiness | FCSTM DSL 已区分 condition 与 numeric，solver 不把 Int 隐式转 bool |

## 后续建议

| 优先级 | 建议 | 说明 |
|---|---|---|
| 🟡 M | 未来考虑为 condition expression 引入更精确的 bool 类型分类 | 当前 `_infer_expr_type` 沿用既有 `&&` / `||` / comparison 的 `'int'` 粗分类，现有 Go/Rust/Python/C-like renderer 均不受影响；若后续 DSL 类型系统显式支持 bool，可整体迁移 |
| 🟢 后续 | 在 PR-157-D/E 中补 editor/docs acceptance | 本 PR 已提供 renderer/solver 后端能力，后续可以面向用户文档、编辑器提示、最终 acceptance 样例收尾 |

