### PR TITLE
收口 SysDeSim 终止态回归与文档

### DIFF
--- a/docs/source/index_en.rst
+++ b/docs/source/index_en.rst
@@ -122,6 +122,7 @@ Tutorials
     tutorials/visualization/index
     tutorials/cli/index
     tutorials/grammar/index
+    tutorials/sysdesim/index
 
 * :doc:`tutorials/installation/index`
 * :doc:`tutorials/structure/index`
@@ -131,6 +132,7 @@ Tutorials
 * :doc:`tutorials/visualization/index`
 * :doc:`tutorials/cli/index`
 * :doc:`tutorials/grammar/index`
+* :doc:`tutorials/sysdesim/index`
 
 Best Practice
 -------------------------

--- a/docs/source/index_zh.rst
+++ b/docs/source/index_zh.rst
@@ -124,6 +124,7 @@ pyfcstm 遵循三阶段流水线：
     tutorials/visualization/index_zh
     tutorials/cli/index_zh
     tutorials/grammar/index_zh
+    tutorials/sysdesim/index_zh
 
 * :doc:`tutorials/installation/index_zh`
 * :doc:`tutorials/structure/index_zh`
@@ -133,6 +134,7 @@ pyfcstm 遵循三阶段流水线：
 * :doc:`tutorials/visualization/index_zh`
 * :doc:`tutorials/cli/index_zh`
 * :doc:`tutorials/grammar/index_zh`
+* :doc:`tutorials/sysdesim/index_zh`
 
 最佳实践
 -------------------------

--- a/docs/source/tutorials/sysdesim/index.rst
+++ b/docs/source/tutorials/sysdesim/index.rst
@@ -1,0 +1,104 @@
+SysDeSim FinalState maintenance
+===============================
+
+This page documents the SysDeSim ``uml:FinalState`` compatibility contract used
+by the ``dev/damnx`` branch. It is a branch-specific maintenance note for the
+SysDeSim XML/XMI import path, not a new FCSTM language feature.
+
+Scope
+-----
+
+SysDeSim state-machine diagrams render UML final states as a bullseye marker.
+In XML/XMI these vertices appear as ``uml:FinalState``. The converter does not
+emit them as ordinary FCSTM states. Instead, supported transitions that target a
+FinalState are lowered onto FCSTM exit semantics.
+
+The supported shapes are deliberately narrow:
+
+* A leaf state targeting a FinalState in the same region lowers to
+  ``State -> [*]``.
+* A nested leaf state targeting a FinalState owned by an ancestor region lowers
+  to a route-flag exit chain.
+* FinalState sources, outgoing FinalState transitions, unrelated-region jumps,
+  ``exitPoint`` and ``terminate`` variants remain explicit non-goals until real
+  samples define their intended semantics.
+
+Lowering contracts
+------------------
+
+Same-level FinalState transitions are rendered directly as FCSTM exits::
+
+    SS -> [*];
+
+Cross-level FinalState transitions use one reserved route flag. The first hop
+exits the source composite and sets the flag. Ancestor hops keep exiting while
+the flag is active, and the last hop clears it::
+
+    def int __sysdesim_flag_route_control_e__tx_dqgyfg = 0;
+
+    state StateMachine {
+        state Control {
+            state EState;
+            EState -> [*] effect {
+                __sysdesim_flag_route_control_e__tx_dqgyfg = 1;
+            }
+        }
+
+        Control -> [*] : if [__sysdesim_flag_route_control_e__tx_dqgyfg > 0] effect {
+            __sysdesim_flag_route_control_e__tx_dqgyfg = 0;
+        };
+    }
+
+Route flags are variables, not states. They must not appear as rendered state
+nodes or state-lane cells.
+
+Timeline and report contract
+----------------------------
+
+After the runtime exits through ``[*]``, timeline validation records the ended
+sentinel as the string ``"[*]"``. This sentinel is not a normal model state path
+and must not be passed through ordinary state lookup.
+
+The timeline import report exposes XML provenance through the fixed field
+``report["phase10"]["termination"]``. Each row has exactly these keys::
+
+    {
+        "machine_alias": "...",
+        "source_path": ["..."],
+        "target_id": "...",
+        "target_path": [],
+        "target_vertex_type": "final",
+        "transition_ids": ["..."],
+        "reached": true,
+        "ended_step_ids": ["s27"],
+    }
+
+Downstream code should preserve those keys. Any future schema extension must be
+reviewed together with this maintenance page and the FS-5 regression tests.
+
+Visualization contract
+----------------------
+
+User-facing views must describe ended machines as ``已终止`` or equivalent human
+text. They must not display ``__sysdesim_final_*`` as a state, pseudo state,
+lifeline state-cell value, SVG label or PNG label.
+
+SVG/PNG overlays and CLI summaries should derive their termination text from the
+same termination summary used by the JSON report. This keeps report, CLI and
+visual output aligned.
+
+Regression evidence
+-------------------
+
+The checked-in regression fixtures are:
+
+* ``test/testfile/sysdesim/final_state_same_level_model2.xml`` for same-level
+  FinalState lowering.
+* ``test/testfile/sysdesim/final_state_cross_level_model0608.xml`` for
+  cross-level route-flag lowering, ended timeline rows and visible termination
+  provenance.
+
+The focused FS-5 regression entry point is
+``test/convert/sysdesim/test_final_state_regression.py``. Unit tests must use
+checked-in fixtures only. External files under ``/data/sync/work`` are allowed
+for local smoke evidence, but not as pytest dependencies.

