### PR TITLE
实现 SysDeSim timeline 已终止状态语义

### DIFF
--- a/pyfcstm/convert/sysdesim/timeline_verify.py
+++ b/pyfcstm/convert/sysdesim/timeline_verify.py
@@ -781,10 +781,7 @@ def _build_machine_trace(
             occurrence_symbol = "tau__{alias}__{step_id}__{index}".format(
                 alias=output.output_name, step_id=step.step_id, index=auto_index
             )
-            previous_cycle_count = runtime.cycle_count
             runtime.cycle([])
-            if not runtime.is_ended and runtime.cycle_count == previous_cycle_count:
-                break
             to_state_path = _runtime_state_path(runtime)
             auto_occurrences.append(
                 SysDeSimTimelineAutoOccurrence(

--- a/pyfcstm/convert/sysdesim/timeline_verify.py
+++ b/pyfcstm/convert/sysdesim/timeline_verify.py
@@ -605,6 +605,12 @@ def _current_auto_transition(runtime: SimulationRuntime):
     current_state = runtime.current_state
     for transition in current_state.transitions_from:
         if transition.event is None and transition.guard is None:
+            # Intentional SimulationRuntime-internal coupling: Phase10 needs to
+            # mirror ``cycle([])`` transition selection without actually
+            # probing with a real cycle, because a rejected auto transition
+            # would otherwise still run leaf ``during`` actions and mutate the
+            # imported trace.  Keep this guard aligned with
+            # ``SimulationRuntime._select_transition(validate_stoppable=True)``.
             if current_state.is_stoppable and not runtime._validate_transition(
                 runtime.stack,
                 runtime.vars,
@@ -690,6 +696,9 @@ def _build_state_windows(
                 current.pre_state_path == _ENDED_STATE_PATH
                 and current.post_state_path == _ENDED_STATE_PATH
             ):
+                # Once the machine has already ended, avoid creating repeated
+                # ``[*]`` -> ``[*]`` open-interval windows that could make the
+                # ended sentinel look like a queryable ordinary state.
                 continue
             windows.append(
                 SysDeSimTimelineStateWindow(

--- a/pyfcstm/convert/sysdesim/timeline_verify.py
+++ b/pyfcstm/convert/sysdesim/timeline_verify.py
@@ -53,6 +53,7 @@ _TIME_UNITS = {
 }
 _INITIAL_TIME_SYMBOL = "t00"
 _INITIAL_SOURCE_STEP_ID = "initial"
+_ENDED_STATE_PATH = "[*]"
 
 
 @dataclass(frozen=True)
@@ -599,10 +600,27 @@ def _coerce_runtime_input(define_type: str, value_text: str) -> object:
 
 def _current_auto_transition(runtime: SimulationRuntime):
     """Return the first unconditional outgoing transition of the current leaf state."""
-    for transition in runtime.current_state.transitions_from:
+    if runtime.is_ended:
+        return None
+    current_state = runtime.current_state
+    for transition in current_state.transitions_from:
         if transition.event is None and transition.guard is None:
+            if current_state.is_stoppable and not runtime._validate_transition(
+                runtime.stack,
+                runtime.vars,
+                transition,
+                {},
+            ):
+                continue
             return transition
     return None
+
+
+def _runtime_state_path(runtime: SimulationRuntime) -> str:
+    """Return the current runtime state path, or the ended sentinel."""
+    if runtime.is_ended:
+        return _ENDED_STATE_PATH
+    return ".".join(runtime.current_state.path)
 
 
 def _build_state_windows(
@@ -668,6 +686,11 @@ def _build_state_windows(
                 )
             )
         else:
+            if (
+                current.pre_state_path == _ENDED_STATE_PATH
+                and current.post_state_path == _ENDED_STATE_PATH
+            ):
+                continue
             windows.append(
                 SysDeSimTimelineStateWindow(
                     machine_alias=machine_alias,
@@ -714,7 +737,7 @@ def _build_machine_trace(
             runtime.vars[local_name] = float("nan")
 
     runtime.cycle([])
-    initial_state_path = ".".join(runtime.current_state.path)
+    initial_state_path = _runtime_state_path(runtime)
     initial_vars = tuple(
         (name, _format_runtime_number(value))
         for name, value in sorted(runtime.vars.items())
@@ -722,7 +745,7 @@ def _build_machine_trace(
 
     trace_steps = []
     for index, step in enumerate(scenario.steps):
-        pre_state_path = ".".join(runtime.current_state.path)
+        pre_state_path = _runtime_state_path(runtime)
         applied_inputs = []
         for action in step.actions:
             if not isinstance(action, SysDeSimTimelineScenarioSetInputAction):
@@ -737,8 +760,9 @@ def _build_machine_trace(
             applied_inputs.append((action.input_name, local_name, action.value_text))
 
         bound_event_path = _resolve_bound_event(step, binding)
-        runtime.cycle([bound_event_path] if bound_event_path else [])
-        post_state_path = ".".join(runtime.current_state.path)
+        if not runtime.is_ended:
+            runtime.cycle([bound_event_path] if bound_event_path else [])
+        post_state_path = _runtime_state_path(runtime)
 
         auto_occurrences = []
         right_emit_step_id = _find_next_emit_step_id(scenario.steps, index)
@@ -752,13 +776,16 @@ def _build_machine_trace(
             auto_transition = _current_auto_transition(runtime)
             if auto_transition is None:
                 break
-            from_state_path = ".".join(runtime.current_state.path)
+            from_state_path = _runtime_state_path(runtime)
             auto_index += 1
             occurrence_symbol = "tau__{alias}__{step_id}__{index}".format(
                 alias=output.output_name, step_id=step.step_id, index=auto_index
             )
+            previous_cycle_count = runtime.cycle_count
             runtime.cycle([])
-            to_state_path = ".".join(runtime.current_state.path)
+            if not runtime.is_ended and runtime.cycle_count == previous_cycle_count:
+                break
+            to_state_path = _runtime_state_path(runtime)
             auto_occurrences.append(
                 SysDeSimTimelineAutoOccurrence(
                     machine_alias=output.output_name,
@@ -776,6 +803,8 @@ def _build_machine_trace(
                     ),
                 )
             )
+            if runtime.is_ended:
+                break
 
         trace_steps.append(
             SysDeSimTimelineStepExecution(
@@ -783,7 +812,7 @@ def _build_machine_trace(
                 time_symbol=step.time_symbol,
                 pre_state_path=pre_state_path,
                 post_state_path=post_state_path,
-                stabilized_state_path=".".join(runtime.current_state.path),
+                stabilized_state_path=_runtime_state_path(runtime),
                 bound_event_path=bound_event_path,
                 applied_inputs=tuple(applied_inputs),
                 auto_occurrences=tuple(auto_occurrences),
@@ -1090,6 +1119,8 @@ def _state_seen_in_trace(
     state_path: str,
 ) -> bool:
     """Return whether one state appears anywhere in the imported trace."""
+    if state_path == _ENDED_STATE_PATH:
+        return False
     if trace.initial_state_path == state_path:
         return True
     if any(
@@ -1433,9 +1464,7 @@ def _build_witness_steps(
                 # mirrors the ``-->Sig13`` outbound notation below.
                 actions.append("{}<--".format(action.event_name))
             elif isinstance(action, SysDeSimTimelineScenarioSetInputAction):
-                actions.append(
-                    "{}={}".format(action.input_name, action.value_text)
-                )
+                actions.append("{}={}".format(action.input_name, action.value_text))
         for note in step.notes:
             if isinstance(note, str) and note.startswith("outbound_signal="):
                 signal = note.split("=", 1)[1].strip()
@@ -1470,9 +1499,7 @@ def _render_scenario_actions(
         if isinstance(action, SysDeSimTimelineScenarioEmitAction):
             rendered.append("{}<--".format(action.event_name))
         elif isinstance(action, SysDeSimTimelineScenarioSetInputAction):
-            rendered.append(
-                "{}={}".format(action.input_name, action.value_text)
-            )
+            rendered.append("{}={}".format(action.input_name, action.value_text))
     for note in notes:
         if isinstance(note, str) and note.startswith("outbound_signal="):
             signal = note.split("=", 1)[1].strip()

--- a/test/convert/sysdesim/test_phase9_11.py
+++ b/test/convert/sysdesim/test_phase9_11.py
@@ -12,6 +12,7 @@ from pyfcstm.convert.sysdesim import (
     build_sysdesim_phase9_report,
     solve_sysdesim_state_coexistence,
 )
+from pyfcstm.convert.sysdesim.timeline_verify import _state_seen_in_trace
 
 pytestmark = pytest.mark.unittest
 
@@ -974,7 +975,9 @@ def test_phase10_does_not_record_failed_unclosed_child_final_auto(
         "TimelineUnclosedChildFinal.Parent.Done",
         "TimelineUnclosedChildFinal.Parent.Done",
     ]
+
     assert all(step.auto_occurrences == () for step in trace.steps)
+    assert not _state_seen_in_trace(trace, "[*]")
     assert [
         (item.source_step_id, item.state_path, item.start_symbol, item.end_symbol)
         for item in trace.state_windows

--- a/test/convert/sysdesim/test_phase9_11.py
+++ b/test/convert/sysdesim/test_phase9_11.py
@@ -180,6 +180,249 @@ def _build_parallel_timeline_xml(tmp_path: Path) -> Path:
     )
 
 
+def _build_same_level_final_timeline_xml(tmp_path: Path) -> Path:
+    """Build a compact timeline where one inbound signal terminates the runtime."""
+    return _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Timeline Ended" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Timeline Ended">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_root" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_end" source="state_idle" target="final_root">
+                    <trigger xmi:type="uml:Trigger" xmi:id="trigger_end" event="signal_evt_end"/>
+                  </transition>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_tail" source="state_other" target="state_other">
+                    <trigger xmi:type="uml:Trigger" xmi:id="trigger_tail" event="signal_evt_tail"/>
+                  </transition>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_other" name="Other"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_root" name=""/>
+                </region>
+              </ownedBehavior>
+              <ownedBehavior xmi:type="uml:Interaction" xmi:id="interaction_1" name="Scenario">
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_control" name="控制"/>
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_module" name="模块"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_control" name="控制" represents="prop_control"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_module" name="模块" represents="prop_module"/>
+                <fragment xmi:type="uml:StateInvariant" xmi:id="inv_internal" covered="ll_control">
+                  <invariant xmi:type="uml:Constraint" xmi:id="inv_internal_rule">
+                    <specification xmi:type="uml:OpaqueExpression" xmi:id="inv_internal_expr">
+                      <body>ready</body>
+                    </specification>
+                  </invariant>
+                </fragment>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="end_send" covered="ll_module" message="msg_end"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="end_recv" covered="ll_control" message="msg_end"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_send" covered="ll_module" message="msg_tail"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_recv" covered="ll_control" message="msg_tail"/>
+                <message xmi:type="uml:Message" xmi:id="msg_end" sendEvent="end_send" receiveEvent="end_recv" signature="signal_end"/>
+                <message xmi:type="uml:Message" xmi:id="msg_tail" sendEvent="tail_send" receiveEvent="tail_recv" signature="signal_tail"/>
+              </ownedBehavior>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_end" name="SigEnd"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_end" signal="signal_end"/>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_tail" name="SigTail"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_tail" signal="signal_tail"/>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+
+def _build_hidden_auto_final_timeline_xml(tmp_path: Path) -> Path:
+    """Build a compact timeline where a hidden auto transition terminates."""
+    return _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Timeline Auto Ended" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Timeline Auto Ended">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_root" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_start" source="state_idle" target="state_done">
+                    <trigger xmi:type="uml:Trigger" xmi:id="trigger_start" event="signal_evt_start"/>
+                  </transition>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_done_final" source="state_done" target="final_root"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_tail" source="state_other" target="state_other">
+                    <trigger xmi:type="uml:Trigger" xmi:id="trigger_tail" event="signal_evt_tail"/>
+                  </transition>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_done" name="Done"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_other" name="Other"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_root" name=""/>
+                </region>
+              </ownedBehavior>
+              <ownedBehavior xmi:type="uml:Interaction" xmi:id="interaction_1" name="Scenario">
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_control" name="控制"/>
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_module" name="模块"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_control" name="控制" represents="prop_control"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_module" name="模块" represents="prop_module"/>
+                <fragment xmi:type="uml:StateInvariant" xmi:id="inv_internal" covered="ll_control">
+                  <invariant xmi:type="uml:Constraint" xmi:id="inv_internal_rule">
+                    <specification xmi:type="uml:OpaqueExpression" xmi:id="inv_internal_expr">
+                      <body>ready</body>
+                    </specification>
+                  </invariant>
+                </fragment>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="start_send" covered="ll_module" message="msg_start"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="start_recv" covered="ll_control" message="msg_start"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_send" covered="ll_module" message="msg_tail"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_recv" covered="ll_control" message="msg_tail"/>
+                <message xmi:type="uml:Message" xmi:id="msg_start" sendEvent="start_send" receiveEvent="start_recv" signature="signal_start"/>
+                <message xmi:type="uml:Message" xmi:id="msg_tail" sendEvent="tail_send" receiveEvent="tail_recv" signature="signal_tail"/>
+              </ownedBehavior>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_start" name="SigStart"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_start" signal="signal_start"/>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_tail" name="SigTail"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_tail" signal="signal_tail"/>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+
+def _build_parallel_hidden_auto_final_timeline_xml(tmp_path: Path) -> Path:
+    """Build a two-output timeline where one split output terminates early."""
+    return _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Timeline Parallel Ended" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Timeline Parallel Ended">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_root_init" source="init_root" target="state_control"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_root" name=""/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_control" name="Control">
+                    <region xmi:type="uml:Region" xmi:id="region_left" name="">
+                      <transition xmi:type="uml:Transition" xmi:id="tx_left_init" source="init_left" target="state_idle"/>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_start" source="state_idle" target="state_done">
+                        <trigger xmi:type="uml:Trigger" xmi:id="trigger_start" event="signal_evt_start"/>
+                      </transition>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_done_final" source="state_done" target="final_root"/>
+                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_left"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_done" name="Done"/>
+                    </region>
+                    <region xmi:type="uml:Region" xmi:id="region_right" name="">
+                      <transition xmi:type="uml:Transition" xmi:id="tx_right_init" source="init_right" target="state_wait"/>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_tail" source="state_wait" target="state_other">
+                        <trigger xmi:type="uml:Trigger" xmi:id="trigger_tail" event="signal_evt_tail"/>
+                      </transition>
+                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_right"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_wait" name="Wait"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_other" name="Other"/>
+                    </region>
+                  </subvertex>
+                </region>
+              </ownedBehavior>
+              <ownedBehavior xmi:type="uml:Interaction" xmi:id="interaction_1" name="Scenario">
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_control" name="控制"/>
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_module" name="模块"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_control" name="控制" represents="prop_control"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_module" name="模块" represents="prop_module"/>
+                <fragment xmi:type="uml:StateInvariant" xmi:id="inv_internal" covered="ll_control">
+                  <invariant xmi:type="uml:Constraint" xmi:id="inv_internal_rule">
+                    <specification xmi:type="uml:OpaqueExpression" xmi:id="inv_internal_expr">
+                      <body>ready</body>
+                    </specification>
+                  </invariant>
+                </fragment>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="start_send" covered="ll_module" message="msg_start"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="start_recv" covered="ll_control" message="msg_start"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_send" covered="ll_module" message="msg_tail"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_recv" covered="ll_control" message="msg_tail"/>
+                <message xmi:type="uml:Message" xmi:id="msg_start" sendEvent="start_send" receiveEvent="start_recv" signature="signal_start"/>
+                <message xmi:type="uml:Message" xmi:id="msg_tail" sendEvent="tail_send" receiveEvent="tail_recv" signature="signal_tail"/>
+              </ownedBehavior>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_start" name="SigStart"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_start" signal="signal_start"/>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_tail" name="SigTail"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_tail" signal="signal_tail"/>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+
+def _build_unclosed_child_final_timeline_xml(tmp_path: Path) -> Path:
+    """Build a nested final that cannot close the parent composite."""
+    return _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Timeline Unclosed Child Final" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Timeline Unclosed Child Final">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_root_init" source="init_root" target="state_parent"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_parent" name="Parent">
+                    <region xmi:type="uml:Region" xmi:id="region_parent" name="">
+                      <transition xmi:type="uml:Transition" xmi:id="tx_parent_init" source="init_parent" target="state_idle"/>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_start" source="state_idle" target="state_done">
+                        <trigger xmi:type="uml:Trigger" xmi:id="trigger_start" event="signal_evt_start"/>
+                      </transition>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_done_final" source="state_done" target="final_parent"/>
+                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_parent"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_done" name="Done"/>
+                      <subvertex xmi:type="uml:FinalState" xmi:id="final_parent" name=""/>
+                    </region>
+                  </subvertex>
+                </region>
+              </ownedBehavior>
+              <ownedBehavior xmi:type="uml:Interaction" xmi:id="interaction_1" name="Scenario">
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_control" name="控制"/>
+                <ownedAttribute xmi:type="uml:Property" xmi:id="prop_module" name="模块"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_control" name="控制" represents="prop_control"/>
+                <lifeline xmi:type="uml:Lifeline" xmi:id="ll_module" name="模块" represents="prop_module"/>
+                <fragment xmi:type="uml:StateInvariant" xmi:id="inv_internal" covered="ll_control">
+                  <invariant xmi:type="uml:Constraint" xmi:id="inv_internal_rule">
+                    <specification xmi:type="uml:OpaqueExpression" xmi:id="inv_internal_expr">
+                      <body>ready</body>
+                    </specification>
+                  </invariant>
+                </fragment>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="start_send" covered="ll_module" message="msg_start"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="start_recv" covered="ll_control" message="msg_start"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_send" covered="ll_module" message="msg_tail"/>
+                <fragment xmi:type="uml:MessageOccurrenceSpecification" xmi:id="tail_recv" covered="ll_control" message="msg_tail"/>
+                <message xmi:type="uml:Message" xmi:id="msg_start" sendEvent="start_send" receiveEvent="start_recv" signature="signal_start"/>
+                <message xmi:type="uml:Message" xmi:id="msg_tail" sendEvent="tail_send" receiveEvent="tail_recv" signature="signal_tail"/>
+              </ownedBehavior>
+            </packagedElement>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_start" name="SigStart"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_start" signal="signal_start"/>
+            <packagedElement xmi:type="uml:Signal" xmi:id="signal_tail" name="SigTail"/>
+            <packagedElement xmi:type="uml:SignalEvent" xmi:id="signal_evt_tail" signal="signal_tail"/>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+
 def test_phase9_builds_output_family_from_parallel_timeline_xml(tmp_path: Path):
     """Phase9 should expose the compatibility output family and parsed models."""
     xml_file = _build_parallel_timeline_xml(tmp_path)
@@ -505,3 +748,237 @@ def test_phase11_accepts_suffix_state_refs_for_nested_states(tmp_path: Path):
         unsat_timeline.reason
         == "The left queried state never appears in the imported trajectory."
     )
+
+
+def test_phase10_marks_same_level_final_runtime_as_ended_after_signal(
+    tmp_path: Path,
+):
+    """A signal transition to ``[*]`` should keep later trace rows safe."""
+    xml_file = _build_same_level_final_timeline_xml(tmp_path)
+
+    report = build_sysdesim_phase10_report(str(xml_file))
+
+    assert [trace.machine_alias for trace in report.traces] == ["TimelineEnded"]
+    trace = report.traces[0]
+    assert trace.initial_state_path == "TimelineEnded.Idle"
+    assert [step.step_id for step in trace.steps] == ["s01", "s02"]
+    assert (
+        trace.steps[0].pre_state_path,
+        trace.steps[0].bound_event_path,
+        trace.steps[0].post_state_path,
+        trace.steps[0].stabilized_state_path,
+    ) == ("TimelineEnded.Idle", "/SIGEND", "[*]", "[*]")
+    assert (
+        trace.steps[1].pre_state_path,
+        trace.steps[1].bound_event_path,
+        trace.steps[1].post_state_path,
+        trace.steps[1].stabilized_state_path,
+    ) == ("[*]", "/SIGTAIL", "[*]", "[*]")
+    assert trace.steps[0].auto_occurrences == ()
+    assert trace.steps[1].auto_occurrences == ()
+    assert [
+        (item.source_step_id, item.state_path, item.start_symbol, item.end_symbol)
+        for item in trace.state_windows
+    ] == [
+        ("initial", "TimelineEnded.Idle", "t00", "t01"),
+        ("s01", "[*]", "t01", "t02"),
+    ]
+    assert not any(
+        "__sysdesim_final_" in value
+        for step in trace.steps
+        for value in (
+            step.pre_state_path,
+            step.post_state_path,
+            step.stabilized_state_path,
+        )
+    )
+
+
+def test_phase10_records_hidden_auto_final_transition_to_ended(tmp_path: Path):
+    """A hidden auto transition that exits should be recorded as ``Done -> [*]``."""
+    xml_file = _build_hidden_auto_final_timeline_xml(tmp_path)
+
+    report = build_sysdesim_phase10_report(str(xml_file))
+
+    trace = report.traces[0]
+    assert trace.machine_alias == "TimelineAutoEnded"
+    assert trace.initial_state_path == "TimelineAutoEnded.Idle"
+    assert (
+        trace.steps[0].pre_state_path,
+        trace.steps[0].bound_event_path,
+        trace.steps[0].post_state_path,
+        trace.steps[0].stabilized_state_path,
+    ) == (
+        "TimelineAutoEnded.Idle",
+        "/SIGSTART",
+        "TimelineAutoEnded.Done",
+        "[*]",
+    )
+    assert [
+        (
+            item.occurrence_symbol,
+            item.from_state_path,
+            item.to_state_path,
+            item.right_observation_step_id,
+            item.right_emit_step_id,
+        )
+        for item in trace.steps[0].auto_occurrences
+    ] == [
+        (
+            "tau__TimelineAutoEnded__s01__1",
+            "TimelineAutoEnded.Done",
+            "[*]",
+            "s02",
+            "s02",
+        )
+    ]
+    assert (
+        trace.steps[1].pre_state_path,
+        trace.steps[1].bound_event_path,
+        trace.steps[1].post_state_path,
+        trace.steps[1].stabilized_state_path,
+        trace.steps[1].auto_occurrences,
+    ) == ("[*]", "/SIGTAIL", "[*]", "[*]", ())
+    assert [
+        (
+            item.source_step_id,
+            item.state_path,
+            item.start_symbol,
+            item.end_symbol,
+            item.note,
+        )
+        for item in trace.state_windows
+    ] == [
+        (
+            "initial",
+            "TimelineAutoEnded.Idle",
+            "t00",
+            "t01",
+            "initial_before_first_step",
+        ),
+        (
+            "s01",
+            "TimelineAutoEnded.Done",
+            "t01",
+            "tau__TimelineAutoEnded__s01__1",
+            "before_hidden_auto",
+        ),
+        (
+            "s01",
+            "[*]",
+            "tau__TimelineAutoEnded__s01__1",
+            "t02",
+            "after_hidden_auto",
+        ),
+    ]
+
+
+def test_phase11_does_not_extend_pre_ended_state_windows(tmp_path: Path):
+    """Ended split outputs should not keep their final ordinary state alive."""
+    xml_file = _build_parallel_hidden_auto_final_timeline_xml(tmp_path)
+
+    phase10 = build_sysdesim_phase10_report(str(xml_file))
+    trace_index = {trace.machine_alias: trace for trace in phase10.traces}
+    left_trace = trace_index["TimelineParallelEnded__Control_region1"]
+    right_trace = trace_index["TimelineParallelEnded__Control_region2"]
+
+    assert left_trace.steps[0].post_state_path == "TimelineParallelEnded.Control.Done"
+    assert left_trace.steps[0].stabilized_state_path == "[*]"
+    assert left_trace.steps[1].pre_state_path == "[*]"
+    assert right_trace.steps[1].post_state_path == "TimelineParallelEnded.Control.Other"
+    assert [
+        (item.state_path, item.start_symbol, item.end_symbol)
+        for item in left_trace.state_windows
+        if item.state_path == "TimelineParallelEnded.Control.Done"
+    ] == [
+        (
+            "TimelineParallelEnded.Control.Done",
+            "t01",
+            "tau__TimelineParallelEnded__Control_region1__s01__1",
+        )
+    ]
+
+    preview = build_sysdesim_state_coexistence_constraint_preview(
+        str(xml_file),
+        "TimelineParallelEnded__Control_region1",
+        "Done",
+        "TimelineParallelEnded__Control_region2",
+        "Other",
+    )
+    result = solve_sysdesim_state_coexistence(
+        str(xml_file),
+        "TimelineParallelEnded__Control_region1",
+        "Done",
+        "TimelineParallelEnded__Control_region2",
+        "Other",
+    )
+    assert preview.candidate_count == 0
+    assert result.status == "unsat"
+    assert result.solver_status == "unsat"
+
+    interval_result = solve_sysdesim_state_coexistence(
+        str(xml_file),
+        "TimelineParallelEnded__Control_region1",
+        "Done",
+        "TimelineParallelEnded__Control_region2",
+        "Wait",
+        observation_scope="open_interval",
+    )
+    assert interval_result.status == "sat"
+    assert interval_result.observation_kind == "open_interval"
+
+
+def test_phase10_real_cross_level_final_fixture_handles_ended_without_hidden_final():
+    """The real model0608 fixture should remain importable after ended support."""
+    xml_file = (
+        Path(__file__).parents[2]
+        / "testfile/sysdesim/final_state_cross_level_model0608.xml"
+    )
+
+    report = build_sysdesim_phase10_report(str(xml_file))
+
+    all_state_paths = [
+        value
+        for trace in report.traces
+        for step in trace.steps
+        for value in (
+            step.pre_state_path,
+            step.post_state_path,
+            step.stabilized_state_path,
+        )
+    ]
+    all_state_paths.extend(
+        value
+        for trace in report.traces
+        for window in trace.state_windows
+        for value in (window.state_path,)
+    )
+    assert all_state_paths
+    assert not any("__sysdesim_final_" in value for value in all_state_paths)
+
+
+def test_phase10_does_not_record_failed_unclosed_child_final_auto(
+    tmp_path: Path,
+):
+    """A rejected child-final auto transition should not create fake tau rows."""
+    xml_file = _build_unclosed_child_final_timeline_xml(tmp_path)
+
+    report = build_sysdesim_phase10_report(str(xml_file))
+
+    trace = report.traces[0]
+    assert [step.post_state_path for step in trace.steps] == [
+        "TimelineUnclosedChildFinal.Parent.Done",
+        "TimelineUnclosedChildFinal.Parent.Done",
+    ]
+    assert [step.stabilized_state_path for step in trace.steps] == [
+        "TimelineUnclosedChildFinal.Parent.Done",
+        "TimelineUnclosedChildFinal.Parent.Done",
+    ]
+    assert all(step.auto_occurrences == () for step in trace.steps)
+    assert [
+        (item.source_step_id, item.state_path, item.start_symbol, item.end_symbol)
+        for item in trace.state_windows
+    ] == [
+        ("initial", "TimelineUnclosedChildFinal.Parent.Idle", "t00", "t01"),
+        ("s01", "TimelineUnclosedChildFinal.Parent.Done", "t01", "t02"),
+    ]


### PR DESCRIPTION
## PR 定位

本 PR 是 umbrella PR [#162](https://github.com/HansBug/pyfcstm/pull/162) 的 **FS-3：timeline ended 语义** leaf PR，base 为 `subpr/finalstate-exit-plan`。本 PR 只服务 `dev/damnx` / SysDeSim XML 转换支线，不作为 `main` 主线合并承诺。

## 本 PR 只做什么

修复 `pyfcstm.convert.sysdesim.timeline_verify` 在 FCSTM runtime 已经结束后仍继续读取 `runtime.current_state` 的问题，让 Phase10/Phase11 的导入轨迹、状态窗口、后续信号和 coexistence 查询都能把终止态当成一个只读的 `[*]` / ended 标记处理。

## 不做什么

- 不修改 FCSTM DSL grammar / parser / model / `SimulationRuntime` 底座。
- 不把 `uml:FinalState` 或兼容 pseudo state 渲染成普通 state。
- 不扩展 signal+guard transition 支持。
- 不改 MiniRacer renderer 的图形样式；FS-4 再处理可视化 payload / PNG 报告对齐。
- 不在本 PR 里新增 FS-5 的文档收口。

## 当前已知失败点

`_build_machine_trace()` 当前流程多处直接执行：

```python
".".join(runtime.current_state.path)
```

一旦 FS-1 / FS-2 生成的 `State -> [*]` 或 route flag 退出链使 `SimulationRuntime.is_ended == True`，`runtime.stack` 会清空，`runtime.current_state` 会按底座设计抛出：

```text
IndexError: Cannot access current_state: runtime has ended.
```

这会让 timeline 验证在“已经正确结束”的场景里反而失败；后续顺序图消息也无法被标记为 after termination / dropped。

## 目标行为

| 场景 | 目标结果 |
|---|---|
| 初始化后立刻 ended | trace 初始状态写成 ended sentinel，不访问 `current_state`。 |
| 某个 scenario step 触发 `[*]` 退出 | 该 step 的 `post_state_path` / `stabilized_state_path` 写成 ended sentinel。 |
| ended 后还有后续消息 | 不再调用 `runtime.cycle()` 去驱动已结束机器；该 step 的 pre/post/stabilized 都保持 ended sentinel，`bound_event_path` 仍可记录但不应造成异常。 |
| ended 前存在 hidden auto transition | auto occurrence 正常记录；若 auto 后 runtime ended，`to_state_path` 写 ended sentinel。 |
| 状态窗口 | 触发结束的 step 到下一观测之间可使用 ended sentinel；已经 ended 的后续 step 之间不再重复制造 `[*] -> [*]` 窗口，避免把终止态当成可查询普通状态窗口。 |
| coexistence 查询普通状态 | ended 后不把最后普通状态延长成可共存窗口；查询应按真实 ended 轨迹返回 sat / unsat。 |

ended sentinel 建议固定为 `"[*]"`，并只在 timeline/report 层使用；它不是 FCSTM 模型内状态路径，也不参与 `_resolve_state_path()` 的普通状态解析。任何内部 helper 如果意外收到 `"[*]"` 作为待查询 state，也必须防御性地视为“不可作为普通状态查询”。

## 允许改动范围

| 文件 | 允许改动 |
|---|---|
| `pyfcstm/convert/sysdesim/timeline_verify.py` | 增加 runtime ended 安全 helper；改 `_build_machine_trace()` / `_current_auto_transition()` / state window 构造 / timeline report 状态读取。 |
| `test/convert/sysdesim/test_phase9_11.py` | 增加 FS-3 TDD 用例和必要 XML fixture builder。 |
| `test/testfile/sysdesim/` | 如需要，可复制真实 FinalState fixture；优先使用已有 `final_state_cross_level_model0608.xml` 做 smoke，不手写替代真实样本。 |

## TDD 执行清单

1. **T1：最小同层 FinalState ended trace**
   - 构造一个 compact SysDeSim XML：`Idle --SigEnd--> FinalState`，sequence 里先发 `SigEnd`，再发一个后续无关 signal。
   - 先断言当前会因 `runtime.current_state` 访问 ended runtime 抛 `IndexError`。
   - 修复后断言 `build_sysdesim_phase10_report()` 成功，触发结束的 step `post_state_path == "[*]"`，后续 step 的 `pre_state_path/post_state_path/stabilized_state_path` 都是 `"[*]"`。

2. **T2：hidden auto 结束路径**
   - 构造 `Idle --SigStart--> Done; Done -> FinalState;`，sequence 只发 `SigStart` 后还有下一条观测。
   - fixture 至少包含 2 个 scenario step，确保 `_build_state_windows()` 进入 `scenario_steps[:-1]` 分支。
   - 断言 auto occurrence 记录 `Done -> [*]`，auto 内部 `runtime.cycle([])` 刚触发 ended 后不会在同一轮读取裸 `current_state`。
   - 断言 auto loop 结束后的 `stabilized_state_path == "[*]"`，且不抛 `IndexError`。
   - 断言 state windows 包含 `Done` 到 hidden auto 的窗口，以及 `"[*]"` 到下一观测 step 的窗口。

3. **T3：coexistence 不把 ended 前最后状态错误延长**
   - 使用 T2 fixture 或扩展为两个输出机器。
   - 查询 ended 后本不该持续的最后普通状态与另一路状态共存，固定断言 `status == "unsat"` 且 preview `candidate_count == 0`。
   - 查询 ended 前窗口内的普通状态仍按原有 open interval 语义工作，避免误伤已有 Phase11 行为。

4. **T4：真实样本 smoke**
   - 对 `test/testfile/sysdesim/final_state_cross_level_model0608.xml` 运行 `build_sysdesim_phase10_report()`。
   - 开工前先打印 trace sanity：若真实 sequence 触发 ended，则断言 trace 中使用 `"[*]"`；若当前真实 sequence 未触发 ended，则 T4 只作为“不抛错 + 不泄露 `__sysdesim_final_`” smoke，ended 覆盖由 T1/T2/T3 compact fixture 保证。

5. **T5：回归测试**
   - 保留现有 `test_phase10_builds_runtime_traces_and_hidden_auto_windows`、`test_phase11_solves_sat_and_unsat_state_coexistence_queries`、`test_phase11_builds_single_solved_timeline_report` 的期望不变。
   - 本 PR 不应改变非 ended 样本的状态路径、auto symbol、Z3 约束顺序。

## 实现步骤

1. 在 `timeline_verify.py` 增加一个模块级 sentinel，例如：

   ```python
   _ENDED_STATE_PATH = "[*]"
   ```

2. 增加只读 helper：

   ```python
   def _runtime_state_path(runtime: SimulationRuntime) -> str:
       if runtime.is_ended:
           return _ENDED_STATE_PATH
       return ".".join(runtime.current_state.path)
   ```

3. 修改 `_current_auto_transition(runtime)`：
   - 如果 `runtime.is_ended`，直接返回 `None`；
   - 否则再读取 `runtime.current_state.transitions_from`。

4. 修改 `_build_machine_trace()` 中所有状态读取：
   - 初始化后、step 前、step 后、auto 前、auto 后、`stabilized_state_path` 都必须通过 `_runtime_state_path()`；
   - auto loop 内的 `runtime.cycle([])` 可能当场触发 `[*]` 退出，所以 cycle 后立即取 `to_state_path` 时也必须使用 `_runtime_state_path()`；若已 ended，可记录 `to_state_path == "[*]"` 后结束 auto loop。
   - 如果 runtime 已 ended，则跳过后续 `runtime.cycle()`，但仍生成该 scenario step 的 trace row，用 ended sentinel 表示机器已终止；
   - ended 后的输入赋值可以继续写入 `runtime.vars` 快照，事件只记录绑定结果，不驱动状态变化。

5. 修改 `_build_state_windows()`：
   - 触发结束的 step 到下一观测 step 的窗口可以是 `"[*]"`，用于表示“已经终止”；
   - 已经 ended 的后续 step 之间不要继续追加重复的 `"[*]" -> "[*]"` open interval；
   - 不能继续沿用结束前最后普通 state，否则 Phase11 会把终止前状态错误延长成可共存窗口。

6. 检查 `_state_seen_in_trace()`、`_build_candidate_summary_notes()`、`_build_witness_steps()`、`build_sysdesim_state_coexistence_timeline_report()`：
   - 普通状态查询仍只通过 `_resolve_state_path()` 解析真实 state；
   - ended sentinel 可出现在 trace/timeline payload 中，但不要求用户能以 `"[*]"` 作为查询 state；
   - `_state_seen_in_trace()` 等 helper 若意外收到 `_ENDED_STATE_PATH`，应防御性返回 `False`，避免构造虚假的 ended-state coexistence。

## 准出标准

| 准出项 | 标准 |
|---|---|
| 单元测试 | `pytest test/convert/sysdesim/test_phase9_11.py -q --tb=short` 通过。 |
| SysDeSim 回归 | `pytest test/convert/sysdesim -q --tb=short` 通过。 |
| 真实样本 smoke | `final_state_cross_level_model0608.xml` 的 Phase10 构建不因 ended runtime 抛错；smoke 输出中不含 `__sysdesim_final_`。 |
| Codecov | 本 PR modified coverable lines 全覆盖，或仅剩明确不可覆盖 defensive 分支。 |
| 边界 | 不修改 FCSTM 底座，不生成 `state __sysdesim_final_`，不改 MiniRacer 图形样式。 |

## 本地验证命令

真实样本 smoke 先作为 sanity 输出使用；是否触发 ended 以 trace 打印为准，最终 ended 分支覆盖以 T1/T2/T3 单元测试为准。

```bash
pytest test/convert/sysdesim/test_phase9_11.py -q --tb=short
pytest test/convert/sysdesim -q --tb=short
python - <<'PY'
from pathlib import Path
from pyfcstm.convert.sysdesim import build_sysdesim_phase10_report
p = Path('test/testfile/sysdesim/final_state_cross_level_model0608.xml')
report = build_sysdesim_phase10_report(str(p))
print(len(report.traces), any('[*]' in step.stabilized_state_path for trace in report.traces for step in trace.steps))
print(any('__sysdesim_final_' in step.stabilized_state_path for trace in report.traces for step in trace.steps))
PY
```


