### PR TITLE
实现 SysDeSim 同层终止态转换为 FCSTM 退出态

### DIFF
--- a/pyfcstm/convert/sysdesim/convert.py
+++ b/pyfcstm/convert/sysdesim/convert.py
@@ -2228,6 +2228,14 @@ def _lower_cross_level_transition(
     source = machine.get_vertex(transition.source_id)
     target = machine.get_vertex(transition.target_id)
     if source.vertex_type != "state" or target.vertex_type != "state":
+        if target.vertex_type == "final":
+            raise NotImplementedError(
+                f"Phase4 does not support cross-level transitions targeting FinalState: {transition.transition_id}"
+            )
+        if source.vertex_type == "final":
+            raise NotImplementedError(
+                f"Phase4 does not support cross-level transitions from FinalState source: {transition.transition_id}"
+            )
         raise NotImplementedError(
             f"Phase4 only supports state-to-state cross-level transitions: {transition.transition_id}"
         )
@@ -2550,6 +2558,10 @@ def _build_transition(
         if (
             source.vertex_type != "state" or target.vertex_type != "state"
         ):  # pragma: no cover
+            if source.vertex_type == "state" and target.vertex_type == "final":
+                raise NotImplementedError(
+                    f"Phase3 does not support uml:TimeEvent transitions targeting FinalState: {transition.transition_id}"
+                )
             raise NotImplementedError(
                 f"Phase3 only supports state-to-state uml:TimeEvent transitions: {transition.transition_id}"
             )
@@ -2569,6 +2581,14 @@ def _build_transition(
             f"Phase2 does not support transitions with both signal and guard: {transition.transition_id}"
         )
     if source.vertex_type == "pseudostate":
+        if target.vertex_type == "final":
+            raise NotImplementedError(
+                f"Phase2 does not support init pseudostate targeting FinalState target: {transition.transition_id}"
+            )
+        if target.vertex_type != "state":
+            raise NotImplementedError(
+                f"Phase2 only supports init pseudostate targeting states: {transition.transition_id}"
+            )
         return dsl_nodes.TransitionDefinition(
             from_state=dsl_nodes.INIT_STATE,
             to_state=target.safe_name,
@@ -2577,7 +2597,11 @@ def _build_transition(
             post_operations=[],
         )
 
-    if source.vertex_type != "state" or target.vertex_type != "state":
+    if source.vertex_type == "final":
+        raise NotImplementedError(
+            f"Phase2 does not support FinalState source transitions: {transition.transition_id}"
+        )
+    if source.vertex_type != "state":
         raise NotImplementedError(
             f"Phase2 only supports init pseudostate and state-to-state transitions: {transition.transition_id}"
         )
@@ -2587,6 +2611,27 @@ def _build_transition(
         if transition.trigger_kind == "signal"
         else None
     )
+
+    if target.vertex_type == "final":
+        if source.is_composite:
+            raise NotImplementedError(
+                f"Phase2 does not support composite source to FinalState target transitions: {transition.transition_id}"
+            )
+        if source.parent_region_id != target.parent_region_id:
+            raise NotImplementedError(
+                f"Phase2 does not support cross-level transitions targeting FinalState: {transition.transition_id}"
+            )
+        return dsl_nodes.TransitionDefinition(
+            from_state=source.safe_name,
+            to_state=dsl_nodes.EXIT_STATE,
+            event_id=event_id,
+            condition_expr=transition.guard_expr_ir,
+            post_operations=[],
+        )
+    if target.vertex_type != "state":
+        raise NotImplementedError(
+            f"Phase2 only supports init pseudostate, state-to-state transitions, and leaf state to FinalState target transitions: {transition.transition_id}"
+        )
 
     return dsl_nodes.TransitionDefinition(
         from_state=source.safe_name,

--- a/test/convert/sysdesim/test_phase0_2.py
+++ b/test/convert/sysdesim/test_phase0_2.py
@@ -10,6 +10,7 @@ import pytest
 
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.dsl import node as dsl_nodes
+from pyfcstm.convert.sysdesim import convert as sysdesim_convert
 from pyfcstm.convert.sysdesim import (
     build_machine_ast,
     convert_sysdesim_xml_to_ast,
@@ -1706,6 +1707,136 @@ def test_phase2_rejects_init_pseudostate_targeting_final_state(tmp_path: Path):
         NotImplementedError, match=r"init pseudostate.*FinalState target"
     ):
         convert_sysdesim_xml_to_ast(str(xml_file))
+
+
+def _make_transition_fallback_machine(
+    source: IrVertex,
+    target: IrVertex,
+    transition: IrTransition,
+) -> IrMachine:
+    """Build a normalized-enough IR machine for direct transition fallback tests."""
+    root_region = IrRegion(
+        region_id="region_root",
+        owner_state_id=None,
+        vertices=[source, target],
+        transitions=[transition],
+    )
+    machine = IrMachine(
+        machine_id="machine_1",
+        name="Fallback",
+        root_region=root_region,
+        safe_name="Fallback",
+        display_name="Fallback",
+    )
+    machine.rebuild_indexes()
+    return machine
+
+
+def test_phase2_rejects_init_pseudostate_targeting_non_state_non_final_vertex():
+    """The init fallback should reject targets that are neither states nor FinalState."""
+    machine = _make_transition_fallback_machine(
+        IrVertex(
+            vertex_id="init_1",
+            vertex_type="pseudostate",
+            raw_name="",
+            safe_name=None,
+            parent_region_id="region_root",
+        ),
+        IrVertex(
+            vertex_id="join_1",
+            vertex_type="pseudostate",
+            raw_name="Join",
+            safe_name="Join",
+            parent_region_id="region_root",
+        ),
+        IrTransition(
+            transition_id="tx_init_to_join",
+            source_id="init_1",
+            target_id="join_1",
+            trigger_kind="none",
+            trigger_ref_id=None,
+            guard_expr_raw=None,
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="init pseudostate targeting states"):
+        sysdesim_convert._build_transition(
+            machine,
+            machine.get_transition("tx_init_to_join"),
+            sysdesim_convert._AstBuildContext(),
+        )
+
+
+def test_phase2_rejects_state_to_final_target_with_region_mismatch_in_transition_fallback():
+    """The Phase2 final-target fallback must not lower region-mismatched edges."""
+    machine = _make_transition_fallback_machine(
+        IrVertex(
+            vertex_id="state_idle",
+            vertex_type="state",
+            raw_name="Idle",
+            safe_name="Idle",
+            parent_region_id="region_source",
+        ),
+        IrVertex(
+            vertex_id="final_done",
+            vertex_type="final",
+            raw_name="",
+            safe_name=None,
+            parent_region_id="region_target",
+        ),
+        IrTransition(
+            transition_id="tx_region_mismatch_final",
+            source_id="state_idle",
+            target_id="final_done",
+            trigger_kind="none",
+            trigger_ref_id=None,
+            guard_expr_raw=None,
+        ),
+    )
+
+    with pytest.raises(
+        NotImplementedError, match="cross-level transitions targeting FinalState"
+    ):
+        sysdesim_convert._build_transition(
+            machine,
+            machine.get_transition("tx_region_mismatch_final"),
+            sysdesim_convert._AstBuildContext(),
+        )
+
+
+def test_phase2_rejects_state_to_non_state_non_final_target_in_transition_fallback():
+    """The state transition fallback should reject non-state targets except FinalState."""
+    machine = _make_transition_fallback_machine(
+        IrVertex(
+            vertex_id="state_idle",
+            vertex_type="state",
+            raw_name="Idle",
+            safe_name="Idle",
+            parent_region_id="region_root",
+        ),
+        IrVertex(
+            vertex_id="choice_1",
+            vertex_type="pseudostate",
+            raw_name="Choice",
+            safe_name="Choice",
+            parent_region_id="region_root",
+        ),
+        IrTransition(
+            transition_id="tx_state_to_choice",
+            source_id="state_idle",
+            target_id="choice_1",
+            trigger_kind="none",
+            trigger_ref_id=None,
+            guard_expr_raw=None,
+        ),
+    )
+
+    with pytest.raises(NotImplementedError, match="leaf state to FinalState target"):
+        sysdesim_convert._build_transition(
+            machine,
+            machine.get_transition("tx_state_to_choice"),
+            sysdesim_convert._AstBuildContext(),
+        )
 
 
 def test_phase2_rejects_composite_source_final_target_without_force_lowering(

--- a/test/convert/sysdesim/test_phase0_2.py
+++ b/test/convert/sysdesim/test_phase0_2.py
@@ -1,6 +1,7 @@
 """Unit tests for the SysDeSim phase0-2 conversion pipeline."""
 
 import inspect
+import re
 from dataclasses import fields
 from pathlib import Path
 from textwrap import dedent
@@ -32,7 +33,6 @@ from pyfcstm.convert.sysdesim.ir import (
     IrVariable,
     IrVertex,
 )
-from pyfcstm.model import expr as model_expr
 from pyfcstm.model.model import StateMachine, parse_dsl_node_to_state_machine
 
 pytestmark = pytest.mark.unittest
@@ -79,6 +79,33 @@ def _assert_dsl_code_loads_to_state_machine(dsl_code: str) -> StateMachine:
     """Assert that DSL text can be parsed and loaded into the public StateMachine model."""
     parsed_program = parse_with_grammar_entry(dsl_code, entry_name="state_machine_dsl")
     return _assert_program_loads_to_state_machine(parsed_program)
+
+
+def _assert_ast_has_exit_transition(
+    state: dsl_nodes.StateDefinition,
+    from_state: str,
+    *,
+    event_id: str = None,
+    guard_text: str = None,
+) -> dsl_nodes.TransitionDefinition:
+    """Assert that a state contains exactly one transition to the FCSTM exit state."""
+    matches = [
+        transition
+        for transition in state.transitions
+        if transition.from_state == from_state
+        and transition.to_state is dsl_nodes.EXIT_STATE
+    ]
+    assert len(matches) == 1
+    transition = matches[0]
+    assert (str(transition.event_id) if transition.event_id is not None else None) == (
+        event_id
+    )
+    assert (
+        str(transition.condition_expr)
+        if transition.condition_expr is not None
+        else None
+    ) == guard_text
+    return transition
 
 
 def test_phase0_can_parse_graph_structure_and_events(tmp_path: Path):
@@ -1421,6 +1448,316 @@ def test_convert_sysdesim_xml_to_dsl_runs_end_to_end(tmp_path: Path):
     )
 
 
+def test_phase2_real_model2_lowers_same_level_final_target_to_exit_state():
+    """The real model2.xml sample should lower a same-level FinalState target to ``[*]``."""
+    xml_file = (
+        Path(__file__).resolve().parents[2]
+        / "testfile/sysdesim/final_state_same_level_model2.xml"
+    )
+
+    dsl_code = _normalize_newlines(convert_sysdesim_xml_to_dsl(str(xml_file)))
+    program = convert_sysdesim_xml_to_ast(str(xml_file))
+    validate_program_roundtrip(program)
+
+    assert re.search(r"\bSS\s*->\s*\[\*\]\s*;", dsl_code)
+    assert "__sysdesim_final_" not in dsl_code
+    assert "_rJto4GCxEfGqsb6wf6ZObA" not in dsl_code
+    assert "state Done" not in dsl_code
+    _assert_ast_has_exit_transition(program.root_state, "SS")
+
+
+def test_phase2_lowers_none_trigger_final_target_to_exit_state(tmp_path: Path):
+    """A leaf state transition to a same-level FinalState should become ``-> [*]``."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Target" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Target">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
+                </region>
+              </ownedBehavior>
+            </packagedElement>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    dsl_code = _normalize_newlines(convert_sysdesim_xml_to_dsl(str(xml_file)))
+    program = convert_sysdesim_xml_to_ast(str(xml_file))
+    validate_program_roundtrip(program)
+
+    expected_dsl = dedent(
+        """\
+        state FinalTarget named 'Final Target' {
+            state Idle;
+            [*] -> Idle;
+            Idle -> [*];
+        }"""
+    )
+    assert dsl_code == expected_dsl
+    assert _normalize_newlines(str(program)) == expected_dsl
+    assert "state Done" not in dsl_code
+    _assert_ast_has_exit_transition(program.root_state, "Idle")
+
+
+def test_phase2_lowers_guarded_final_target_to_exit_state(tmp_path: Path):
+    """A guard-only transition to FinalState should keep its guard on ``-> [*]``."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Target" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Target">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done">
+                    <ownedRule xmi:type="uml:Constraint" xmi:id="finish_guard_rule">
+                      <specification xmi:type="uml:OpaqueExpression" xmi:id="finish_guard_expr">
+                        <body> count &gt; 0 </body>
+                      </specification>
+                    </ownedRule>
+                  </transition>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
+                </region>
+              </ownedBehavior>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="var_count" name="count" type="primitive_int">
+                <defaultValue xmi:type="uml:LiteralInteger" xmi:id="var_count_default" value="0"/>
+              </ownedAttribute>
+            </packagedElement>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    dsl_code = _normalize_newlines(convert_sysdesim_xml_to_dsl(str(xml_file)))
+    program = convert_sysdesim_xml_to_ast(str(xml_file))
+    validate_program_roundtrip(program)
+
+    assert "def int count = 0;" in dsl_code
+    assert "Idle -> [*] : if [count > 0];" in dsl_code
+    _assert_ast_has_exit_transition(program.root_state, "Idle", guard_text="count > 0")
+
+
+def test_phase2_lowers_signal_final_target_to_exit_state(tmp_path: Path):
+    """A signal transition to FinalState should keep the signal on ``-> [*]``."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Target" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Target">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done">
+                    <trigger xmi:type="uml:Trigger" xmi:id="trigger_go" event="signal_event_go"/>
+                  </transition>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
+                </region>
+              </ownedBehavior>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_go" name="Go"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_event_go" name="" signal="signal_go"/>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    dsl_code = _normalize_newlines(convert_sysdesim_xml_to_dsl(str(xml_file)))
+    program = convert_sysdesim_xml_to_ast(str(xml_file))
+    validate_program_roundtrip(program)
+
+    expected_dsl = dedent(
+        """\
+        state FinalTarget named 'Final Target' {
+            state Idle;
+            event GO named 'Go';
+            [*] -> Idle;
+            Idle -> [*] : /GO;
+        }"""
+    )
+    assert dsl_code == expected_dsl
+    assert _normalize_newlines(str(program)) == expected_dsl
+    _assert_ast_has_exit_transition(program.root_state, "Idle", event_id="/GO")
+
+
+def test_phase2_rejects_signal_guard_final_target_without_expanding_scope(
+    tmp_path: Path,
+):
+    """Signal+guard transitions remain unsupported even when targeting FinalState."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Target" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Target">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done">
+                    <trigger xmi:type="uml:Trigger" xmi:id="trigger_go" event="signal_event_go"/>
+                    <ownedRule xmi:type="uml:Constraint" xmi:id="finish_guard_rule">
+                      <specification xmi:type="uml:OpaqueExpression" xmi:id="finish_guard_expr">
+                        <body> count &gt; 0 </body>
+                      </specification>
+                    </ownedRule>
+                  </transition>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
+                </region>
+              </ownedBehavior>
+              <ownedAttribute xmi:type="uml:Property" xmi:id="var_count" name="count" type="primitive_int">
+                <defaultValue xmi:type="uml:LiteralInteger" xmi:id="var_count_default" value="0"/>
+              </ownedAttribute>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_go" name="Go"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_event_go" name="" signal="signal_go"/>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    with pytest.raises(NotImplementedError, match="both signal and guard"):
+        convert_sysdesim_xml_to_ast(str(xml_file))
+
+
+def test_phase2_rejects_final_state_source_transition(tmp_path: Path):
+    """A FinalState source transition should fail with a clear message."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Source" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Source">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="final_done" target="state_after"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_after" name="After"/>
+                </region>
+              </ownedBehavior>
+            </packagedElement>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    with pytest.raises(NotImplementedError, match="FinalState source"):
+        convert_sysdesim_xml_to_ast(str(xml_file))
+
+
+def test_phase2_rejects_init_pseudostate_targeting_final_state(tmp_path: Path):
+    """An init pseudostate must not target FinalState directly in FS-1."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Init Final" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Init Final">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="final_done"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
+                </region>
+              </ownedBehavior>
+            </packagedElement>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    with pytest.raises(
+        NotImplementedError, match=r"init pseudostate.*FinalState target"
+    ):
+        convert_sysdesim_xml_to_ast(str(xml_file))
+
+
+def test_phase2_rejects_composite_source_final_target_without_force_lowering(
+    tmp_path: Path,
+):
+    """Composite-source FinalState transitions should not be lowered as force transitions."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Composite Final" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Composite Final">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init_root" source="init_root" target="state_outer"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_outer" name="Outer">
+                    <region xmi:type="uml:Region" xmi:id="region_outer" name="">
+                      <transition xmi:type="uml:Transition" xmi:id="tx_init_outer" source="init_outer" target="state_h"/>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_h" target="final_done">
+                        <trigger xmi:type="uml:Trigger" xmi:id="trigger_go" event="signal_event_go"/>
+                      </transition>
+                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_outer"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_h" name="H">
+                        <region xmi:type="uml:Region" xmi:id="region_h" name="">
+                          <transition xmi:type="uml:Transition" xmi:id="tx_init_h" source="init_h" target="state_inner"/>
+                          <subvertex xmi:type="uml:Pseudostate" xmi:id="init_h"/>
+                          <subvertex xmi:type="uml:State" xmi:id="state_inner" name="Inner"/>
+                        </region>
+                      </subvertex>
+                      <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
+                    </region>
+                  </subvertex>
+                </region>
+              </ownedBehavior>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_go" name="Go"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_event_go" name="" signal="signal_go"/>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    with pytest.raises(
+        NotImplementedError, match=r"composite source.*FinalState target"
+    ):
+        convert_sysdesim_xml_to_ast(str(xml_file))
+
+
 class TestSysDeSimCoverageScenarios:
     def test_phase0_load_parses_type_default_and_machine_selection_variants(
         self, tmp_path: Path
@@ -2454,29 +2791,6 @@ class TestSysDeSimCoverageScenarios:
             </xmi:XMI>
             """,
                 "both signal and guard",
-            ),
-            (
-                """
-            <?xml version="1.0" encoding="UTF-8"?>
-            <xmi:XMI xmi:version="20131001"
-                     xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
-                     xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
-              <uml:Model xmi:id="model_1" name="model">
-                <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Target" classifierBehavior="machine_1">
-                  <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Target">
-                    <region xmi:type="uml:Region" xmi:id="region_root" name="">
-                      <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
-                      <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_1"/>
-                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
-                      <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
-                      <subvertex xmi:type="uml:FinalState" xmi:id="final_1" name="Done"/>
-                    </region>
-                  </ownedBehavior>
-                </packagedElement>
-              </uml:Model>
-            </xmi:XMI>
-            """,
-                "state-to-state transitions",
             ),
         ],
     )

--- a/test/convert/sysdesim/test_phase4.py
+++ b/test/convert/sysdesim/test_phase4.py
@@ -421,6 +421,36 @@ def test_phase4_ancestor_target_cross_level_transition_is_still_rejected(tmp_pat
                      xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
                      xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
               <uml:Model xmi:id="model_1" name="model">
+                <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Cross Final Source" classifierBehavior="machine_1">
+                  <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Cross Final Source">
+                    <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                      <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_root" target="state_parent"/>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_cross_final_source" source="final_source" target="state_ready"/>
+                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_parent" name="Parent">
+                        <region xmi:type="uml:Region" xmi:id="region_parent" name="">
+                          <transition xmi:type="uml:Transition" xmi:id="tx_parent_init" source="init_parent" target="state_source"/>
+                          <subvertex xmi:type="uml:Pseudostate" xmi:id="init_parent"/>
+                          <subvertex xmi:type="uml:State" xmi:id="state_source" name="Source"/>
+                          <subvertex xmi:type="uml:FinalState" xmi:id="final_source" name=""/>
+                        </region>
+                      </subvertex>
+                      <subvertex xmi:type="uml:State" xmi:id="state_ready" name="Ready"/>
+                    </region>
+                  </ownedBehavior>
+                </packagedElement>
+              </uml:Model>
+            </xmi:XMI>
+            """,
+            "cross-level transitions from FinalState source",
+        ),
+        (
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <xmi:XMI xmi:version="20131001"
+                     xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                     xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+              <uml:Model xmi:id="model_1" name="model">
                 <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Cross Signal Guard" classifierBehavior="machine_1">
                   <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Cross Signal Guard">
                     <region xmi:type="uml:Region" xmi:id="region_root" name="">

--- a/test/convert/sysdesim/test_phase4.py
+++ b/test/convert/sysdesim/test_phase4.py
@@ -412,7 +412,7 @@ def test_phase4_ancestor_target_cross_level_transition_is_still_rejected(tmp_pat
               </uml:Model>
             </xmi:XMI>
             """,
-            "state-to-state cross-level transitions",
+            "cross-level transitions targeting FinalState",
         ),
         (
             """

--- a/test/testfile/sysdesim/final_state_same_level_model2.xml
+++ b/test/testfile/sysdesim/final_state_same_level_model2.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xmi:XMI xmi:version="20131001" xmlns:xmi="http://www.omg.org/spec/XMI/20131001" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:Blocks="http://www.ht0003.com/sds/sysml/1.6/SysML/Blocks" xmlns:DiagramRepresentation="http://www.ht0003.com/sds/1.0.0/DiagramRepresentation" xmlns:Diagrams="http://www.ht0003.com/sds/1.0.0/Diagrams" xmlns:domain="http://www.sysdesim.arch/uml2/stereotype" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xsi:schemaLocation="http://www.ht0003.com/sds/sysml/1.6/SysML/Blocks http://www.ht0003.com/sds/sysml/1.6/SysML#//blocks">
+  <uml:Model xmi:id="1780562895625__IHHPkF_yEfG4KaDTdrs0Xg" name="model">
+    <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRkF_yEfG4KaDTdrs0Xg" source="SDSDiagram"/>
+    <ownedComment xmi:type="uml:Comment" xmi:id="1780562896169__IMTRkV_yEfG4KaDTdrs0Xg">
+      <body>Author:win7.&amp;#10;Created:Thu Jun 04 16:48:15 CST 2026.&amp;#10;Comment:新建项目工程.&amp;#10;</body>
+    </ownedComment>
+    <packagedElement xmi:type="uml:Class" xmi:id="_TT_J4GCxEfGqsb6wf6ZObA" name="A"/>
+    <packagedElement xmi:type="uml:Class" xmi:id="_UpiAgGCxEfGqsb6wf6ZObA" name="B"/>
+    <packagedElement xmi:type="uml:Collaboration" xmi:id="_WV1KQGCxEfGqsb6wf6ZObA" name="model1" classifierBehavior="_WV-7QGCxEfGqsb6wf6ZObA">
+      <ownedBehavior xmi:type="uml:Interaction" xmi:id="_WV-7QGCxEfGqsb6wf6ZObA" name="model1">
+        <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WWWHoGCxEfGqsb6wf6ZObA" source="SDSDiagram">
+          <contents xmi:type="Diagrams:SDSDiagram" xmi:id="_WWYj4GCxEfGqsb6wf6ZObA" name="model1" context="_WV-7QGCxEfGqsb6wf6ZObA" ownerOfDiagram="_WV-7QGCxEfGqsb6wf6ZObA" notationId="51cd6cc0-5c83-45d7-bd32-4df54e7d2944.dgm" kindId="SysML Sequence Diagram">
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WWYj4WCxEfGqsb6wf6ZObA" source="SDSDiagram">
+              <contents xmi:type="DiagramRepresentation:DiagramRepresentation" xmi:id="_WWZK8GCxEfGqsb6wf6ZObA" type="SysML Sequence Diagram" usedObjects="_WV-7QGCxEfGqsb6wf6ZObA _ZKsekGCxEfGqsb6wf6ZObA _ZgRF8GCxEfGqsb6wf6ZObA _uN_5QGCxEfGqsb6wf6ZObA _uOQX8GCxEfGqsb6wf6ZObA _uOaI8GCxEfGqsb6wf6ZObA _xrOOEGCxEfGqsb6wf6ZObA _xrTtoGCxEfGqsb6wf6ZObA _xrYmIGCxEfGqsb6wf6ZObA">
+                <binaryObject xmi:type="DiagramRepresentation:StreamIdentityBinaryObject" xmi:id="_WWbnMGCxEfGqsb6wf6ZObA" streamContentID="51cd6cc0-5c83-45d7-bd32-4df54e7d2944"/>
+              </contents>
+            </eAnnotations>
+            <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_WWcOQGCxEfGqsb6wf6ZObA" source="http://www.sysdesim.arch/uml2/stereotype">
+              <contents xmi:type="domain:StereotypeInstance" xmi:id="_WWcOQWCxEfGqsb6wf6ZObA" base="_WWYj4GCxEfGqsb6wf6ZObA">
+                <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_xTmxMK7dEeu2qI_7PGwqxg"/>
+              </contents>
+            </eAnnotations>
+          </contents>
+        </eAnnotations>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZK1ogGCxEfGqsb6wf6ZObA" name="" type="_TT_J4GCxEfGqsb6wf6ZObA"/>
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ZgV-cGCxEfGqsb6wf6ZObA" name="" type="_UpiAgGCxEfGqsb6wf6ZObA"/>
+        <lifeline xmi:type="uml:Lifeline" xmi:id="_ZKsekGCxEfGqsb6wf6ZObA" name="" represents="_ZK1ogGCxEfGqsb6wf6ZObA" coveredBy="_uN_5QGCxEfGqsb6wf6ZObA _uRJT4GCxEfGqsb6wf6ZObA _xrOOEGCxEfGqsb6wf6ZObA _xrkMUGCxEfGqsb6wf6ZObA"/>
+        <lifeline xmi:type="uml:Lifeline" xmi:id="_ZgRF8GCxEfGqsb6wf6ZObA" name="" represents="_ZgV-cGCxEfGqsb6wf6ZObA" coveredBy="_uOQX8GCxEfGqsb6wf6ZObA _uRD0UGCxEfGqsb6wf6ZObA _xrTtoGCxEfGqsb6wf6ZObA _xriXIGCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_uRJT4GCxEfGqsb6wf6ZObA" name="sendEvent" covered="_ZKsekGCxEfGqsb6wf6ZObA" message="_uOaI8GCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_uRD0UGCxEfGqsb6wf6ZObA" name="receiveEvent" covered="_ZgRF8GCxEfGqsb6wf6ZObA" message="_uOaI8GCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_xrkMUGCxEfGqsb6wf6ZObA" name="sendEvent" covered="_ZKsekGCxEfGqsb6wf6ZObA" message="_xrYmIGCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="_xriXIGCxEfGqsb6wf6ZObA" name="receiveEvent" covered="_ZgRF8GCxEfGqsb6wf6ZObA" message="_xrYmIGCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_uN_5QGCxEfGqsb6wf6ZObA" name="" covered="_ZKsekGCxEfGqsb6wf6ZObA" start="_uRJT4GCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_uOQX8GCxEfGqsb6wf6ZObA" name="" covered="_ZgRF8GCxEfGqsb6wf6ZObA" start="_uRD0UGCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_xrOOEGCxEfGqsb6wf6ZObA" name="" covered="_ZKsekGCxEfGqsb6wf6ZObA" start="_xrkMUGCxEfGqsb6wf6ZObA"/>
+        <fragment xmi:type="uml:BehaviorExecutionSpecification" xmi:id="_xrTtoGCxEfGqsb6wf6ZObA" name="" covered="_ZgRF8GCxEfGqsb6wf6ZObA" start="_xriXIGCxEfGqsb6wf6ZObA"/>
+        <message xmi:type="uml:Message" xmi:id="_uOaI8GCxEfGqsb6wf6ZObA" name="" messageSort="asynchCall" receiveEvent="_uRD0UGCxEfGqsb6wf6ZObA" sendEvent="_uRJT4GCxEfGqsb6wf6ZObA" signature="_b9CqYGCxEfGqsb6wf6ZObA"/>
+        <message xmi:type="uml:Message" xmi:id="_xrYmIGCxEfGqsb6wf6ZObA" name="" messageSort="asynchCall" receiveEvent="_xriXIGCxEfGqsb6wf6ZObA" sendEvent="_xrkMUGCxEfGqsb6wf6ZObA" signature="_eOzRoGCxEfGqsb6wf6ZObA"/>
+      </ownedBehavior>
+    </packagedElement>
+    <packagedElement xmi:type="uml:Signal" xmi:id="_b9CqYGCxEfGqsb6wf6ZObA" name="C"/>
+    <packagedElement xmi:type="uml:Signal" xmi:id="_eOzRoGCxEfGqsb6wf6ZObA" name="D"/>
+    <packagedElement xmi:type="uml:StateMachine" xmi:id="_fj3AEGCxEfGqsb6wf6ZObA" name="model1">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fkAKAGCxEfGqsb6wf6ZObA" source="SDSDiagram">
+        <contents xmi:type="Diagrams:SDSDiagram" xmi:id="_fkAKAWCxEfGqsb6wf6ZObA" name="model1" context="_fj3AEGCxEfGqsb6wf6ZObA" ownerOfDiagram="_fj3AEGCxEfGqsb6wf6ZObA" notationId="27bc1efb-cfb7-40da-b5ae-e82faf03c21e.dgm" kindId="SysML State Machine Diagram">
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fkAKAmCxEfGqsb6wf6ZObA" source="SDSDiagram">
+            <contents xmi:type="DiagramRepresentation:DiagramRepresentation" xmi:id="_fkAKA2CxEfGqsb6wf6ZObA" type="SysML State Machine Diagram" usedObjects="_fnRgcGCxEfGqsb6wf6ZObA _fo-JkGCxEfGqsb6wf6ZObA _fqGK8GCxEfGqsb6wf6ZObA _icDVMGCxEfGqsb6wf6ZObA _m5M18GCxEfGqsb6wf6ZObA _obJw4GCxEfGqsb6wf6ZObA _qV93wGCxEfGqsb6wf6ZObA _rJto4GCxEfGqsb6wf6ZObA _rpn4AGCxEfGqsb6wf6ZObA">
+              <binaryObject xmi:type="DiagramRepresentation:StreamIdentityBinaryObject" xmi:id="_fkAKBWCxEfGqsb6wf6ZObA" streamContentID="27bc1efb-cfb7-40da-b5ae-e82faf03c21e"/>
+            </contents>
+          </eAnnotations>
+          <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="_fkAKBmCxEfGqsb6wf6ZObA" source="http://www.sysdesim.arch/uml2/stereotype">
+            <contents xmi:type="domain:StereotypeInstance" xmi:id="_fkAKB2CxEfGqsb6wf6ZObA" base="_fkAKAWCxEfGqsb6wf6ZObA">
+              <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_xTmxMK7dEeu2qI_7PGwqxg"/>
+            </contents>
+          </eAnnotations>
+        </contents>
+      </eAnnotations>
+      <region xmi:type="uml:Region" xmi:id="_fkAKBGCxEfGqsb6wf6ZObA" name="">
+        <transition xmi:type="uml:Transition" xmi:id="_fqGK8GCxEfGqsb6wf6ZObA" name="" source="_fnRgcGCxEfGqsb6wf6ZObA" target="_fo-JkGCxEfGqsb6wf6ZObA"/>
+        <transition xmi:type="uml:Transition" xmi:id="_m5M18GCxEfGqsb6wf6ZObA" name="" source="_fo-JkGCxEfGqsb6wf6ZObA" target="_icDVMGCxEfGqsb6wf6ZObA">
+          <trigger xmi:type="uml:Trigger" xmi:id="_n6mBgGCxEfGqsb6wf6ZObA" name="" event="_n6tWQGCxEfGqsb6wf6ZObA"/>
+        </transition>
+        <transition xmi:type="uml:Transition" xmi:id="_qV93wGCxEfGqsb6wf6ZObA" name="" source="_icDVMGCxEfGqsb6wf6ZObA" target="_obJw4GCxEfGqsb6wf6ZObA">
+          <trigger xmi:type="uml:Trigger" xmi:id="_qy7gkGCxEfGqsb6wf6ZObA" name="" event="_qzC1UGCxEfGqsb6wf6ZObA"/>
+        </transition>
+        <transition xmi:type="uml:Transition" xmi:id="_rpn4AGCxEfGqsb6wf6ZObA" name="" source="_obJw4GCxEfGqsb6wf6ZObA" target="_rJto4GCxEfGqsb6wf6ZObA"/>
+        <subvertex xmi:type="uml:Pseudostate" xmi:id="_fnRgcGCxEfGqsb6wf6ZObA"/>
+        <subvertex xmi:type="uml:State" xmi:id="_fo-JkGCxEfGqsb6wf6ZObA" name="QQ"/>
+        <subvertex xmi:type="uml:State" xmi:id="_icDVMGCxEfGqsb6wf6ZObA" name="KK"/>
+        <subvertex xmi:type="uml:State" xmi:id="_obJw4GCxEfGqsb6wf6ZObA" name="SS"/>
+        <subvertex xmi:type="uml:FinalState" xmi:id="_rJto4GCxEfGqsb6wf6ZObA" name=""/>
+      </region>
+    </packagedElement>
+    <packagedElement xmi:type="uml:SignalEvent" xmi:id="_n6tWQGCxEfGqsb6wf6ZObA" name="" signal="_b9CqYGCxEfGqsb6wf6ZObA"/>
+    <packagedElement xmi:type="uml:SignalEvent" xmi:id="_qzC1UGCxEfGqsb6wf6ZObA" name="" signal="_eOzRoGCxEfGqsb6wf6ZObA"/>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRkl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRk1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.eclipse.org/uml2/5.0.0/UML/Profile/Standard#/"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRlF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRlV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRkl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://UML_PROFILES/Standard.profile.uml#_1"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRll_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRl1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_MVcY4A6vEey0yZHOgXORCw"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRmF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRmV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRll_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_qB6okHV_EeuLv4CJTW7N3w"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRml_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRm1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://UML_PROFILES/SimulationProfile.profile.uml#_0JguYADOEey2osNp1BFDrQ"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRnF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRnV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRml_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://UML_PROFILES/SimulationProfile.profile.uml#_7NGXkOkBEeudKb4gifbFSQ"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRnl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRn1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://UML_PROFILES/UIPrototypingProfile.profile.uml#_wMX_oO3kEeufv-wepAOgeA"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRoF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRoV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRnl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://UML_PROFILES/UIPrototypingProfile.profile.uml#_layK4Ok6EeuRueHEtlfuZQ"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRol_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRo1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://UML_PROFILES/DependencyMatrix.profile.uml#_tWAbgPZgEeuqpMQQX6G9NA"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRpF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRpV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRol_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://UML_PROFILES/DependencyMatrix.profile.uml#_qB6okHV_EeuLv4CJTW7N3w"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRpl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRp1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#/"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRqF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRqV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRpl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRql_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRq1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//activities"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRrF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRrV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRql_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_Activities"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRrl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRr1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//allocations"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRsF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRsV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRrl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_Allocations"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRsl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRs1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//blocks"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRtF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRtV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRsl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_Blocks"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRtl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRt1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//constraintblocks"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRuF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRuV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRtl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_ConstraintBlocks"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRul_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRu1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//deprecatedelements"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRvF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRvV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRul_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_DeprecatedElements"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRvl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRv1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//modelelements"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRwF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRwV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRvl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_ModelElements"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRwl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRw1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//portsandflows"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRxF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRxV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRwl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_Ports_u0026Flows"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRxl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRx1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="http://www.ht0003.com/sds/sysml/1.6/SysML#//requirements"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRyF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRyV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRxl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SysML.profile.uml#SysML.package_packagedElement_Requirements"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRyl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRy1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://SysML16_PROFILES/sysml-extensions.profile.uml#_nWzR8PsdEeuOLcOGxqRZFA"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRzF_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTRzV_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRyl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/sysml-extensions.profile.uml#_OY018LLmEeuf5bOSuACxqQ"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTRzl_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTRz1_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://SysML16_PROFILES/SACustomizationForSysML.profile.uml#_73qvAEJ_EfCDQNDQ_BpU2w"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTR0F_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTR0V_yEfG4KaDTdrs0Xg" base="1780562896169__IMTRzl_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SACustomizationForSysML.profile.uml#_8XSLkEJxEfCTGugH4uwNrg"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTR0l_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTR01_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://SysML16_PROFILES/SACustomizationForSysML.profile.uml#_732VMEJ_EfCDQNDQ_BpU2w"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTR1F_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTR1V_yEfG4KaDTdrs0Xg" base="1780562896169__IMTR0l_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SACustomizationForSysML.profile.uml#_kDzkIEJyEfCTGugH4uwNrg"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTR1l_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTR11_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://UML2_PROFILES/Validation_Profile.profile.uml#_HeGzEI-iEfCytOfVhK1VBQ"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTR2F_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTR2V_yEfG4KaDTdrs0Xg" base="1780562896169__IMTR1l_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://UML2_PROFILES/Validation_Profile.profile.uml#_11_5_f720368_1159529670215_231387_1"/>
+    </profileApplication>
+    <profileApplication xmi:type="uml:ProfileApplication" xmi:id="1780562896169__IMTR2l_yEfG4KaDTdrs0Xg">
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTR21_yEfG4KaDTdrs0Xg" source="http://www.eclipse.org/uml2/2.0.0/UML">
+        <references xmi:type="ecore:EPackage" href="pathmap://SysML16_PROFILES/SACustomizationForRequirements.profile.uml#_C9sQcbPUEfC9Jfe_fp8AhA"/>
+      </eAnnotations>
+      <eAnnotations xmi:type="ecore:EAnnotation" xmi:id="1780562896169__IMTR3F_yEfG4KaDTdrs0Xg" source="http://www.sysdesim.arch/uml2/stereotype">
+        <contents xmi:type="domain:StereotypeInstance" xmi:id="1780562896169__IMTR3V_yEfG4KaDTdrs0Xg" base="1780562896169__IMTR2l_yEfG4KaDTdrs0Xg">
+          <type xmi:type="uml:Stereotype" href="pathmap://UML_PROFILES/SDSProfile.profile.uml#_zouKwHV_EeuLv4CJTW7N3w"/>
+        </contents>
+      </eAnnotations>
+      <appliedProfile xmi:type="uml:Profile" href="pathmap://SysML16_PROFILES/SACustomizationForRequirements.profile.uml#_18_0beta_8f90291_1391001597107_586303_6259"/>
+    </profileApplication>
+  </uml:Model>
+  <Blocks:Block xmi:id="_TVHyUGCxEfGqsb6wf6ZObA" base_Class="_TT_J4GCxEfGqsb6wf6ZObA"/>
+  <Blocks:Block xmi:id="_Up_TgGCxEfGqsb6wf6ZObA" base_Class="_UpiAgGCxEfGqsb6wf6ZObA"/>
+</xmi:XMI>


### PR DESCRIPTION
## 本 PR 只做什么

本 PR 只实现 **FS-1：SysDeSim XML 同层 `uml:FinalState` target 转成 FCSTM 退出态 `[*]`**。

一句话目标：真实样本 `model2.xml` 里的 `SS -> uml:FinalState` 转换后必须变成 FCSTM DSL 的 `SS -> [*];`，并且不能生成任何可见的兼容状态。

| 项目 | 结论 |
|---|---|
| 适用分支 | `dev/damnx` 支线专属，不承诺进入 `main`。 |
| 本 PR 范围 | 只处理同一 region 内 **leaf state** `-> uml:FinalState`。真实样本 source 是 leaf state `SS`。 |
| 不改内容 | 不改 FCSTM grammar / parser / model / runtime。 |
| 不生成内容 | 不生成 `__sysdesim_final_*`、hidden pseudo state、普通 final state。 |
| 不在本 PR 做 | 跨层 FinalState、composite-source FinalState、timeline ended 语义、MiniRacer 可视化改造、signal+guard 扩展。 |

## 执行清单

本 PR 是 leaf PR，不维护子 PR 队列、状态看板或流程图；这里只保留开发时可以直接照做的执行清单。

1. 用真实样本 smoke 复现当前 `model2.xml` 的 final target unsupported 失败。
2. 写 FS-1 测试，确认新增成功路径测试在当前实现下失败。
3. 做最小 converter 修改，只支持同层 leaf `state -> uml:FinalState` 到 `[*]`。
4. 跑指定单测、SysDeSim 回归和真实样本 smoke。
5. push 后观察 CI / codecov。
6. 启动三路强对抗 review；C/I 问题修完后等待用户合并指令。

## 真实样本与基线复现

### 真实样本

| 文件 | 用途 | FS-1 预期 |
|---|---|---|
| `/data/sync/work/20260424文档拷贝/给北航/model2.xml` | 同层 FinalState 真实样本 | 转换成功，DSL 包含 `SS -> [*];`。 |
| `/data/sync/work/20260424文档拷贝/给北航/StateMachine2.png` | 样本状态图视觉证据 | 末端靶心对应 XML 的 `uml:FinalState`。 |
| `/data/sync/work/20260424文档拷贝/给北航(1)/model0608.xml` | 跨层 FinalState 样本 | 本 PR 不修；仍明确报 unsupported。 |

`model2.xml` 的关键 XML 元素必须保留：

| XML id | 类型 | 关键属性 | 用途 |
|---|---|---|---|
| `_obJw4GCxEfGqsb6wf6ZObA` | `uml:State` | `name="SS"` | final transition source。 |
| `_rJto4GCxEfGqsb6wf6ZObA` | `uml:FinalState` | `name=""` | final transition target；不得输出为普通 state。 |
| `_rpn4AGCxEfGqsb6wf6ZObA` | `uml:Transition` | `source="_obJw4GCxEfGqsb6wf6ZObA" target="_rJto4GCxEfGqsb6wf6ZObA"` | 真实同层 final transition。 |

### fixture 规则

1. 测试 fixture 路径固定为 `test/testfile/sysdesim/final_state_same_level_model2.xml`。
2. fixture 必须来自真实 `/data/.../给北航/model2.xml`，不能手写替代。最直接命令如下：

```bash
cp "/data/sync/work/20260424文档拷贝/给北航/model2.xml" \
    test/testfile/sysdesim/final_state_same_level_model2.xml
```

3. 允许为了测试体积做 **只删除不新增/不改语义** 的最小化，但必须保留上表三个 id、原 `source/target`、原 `name` 属性和所属 region 关系。
4. 如果做了最小化，提交里必须能用下面命令证明关键元素还在：

```bash
rg -n '_obJw4GCxEfGqsb6wf6ZObA|_rJto4GCxEfGqsb6wf6ZObA|_rpn4AGCxEfGqsb6wf6ZObA|uml:FinalState|name="SS"' \
    test/testfile/sysdesim/final_state_same_level_model2.xml
```

### 开工前必须复现一次当前失败

```bash
python - <<'PY'
from pathlib import Path
from pyfcstm.convert.sysdesim import convert_sysdesim_xml_to_dsl

for path in [
    "/data/sync/work/20260424文档拷贝/给北航/model2.xml",
    "/data/sync/work/20260424文档拷贝/给北航(1)/model0608.xml",
]:
    try:
        text = convert_sysdesim_xml_to_dsl(path)
    except Exception as exc:
        print(f"{Path(path).name}: {type(exc).__name__}: {exc}")
    else:
        print(f"{Path(path).name}: OK chars={len(text)} has_exit={'-> [*]' in text} has_synthetic={'__sysdesim_final_' in text}")
PY
```

开工前预期：

- `model2.xml` 失败，错误包含 `state-to-state transitions` 或等价的 final target unsupported 信息。
- `model0608.xml` 失败，当前通常来自 Phase4 跨层 final target；该失败不在 FS-1 修复范围内。

FS-1 完成后预期：

- `model2.xml: OK ... has_exit=True has_synthetic=False`
- `model0608.xml` 不要求成功；失败文案必须同时带有 `cross-level` 和 `FinalState`，避免把跨层 final 误判成普通 state-to-state 问题。

## TDD 通用断言规则

新增测试全部放在 `test/convert/sysdesim/test_phase0_2.py`。断言优先级固定如下：

1. **主断言用 AST / model 等价**：通过 `convert_sysdesim_xml_to_ast()` 和 `validate_program_roundtrip()` 查 `TransitionDefinition.to_state is dsl_nodes.EXIT_STATE`，不要只靠字符串巧合。
2. **DSL 文本只做辅助断言**：文本断言使用 `_normalize_newlines()` 后的精确片段，或使用正则 `r'\bSS\s*->\s*\[\*\]\s*;'`；不要用易受缩进影响的裸多行 `in`。
3. **所有成功路径都必须 roundtrip**：`convert_sysdesim_xml_to_ast()` -> `validate_program_roundtrip()` 不报错。
4. **所有失败路径都必须 match 明确关键词**：不能只匹配泛化的 `state-to-state transitions`。

建议新增本地 helper，避免每个测试重复写错：

```python
def _assert_ast_has_exit_transition(state, from_state, *, event_id=None, guard_text=None):
    # 在 state.transitions 中找 from_state == from_state 且 to_state is dsl_nodes.EXIT_STATE 的 transition；
    # 同时按需核对 event / guard。
```

## 可直接复制的最小 XMI 模板

下面模板用于 T2–T8，避免开发者自行推导 XMI 结构。

### 模板 A：T2 none trigger final target

```xml
<?xml version="1.0" encoding="UTF-8"?>
<xmi:XMI xmi:version="20131001"
         xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
         xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
  <uml:Model xmi:id="model_1" name="model">
    <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Target" classifierBehavior="machine_1">
      <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Target">
        <region xmi:type="uml:Region" xmi:id="region_root" name="">
          <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
          <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done"/>
          <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
          <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
          <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
        </region>
      </ownedBehavior>
    </packagedElement>
  </uml:Model>
</xmi:XMI>
```

### 模板 B：T3 guard-only final target

以模板 A 为基础，做两个精确改动：

1. 把 `tx_finish` 替换为：

```xml
<transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done">
  <ownedRule xmi:type="uml:Constraint" xmi:id="finish_guard_rule">
    <specification xmi:type="uml:OpaqueExpression" xmi:id="finish_guard_expr">
      <body> count &gt; 0 </body>
    </specification>
  </ownedRule>
</transition>
```

2. 在 `</packagedElement>` 前、`</uml:Model>` 内增加变量定义，保证 roundtrip 不因未知 guard 变量失败：

```xml
<ownedAttribute xmi:type="uml:Property" xmi:id="var_count" name="count" type="primitive_int">
  <defaultValue xmi:type="uml:LiteralInteger" xmi:id="var_count_default" value="0"/>
</ownedAttribute>
```

### 模板 C：T4 signal final target

```xml
<?xml version="1.0" encoding="UTF-8"?>
<xmi:XMI xmi:version="20131001"
         xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
         xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
  <uml:Model xmi:id="model_1" name="model">
    <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Target" classifierBehavior="machine_1">
      <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Target">
        <region xmi:type="uml:Region" xmi:id="region_root" name="">
          <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_1" target="state_idle"/>
          <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done">
            <trigger xmi:type="uml:Trigger" xmi:id="trigger_go" event="signal_event_go"/>
          </transition>
          <subvertex xmi:type="uml:Pseudostate" xmi:id="init_1"/>
          <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
          <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name="Done"/>
        </region>
      </ownedBehavior>
    </packagedElement>
    <packagedElement xmi:type="uml:Signal" xmi:id="signal_go" name="Go"/>
    <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_event_go" name="" signal="signal_go"/>
  </uml:Model>
</xmi:XMI>
```

### T5–T8 模板改法

| 测试 | 以哪个模板为基础 | 精确改法 |
|---|---|---|
| T5 signal+guard final target | 模板 C | 在 `tx_finish` 内同时保留 `<trigger ... event="signal_event_go"/>`，并追加模板 B 的 `<ownedRule ... count &gt; 0 ...>`；同时按模板 B 加 `var_count`。 |
| T6 final source | 模板 A | 增加第二个 state `state_after name="After"`；把 `tx_finish` 改成 `source="final_done" target="state_after"`。 |
| T7 init -> final | 模板 A | 把 `tx_init` 改成 `source="init_1" target="final_done"`，并删除或保留不参与路径的 `state_idle` 均可；错误 match 必须使用 `init pseudostate.*FinalState target`。 |
| T8 composite-source final target | 模板 C | 把 `state_idle` 改成带 child region 的 composite state `H`，并让 `tx_finish source="state_h" target="final_done"`；预期仍 unsupported，错误 match 使用 `composite source.*FinalState target`。 |

## TDD：先写哪些测试

### T1：真实 `model2.xml` 同层 FinalState smoke

新增测试名：

```python
def test_phase2_real_model2_lowers_same_level_final_target_to_exit_state():
```

步骤与断言：

1. 读取 `test/testfile/sysdesim/final_state_same_level_model2.xml`。
2. 调用 `convert_sysdesim_xml_to_dsl()`。
3. DSL 辅助断言：
   - 正则命中 `r'\bSS\s*->\s*\[\*\]\s*;'`
   - 不包含 `__sysdesim_final_`
   - 不包含 final target id `_rJto4GCxEfGqsb6wf6ZObA`
   - 不包含由 final vertex 生成的普通 state，例如 `state Done` / `state __sysdesim_final_`。
4. AST 主断言：`convert_sysdesim_xml_to_ast()` 后 root state 内存在 `from_state == "SS"` 且 `to_state is dsl_nodes.EXIT_STATE` 的 transition。
5. Roundtrip：`validate_program_roundtrip()` 通过。

### T2：最小 none trigger final target

新增测试名：

```python
def test_phase2_lowers_none_trigger_final_target_to_exit_state(tmp_path):
```

最小 XML 的关键属性必须是：

| 元素 | id / name | safe name 预期 |
|---|---|---|
| `uml:StateMachine` | `name="Final Target"` | `FinalTarget` |
| init pseudostate | `xmi:id="init_1"` | 不输出 state |
| source state | `xmi:id="state_idle" name="Idle"` | `Idle` |
| final target | `xmi:id="final_done" name="Done"` | 不输出 state |
| final transition | `xmi:id="tx_finish" source="state_idle" target="final_done"` | `Idle -> [*]` |

断言方式：

- DSL 用 `_normalize_newlines(dsl_code) == dedent(...)` 做精确断言，因为该 XML 是最小可控 fixture。
- AST 主断言：`Idle -> EXIT_STATE`。
- DSL 负断言：不包含 `state Done`。

### T3：guard-only final target

新增测试名：

```python
def test_phase2_lowers_guarded_final_target_to_exit_state(tmp_path):
```

最小 XML 在 T2 基础上新增：

| 元素 | 关键属性 | safe name 预期 |
|---|---|---|
| variable | `ownedAttribute xmi:id="var_count" name="count" type="primitive_int"` + default `0` | `count` |
| guard | transition ownedRule body `count > 0` | guard `count > 0` |

断言方式：

- DSL 辅助断言包含 `def int count = 0;` 和 `Idle -> [*] : if [count > 0];`。
- AST 主断言：`Idle -> EXIT_STATE` 且 guard roundtrip 后未丢失。
- `validate_program_roundtrip()` 通过。

### T4：signal final target

新增测试名：

```python
def test_phase2_lowers_signal_final_target_to_exit_state(tmp_path):
```

最小 XML 在 T2 基础上新增：

| 元素 | 关键属性 | safe name 预期 |
|---|---|---|
| signal | `xmi:id="signal_go" name="Go"` | `GO` |
| signal event | `xmi:id="signal_event_go" signal="signal_go"` | 引用 `GO` |
| trigger | `event="signal_event_go"` | transition event `/GO` |

断言方式：

- DSL 辅助断言包含 `event GO named 'Go';` 和 `Idle -> [*] : /GO;`。
- AST 主断言：`Idle -> EXIT_STATE` 且 `event_id` 指向 `/GO`。
- `validate_program_roundtrip()` 通过。

### T5：signal+guard final target 仍然不扩展

新增测试名：

```python
def test_phase2_rejects_signal_guard_final_target_without_expanding_scope(tmp_path):
```

最小 XML：T4 的 signal trigger + T3 的 guard 同时出现在 `Idle -> final_done` 上。

预期：仍抛 `NotImplementedError`，错误包含：

```text
both signal and guard
```

### T6：final source 必须明确失败

新增测试名：

```python
def test_phase2_rejects_final_state_source_transition(tmp_path):
```

最小 XML：

```text
uml:FinalState -> Idle
```

预期：抛 `NotImplementedError`，错误至少包含：

```text
FinalState source
```

### T7：init pseudostate 不能直接指向 final

新增测试名：

```python
def test_phase2_rejects_init_pseudostate_targeting_final_state(tmp_path):
```

最小 XML：

```text
init -> uml:FinalState
```

预期：抛 `NotImplementedError`，`pytest.raises(..., match=r"init pseudostate.*FinalState target")` 能命中。实现文案建议固定为：

```text
Phase2 does not support init pseudostate targeting FinalState target: <transition_id>
```

### T8：composite-source / force-transition 相关 final target 不在 FS-1 偷偷支持

新增测试名：

```python
def test_phase2_rejects_composite_source_final_target_without_force_lowering(tmp_path):
```

最小 XML：在一个非 root composite region 内放 `H` 和 `final_done`，其中 `H` 是 composite state，且 transition 为：

```text
H --Go--> uml:FinalState
```

预期：抛 `NotImplementedError`，错误至少包含：

```text
composite source
FinalState target
```

目的：防止 `_is_force_transition_candidate()` / `_build_force_transition()` 周边形态被误降级成普通 `H -> [*]`，因为这会改变 composite-source 外迁语义。本 PR 不实现 force-transition + final target。

### 需要同步改掉的旧测试

当前 `test_phase2_rejects_unsupported_public_scenarios` 里有 `Final Target` 用例期待 `state-to-state transitions`。FS-1 实现后这个用例必须移出 unsupported 参数表，改由 T2/T3/T4 覆盖成功路径。

## 实现：只允许怎么改

只改以下位置，除非上述 TDD 测试证明必须扩大范围：

| 文件 | 函数 | 允许改动 |
|---|---|---|
| `pyfcstm/convert/sysdesim/convert.py` | `_build_transition()` | 增加 **leaf** `state -> final` 同层 lowering 分支，输出 `dsl_nodes.EXIT_STATE`。 |
| `pyfcstm/convert/sysdesim/convert.py` | `_build_transition()` | 给 `final source`、`init -> final`、`composite source -> final` 更清晰错误。 |
| `pyfcstm/convert/sysdesim/convert.py` | `_lower_cross_level_transition()` | 只允许把跨层 final target 的错误文案改清楚，且文案同时包含 `cross-level` 与 `FinalState`；不实现跨层。 |
| `pyfcstm/convert/sysdesim/convert.py` | `_build_force_transition()` | 原则上不动；若只为错误文案兜底，必须仍保持 unsupported，不得实现 final target force lowering。 |
| `test/convert/sysdesim/test_phase0_2.py` | 新增/调整测试 | 补 T1–T8 和旧 unsupported 用例迁移。 |
| `test/testfile/sysdesim/final_state_same_level_model2.xml` | 新增 fixture | 来自真实 `model2.xml`；可删除无关元素，但不能手写替代、不能改关键 id/属性/region 关系。 |

### `_build_transition()` 的目标逻辑

按这个顺序写，避免误吞 unsupported shape：

```text
1. 解析 source / target。
2. time trigger 仍走现有 Phase3 分支；time -> final 不在 FS-1 支持。
3. 非 signal/none 仍报 unsupported。
4. signal+guard 仍报 both signal and guard，不因 target final 放宽。
5. 在当前 `if source.vertex_type == "pseudostate":` 块附近处理 init 分支：
   - target 必须是 state；
   - target 是 final 时抛 `Phase2 does not support init pseudostate targeting FinalState target: <transition_id>`。
6. 如果 source 是 final：抛清晰 FinalState source unsupported。
7. 如果 source 是 state 且 target 是 final：
   - source 必须是 leaf；source.is_composite 为 True 时抛 composite source -> FinalState target unsupported；
   - source.parent_region_id 必须等于 target.parent_region_id；不相等时抛 cross-level FinalState target unsupported；
   - 返回 TransitionDefinition(from_state=source.safe_name, to_state=dsl_nodes.EXIT_STATE, event_id=原 signal 事件或 None, condition_expr=原 guard, post_operations=[])
8. 其余保持现有 state -> state 逻辑。
```

不要给 final vertex 分配 state 名称，不要把 final vertex 加入 `substates`，不要新增 synthetic state。

## 本地验证命令

### 必跑单测

```bash
pytest test/convert/sysdesim/test_phase0_2.py -q --tb=short
pytest test/convert/sysdesim -q --tb=short
```

### 必跑真实样本 smoke

```bash
python - <<'PY'
import re
from pathlib import Path
from pyfcstm.convert.sysdesim import convert_sysdesim_xml_to_dsl

path = "/data/sync/work/20260424文档拷贝/给北航/model2.xml"
text = convert_sysdesim_xml_to_dsl(path)
print(f"{Path(path).name}: OK chars={len(text)} has_synthetic={'__sysdesim_final_' in text}")
assert re.search(r"\bSS\s*->\s*\[\*\]\s*;", text)
assert "__sysdesim_final_" not in text
assert "_rJto4GCxEfGqsb6wf6ZObA" not in text
PY
```

### 必跑跨层非目标 smoke

```bash
python - <<'PY'
from pyfcstm.convert.sysdesim import convert_sysdesim_xml_to_dsl
path = "/data/sync/work/20260424文档拷贝/给北航(1)/model0608.xml"
try:
    convert_sysdesim_xml_to_dsl(path)
except NotImplementedError as exc:
    message = str(exc)
    print(type(exc).__name__, message)
    assert "cross-level" in message
    assert "FinalState" in message
else:
    raise AssertionError("FS-1 should not silently implement cross-level FinalState")
PY
```

## push 后验证流程

1. 提交信息建议：

```text
feat(sysdesim): lower same-level uml:FinalState target to exit state
```

2. push 当前分支：

```bash
git push origin subpr/finalstate-fs1-same-level-exit
```

3. 看 CI：

```bash
gh pr checks 163 --repo HansBug/pyfcstm --watch
```

4. 等 codecov comment 出现后，必须看 patch coverage：
   - patch coverage 不低于 90%，project coverage 不下降。
   - 如果 codecov 标红或指出未覆盖新增分支，补测试后再 push。
   - codecov comment 也算 review 输入，不允许忽略。

## 最终准出标准

| 类别 | 必须满足 |
|---|---|
| 范围 | 只实现同层 **leaf** `state -> uml:FinalState`；跨层和 composite-source final target 仍不成功。 |
| DSL | `model2.xml` 输出正则可匹配的 `SS -> [*];`。 |
| 用户面 | 输出中没有 `__sysdesim_final_*`，没有 final XML id，没有 final 普通 state。 |
| AST | 成功路径中 `to_state is dsl_nodes.EXIT_STATE`，不是字符串 `"[*]"` 或 synthetic state 名。 |
| 语义保留 | none trigger、guard-only、signal trigger 三类 final target 测试通过。 |
| 语义不扩展 | signal+guard final target 仍按现有限制失败。 |
| 错误可读 | final source、init -> final、composite-source final、跨层 final target 均有可定位错误。 |
| 回归 | `pytest test/convert/sysdesim -q --tb=short` 通过。 |
| CI | GitHub required checks 全部通过。 |
| 覆盖率 | codecov 无 C/I 级覆盖率问题；patch coverage 不低于 90%，且 project coverage 不下降；若 codecov 标红必须补测。 |
| review | 三路强对抗 reviewer 的 C/I 问题全部解决；M 级不阻塞但能顺手修则修。 |
| 合并 | 不自行 merge，等用户明确指令。 |

## 重新计划 review 要求

三路 reviewer 只审查一件事：**这个 FS-1 plan 是否已经足够专注、足够机械可执行、准出标准是否明确**。

每个 reviewer 必须自行把中文 comment 发到本 PR，格式如下：

```text
## <身份>：PR-FS-1 计划可执行性 review
结论：READY / NOT READY

| 级别 | 问题 | 证据 | 建议 |
|---|---|---|---|
| C/I/M | ... | ... | ... |
```

分级标准：

- C：计划会引导实现错误语义，或验收标准与 FS-1 冲突。
- I：计划缺少关键测试、关键命令、关键准出条件，导致开发无法无脑执行。
- M：措辞、排版、非阻塞补充建议。

进入 TDD 的门槛：三路 reviewer 全部 `READY`，且 C/I=0。