--- a/docs/source/tutorials/sysdesim/index_zh.rst
+++ b/docs/source/tutorials/sysdesim/index_zh.rst
@@ -1,0 +1,98 @@
+SysDeSim FinalState 维护说明
+================================
+
+本文记录 ``dev/damnx`` 支线里的 SysDeSim ``uml:FinalState`` 兼容契约。这是
+SysDeSim XML/XMI 导入路径的维护说明，不是 FCSTM 语言的新特性。
+
+范围
+----
+
+SysDeSim 状态机图中，UML final state 通常画成靶心终止点。在 XML/XMI 中，
+这些顶点表现为 ``uml:FinalState``。converter 不会把它们输出成普通 FCSTM
+状态，而是把已支持的 FinalState target 转换成 FCSTM 退出语义。
+
+当前只支持经过真实样本确认的窄范围形态：
+
+* 同一 region 内，leaf state 指向 FinalState 时，降级为 ``State -> [*]``。
+* 嵌套 leaf state 指向祖先 region 拥有的 FinalState 时，降级为 route flag 退出链。
+* FinalState 作为 source、FinalState outgoing transition、无关 region 跳转、
+  ``exitPoint`` 和 ``terminate`` 等变体仍是显式非目标；只有拿到真实样本并确认语义后，
+  才能另开扩展项。
+
+转换契约
+--------
+
+同层 FinalState transition 直接渲染为 FCSTM 退出：
+
+.. code-block:: fcstm
+
+   SS -> [*];
+
+跨层 FinalState transition 使用一个保留 route flag。第一跳退出 source composite
+并设置 flag；祖先层级在 flag 激活时继续退出；最后一跳清理 flag：
+
+.. code-block:: fcstm
+
+   def int __sysdesim_flag_route_control_e__tx_dqgyfg = 0;
+
+   state StateMachine {
+       state Control {
+           state EState;
+           EState -> [*] effect {
+               __sysdesim_flag_route_control_e__tx_dqgyfg = 1;
+           }
+       }
+
+       Control -> [*] : if [__sysdesim_flag_route_control_e__tx_dqgyfg > 0] effect {
+           __sysdesim_flag_route_control_e__tx_dqgyfg = 0;
+       };
+   }
+
+route flag 是变量，不是状态。它不能出现在状态节点、右侧状态泳道 cell 或其它状态可视化位置。
+
+Timeline 与 report 契约
+-----------------------------
+
+runtime 通过 ``[*]`` 退出后，timeline validation 使用字符串 ``"[*]"`` 作为 ended sentinel。
+这个 sentinel 不是普通模型状态路径，不应交给普通 state lookup 解析。
+
+导入报告通过固定字段 ``report["phase10"]["termination"]`` 保留 XML 来源信息。
+每一行必须精确包含这些 key：
+
+.. code-block:: python
+
+   {
+       "machine_alias": "...",
+       "source_path": ["..."],
+       "target_id": "...",
+       "target_path": [],
+       "target_vertex_type": "final",
+       "transition_ids": ["..."],
+       "reached": True,
+       "ended_step_ids": ["s27"],
+   }
+
+下游代码必须保留这些字段名。未来如果需要扩展 schema，必须同步更新本文档和 FS-5 回归测试，
+不能 silent rename。
+
+可视化契约
+----------
+
+用户可见视图应把已结束机器显示为 ``已终止`` 或等价的人类可读文本。不得把
+``__sysdesim_final_*`` 显示成普通状态、pseudo state、lifeline 状态 cell、SVG label
+或 PNG label。
+
+SVG/PNG overlay 和 CLI summary 的终止文案，应来自 JSON report 使用的同一份 termination summary。
+这样 report、CLI 和可视化输出不会产生三套互相漂移的逻辑。
+
+回归证据
+--------
+
+仓库内固定使用以下 fixture：
+
+* ``test/testfile/sysdesim/final_state_same_level_model2.xml``：覆盖同层 FinalState 降级。
+* ``test/testfile/sysdesim/final_state_cross_level_model0608.xml``：覆盖跨层 route flag、
+  ended timeline row 和可见终止来源。
+
+FS-5 的集中回归入口是 ``test/convert/sysdesim/test_final_state_regression.py``。单元测试只能使用
+checked-in fixture。``/data/sync/work`` 下的外部真实文件只能作为本地 smoke 证据，不能作为 pytest 依赖。

