### PR TITLE
PR-A5b：建立求解器层表达式定义域接口（#114）

### DIFF
--- a/pyfcstm/solver/domain.py
+++ b/pyfcstm/solver/domain.py
@@ -1,0 +1,628 @@
+"""Runtime-definedness translation for solver-layer expressions.
+
+This module keeps FCSTM expression runtime-domain constraints separate from
+the Z3 value expression.  Z3 arithmetic operators are total, while FCSTM
+runtime expression evaluation is not: division by zero, modulo by zero, and
+square root of a negative value are runtime-domain failures.  Callers decide
+when to add the returned definedness constraints to a solver.
+"""
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+import z3
+
+from pyfcstm.model.expr import (
+    BinaryOp,
+    Boolean,
+    ConditionalOp,
+    Expr,
+    Float,
+    Integer,
+    UFunc,
+    UnaryOp,
+    Variable,
+)
+
+from .expr import _apply_binary_z3, _apply_ufunc_z3, _apply_unary_z3, expr_to_z3
+from .logical import is_sat
+
+_Z3Expr = Union[z3.ArithRef, z3.BoolRef]
+_Z3Vars = Dict[str, _Z3Expr]
+
+
+@dataclass(frozen=True)
+class DomainSource:
+    """Pure source metadata for domain constraints and failures."""
+
+    label: Optional[str] = None
+    step: Optional[int] = None
+    snapshot: Optional[str] = None
+    prefix_id: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DomainConstraint:
+    """Runtime-definedness constraint plus optional source metadata."""
+
+    constraint: z3.ExprRef
+    source: Optional[DomainSource] = None
+
+
+@dataclass(frozen=True)
+class TranslationFailure:
+    """Expected expression translation failure in pure solver-layer form."""
+
+    kind: str
+    reason: str
+    source: Optional[DomainSource] = None
+
+
+@dataclass(frozen=True)
+class BranchFeasibility:
+    """Recorded branch reachability query for conditional expressions."""
+
+    selector: z3.ExprRef
+    status: str
+    source: Optional[DomainSource] = None
+
+
+@dataclass(frozen=True)
+class ExprDomain:
+    """Domain-aware translation result for one expression."""
+
+    z3_expr: Optional[_Z3Expr]
+    expr_constraints: Tuple[z3.ExprRef, ...] = ()
+    assumptions: Tuple[z3.ExprRef, ...] = ()
+    definedness_constraints: Tuple[DomainConstraint, ...] = ()
+    failure: Optional[TranslationFailure] = None
+    feasibility_checks: Tuple[BranchFeasibility, ...] = ()
+
+
+def _failure_from_exception(
+    err: Union[NotImplementedError, ValueError, TypeError, z3.Z3Exception],
+    source: Optional[DomainSource],
+) -> TranslationFailure:
+    """Convert an expected translation exception to a pure failure object."""
+    if isinstance(err, NotImplementedError):
+        return TranslationFailure("not_implemented", str(err), source=source)
+    if isinstance(err, ValueError):
+        return TranslationFailure("value_error", str(err), source=source)
+    if isinstance(err, TypeError):
+        return TranslationFailure("type_error", str(err), source=source)
+    return TranslationFailure("z3_error", str(err), source=source)
+
+
+def _failure_result(
+    failure: TranslationFailure,
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    definedness_constraints: Sequence[DomainConstraint] = (),
+    feasibility_checks: Sequence[BranchFeasibility] = (),
+) -> ExprDomain:
+    """Build a failed expression-domain result."""
+    return ExprDomain(
+        z3_expr=None,
+        assumptions=tuple(assumptions),
+        definedness_constraints=tuple(definedness_constraints),
+        failure=failure,
+        feasibility_checks=tuple(feasibility_checks),
+    )
+
+
+def _expr_to_z3_or_failure(
+    expr: Expr,
+    z3_vars: _Z3Vars,
+    source: Optional[DomainSource],
+) -> Tuple[Optional[_Z3Expr], Optional[TranslationFailure]]:
+    """Translate through ``expr_to_z3`` and normalize expected failures."""
+    try:
+        return expr_to_z3(expr, z3_vars), None
+    except NotImplementedError as err:
+        # NotImplementedError: expr_to_z3 raises this for supported expression
+        # nodes whose math function is intentionally unsupported by Z3.
+        return None, _failure_from_exception(err, source)
+    except ValueError as err:
+        # ValueError: expr_to_z3 raises this for unknown variables, unknown
+        # operators, and unsupported expression object types.
+        return None, _failure_from_exception(err, source)
+    except TypeError as err:
+        # TypeError: Python/Z3 operator overloads can reject malformed operand
+        # combinations before Z3 wraps the failure.
+        return None, _failure_from_exception(err, source)
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 rejects sort/operator-domain mismatches.
+        return None, _failure_from_exception(err, source)
+
+
+def _apply_or_failure(
+    func,
+    source: Optional[DomainSource],
+) -> Tuple[Optional[_Z3Expr], Optional[TranslationFailure]]:
+    """Run a Z3 operation and normalize only documented failure classes."""
+    try:
+        return func(), None
+    except NotImplementedError as err:
+        # NotImplementedError: math functions may be intentionally unsupported.
+        return None, _failure_from_exception(err, source)
+    except ValueError as err:
+        # ValueError: operator/function dispatch rejects unknown names.
+        return None, _failure_from_exception(err, source)
+    except TypeError as err:
+        # TypeError: Python/Z3 operators reject unsupported operand sorts.
+        return None, _failure_from_exception(err, source)
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 rejects sort/operator-domain mismatches.
+        return None, _failure_from_exception(err, source)
+
+
+def _with_parts(
+    z3_expr: Optional[_Z3Expr],
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    definedness_constraints: Sequence[DomainConstraint] = (),
+    failure: Optional[TranslationFailure] = None,
+    feasibility_checks: Sequence[BranchFeasibility] = (),
+) -> ExprDomain:
+    """Build an expression-domain result from collected pieces."""
+    return ExprDomain(
+        z3_expr=z3_expr,
+        assumptions=tuple(assumptions),
+        definedness_constraints=tuple(definedness_constraints),
+        failure=failure,
+        feasibility_checks=tuple(feasibility_checks),
+    )
+
+
+def _constraint_exprs(items: Sequence[DomainConstraint]) -> Tuple[z3.ExprRef, ...]:
+    """Return raw Z3 constraints from domain constraint objects."""
+    return tuple(item.constraint for item in items)
+
+
+def _branch_feasibility(
+    selector: z3.ExprRef,
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    condition_domains: Sequence[DomainConstraint],
+    source: Optional[DomainSource],
+    timeout_ms: Optional[int],
+) -> BranchFeasibility:
+    """Check whether one conditional value branch is reachable."""
+    result = is_sat(
+        (
+            *assumptions,
+            *path_conditions,
+            *_constraint_exprs(condition_domains),
+            selector,
+        ),
+        timeout_ms=timeout_ms,
+    )
+    status = result.kind if result.kind in ("sat", "unsat") else "unknown"
+    return BranchFeasibility(selector=selector, status=status, source=source)
+
+
+def _translate_expr_domain(
+    expr: Expr,
+    z3_vars: _Z3Vars,
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    source: Optional[DomainSource],
+    prune_unreachable: bool,
+    timeout_ms: Optional[int],
+) -> ExprDomain:
+    """Recursive implementation for domain-aware expression translation."""
+    if isinstance(expr, (Integer, Float, Boolean, Variable)):
+        z3_expr, failure = _expr_to_z3_or_failure(expr, z3_vars, source)
+        if failure is not None:
+            return _failure_result(failure, assumptions=assumptions)
+        return _with_parts(z3_expr, assumptions=assumptions)
+
+    if isinstance(expr, ConditionalOp):
+        return _translate_conditional_domain(
+            expr,
+            z3_vars,
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            source=source,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+
+    if isinstance(expr, BinaryOp):
+        left = _translate_expr_domain(
+            expr.x,
+            z3_vars,
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            source=source,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+        if left.failure is not None:
+            return left
+        right = _translate_expr_domain(
+            expr.y,
+            z3_vars,
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            source=source,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+        if right.failure is not None:
+            return right
+
+        domains = [*left.definedness_constraints, *right.definedness_constraints]
+        if expr.op in ("/", "%"):
+            try:
+                domains.append(DomainConstraint(right.z3_expr != 0, source=source))
+            except TypeError as err:
+                # TypeError: malformed divisor expressions may not compare to zero.
+                return _failure_result(
+                    _failure_from_exception(err, source),
+                    assumptions=assumptions,
+                    definedness_constraints=domains,
+                )
+            except z3.Z3Exception as err:
+                # Z3Exception: Z3 can reject divisor comparison sort mismatches.
+                return _failure_result(
+                    _failure_from_exception(err, source),
+                    assumptions=assumptions,
+                    definedness_constraints=domains,
+                )
+
+        z3_expr, failure = _apply_or_failure(
+            lambda: _apply_binary_z3(
+                expr.op,
+                left.z3_expr,
+                right.z3_expr,
+                expr.x,
+                expr.y,
+            ),
+            source,
+        )
+        return _with_parts(
+            z3_expr,
+            assumptions=assumptions,
+            definedness_constraints=domains,
+            failure=failure,
+            feasibility_checks=(
+                *left.feasibility_checks,
+                *right.feasibility_checks,
+            ),
+        )
+
+    if isinstance(expr, UnaryOp):
+        operand = _translate_expr_domain(
+            expr.x,
+            z3_vars,
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            source=source,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+        if operand.failure is not None:
+            return operand
+        z3_expr, failure = _apply_or_failure(
+            lambda: _apply_unary_z3(expr.op, operand.z3_expr),
+            source,
+        )
+        return _with_parts(
+            z3_expr,
+            assumptions=assumptions,
+            definedness_constraints=operand.definedness_constraints,
+            failure=failure,
+            feasibility_checks=operand.feasibility_checks,
+        )
+
+    if isinstance(expr, UFunc):
+        operand = _translate_expr_domain(
+            expr.x,
+            z3_vars,
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            source=source,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+        if operand.failure is not None:
+            return operand
+        domains = list(operand.definedness_constraints)
+        if expr.func == "sqrt":
+            try:
+                domains.append(DomainConstraint(operand.z3_expr >= 0, source=source))
+            except TypeError as err:
+                # TypeError: malformed sqrt operands may not compare to zero.
+                return _failure_result(
+                    _failure_from_exception(err, source),
+                    assumptions=assumptions,
+                    definedness_constraints=domains,
+                )
+            except z3.Z3Exception as err:
+                # Z3Exception: Z3 can reject sqrt operand sort comparisons.
+                return _failure_result(
+                    _failure_from_exception(err, source),
+                    assumptions=assumptions,
+                    definedness_constraints=domains,
+                )
+        z3_expr, failure = _apply_or_failure(
+            lambda: _apply_ufunc_z3(expr.func, operand.z3_expr),
+            source,
+        )
+        return _with_parts(
+            z3_expr,
+            assumptions=assumptions,
+            definedness_constraints=domains,
+            failure=failure,
+            feasibility_checks=operand.feasibility_checks,
+        )
+
+    return _failure_result(
+        TranslationFailure(
+            "value_error",
+            f"Unsupported expression type: {type(expr).__name__}",
+            source=source,
+        ),
+        assumptions=assumptions,
+    )
+
+
+def _translate_conditional_domain(
+    expr: ConditionalOp,
+    z3_vars: _Z3Vars,
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    source: Optional[DomainSource],
+    prune_unreachable: bool,
+    timeout_ms: Optional[int],
+) -> ExprDomain:
+    """Translate a conditional expression with runtime short-circuit semantics."""
+    condition = _translate_expr_domain(
+        expr.cond,
+        z3_vars,
+        assumptions=assumptions,
+        path_conditions=path_conditions,
+        source=source,
+        prune_unreachable=prune_unreachable,
+        timeout_ms=timeout_ms,
+    )
+    if condition.failure is not None:
+        return condition
+
+    condition_domains = condition.definedness_constraints
+    true_selector = condition.z3_expr
+    try:
+        false_selector = z3.Not(condition.z3_expr)
+    except TypeError as err:
+        # TypeError: malformed ternary conditions may not be Boolean values.
+        return _failure_result(
+            _failure_from_exception(err, source),
+            assumptions=assumptions,
+            definedness_constraints=condition_domains,
+            feasibility_checks=condition.feasibility_checks,
+        )
+    except z3.Z3Exception as err:
+        # Z3Exception: Z3 rejects non-Boolean ternary conditions.
+        return _failure_result(
+            _failure_from_exception(err, source),
+            assumptions=assumptions,
+            definedness_constraints=condition_domains,
+            feasibility_checks=condition.feasibility_checks,
+        )
+    feasibility_checks: List[BranchFeasibility] = list(condition.feasibility_checks)
+    if prune_unreachable:
+        true_check = _branch_feasibility(
+            true_selector,
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            condition_domains=condition_domains,
+            source=source,
+            timeout_ms=timeout_ms,
+        )
+        false_check = _branch_feasibility(
+            false_selector,
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            condition_domains=condition_domains,
+            source=source,
+            timeout_ms=timeout_ms,
+        )
+        feasibility_checks.extend((true_check, false_check))
+        true_reachable = true_check.status != "unsat"
+        false_reachable = false_check.status != "unsat"
+    else:
+        true_reachable = True
+        false_reachable = True
+
+    branch_path = (*path_conditions, *_constraint_exprs(condition_domains))
+    true_result = false_result = None
+    if true_reachable:
+        true_result = _translate_expr_domain(
+            expr.if_true,
+            z3_vars,
+            assumptions=assumptions,
+            path_conditions=(*branch_path, true_selector),
+            source=source,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+        feasibility_checks.extend(true_result.feasibility_checks)
+        if true_result.failure is not None:
+            return _failure_result(
+                true_result.failure,
+                assumptions=assumptions,
+                definedness_constraints=(
+                    *condition_domains,
+                    *true_result.definedness_constraints,
+                ),
+                feasibility_checks=feasibility_checks,
+            )
+    if false_reachable:
+        false_result = _translate_expr_domain(
+            expr.if_false,
+            z3_vars,
+            assumptions=assumptions,
+            path_conditions=(*branch_path, false_selector),
+            source=source,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+        feasibility_checks.extend(false_result.feasibility_checks)
+        if false_result.failure is not None:
+            return _failure_result(
+                false_result.failure,
+                assumptions=assumptions,
+                definedness_constraints=(
+                    *condition_domains,
+                    *false_result.definedness_constraints,
+                ),
+                feasibility_checks=feasibility_checks,
+            )
+
+    if not true_reachable and not false_reachable:
+        return _failure_result(
+            TranslationFailure(
+                "no_reachable_branch",
+                "Conditional expression has no reachable value branch.",
+                source=source,
+            ),
+            assumptions=assumptions,
+            definedness_constraints=condition_domains,
+            feasibility_checks=feasibility_checks,
+        )
+
+    if true_reachable and not false_reachable:
+        return _with_parts(
+            true_result.z3_expr,
+            assumptions=assumptions,
+            definedness_constraints=(
+                *condition_domains,
+                *true_result.definedness_constraints,
+            ),
+            feasibility_checks=feasibility_checks,
+        )
+    if false_reachable and not true_reachable:
+        return _with_parts(
+            false_result.z3_expr,
+            assumptions=assumptions,
+            definedness_constraints=(
+                *condition_domains,
+                *false_result.definedness_constraints,
+            ),
+            feasibility_checks=feasibility_checks,
+        )
+
+    domains: List[DomainConstraint] = list(condition_domains)
+    for item in true_result.definedness_constraints:
+        domains.append(
+            DomainConstraint(
+                z3.Implies(condition.z3_expr, item.constraint),
+                source=item.source,
+            )
+        )
+    for item in false_result.definedness_constraints:
+        domains.append(
+            DomainConstraint(
+                z3.Implies(z3.Not(condition.z3_expr), item.constraint),
+                source=item.source,
+            )
+        )
+    z3_expr, failure = _apply_or_failure(
+        lambda: z3.If(condition.z3_expr, true_result.z3_expr, false_result.z3_expr),
+        source,
+    )
+    return _with_parts(
+        z3_expr,
+        assumptions=assumptions,
+        definedness_constraints=domains,
+        failure=failure,
+        feasibility_checks=feasibility_checks,
+    )
+
+
+def translate_expr_domain(
+    expr: Expr,
+    z3_vars: _Z3Vars,
+    *,
+    assumptions: Sequence[z3.ExprRef] = (),
+    path_conditions: Sequence[z3.ExprRef] = (),
+    source: Optional[DomainSource] = None,
+    prune_unreachable: bool = True,
+    timeout_ms: Optional[int] = None,
+) -> ExprDomain:
+    """Translate an expression and return runtime-definedness metadata.
+
+    :param expr: Expression to translate.
+    :type expr: Expr
+    :param z3_vars: Symbolic variable mapping.
+    :type z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    :param assumptions: Caller-known facts preserved on the result.
+    :type assumptions: Sequence[z3.ExprRef], optional
+    :param path_conditions: Current path predicates used only for branch
+        feasibility pruning; they are not stored on the result.
+    :type path_conditions: Sequence[z3.ExprRef], optional
+    :param source: Optional pure source metadata.
+    :type source: Optional[DomainSource], optional
+    :param prune_unreachable: Whether to skip value branches proved unreachable,
+        defaults to ``True``.
+    :type prune_unreachable: bool, optional
+    :param timeout_ms: Optional timeout for branch reachability checks.
+    :type timeout_ms: Optional[int], optional
+    :return: Domain-aware expression translation.
+    :rtype: ExprDomain
+    """
+    return _translate_expr_domain(
+        expr,
+        z3_vars,
+        assumptions=tuple(assumptions),
+        path_conditions=tuple(path_conditions),
+        source=source,
+        prune_unreachable=prune_unreachable,
+        timeout_ms=timeout_ms,
+    )
+
+
+def merge_definedness_constraints(*items) -> Tuple[DomainConstraint, ...]:
+    """Flatten expression-domain and domain-constraint inputs in order.
+
+    Each returned constraint must hold at the evaluation point.  The helper does
+    not run a solver and does not remove contradictory constraints.
+    """
+    merged: List[DomainConstraint] = []
+    for item in items:
+        if isinstance(item, DomainConstraint):
+            merged.append(item)
+        elif isinstance(item, ExprDomain):
+            merged.extend(item.definedness_constraints)
+        elif isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+            for sub_item in item:
+                if not isinstance(sub_item, DomainConstraint):
+                    raise TypeError(
+                        "Unsupported definedness item: {type_name}".format(
+                            type_name=type(sub_item).__name__,
+                        )
+                    )
+                merged.append(sub_item)
+        else:
+            raise TypeError(
+                "Unsupported definedness item: {type_name}".format(
+                    type_name=type(item).__name__,
+                )
+            )
+    return tuple(merged)
+
+
+__all__ = [
+    "BranchFeasibility",
+    "DomainConstraint",
+    "DomainSource",
+    "ExprDomain",
+    "TranslationFailure",
+    "merge_definedness_constraints",
+    "translate_expr_domain",
+]

--- a/pyfcstm/solver/domain.py
+++ b/pyfcstm/solver/domain.py
@@ -9,7 +9,7 @@ when to add the returned definedness constraints to a solver.
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import z3
 
@@ -70,7 +70,11 @@ class BranchFeasibility:
 
 @dataclass(frozen=True)
 class ExprDomain:
-    """Domain-aware translation result for one expression."""
+    """Domain-aware translation result for one expression.
+
+    ``expr_constraints`` is reserved for future solver-only value constraints.
+    The current translator does not populate it; every path returns ``()``.
+    """
 
     z3_expr: Optional[_Z3Expr]
     expr_constraints: Tuple[z3.ExprRef, ...] = ()
@@ -91,7 +95,9 @@ def _failure_from_exception(
         return TranslationFailure("value_error", str(err), source=source)
     if isinstance(err, TypeError):
         return TranslationFailure("type_error", str(err), source=source)
-    return TranslationFailure("z3_error", str(err), source=source)
+    if isinstance(err, z3.Z3Exception):
+        return TranslationFailure("z3_error", str(err), source=source)
+    raise AssertionError(f"Unexpected translation exception: {type(err).__name__}") from err
 
 
 def _failure_result(
@@ -137,7 +143,7 @@ def _expr_to_z3_or_failure(
 
 
 def _apply_or_failure(
-    func,
+    func: Callable[[], _Z3Expr],
     source: Optional[DomainSource],
 ) -> Tuple[Optional[_Z3Expr], Optional[TranslationFailure]]:
     """Run a Z3 operation and normalize only documented failure classes."""
@@ -247,13 +253,27 @@ def _translate_expr_domain(
             expr.y,
             z3_vars,
             assumptions=assumptions,
-            path_conditions=path_conditions,
+            path_conditions=(
+                *path_conditions,
+                *_constraint_exprs(left.definedness_constraints),
+            ),
             source=source,
             prune_unreachable=prune_unreachable,
             timeout_ms=timeout_ms,
         )
         if right.failure is not None:
-            return right
+            return _failure_result(
+                right.failure,
+                assumptions=assumptions,
+                definedness_constraints=(
+                    *left.definedness_constraints,
+                    *right.definedness_constraints,
+                ),
+                feasibility_checks=(
+                    *left.feasibility_checks,
+                    *right.feasibility_checks,
+                ),
+            )
 
         domains = [*left.definedness_constraints, *right.definedness_constraints]
         if expr.op in ("/", "%"):
@@ -281,6 +301,7 @@ def _translate_expr_domain(
                 right.z3_expr,
                 expr.x,
                 expr.y,
+                warning_stacklevel=6,
             ),
             source,
         )
@@ -308,7 +329,11 @@ def _translate_expr_domain(
         if operand.failure is not None:
             return operand
         z3_expr, failure = _apply_or_failure(
-            lambda: _apply_unary_z3(expr.op, operand.z3_expr),
+            lambda: _apply_unary_z3(
+                expr.op,
+                operand.z3_expr,
+                warning_stacklevel=6,
+            ),
             source,
         )
         return _with_parts(

--- a/pyfcstm/solver/expr.py
+++ b/pyfcstm/solver/expr.py
@@ -86,6 +86,8 @@ def _apply_binary_z3(
     right: Union[z3.ArithRef, z3.BoolRef],
     left_expr: Expr,
     right_expr: Expr,
+    *,
+    warning_stacklevel: int = 2,
 ) -> Union[z3.ArithRef, z3.BoolRef]:
     """Apply a DSL binary operator to already translated Z3 operands."""
     if op == "+":
@@ -114,14 +116,14 @@ def _apply_binary_z3(
                 "Z3's nonlinear arithmetic solver has limited support for this pattern. "
                 "Consider using alternative formulations or constraints if possible.",
                 UserWarning,
-                stacklevel=2,
+                stacklevel=warning_stacklevel,
             )
         elif right_is_var:
             warnings.warn(
                 "Power operation with variable exponent (constant ** x) may be slow in Z3. "
                 "Performance depends on the solver's ability to handle exponential constraints.",
                 UserWarning,
-                stacklevel=2,
+                stacklevel=warning_stacklevel,
             )
         # x ** constant is generally fine, no warning needed
 
@@ -135,7 +137,7 @@ def _apply_binary_z3(
             "For full bitwise operation support, consider using Z3 BitVec types. "
             "The operation may not work as expected for negative numbers.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=warning_stacklevel,
         )
         return left & right
     elif op == "|":
@@ -144,7 +146,7 @@ def _apply_binary_z3(
             "For full bitwise operation support, consider using Z3 BitVec types. "
             "The operation may not work as expected for negative numbers.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=warning_stacklevel,
         )
         return left | right
     elif op == "^":
@@ -153,7 +155,7 @@ def _apply_binary_z3(
             "For full bitwise operation support, consider using Z3 BitVec types. "
             "The operation may not work as expected for negative numbers.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=warning_stacklevel,
         )
         return left ^ right
     elif op == "<<":
@@ -161,7 +163,7 @@ def _apply_binary_z3(
             "Left shift (<<) on Z3 Int types has limited support. "
             "For full bitwise operation support, consider using Z3 BitVec types.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=warning_stacklevel,
         )
         return left << right
     elif op == ">>":
@@ -169,7 +171,7 @@ def _apply_binary_z3(
             "Right shift (>>) on Z3 Int types has limited support. "
             "For full bitwise operation support, consider using Z3 BitVec types.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=warning_stacklevel,
         )
         return left >> right
 
@@ -200,6 +202,8 @@ def _apply_binary_z3(
 def _apply_unary_z3(
     op: str,
     operand: Union[z3.ArithRef, z3.BoolRef],
+    *,
+    warning_stacklevel: int = 2,
 ) -> Union[z3.ArithRef, z3.BoolRef]:
     """Apply a DSL unary operator to an already translated Z3 operand."""
     if op == "-":
@@ -212,7 +216,7 @@ def _apply_unary_z3(
             "For full bitwise operation support, consider using Z3 BitVec types. "
             "The operation may not work as expected.",
             UserWarning,
-            stacklevel=2,
+            stacklevel=warning_stacklevel,
         )
         return ~operand
     elif op in ("!", "not"):
@@ -399,12 +403,19 @@ def expr_to_z3(
     elif isinstance(expr, BinaryOp):
         left = expr_to_z3(expr.x, z3_vars)
         right = expr_to_z3(expr.y, z3_vars)
-        return _apply_binary_z3(expr.op, left, right, expr.x, expr.y)
+        return _apply_binary_z3(
+            expr.op,
+            left,
+            right,
+            expr.x,
+            expr.y,
+            warning_stacklevel=3,
+        )
 
     # Handle unary operators
     elif isinstance(expr, UnaryOp):
         operand = expr_to_z3(expr.x, z3_vars)
-        return _apply_unary_z3(expr.op, operand)
+        return _apply_unary_z3(expr.op, operand, warning_stacklevel=3)
 
     # Handle conditional expressions (ternary operator)
     elif isinstance(expr, ConditionalOp):

--- a/pyfcstm/solver/expr.py
+++ b/pyfcstm/solver/expr.py
@@ -80,6 +80,272 @@ def python_round_to_z3(operand: Union[z3.ArithRef, z3.BoolRef]) -> z3.ArithRef:
     )
 
 
+def _apply_binary_z3(
+    op: str,
+    left: Union[z3.ArithRef, z3.BoolRef],
+    right: Union[z3.ArithRef, z3.BoolRef],
+    left_expr: Expr,
+    right_expr: Expr,
+) -> Union[z3.ArithRef, z3.BoolRef]:
+    """Apply a DSL binary operator to already translated Z3 operands."""
+    if op == "+":
+        return left + right
+    elif op == "-":
+        return left - right
+    elif op == "*":
+        return left * right
+    elif op == "/":
+        return left / right
+    elif op == "%":
+        return left % right
+    elif op == "**":
+        # Power operator in Z3 has different performance characteristics:
+        # - x ** constant: Generally OK (e.g., x**2, x**3)
+        # - constant ** x: Slower but acceptable (e.g., 2**x)
+        # - x ** y: Very slow, may not terminate in reasonable time
+        #
+        # Check if both operands are variables (worst case)
+        left_is_var = isinstance(left_expr, Variable)
+        right_is_var = isinstance(right_expr, Variable)
+
+        if left_is_var and right_is_var:
+            warnings.warn(
+                "Power operation with two variables (x ** y) may be very slow in Z3. "
+                "Z3's nonlinear arithmetic solver has limited support for this pattern. "
+                "Consider using alternative formulations or constraints if possible.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif right_is_var:
+            warnings.warn(
+                "Power operation with variable exponent (constant ** x) may be slow in Z3. "
+                "Performance depends on the solver's ability to handle exponential constraints.",
+                UserWarning,
+                stacklevel=2,
+            )
+        # x ** constant is generally fine, no warning needed
+
+        return left**right
+
+    # Bitwise operators
+    # Note: These work on Z3 Int but have limitations compared to BitVec
+    elif op == "&":
+        warnings.warn(
+            "Bitwise AND (&) on Z3 Int types has limited support. "
+            "For full bitwise operation support, consider using Z3 BitVec types. "
+            "The operation may not work as expected for negative numbers.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return left & right
+    elif op == "|":
+        warnings.warn(
+            "Bitwise OR (|) on Z3 Int types has limited support. "
+            "For full bitwise operation support, consider using Z3 BitVec types. "
+            "The operation may not work as expected for negative numbers.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return left | right
+    elif op == "^":
+        warnings.warn(
+            "Bitwise XOR (^) on Z3 Int types has limited support. "
+            "For full bitwise operation support, consider using Z3 BitVec types. "
+            "The operation may not work as expected for negative numbers.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return left ^ right
+    elif op == "<<":
+        warnings.warn(
+            "Left shift (<<) on Z3 Int types has limited support. "
+            "For full bitwise operation support, consider using Z3 BitVec types.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return left << right
+    elif op == ">>":
+        warnings.warn(
+            "Right shift (>>) on Z3 Int types has limited support. "
+            "For full bitwise operation support, consider using Z3 BitVec types.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return left >> right
+
+    # Comparison operators
+    elif op == "<":
+        return left < right
+    elif op == "<=":
+        return left <= right
+    elif op == ">":
+        return left > right
+    elif op == ">=":
+        return left >= right
+    elif op == "==":
+        return left == right
+    elif op == "!=":
+        return left != right
+
+    # Logical operators
+    elif op in ("&&", "and"):
+        return z3.And(left, right)
+    elif op in ("||", "or"):
+        return z3.Or(left, right)
+
+    else:
+        raise ValueError(f"Unsupported binary operator: {op}")
+
+
+def _apply_unary_z3(
+    op: str,
+    operand: Union[z3.ArithRef, z3.BoolRef],
+) -> Union[z3.ArithRef, z3.BoolRef]:
+    """Apply a DSL unary operator to an already translated Z3 operand."""
+    if op == "-":
+        return -operand
+    elif op == "+":
+        return operand
+    elif op == "~":
+        warnings.warn(
+            "Bitwise NOT (~) on Z3 Int types has limited support. "
+            "For full bitwise operation support, consider using Z3 BitVec types. "
+            "The operation may not work as expected.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return ~operand
+    elif op in ("!", "not"):
+        return z3.Not(operand)
+    else:
+        raise ValueError(f"Unsupported unary operator: {op}")
+
+
+def _apply_ufunc_z3(
+    func: str,
+    operand: Union[z3.ArithRef, z3.BoolRef],
+) -> Union[z3.ArithRef, z3.BoolRef]:
+    """Apply a supported unary math function to a Z3 operand."""
+    # Absolute value and sign functions
+    if func == "abs":
+        # Use conditional expression for absolute value
+        return z3.If(operand >= 0, operand, -operand)
+
+    elif func == "sign":
+        # Sign function: returns -1, 0, or 1
+        zero = z3.IntVal(0) if z3.is_int(operand) else z3.RealVal(0)
+        one = z3.IntVal(1) if z3.is_int(operand) else z3.RealVal(1)
+        minus_one = z3.IntVal(-1) if z3.is_int(operand) else z3.RealVal(-1)
+        return z3.If(operand == zero, zero, z3.If(operand > zero, one, minus_one))
+
+    # Rounding functions (for Real numbers)
+    elif func == "floor":
+        # Z3 has ToInt which performs floor for non-negative reals
+        # For general floor, we need to handle negative numbers
+        if z3.is_real(operand):
+            return z3.ToInt(operand)
+        elif z3.is_int(operand):
+            # Already an integer
+            return operand
+        else:
+            # Try to convert to Real first (silent conversion)
+            return z3.ToInt(z3.ToReal(operand))
+
+    elif func == "ceil":
+        # Ceiling: ceil(x) = -floor(-x)
+        if z3.is_real(operand):
+            return -z3.ToInt(-operand)
+        elif z3.is_int(operand):
+            # Already an integer
+            return operand
+        else:
+            # Try to convert to Real first (silent conversion)
+            return -z3.ToInt(-z3.ToReal(operand))
+
+    elif func == "trunc":
+        # Truncate towards zero
+        if z3.is_real(operand):
+            zero = z3.RealVal(0)
+            return z3.If(operand >= zero, z3.ToInt(operand), -z3.ToInt(-operand))
+        elif z3.is_int(operand):
+            # Already an integer
+            return operand
+        else:
+            # Try to convert to Real first (silent conversion)
+            real_operand = z3.ToReal(operand)
+            zero = z3.RealVal(0)
+            return z3.If(
+                real_operand >= zero,
+                z3.ToInt(real_operand),
+                -z3.ToInt(-real_operand),
+            )
+
+    # Min/Max functions (if operand is a comparison, we can use If)
+    # Note: These would need special handling as they typically take 2 arguments
+
+    # Power and root functions
+    elif func == "sqrt":
+        # Z3 has limited support for sqrt
+        # We can use z3.Sqrt for Real numbers in some theories
+        if z3.is_real(operand):
+            return z3.Sqrt(operand)
+        elif z3.is_int(operand):
+            # Convert Int to Real for sqrt (silent conversion)
+            return z3.Sqrt(z3.ToReal(operand))
+        else:
+            raise NotImplementedError(
+                f"sqrt requires Real or Int operand, got {operand.sort()}. "
+                f"Cannot convert to Real."
+            )
+
+    elif func == "cbrt":
+        # Cube root: x^(1/3)
+        # Z3 doesn't have native cbrt, would need uninterpreted function
+        raise NotImplementedError(
+            "Mathematical function 'cbrt' is not directly supported in Z3. "
+            "Consider using uninterpreted functions or polynomial constraints (y^3 = x)."
+        )
+
+    elif func == "exp":
+        # Exponential function
+        raise NotImplementedError(
+            "Mathematical function 'exp' is not directly supported in Z3. "
+            "Consider using uninterpreted functions or approximations."
+        )
+
+    # Logarithmic functions
+    elif func in ("log", "log10", "log2", "log1p"):
+        raise NotImplementedError(
+            f"Logarithmic function '{func}' is not directly supported in Z3. "
+            f"Consider using uninterpreted functions or approximations."
+        )
+
+    # Trigonometric functions
+    elif func in ("sin", "cos", "tan", "asin", "acos", "atan"):
+        raise NotImplementedError(
+            f"Trigonometric function '{func}' is not directly supported in Z3. "
+            f"Consider using uninterpreted functions or approximations."
+        )
+
+    # Hyperbolic functions
+    elif func in ("sinh", "cosh", "tanh", "asinh", "acosh", "atanh"):
+        raise NotImplementedError(
+            f"Hyperbolic function '{func}' is not directly supported in Z3. "
+            f"Consider using uninterpreted functions or approximations."
+        )
+
+    # Round function
+    elif func == "round":
+        return python_round_to_z3(operand)
+
+    else:
+        raise NotImplementedError(
+            f"Mathematical function '{func}' is not supported in Z3 conversion. "
+            f"Supported functions: abs, sign, floor, ceil, trunc, round, sqrt (Real only). "
+            f"Unsupported: trigonometric, hyperbolic, logarithmic, and exponential functions."
+        )
+
+
 def expr_to_z3(
     expr: Expr, z3_vars: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
 ) -> Union[z3.ArithRef, z3.BoolRef]:
@@ -133,137 +399,12 @@ def expr_to_z3(
     elif isinstance(expr, BinaryOp):
         left = expr_to_z3(expr.x, z3_vars)
         right = expr_to_z3(expr.y, z3_vars)
-
-        # Arithmetic operators
-        if expr.op == "+":
-            return left + right
-        elif expr.op == "-":
-            return left - right
-        elif expr.op == "*":
-            return left * right
-        elif expr.op == "/":
-            return left / right
-        elif expr.op == "%":
-            return left % right
-        elif expr.op == "**":
-            # Power operator in Z3 has different performance characteristics:
-            # - x ** constant: Generally OK (e.g., x**2, x**3)
-            # - constant ** x: Slower but acceptable (e.g., 2**x)
-            # - x ** y: Very slow, may not terminate in reasonable time
-            #
-            # Check if both operands are variables (worst case)
-            left_is_var = isinstance(expr.x, Variable)
-            right_is_var = isinstance(expr.y, Variable)
-
-            if left_is_var and right_is_var:
-                warnings.warn(
-                    "Power operation with two variables (x ** y) may be very slow in Z3. "
-                    "Z3's nonlinear arithmetic solver has limited support for this pattern. "
-                    "Consider using alternative formulations or constraints if possible.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            elif right_is_var:
-                warnings.warn(
-                    "Power operation with variable exponent (constant ** x) may be slow in Z3. "
-                    "Performance depends on the solver's ability to handle exponential constraints.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            # x ** constant is generally fine, no warning needed
-
-            return left**right
-
-        # Bitwise operators
-        # Note: These work on Z3 Int but have limitations compared to BitVec
-        elif expr.op == "&":
-            warnings.warn(
-                "Bitwise AND (&) on Z3 Int types has limited support. "
-                "For full bitwise operation support, consider using Z3 BitVec types. "
-                "The operation may not work as expected for negative numbers.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return left & right
-        elif expr.op == "|":
-            warnings.warn(
-                "Bitwise OR (|) on Z3 Int types has limited support. "
-                "For full bitwise operation support, consider using Z3 BitVec types. "
-                "The operation may not work as expected for negative numbers.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return left | right
-        elif expr.op == "^":
-            warnings.warn(
-                "Bitwise XOR (^) on Z3 Int types has limited support. "
-                "For full bitwise operation support, consider using Z3 BitVec types. "
-                "The operation may not work as expected for negative numbers.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return left ^ right
-        elif expr.op == "<<":
-            warnings.warn(
-                "Left shift (<<) on Z3 Int types has limited support. "
-                "For full bitwise operation support, consider using Z3 BitVec types.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return left << right
-        elif expr.op == ">>":
-            warnings.warn(
-                "Right shift (>>) on Z3 Int types has limited support. "
-                "For full bitwise operation support, consider using Z3 BitVec types.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return left >> right
-
-        # Comparison operators
-        elif expr.op == "<":
-            return left < right
-        elif expr.op == "<=":
-            return left <= right
-        elif expr.op == ">":
-            return left > right
-        elif expr.op == ">=":
-            return left >= right
-        elif expr.op == "==":
-            return left == right
-        elif expr.op == "!=":
-            return left != right
-
-        # Logical operators
-        elif expr.op in ("&&", "and"):
-            return z3.And(left, right)
-        elif expr.op in ("||", "or"):
-            return z3.Or(left, right)
-
-        else:
-            raise ValueError(f"Unsupported binary operator: {expr.op}")
+        return _apply_binary_z3(expr.op, left, right, expr.x, expr.y)
 
     # Handle unary operators
     elif isinstance(expr, UnaryOp):
         operand = expr_to_z3(expr.x, z3_vars)
-
-        if expr.op == "-":
-            return -operand
-        elif expr.op == "+":
-            return operand
-        elif expr.op == "~":
-            warnings.warn(
-                "Bitwise NOT (~) on Z3 Int types has limited support. "
-                "For full bitwise operation support, consider using Z3 BitVec types. "
-                "The operation may not work as expected.",
-                UserWarning,
-                stacklevel=2,
-            )
-            return ~operand
-        elif expr.op in ("!", "not"):
-            return z3.Not(operand)
-        else:
-            raise ValueError(f"Unsupported unary operator: {expr.op}")
+        return _apply_unary_z3(expr.op, operand)
 
     # Handle conditional expressions (ternary operator)
     elif isinstance(expr, ConditionalOp):
@@ -275,125 +416,7 @@ def expr_to_z3(
     # Handle mathematical functions
     elif isinstance(expr, UFunc):
         operand = expr_to_z3(expr.x, z3_vars)
-
-        # Absolute value and sign functions
-        if expr.func == "abs":
-            # Use conditional expression for absolute value
-            return z3.If(operand >= 0, operand, -operand)
-
-        elif expr.func == "sign":
-            # Sign function: returns -1, 0, or 1
-            zero = z3.IntVal(0) if z3.is_int(operand) else z3.RealVal(0)
-            one = z3.IntVal(1) if z3.is_int(operand) else z3.RealVal(1)
-            minus_one = z3.IntVal(-1) if z3.is_int(operand) else z3.RealVal(-1)
-            return z3.If(operand == zero, zero, z3.If(operand > zero, one, minus_one))
-
-        # Rounding functions (for Real numbers)
-        elif expr.func == "floor":
-            # Z3 has ToInt which performs floor for non-negative reals
-            # For general floor, we need to handle negative numbers
-            if z3.is_real(operand):
-                return z3.ToInt(operand)
-            elif z3.is_int(operand):
-                # Already an integer
-                return operand
-            else:
-                # Try to convert to Real first (silent conversion)
-                return z3.ToInt(z3.ToReal(operand))
-
-        elif expr.func == "ceil":
-            # Ceiling: ceil(x) = -floor(-x)
-            if z3.is_real(operand):
-                return -z3.ToInt(-operand)
-            elif z3.is_int(operand):
-                # Already an integer
-                return operand
-            else:
-                # Try to convert to Real first (silent conversion)
-                return -z3.ToInt(-z3.ToReal(operand))
-
-        elif expr.func == "trunc":
-            # Truncate towards zero
-            if z3.is_real(operand):
-                zero = z3.RealVal(0)
-                return z3.If(operand >= zero, z3.ToInt(operand), -z3.ToInt(-operand))
-            elif z3.is_int(operand):
-                # Already an integer
-                return operand
-            else:
-                # Try to convert to Real first (silent conversion)
-                real_operand = z3.ToReal(operand)
-                zero = z3.RealVal(0)
-                return z3.If(
-                    real_operand >= zero,
-                    z3.ToInt(real_operand),
-                    -z3.ToInt(-real_operand),
-                )
-
-        # Min/Max functions (if operand is a comparison, we can use If)
-        # Note: These would need special handling as they typically take 2 arguments
-
-        # Power and root functions
-        elif expr.func == "sqrt":
-            # Z3 has limited support for sqrt
-            # We can use z3.Sqrt for Real numbers in some theories
-            if z3.is_real(operand):
-                return z3.Sqrt(operand)
-            elif z3.is_int(operand):
-                # Convert Int to Real for sqrt (silent conversion)
-                return z3.Sqrt(z3.ToReal(operand))
-            else:
-                raise NotImplementedError(
-                    f"sqrt requires Real or Int operand, got {operand.sort()}. "
-                    f"Cannot convert to Real."
-                )
-
-        elif expr.func == "cbrt":
-            # Cube root: x^(1/3)
-            # Z3 doesn't have native cbrt, would need uninterpreted function
-            raise NotImplementedError(
-                "Mathematical function 'cbrt' is not directly supported in Z3. "
-                "Consider using uninterpreted functions or polynomial constraints (y^3 = x)."
-            )
-
-        elif expr.func == "exp":
-            # Exponential function
-            raise NotImplementedError(
-                "Mathematical function 'exp' is not directly supported in Z3. "
-                "Consider using uninterpreted functions or approximations."
-            )
-
-        # Logarithmic functions
-        elif expr.func in ("log", "log10", "log2", "log1p"):
-            raise NotImplementedError(
-                f"Logarithmic function '{expr.func}' is not directly supported in Z3. "
-                f"Consider using uninterpreted functions or approximations."
-            )
-
-        # Trigonometric functions
-        elif expr.func in ("sin", "cos", "tan", "asin", "acos", "atan"):
-            raise NotImplementedError(
-                f"Trigonometric function '{expr.func}' is not directly supported in Z3. "
-                f"Consider using uninterpreted functions or approximations."
-            )
-
-        # Hyperbolic functions
-        elif expr.func in ("sinh", "cosh", "tanh", "asinh", "acosh", "atanh"):
-            raise NotImplementedError(
-                f"Hyperbolic function '{expr.func}' is not directly supported in Z3. "
-                f"Consider using uninterpreted functions or approximations."
-            )
-
-        # Round function
-        elif expr.func == "round":
-            return python_round_to_z3(operand)
-
-        else:
-            raise NotImplementedError(
-                f"Mathematical function '{expr.func}' is not supported in Z3 conversion. "
-                f"Supported functions: abs, sign, floor, ceil, trunc, round, sqrt (Real only). "
-                f"Unsupported: trigonometric, hyperbolic, logarithmic, and exponential functions."
-            )
+        return _apply_ufunc_z3(expr.func, operand)
 
     else:
         raise ValueError(f"Unsupported expression type: {type(expr).__name__}")

--- a/test/solver/test_domain.py
+++ b/test/solver/test_domain.py
@@ -1,0 +1,485 @@
+"""Tests for solver-layer expression runtime-domain translation."""
+
+from dataclasses import FrozenInstanceError
+from typing import List, cast
+
+import pytest
+import z3
+
+from pyfcstm.model.expr import BinaryOp, Boolean, Expr, Integer, UFunc, UnaryOp, Variable
+from pyfcstm.solver.expr import expr_to_z3
+
+
+def bool_expr(item) -> z3.ExprRef:
+    """Cast a Z3 boolean expression through the broad upstream stubs."""
+    return cast(z3.ExprRef, item)
+
+
+def exprs(*items) -> List[z3.ExprRef]:
+    """Cast Z3 expressions through the broad upstream stubs."""
+    return [cast(z3.ExprRef, item) for item in items]
+
+
+@pytest.mark.unittest
+class TestDomainDataStructures:
+    """Test the frozen pure-data objects exposed by solver.domain."""
+
+    def test_domain_source_is_frozen_and_preserves_tracking_fields(self):
+        """Source labels are pure metadata, not solver semantics."""
+        from pyfcstm.solver.domain import DomainSource
+
+        source = DomainSource(
+            label="guard",
+            step=3,
+            snapshot="before",
+            prefix_id="root.init",
+        )
+
+        assert source.label == "guard"
+        assert source.step == 3
+        assert source.snapshot == "before"
+        assert source.prefix_id == "root.init"
+        with pytest.raises(FrozenInstanceError):
+            setattr(source, "step", 4)
+
+    def test_translation_failure_is_pure_solver_data(self):
+        """Translation failures do not carry verification or diagnostic results."""
+        from pyfcstm.solver.domain import DomainSource, TranslationFailure
+
+        source = DomainSource(label="expr")
+        failure = TranslationFailure(
+            kind="not_implemented",
+            reason="unsupported function",
+            source=source,
+        )
+
+        assert failure.kind == "not_implemented"
+        assert failure.reason == "unsupported function"
+        assert failure.source is source
+        assert not hasattr(failure, "diagnostics")
+        assert not hasattr(failure, "severity")
+
+
+@pytest.mark.unittest
+class TestTranslateExprDomain:
+    """Test domain-aware expression translation."""
+
+    def test_division_returns_z3_value_and_denominator_definedness(self):
+        """Division is still translated while the non-zero divisor is returned."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x, y = z3.Ints("x y")
+        expr = BinaryOp(Variable("x"), "/", Variable("y"))
+
+        result = translate_expr_domain(expr, {"x": x, "y": y})
+
+        assert result.failure is None
+        assert result.z3_expr is not None
+        assert str(result.z3_expr) == str(expr_to_z3(expr, {"x": x, "y": y}))
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "y != 0"
+        ]
+
+        solver = z3.Solver()
+        solver.add(result.definedness_constraints[0].constraint, y == 0)
+        assert solver.check() == z3.unsat
+
+    def test_generated_definedness_preserves_domain_source(self):
+        """Generated constraints keep pure source metadata for later callers."""
+        from pyfcstm.solver.domain import DomainSource, translate_expr_domain
+
+        x, y = z3.Ints("x y")
+        source = DomainSource(label="guard", step=2, snapshot="before")
+        result = translate_expr_domain(
+            BinaryOp(Variable("x"), "/", Variable("y")),
+            {"x": x, "y": y},
+            source=source,
+        )
+
+        assert result.failure is None
+        assert result.definedness_constraints[0].source is source
+
+    def test_modulo_returns_non_zero_divisor_definedness(self):
+        """Modulo has the same runtime-domain constraint as division."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x, y = z3.Ints("x y")
+        result = translate_expr_domain(
+            BinaryOp(Variable("x"), "%", Variable("y")),
+            {"x": x, "y": y},
+        )
+
+        assert result.failure is None
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "y != 0"
+        ]
+
+    def test_binary_left_child_failure_short_circuits(self):
+        """A failed left operand is returned before translating the right operand."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(BinaryOp(Variable("missing"), "+", Integer(1)), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "missing" in result.failure.reason
+
+    def test_binary_right_child_failure_short_circuits(self):
+        """A failed right operand is returned before applying the operator."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(
+            BinaryOp(Integer(1), "+", Variable("missing")),
+            {},
+        )
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "missing" in result.failure.reason
+
+    def test_unknown_binary_operator_is_structured_failure(self):
+        """Unknown operators are normalized instead of leaking raw exceptions."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(BinaryOp(Integer(1), "???", Integer(2)), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "???" in result.failure.reason
+
+    def test_unary_operator_preserves_child_definedness_on_failure(self):
+        """Unary failures keep child definedness constraints for caller context."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x, y = z3.Ints("x y")
+        expr = UnaryOp("???", BinaryOp(Variable("x"), "/", Variable("y")))
+
+        result = translate_expr_domain(expr, {"x": x, "y": y})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "y != 0"
+        ]
+
+    def test_sqrt_returns_non_negative_operand_definedness(self):
+        """Square root preserves the value translation and adds ``operand >= 0``."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Real("x")
+        expr = UFunc("sqrt", Variable("x"))
+
+        result = translate_expr_domain(expr, {"x": x})
+
+        assert result.failure is None
+        assert result.z3_expr is not None
+        assert str(result.z3_expr) == str(expr_to_z3(expr, {"x": x}))
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "x >= 0"
+        ]
+
+    def test_sqrt_rejects_boolean_operand_as_structured_failure(self):
+        """Malformed sqrt operands become pure failures with no verification data."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(UFunc("sqrt", Boolean(True)), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind in ("type_error", "z3_error")
+        assert result.definedness_constraints == ()
+
+    def test_ufunc_child_failure_short_circuits(self):
+        """A failed function operand is returned before applying the function."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(UFunc("sqrt", Variable("missing")), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "missing" in result.failure.reason
+
+    def test_round_keeps_existing_value_translation_without_definedness(self):
+        """The domain layer does not redefine Python round semantics."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Real("x")
+        expr = UFunc("round", Variable("x"))
+
+        result = translate_expr_domain(expr, {"x": x})
+
+        assert result.failure is None
+        assert result.z3_expr is not None
+        assert str(result.z3_expr) == str(expr_to_z3(expr, {"x": x}))
+        assert result.definedness_constraints == ()
+
+    def test_unreachable_conditional_branch_is_pruned_before_translation(self):
+        """Unselected value branches can contain unsupported expressions."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Real("x")
+        expr = Boolean(True).select(Integer(1), UFunc("sin", Variable("x")))
+
+        result = translate_expr_domain(expr, {"x": x})
+
+        assert result.failure is None
+        assert result.z3_expr is not None
+        assert str(z3.simplify(result.z3_expr)) == "1"
+        assert result.definedness_constraints == ()
+        assert [item.status for item in result.feasibility_checks] == ["sat", "unsat"]
+
+    def test_pruned_conditional_stays_pruned_inside_outer_expression(self):
+        """Outer expressions use pruned child Z3 values, not raw child ASTs."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Real("x")
+        inner = Boolean(True).select(Integer(1), UFunc("sin", Variable("x")))
+        expr = BinaryOp(inner, "+", Integer(1))
+
+        result = translate_expr_domain(expr, {"x": x})
+
+        assert result.failure is None
+        assert result.z3_expr is not None
+        assert str(z3.simplify(result.z3_expr)) == "2"
+        assert result.definedness_constraints == ()
+
+    def test_pruning_can_be_disabled_for_research_callers(self):
+        """Disabling pruning translates both branches and exposes branch failures."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Real("x")
+        expr = Boolean(True).select(Integer(1), UFunc("sin", Variable("x")))
+
+        result = translate_expr_domain(expr, {"x": x}, prune_unreachable=False)
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "not_implemented"
+        assert result.feasibility_checks == ()
+
+    def test_only_false_conditional_branch_can_survive_pruning(self):
+        """A proved-false selector returns the false value without true failures."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Real("x")
+        expr = Boolean(False).select(UFunc("sin", Variable("x")), Integer(3))
+
+        result = translate_expr_domain(expr, {"x": x})
+
+        assert result.failure is None
+        assert result.z3_expr is not None
+        assert str(z3.simplify(result.z3_expr)) == "3"
+        assert [item.status for item in result.feasibility_checks] == ["unsat", "sat"]
+
+    def test_reachable_conditional_branch_failure_is_structured(self):
+        """Symbolic reachable branches are translated and can fail structurally."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        flag = z3.Bool("flag")
+        x = z3.Real("x")
+        expr = Variable("flag").select(Integer(1), UFunc("sin", Variable("x")))
+
+        result = translate_expr_domain(expr, {"flag": flag, "x": x})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "not_implemented"
+        assert "sin" in result.failure.reason
+
+    def test_non_boolean_conditional_condition_is_structured_failure(self):
+        """Malformed ternary conditions are returned as pure translation failures."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(Integer(1).select(Integer(2), Integer(3)), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "z3_error"
+
+    def test_reachable_conditional_domain_constraints_are_selector_wrapped(self):
+        """Value branch domain constraints are qualified by their selector."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        flag = z3.Bool("flag")
+        x = z3.Int("x")
+        expr = Variable("flag").select(
+            BinaryOp(Variable("x"), "/", Integer(2)),
+            Integer(0),
+        )
+
+        result = translate_expr_domain(expr, {"flag": flag, "x": x})
+
+        assert result.failure is None
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "Implies(flag, 2 != 0)"
+        ]
+
+    def test_false_branch_domain_constraints_are_selector_wrapped(self):
+        """False-branch domain constraints are guarded by the negated selector."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        flag = z3.Bool("flag")
+        x = z3.Int("x")
+        expr = Variable("flag").select(
+            Integer(0),
+            BinaryOp(Variable("x"), "/", Integer(2)),
+        )
+
+        result = translate_expr_domain(expr, {"flag": flag, "x": x})
+
+        assert result.failure is None
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "Implies(Not(flag), 2 != 0)"
+        ]
+
+    def test_contradictory_assumptions_report_no_reachable_branch(self):
+        """If both selectors are impossible, no fake value is manufactured."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        flag = z3.Bool("flag")
+        result = translate_expr_domain(
+            Variable("flag").select(Integer(1), Integer(0)),
+            {"flag": flag},
+            assumptions=exprs(flag, z3.Not(flag)),
+        )
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "no_reachable_branch"
+        assert [item.status for item in result.feasibility_checks] == ["unsat", "unsat"]
+
+    def test_unknown_branch_feasibility_does_not_prune(self, monkeypatch):
+        """Unknown branch reachability keeps branches live and records metadata."""
+        from pyfcstm.solver import domain
+        from pyfcstm.solver.domain import translate_expr_domain
+        from pyfcstm.solver.logical import SatResult
+
+        calls = []
+
+        def always_unknown(constraints, *, timeout_ms=None, get_model=False):
+            calls.append((tuple(constraints), timeout_ms, get_model))
+            return SatResult(kind="unknown")
+
+        monkeypatch.setattr(domain, "is_sat", always_unknown)
+        flag = z3.Bool("flag")
+        x = z3.Int("x")
+        expr = Variable("flag").select(
+            BinaryOp(Variable("x"), "/", Integer(2)),
+            Integer(0),
+        )
+
+        result = translate_expr_domain(
+            expr,
+            {"flag": flag, "x": x},
+            timeout_ms=9,
+        )
+
+        assert result.failure is None
+        assert len(calls) == 2
+        assert {item.status for item in result.feasibility_checks} == {"unknown"}
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "Implies(flag, 2 != 0)"
+        ]
+
+    def test_assumptions_are_preserved_but_path_conditions_are_not_stored(self):
+        """Path conditions guide pruning while assumptions stay in the result."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        flag = z3.Bool("flag")
+        expr = Variable("flag").select(Integer(1), Integer(0))
+
+        result = translate_expr_domain(
+            expr,
+            {"flag": flag},
+            assumptions=exprs(flag == z3.BoolVal(True)),
+            path_conditions=exprs(flag),
+        )
+
+        assert result.failure is None
+        assert result.assumptions == (flag == z3.BoolVal(True),)
+        assert not hasattr(result, "path_conditions")
+
+    def test_expected_translation_failure_has_no_z3_value(self):
+        """Failure and translated value are mutually exclusive."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(Variable("missing"), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "missing" in result.failure.reason
+
+    def test_unsupported_expression_object_is_structured_failure(self):
+        """Unknown expression subclasses fail loudly as pure solver data."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        class UnknownExpr(Expr):
+            pass
+
+        result = translate_expr_domain(UnknownExpr(), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "UnknownExpr" in result.failure.reason
+
+
+@pytest.mark.unittest
+class TestMergeDefinednessConstraints:
+    """Test domain constraint collection merging."""
+
+    def test_merge_accepts_expr_domain_and_direct_constraints(self):
+        """The merge helper flattens supported inputs in order."""
+        from pyfcstm.solver.domain import (
+            DomainConstraint,
+            DomainSource,
+            ExprDomain,
+            merge_definedness_constraints,
+        )
+
+        x = z3.Int("x")
+        source = DomainSource(label="direct")
+        direct = DomainConstraint(bool_expr(x != 0), source=source)
+        from_domain = ExprDomain(
+            z3_expr=x,
+            definedness_constraints=(DomainConstraint(bool_expr(x >= 0)),),
+        )
+
+        merged = merge_definedness_constraints(from_domain, [direct])
+
+        assert [str(item.constraint) for item in merged] == ["x >= 0", "x != 0"]
+        assert merged[1].source is source
+
+    def test_merge_preserves_contradictory_constraints(self):
+        """Merging does not hide contradictions or run solver policy."""
+        from pyfcstm.solver.domain import DomainConstraint, merge_definedness_constraints
+
+        x = z3.Int("x")
+        merged = merge_definedness_constraints(
+            DomainConstraint(bool_expr(x > 0)),
+            DomainConstraint(bool_expr(x < 0)),
+        )
+
+        solver = z3.Solver()
+        solver.add(*[item.constraint for item in merged])
+        assert solver.check() == z3.unsat
+
+    def test_merge_rejects_unknown_input_shape(self):
+        """Unsupported merge inputs fail loudly instead of being swallowed."""
+        from pyfcstm.solver.domain import merge_definedness_constraints
+
+        with pytest.raises(TypeError, match="Unsupported definedness item"):
+            merge_definedness_constraints(object())
+
+    def test_merge_rejects_unknown_nested_input_shape(self):
+        """Nested iterables may contain only domain constraints."""
+        from pyfcstm.solver.domain import merge_definedness_constraints
+
+        with pytest.raises(TypeError, match="Unsupported definedness item"):
+            merge_definedness_constraints([object()])

--- a/test/solver/test_domain.py
+++ b/test/solver/test_domain.py
@@ -291,6 +291,55 @@ class TestTranslateExprDomain:
         assert result.failure.kind == "not_implemented"
         assert "sin" in result.failure.reason
 
+    def test_reachable_true_conditional_branch_failure_is_structured(self):
+        """Failures in the reachable true branch keep feasibility metadata."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        flag = z3.Bool("flag")
+        x = z3.Real("x")
+        expr = Variable("flag").select(UFunc("sin", Variable("x")), Integer(1))
+
+        result = translate_expr_domain(expr, {"flag": flag, "x": x})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "not_implemented"
+        assert [item.status for item in result.feasibility_checks[:2]] == ["sat", "sat"]
+
+    def test_conditional_condition_failure_is_returned_directly(self):
+        """A failed condition cannot manufacture either value branch."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(
+            Variable("missing").select(Integer(1), Integer(0)),
+            {},
+        )
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "missing" in result.failure.reason
+
+    def test_conditional_type_error_from_negated_selector_is_structured(
+        self,
+        monkeypatch,
+    ):
+        """Malformed selector negation is normalized as a pure failure."""
+        from pyfcstm.solver import domain
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        def reject_not(_expr):
+            raise TypeError("selector cannot be negated")
+
+        monkeypatch.setattr(domain.z3, "Not", reject_not)
+
+        result = translate_expr_domain(Boolean(True).select(Integer(1), Integer(0)), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "type_error"
+        assert "selector cannot be negated" in result.failure.reason
+
     def test_non_boolean_conditional_condition_is_structured_failure(self):
         """Malformed ternary conditions are returned as pure translation failures."""
         from pyfcstm.solver.domain import translate_expr_domain
@@ -414,6 +463,153 @@ class TestTranslateExprDomain:
         assert result.failure is not None
         assert result.failure.kind == "value_error"
         assert "missing" in result.failure.reason
+
+    @pytest.mark.parametrize(
+        "err, kind",
+        [
+            (NotImplementedError("leaf not implemented"), "not_implemented"),
+            (TypeError("leaf type mismatch"), "type_error"),
+            (z3.Z3Exception("leaf z3 mismatch"), "z3_error"),
+        ],
+    )
+    def test_leaf_translation_expected_exceptions_are_structured(
+        self,
+        monkeypatch,
+        err,
+        kind,
+    ):
+        """Expected leaf translation errors become pure failure metadata."""
+        from pyfcstm.solver import domain
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        def reject_expr(_expr, _z3_vars):
+            raise err
+
+        monkeypatch.setattr(domain, "expr_to_z3", reject_expr)
+
+        result = translate_expr_domain(Integer(1), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == kind
+        assert result.failure.reason == str(err)
+
+    @pytest.mark.parametrize(
+        "err, kind",
+        [
+            (TypeError("unary type mismatch"), "type_error"),
+            (z3.Z3Exception("unary z3 mismatch"), "z3_error"),
+        ],
+    )
+    def test_unary_apply_expected_exceptions_are_structured(
+        self,
+        monkeypatch,
+        err,
+        kind,
+    ):
+        """Expected unary application errors keep child domain constraints."""
+        from pyfcstm.solver import domain
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        def reject_unary(_op, _operand):
+            raise err
+
+        monkeypatch.setattr(domain, "_apply_unary_z3", reject_unary)
+        result = translate_expr_domain(UnaryOp("-", Integer(1)), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == kind
+        assert result.failure.reason == str(err)
+
+    def test_unary_child_failure_short_circuits(self):
+        """A failed unary operand is returned before applying the operator."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        result = translate_expr_domain(UnaryOp("-", Variable("missing")), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert "missing" in result.failure.reason
+
+    @pytest.mark.parametrize(
+        "err, kind",
+        [
+            (TypeError("divisor cannot compare"), "type_error"),
+            (z3.Z3Exception("divisor z3 mismatch"), "z3_error"),
+        ],
+    )
+    def test_divisor_compare_expected_exceptions_are_structured(
+        self,
+        monkeypatch,
+        err,
+        kind,
+    ):
+        """Divisor-domain comparison failures are structured and local."""
+        from pyfcstm.solver import domain
+        from pyfcstm.solver.domain import ExprDomain, translate_expr_domain
+
+        class BadDivisor(Expr):
+            pass
+
+        class RaisingComparison:
+            def __ne__(self, _other):
+                raise err
+
+        original_translate = domain._translate_expr_domain
+
+        def translate_with_bad_divisor(expr, z3_vars, **kwargs):
+            if isinstance(expr, BadDivisor):
+                return ExprDomain(
+                    z3_expr=RaisingComparison(),
+                    assumptions=tuple(kwargs["assumptions"]),
+                )
+            return original_translate(expr, z3_vars, **kwargs)
+
+        monkeypatch.setattr(domain, "_translate_expr_domain", translate_with_bad_divisor)
+
+        result = translate_expr_domain(BinaryOp(Integer(1), "/", BadDivisor()), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == kind
+        assert result.failure.reason == str(err)
+
+    def test_sqrt_operand_compare_z3_exception_is_structured(self, monkeypatch):
+        """Sqrt-domain comparison Z3 failures are normalized."""
+        from pyfcstm.solver import domain
+        from pyfcstm.solver.domain import ExprDomain, translate_expr_domain
+
+        class BadSqrtOperand(Expr):
+            pass
+
+        class RaisingComparison:
+            def __ge__(self, _other):
+                raise z3.Z3Exception("sqrt z3 mismatch")
+
+        original_translate = domain._translate_expr_domain
+
+        def translate_with_bad_sqrt_operand(expr, z3_vars, **kwargs):
+            if isinstance(expr, BadSqrtOperand):
+                return ExprDomain(
+                    z3_expr=RaisingComparison(),
+                    assumptions=tuple(kwargs["assumptions"]),
+                )
+            return original_translate(expr, z3_vars, **kwargs)
+
+        monkeypatch.setattr(
+            domain,
+            "_translate_expr_domain",
+            translate_with_bad_sqrt_operand,
+        )
+
+        result = translate_expr_domain(UFunc("sqrt", BadSqrtOperand()), {})
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "z3_error"
+        assert result.failure.reason == "sqrt z3 mismatch"
 
     def test_unsupported_expression_object_is_structured_failure(self):
         """Unknown expression subclasses fail loudly as pure solver data."""

--- a/test/solver/test_domain.py
+++ b/test/solver/test_domain.py
@@ -1,5 +1,6 @@
 """Tests for solver-layer expression runtime-domain translation."""
 
+import warnings
 from dataclasses import FrozenInstanceError
 from typing import List, cast
 
@@ -248,6 +249,53 @@ class TestTranslateExprDomain:
         assert str(z3.simplify(result.z3_expr)) == "2"
         assert result.definedness_constraints == ()
 
+    def test_sibling_definedness_prunes_later_conditional_branch(self):
+        """Earlier eager operands constrain later sibling branch feasibility."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Int("x")
+        y = z3.Real("y")
+        expr = BinaryOp(
+            BinaryOp(Integer(1), "/", Variable("x")),
+            "+",
+            BinaryOp(Variable("x"), "==", Integer(0)).select(
+                UFunc("sin", Variable("y")),
+                Integer(0),
+            ),
+        )
+
+        result = translate_expr_domain(expr, {"x": x, "y": y})
+
+        assert result.failure is None
+        assert result.z3_expr is not None
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "x != 0"
+        ]
+        assert [
+            (str(item.selector), item.status) for item in result.feasibility_checks
+        ] == [("0 == x", "unsat"), ("Not(0 == x)", "sat")]
+
+    def test_binary_right_failure_keeps_left_definedness(self):
+        """Right-side failures preserve constraints from already evaluated left."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Int("x")
+        result = translate_expr_domain(
+            BinaryOp(
+                BinaryOp(Integer(1), "/", Variable("x")),
+                "+",
+                Variable("missing"),
+            ),
+            {"x": x},
+        )
+
+        assert result.z3_expr is None
+        assert result.failure is not None
+        assert result.failure.kind == "value_error"
+        assert [str(item.constraint) for item in result.definedness_constraints] == [
+            "x != 0"
+        ]
+
     def test_pruning_can_be_disabled_for_research_callers(self):
         """Disabling pruning translates both branches and exposes branch failures."""
         from pyfcstm.solver.domain import translate_expr_domain
@@ -453,6 +501,34 @@ class TestTranslateExprDomain:
         assert result.assumptions == (flag == z3.BoolVal(True),)
         assert not hasattr(result, "path_conditions")
 
+    def test_expr_constraints_are_currently_empty_extension_slot(self):
+        """Expression constraints are reserved by the current translator."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x, y = z3.Ints("x y")
+        result = translate_expr_domain(
+            BinaryOp(BinaryOp(Variable("x"), "/", Variable("y")), "+", Integer(1)),
+            {"x": x, "y": y},
+        )
+
+        assert result.failure is None
+        assert result.expr_constraints == ()
+
+    def test_domain_warning_location_points_to_caller(self):
+        """Operation warnings point to the caller instead of solver internals."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Int("x")
+        expr = BinaryOp(Integer(2), "**", Variable("x"))
+
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            translate_expr_domain(expr, {"x": x})
+
+        assert len(records) == 1
+        assert "variable exponent" in str(records[0].message).lower()
+        assert records[0].filename == __file__
+
     def test_expected_translation_failure_has_no_z3_value(self):
         """Failure and translated value are mutually exclusive."""
         from pyfcstm.solver.domain import translate_expr_domain
@@ -463,6 +539,13 @@ class TestTranslateExprDomain:
         assert result.failure is not None
         assert result.failure.kind == "value_error"
         assert "missing" in result.failure.reason
+
+    def test_unlisted_translation_exception_type_is_not_reclassified(self):
+        """Only documented exception classes are normalized."""
+        from pyfcstm.solver.domain import _failure_from_exception
+
+        with pytest.raises(AssertionError, match="RuntimeError"):
+            _failure_from_exception(RuntimeError("unexpected"), None)
 
     @pytest.mark.parametrize(
         "err, kind",
@@ -511,7 +594,7 @@ class TestTranslateExprDomain:
         from pyfcstm.solver import domain
         from pyfcstm.solver.domain import translate_expr_domain
 
-        def reject_unary(_op, _operand):
+        def reject_unary(_op, _operand, **_kwargs):
             raise err
 
         monkeypatch.setattr(domain, "_apply_unary_z3", reject_unary)


### PR DESCRIPTION
## PR-A5b 定位

本 PR 是第 3 层议题 [#114](https://github.com/HansBug/pyfcstm/issues/114) 下 PR-A5 总控计划 [#142](https://github.com/HansBug/pyfcstm/pull/142) 的第二个实现子 PR，归属 PR-A 总伞 [#127](https://github.com/HansBug/pyfcstm/pull/127)。

- 基准分支：`dev/issue114-pr-a-verify`
- 来源分支：`dev/issue114-pr-a5b-solver-domain`
- 当前进度：🟨 代码复审通过，等待用户验收
- 上游依赖：PR-A4 [#132](https://github.com/HansBug/pyfcstm/pull/132) 已合入 #127；PR-A5a [#169](https://github.com/HansBug/pyfcstm/pull/169) 已合入 #127，merge commit `82308d78165eb4a8b0dc2547e22cfaf3c7b31051`
- 本 PR 目标：建立 `pyfcstm/solver/domain.py`，把表达式运行时有定义性和定义域约束沉到纯求解器层，为 PR-A5c 的路径敏感操作块执行和 PR-A5d 的验证层重接线提供可复用接口

本 PR 不做验证层重接线，也不接入诊断策略。`pyfcstm.solver.*` 必须保持纯基础设施：只产出求解器层数据，不返回 `AlgorithmResult`，不理解状态机生命周期、迁移声明顺序或诊断严重级别。

---

## 子项表

| 子项 | 进度 | 目标 | 依赖项目 | 依赖关系 | 合入条件 | 写入范围 | 禁止范围 | 验收重点 |
|---|---|---|---|---|---|---|---|---|
| PR-A5b | 🟨 代码复审通过，等待用户验收 | 建立 `solver.domain`：表达式运行时有定义性和定义域翻译 | PR-A4 [#132]；PR-A5a [#169] 已合入结果；现有 `pyfcstm/solver/expr.py`；现有 `pyfcstm/solver/logical.py` | 依赖 PR-A4 和 PR-A5a 已合入结果；PR-A5c / PR-A5d 对本 PR 是硬依赖，必须等定义域接口冻结并合入后消费；本 PR 不依赖 PR-A5c / PR-A5d | 三路计划复审 C/I 已写回正文；TDD 用例先红后绿；CI 全绿；Codecov 修改行覆盖达标；三路代码复审 C=0 / I=0；定义域接口冻结表与实际实现一致 | `pyfcstm/solver/domain.py`、`test/solver/test_domain.py`；必要时小改 `pyfcstm/solver/expr.py`，但只允许内部 helper、类型注解或文档，不允许改变 `expr_to_z3()` 公共签名和返回值 | 不导入 `pyfcstm.verify`、诊断层、注册表或检查策略；不承载根初始路径、状态机生命周期、迁移触发、声明顺序；不返回 `AlgorithmResult`；不改诊断层、模型层、DSL、编辑器、`codes.yaml`、`schema.json` | 输出纯数据结果；覆盖除零、平方根、条件表达式、四舍五入、函数调用、不支持表达式；接口区分表达式约束、调用方假设、定义域约束；预留步号、快照、前缀标识扩展点 |

---

## 依赖图

图中颜色按本 PR 视角维护：#127 / #132 / #142 是本 PR 的上游节点，所以用蓝色；#169 已合入，用绿色；未完成子 PR 用黄色。

```mermaid
flowchart TD
    PRA["PR-A 总伞 #127<br/>上游总伞，承载 PR-A1 到 PR-A5 的合入判断<br/>🟦 上游打开中"]
    PRA4["PR-A4 #132<br/>上游已落地 8 个 SMT 局部原始算法<br/>🟦 上游已合入"]
    PRA5["PR-A5 #142<br/>上游总控迁移计划，拆分 PR-A5a 到 PR-A5d<br/>🟦 上游计划"]
    PRA5a["PR-A5a #169<br/>已修复初始值表达式运行时有定义性问题<br/>✅ 已合入"]
    PRA5b["PR-A5b<br/>建立求解器层表达式定义域接口<br/>🟨 代码复审通过，等待用户验收"]
    PRA5c["PR-A5c<br/>扩展求解器层操作块路径敏感执行<br/>🟨 待启动"]
    PRA5d["PR-A5d<br/>验证层接线、清理和内部拆分<br/>🟨 待启动"]

    PRA --> PRA4
    PRA4 --> PRA5
    PRA5 --> PRA5a
    PRA5a --> PRA5b
    PRA5b --> PRA5c
    PRA5a --> PRA5d
    PRA5b --> PRA5d
    PRA5c --> PRA5d

    classDef u fill:#dbeafe,stroke:#2563eb,color:#111827
    classDef g fill:#dcfce7,stroke:#16a34a,color:#111827
    classDef y fill:#fef3c7,stroke:#d97706,color:#111827
    class PRA,PRA4,PRA5 u
    class PRA5a g
    class PRA5b,PRA5c,PRA5d y
```

后续维护规则：表格必须保留“进度”和“依赖关系”列；依赖图节点必须包含一句话说明和同款进度行；颜色按上游蓝色、已完成绿色、未完成黄色维护。

---

## 定义域接口冻结表

本表已按当前实现同步；后续若修复 review 问题导致字段语义变化，必须继续同步本表。

| 接口项 | 进度 | 冻结草案 | 依赖项目 | 依赖关系 | 验收方式 |
|---|---|---|---|---|---|
| `DomainSource` | ✅ 已实现 | 纯追踪标签：`label: Optional[str]`、`step: Optional[int]`、`snapshot: Optional[str]`、`prefix_id: Optional[str]`。它只描述来源，不参与 Z3 语义判断 | 无状态纯数据 | 供 `DomainConstraint`、`TranslationFailure` 保存来源；为未来搜索算法预留步号、快照、前缀标识 | 单测断言字段可传入、可保留、不会导入验证层 |
| `DomainConstraint` | ✅ 已实现 | 定义域约束单元：`constraint: z3.ExprRef`、`source: Optional[DomainSource]`。多个约束合并时按合取语义使用；本层不主动判定矛盾 | Z3 布尔约束 | 被 `ExprDomain.definedness_constraints` 持有；调用方决定何时把它作为硬约束加入求解器 | 单测覆盖除零、取模、平方根来源保留；矛盾约束原样保留 |
| `TranslationFailure` | ✅ 已实现 | 纯翻译失败：`kind: str`、`reason: str`、`source: Optional[DomainSource]`。用于不支持函数、未知变量、Z3 sort/operator 错误；不包含 `AlgorithmResult`、严重级别或诊断码 | 现有 `expr_to_z3()` 可能抛出的已知错误类型 | 被 `ExprDomain.failure` 持有；验证层在 PR-A5d 再把它转成原始算法结果 | 单测覆盖不支持函数、未知变量、异常归一化；意外异常继续抛出 |
| `BranchFeasibility` | ✅ 已实现 | 分支可达性记录：`selector: z3.ExprRef`、`status: str`、`source: Optional[DomainSource]`。`status` 只允许 `sat` / `unsat` / `unknown`；`unknown` 包含求解器超时 | `solver.logical.is_sat()` 或等价 Z3 查询 | 仅用于解释条件表达式裁剪；`unknown` 不作为失败，只让分支按可达处理 | 单测覆盖可达、不可达、`unknown` 不裁剪 |
| `ExprDomain` | ✅ 已实现 | 单个表达式结果：`z3_expr: Optional[z3.ExprRef]`、`expr_constraints: Tuple[z3.ExprRef, ...]`、`assumptions: Tuple[z3.ExprRef, ...]`、`definedness_constraints: Tuple[DomainConstraint, ...]`、`failure: Optional[TranslationFailure]`、`feasibility_checks: Tuple[BranchFeasibility, ...]` | 现有 `solver.expr`；Z3 表达式对象 | `translate_expr_domain()` 唯一返回类型；供 PR-A5c / PR-A5d 只读消费 | 单测断言字段稳定；不得出现验证层结果类型、诊断字段或策略字段 |
| `translate_expr_domain(expr, z3_vars, *, assumptions=(), path_conditions=(), source=None, prune_unreachable=True, timeout_ms=None)` | ✅ 已实现 | 对单个表达式做定义域感知翻译；返回 `ExprDomain`。`assumptions` 是调用方已知事实，随结果原样保留；`path_conditions` 是当前路径前缀，仅参与分支可达性判断；`timeout_ms` 只影响分支裁剪查询，不改变表达式翻译 | 现有 `expr_to_z3()`；必要时复用内部 helper | PR-A5c 操作块执行和 PR-A5d 初始值 / 守卫编码必须通过本函数消费定义域信息 | 已覆盖除零、平方根、条件表达式、四舍五入、函数调用、不支持表达式 |
| `merge_definedness_constraints(*items)` | ✅ 已实现 | 合并多个 `ExprDomain` 或 `DomainConstraint` 序列，返回 `Tuple[DomainConstraint, ...]`。合并语义是“全部都必须有定义”，即调用方加入求解器时按合取使用；本函数不做可满足性判断，不吞矛盾 | `DomainConstraint` | 供调用层按路径或步骤累积约束；PR-A5c 可直接复用 | 单测覆盖多约束、来源保留、矛盾约束不被删除、非法输入拒绝 |

接口约束：

- `expr_to_z3()` 的公共签名和返回类型在本 PR 冻结不变；定义域感知逻辑只能通过 `solver.domain` 暴露。
- `pyfcstm/solver/__init__.py` 本 PR 不强制再导出新接口；消费路径先冻结为 `from pyfcstm.solver.domain import ...`。是否做顶层再导出留给后续文档或接线 PR。
- `solver.domain` 可以复用、拆出或包裹 `solver.expr` 的内部 helper，但不得在 `domain.py` 中制造第三套长期平行的操作符语义。当前实现通过在 `solver.expr` 中抽出内部 helper 复用现有运算分派，避免在 `domain.py` 中制造第三套长期平行的操作符语义；测试覆盖 `z3_expr` 与 `expr_to_z3()` 值翻译一致性。
- 验证层现有 `_binary_z3_or_result()` / `_unary_z3_or_result()` / `_ufunc_z3_or_result()` 不在本 PR 迁移；PR-A5d 再把验证层包装改为消费 `solver.domain` 的纯数据结果。

---

## 条件表达式与偏函数语义

| 场景 | 冻结规则 | 验收重点 |
|---|---|---|
| Z3 偏函数 | 除零、取模除零、负数平方根等不作为翻译失败；翻译结果的 `z3_expr` 仍保留现有 Z3 值表达式，运行时有定义性以 `definedness_constraints` 单独返回 | `x / y` 返回 Z3 除法表达式，同时返回 `y != 0`；调用方决定是否把定义域约束作为硬约束 |
| 条件表达式默认行为 | 对条件本身先翻译并收集定义域；对可达分支翻译值表达式；分支定义域约束必须用 selector 包成 `Implies(selector, constraint)` 后返回 | `(y != 0) ? (x / y) : 0` 的分支定义域形态为 `Implies(y != 0, y != 0)` |
| 不可达分支裁剪 | 若 `assumptions + path_conditions + 条件定义域 + selector` 被证明 `unsat`，该分支不翻译、不返回失败、不返回定义域约束；若结果是 `sat` 或 `unknown`，按可达处理 | `true ? 1 : sin(x)` 不因未选中分支失败；符号条件下的 `sin(x)` 若可达则返回结构化失败 |
| `unknown` / 超时 | 分支可达性查询返回 `unknown` 时，不裁剪分支；在 `feasibility_checks` 记录 `unknown`，但不转成验证层失败 | 单测用 monkeypatch 或等价方式覆盖 `unknown` 不裁剪 |
| 四舍五入 | `round()` 沿用现有 `python_round_to_z3()` 值语义；定义域层不重新定义取整规则，只证明它不会新增运行时定义域约束且不会改变现有翻译 | `round(x)` 的 `definedness_constraints` 为空，`z3_expr` 与现有翻译保持一致 |

---

## 明确不做

| 不做项 | 原因 |
|---|---|
| 不改 `pyfcstm.verify.smt_local` 接线 | 验证层接线和重复包装清理属于 PR-A5d |
| 不扩展 `pyfcstm/solver/operation.py` | 路径敏感操作块执行属于 PR-A5c |
| 不接入 `inspect_model()` 或诊断适配层 | 诊断策略由后续诊断层 PR 统一处理 |
| 不修改 `codes.yaml` / `schema.json` / `editors/**` | 这些属于诊断层和编辑器范围，不属于求解器层定义域接口 |
| 不创建 `pyfcstm/verify/search.py` / `pyfcstm/verify/reachability.py` | 文件名继续留给第 3 组 / dev/verify 集成 |
| 不让 `solver.domain` 返回 `AlgorithmResult` | 求解器层只返回纯数据结果，验证层负责原始算法结果 |
| 不承载 FCSTM 生命周期或迁移顺序语义 | 根初始路径、首次周期、迁移触发和声明顺序属于 `pyfcstm.verify.encoding.*` |
| 不为了保留旧门面牺牲清晰架构 | 当前没有外部历史包袱；确认事实执行逻辑不回退时允许大胆重构，但本 PR 仍只做求解器层接口 |

---

## TDD 验收计划

| 用例 | 当前风险 | 预期结果 |
|---|---|---|
| 整数除零 | 裸 `expr_to_z3()` 可翻译表达式，但调用层拿不到运行时有定义性约束 | `x / y` 产生 `y != 0` 定义域约束；`1 / 0` 的定义域约束不可满足 |
| 取模除零 | 取模和除法的定义域约束遗漏 | `x % y` 产生 `y != 0` 定义域约束 |
| 平方根 | `sqrt(x)` 对负数输入的定义域约束遗漏 | `sqrt(x)` 产生 `x >= 0` 定义域约束；不支持函数走结构化失败或保守结果 |
| 四舍五入 | `round()` 被误改值语义 | `round()` 的 Z3 值翻译继续复用 `python_round_to_z3()`；定义域约束为空 |
| 条件表达式 | 未选中分支的未定义表达式污染选中分支，或可达分支定义域未加 selector | 不可达分支被裁剪；可达分支定义域以 `Implies(selector, constraint)` 返回 |
| 函数调用 | 所有函数调用都被当成安全，或所有函数调用都被当成不支持 | 已知函数按现有翻译语义补定义域；不支持函数给出结构化失败，不吞意外异常 |
| 不支持表达式 | 意外表达式抛出裸预期异常或产出确定性假约束 | 预期翻译失败返回 `TranslationFailure`；未列明的意外异常继续暴露 |
| 约束合并 | 合并语义不清导致下游按析取使用 | 合并结果保留全部约束；调用方按合取加入求解器 |
| 纯求解器边界 | `solver.domain` 反向导入验证层或诊断层 | 边界检查命令输出为空 |

必跑命令：

```bash
pytest test/solver/test_domain.py -q
pytest test/solver/ -q
pytest test/verify/test_smt_local.py -q
SKIP_SLOW_TESTS=1 make unittest
git diff --check
```

`test/verify/test_smt_local.py` 是回归 guard：PR-A5b 不改验证层，但不能让新求解器接口破坏 PR-A5a 已修复的初始值有定义性语义。

边界检查：

```bash
BASE=$(git merge-base HEAD origin/dev/issue114-pr-a-verify)
git diff --name-only "$BASE" | rg '^(pyfcstm/diagnostics/|codes\.yaml|schema\.json|editors/|pyfcstm/verify/(search|reachability)\.py|pyfcstm/model/|pyfcstm/dsl/)'
rg 'pyfcstm\.verify|pyfcstm\.diagnostics|pyfcstm\.verify\.registry|from pyfcstm import .*\b(verify|diagnostics)\b|from \.+(verify|diagnostics)\b|from \.+ import .*\b(verify|diagnostics)\b|import \.+(verify|diagnostics)\b|inspect_model|diagnostics\.inspect' pyfcstm/solver
rg 'from pyfcstm\.diagnostics|import pyfcstm\.diagnostics|codes\.yaml|schema\.json|editors/' pyfcstm/verify
rg 'solver\.safety|check_expr_safety' pyfcstm/verify
```

最后一条是 #114 / #142 的全程门禁，在 PR-A5b 中只作为回归 guard，避免原始验证默认接入 `solver.safety`。


---

## 当前实现与验证结果

| 项目 | 结果 |
|---|---|
| 实现提交 | `4a5f6047`：`PR-A5b 建立求解器定义域接口 [skip-slow]`；`a9eecfa2`：`PR-A5b 补强定义域接口覆盖率 [skip-slow]`；`4bd3d502`：`PR-A5b 修复定义域顺序传播 [skip-slow]` |
| 写入范围 | `pyfcstm/solver/domain.py`、`pyfcstm/solver/expr.py`、`test/solver/test_domain.py` |
| 本地单测 | `pytest test/solver/test_domain.py -q`：47 passed；`pytest test/solver/test_expr.py -q`：61 passed；`pytest test/solver/ -q`：229 passed；`pytest test/verify/test_smt_local.py -q`：226 passed |
| 本地全量快测 | `SKIP_SLOW_TESTS=1 make unittest`：9240 passed、164 skipped、63 deselected |
| 覆盖率 | `pyfcstm/solver/domain.py` 和 `pyfcstm/solver/expr.py` 当前本地 coverage 均为 100%；整体 coverage 为 95% |
| 边界检查 | `solver` 没有反向导入 `verify` / `diagnostics`；本 PR 没有改 `pyfcstm/verify`、诊断层、模型层、DSL 或编辑器 |
| 当前待办 | CI 33 项全绿；Codecov 已确认所有修改可覆盖行均覆盖；修复后二轮三路代码复审 C=0 / I=0，仅剩 M 级非阻塞建议；等待用户验收，不在本 PR 内合并 |

---

## 三路计划复审结论

| reviewer | 进度 | 首轮结论 | 已写回正文的处理 |
|---|---|---|---|
| `codex reviewer` | ✅ 已完成 | C=0 / I=2 / M=2 | 补充 caller assumptions / path conditions、分支裁剪、`unknown` 语义；恢复完整边界检查正则；说明 #142 作为本 PR 上游节点使用蓝色 |
| `claude reviewer` | ✅ 已完成 | C=0 / I=3 / M=2 | 补充 `ExprDomain` / `TranslationFailure` 字段草案；冻结 `expr_to_z3()` 公共签名；明确条件表达式 `Implies` 编码；说明 verify 回归测试动机 |
| `deepseek reviewer` | ✅ 已完成 | C=2 / I=3 / M=3 | 把接口冻结表从职责描述改成字段 / 签名 / 合并语义草案；明确 Z3 偏函数定义域以元数据返回；说明与 `expr_to_z3()` 和验证层重复逻辑的迁移关系 |

当前处理结论：三路 reviewer 均认为 PR #171 与 #142 / #127 的 A5b 大方向一致；首轮 C/I 级意见已写回本正文，二轮计划复审 C=0 / I=0，M 级可实现性意见已尽量在实现和测试中覆盖。

---

## 修复后二轮代码复审结论

| reviewer | 进度 | 结论 | PR 评论 | 处理结论 |
|---|---|---|---|---|
| `claude reviewer` | ✅ 已完成 | C=0 / I=0 / M=2 | [评论](https://github.com/HansBug/pyfcstm/pull/171#issuecomment-4659135488) | 无阻塞项；M 级建议不阻塞，后续 PR-A5c / PR-A5d 可继续参考 |
| `deepseek reviewer` | ✅ 已完成 | C=0 / I=0 / M=1 | [评论](https://github.com/HansBug/pyfcstm/pull/171#issuecomment-4659149643) | 无阻塞项；首轮 I-1 已用多组对抗用例确认修复 |
| `codex reviewer` | ✅ 已完成 | C=0 / I=0 / M=1 | [评论](https://github.com/HansBug/pyfcstm/pull/171#issuecomment-4659172599) | 无阻塞项；确认定义域顺序传播、边界约束、CodeCov 和 CI 均可验收 |

最终状态：CI 33 项全绿；Codecov 已确认所有修改可覆盖行均覆盖；三路修复后二轮代码复审均无 C/I 阻塞项。本 PR 已 ready，等待用户验收，不在本 PR 内合并。







