### PR TITLE
对齐 SysDeSim 终止态可视化与报告表达

### DIFF
--- a/pyfcstm/convert/sysdesim/__init__.py
+++ b/pyfcstm/convert/sysdesim/__init__.py
@@ -130,7 +130,9 @@ from .timeline_verify import (
     build_sysdesim_state_coexistence_timeline_report,
     build_sysdesim_phase10_report,
     build_sysdesim_phase9_report,
+    build_sysdesim_termination_summary,
     build_sysdesim_timeline_import_report,
+    format_sysdesim_termination_summary_lines,
     solve_sysdesim_state_coexistence,
 )
 from .timeline_plantuml import (
@@ -206,6 +208,7 @@ __all__ = [
     "build_sysdesim_phase56_report",
     "build_sysdesim_phase9_report",
     "build_sysdesim_phase78_report",
+    "build_sysdesim_termination_summary",
     "build_sysdesim_timeline_plantuml",
     "build_sysdesim_timeline_plantuml_from_xml",
     "build_sysdesim_state_coexistence_constraint_preview",
@@ -216,6 +219,7 @@ __all__ = [
     "convert_sysdesim_xml_to_dsls",
     "emit_program",
     "extract_sysdesim_interactions",
+    "format_sysdesim_termination_summary_lines",
     "load_sysdesim_machine",
     "load_sysdesim_raw_xmi",
     "load_sysdesim_xml",

--- a/pyfcstm/convert/sysdesim/render.py
+++ b/pyfcstm/convert/sysdesim/render.py
@@ -48,6 +48,8 @@ from .timeline import (
 from .timeline_verify import (
     SysDeSimPhase10Report,
     build_sysdesim_phase10_report,
+    build_sysdesim_termination_summary,
+    format_sysdesim_termination_summary_lines,
 )
 
 
@@ -347,6 +349,8 @@ def _shorten_state_path(state_path: str) -> str:
     """
     if not isinstance(state_path, str) or not state_path:
         return ""
+    if state_path == "[*]":
+        return "已终止"
     if ".Control." in state_path:
         return state_path.split(".Control.", 1)[1]
     if state_path.endswith(".Control"):
@@ -618,6 +622,11 @@ def build_overlay_from_diagnostics(
     """
     diagnostics = list(diagnostics or ())
     summary_lines = list(summary_lines or ())
+    summary_lines.extend(
+        format_sysdesim_termination_summary_lines(
+            build_sysdesim_termination_summary(phase10_report)
+        )
+    )
 
     error_count = sum(1 for d in diagnostics if (d.level or "").lower() == "error")
     warning_count = sum(

--- a/pyfcstm/convert/sysdesim/timeline_verify.py
+++ b/pyfcstm/convert/sysdesim/timeline_verify.py
@@ -1983,6 +1983,141 @@ def solve_sysdesim_state_coexistence(
     )
 
 
+def _output_contains_source_path(
+    output: SysDeSimPhase9Output, source_path: Tuple[str, ...]
+) -> bool:
+    """Return whether one Phase9 output contains the XML source state path."""
+    if not source_path:
+        return False
+    state_by_path = {
+        tuple(state.path): state for state in output.machine.walk_states()
+    }
+    for state in output.machine.walk_states():
+        path = tuple(state.path)
+        if path[-len(source_path) :] == source_path:
+            return True
+        if len(path) < len(source_path):
+            continue
+        suffix_paths = [
+            path[:index]
+            for index in range(
+                len(path) - len(source_path) + 1, len(path) + 1
+            )
+        ]
+        labels = []
+        complete = True
+        for item_path in suffix_paths:
+            item = state_by_path.get(tuple(item_path))
+            if item is None:
+                complete = False
+                break
+            labels.append(str(getattr(item, "extra_name", None) or item.name))
+        if complete and tuple(labels) == source_path:
+            return True
+    return False
+
+
+def build_sysdesim_termination_summary(
+    phase10_report: SysDeSimPhase10Report,
+) -> List[Dict[str, object]]:
+    """Build user-facing XML FinalState termination summary rows.
+
+    The returned list is the stable ``report["phase10"]["termination"]``
+    contract. It is derived from existing Phase7/8 graph data and Phase10
+    traces only; it does not alter runtime execution semantics.
+    """
+    final_edges = [
+        edge
+        for edge in phase10_report.phase9_report.phase78_report.machine_graph
+        if getattr(edge, "target_vertex_type", None) == "final"
+    ]
+    if not final_edges:
+        return []
+
+    traces_by_alias = {trace.machine_alias: trace for trace in phase10_report.traces}
+    summaries: List[Dict[str, object]] = []
+    for edge in final_edges:
+        matched_aliases = [
+            output.output_name
+            for output in phase10_report.phase9_report.outputs
+            if _output_contains_source_path(output, edge.source_path)
+        ]
+        if not matched_aliases:
+            matched_aliases = [trace.machine_alias for trace in phase10_report.traces]
+        for alias in matched_aliases:
+            trace = traces_by_alias.get(alias)
+            ended_step_ids: List[str] = []
+            if trace is not None:
+                for step in trace.steps:
+                    if (
+                        step.post_state_path == _ENDED_STATE_PATH
+                        or step.stabilized_state_path == _ENDED_STATE_PATH
+                    ):
+                        ended_step_ids.append(step.step_id)
+            summaries.append(
+                {
+                    "machine_alias": alias,
+                    "source_path": list(edge.source_path),
+                    "target_id": edge.target_id,
+                    "target_path": list(edge.target_path),
+                    "target_vertex_type": edge.target_vertex_type,
+                    "transition_ids": list(edge.transition_ids),
+                    "reached": bool(ended_step_ids),
+                    "ended_step_ids": ended_step_ids,
+                }
+            )
+    return summaries
+
+
+def format_sysdesim_termination_summary_lines(
+    termination: Iterable[Dict[str, object]],
+) -> List[str]:
+    """Format termination rows for overlay banners and CLI stdout."""
+    lines: List[str] = []
+    for item in termination:
+        machine_alias = str(item.get("machine_alias") or "?")
+        target_id = str(item.get("target_id") or "?")
+        transition_ids = item.get("transition_ids") or []
+        if isinstance(transition_ids, (list, tuple)):
+            transition_text = (
+                ", ".join(str(value) for value in transition_ids) or "?"
+            )
+        else:
+            transition_text = str(transition_ids)
+        ended_steps = item.get("ended_step_ids") or []
+        if isinstance(ended_steps, (list, tuple)):
+            step_text = ", ".join(str(value) for value in ended_steps)
+        else:
+            step_text = str(ended_steps)
+        source_path = item.get("source_path") or []
+        if isinstance(source_path, (list, tuple)):
+            source_text = ".".join(str(value) for value in source_path) or "?"
+        else:
+            source_text = str(source_path)
+        if item.get("reached"):
+            lines.append(
+                "已终止: {alias} reached [*] at {steps} via transition "
+                "{tx} -> XML FinalState {target} from {source}.".format(
+                    alias=machine_alias,
+                    steps=step_text or "?",
+                    tx=transition_text,
+                    target=target_id,
+                    source=source_text,
+                )
+            )
+        else:
+            lines.append(
+                "未触发终止: {alias} has XML FinalState {target} via "
+                "transition {tx} from {source}.".format(
+                    alias=machine_alias,
+                    target=target_id,
+                    tx=transition_text,
+                    source=source_text,
+                )
+            )
+    return lines
+
+
 def build_sysdesim_timeline_import_report(
     xml_path: str,
     machine_name: Optional[str] = None,
@@ -2071,6 +2206,7 @@ def build_sysdesim_timeline_import_report(
             "bindings": [asdict(item) for item in phase10_report.bindings],
             "traces": [asdict(item) for item in phase10_report.traces],
             "diagnostics": list(phase10_report.diagnostics),
+            "termination": build_sysdesim_termination_summary(phase10_report),
         },
     }
 
@@ -2144,6 +2280,8 @@ __all__ = [
     "build_sysdesim_state_coexistence_timeline_report",
     "build_sysdesim_phase9_report",
     "build_sysdesim_phase10_report",
+    "build_sysdesim_termination_summary",
     "build_sysdesim_timeline_import_report",
+    "format_sysdesim_termination_summary_lines",
     "solve_sysdesim_state_coexistence",
 ]

--- a/pyfcstm/entry/sysdesim.py
+++ b/pyfcstm/entry/sysdesim.py
@@ -73,6 +73,7 @@ from ..convert.sysdesim.timeline import (
 from ..convert.sysdesim.timeline_verify import (
     SysDeSimPhase10Report,
     build_sysdesim_phase10_report,
+    format_sysdesim_termination_summary_lines,
 )
 
 
@@ -1060,6 +1061,16 @@ def _emit_sysdesim_validate_summary(
                 state=trace["initial_state_path"],
             )
         )
+    termination = phase10.get("termination") or []
+    termination_lines = format_sysdesim_termination_summary_lines(termination)
+    if termination_lines:
+        click.echo(
+            "  {label}:".format(
+                label=click.style("Termination", fg="white", bold=True),
+            )
+        )
+        for line in termination_lines:
+            click.echo("    " + line)
 
     if not has_state_query:
         click.echo(

--- a/test/convert/sysdesim/test_phase9_11.py
+++ b/test/convert/sysdesim/test_phase9_11.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 from textwrap import dedent
+from types import SimpleNamespace
 
 import pytest
 
@@ -10,9 +11,15 @@ from pyfcstm.convert.sysdesim import (
     build_sysdesim_state_coexistence_timeline_report,
     build_sysdesim_phase10_report,
     build_sysdesim_phase9_report,
+    build_sysdesim_termination_summary,
+    build_sysdesim_timeline_import_report,
+    format_sysdesim_termination_summary_lines,
     solve_sysdesim_state_coexistence,
 )
-from pyfcstm.convert.sysdesim.timeline_verify import _state_seen_in_trace
+from pyfcstm.convert.sysdesim.timeline_verify import (
+    _output_contains_source_path,
+    _state_seen_in_trace,
+)
 
 pytestmark = pytest.mark.unittest
 
@@ -985,3 +992,123 @@ def test_phase10_does_not_record_failed_unclosed_child_final_auto(
         ("initial", "TimelineUnclosedChildFinal.Parent.Idle", "t00", "t01"),
         ("s01", "TimelineUnclosedChildFinal.Parent.Done", "t01", "t02"),
     ]
+
+
+def test_final_state_termination_summary_uses_trace_alias_when_no_output_matches():
+    """FinalState rows should still report a trace when source matching fails."""
+
+    class FakeMachine:
+        """Minimal machine stub exposing the ``walk_states`` contract."""
+
+        def walk_states(self):
+            """Return one unrelated state so source-path matching fails."""
+            return [
+                SimpleNamespace(
+                    path=("Root", "Other"),
+                    name="Other",
+                    extra_name=None,
+                )
+            ]
+
+    phase10_report = SimpleNamespace(
+        phase9_report=SimpleNamespace(
+            phase78_report=SimpleNamespace(
+                machine_graph=[
+                    SimpleNamespace(
+                        source_path=("NoSuchSource",),
+                        target_id="final_root",
+                        target_path=("Root",),
+                        target_vertex_type="final",
+                        transition_ids=("tx_end",),
+                    )
+                ],
+            ),
+            outputs=(
+                SimpleNamespace(
+                    output_name="NoMatchOutput",
+                    machine=FakeMachine(),
+                ),
+            ),
+        ),
+        traces=(
+            SimpleNamespace(
+                machine_alias="TraceOnlyOutput",
+                steps=(
+                    SimpleNamespace(
+                        step_id="s01",
+                        post_state_path="[*]",
+                        stabilized_state_path="[*]",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    summary = build_sysdesim_termination_summary(phase10_report)
+
+    assert summary == [
+        {
+            "machine_alias": "TraceOnlyOutput",
+            "source_path": ["NoSuchSource"],
+            "target_id": "final_root",
+            "target_path": ["Root"],
+            "target_vertex_type": "final",
+            "transition_ids": ["tx_end"],
+            "reached": True,
+            "ended_step_ids": ["s01"],
+        }
+    ]
+
+
+def test_final_state_termination_formatter_accepts_scalar_defensive_fields():
+    """Formatter should degrade predictably for scalar report fields."""
+    lines = format_sysdesim_termination_summary_lines(
+        [
+            {
+                "machine_alias": "MachineA",
+                "source_path": "Root.Idle",
+                "target_id": "final_root",
+                "transition_ids": "tx_end",
+                "ended_step_ids": "s01",
+                "reached": False,
+            }
+        ]
+    )
+
+    assert lines == [
+        "未触发终止: MachineA has XML FinalState final_root via "
+        "transition tx_end from Root.Idle."
+    ]
+
+
+def test_output_contains_source_path_handles_empty_and_incomplete_paths():
+    """Source-path matching should reject empty and incomplete fake machines."""
+
+    class IncompleteMachine:
+        """Machine stub missing the parent path for its only leaf state."""
+
+        def walk_states(self):
+            """Return only the leaf, forcing a missing-parent lookup."""
+            return [
+                SimpleNamespace(
+                    path=("Root", "Parent", "Leaf"),
+                    name="Leaf",
+                    extra_name="LeafLabel",
+                )
+            ]
+
+    output = SimpleNamespace(machine=IncompleteMachine())
+
+    assert not _output_contains_source_path(output, ())
+    assert not _output_contains_source_path(output, ("ParentLabel", "LeafLabel"))
+
+
+def test_timeline_import_report_rejects_partial_phase11_query(tmp_path: Path):
+    """Phase11 query arguments should be provided as an all-or-nothing group."""
+    xml_file = _build_same_level_final_timeline_xml(tmp_path)
+
+    with pytest.raises(ValueError):
+        build_sysdesim_timeline_import_report(
+            str(xml_file),
+            left_machine_alias="TimelineEnded",
+        )

--- a/test/convert/sysdesim/test_render.py
+++ b/test/convert/sysdesim/test_render.py
@@ -14,7 +14,10 @@ from pathlib import Path
 
 import pytest
 
-from pyfcstm.convert.sysdesim import build_sysdesim_phase10_report
+from pyfcstm.convert.sysdesim import (
+    build_sysdesim_phase10_report,
+    build_sysdesim_timeline_import_report,
+)
 from pyfcstm.convert.sysdesim import render as render_module
 from pyfcstm.convert.sysdesim.ir import IrDiagnostic
 from pyfcstm.convert.sysdesim.render import (
@@ -40,6 +43,13 @@ def _png_dimensions(data: bytes) -> tuple:
 def _build_parallel_timeline_xml(tmp_path: Path) -> Path:
     """Reuse the canonical phase9_11 fixture for renderer tests."""
     from test.convert.sysdesim.test_phase9_11 import _build_parallel_timeline_xml as _orig
+
+    return _orig(tmp_path)
+
+
+def _build_same_level_final_timeline_xml(tmp_path: Path) -> Path:
+    """Reuse the compact FinalState fixture for renderer tests."""
+    from test.convert.sysdesim.test_phase9_11 import _build_same_level_final_timeline_xml as _orig
 
     return _orig(tmp_path)
 
@@ -741,3 +751,86 @@ def test_render_overlay_state_cells_highlight_first_coexistence(tmp_path: Path):
     decorated = render_sysdesim_timeline_svg(phase10_report=phase10, overlay=overlay)
     # First-coexistence cell uses the "good" severity green (#1f8b3a).
     assert "#1f8b3a" in decorated
+
+
+@pytest.mark.unittest
+def test_overlay_state_cells_show_ended_label_for_final_state(tmp_path: Path):
+    """The state table displays runtime ended sentinel as a user label."""
+    xml_file = _build_same_level_final_timeline_xml(tmp_path)
+    phase10 = build_sysdesim_phase10_report(str(xml_file))
+    overlay = build_overlay_from_diagnostics(
+        phase10_report=phase10, diagnostics=[], include_state_cells=True
+    )
+    assert overlay is not None
+    machine_columns = [
+        index
+        for index, column in enumerate(overlay["state_columns"])
+        if column["kind"] == "machine"
+    ]
+    assert machine_columns
+    machine_cells = [
+        row["cells"][index]
+        for row in overlay["step_states"]
+        for index in machine_columns
+    ]
+    assert "已终止" in machine_cells
+    assert "[*]" not in machine_cells
+    assert "__sysdesim_final_" not in repr(overlay)
+
+
+@pytest.mark.unittest
+def test_render_overlay_final_state_summary_visible_in_svg(tmp_path: Path):
+    """SVG overlay surfaces ended state and original XML FinalState provenance."""
+    xml_file = _build_same_level_final_timeline_xml(tmp_path)
+    phase10 = build_sysdesim_phase10_report(str(xml_file))
+    overlay = build_overlay_from_diagnostics(
+        phase10_report=phase10, diagnostics=[], include_state_cells=True
+    )
+    svg = render_sysdesim_timeline_svg(phase10_report=phase10, overlay=overlay)
+    assert "已终止" in svg
+    assert "final_root" in svg
+    assert "tx_end" in svg
+    assert "__sysdesim_final_" not in svg
+    assert "SigEnd" in svg
+
+
+@pytest.mark.unittest
+def test_render_overlay_final_state_summary_png_path(tmp_path: Path):
+    """PNG rendering accepts the same termination overlay payload."""
+    xml_file = _build_same_level_final_timeline_xml(tmp_path)
+    phase10 = build_sysdesim_phase10_report(str(xml_file))
+    overlay = build_overlay_from_diagnostics(
+        phase10_report=phase10, diagnostics=[], include_state_cells=True
+    )
+    png = render_sysdesim_timeline_png(phase10_report=phase10, overlay=overlay)
+    assert png[:8] == _PNG_MAGIC
+    width, height = _png_dimensions(png)
+    assert width > 0
+    assert height > 0
+
+
+@pytest.mark.unittest
+def test_real_cross_level_final_state_render_summary_smoke():
+    """The real cross-level fixture reports and renders termination without leaks."""
+    xml_file = Path("test/testfile/sysdesim/final_state_cross_level_model0608.xml")
+    phase10 = build_sysdesim_phase10_report(str(xml_file))
+    final_edges = [
+        item
+        for item in phase10.phase9_report.phase78_report.machine_graph
+        if item.target_vertex_type == "final"
+    ]
+    assert final_edges
+    report = build_sysdesim_timeline_import_report(str(xml_file))
+    termination = report["phase10"]["termination"]
+    assert termination
+    assert any(item["target_vertex_type"] == "final" for item in termination)
+    assert any(item["reached"] and item["ended_step_ids"] for item in termination)
+    overlay = build_overlay_from_diagnostics(
+        phase10_report=phase10, diagnostics=[], include_state_cells=True
+    )
+    svg = render_sysdesim_timeline_svg(phase10_report=phase10, overlay=overlay)
+    assert "已终止" in svg
+    assert final_edges[0].target_id in svg
+    assert "__sysdesim_final_" not in svg
+    assert "__sysdesim_final_" not in repr(overlay)
+    assert "__sysdesim_final_" not in repr(report)

--- a/test/entry/test_sysdesim.py
+++ b/test/entry/test_sysdesim.py
@@ -11,7 +11,10 @@ from click.testing import CliRunner
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.entry import pyfcstmcli
 from pyfcstm.model.model import StateMachine, parse_dsl_node_to_state_machine
-from test.convert.sysdesim.test_phase9_11 import _build_parallel_timeline_xml
+from test.convert.sysdesim.test_phase9_11 import (
+    _build_parallel_timeline_xml,
+    _build_same_level_final_timeline_xml,
+)
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -1444,6 +1447,67 @@ def test_validate_render_diagram_emits_overlay_with_summary_lines(tmp_path: Path
     assert ">co<" in text
     # v3: time column header is the leftmost cell of the table.
     assert ">t<" in text
+
+
+@pytest.mark.unittest
+def test_validate_final_state_report_and_render_show_termination(tmp_path: Path):
+    """``validate`` writes fixed termination schema and visible final provenance."""
+    xml_file = _build_same_level_final_timeline_xml(tmp_path)
+    out_svg = tmp_path / "final_validate.svg"
+    report_file = tmp_path / "final_validate.json"
+    result = CliRunner().invoke(
+        pyfcstmcli,
+        [
+            "sysdesim",
+            "validate",
+            "--no-static-check",
+            "-i",
+            str(xml_file),
+            "--render-diagram",
+            str(out_svg),
+            "--report-file",
+            str(report_file),
+        ],
+        color=False,
+    )
+    output = _strip_ansi(result.output)
+    assert result.exit_code == 0, result.output
+    assert "Termination" in output
+    assert "已终止" in output
+    assert "TimelineEnded" in output
+    assert "tx_end" in output
+    assert "final_root" in output
+    assert "__sysdesim_final_" not in output
+
+    report = json.loads(report_file.read_text(encoding="utf-8"))
+    termination = report["phase10"]["termination"]
+    assert isinstance(termination, list)
+    assert termination
+    row = termination[0]
+    assert set(row) >= {
+        "machine_alias",
+        "source_path",
+        "target_id",
+        "target_path",
+        "target_vertex_type",
+        "transition_ids",
+        "reached",
+        "ended_step_ids",
+    }
+    assert row["machine_alias"] == "TimelineEnded"
+    assert row["source_path"] == ["Idle"]
+    assert row["target_id"] == "final_root"
+    assert row["target_vertex_type"] == "final"
+    assert row["transition_ids"] == ["tx_end"]
+    assert row["reached"] is True
+    assert row["ended_step_ids"]
+    assert "__sysdesim_final_" not in report_file.read_text(encoding="utf-8")
+
+    svg = out_svg.read_text(encoding="utf-8")
+    assert "已终止" in svg
+    assert "final_root" in svg
+    assert "tx_end" in svg
+    assert "__sysdesim_final_" not in svg
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
## PR 定位

本 PR 是 umbrella PR [#162](https://github.com/HansBug/pyfcstm/pull/162) 的 **FS-4：可视化与报告对齐** leaf PR，base 为 `subpr/finalstate-exit-plan`。本 PR 只服务 `dev/damnx` / SysDeSim XML 转换支线，不作为 `main` 主线合并承诺。

## 本 PR 只做什么

把 FS-1 / FS-2 / FS-3 已经产生的 `[*]` 终止语义，在 **MiniRacer SVG/PNG 渲染、右侧状态泳道 overlay、validate/report 文字** 中表达成人能读懂的“已终止 / XML FinalState 来源”，并继续保证兼容用的内部名称不会出现在下游可视化或报告主路径里。

一句话目标：当 Phase10 trace 中出现 ended sentinel `[*]` 时，右侧状态泳道和导出的 SVG/PNG 只显示“已终止”这种用户语义；报告/overlay banner/CLI stdout 都能说明这是由 XML 里的 `uml:FinalState` 靶心触发，并列出原始 transition id / FinalState id 以便追溯。

## 不做什么

- 不修改 FCSTM DSL grammar / parser / model / `SimulationRuntime` 底座。
- 不修改 SysDeSim XML lowering 语义；同层 / 跨层 FinalState 转换已经在 FS-1 / FS-2 完成。
- 不修改 `timeline_verify` 的 runtime ended 驱动语义；FS-3 已完成。
- 不新增 signal+guard transition 支持。
- 不把 `uml:FinalState`、`__sysdesim_final_*` 或兼容 pseudo state 渲染成普通 state。
- 不做 FS-5 的样本总回归文档收口。

## 当前基线与待修点

FS-3 后，Phase10 trace 已经能安全输出 ended sentinel：

```text
post_state_path / stabilized_state_path = "[*]"
```

但 FS-4 当前还缺三件事：

| 待修点 | 当前风险 | FS-4 目标 |
|---|---|---|
| 状态泳道 cell | `_shorten_state_path("[*]")` 当前只原样返回 `[*]`，用户不知道它对应 XML 靶心终止态 | overlay 状态 cell 显示为 `已终止`，不显示 synthetic final state 名。 |
| overlay / SVG / PNG | banner 只说明 static-check / Phase11，不说明机器何时到达终止，也不说明 XML FinalState 来源 | banner/summary lines 增加终止来源说明，例如 `已终止: <alias> reached XML FinalState <id> via transition <id>`。 |
| JSON/CLI 报告 | `phase78.machine_graph` 已含 `target_vertex_type="final"`、`target_id`、`transition_ids`，但 report/CLI 没有聚合成用户可读的终止摘要 | `report["phase10"]["termination"]` 增加稳定 schema；CLI summary 必须打印终止来源，便于不看 JSON 的用户定位。 |

## 固定数据契约

FS-4 必须在 `build_sysdesim_timeline_import_report()` 返回的 dict 中增加以下字段；这是本 PR 落地后的契约，FS-5 和后续下游不得 silent rename：

```python
report["phase10"]["termination"] == [
    {
        "machine_alias": "...",
        "source_path": ["...", "..."],
        "target_id": "...",                 # 原始 XML FinalState id
        "target_path": ["..."] or [],
        "target_vertex_type": "final",
        "transition_ids": ["..."],          # 原始 XML transition id，允许为空但 key 必须存在
        "reached": True or False,            # Phase10 trace 是否实际到达 [*]
        "ended_step_ids": ["sNN", "..."],   # reached=False 时为空 list
    },
]
```

约束：

- 只在 dict report 层增加 `report["phase10"]["termination"]`；**不修改** `SysDeSimPhase10Report` dataclass。
- `target_vertex_type` 只收集 `"final"`；没有 XML FinalState target 时该 list 为空。
- `reached=True` 的判定：同一 `machine_alias` 的 Phase10 trace 任一 step 的 `post_state_path == "[*]"` 或 `stabilized_state_path == "[*]"`。
- `ended_step_ids` 收集实际出现 ended sentinel 的 scenario step id；同一机器可有多个 step，顺序保持 trace 顺序。
- overlay/banner/stdout 的终止文案必须由同一份 termination summary 派生，避免 report、图和 CLI 三套逻辑漂移。
- 用户可见文本不得包含 `__sysdesim_final_`。

## 允许改动范围

| 文件 | 允许改动 |
|---|---|
| `pyfcstm/convert/sysdesim/render.py` | 终止态 display label；从 Phase10/Phase7/8 信息构造 overlay summary lines；确保 state-cell payload / SVG 不泄露 `__sysdesim_final_*`。 |
| `pyfcstm/convert/sysdesim/timeline_verify.py` | 增加只读 termination summary helper / `report["phase10"]["termination"]` 字段；不得改 runtime driving 语义；不得改 `SysDeSimPhase10Report` dataclass。 |
| `pyfcstm/entry/sysdesim.py` | validate / static-check / sequence-render 的报告和 render summary 接线；CLI stdout 必须增加人类可读终止来源。 |
| `test/convert/sysdesim/test_render.py` | MiniRacer SVG/PNG overlay TDD。 |
| `test/entry/test_sysdesim.py` | CLI report / render integration TDD。 |
| `js/sysdesim_render/src/sequence_svg.js` + bundle | 只有当 Python payload 不能满足视觉目标时才允许改；若改 JS，必须 `cd js/sysdesim_render && npm run build` 并同步 `dist/pyfcstm-sysdesim-render.js` 到 `pyfcstm/convert/sysdesim/_render_assets/`。优先不改 JS。 |

## TDD 执行清单

### T1：状态泳道把 ended sentinel 显示为“已终止”

- 输入：复用 `test.convert.sysdesim.test_phase9_11._build_same_level_final_timeline_xml()`；若跨测试模块 private helper 耦合明显，可把最小 fixture builder 复制到 `test_render.py`，不得依赖外部文件。
- 调用：`build_sysdesim_phase10_report()` + `build_overlay_from_diagnostics(include_state_cells=True)`。
- 当前 overlay 结构验收路径：
  - `overlay["state_columns"]` 存在且包含机器列；
  - `overlay["step_states"]` 为 row list；
  - 每个 row 形如 `{"step_id": "sNN", "cells": [...], "highlight": ...}`；
  - machine cell 文本位于 `cells` 中对应 `state_columns[k]["kind"] == "machine"` 的列。
- 断言：
  - 触发结束后的后续 step machine cell 显示 `已终止`；
  - payload 中不出现 `__sysdesim_final_`；
  - 如仍保留 raw `[*]`，只能在机器可读字段中出现，不应作为右侧状态泳道展示文本出现。

### T2：SVG overlay 可视化显示终止语义和 XML 来源

- 输入：同 T1。
- 调用：`render_sysdesim_timeline_svg(phase10_report=..., overlay=...)`。
- 断言：
  - SVG 中包含 `已终止`；
  - SVG/banner 中包含原始 XML FinalState id（最小 fixture 为 `final_root`）和原始 transition id；
  - SVG 中不包含 `__sysdesim_final_`；
  - 普通 signal / lifeline / state table 仍正常存在。

### T3：PNG 路径同样可渲染带终止 overlay 的图

- 输入：同 T1。
- 调用：`render_sysdesim_timeline_png(phase10_report=..., overlay=...)`。
- 断言：PNG magic 正确、宽高有效、不抛 `SysdesimRenderError`。PNG 字节不做 OCR；文本语义由同一 payload 的 SVG 断言覆盖。

### T4：validate report 输出固定 termination schema

- 输入：同 T1 的 XML。
- 调用：`build_sysdesim_timeline_import_report()` 或 `pyfcstm sysdesim validate --report-file ...`。
- 断言：
  - `report["phase10"]["termination"]` 存在且为 list；
  - 至少一项包含 `machine_alias`、`source_path`、`target_id == "final_root"`、`target_vertex_type == "final"`、`transition_ids`、`reached`、`ended_step_ids`；
  - reached 样本中 `reached is True` 且 `ended_step_ids` 非空；
  - 报告不出现 `__sysdesim_final_`；
  - 不改变已有 `phase10["traces"]` / `phase11` 字段语义。

### T5：validate `--render-diagram` 集成终止 summary lines 和 CLI stdout

- 输入：同 T1 的 XML。
- 调用：CLI `sysdesim validate --no-static-check -i <xml> --render-diagram <out.svg> --report-file <out.json>`。
- 断言：
  - 输出 SVG 包含 `已终止`、XML FinalState id、source transition id；
  - stdout **必须**包含终止来源摘要：machine alias、`已终止` 或 `[*]`、source transition id、XML FinalState id；仅打印 render 写出成功不算通过；
  - report JSON 含 `phase10.termination` 固定 schema；
  - SVG/stdout/report 不包含 `__sysdesim_final_`。

### T6：真实跨层样本 smoke 不泄露兼容状态

- 输入：`test/testfile/sysdesim/final_state_cross_level_model0608.xml`。
- 调用：`build_sysdesim_phase10_report()` + overlay SVG/PNG render + `build_sysdesim_timeline_import_report()`。
- 当前 fixture 的必测断言：
  - `phase78.machine_graph` 至少有一条 `target_vertex_type == "final"` 的 edge；
  - `report["phase10"]["termination"]` 至少有一项 `target_vertex_type == "final"` 且 `target_id` 为真实 XML FinalState id；
  - 当前样本 Phase10 trace 已出现 ended sentinel，因此至少一项 `reached is True` 且 `ended_step_ids` 非空；
  - SVG / overlay payload / report 不出现 `__sysdesim_final_`；
  - SVG/overlay 中出现 `已终止`。
- 长期兜底语义：如果未来真实样本 sequence 改到不触发 ended，则该 edge 的 summary 保留 `reached=False`、`ended_step_ids=[]`，但仍必须保留 XML FinalState target 信息。

## 实现步骤

1. **定义展示语义**
   - 在 render/report 层固定用户可见 ended label：`已终止`。
   - `_shorten_state_path("[*]")` 返回 `已终止`；普通 state path 继续保持当前短名规则。
   - 不把 `已终止` 当成可查询状态；它只是展示文本。

2. **构造 termination summary helper**
   - 从 `phase10_report.phase9_report.phase78_report.machine_graph` 收集 `target_vertex_type == "final"` 的 transition。
   - 每条 summary 至少包含固定数据契约列出的 8 个 key。
   - 按 `machine_alias` 关联 Phase10 trace；trace 中出现 `[*]` 则 `reached=True` 并填充 `ended_step_ids`，否则 `reached=False` 且 `ended_step_ids=[]`。
   - summary 文案必须使用原始 XML id / state path，不使用 `__sysdesim_final_*` safe name。

3. **overlay/banner 接线**
   - `build_overlay_from_diagnostics()` 在 caller 传入 summary_lines 之外自动追加 termination summary，或提供明确 helper 由 CLI/调用方追加；最终 validate/static render 使用同一逻辑。
   - banner 文案保持短句，避免挤爆 SVG：例如 `已终止: StateMachine reached [*] via tx_end -> FinalState final_root.`。
   - 中文展示使用 `已终止`，但 transition / XML id 保持原文。

4. **report/CLI 接线**
   - `build_sysdesim_timeline_import_report()` 必须写入 `report["phase10"]["termination"]`，不破坏既有 `phase10["traces"]`。
   - `_emit_sysdesim_validate_summary()` 必须打印简短 termination summary；没有 FinalState 时不输出额外段落。
   - `sequence-render --diagnostics-file` 读取 validate report 时，如 report 内有 termination summary，也应能透传到 overlay banner；若改动过大，本 PR 至少覆盖 validate/static render 路径，并在代码注释或 PR comment 说明后续补齐点。

5. **避免 JS 改动优先**
   - 首选只改 Python payload 文本，让既有 JS state table / banner 渲染即可。
   - 只有需要特殊样式时才改 `js/sysdesim_render/src/sequence_svg.js`；一旦改 JS，必须运行 `cd js/sysdesim_render && npm run build`，并提交 source + bundle。

## 准出标准

| 准出项 | 标准 |
|---|---|
| 单元测试 | `pytest test/convert/sysdesim/test_render.py -q --tb=short` 通过。 |
| CLI 集成 | `pytest test/entry/test_sysdesim.py -q --tb=short` 通过。 |
| SysDeSim 回归 | `pytest test/convert/sysdesim -q --tb=short` 通过。 |
| 真实样本 smoke | `final_state_cross_level_model0608.xml` 的 SVG/PNG render 成功，payload/SVG/report 不泄露 `__sysdesim_final_`，且当前样本显示 `已终止` 与 XML FinalState 来源。 |
| Codecov | 本 PR modified coverable lines 全覆盖；PIL/resvg 初始化超时等 optional dependency / defensive 分支可接受已有或新增 `# pragma: no cover`，但主路径不得漏测。 |
| JS 构建 | 若改 JS 或 bundle，必须通过 `cd js/sysdesim_render && npm run build`，再跑 render 测试确认 bundle 与 Python payload 匹配。 |
| 边界 | 不修改 FCSTM 底座；不生成 / 渲染 hidden final state；不更改 FS-1/FS-2 lowering 和 FS-3 runtime ended 语义。 |

## 本地验证命令

```bash
pytest test/convert/sysdesim/test_render.py -q --tb=short
pytest test/entry/test_sysdesim.py -q --tb=short
pytest test/convert/sysdesim -q --tb=short
python - <<'PY'
from pathlib import Path
from pyfcstm.convert.sysdesim import build_sysdesim_phase10_report, render_sysdesim_timeline_svg
from pyfcstm.convert.sysdesim.render import build_overlay_from_diagnostics
p = Path('test/testfile/sysdesim/final_state_cross_level_model0608.xml')
report = build_sysdesim_phase10_report(str(p))
overlay = build_overlay_from_diagnostics(phase10_report=report, include_state_cells=True)
svg = render_sysdesim_timeline_svg(phase10_report=report, overlay=overlay)
print('has_ended_label=', '已终止' in svg)
print('leaks_hidden_final=', '__sysdesim_final_' in svg)
print('has_final_target=', 'FinalState' in svg or 'final' in svg.lower())
PY
```