--- a/test/convert/sysdesim/test_final_state_regression.py
+++ b/test/convert/sysdesim/test_final_state_regression.py
@@ -1,0 +1,270 @@
+"""FS-5 regression tests for SysDeSim UML FinalState support."""
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+
+from pyfcstm.convert.sysdesim import (
+    build_sysdesim_phase10_report,
+    build_sysdesim_timeline_import_report,
+    convert_sysdesim_xml_to_ast,
+    convert_sysdesim_xml_to_asts,
+    convert_sysdesim_xml_to_dsl,
+    convert_sysdesim_xml_to_dsls,
+    validate_program_roundtrip,
+)
+from pyfcstm.convert.sysdesim.render import (
+    build_overlay_from_diagnostics,
+    render_sysdesim_timeline_svg,
+)
+from pyfcstm.dsl import node as dsl_nodes
+from pyfcstm.entry import pyfcstmcli
+
+pytestmark = pytest.mark.unittest
+
+_FIXTURE_ROOT = Path(__file__).resolve().parents[2] / "testfile/sysdesim"
+_SAME_LEVEL_FINAL = _FIXTURE_ROOT / "final_state_same_level_model2.xml"
+_CROSS_LEVEL_FINAL = _FIXTURE_ROOT / "final_state_cross_level_model0608.xml"
+_REAL_CROSS_FINAL_ID = "_yirz0GMdEfG32u33dqGYFg"
+_REAL_CROSS_TRANSITION_ID = "_y7sJsGMdEfG32u33dqGYFg"
+_TERMINATION_KEYS = {
+    "machine_alias",
+    "source_path",
+    "target_id",
+    "target_path",
+    "target_vertex_type",
+    "transition_ids",
+    "reached",
+    "ended_step_ids",
+}
+
+
+def _normalize_newlines(text: str) -> str:
+    """Normalize text line endings for cross-platform DSL assertions."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _write_xml(tmp_path: Path, content: str) -> Path:
+    """Write a compact SysDeSim XML fixture under ``tmp_path``."""
+    xml_file = tmp_path / "sample.sysdesim.xml"
+    xml_file.write_text(dedent(content).strip() + "\n", encoding="utf-8")
+    return xml_file
+
+
+def _machine_state_cells(overlay):
+    """Return all rendered machine-state cell texts from one overlay payload."""
+    machine_indexes = [
+        index
+        for index, column in enumerate(overlay["state_columns"])
+        if column["kind"] == "machine"
+    ]
+    assert machine_indexes
+    return [
+        row["cells"][index]
+        for row in overlay["step_states"]
+        for index in machine_indexes
+    ]
+
+
+def test_same_level_final_state_fixture_stays_plain_exit_transition():
+    """The real model2 fixture keeps the FS-1 same-level FinalState contract."""
+    program = convert_sysdesim_xml_to_ast(str(_SAME_LEVEL_FINAL))
+    dsl_code = _normalize_newlines(convert_sysdesim_xml_to_dsl(str(_SAME_LEVEL_FINAL)))
+    validate_program_roundtrip(program)
+
+    exit_transitions = [
+        transition
+        for transition in program.root_state.transitions
+        if transition.from_state == "SS" and transition.to_state is dsl_nodes.EXIT_STATE
+    ]
+
+    assert len(exit_transitions) == 1
+    assert "SS -> [*];" in dsl_code
+    assert "state __sysdesim_final_" not in dsl_code
+    assert "__sysdesim_flag_route_" not in dsl_code
+    assert "_rJto4GCxEfGqsb6wf6ZObA" not in dsl_code
+
+
+def test_cross_level_final_state_fixture_keeps_route_flag_exit_chain():
+    """The real model0608 fixture keeps the FS-2 route-flag exit-chain contract."""
+    programs = convert_sysdesim_xml_to_asts(str(_CROSS_LEVEL_FINAL))
+    outputs = {
+        name: _normalize_newlines(text)
+        for name, text in convert_sysdesim_xml_to_dsls(str(_CROSS_LEVEL_FINAL)).items()
+    }
+
+    for program in programs.values():
+        validate_program_roundtrip(program)
+    for text in outputs.values():
+        assert "state __sysdesim_final_" not in text
+        assert _REAL_CROSS_FINAL_ID not in text
+
+    route_outputs = {
+        name: text for name, text in outputs.items() if "__sysdesim_flag_route_" in text
+    }
+    assert set(route_outputs) == {"StateMachine__Control_region1"}
+    route_text = route_outputs["StateMachine__Control_region1"]
+    route_flag = "__sysdesim_flag_route_control_e__tx_dqgyfg"
+
+    assert route_flag in route_text
+    assert "EState -> [*] effect {" in route_text
+    assert f"{route_flag} = 1;" in route_text
+    assert f"Control -> [*] : if [{route_flag} > 0] effect {{" in route_text
+    assert f"{route_flag} = 0;" in route_text
+
+
+def test_final_state_trace_report_overlay_and_svg_share_one_public_contract():
+    """The checked-in cross-level fixture exercises the FS-3/FS-4 downstream chain."""
+    phase10 = build_sysdesim_phase10_report(str(_CROSS_LEVEL_FINAL))
+    report = build_sysdesim_timeline_import_report(str(_CROSS_LEVEL_FINAL))
+    overlay = build_overlay_from_diagnostics(
+        phase10_report=phase10, diagnostics=[], include_state_cells=True
+    )
+    svg = render_sysdesim_timeline_svg(phase10_report=phase10, overlay=overlay)
+
+    assert any(
+        step.post_state_path == "[*]" or step.stabilized_state_path == "[*]"
+        for trace in phase10.traces
+        for step in trace.steps
+    )
+
+    termination = report["phase10"]["termination"]
+    assert len(termination) == 1
+    row = termination[0]
+    assert set(row) == _TERMINATION_KEYS
+    assert row["machine_alias"] == "StateMachine__Control_region1"
+    assert row["source_path"] == ["Control", "E"]
+    assert row["target_id"] == _REAL_CROSS_FINAL_ID
+    assert row["target_path"] == []
+    assert row["target_vertex_type"] == "final"
+    assert row["transition_ids"] == [_REAL_CROSS_TRANSITION_ID]
+    assert row["reached"] is True
+    assert row["ended_step_ids"] == ["s27", "s28", "s29"]
+
+    machine_cells = _machine_state_cells(overlay)
+    assert "已终止" in machine_cells
+    assert "[*]" not in machine_cells
+    assert "已终止" in svg
+    assert _REAL_CROSS_FINAL_ID in svg
+    assert _REAL_CROSS_TRANSITION_ID in svg
+    assert "__sysdesim_final_" not in svg
+    assert "__sysdesim_final_" not in repr(overlay)
+    assert "__sysdesim_final_" not in repr(report)
+
+
+def test_validate_cli_render_report_keeps_final_state_contract(tmp_path: Path):
+    """The CLI smoke path uses ``--report-file`` and preserves termination provenance."""
+    out_svg = tmp_path / "timeline.svg"
+    report_file = tmp_path / "timeline.json"
+    result = CliRunner().invoke(
+        pyfcstmcli,
+        [
+            "sysdesim",
+            "validate",
+            "--no-static-check",
+            "-i",
+            str(_CROSS_LEVEL_FINAL),
+            "--render-diagram",
+            str(out_svg),
+            "--render-format",
+            "svg",
+            "--report-file",
+            str(report_file),
+        ],
+        color=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Termination" in result.output
+    assert "已终止" in result.output
+    assert "StateMachine__Control_region1" in result.output
+    assert _REAL_CROSS_FINAL_ID in result.output
+    assert _REAL_CROSS_TRANSITION_ID in result.output
+    assert "__sysdesim_final_" not in result.output
+
+    report_text = report_file.read_text(encoding="utf-8")
+    svg_text = out_svg.read_text(encoding="utf-8")
+    assert "phase10" in report_text
+    assert "termination" in report_text
+    assert "已终止" in svg_text
+    assert _REAL_CROSS_FINAL_ID in svg_text
+    assert "__sysdesim_final_" not in report_text
+    assert "__sysdesim_final_" not in svg_text
+
+
+def test_final_state_source_remains_fail_loud(tmp_path: Path):
+    """Unsupported FinalState source transitions stay explicit non-goals."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Final Source" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Final Source">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_root" target="state_idle"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_finish" source="state_idle" target="final_done"/>
+                  <transition xmi:type="uml:Transition" xmi:id="tx_bad" source="final_done" target="state_idle"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_idle" name="Idle"/>
+                  <subvertex xmi:type="uml:FinalState" xmi:id="final_done" name=""/>
+                </region>
+              </ownedBehavior>
+            </packagedElement>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    with pytest.raises(NotImplementedError, match="FinalState source"):
+        convert_sysdesim_xml_to_ast(str(xml_file))
+
+
+def test_unrelated_region_cross_level_final_state_remains_fail_loud(tmp_path: Path):
+    """Unrelated-region FinalState jumps are still outside the supported subset."""
+    xml_file = _write_xml(
+        tmp_path,
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <xmi:XMI xmi:version="20131001"
+                 xmlns:xmi="http://www.omg.org/spec/XMI/20131001"
+                 xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML">
+          <uml:Model xmi:id="model_1" name="model">
+            <packagedElement xmi:type="uml:Class" xmi:id="class_1" name="Unrelated Final" classifierBehavior="machine_1">
+              <ownedBehavior xmi:type="uml:StateMachine" xmi:id="machine_1" name="Unrelated Final">
+                <region xmi:type="uml:Region" xmi:id="region_root" name="">
+                  <transition xmi:type="uml:Transition" xmi:id="tx_init" source="init_root" target="state_left"/>
+                  <subvertex xmi:type="uml:Pseudostate" xmi:id="init_root"/>
+                  <subvertex xmi:type="uml:State" xmi:id="state_left" name="Left">
+                    <region xmi:type="uml:Region" xmi:id="region_left" name="">
+                      <transition xmi:type="uml:Transition" xmi:id="tx_left_init" source="init_left" target="state_source"/>
+                      <transition xmi:type="uml:Transition" xmi:id="tx_unrelated" source="state_source" target="final_right"/>
+                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_left"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_source" name="Source"/>
+                    </region>
+                  </subvertex>
+                  <subvertex xmi:type="uml:State" xmi:id="state_right" name="Right">
+                    <region xmi:type="uml:Region" xmi:id="region_right" name="">
+                      <transition xmi:type="uml:Transition" xmi:id="tx_right_init" source="init_right" target="state_sink"/>
+                      <subvertex xmi:type="uml:Pseudostate" xmi:id="init_right"/>
+                      <subvertex xmi:type="uml:State" xmi:id="state_sink" name="Sink"/>
+                      <subvertex xmi:type="uml:FinalState" xmi:id="final_right" name=""/>
+                    </region>
+                  </subvertex>
+                </region>
+              </ownedBehavior>
+            </packagedElement>
+          </uml:Model>
+        </xmi:XMI>
+        """,
+    )
+
+    with pytest.raises(
+        NotImplementedError, match="cross-level FinalState target outside source subtree"
+    ):
+        convert_sysdesim_xml_to_ast(str(xml_file))


### PR DESCRIPTION
## PR 定位

本 PR 是 umbrella PR [#162](https://github.com/HansBug/pyfcstm/pull/162) 的 **FS-5：回归与文档收口** leaf PR，base 为 `subpr/finalstate-exit-plan`。本 PR 只服务 `dev/damnx` / SysDeSim XML 转换支线，不作为 `main` 主线合并承诺。

## 本 PR 只做什么

把 FS-1 到 FS-4 已经合入的 SysDeSim `uml:FinalState` 支持固化为可长期维护的回归矩阵和文档锚点：

1. 增加一个集中式 final-state 回归测试文件，覆盖同层 final、跨层 final、timeline ended、report termination schema、SVG/PNG/CLI 可视化表达和关键负例。
2. 增加或补强 SysDeSim 维护文档，明确 `uml:FinalState -> [*]`、route flag 退出链、`[*]` ended sentinel、`report["phase10"]["termination"]` schema、以及“不暴露 `__sysdesim_final_*`”的下游契约。
3. 增加真实样本 smoke 入口，能一键验证当前仓库 fixture 与 `/data/sync/work/20260424文档拷贝` 真实样本一致的关键语义。
4. 不改变 FS-1/FS-2/FS-3/FS-4 已合入的运行语义；如发现行为缺口，先以测试暴露，再做最小修复并在本 PR 留明原因。

## 不做什么

- 不修改 FCSTM DSL grammar / parser / model / `SimulationRuntime` 底座。
- 不新增 signal+guard transition 降级方案；那是 issue [#154](https://github.com/HansBug/pyfcstm/issues/154) 的独立主题。
- 不支持新的 UML 变体，例如 `exitPoint`、`terminate`、并行 region completion 或无关 region 跳 final；这些若出现真实样本，另开扩展项。
- 不改 MiniRacer JS bundle，除非测试证明 Python payload / 文档无法表达既有契约；默认不动 `js/sysdesim_render/`。
- 不把 `uml:FinalState`、`__sysdesim_final_*` 或兼容中继状态渲染成普通 state。
- 不做大范围文档重构；只补 SysDeSim final-state 相关的最小维护说明。

## 当前基线

| 阶段 | 已合入 PR | 当前能力 |
|---|---|---|
| FS-1 | [#163](https://github.com/HansBug/pyfcstm/pull/163) | 同层 leaf `state -> uml:FinalState` 降为 FCSTM `State -> [*]`，不生成 hidden final state。 |
| FS-2 | [#165](https://github.com/HansBug/pyfcstm/pull/165) | 跨层 leaf `state -> ancestor-region FinalState` 降为 route flag 退出链，不生成 `__sysdesim_final_*` state。 |
| FS-3 | [#167](https://github.com/HansBug/pyfcstm/pull/167) | `timeline_verify` 在 runtime ended 后使用 `[*]` ended sentinel，不再访问 `runtime.current_state`。 |
| FS-4 | [#168](https://github.com/HansBug/pyfcstm/pull/168) | 状态泳道/SVG/PNG/CLI/report 显示“已终止”，并通过 `report["phase10"]["termination"]` 保留 XML FinalState 来源。 |

## 允许改动范围

| 路径 | 允许改动 |
|---|---|
| `test/convert/sysdesim/test_final_state_regression.py` | 新增集中式 FS-5 回归测试，复用已有 checked-in fixture，不读取外部 `/data`。 |
| `test/entry/test_sysdesim.py` | 如需要，补 CLI 文档契约回归；避免重复已有覆盖。 |
| `test/testfile/sysdesim/` | 仅允许增加来自真实 XML 的最小 fixture；优先复用已有 `final_state_same_level_model2.xml` 和 `final_state_cross_level_model0608.xml`。 |
| `docs/source/tutorials/sysdesim/index.rst` | 新增英文 SysDeSim final-state 维护页，作为该专题的默认文档入口。 |
| `docs/source/tutorials/sysdesim/index_zh.rst` | 新增中文 SysDeSim final-state 维护页，作为本支线主要交付说明。 |
| `docs/source/index_en.rst` / `docs/source/index_zh.rst` | 仅为挂载 SysDeSim tutorial toctree 和列表项做最小更新；不得编辑生成的 `docs/source/index.rst`。 |
| `docs/source/api_doc/convert/sysdesim/index.rst` | 仅在确需从 API 文档交叉引用维护说明时做最小链接；主要说明不得塞进 auto API stub。 |
| `pyfcstm/convert/sysdesim/...` / `pyfcstm/entry/sysdesim.py` | 只允许为回归暴露出的真实缺口做最小修复；不得改变已冻结的公开契约字段名。 |

## TDD 执行清单

### T1：集中式同层 FinalState 回归

- 输入：`test/testfile/sysdesim/final_state_same_level_model2.xml`。
- 调用：`convert_sysdesim_xml_to_dsl()`、`convert_sysdesim_xml_to_ast()` 或既有 AST helper。
- 断言：
  - 转换成功；DSL 包含 `SS -> [*]`；
  - AST 中目标是 `dsl_nodes.EXIT_STATE`；
  - DSL 不包含 `state __sysdesim_final_`，不包含原始 FinalState id；
  - roundtrip / model build 不退化。

### T2：集中式跨层 FinalState route flag 回归

- 输入：`test/testfile/sysdesim/final_state_cross_level_model0608.xml`。
- 调用：`convert_sysdesim_xml_to_dsls()`。
- 断言：
  - 至少一个输出包含 `__sysdesim_flag_route_`；
  - 相关输出包含 `EState -> [*]` 和 `Control -> [*]`；
  - route flag 设置与清理均存在；
  - DSL 不包含 `state __sysdesim_final_`，不包含 XML FinalState id `_yirz0GMdEfG32u33dqGYFg`。

### T3：timeline ended / report / overlay 一体化回归

- 输入：`test/testfile/sysdesim/final_state_cross_level_model0608.xml`。
- 调用：`build_sysdesim_phase10_report()`、`build_sysdesim_timeline_import_report()`、`build_overlay_from_diagnostics(include_state_cells=True)`、`render_sysdesim_timeline_svg()`。
- 断言：
  - Phase10 trace 至少一个 step 的 `post_state_path == "[*]"` 或 `stabilized_state_path == "[*]"`；
  - `report["phase10"]["termination"]` 至少一项，且第一项必须满足 `set(row) == {"machine_alias", "source_path", "target_id", "target_path", "target_vertex_type", "transition_ids", "reached", "ended_step_ids"}`；如未来要新增字段，必须先更新本文档契约；
  - 对真实样本，`target_id == "_yirz0GMdEfG32u33dqGYFg"`，`target_vertex_type == "final"`，`reached is True`；
  - overlay / SVG 含 `已终止`，不含 `__sysdesim_final_`。

### T4：CLI validate / render smoke 回归

- 输入：最小同层 final fixture 或真实跨层 fixture。
- 调用：Click runner 执行等价于 `pyfcstm sysdesim validate --no-static-check -i <fixture.xml> --render-diagram <out.svg> --render-format svg --report-file <report.json>` 的测试路径。
- 断言：
  - stdout 包含 `Termination`、`已终止`、machine alias、transition id、FinalState id；
  - report JSON 含 `phase10.termination`；
  - SVG 文件含 `已终止` 且不含 `__sysdesim_final_`。

### T5：负例与非目标锁定

- 输入：已有或新增最小 XML，覆盖以下两类未支持形态：
  1. FinalState 作为 transition source（等价于 FinalState 带 outgoing transition），优先引用或集中断言 `test_phase0_2.py::test_phase2_rejects_final_state_source_transition` 覆盖的语义；
  2. source 不在 final owner region 子树内的跨层 final，优先引用或集中断言 `test_phase4.py::test_phase4_rejects_unrelated_region_cross_level_final_target` 覆盖的语义。
- 断言：
  - fail-loud；错误信息必须包含 `FinalState` 和具体原因关键词；
  - 不允许静默生成普通 state、pseudo state 或 hidden final state。
- 如果这些负例已由现有测试覆盖，本 PR 只需在集中式回归文件中引用或补充更明确的断言，避免重复造大量 fixture。

### T6：文档锚定

- 在 `docs/source/tutorials/sysdesim/index.rst` 和 `docs/source/tutorials/sysdesim/index_zh.rst` 增加 SysDeSim final-state 维护说明，并在 `docs/source/index_en.rst` / `docs/source/index_zh.rst` 的 tutorial toctree 与列表中挂载；至少包含：
  - `uml:FinalState` 在视觉上对应靶心终止点；
  - 同层 final lowering：`State -> [*]`；
  - 跨层 final lowering：route flag 退出链；
  - timeline/report 层的 `[*]` ended sentinel 不是普通状态路径；
  - `report["phase10"]["termination"]` schema 固定字段；
  - 用户可见可视化不得出现 `__sysdesim_final_*`；
  - 新 UML 变体必须有真实样本后另开扩展项。
- 中文 `.rst` 中凡是 ``[*]``、``report["phase10"]["termination"]``、``__sysdesim_final_*`` 等 inline literal 后接全角括号或中文紧邻文本时，必须使用 `\ ` 修复 reST inline markup 边界，并以构建后 HTML 中无 `class="problematic"` 作为准出。

## 准出标准

本 PR 完成前必须满足：

```bash
pytest test/convert/sysdesim/test_final_state_regression.py -q --tb=short
pytest test/convert/sysdesim/test_phase0_2.py test/convert/sysdesim/test_phase4.py test/convert/sysdesim/test_phase9_11.py test/convert/sysdesim/test_render.py -q --tb=short
pytest test/entry/test_sysdesim.py -q --tb=short
pytest test/convert/sysdesim -q --tb=short
```

`test/convert/sysdesim/test_phase12_visualization.py` 当前没有 final-state 专题覆盖，因此不列入强制命令；如果 FS-5 实现过程中新增 Phase12 final-state 测试，必须把该文件加入上述回归命令。

如修改文档，还必须至少执行一种文档检查：

```bash
NO_CONTENTS_BUILD=1 READTHEDOCS_LANGUAGE=zh sphinx-build -b html docs/source /tmp/pyfcstm-html-check-zh
rg -n 'class="problematic"|\*\*[^<]*\*\*|<span class="problematic"[^\n]*>``</span>' /tmp/pyfcstm-html-check-zh -g '*.html'
```

如果环境缺少文档依赖，必须说明缺少的依赖，并至少执行 `python -m py_compile docs/source/conf.py`、涉及 Python 文件的 `python -m py_compile ...` 和相关 pytest 完成代码侧验证。

CI / Codecov 准出：

- GitHub Actions 全绿。
- Codecov modified coverable lines 全覆盖；文档-only 行不要求 coverage。
- 三路实现后 review 均 C=0、I=0；M 级不阻塞但能顺手修的优先修。

## 真实样本 smoke 命令

本 PR 不依赖外部 `/data` 路径跑单元测试，但本地验收应记录一次真实样本 smoke：

```bash
python - <<'PY'
from pathlib import Path
from pyfcstm.convert.sysdesim import (
    build_sysdesim_phase10_report,
    build_sysdesim_timeline_import_report,
    convert_sysdesim_xml_to_dsl,
    convert_sysdesim_xml_to_dsls,
)
from pyfcstm.convert.sysdesim.render import build_overlay_from_diagnostics, render_sysdesim_timeline_svg

same = Path('/data/sync/work/20260424文档拷贝/给北航/model2.xml')
cross = Path('/data/sync/work/20260424文档拷贝/给北航(1)/model0608.xml')

same_dsl = convert_sysdesim_xml_to_dsl(str(same))
print('model2', 'has_exit=', 'SS -> [*]' in same_dsl, 'hidden=', '__sysdesim_final_' in same_dsl)

outputs = convert_sysdesim_xml_to_dsls(str(cross))
route_outputs = [name for name, text in outputs.items() if '__sysdesim_flag_route_' in text]
print('model0608', 'route_outputs=', route_outputs)

phase10 = build_sysdesim_phase10_report(str(cross))
report = build_sysdesim_timeline_import_report(str(cross))
overlay = build_overlay_from_diagnostics(phase10_report=phase10, include_state_cells=True)
svg = render_sysdesim_timeline_svg(phase10_report=phase10, overlay=overlay)
print('termination_count=', len(report['phase10']['termination']))
print('has_ended_label=', '已终止' in svg)
print('leaks_hidden_final=', '__sysdesim_final_' in svg or '__sysdesim_final_' in repr(overlay))
PY
```

预期：同层样本有 `SS -> [*]`；跨层样本有 route flag 输出；termination summary 非空；SVG / overlay 显示“已终止”且不泄露 `__sysdesim_final_`。

此外，本地 smoke 需要在 `/data/sync/work/20260424文档拷贝` 存在时记录非 final 样本不退化检查，对齐 #162 的收口验收口径：

- `/data/sync/work/20260424文档拷贝/给北航/model1.xml`
- `/data/sync/work/20260424文档拷贝/给北航/model1_fix.xml`
- `/data/sync/work/20260424文档拷贝/daochu/单个用例.xml`
- `/data/sync/work/20260424文档拷贝/daochu/三个用例.xml`

这些路径不得作为 pytest 单元测试依赖；单元测试只使用 checked-in fixture。若本地环境没有 `/data`，PR 说明中记录“外部真实样本不可用”，但仍必须跑完 checked-in fixture 的 pytest 矩阵。

建议 smoke 代码形态：

```bash
python - <<'PY'
from pathlib import Path
from pyfcstm.convert.sysdesim import build_sysdesim_timeline_import_report, convert_sysdesim_xml_to_dsls

samples = [
    Path('/data/sync/work/20260424文档拷贝/给北航/model1.xml'),
    Path('/data/sync/work/20260424文档拷贝/给北航/model1_fix.xml'),
    Path('/data/sync/work/20260424文档拷贝/daochu/单个用例.xml'),
    Path('/data/sync/work/20260424文档拷贝/daochu/三个用例.xml'),
]
for path in samples:
    if not path.exists():
        print(path, 'SKIP missing')
        continue
    outputs = convert_sysdesim_xml_to_dsls(str(path))
    print(path.name, 'outputs=', sorted(outputs), 'hidden_final=', any('__sysdesim_final_' in text for text in outputs.values()))
    report = build_sysdesim_timeline_import_report(str(path))
    print(path.name, 'phase10_traces=', len(report['phase10']['traces']))
PY
```


