### PR TITLE
PR-A5a：修复初始值表达式运行时有定义性问题（#114）

### DIFF
--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -2853,7 +2853,7 @@ def composite_init_guards_incomplete(
         event_vars: Dict[str, z3.BoolRef] = {}
         triggers: List[z3.ExprRef] = []
         per_composite_failed = False
-        init_constraints, result = _build_init_constraints_or_result(
+        _, result = _build_init_constraints_or_result(
             variables,
             z3_vars,
             smt_timeout_ms=smt_timeout_ms,
@@ -2871,10 +2871,7 @@ def composite_init_guards_incomplete(
                 transition,
                 z3_vars,
                 event_vars,
-                context_constraints=[
-                    *init_constraints,
-                    *type_constraints,
-                ],
+                context_constraints=type_constraints,
                 smt_timeout_ms=smt_timeout_ms,
             )
             if result is not None:
@@ -2896,7 +2893,6 @@ def composite_init_guards_incomplete(
         sat_result = is_sat(
             [
                 no_coverage,
-                *init_constraints,
                 *type_constraints,
             ],
             timeout_ms=smt_timeout_ms,

--- a/pyfcstm/verify/smt_local.py
+++ b/pyfcstm/verify/smt_local.py
@@ -1491,6 +1491,8 @@ def _root_initial_path_context(
 def _build_init_constraints_or_result(
     variables: Sequence[VarDefine],
     z3_vars: _Z3Vars,
+    *,
+    smt_timeout_ms: Optional[int] = None,
 ) -> Tuple[Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]:
     """Build constraints pinning variables to their DSL initial values.
 
@@ -1498,14 +1500,30 @@ def _build_init_constraints_or_result(
     :type variables: Sequence[VarDefine]
     :param z3_vars: Z3 variable mapping.
     :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int], optional
     :return: Pair of constraints and optional failure result.
     :rtype: Tuple[Optional[Tuple[z3.ExprRef, ...]], Optional[AlgorithmResult]]
     """
     constraints: List[z3.ExprRef] = []
     for variable in variables:
-        init_value, result = _expr_to_z3_or_result(variable.init, z3_vars)
+        init_value, init_domains, result = _expr_z3_and_domains_or_result(
+            variable.init,
+            z3_vars,
+            context_constraints=constraints,
+            smt_timeout_ms=smt_timeout_ms,
+        )
         if result is not None:
             return None, result
+        if init_domains:
+            result = _definedness_feasibility_or_result(
+                [*constraints, *init_domains],
+                reason="Initializer runtime definedness constraints are unsatisfiable.",
+                smt_timeout_ms=smt_timeout_ms,
+            )
+            if result is not None:
+                return None, result
+            constraints.extend(init_domains)
         constraints.append(z3_vars[variable.name] == init_value)
     return tuple(constraints), None
 
@@ -1755,7 +1773,11 @@ def forced_guard_unsat_under_init(
         return AlgorithmResult(kind="sat")
 
     z3_vars = _z3_vars(variables)
-    init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
+    init_constraints, result = _build_init_constraints_or_result(
+        variables,
+        z3_vars,
+        smt_timeout_ms=smt_timeout_ms,
+    )
     if result is not None:
         return result
     guard_z3, guard_domains, result = _expr_z3_and_domains_or_result(
@@ -2693,7 +2715,11 @@ def enter_postcondition_implies_during_precondition(
         return AlgorithmResult(kind="sat")
 
     z3_vars = _z3_vars(variables)
-    init_constraints, result = _build_init_constraints_or_result(variables, z3_vars)
+    init_constraints, result = _build_init_constraints_or_result(
+        variables,
+        z3_vars,
+        smt_timeout_ms=smt_timeout_ms,
+    )
     if result is not None:
         return result
 
@@ -2827,13 +2853,28 @@ def composite_init_guards_incomplete(
         event_vars: Dict[str, z3.BoolRef] = {}
         triggers: List[z3.ExprRef] = []
         per_composite_failed = False
+        init_constraints, result = _build_init_constraints_or_result(
+            variables,
+            z3_vars,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        if result is not None:
+            first_indeterminate_result = _first_indeterminate(
+                first_indeterminate_result,
+                result.kind,
+                result.reason,
+            )
+            continue
         type_constraints = _build_type_constraints(variables, z3_vars)
         for transition in init_transitions:
             trigger, trigger_domains, result = _transition_trigger_or_result(
                 transition,
                 z3_vars,
                 event_vars,
-                context_constraints=type_constraints,
+                context_constraints=[
+                    *init_constraints,
+                    *type_constraints,
+                ],
                 smt_timeout_ms=smt_timeout_ms,
             )
             if result is not None:
@@ -2855,6 +2896,7 @@ def composite_init_guards_incomplete(
         sat_result = is_sat(
             [
                 no_coverage,
+                *init_constraints,
                 *type_constraints,
             ],
             timeout_ms=smt_timeout_ms,

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -276,6 +276,28 @@ def test_initializer_translation_failure_is_undecidable_skip():
     assert result.kind == "undecidable_skip"
 
 
+def test_initializer_runtime_undefined_is_undecidable_skip():
+    """Initializer runtime-domain failures are checked after translation."""
+    machine = parse_machine(
+        """
+        def int x = 1 / 0;
+        state System {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+
+    constraints, result = smt_local._build_init_constraints_or_result(
+        variables(machine),
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert constraints is None
+    assert result.kind == "undecidable_skip"
+    assert result.reason == "Initializer runtime definedness constraints are unsatisfiable."
+
+
 def test_guard_translation_failure_is_normalized():
     """Guard translation failure propagates through guard helper."""
     transition = Transition(
@@ -1444,6 +1466,23 @@ class TestDeadGuard:
         assert result.kind == "undecidable_skip"
         assert "runtime definedness" in result.reason
 
+    def test_runtime_undefined_initializer_does_not_affect_dead_guard(self):
+        machine = parse_machine(
+            """
+            def int x = 1 / 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x == 0];
+            }
+            """
+        )
+
+        result = dead_guard(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
     def test_non_linear_variable_multiplication_runs_full_power(self):
         machine = parse_machine(
             """
@@ -1509,6 +1548,23 @@ class TestGuardTautology:
                 state B;
                 [*] -> A;
                 A -> B : if [x > 0];
+            }
+            """
+        )
+
+        result = guard_tautology(root_transition(machine), variables(machine))
+
+        assert result == AlgorithmResult(kind="sat")
+
+    def test_runtime_undefined_initializer_does_not_affect_guard_tautology(self):
+        machine = parse_machine(
+            """
+            def int x = 1 / 0;
+            state System {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [x == 0];
             }
             """
         )
@@ -1659,6 +1715,30 @@ class TestForcedGuardUnsatUnderInit:
 
         assert result.kind == "undecidable_skip"
         assert "runtime definedness" in result.reason
+
+    def test_runtime_undefined_initializer_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 1 / 0;
+            state System {
+                state A {
+                    state Sub1;
+                    state Sub2;
+                    [*] -> Sub1;
+                    Sub1 -> Sub2;
+                }
+                state B;
+                [*] -> A;
+                !A -> B : if [x == 0];
+            }
+            """
+        )
+        transition = transition_by_guard(machine, "x == 0")
+
+        result = forced_guard_unsat_under_init(transition, variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert result.reason == "Initializer runtime definedness constraints are unsatisfiable."
 
     def test_does_not_trigger_when_forced_guard_true_at_init(self):
         machine = parse_machine(
@@ -3047,6 +3127,30 @@ class TestEnterPostconditionImpliesDuringPrecondition:
         assert result.kind == "unsat"
         diag = assert_single_diag(result, "I_ENTER_DURING_CONTRADICT")
         assert diag["data"]["branch_taken"] == "false"
+
+    def test_runtime_undefined_initializer_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int mode = 1 / 0;
+            def int x = 0;
+            state System {
+                state Idle {
+                    during { x = (mode > 0) ? 10 : 20; }
+                }
+                [*] -> Idle;
+            }
+            """
+        )
+        state = machine.root_state.substates["Idle"]
+
+        result = enter_postcondition_implies_during_precondition(
+            state, variables(machine)
+        )
+
+        assert result.kind == "undecidable_skip"
+        assert result.reason == (
+            "Initializer runtime definedness constraints are unsatisfiable."
+        )
 
     def test_triggers_when_enter_determines_during_ternary_true_branch(self):
         machine = parse_machine(
@@ -5097,6 +5201,26 @@ class TestCompositeInitGuardsIncomplete:
         result = composite_init_guards_incomplete(machine, variables(machine))
 
         assert result == AlgorithmResult(kind="unsat")
+
+    def test_runtime_undefined_initializer_is_undecidable(self):
+        machine = parse_machine(
+            """
+            def int x = 1 / 0;
+            state Root {
+                state A;
+                state B;
+                [*] -> A : if [x > 0];
+                [*] -> B : if [x <= 0];
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "undecidable_skip"
+        assert result.reason == (
+            "Initializer runtime definedness constraints are unsatisfiable."
+        )
 
     def test_timeout_propagates_when_no_diagnostic_exists(self, monkeypatch):
         machine = parse_machine(

--- a/test/verify/test_smt_local.py
+++ b/test/verify/test_smt_local.py
@@ -298,6 +298,70 @@ def test_initializer_runtime_undefined_is_undecidable_skip():
     assert result.reason == "Initializer runtime definedness constraints are unsatisfiable."
 
 
+def test_initializer_satisfiable_runtime_domain_constraints_are_kept():
+    """Valid initializer domain constraints remain in the init context."""
+    machine = parse_machine(
+        """
+        def int x = 1 / 2;
+        state System {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+
+    constraints, result = smt_local._build_init_constraints_or_result(
+        variables(machine),
+        {"x": smt_local.z3.Int("x")},
+    )
+
+    assert result is None
+    assert constraints is not None
+    constraint_text = {str(item) for item in constraints}
+    assert "2 != 0" in constraint_text
+    assert "x == 1/2" in constraint_text
+
+
+def test_initializer_domain_checks_include_prior_initializers(monkeypatch):
+    """Later initializer domain checks see prior initializer constraints."""
+    machine = parse_machine(
+        """
+        def int x = 1 / 2;
+        def int y = 3 / 4;
+        state System {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    calls = []
+    original = smt_local._definedness_feasibility_or_result
+
+    def record_constraints(constraints, *, reason, smt_timeout_ms=None):
+        calls.append(tuple(str(item) for item in constraints))
+        return original(
+            constraints,
+            reason=reason,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+
+    monkeypatch.setattr(
+        smt_local,
+        "_definedness_feasibility_or_result",
+        record_constraints,
+    )
+
+    constraints, result = smt_local._build_init_constraints_or_result(
+        variables(machine),
+        {"x": smt_local.z3.Int("x"), "y": smt_local.z3.Int("y")},
+    )
+
+    assert result is None
+    assert constraints is not None
+    assert calls[0] == ("2 != 0",)
+    assert calls[1] == ("2 != 0", "x == 1/2", "4 != 0")
+
+
 def test_guard_translation_failure_is_normalized():
     """Guard translation failure propagates through guard helper."""
     transition = Transition(
@@ -5052,6 +5116,24 @@ class TestCompositeInitGuardsIncomplete:
         assert result.kind == "sat"
         assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
 
+    def test_initializer_value_does_not_narrow_guard_coverage_gap(self):
+        machine = parse_machine(
+            """
+            def int x = 1;
+            state Root {
+                state A;
+                state B;
+                [*] -> A : if [x > 0];
+                [*] -> B : if [x < 0];
+            }
+            """
+        )
+
+        result = composite_init_guards_incomplete(machine, variables(machine))
+
+        assert result.kind == "sat"
+        assert_single_diag(result, "W_COMPOSITE_INIT_INCOMPLETE")
+
     def test_init_events_with_underscore_path_boundary_use_distinct_witness_bools(self):
         machine = parse_machine(
             """
@@ -5299,7 +5381,7 @@ class TestCompositeInitGuardsIncomplete:
     def test_nested_composite_reports_nested_state(self):
         machine = parse_machine(
             """
-            def int x = 0;
+            def int x = 1;
             state Root {
                 state Outer {
                     state Inner1;


### PR DESCRIPTION
## PR-A5a 定位

本 PR 是第 3 层议题 [#114](https://github.com/HansBug/pyfcstm/issues/114) 下 PR-A5 总控计划 [#142](https://github.com/HansBug/pyfcstm/pull/142) 的第一个实现子 PR，归属 PR-A 总伞 [#127](https://github.com/HansBug/pyfcstm/pull/127)。

- 基准分支：`dev/issue114-pr-a-verify`
- 来源分支：`dev/issue114-pr-a5a-initializer-definedness`
- 当前进度：✅ ready，等待维护者验收；不合并，等待下一步指示
- 上游依赖：PR-A4 [#132](https://github.com/HansBug/pyfcstm/pull/132) 已合入 #127，现有 `pyfcstm.verify.smt_local` 和 `test/verify/test_smt_local.py` 是本 PR 的直接工作面
- 本 PR 目标：只修初始值表达式运行时有定义性正确性问题，不夹带大规模架构拆分

---

## 子项表

| 子项 | 进度 | 目标 | 依赖项目 | 依赖关系 | 合入条件 | 写入范围 | 禁止范围 | 验收重点 |
|---|---|---|---|---|---|---|---|---|
| PR-A5a | ✅ ready 待验收 | 修复初始值表达式运行时有定义性正确性问题 | PR-A4 [#132]；现有 `pyfcstm.verify.smt_local`；现有 `test/verify/test_smt_local.py` | 依赖 PR-A4；不依赖 PR-A5b / PR-A5c / PR-A5d；建议阻塞 #127 最终合入 | CI 33/33 通过；Codecov 显示修改行全覆盖；二次多路复审 C=0 / I=0；等待维护者验收 | `pyfcstm/verify/smt_local.py`、`test/verify/test_smt_local.py` | 不新增 `solver.domain`；不抽 `verify/result.py`；不改注册表接线；不改诊断层、模型层、DSL、编辑器、`codes.yaml`、`schema.json`、`verify/search.py`、`verify/reachability.py` | `def int x = 1 / 0;` 不再被当成普通初值；初始值定义域约束进入初始上下文；只要求消费初始值的算法返回保守结果；不消费初始值的算法行为不回退 |

---

## 依赖图

```mermaid
flowchart TD
    PRA["PR-A 总伞 #127<br/>上游总伞，承载 PR-A1 到 PR-A5 的合入判断<br/>🟦 上游打开中"]
    PRA4["PR-A4 #132<br/>上游已落地 8 个 SMT 局部原始算法<br/>🟦 上游已合入"]
    PRA5["PR-A5 #142<br/>总控迁移计划，拆分 PR-A5a 到 PR-A5d<br/>🟦 上游计划"]
    PRA5a["PR-A5a<br/>修初始值表达式运行时有定义性问题<br/>✅ ready 待验收"]

    PRA --> PRA4
    PRA4 --> PRA5
    PRA5 --> PRA5a

    classDef u fill:#dbeafe,stroke:#2563eb,color:#111827
    classDef y fill:#fef3c7,stroke:#d97706,color:#111827
    class PRA,PRA4,PRA5 u
    class PRA5a y
```

后续维护规则：表格保留“进度”和“依赖关系”列；依赖图节点保留一句话说明和同款进度行；颜色按上游蓝色、已完成绿色、未完成黄色维护。

本图只展示 PR-A5a 的上游入边；PR-A5a 对 PR-A5b / PR-A5d 的后续解锁关系以 [#142](https://github.com/HansBug/pyfcstm/pull/142) 和 [#127](https://github.com/HansBug/pyfcstm/pull/127) 的完整依赖图为准。

---

## 明确不做

| 不做项 | 原因 |
|---|---|
| 不新增 `pyfcstm/solver/domain.py` | 这是 PR-A5b 的范围；PR-A5a 只做集中正确性修复 |
| 不扩展 `pyfcstm/solver/operation.py` | 这是 PR-A5c 的范围；路径敏感操作块接口不在本 PR 冻结 |
| 不抽取 `pyfcstm/verify/result.py`、`verify/encoding/**`、`verify/algorithms/**` | 这是 PR-A5d 的范围；本 PR 不做验证层重接线 |
| 不改注册表接线 | PR-A4 已接好的 8 个 SMT 局部算法必须保持可调用 |
| 不接入诊断层或 `inspect_model()` 策略 | 本 PR 是原始验证正确性修复，不做警告 / 信息 / 错误转换 |
| 不修改 DSL / 模型层语义来绕过问题 | 问题在初始 SMT 上下文缺少运行时有定义性约束，不应该改语言语义 |

---

## TDD 验收计划

| 用例 | 当前风险 | 预期结果 |
|---|---|---|
| 初始值除零：`def int x = 1 / 0;` | `_build_init_constraints_or_result()` 当前使用裸翻译路径，`1 / 0` 翻译成功但运行时未定义，定义域约束没有进入初始上下文 | `_build_init_constraints_or_result()` 通过定义域感知路径收集 `0 != 0` 这类约束；消费初始值的入口返回 `kind='undecidable_skip'`，并使用现有英语完整句风格的 reason：`Initializer runtime definedness constraints are unsatisfiable.` |
| 消费初始值的算法入口 | `forced_guard_unsat_under_init()`、`enter_postcondition_implies_during_precondition()`、`composite_init_guards_incomplete()` 会基于非法初始上下文给出确定性结论 | 三个入口都透传初始值定义域失败，不能发确定性诊断；至少覆盖除零 DSL 端到端用例 |
| 不消费初始值的算法入口 | 误把初始值约束接入 `dead_guard()` / `guard_tautology()` 会改变 PR-A4 已落地语义 | `dead_guard()` / `guard_tautology()` 不因 `def int x = 1 / 0;` 改变行为；它们仍只检查守卫自身定义域和类型约束 |
| 程序化非法初始值引用 | DSL 的 `init_expression` 当前不允许变量引用；若测试误写 `def int y = x + 1;` 会越界到 DSL / 模型层 | 不修改 DSL / 模型层；仅保留 helper 级防御性测试，直接构造 `VarDefine.init = Variable("missing")` 时返回 `kind='undecidable_skip'`，reason 沿用现有翻译失败文本或明确的英语完整句，不引入新的 `ResultKind` |
| 不支持或部分支持的初始值表达式 | 抛异常或产出过强结论 | 继续使用现有 `kind='undecidable_skip'`；不新增 `inconclusive`、`skip` 或其他结果类型；不发确定性诊断 |
| PR-A4 八个原始算法回归 | 正确性修复可能改变结果类型、原因或证据字段 | 注册表 8 个实现均可调用；结果类型 / 原因、证据字段语义和既有测试不回退；对消费初始值和不消费初始值两类入口分别加定向断言 |

约束澄清：

- PR-A5a 不新增 `ResultKind` 成员；保守跳过统一使用现有 `undecidable_skip`。
- PR-A5a 不把 snake_case reason 当成新契约；reason 沿用现有代码里的英语完整句风格。
- PR-A5a 不承诺 DSL 初始值支持变量引用；变量引用相关测试只允许作为 helper 级防御性覆盖。
- PR-A5a 不修改 `dead_guard()` / `guard_tautology()` 的“纯守卫、不绑定 DSL 初始值”契约。

必跑命令：

```bash
pytest test/verify/test_smt_local.py -q
pytest test/verify/ -q
pytest test/solver/ -q
SKIP_SLOW_TESTS=1 make unittest
git diff --check
```

边界检查：

```bash
BASE=$(git merge-base HEAD origin/dev/issue114-pr-a-verify)
git diff --name-only "$BASE" | rg '^(pyfcstm/diagnostics/|codes\.yaml|schema\.json|editors/|pyfcstm/verify/(search|reachability)\.py|pyfcstm/model/|pyfcstm/dsl/)'
rg 'pyfcstm\.verify|pyfcstm\.diagnostics|inspect_model|diagnostics\.inspect' pyfcstm/solver
rg 'from pyfcstm\.diagnostics|import pyfcstm\.diagnostics|codes\.yaml|schema\.json|editors/' pyfcstm/verify
rg 'solver\.safety|check_expr_safety' pyfcstm/verify
```

---

## 三路复审要求

三路 reviewer 已独立核实本 PR、PR-A5 [#142](https://github.com/HansBug/pyfcstm/pull/142)、PR-A 总伞 [#127](https://github.com/HansBug/pyfcstm/pull/127) 中的 PR-A5a 信息是否一致，并把首轮评论写入本 PR。

首轮结论：

| reviewer | 结论 | 已写回正文的处理 |
|---|---|---|
| `codex reviewer` | C=0 / I=2 / M=2 | 去掉 DSL 不可达的链式 initializer 门禁；reason 契约改成可机械验收的现有风格 |
| `claude reviewer` | C=0 / I=4 / M=3 | `ResultKind` 统一为 `undecidable_skip`；区分“翻译失败”和“翻译成功但运行时未定义”；删除写入范围单边放宽 |
| `deepseek reviewer` | C=0 / I=2 / M=2 | 明确只有消费初始值的 3 个入口必须因非法初始上下文保守跳过；不消费初始值的入口保持原语义 |

后续代码 review 仍按同样 C/I/M 规则执行：有 C/I 级问题时必须修复；M 级不阻塞但能顺手解决时尽量解决。
二轮代码复审结论：

| reviewer | 结论 | 评论 | 处理 |
|---|---|---|---|
| `codex reviewer` | C=0 / I=0 / M=0 | [评论](https://github.com/HansBug/pyfcstm/pull/169#issuecomment-4657108766) | 无阻塞项 |
| `claude reviewer` | C=0 / I=0 / M=3 | [评论](https://github.com/HansBug/pyfcstm/pull/169#issuecomment-4657106410) | M 级为性能 / 文档 / 测试鲁棒性建议，不阻塞；暂不因 M 级再开一轮提交 |
| `deepseek reviewer` | C=0 / I=0 / M=1 | [评论](https://github.com/HansBug/pyfcstm/pull/169#issuecomment-4657142120) | M 级为冗余调用性能建议，不阻塞；暂不因 M 级再开一轮提交 |

当前结论：CI、Codecov、二轮三路复审均已收敛；本 PR 等待维护者验收，不在本会话合并。



