### PR TITLE
PR-A5c：扩展求解器层操作块路径敏感执行（#114）

### DIFF
--- a/pyfcstm/solver/operation.py
+++ b/pyfcstm/solver/operation.py
@@ -25,20 +25,114 @@ Example::
     >>> # new_state['y'] represents the Z3 expression: (5 + 1) * 2
 """
 
-from typing import List, Dict, Optional, Union
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import List, Dict, Mapping, Optional, Sequence, Tuple, Union
 
 import z3
 
 from .expr import expr_to_z3
+from .domain import (
+    DomainConstraint,
+    DomainSource,
+    TranslationFailure,
+    merge_definedness_constraints,
+    translate_expr_domain,
+)
+from .logical import is_sat
 from ..dsl.parse import parse_with_grammar_entry
 from ..dsl import node as dsl_nodes
 from ..model.expr import parse_expr_node_to_expr
 from ..model.model import IfBlock, IfBlockBranch, Operation, OperationStatement
 
 
+_Z3Expr = Union[z3.ArithRef, z3.BoolRef]
+_Z3Env = Dict[str, _Z3Expr]
+
+OperationSource = DomainSource
+
+
+@dataclass(frozen=True)
+class OperationFailure:
+    """Pure solver-layer operation execution failure."""
+
+    kind: str
+    reason: str
+    source: Optional[DomainSource] = None
+    translation_failure: Optional[TranslationFailure] = None
+
+
+@dataclass(frozen=True)
+class OperationStep:
+    """One successful assignment step in a domain-aware operation execution."""
+
+    source: Optional[DomainSource]
+    before: Mapping[str, _Z3Expr]
+    after: Mapping[str, _Z3Expr]
+    path_conditions: Tuple[z3.ExprRef, ...] = ()
+    definedness_constraints: Tuple[DomainConstraint, ...] = ()
+
+
+@dataclass(frozen=True)
+class OperationBranch:
+    """One source branch in a domain-aware operation execution."""
+
+    branch_id: Optional[str]
+    branch_kind: str
+    selector: z3.ExprRef
+    path_conditions: Tuple[z3.ExprRef, ...] = ()
+    status: str = "sat"
+    result_env: Optional[Mapping[str, _Z3Expr]] = None
+    definedness_constraints: Tuple[DomainConstraint, ...] = ()
+    failure: Optional[OperationFailure] = None
+
+    def __post_init__(self) -> None:
+        if self.branch_kind not in ("if", "elif", "else"):
+            raise ValueError(f"Unsupported operation branch kind: {self.branch_kind}")
+        if self.status not in ("sat", "unsat", "unknown"):
+            raise ValueError(f"Unsupported operation branch status: {self.status}")
+        if self.status == "unsat":
+            if self.result_env is not None:
+                raise ValueError(
+                    "Unreachable operation branches must not carry result_env."
+                )
+            if self.definedness_constraints:
+                raise ValueError(
+                    "Unreachable operation branches must not carry definedness constraints."
+                )
+            if self.failure is not None:
+                raise ValueError(
+                    "Unreachable operation branches must not carry failures."
+                )
+
+
+@dataclass(frozen=True)
+class OperationExecution:
+    """Domain-aware operation block execution result."""
+
+    env: Mapping[str, _Z3Expr]
+    visible_names: Tuple[str, ...]
+    expr_constraints: Tuple[z3.ExprRef, ...] = ()
+    definedness_constraints: Tuple[DomainConstraint, ...] = ()
+    steps: Tuple[OperationStep, ...] = ()
+    branches: Tuple[OperationBranch, ...] = ()
+    failure: Optional[OperationFailure] = None
+
+
+@dataclass
+class _ExecutionResult:
+    """Internal mutable execution carrier."""
+
+    env: _Z3Env
+    definedness_constraints: Tuple[DomainConstraint, ...]
+    steps: Tuple[OperationStep, ...]
+    branches: Tuple[OperationBranch, ...]
+    failure: Optional[OperationFailure]
+    next_step: int
+
+
 def parse_operations(
-    code: str,
-    allowed_vars: Optional[List[str]] = None
+    code: str, allowed_vars: Optional[List[str]] = None
 ) -> List[OperationStatement]:
     """
     Parse DSL operation code string into a list of operation statements.
@@ -85,8 +179,8 @@ def parse_operations(
                 )
 
     def _convert_statements(
-            statements: List[dsl_nodes.OperationalStatement],
-            available_names: Optional[set],
+        statements: List[dsl_nodes.OperationalStatement],
+        available_names: Optional[set],
     ) -> List[OperationStatement]:
         converted = []
         current_names = None if available_names is None else set(available_names)
@@ -113,7 +207,9 @@ def parse_operations(
                             _validate_expression_variables(condition, base_names)
 
                     branch_names = None if base_names is None else set(base_names)
-                    branch_statements = _convert_statements(branch.statements, branch_names)
+                    branch_statements = _convert_statements(
+                        branch.statements, branch_names
+                    )
                     branches.append(
                         IfBlockBranch(
                             condition=condition,
@@ -124,7 +220,9 @@ def parse_operations(
                 converted.append(IfBlock(branches=branches))
                 continue
 
-            raise TypeError(f'Unknown operational statement node type {type(statement)!r}.')
+            raise TypeError(
+                f"Unknown operational statement node type {type(statement)!r}."
+            )
 
         return converted
 
@@ -133,8 +231,8 @@ def parse_operations(
 
 
 def _execute_operation_statements_symbolically(
-        statements: List[OperationStatement],
-        exprs: Dict[str, Union[z3.ArithRef, z3.BoolRef]],
+    statements: List[OperationStatement],
+    exprs: Dict[str, Union[z3.ArithRef, z3.BoolRef]],
 ) -> Dict[str, Union[z3.ArithRef, z3.BoolRef]]:
     """
     Execute a sequence of operation statements symbolically.
@@ -150,18 +248,20 @@ def _execute_operation_statements_symbolically(
 
     for statement in statements:
         if isinstance(statement, Operation):
-            current_exprs[statement.var_name] = expr_to_z3(statement.expr, current_exprs)
+            current_exprs[statement.var_name] = expr_to_z3(
+                statement.expr, current_exprs
+            )
         elif isinstance(statement, IfBlock):
             current_exprs = _execute_if_block_symbolically(statement, current_exprs)
         else:
-            raise TypeError(f'Unknown operation statement type {type(statement)!r}.')
+            raise TypeError(f"Unknown operation statement type {type(statement)!r}.")
 
     return current_exprs
 
 
 def _execute_if_block_symbolically(
-        if_block: IfBlock,
-        exprs: Dict[str, Union[z3.ArithRef, z3.BoolRef]],
+    if_block: IfBlock,
+    exprs: Dict[str, Union[z3.ArithRef, z3.BoolRef]],
 ) -> Dict[str, Union[z3.ArithRef, z3.BoolRef]]:
     """
     Execute an ``if`` block symbolically with branch-local merge semantics.
@@ -183,12 +283,16 @@ def _execute_if_block_symbolically(
     branch_results = []
 
     for branch in if_block.branches:
-        branch_results.append((
-            expr_to_z3(branch.condition, base_exprs)
-            if branch.condition is not None
-            else None,
-            _execute_operation_statements_symbolically(branch.statements, base_exprs),
-        ))
+        branch_results.append(
+            (
+                expr_to_z3(branch.condition, base_exprs)
+                if branch.condition is not None
+                else None,
+                _execute_operation_statements_symbolically(
+                    branch.statements, base_exprs
+                ),
+            )
+        )
 
     merged_exprs = dict(base_exprs)
     for name in visible_names:
@@ -204,9 +308,513 @@ def _execute_if_block_symbolically(
     return merged_exprs
 
 
+def _as_operation_list(
+    operations: Union[OperationStatement, List[OperationStatement]],
+) -> List[OperationStatement]:
+    if isinstance(operations, OperationStatement):
+        return [operations]
+    return list(operations)
+
+
+def _constraint_exprs(items: Sequence[DomainConstraint]) -> Tuple[z3.ExprRef, ...]:
+    return tuple(item.constraint for item in items)
+
+
+def _true_expr() -> z3.BoolRef:
+    return z3.BoolVal(True)
+
+
+def _and_expr(items: Sequence[z3.ExprRef]) -> z3.ExprRef:
+    if not items:
+        return _true_expr()
+    if len(items) == 1:
+        return items[0]
+    return z3.And(*items)
+
+
+def _path_guard(
+    domains: Sequence[DomainConstraint],
+    path_conditions: Sequence[z3.ExprRef],
+) -> Tuple[DomainConstraint, ...]:
+    if not domains:
+        return ()
+    if not path_conditions:
+        return tuple(domains)
+    guard = _and_expr(tuple(path_conditions))
+    return tuple(
+        DomainConstraint(
+            z3.Implies(guard, item.constraint),
+            source=item.source,
+        )
+        for item in domains
+    )
+
+
+def _operation_failure_from_translation(
+    failure: TranslationFailure,
+) -> OperationFailure:
+    return OperationFailure(
+        kind=failure.kind,
+        reason=failure.reason,
+        source=failure.source,
+        translation_failure=failure,
+    )
+
+
+def _operation_failure(
+    kind: str,
+    reason: str,
+    source: Optional[DomainSource],
+) -> OperationFailure:
+    return OperationFailure(kind=kind, reason=reason, source=source)
+
+
+def _normalize_solver_status(status: str) -> str:
+    return status if status in ("sat", "unsat") else "unknown"
+
+
+def _translate_operation_expr(
+    expr,
+    env: _Z3Env,
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    definedness_constraints: Sequence[DomainConstraint],
+    source: Optional[DomainSource],
+    prune_unreachable: bool,
+    timeout_ms: Optional[int],
+):
+    return translate_expr_domain(
+        expr,
+        env,
+        assumptions=assumptions,
+        path_conditions=(
+            *path_conditions,
+            *_constraint_exprs(definedness_constraints),
+        ),
+        source=source,
+        prune_unreachable=prune_unreachable,
+        timeout_ms=timeout_ms,
+    )
+
+
+def _branch_status(
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    definedness_constraints: Sequence[DomainConstraint],
+    selector: z3.ExprRef,
+    prune_unreachable: bool,
+    timeout_ms: Optional[int],
+) -> str:
+    if not prune_unreachable:
+        return "sat"
+    result = is_sat(
+        (
+            *assumptions,
+            *path_conditions,
+            *_constraint_exprs(definedness_constraints),
+            selector,
+        ),
+        timeout_ms=timeout_ms,
+    )
+    return _normalize_solver_status(result.kind)
+
+
+def _execute_operation_statements_domain(
+    statements: Sequence[OperationStatement],
+    env: _Z3Env,
+    *,
+    visible_names: Tuple[str, ...],
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    definedness_constraints: Sequence[DomainConstraint],
+    source: Optional[DomainSource],
+    prune_unreachable: bool,
+    timeout_ms: Optional[int],
+    step_start: int,
+) -> _ExecutionResult:
+    current_env = dict(env)
+    current_domains: Tuple[DomainConstraint, ...] = tuple(definedness_constraints)
+    steps: List[OperationStep] = []
+    branches: List[OperationBranch] = []
+    step_index = step_start
+
+    for statement in statements:
+        if isinstance(statement, Operation):
+            before = dict(current_env)
+            step_source = (
+                DomainSource(
+                    label=source.label,
+                    step=step_index,
+                    snapshot=source.snapshot,
+                    prefix_id=source.prefix_id,
+                )
+                if source is not None
+                else DomainSource(step=step_index)
+            )
+            result = _translate_operation_expr(
+                statement.expr,
+                current_env,
+                assumptions=assumptions,
+                path_conditions=path_conditions,
+                definedness_constraints=current_domains,
+                source=step_source,
+                prune_unreachable=prune_unreachable,
+                timeout_ms=timeout_ms,
+            )
+            step_domains = _path_guard(
+                result.definedness_constraints,
+                path_conditions,
+            )
+            combined_domains = (*current_domains, *step_domains)
+            if result.failure is not None:
+                return _ExecutionResult(
+                    env=current_env,
+                    definedness_constraints=combined_domains,
+                    steps=tuple(steps),
+                    branches=tuple(branches),
+                    failure=_operation_failure_from_translation(result.failure),
+                    next_step=step_index,
+                )
+
+            current_env = dict(current_env)
+            current_env[statement.var_name] = result.z3_expr
+            step = OperationStep(
+                source=step_source,
+                before=before,
+                after=dict(current_env),
+                path_conditions=tuple(path_conditions),
+                definedness_constraints=step_domains,
+            )
+            steps.append(step)
+            current_domains = combined_domains
+            step_index += 1
+            continue
+
+        if isinstance(statement, IfBlock):
+            result = _execute_if_block_domain(
+                statement,
+                current_env,
+                visible_names=visible_names,
+                assumptions=assumptions,
+                path_conditions=path_conditions,
+                definedness_constraints=current_domains,
+                source=source,
+                prune_unreachable=prune_unreachable,
+                timeout_ms=timeout_ms,
+                step_start=step_index,
+            )
+            branches.extend(result.branches)
+            steps.extend(result.steps)
+            current_env = result.env
+            current_domains = result.definedness_constraints
+            step_index = result.next_step
+            if result.failure is not None:
+                return _ExecutionResult(
+                    env=current_env,
+                    definedness_constraints=current_domains,
+                    steps=tuple(steps),
+                    branches=tuple(branches),
+                    failure=result.failure,
+                    next_step=step_index,
+                )
+            continue
+
+        return _ExecutionResult(
+            env=current_env,
+            definedness_constraints=current_domains,
+            steps=tuple(steps),
+            branches=tuple(branches),
+            failure=_operation_failure(
+                "unsupported_statement",
+                f"Unknown operation statement type {type(statement).__name__}.",
+                source,
+            ),
+            next_step=step_index,
+        )
+
+    return _ExecutionResult(
+        env=current_env,
+        definedness_constraints=current_domains,
+        steps=tuple(steps),
+        branches=tuple(branches),
+        failure=None,
+        next_step=step_index,
+    )
+
+
+def _execute_if_block_domain(
+    if_block: IfBlock,
+    env: _Z3Env,
+    *,
+    visible_names: Tuple[str, ...],
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    definedness_constraints: Sequence[DomainConstraint],
+    source: Optional[DomainSource],
+    prune_unreachable: bool,
+    timeout_ms: Optional[int],
+    step_start: int,
+) -> _ExecutionResult:
+    base_env = dict(env)
+    merge_names = tuple(base_env.keys())
+    prefix_selectors: List[z3.ExprRef] = []
+    branch_results = []
+    branches: List[OperationBranch] = []
+    steps: List[OperationStep] = []
+    all_domains: List[DomainConstraint] = list(definedness_constraints)
+    step_index = step_start
+
+    for index, branch in enumerate(if_block.branches):
+        branch_kind = (
+            "if" if index == 0 else ("else" if branch.condition is None else "elif")
+        )
+        branch_id = str(index)
+        arrival_conditions = (*path_conditions, *prefix_selectors)
+        local_domains: List[DomainConstraint] = []
+
+        if branch.condition is None:
+            condition_expr = None
+            selector = _and_expr(tuple(prefix_selectors))
+        else:
+            if prefix_selectors:
+                arrival_status = _branch_status(
+                    assumptions=assumptions,
+                    path_conditions=path_conditions,
+                    definedness_constraints=tuple(all_domains),
+                    selector=_and_expr(tuple(prefix_selectors)),
+                    prune_unreachable=prune_unreachable,
+                    timeout_ms=timeout_ms,
+                )
+                if arrival_status == "unsat":
+                    branches.append(
+                        OperationBranch(
+                            branch_id=branch_id,
+                            branch_kind=branch_kind,
+                            selector=_and_expr(tuple(prefix_selectors)),
+                            path_conditions=arrival_conditions,
+                            status="unsat",
+                            result_env=None,
+                            definedness_constraints=(),
+                            failure=None,
+                        )
+                    )
+                    continue
+
+            condition_result = _translate_operation_expr(
+                branch.condition,
+                base_env,
+                assumptions=assumptions,
+                path_conditions=arrival_conditions,
+                definedness_constraints=all_domains,
+                source=source,
+                prune_unreachable=prune_unreachable,
+                timeout_ms=timeout_ms,
+            )
+            condition_domains = _path_guard(
+                condition_result.definedness_constraints,
+                arrival_conditions,
+            )
+            all_domains.extend(condition_domains)
+            local_domains.extend(condition_domains)
+            if condition_result.failure is not None:
+                return _ExecutionResult(
+                    env=base_env,
+                    definedness_constraints=tuple(all_domains),
+                    steps=tuple(steps),
+                    branches=tuple(branches),
+                    failure=_operation_failure_from_translation(
+                        condition_result.failure
+                    ),
+                    next_step=step_index,
+                )
+            if not z3.is_bool(condition_result.z3_expr):
+                return _ExecutionResult(
+                    env=base_env,
+                    definedness_constraints=tuple(all_domains),
+                    steps=tuple(steps),
+                    branches=tuple(branches),
+                    failure=_operation_failure(
+                        "non_bool_condition",
+                        "Operation if condition did not translate to a Boolean Z3 expression.",
+                        source,
+                    ),
+                    next_step=step_index,
+                )
+            condition_expr = condition_result.z3_expr
+            selector = (
+                condition_expr
+                if not prefix_selectors
+                else z3.And(*prefix_selectors, condition_expr)
+            )
+
+        status = _branch_status(
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            definedness_constraints=tuple(all_domains),
+            selector=selector,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+
+        if status == "unsat":
+            branches.append(
+                OperationBranch(
+                    branch_id=branch_id,
+                    branch_kind=branch_kind,
+                    selector=selector,
+                    path_conditions=(*path_conditions, selector),
+                    status=status,
+                    result_env=None,
+                    definedness_constraints=(),
+                    failure=None,
+                )
+            )
+        else:
+            branch_result = _execute_operation_statements_domain(
+                branch.statements,
+                base_env,
+                visible_names=visible_names,
+                assumptions=assumptions,
+                path_conditions=(*path_conditions, selector),
+                definedness_constraints=tuple(all_domains),
+                source=source,
+                prune_unreachable=prune_unreachable,
+                timeout_ms=timeout_ms,
+                step_start=step_index,
+            )
+            steps.extend(branch_result.steps)
+            nested_branches = branch_result.branches
+            branch_body_definedness = branch_result.definedness_constraints[
+                len(all_domains) :
+            ]
+            branch_definedness = (*local_domains, *branch_body_definedness)
+            result_env = {
+                name: branch_result.env[name]
+                for name in merge_names
+                if name in branch_result.env
+            }
+            branch_obj = OperationBranch(
+                branch_id=branch_id,
+                branch_kind=branch_kind,
+                selector=selector,
+                path_conditions=(*path_conditions, selector),
+                status=status,
+                result_env=result_env,
+                definedness_constraints=branch_definedness,
+                failure=branch_result.failure,
+            )
+            branches.append(branch_obj)
+            branches.extend(nested_branches)
+            all_domains.extend(branch_body_definedness)
+            branch_results.append((selector, result_env))
+            step_index = branch_result.next_step
+            if branch_result.failure is not None:
+                return _ExecutionResult(
+                    env=base_env,
+                    definedness_constraints=tuple(all_domains),
+                    steps=tuple(steps),
+                    branches=tuple(branches),
+                    failure=branch_result.failure,
+                    next_step=step_index,
+                )
+
+        if branch.condition is not None:
+            prefix_selectors.append(z3.Not(condition_expr))
+
+    merged_env = dict(base_env)
+    for name in merge_names:
+        merged_value = base_env[name]
+        for selector, result_env in reversed(branch_results):
+            merged_value = z3.If(selector, result_env[name], merged_value)
+        merged_env[name] = merged_value
+
+    return _ExecutionResult(
+        env=merged_env,
+        definedness_constraints=tuple(all_domains),
+        steps=tuple(steps),
+        branches=tuple(branches),
+        failure=None,
+        next_step=step_index,
+    )
+
+
+def execute_operations_domain(
+    operations: Union[OperationStatement, List[OperationStatement]],
+    var_exprs: Dict[str, _Z3Expr],
+    *,
+    assumptions: Sequence[z3.ExprRef] = (),
+    path_conditions: Sequence[z3.ExprRef] = (),
+    source: Optional[DomainSource] = None,
+    prune_unreachable: bool = True,
+    timeout_ms: Optional[int] = None,
+) -> OperationExecution:
+    """Execute operation statements with runtime-definedness metadata."""
+    operation_list = _as_operation_list(operations)
+    visible_names = tuple(var_exprs.keys())
+    result = _execute_operation_statements_domain(
+        operation_list,
+        dict(var_exprs),
+        visible_names=visible_names,
+        assumptions=tuple(assumptions),
+        path_conditions=tuple(path_conditions),
+        definedness_constraints=(),
+        source=source,
+        prune_unreachable=prune_unreachable,
+        timeout_ms=timeout_ms,
+        step_start=0,
+    )
+    env = {name: result.env[name] for name in visible_names}
+    return OperationExecution(
+        env=env,
+        visible_names=visible_names,
+        expr_constraints=(),
+        definedness_constraints=result.definedness_constraints,
+        steps=result.steps,
+        branches=result.branches,
+        failure=result.failure,
+    )
+
+
+def merge_operation_definedness(*items) -> Tuple[DomainConstraint, ...]:
+    """Flatten operation-domain and domain-constraint inputs in order."""
+    merged: List[DomainConstraint] = []
+    for item in items:
+        if isinstance(item, DomainConstraint):
+            merged.append(item)
+        elif isinstance(item, (OperationExecution, OperationStep, OperationBranch)):
+            merged.extend(item.definedness_constraints)
+        elif isinstance(item, Iterable) and not isinstance(item, (str, bytes)):
+            for sub_item in item:
+                if isinstance(
+                    sub_item,
+                    (
+                        DomainConstraint,
+                        OperationExecution,
+                        OperationStep,
+                        OperationBranch,
+                    ),
+                ):
+                    merged.extend(merge_operation_definedness(sub_item))
+                    continue
+                raise TypeError(
+                    "Unsupported operation definedness item: {type_name}".format(
+                        type_name=type(sub_item).__name__,
+                    )
+                )
+        else:
+            raise TypeError(
+                "Unsupported operation definedness item: {type_name}".format(
+                    type_name=type(item).__name__,
+                )
+            )
+    return merge_definedness_constraints(merged)
+
+
 def execute_operations(
     operations: Union[OperationStatement, List[OperationStatement]],
-    var_exprs: Dict[str, Union[z3.ArithRef, z3.BoolRef]]
+    var_exprs: Dict[str, Union[z3.ArithRef, z3.BoolRef]],
 ) -> Dict[str, Union[z3.ArithRef, z3.BoolRef]]:
     """
     Execute operation statements on a Z3 variable expression dictionary.
@@ -258,10 +866,23 @@ def execute_operations(
         >>> solver.check()
         sat
     """
-    if isinstance(operations, OperationStatement):
-        operations = [operations]
-
+    operation_list = _as_operation_list(operations)
     original_var_names = list(var_exprs.keys())
-    current_exprs = _execute_operation_statements_symbolically(operations, var_exprs)
+    current_exprs = _execute_operation_statements_symbolically(
+        operation_list, var_exprs
+    )
 
     return {name: current_exprs[name] for name in original_var_names}
+
+
+__all__ = [
+    "OperationBranch",
+    "OperationExecution",
+    "OperationFailure",
+    "OperationSource",
+    "OperationStep",
+    "execute_operations",
+    "execute_operations_domain",
+    "merge_operation_definedness",
+    "parse_operations",
+]

--- a/pyfcstm/solver/operation.py
+++ b/pyfcstm/solver/operation.py
@@ -465,6 +465,20 @@ def _branch_status(
     return _normalize_solver_status(result.kind)
 
 
+def _merge_branch_env(
+    base_env: _Z3Env,
+    merge_names: Sequence[str],
+    branch_results: Sequence[Tuple[z3.ExprRef, Mapping[str, _Z3Expr]]],
+) -> _Z3Env:
+    merged_env = dict(base_env)
+    for name in merge_names:
+        merged_value = base_env[name]
+        for selector, result_env in reversed(branch_results):
+            merged_value = z3.If(selector, result_env[name], merged_value)
+        merged_env[name] = merged_value
+    return merged_env
+
+
 def _execute_operation_statements_domain(
     statements: Sequence[OperationStatement],
     env: _Z3Env,
@@ -776,7 +790,7 @@ def _execute_if_block_domain(
             step_index = branch_result.next_step
             if branch_result.failure is not None:
                 return _ExecutionResult(
-                    env=base_env,
+                    env=_merge_branch_env(base_env, merge_names, branch_results),
                     definedness_constraints=tuple(all_domains),
                     steps=tuple(steps),
                     branches=tuple(branches),
@@ -787,12 +801,7 @@ def _execute_if_block_domain(
         if branch.condition is not None:
             prefix_selectors.append(z3.Not(condition_expr))
 
-    merged_env = dict(base_env)
-    for name in merge_names:
-        merged_value = base_env[name]
-        for selector, result_env in reversed(branch_results):
-            merged_value = z3.If(selector, result_env[name], merged_value)
-        merged_env[name] = merged_value
+    merged_env = _merge_branch_env(base_env, merge_names, branch_results)
 
     return _ExecutionResult(
         env=merged_env,

--- a/pyfcstm/solver/operation.py
+++ b/pyfcstm/solver/operation.py
@@ -373,6 +373,50 @@ def _normalize_solver_status(status: str) -> str:
     return status if status in ("sat", "unsat") else "unknown"
 
 
+def _execution_point_status(
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    path_conditions: Sequence[z3.ExprRef],
+    definedness_constraints: Sequence[DomainConstraint],
+    prune_unreachable: bool,
+    timeout_ms: Optional[int],
+) -> str:
+    if not prune_unreachable:
+        return "sat"
+    result = is_sat(
+        (
+            *assumptions,
+            *path_conditions,
+            *_constraint_exprs(definedness_constraints),
+        ),
+        timeout_ms=timeout_ms,
+    )
+    return _normalize_solver_status(result.kind)
+
+
+def _condition_expr_for_metadata(expr, env: _Z3Env) -> Optional[z3.ExprRef]:
+    try:
+        condition_expr = expr_to_z3(expr, env)
+    except NotImplementedError:
+        # NotImplementedError: expr_to_z3 raises this for supported expression
+        # nodes whose math function is intentionally unsupported by Z3.
+        return None
+    except ValueError:
+        # ValueError: expr_to_z3 raises this for unknown variables, unknown
+        # operators, and unsupported expression object types.
+        return None
+    except TypeError:
+        # TypeError: Python/Z3 operator overloads can reject malformed operand
+        # combinations before Z3 wraps the failure.
+        return None
+    except z3.Z3Exception:
+        # Z3Exception: Z3 rejects sort/operator-domain mismatches.
+        return None
+    if not z3.is_bool(condition_expr):
+        return None
+    return condition_expr
+
+
 def _translate_operation_expr(
     expr,
     env: _Z3Env,
@@ -441,6 +485,16 @@ def _execute_operation_statements_domain(
     step_index = step_start
 
     for statement in statements:
+        point_status = _execution_point_status(
+            assumptions=assumptions,
+            path_conditions=path_conditions,
+            definedness_constraints=current_domains,
+            prune_unreachable=prune_unreachable,
+            timeout_ms=timeout_ms,
+        )
+        if point_status == "unsat":
+            break
+
         if isinstance(statement, Operation):
             before = dict(current_env)
             step_source = (
@@ -588,18 +642,28 @@ def _execute_if_block_domain(
                     timeout_ms=timeout_ms,
                 )
                 if arrival_status == "unsat":
+                    condition_expr = _condition_expr_for_metadata(
+                        branch.condition, base_env
+                    )
+                    selector = (
+                        _and_expr((*prefix_selectors, condition_expr))
+                        if condition_expr is not None
+                        else _and_expr(tuple(prefix_selectors))
+                    )
                     branches.append(
                         OperationBranch(
                             branch_id=branch_id,
                             branch_kind=branch_kind,
-                            selector=_and_expr(tuple(prefix_selectors)),
-                            path_conditions=arrival_conditions,
+                            selector=selector,
+                            path_conditions=(*path_conditions, selector),
                             status="unsat",
                             result_env=None,
                             definedness_constraints=(),
                             failure=None,
                         )
                     )
+                    if condition_expr is not None:
+                        prefix_selectors.append(z3.Not(condition_expr))
                     continue
 
             condition_result = _translate_operation_expr(

--- a/pyfcstm/solver/operation.py
+++ b/pyfcstm/solver/operation.py
@@ -568,7 +568,7 @@ def _execute_if_block_domain(
 
     for index, branch in enumerate(if_block.branches):
         branch_kind = (
-            "if" if index == 0 else ("else" if branch.condition is None else "elif")
+            "else" if branch.condition is None else ("if" if index == 0 else "elif")
         )
         branch_id = str(index)
         arrival_conditions = (*path_conditions, *prefix_selectors)

--- a/pyfcstm/solver/operation.py
+++ b/pyfcstm/solver/operation.py
@@ -698,7 +698,7 @@ def _execute_if_block_domain(
             local_domains.extend(condition_domains)
             if condition_result.failure is not None:
                 return _ExecutionResult(
-                    env=base_env,
+                    env=_merge_branch_env(base_env, merge_names, branch_results),
                     definedness_constraints=tuple(all_domains),
                     steps=tuple(steps),
                     branches=tuple(branches),
@@ -709,7 +709,7 @@ def _execute_if_block_domain(
                 )
             if not z3.is_bool(condition_result.z3_expr):
                 return _ExecutionResult(
-                    env=base_env,
+                    env=_merge_branch_env(base_env, merge_names, branch_results),
                     definedness_constraints=tuple(all_domains),
                     steps=tuple(steps),
                     branches=tuple(branches),

--- a/test/solver/test_operation.py
+++ b/test/solver/test_operation.py
@@ -934,6 +934,37 @@ class TestExecuteOperationsDomain:
         assert execution.steps == ()
         assert_z3_expr_equal(execution.env["y"], y)
 
+    def test_branch_body_failure_preserves_partial_branch_env(self):
+        """A branch body failure returns the work environment at the failure point."""
+        x, y, z, w = z3.Ints("x y z w")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                y = 1;
+                z = missing;
+            } else {
+                y = 2;
+            }
+            w = 3;
+            """,
+            allowed_vars=None,
+        )
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y, "z": z, "w": w},
+            path_conditions=(x > 0,),
+        )
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "value_error"
+        assert len(execution.steps) == 1
+        assert len(execution.branches) == 1
+        assert execution.branches[0].failure is execution.failure
+        assert_z3_expr_equal(execution.branches[0].result_env["y"], z3.IntVal(1))
+        assert_constraints_reject((x > 0,), execution.env["y"] != 1)
+        assert_z3_expr_equal(execution.env["w"], w)
+
     def test_unreachable_elif_condition_is_not_translated(self):
         """An unreachable elif condition cannot leak unsupported functions."""
         x = z3.Int("x")

--- a/test/solver/test_operation.py
+++ b/test/solver/test_operation.py
@@ -6,8 +6,23 @@ import pytest
 import z3
 
 from pyfcstm.dsl import parse_with_grammar_entry
-from pyfcstm.solver.operation import parse_operations, execute_operations
-from pyfcstm.model import IfBlock, IfBlockBranch, Operation, parse_dsl_node_to_state_machine
+from pyfcstm.solver.operation import (
+    OperationBranch,
+    OperationFailure,
+    OperationSource,
+    execute_operations,
+    execute_operations_domain,
+    merge_operation_definedness,
+    parse_operations,
+)
+from pyfcstm.solver.domain import DomainConstraint, DomainSource
+from pyfcstm.model import (
+    IfBlock,
+    IfBlockBranch,
+    Operation,
+    OperationStatement,
+    parse_dsl_node_to_state_machine,
+)
 from pyfcstm.model.expr import Variable, Integer, BinaryOp
 from pyfcstm.dsl.error import GrammarParseError
 from pyfcstm.simulate import SimulationRuntime
@@ -31,13 +46,35 @@ def assert_z3_expr_equal(actual_expr, expected_expr):
     )
 
 
+def assert_z3_expr_equivalent(actual_expr, expected_expr):
+    solver = z3.Solver()
+    solver.add(actual_expr != expected_expr)
+    assert solver.check() == z3.unsat, (
+        f"Expected Z3 expr equivalent to {expected_expr}, got {actual_expr}"
+    )
+
+
+def assert_constraints_allow(constraints, *extra_constraints):
+    solver = z3.Solver()
+    solver.add(*constraints)
+    solver.add(*extra_constraints)
+    assert solver.check() == z3.sat
+
+
+def assert_constraints_reject(constraints, *extra_constraints):
+    solver = z3.Solver()
+    solver.add(*constraints)
+    solver.add(*extra_constraints)
+    assert solver.check() == z3.unsat
+
+
 def build_runtime_for_block(block_code: str, initial_values):
     define_lines = [
-        f"def int {name} = {value};"
-        for name, value in initial_values.items()
+        f"def int {name} = {value};" for name, value in initial_values.items()
     ]
     dsl_code = "\n".join(
-        define_lines + [
+        define_lines
+        + [
             "state Root {",
             "    state A {",
             "        during {",
@@ -48,7 +85,7 @@ def build_runtime_for_block(block_code: str, initial_values):
             "}",
         ]
     )
-    ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+    ast = parse_with_grammar_entry(dsl_code, "state_machine_dsl")
     sm = parse_dsl_node_to_state_machine(ast)
     return SimulationRuntime(sm)
 
@@ -104,23 +141,27 @@ class TestParseOperations:
 
     def test_restricted_mode_valid_variables(self):
         """Test restricted mode with valid variables."""
-        ops = parse_operations("x = x + 1; y = x * 2;", allowed_vars=['x', 'y'])
+        ops = parse_operations("x = x + 1; y = x * 2;", allowed_vars=["x", "y"])
         assert len(ops) == 2
 
     def test_restricted_mode_temporary_assignment_target(self):
         """Test restricted mode allows temporary assignment targets."""
-        ops = parse_operations("z = x + 1; y = z * 2;", allowed_vars=['x', 'y'])
-        assert [op.var_name for op in ops] == ['z', 'y']
+        ops = parse_operations("z = x + 1; y = z * 2;", allowed_vars=["x", "y"])
+        assert [op.var_name for op in ops] == ["z", "y"]
 
     def test_restricted_mode_invalid_expression_variable(self):
         """Test restricted mode with invalid variable in expression."""
-        with pytest.raises(ValueError, match="Variable 'z' is not in allowed variables"):
-            parse_operations("x = z + 1;", allowed_vars=['x', 'y'])
+        with pytest.raises(
+            ValueError, match="Variable 'z' is not in allowed variables"
+        ):
+            parse_operations("x = z + 1;", allowed_vars=["x", "y"])
 
     def test_restricted_mode_variable_used_before_assignment(self):
         """Test restricted mode rejects temporary variables used before assignment."""
-        with pytest.raises(ValueError, match="Variable 'z' is not in allowed variables"):
-            parse_operations("y = z + 1; z = x + 1;", allowed_vars=['x', 'y'])
+        with pytest.raises(
+            ValueError, match="Variable 'z' is not in allowed variables"
+        ):
+            parse_operations("y = z + 1; z = x + 1;", allowed_vars=["x", "y"])
 
     def test_parse_with_bitwise_operators(self):
         """Test parsing operations with bitwise operators."""
@@ -144,13 +185,16 @@ class TestParseOperations:
 
     def test_parse_if_statement(self):
         """Test parsing an operation-block if statement."""
-        statements = parse_operations("""
+        statements = parse_operations(
+            """
         if [x > 0] {
             y = x + 1;
         } else {
             y = x + 2;
         }
-        """, allowed_vars=['x', 'y'])
+        """,
+            allowed_vars=["x", "y"],
+        )
 
         assert len(statements) == 1
         assert isinstance(statements[0], IfBlock)
@@ -159,32 +203,45 @@ class TestParseOperations:
 
     def test_parse_if_condition_rejects_unknown_variable(self):
         """Test restricted mode rejects unknown variables in if conditions."""
-        with pytest.raises(ValueError, match="Variable 'missing' is not in allowed variables"):
-            parse_operations("""
+        with pytest.raises(
+            ValueError, match="Variable 'missing' is not in allowed variables"
+        ):
+            parse_operations(
+                """
             if [missing > 0] {
                 x = x + 1;
             }
-            """, allowed_vars=['x'])
+            """,
+                allowed_vars=["x"],
+            )
 
     def test_parse_branch_local_temp_does_not_escape(self):
         """Test restricted mode rejects branch-local temporaries after the if block."""
-        with pytest.raises(ValueError, match="Variable 'tmp' is not in allowed variables"):
-            parse_operations("""
+        with pytest.raises(
+            ValueError, match="Variable 'tmp' is not in allowed variables"
+        ):
+            parse_operations(
+                """
             if [x > 0] {
                 tmp = x + 1;
             }
             y = tmp;
-            """, allowed_vars=['x', 'y'])
+            """,
+                allowed_vars=["x", "y"],
+            )
 
     def test_parse_outer_temp_can_be_used_after_if(self):
         """Test restricted mode allows pre-if temporaries to be used after the if block."""
-        statements = parse_operations("""
+        statements = parse_operations(
+            """
         tmp = x + 1;
         if [x > 0] {
             tmp = tmp + 10;
         }
         y = tmp;
-        """, allowed_vars=['x', 'y'])
+        """,
+            allowed_vars=["x", "y"],
+        )
 
         assert len(statements) == 3
         assert isinstance(statements[1], IfBlock)
@@ -196,57 +253,60 @@ class TestExecuteOperations:
 
     def test_execute_single_operation(self):
         """Test executing a single operation."""
-        op = Operation(var_name='x', expr=Integer(10))
-        x = z3.Int('x')
-        var_exprs = {'x': x}
+        op = Operation(var_name="x", expr=Integer(10))
+        x = z3.Int("x")
+        var_exprs = {"x": x}
 
         new_exprs = execute_operations(op, var_exprs)
-        assert 'x' in new_exprs
+        assert "x" in new_exprs
         # Verify the result is 10
         solver = z3.Solver()
-        solver.add(new_exprs['x'] == 10)
+        solver.add(new_exprs["x"] == 10)
         assert solver.check() == z3.sat
 
     def test_execute_operation_list(self):
         """Test executing a list of operations."""
         ops = [
-            Operation(var_name='x', expr=Integer(5)),
-            Operation(var_name='y', expr=Integer(10))
+            Operation(var_name="x", expr=Integer(5)),
+            Operation(var_name="y", expr=Integer(10)),
         ]
-        x = z3.Int('x')
-        y = z3.Int('y')
-        var_exprs = {'x': x, 'y': y}
+        x = z3.Int("x")
+        y = z3.Int("y")
+        var_exprs = {"x": x, "y": y}
 
         new_exprs = execute_operations(ops, var_exprs)
-        assert 'x' in new_exprs
-        assert 'y' in new_exprs
+        assert "x" in new_exprs
+        assert "y" in new_exprs
 
     def test_execute_with_variable_reference(self):
         """Test executing operation that references a variable."""
         op = Operation(
-            var_name='x',
-            expr=BinaryOp(x=Variable('x'), op='+', y=Integer(1))
+            var_name="x", expr=BinaryOp(x=Variable("x"), op="+", y=Integer(1))
         )
-        x = z3.Int('x')
-        var_exprs = {'x': x}
+        x = z3.Int("x")
+        var_exprs = {"x": x}
 
         new_exprs = execute_operations(op, var_exprs)
 
         # Verify symbolically: new_exprs['x'] should be x + 1
         solver = z3.Solver()
         solver.add(x == 5)
-        solver.add(new_exprs['x'] == 6)
+        solver.add(new_exprs["x"] == 6)
         assert solver.check() == z3.sat
 
     def test_execute_sequential_operations(self):
         """Test executing operations that depend on each other."""
         ops = [
-            Operation(var_name='x', expr=BinaryOp(x=Variable('x'), op='+', y=Integer(2))),
-            Operation(var_name='y', expr=BinaryOp(x=Variable('y'), op='+', y=Variable('x')))
+            Operation(
+                var_name="x", expr=BinaryOp(x=Variable("x"), op="+", y=Integer(2))
+            ),
+            Operation(
+                var_name="y", expr=BinaryOp(x=Variable("y"), op="+", y=Variable("x"))
+            ),
         ]
-        x = z3.Int('x')
-        y = z3.Int('y')
-        var_exprs = {'x': x, 'y': y}
+        x = z3.Int("x")
+        y = z3.Int("y")
+        var_exprs = {"x": x, "y": y}
 
         new_exprs = execute_operations(ops, var_exprs)
 
@@ -254,65 +314,68 @@ class TestExecuteOperations:
         # y should be y + (x + 2)
         solver = z3.Solver()
         solver.add(x == 5, y == 10)
-        solver.add(new_exprs['x'] == 7)  # 5 + 2
-        solver.add(new_exprs['y'] == 17)  # 10 + 7
+        solver.add(new_exprs["x"] == 7)  # 5 + 2
+        solver.add(new_exprs["y"] == 17)  # 10 + 7
         assert solver.check() == z3.sat
 
     def test_execute_does_not_modify_original_state(self):
         """Test that execution does not modify the original state."""
-        op = Operation(var_name='x', expr=Integer(10))
-        x = z3.Int('x')
-        var_exprs = {'x': x}
+        op = Operation(var_name="x", expr=Integer(10))
+        x = z3.Int("x")
+        var_exprs = {"x": x}
 
-        original_x = var_exprs['x']
+        original_x = var_exprs["x"]
         new_exprs = execute_operations(op, var_exprs)
 
         # Original state should be unchanged
-        assert var_exprs['x'] is original_x
+        assert var_exprs["x"] is original_x
         # New state should be different
         assert new_exprs is not var_exprs
 
     def test_execute_with_multiple_variables(self):
         """Test executing operations with multiple variables."""
         ops = [
-            Operation(var_name='x', expr=Integer(10)),
-            Operation(var_name='y', expr=Integer(20)),
+            Operation(var_name="x", expr=Integer(10)),
+            Operation(var_name="y", expr=Integer(20)),
             Operation(
-                var_name='z',
-                expr=BinaryOp(x=Variable('x'), op='+', y=Variable('y'))
-            )
+                var_name="z", expr=BinaryOp(x=Variable("x"), op="+", y=Variable("y"))
+            ),
         ]
-        x = z3.Int('x')
-        y = z3.Int('y')
-        z = z3.Int('z')
-        var_exprs = {'x': x, 'y': y, 'z': z}
+        x = z3.Int("x")
+        y = z3.Int("y")
+        z = z3.Int("z")
+        var_exprs = {"x": x, "y": y, "z": z}
 
         new_exprs = execute_operations(ops, var_exprs)
 
         # z should be 10 + 20 = 30
         solver = z3.Solver()
-        solver.add(new_exprs['z'] == 30)
+        solver.add(new_exprs["z"] == 30)
         assert solver.check() == z3.sat
 
     def test_execute_with_temporary_variable(self):
         """Test executing operations with temporary variables that do not leak."""
         ops = [
-            Operation(var_name='tmp', expr=BinaryOp(x=Variable('x'), op='+', y=Variable('y'))),
-            Operation(var_name='x', expr=BinaryOp(x=Variable('tmp'), op='+', y=Integer(1))),
+            Operation(
+                var_name="tmp", expr=BinaryOp(x=Variable("x"), op="+", y=Variable("y"))
+            ),
+            Operation(
+                var_name="x", expr=BinaryOp(x=Variable("tmp"), op="+", y=Integer(1))
+            ),
         ]
-        x = z3.Int('x')
-        y = z3.Int('y')
-        var_exprs = {'x': x, 'y': y}
+        x = z3.Int("x")
+        y = z3.Int("y")
+        var_exprs = {"x": x, "y": y}
 
         new_exprs = execute_operations(ops, var_exprs)
 
-        assert set(new_exprs.keys()) == {'x', 'y'}
-        assert 'tmp' not in new_exprs
+        assert set(new_exprs.keys()) == {"x", "y"}
+        assert "tmp" not in new_exprs
 
         solver = z3.Solver()
         solver.add(x == 5, y == 10)
-        solver.add(new_exprs['x'] == 16)
-        solver.add(new_exprs['y'] == 10)
+        solver.add(new_exprs["x"] == 16)
+        solver.add(new_exprs["y"] == 10)
         assert solver.check() == z3.sat
 
     def test_execute_with_bitwise_operations(self):
@@ -321,23 +384,23 @@ class TestExecuteOperations:
         # This test verifies that the operation parsing works, but execution
         # with concrete Z3 values may have limitations
         ops = [
-            Operation(var_name='x', expr=Integer(0xFF)),
-            Operation(var_name='y', expr=Integer(0x0F))
+            Operation(var_name="x", expr=Integer(0xFF)),
+            Operation(var_name="y", expr=Integer(0x0F)),
         ]
-        x = z3.Int('x')
-        y = z3.Int('y')
-        var_exprs = {'x': x, 'y': y}
+        x = z3.Int("x")
+        y = z3.Int("y")
+        var_exprs = {"x": x, "y": y}
 
         new_exprs = execute_operations(ops, var_exprs)
 
         # x should be 255, y should be 15
         solver = z3.Solver()
-        solver.add(new_exprs['x'] == 255)
-        solver.add(new_exprs['y'] == 15)
+        solver.add(new_exprs["x"] == 255)
+        solver.add(new_exprs["y"] == 15)
         assert solver.check() == z3.sat
 
     @pytest.mark.parametrize(
-        ['code', 'var_names', 'expected_builder'],
+        ["code", "var_names", "expected_builder"],
         [
             (
                 """
@@ -345,10 +408,10 @@ class TestExecuteOperations:
                     y = x + 10;
                 }
                 """,
-                ['x', 'y'],
+                ["x", "y"],
                 lambda vars_: {
-                    'x': vars_['x'],
-                    'y': z3.If(vars_['x'] > 0, vars_['x'] + 10, vars_['y']),
+                    "x": vars_["x"],
+                    "y": z3.If(vars_["x"] > 0, vars_["x"] + 10, vars_["y"]),
                 },
             ),
             (
@@ -359,10 +422,10 @@ class TestExecuteOperations:
                     y = x + 20;
                 }
                 """,
-                ['x', 'y'],
+                ["x", "y"],
                 lambda vars_: {
-                    'x': vars_['x'],
-                    'y': z3.If(vars_['x'] > 0, vars_['x'] + 10, vars_['x'] + 20),
+                    "x": vars_["x"],
+                    "y": z3.If(vars_["x"] > 0, vars_["x"] + 10, vars_["x"] + 20),
                 },
             ),
             (
@@ -375,15 +438,17 @@ class TestExecuteOperations:
                     y = 30;
                 }
                 """,
-                ['x', 'y', 'mode'],
+                ["x", "y", "mode"],
                 lambda vars_: {
-                    'x': vars_['x'],
-                    'y': z3.If(
-                        z3.IntVal(0) == vars_['mode'],
+                    "x": vars_["x"],
+                    "y": z3.If(
+                        z3.IntVal(0) == vars_["mode"],
                         z3.IntVal(10),
-                        z3.If(z3.IntVal(1) == vars_['mode'], z3.IntVal(20), z3.IntVal(30)),
+                        z3.If(
+                            z3.IntVal(1) == vars_["mode"], z3.IntVal(20), z3.IntVal(30)
+                        ),
                     ),
-                    'mode': vars_['mode'],
+                    "mode": vars_["mode"],
                 },
             ),
             (
@@ -399,13 +464,17 @@ class TestExecuteOperations:
                     z = 999;
                 }
                 """,
-                ['x', 'y', 'z'],
+                ["x", "y", "z"],
                 lambda vars_: {
-                    'x': vars_['x'],
-                    'y': vars_['y'],
-                    'z': z3.If(
-                        vars_['x'] > 0,
-                        z3.If(vars_['y'] > 0, vars_['x'] + 1 + vars_['y'], vars_['x'] + 101),
+                    "x": vars_["x"],
+                    "y": vars_["y"],
+                    "z": z3.If(
+                        vars_["x"] > 0,
+                        z3.If(
+                            vars_["y"] > 0,
+                            vars_["x"] + 1 + vars_["y"],
+                            vars_["x"] + 101,
+                        ),
                         z3.IntVal(999),
                     ),
                 },
@@ -419,13 +488,13 @@ class TestExecuteOperations:
                     y = y + 100;
                 }
                 """,
-                ['x', 'y'],
+                ["x", "y"],
                 lambda vars_: {
-                    'x': z3.If(vars_['x'] > 0, vars_['x'] + 1, vars_['x']),
-                    'y': z3.If(vars_['x'] > 0, vars_['x'] + 11, vars_['y'] + 100),
+                    "x": z3.If(vars_["x"] > 0, vars_["x"] + 1, vars_["x"]),
+                    "y": z3.If(vars_["x"] > 0, vars_["x"] + 11, vars_["y"] + 100),
                 },
             ),
-        ]
+        ],
     )
     def test_execute_if_blocks_symbolically(self, code, var_names, expected_builder):
         statements = parse_operations(code, allowed_vars=var_names)
@@ -440,37 +509,456 @@ class TestExecuteOperations:
 
     def test_execute_branch_local_temp_does_not_leak(self):
         """Test branch-local temporary expressions do not appear in final output."""
-        statements = parse_operations("""
+        statements = parse_operations(
+            """
         if [x > 0] {
             tmp = x + y;
             x = tmp + 1;
         }
-        """, allowed_vars=['x', 'y'])
-        var_exprs = {'x': z3.Int('x'), 'y': z3.Int('y')}
+        """,
+            allowed_vars=["x", "y"],
+        )
+        var_exprs = {"x": z3.Int("x"), "y": z3.Int("y")}
 
         new_exprs = execute_operations(statements, var_exprs)
 
-        assert set(new_exprs.keys()) == {'x', 'y'}
-        assert 'tmp' not in new_exprs
-        assert_z3_expr_equal(new_exprs['x'], z3.If(var_exprs['x'] > 0, var_exprs['x'] + var_exprs['y'] + 1, var_exprs['x']))
-        assert_z3_expr_equal(new_exprs['y'], var_exprs['y'])
+        assert set(new_exprs.keys()) == {"x", "y"}
+        assert "tmp" not in new_exprs
+        assert_z3_expr_equal(
+            new_exprs["x"],
+            z3.If(
+                var_exprs["x"] > 0, var_exprs["x"] + var_exprs["y"] + 1, var_exprs["x"]
+            ),
+        )
+        assert_z3_expr_equal(new_exprs["y"], var_exprs["y"])
 
     def test_execute_outer_temp_participates_in_merge(self):
         """Test pre-if temporary expressions participate in branch merge."""
-        statements = parse_operations("""
+        statements = parse_operations(
+            """
         tmp = x + 1;
         if [x > 0] {
             tmp = tmp + 10;
         }
         y = tmp;
-        """, allowed_vars=['x', 'y'])
-        var_exprs = {'x': z3.Int('x'), 'y': z3.Int('y')}
+        """,
+            allowed_vars=["x", "y"],
+        )
+        var_exprs = {"x": z3.Int("x"), "y": z3.Int("y")}
 
         new_exprs = execute_operations(statements, var_exprs)
 
-        assert set(new_exprs.keys()) == {'x', 'y'}
-        assert_z3_expr_equal(new_exprs['x'], var_exprs['x'])
-        assert_z3_expr_equal(new_exprs['y'], z3.If(var_exprs['x'] > 0, var_exprs['x'] + 11, var_exprs['x'] + 1))
+        assert set(new_exprs.keys()) == {"x", "y"}
+        assert_z3_expr_equal(new_exprs["x"], var_exprs["x"])
+        assert_z3_expr_equal(
+            new_exprs["y"],
+            z3.If(var_exprs["x"] > 0, var_exprs["x"] + 11, var_exprs["x"] + 1),
+        )
+
+
+@pytest.mark.unittest
+class TestExecuteOperationsDomain:
+    """Test domain-aware operation execution."""
+
+    def test_operation_source_is_domain_source_alias(self):
+        """Operation source metadata reuses the expression-domain source type."""
+        assert OperationSource is DomainSource
+
+    def test_operation_branch_rejects_invalid_metadata(self):
+        """Branch metadata keeps unreachable records internally consistent."""
+        selector = z3.BoolVal(True)
+
+        with pytest.raises(ValueError, match="branch kind"):
+            OperationBranch(branch_id=None, branch_kind="case", selector=selector)
+        with pytest.raises(ValueError, match="branch status"):
+            OperationBranch(
+                branch_id=None,
+                branch_kind="if",
+                selector=selector,
+                status="maybe",
+            )
+        with pytest.raises(ValueError, match="result_env"):
+            OperationBranch(
+                branch_id=None,
+                branch_kind="if",
+                selector=selector,
+                status="unsat",
+                result_env={"x": z3.Int("x")},
+            )
+        with pytest.raises(ValueError, match="definedness constraints"):
+            OperationBranch(
+                branch_id=None,
+                branch_kind="if",
+                selector=selector,
+                status="unsat",
+                definedness_constraints=(DomainConstraint(selector),),
+            )
+        with pytest.raises(ValueError, match="failures"):
+            OperationBranch(
+                branch_id=None,
+                branch_kind="if",
+                selector=selector,
+                status="unsat",
+                failure=OperationFailure(kind="value_error", reason="bad branch"),
+            )
+
+    def test_sequential_definedness_prunes_later_unreachable_branch(self):
+        """Earlier domain constraints guide later conditional expression pruning."""
+        statements = parse_operations(
+            """
+            x = 1 / y;
+            z = (y == 0) ? sin(a) : x;
+            """,
+            allowed_vars=None,
+        )
+        var_exprs = {
+            "x": z3.Int("x"),
+            "y": z3.Int("y"),
+            "z": z3.Int("z"),
+            "a": z3.Real("a"),
+        }
+
+        execution = execute_operations_domain(statements, var_exprs)
+
+        assert execution.failure is None
+        assert execution.expr_constraints == ()
+        assert set(execution.env.keys()) == set(var_exprs.keys())
+        assert "tmp" not in execution.env
+        assert [str(item.constraint) for item in execution.definedness_constraints] == [
+            "y != 0"
+        ]
+        assert len(execution.steps) == 2
+        assert_z3_expr_equal(execution.env["z"], execution.env["x"])
+
+    def test_reachable_failure_stops_after_preserving_previous_definedness(self):
+        """The first reachable translation failure stops later statements."""
+        statements = parse_operations(
+            """
+            x = 1 / y;
+            z = missing;
+            w = 1;
+            """,
+            allowed_vars=None,
+        )
+        var_exprs = {
+            "x": z3.Int("x"),
+            "y": z3.Int("y"),
+            "z": z3.Int("z"),
+            "w": z3.Int("w"),
+        }
+
+        execution = execute_operations_domain(statements, var_exprs)
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "value_error"
+        assert execution.failure.translation_failure is not None
+        assert execution.failure.translation_failure.kind == "value_error"
+        assert "missing" in execution.failure.reason
+        assert [step.after for step in execution.steps][-1]["x"] is execution.env["x"]
+        assert len(execution.steps) == 1
+        assert [str(item.constraint) for item in execution.definedness_constraints] == [
+            "y != 0"
+        ]
+        assert_z3_expr_equal(execution.env["w"], var_exprs["w"])
+
+    def test_branch_condition_definedness_is_guarded_by_prior_selectors(self):
+        """An elif condition is evaluated only after earlier branches are skipped."""
+        x, y = z3.Ints("x y")
+        statements = parse_operations(
+            """
+            if [x == 0] {
+                y = 0;
+            } else if [1 / x > 0] {
+                y = 1;
+            } else {
+                y = 2;
+            }
+            """,
+            allowed_vars=["x", "y"],
+        )
+
+        execution = execute_operations_domain(statements, {"x": x, "y": y})
+
+        assert execution.failure is None
+        constraints = [item.constraint for item in execution.definedness_constraints]
+        assert_constraints_allow(constraints, x == 0, execution.env["y"] == 0)
+        assert any(
+            "Implies" in str(item.constraint)
+            for item in execution.definedness_constraints
+        )
+        assert any(
+            "Implies" in str(item.constraint)
+            for item in execution.branches[1].definedness_constraints
+        )
+
+        failing_statements = parse_operations(
+            """
+            if [x > 0] {
+                y = 1;
+            } else if [1 / x > 0] {
+                y = 2;
+            } else {
+                y = 3;
+            }
+            """,
+            allowed_vars=["x", "y"],
+        )
+        failing_execution = execute_operations_domain(
+            failing_statements, {"x": x, "y": y}
+        )
+        failing_constraints = [
+            item.constraint for item in failing_execution.definedness_constraints
+        ]
+
+        assert failing_execution.failure is None
+        assert_constraints_reject(failing_constraints, x == 0)
+
+    def test_nested_if_definedness_keeps_outer_path_prefix(self):
+        """Nested branch body domains are guarded by every active selector."""
+        flag, x, y, z = z3.Ints("flag x y z")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                if [flag > 0] {
+                    z = 1 / (x - y);
+                } else {
+                    z = 0;
+                }
+            } else {
+                z = 2;
+            }
+            """,
+            allowed_vars=["flag", "x", "y", "z"],
+        )
+
+        execution = execute_operations_domain(
+            statements,
+            {"flag": flag, "x": x, "y": y, "z": z},
+        )
+        constraints = [item.constraint for item in execution.definedness_constraints]
+
+        assert execution.failure is None
+        assert any(
+            str(step.path_conditions) == "(0 < x, 0 < flag)" for step in execution.steps
+        )
+        assert_constraints_allow(constraints, x <= 0, x == y)
+        assert_constraints_allow(constraints, x > 0, flag <= 0, x == y)
+        assert_constraints_reject(constraints, x > 0, flag > 0, x == y)
+
+    def test_unreachable_elif_condition_is_not_translated(self):
+        """An unreachable elif condition cannot leak unsupported functions."""
+        x = z3.Int("x")
+        y = z3.Int("y")
+        z = z3.Real("z")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                y = 1;
+            } else if [sin(z) > 0] {
+                y = 2;
+            } else {
+                y = 3;
+            }
+            """,
+            allowed_vars=["x", "y", "z"],
+        )
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y, "z": z},
+            path_conditions=(x > 0,),
+        )
+
+        assert execution.failure is None
+        assert [branch.status for branch in execution.branches] == [
+            "sat",
+            "unsat",
+            "unsat",
+        ]
+        assert execution.branches[1].definedness_constraints == ()
+        assert execution.branches[1].failure is None
+        assert_constraints_allow([], x > 0, execution.env["y"] == 1)
+
+    def test_unreachable_branch_is_recorded_without_execution_or_failure(self):
+        """Pruned branches stay auditable while their statements are not executed."""
+        x = z3.Int("x")
+        y = z3.Int("y")
+        z = z3.Real("z")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                y = 1;
+            } else {
+                y = sin(z);
+            }
+            """,
+            allowed_vars=["x", "y", "z"],
+        )
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y, "z": z},
+            path_conditions=(x > 0,),
+        )
+
+        assert execution.failure is None
+        assert len(execution.branches) == 2
+        assert [branch.branch_kind for branch in execution.branches] == ["if", "else"]
+        assert [branch.status for branch in execution.branches] == ["sat", "unsat"]
+        assert execution.branches[1].result_env is None
+        assert execution.branches[1].definedness_constraints == ()
+        assert execution.branches[1].failure is None
+        assert_constraints_allow(
+            [item.constraint for item in execution.definedness_constraints],
+            x > 0,
+            execution.env["y"] == 1,
+        )
+
+    def test_branch_result_env_uses_pre_if_merge_names_only(self):
+        """Branch-local temporaries are visible in steps but not branch result env."""
+        x, y = z3.Ints("x y")
+        statements = parse_operations(
+            """
+            tmp = x + 1;
+            if [x > 0] {
+                tmp = tmp + 1;
+                inner = tmp + 1;
+            } else {
+                tmp = tmp + 2;
+            }
+            y = tmp;
+            """,
+            allowed_vars=["x", "y"],
+        )
+
+        execution = execute_operations_domain(statements, {"x": x, "y": y})
+
+        assert execution.failure is None
+        assert set(execution.env.keys()) == {"x", "y"}
+        assert "tmp" not in execution.env
+        assert set(execution.branches[0].result_env.keys()) == {"x", "y", "tmp"}
+        assert "inner" not in execution.branches[0].result_env
+        assert any("inner" in step.after for step in execution.steps)
+        assert_z3_expr_equal(execution.env["y"], z3.If(x > 0, x + 2, x + 3))
+
+    def test_unknown_branch_feasibility_keeps_selector_in_merge(self, monkeypatch):
+        """Unknown branch feasibility does not prune value merging."""
+        from pyfcstm.solver import operation
+        from pyfcstm.solver.logical import SatResult
+
+        calls = []
+
+        def always_unknown(constraints, *, timeout_ms=None, get_model=False):
+            calls.append((tuple(constraints), timeout_ms, get_model))
+            return SatResult(kind="unknown")
+
+        monkeypatch.setattr(operation, "is_sat", always_unknown)
+        flag = z3.Int("flag")
+        y = z3.Int("y")
+        statements = parse_operations(
+            """
+            if [flag > 0] {
+                y = 1;
+            } else {
+                y = 0;
+            }
+            """,
+            allowed_vars=["flag", "y"],
+        )
+
+        execution = execute_operations_domain(
+            statements,
+            {"flag": flag, "y": y},
+            timeout_ms=17,
+        )
+
+        assert execution.failure is None
+        assert len(calls) == 2
+        assert {branch.status for branch in execution.branches} == {"unknown"}
+        assert_constraints_allow([], flag > 0, execution.env["y"] == 1)
+        assert_constraints_allow([], flag <= 0, execution.env["y"] == 0)
+
+    def test_non_bool_condition_is_operation_failure_kind(self):
+        """Operation-layer condition type failures use a stable kind."""
+        statement = IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=Integer(1),
+                    statements=[Operation(var_name="y", expr=Integer(1))],
+                ),
+            ]
+        )
+        y = z3.Int("y")
+
+        execution = execute_operations_domain(statement, {"y": y})
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "non_bool_condition"
+        assert execution.failure.translation_failure is None
+        assert execution.steps == ()
+
+    def test_unsupported_statement_is_operation_failure_kind(self):
+        """Unknown operation statements use the stable operation-layer kind."""
+        x = z3.Int("x")
+
+        execution = execute_operations_domain(OperationStatement(), {"x": x})
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "unsupported_statement"
+        assert execution.failure.translation_failure is None
+        assert execution.steps == ()
+        assert_z3_expr_equal(execution.env["x"], x)
+
+    def test_merge_operation_definedness_delegates_for_operation_objects(self):
+        """Operation-level merge accepts executions, steps, and branches."""
+        x, y = z3.Ints("x y")
+        statements = parse_operations(
+            """
+            if [x != 0] {
+                y = 1 / x;
+            } else {
+                y = 0;
+            }
+            """,
+            allowed_vars=["x", "y"],
+        )
+        execution = execute_operations_domain(statements, {"x": x, "y": y})
+
+        merged = merge_operation_definedness(
+            execution,
+            execution.steps[:1],
+            execution.branches[0],
+        )
+
+        assert len(merged) >= len(execution.definedness_constraints)
+        assert all(hasattr(item, "constraint") for item in merged)
+        with pytest.raises(TypeError, match="Unsupported operation definedness item"):
+            merge_operation_definedness(object())
+
+    def test_old_execute_operations_matches_domain_env(self):
+        """The legacy entry point keeps its return shape and value semantics."""
+        statements = parse_operations(
+            """
+            tmp = x + 1;
+            if [x > 0] {
+                tmp = tmp + 10;
+            } else {
+                tmp = tmp + 20;
+            }
+            y = tmp;
+            """,
+            allowed_vars=["x", "y"],
+        )
+        var_exprs = {"x": z3.Int("x"), "y": z3.Int("y")}
+
+        legacy = execute_operations(statements, var_exprs)
+        execution = execute_operations_domain(statements, var_exprs)
+
+        assert execution.failure is None
+        assert set(legacy.keys()) == set(var_exprs.keys())
+        assert set(execution.env.keys()) == set(var_exprs.keys())
+        for name in var_exprs.keys():
+            assert_z3_expr_equivalent(legacy[name], execution.env[name])
 
 
 @pytest.mark.unittest
@@ -480,19 +968,19 @@ class TestIntegration:
     def test_parse_and_execute(self):
         """Test parsing and executing operations together."""
         code = "x = x + 2; y = y + x;"
-        ops = parse_operations(code, allowed_vars=['x', 'y'])
+        ops = parse_operations(code, allowed_vars=["x", "y"])
 
-        x = z3.Int('x')
-        y = z3.Int('y')
-        var_exprs = {'x': x, 'y': y}
+        x = z3.Int("x")
+        y = z3.Int("y")
+        var_exprs = {"x": x, "y": y}
 
         new_exprs = execute_operations(ops, var_exprs)
 
         # x should be x + 2, y should be y + (x + 2)
         solver = z3.Solver()
         solver.add(x == 5, y == 10)
-        solver.add(new_exprs['x'] == 7)  # 5 + 2
-        solver.add(new_exprs['y'] == 17)  # 10 + 7
+        solver.add(new_exprs["x"] == 7)  # 5 + 2
+        solver.add(new_exprs["y"] == 17)  # 10 + 7
         assert solver.check() == z3.sat
 
     def test_parse_and_execute_complex(self):
@@ -501,22 +989,19 @@ class TestIntegration:
         counter = counter + 1;
         result = counter * 10;
         """
-        ops = parse_operations(code, allowed_vars=['counter', 'result'])
+        ops = parse_operations(code, allowed_vars=["counter", "result"])
 
-        counter = z3.Int('counter')
-        result = z3.Int('result')
-        var_exprs = {
-            'counter': counter,
-            'result': result
-        }
+        counter = z3.Int("counter")
+        result = z3.Int("result")
+        var_exprs = {"counter": counter, "result": result}
 
         new_exprs = execute_operations(ops, var_exprs)
 
         # counter should be counter + 1, result should be (counter + 1) * 10
         solver = z3.Solver()
         solver.add(counter == 0)
-        solver.add(new_exprs['counter'] == 1)  # 0 + 1
-        solver.add(new_exprs['result'] == 10)  # 1 * 10
+        solver.add(new_exprs["counter"] == 1)  # 0 + 1
+        solver.add(new_exprs["result"] == 10)  # 1 * 10
         assert solver.check() == z3.sat
 
     def test_parse_and_execute_with_temporary_variable(self):
@@ -525,25 +1010,25 @@ class TestIntegration:
         temp = x + y;
         y = temp * 2;
         """
-        ops = parse_operations(code, allowed_vars=['x', 'y'])
+        ops = parse_operations(code, allowed_vars=["x", "y"])
 
-        x = z3.Int('x')
-        y = z3.Int('y')
-        var_exprs = {'x': x, 'y': y}
+        x = z3.Int("x")
+        y = z3.Int("y")
+        var_exprs = {"x": x, "y": y}
 
         new_exprs = execute_operations(ops, var_exprs)
 
-        assert set(new_exprs.keys()) == {'x', 'y'}
-        assert 'temp' not in new_exprs
+        assert set(new_exprs.keys()) == {"x", "y"}
+        assert "temp" not in new_exprs
 
         solver = z3.Solver()
         solver.add(x == 3, y == 4)
-        solver.add(new_exprs['x'] == 3)
-        solver.add(new_exprs['y'] == 14)
+        solver.add(new_exprs["x"] == 3)
+        solver.add(new_exprs["y"] == 14)
         assert solver.check() == z3.sat
 
     @pytest.mark.parametrize(
-        ['block_code', 'initial_values'],
+        ["block_code", "initial_values"],
         [
             (
                 """
@@ -558,7 +1043,7 @@ class TestIntegration:
                 y = y + 100;
             }
                 """,
-                {'x': 5, 'y': 1, 'flag': 1},
+                {"x": 5, "y": 1, "flag": 1},
             ),
             (
                 """
@@ -573,7 +1058,7 @@ class TestIntegration:
                 y = y + 100;
             }
                 """,
-                {'x': 5, 'y': 1, 'flag': 0},
+                {"x": 5, "y": 1, "flag": 0},
             ),
             (
                 """
@@ -588,24 +1073,20 @@ class TestIntegration:
                 y = y + 100;
             }
                 """,
-                {'x': 0, 'y': 1, 'flag': 0},
+                {"x": 0, "y": 1, "flag": 0},
             ),
-        ]
+        ],
     )
     def test_solver_and_runtime_match_for_if_blocks(self, block_code, initial_values):
-        statements = parse_operations(block_code, allowed_vars=list(initial_values.keys()))
-        var_exprs = {
-            name: z3.Int(name)
-            for name in initial_values.keys()
-        }
+        statements = parse_operations(
+            block_code, allowed_vars=list(initial_values.keys())
+        )
+        var_exprs = {name: z3.Int(name) for name in initial_values.keys()}
         new_exprs = execute_operations(statements, var_exprs)
 
         runtime = build_runtime_for_block(block_code, initial_values)
         runtime.cycle()
 
-        expected_outputs = {
-            name: runtime.vars[name]
-            for name in initial_values.keys()
-        }
+        expected_outputs = {name: runtime.vars[name] for name in initial_values.keys()}
 
         assert_symbolic_outputs(var_exprs, new_exprs, initial_values, expected_outputs)

--- a/test/solver/test_operation.py
+++ b/test/solver/test_operation.py
@@ -178,6 +178,22 @@ class TestParseOperations:
         with pytest.raises(GrammarParseError):
             parse_operations("x = ;")
 
+    def test_parse_unknown_statement_node_raises(self, monkeypatch):
+        """Unexpected DSL operation nodes are rejected explicitly."""
+        from pyfcstm.solver import operation
+
+        class UnknownStatementNode:
+            pass
+
+        monkeypatch.setattr(
+            operation,
+            "parse_with_grammar_entry",
+            lambda code, entry: [UnknownStatementNode()],
+        )
+
+        with pytest.raises(TypeError, match="Unknown operational statement node type"):
+            operation.parse_operations("ignored")
+
     def test_parse_missing_semicolon(self):
         """Test parsing with missing semicolon."""
         with pytest.raises(GrammarParseError):
@@ -555,6 +571,13 @@ class TestExecuteOperations:
             z3.If(var_exprs["x"] > 0, var_exprs["x"] + 11, var_exprs["x"] + 1),
         )
 
+    def test_execute_unknown_statement_type_raises(self):
+        """The legacy executor still raises on unsupported statement objects."""
+        x = z3.Int("x")
+
+        with pytest.raises(TypeError, match="Unknown operation statement type"):
+            execute_operations(OperationStatement(), {"x": x})
+
 
 @pytest.mark.unittest
 class TestExecuteOperationsDomain:
@@ -601,6 +624,26 @@ class TestExecuteOperationsDomain:
                 status="unsat",
                 failure=OperationFailure(kind="value_error", reason="bad branch"),
             )
+
+    def test_else_only_branch_uses_true_selector(self):
+        """A degenerate else-only block uses a true branch selector."""
+        y = z3.Int("y")
+        statement = IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=None,
+                    statements=[Operation(var_name="y", expr=Integer(1))],
+                ),
+            ]
+        )
+
+        execution = execute_operations_domain(statement, {"y": y})
+
+        assert execution.failure is None
+        assert len(execution.branches) == 1
+        assert execution.branches[0].branch_kind == "else"
+        assert z3.is_true(z3.simplify(execution.branches[0].selector))
+        assert_z3_expr_equal(execution.env["y"], z3.IntVal(1))
 
     def test_sequential_definedness_prunes_later_unreachable_branch(self):
         """Earlier domain constraints guide later conditional expression pruning."""
@@ -713,6 +756,30 @@ class TestExecuteOperationsDomain:
         assert failing_execution.failure is None
         assert_constraints_reject(failing_constraints, x == 0)
 
+    def test_reachable_condition_translation_failure_stops_execution(self):
+        """A reachable condition translation failure stops before branch bodies."""
+        a = z3.Real("a")
+        y = z3.Int("y")
+        statements = parse_operations(
+            """
+            if [sin(a) > 0] {
+                y = 1;
+            } else {
+                y = 0;
+            }
+            """,
+            allowed_vars=["a", "y"],
+        )
+
+        execution = execute_operations_domain(statements, {"a": a, "y": y})
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "not_implemented"
+        assert execution.failure.translation_failure is not None
+        assert execution.branches == ()
+        assert execution.steps == ()
+        assert_z3_expr_equal(execution.env["y"], y)
+
     def test_nested_if_definedness_keeps_outer_path_prefix(self):
         """Nested branch body domains are guarded by every active selector."""
         flag, x, y, z = z3.Ints("flag x y z")
@@ -744,6 +811,35 @@ class TestExecuteOperationsDomain:
         assert_constraints_allow(constraints, x <= 0, x == y)
         assert_constraints_allow(constraints, x > 0, flag <= 0, x == y)
         assert_constraints_reject(constraints, x > 0, flag > 0, x == y)
+
+    def test_reachable_branch_body_failure_is_recorded_on_branch(self):
+        """A branch body failure is kept on the executed branch record."""
+        x = z3.Int("x")
+        y = z3.Int("y")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                y = missing;
+            } else {
+                y = 0;
+            }
+            """,
+            allowed_vars=None,
+        )
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y},
+            path_conditions=(x > 0,),
+        )
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "value_error"
+        assert len(execution.branches) == 1
+        assert execution.branches[0].branch_kind == "if"
+        assert execution.branches[0].failure is execution.failure
+        assert execution.steps == ()
+        assert_z3_expr_equal(execution.env["y"], y)
 
     def test_unreachable_elif_condition_is_not_translated(self):
         """An unreachable elif condition cannot leak unsupported functions."""
@@ -878,6 +974,32 @@ class TestExecuteOperationsDomain:
         assert_constraints_allow([], flag > 0, execution.env["y"] == 1)
         assert_constraints_allow([], flag <= 0, execution.env["y"] == 0)
 
+    def test_prune_unreachable_false_keeps_contradictory_branches(self):
+        """Disabling pruning keeps branches even under contradictory paths."""
+        x = z3.Int("x")
+        y = z3.Int("y")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                y = 1;
+            } else {
+                y = 0;
+            }
+            """,
+            allowed_vars=["x", "y"],
+        )
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y},
+            path_conditions=(x <= 0,),
+            prune_unreachable=False,
+        )
+
+        assert execution.failure is None
+        assert [branch.status for branch in execution.branches] == ["sat", "sat"]
+        assert_constraints_allow([], x <= 0, execution.env["y"] == 0)
+
     def test_non_bool_condition_is_operation_failure_kind(self):
         """Operation-layer condition type failures use a stable kind."""
         statement = IfBlock(
@@ -923,15 +1045,20 @@ class TestExecuteOperationsDomain:
             allowed_vars=["x", "y"],
         )
         execution = execute_operations_domain(statements, {"x": x, "y": y})
+        manual_constraint = DomainConstraint(z3.BoolVal(True))
 
         merged = merge_operation_definedness(
+            manual_constraint,
             execution,
             execution.steps[:1],
             execution.branches[0],
         )
 
         assert len(merged) >= len(execution.definedness_constraints)
+        assert manual_constraint in merged
         assert all(hasattr(item, "constraint") for item in merged)
+        with pytest.raises(TypeError, match="Unsupported operation definedness item"):
+            merge_operation_definedness([object()])
         with pytest.raises(TypeError, match="Unsupported operation definedness item"):
             merge_operation_definedness(object())
 

--- a/test/solver/test_operation.py
+++ b/test/solver/test_operation.py
@@ -673,6 +673,99 @@ class TestExecuteOperationsDomain:
         assert len(execution.steps) == 2
         assert_z3_expr_equal(execution.env["z"], execution.env["x"])
 
+    def test_dead_execution_point_skips_later_assignment_translation(self):
+        """A later assignment is skipped once prior domains make the path dead."""
+        statements = parse_operations(
+            """
+            x = 1 / y;
+            z = sin(a);
+            """,
+            allowed_vars=None,
+        )
+        x = z3.Int("x")
+        y = z3.Int("y")
+        z = z3.Int("z")
+        a = z3.Real("a")
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y, "z": z, "a": a},
+            path_conditions=(y == 0,),
+        )
+
+        assert execution.failure is None
+        assert len(execution.steps) == 1
+        assert execution.branches == ()
+        assert_z3_expr_equal(execution.env["z"], z)
+        assert_constraints_reject(
+            [item.constraint for item in execution.definedness_constraints],
+            y == 0,
+        )
+
+    def test_dead_execution_point_skips_later_if_condition_translation(self):
+        """A later if-block is skipped when the whole execution point is dead."""
+        statements = parse_operations(
+            """
+            x = 1 / y;
+            if [sin(a) > 0] {
+                z = 1;
+            } else {
+                z = 2;
+            }
+            """,
+            allowed_vars=None,
+        )
+        x = z3.Int("x")
+        y = z3.Int("y")
+        z = z3.Int("z")
+        a = z3.Real("a")
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y, "z": z, "a": a},
+            path_conditions=(y == 0,),
+        )
+
+        assert execution.failure is None
+        assert len(execution.steps) == 1
+        assert execution.branches == ()
+        assert_z3_expr_equal(execution.env["z"], z)
+        assert_constraints_reject(
+            [item.constraint for item in execution.definedness_constraints],
+            y == 0,
+        )
+
+    def test_dead_execution_point_unknown_status_does_not_skip(self, monkeypatch):
+        """Unknown reachability at a statement boundary must not prune execution."""
+        from pyfcstm.solver import operation
+        from pyfcstm.solver.logical import SatResult
+
+        def always_unknown(constraints, *, timeout_ms=None, get_model=False):
+            return SatResult(kind="unknown")
+
+        monkeypatch.setattr(operation, "is_sat", always_unknown)
+        statements = parse_operations(
+            """
+            x = 1 / y;
+            z = sin(a);
+            """,
+            allowed_vars=None,
+        )
+        x = z3.Int("x")
+        y = z3.Int("y")
+        z = z3.Int("z")
+        a = z3.Real("a")
+
+        execution = execute_operations_domain(
+            statements,
+            {"x": x, "y": y, "z": z, "a": a},
+            path_conditions=(y == 0,),
+        )
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "not_implemented"
+        assert len(execution.steps) == 1
+
     def test_reachable_failure_stops_after_preserving_previous_definedness(self):
         """The first reachable translation failure stops later statements."""
         statements = parse_operations(
@@ -875,6 +968,90 @@ class TestExecuteOperationsDomain:
         assert execution.branches[1].failure is None
         assert_constraints_allow([], x > 0, execution.env["y"] == 1)
 
+    def test_arrival_unsat_elif_selector_keeps_current_condition_metadata(self):
+        """An arrival-unsat elif still records its full effective selector."""
+        x, y = z3.Ints("x y")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                y = 1;
+            } else if [x <= 0] {
+                y = 2;
+            } else if [x == 5] {
+                y = 3;
+            }
+            """,
+            allowed_vars=["x", "y"],
+        )
+
+        execution = execute_operations_domain(statements, {"x": x, "y": y})
+
+        assert execution.failure is None
+        assert [branch.status for branch in execution.branches] == [
+            "sat",
+            "sat",
+            "unsat",
+        ]
+        assert_z3_expr_equivalent(
+            execution.branches[2].selector,
+            z3.And(z3.Not(x > 0), z3.Not(x <= 0), x == 5),
+        )
+        assert execution.branches[2].result_env is None
+
+    @pytest.mark.parametrize(
+        ["failure_factory", "metadata_expr"],
+        [
+            (lambda: ValueError("metadata value failure"), None),
+            (lambda: TypeError("metadata type failure"), None),
+            (lambda: z3.Z3Exception("metadata z3 failure"), None),
+            (None, z3.IntVal(1)),
+        ],
+    )
+    def test_arrival_unsat_elif_metadata_failure_falls_back_to_arrival_selector(
+        self, monkeypatch, failure_factory, metadata_expr
+    ):
+        """Metadata-only condition translation failures do not leak from dead elif."""
+        from pyfcstm.solver import operation
+
+        x, y = z3.Ints("x y")
+        dead_condition = Integer(1)
+        statement = IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=BinaryOp(Variable("x"), ">", Integer(0)),
+                    statements=[Operation(var_name="y", expr=Integer(1))],
+                ),
+                IfBlockBranch(
+                    condition=BinaryOp(Variable("x"), "<=", Integer(0)),
+                    statements=[Operation(var_name="y", expr=Integer(2))],
+                ),
+                IfBlockBranch(
+                    condition=dead_condition,
+                    statements=[Operation(var_name="y", expr=Integer(3))],
+                ),
+            ]
+        )
+        original_expr_to_z3 = operation.expr_to_z3
+
+        def patched_expr_to_z3(expr, env):
+            if expr is dead_condition:
+                if failure_factory is not None:
+                    raise failure_factory()
+                return metadata_expr
+            return original_expr_to_z3(expr, env)
+
+        monkeypatch.setattr(operation, "expr_to_z3", patched_expr_to_z3)
+
+        execution = execute_operations_domain(statement, {"x": x, "y": y})
+
+        assert execution.failure is None
+        assert execution.branches[2].status == "unsat"
+        assert_z3_expr_equivalent(
+            execution.branches[2].selector,
+            z3.And(z3.Not(x > 0), z3.Not(x <= 0)),
+        )
+        assert execution.branches[2].result_env is None
+
     def test_unreachable_branch_is_recorded_without_execution_or_failure(self):
         """Pruned branches stay auditable while their statements are not executed."""
         x = z3.Int("x")
@@ -969,7 +1146,10 @@ class TestExecuteOperationsDomain:
         )
 
         assert execution.failure is None
-        assert len(calls) == 2
+        assert calls
+        assert all(
+            timeout_ms == 17 and not get_model for _, timeout_ms, get_model in calls
+        )
         assert {branch.status for branch in execution.branches} == {"unknown"}
         assert_constraints_allow([], flag > 0, execution.env["y"] == 1)
         assert_constraints_allow([], flag <= 0, execution.env["y"] == 0)

--- a/test/solver/test_operation.py
+++ b/test/solver/test_operation.py
@@ -873,6 +873,40 @@ class TestExecuteOperationsDomain:
         assert execution.steps == ()
         assert_z3_expr_equal(execution.env["y"], y)
 
+    def test_elif_condition_failure_preserves_prior_branch_env(self):
+        """A failing elif condition keeps earlier successful branch environments."""
+        x = z3.Int("x")
+        a = z3.Real("a")
+        y = z3.Int("y")
+        w = z3.Int("w")
+        statements = parse_operations(
+            """
+            if [x > 0] {
+                y = 1;
+            } else if [sin(a) > 0] {
+                y = 2;
+            } else {
+                y = 3;
+            }
+            w = 4;
+            """,
+            allowed_vars=None,
+        )
+
+        execution = execute_operations_domain(
+            statements, {"x": x, "a": a, "y": y, "w": w}
+        )
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "not_implemented"
+        assert len(execution.steps) == 1
+        assert len(execution.branches) == 1
+        assert execution.branches[0].failure is None
+        assert_z3_expr_equal(execution.branches[0].result_env["y"], z3.IntVal(1))
+        assert_constraints_reject((x > 0,), execution.env["y"] != 1)
+        assert_constraints_reject((x <= 0,), execution.env["y"] != y)
+        assert_z3_expr_equal(execution.env["w"], w)
+
     def test_nested_if_definedness_keeps_outer_path_prefix(self):
         """Nested branch body domains are guarded by every active selector."""
         flag, x, y, z = z3.Ints("flag x y z")
@@ -1229,6 +1263,41 @@ class TestExecuteOperationsDomain:
         assert execution.failure.kind == "non_bool_condition"
         assert execution.failure.translation_failure is None
         assert execution.steps == ()
+
+    def test_elif_non_bool_condition_preserves_prior_branch_env(self):
+        """A non-Boolean elif condition keeps earlier successful branch envs."""
+        statement = IfBlock(
+            branches=[
+                IfBlockBranch(
+                    condition=BinaryOp(Variable("x"), ">", Integer(0)),
+                    statements=[Operation(var_name="y", expr=Integer(1))],
+                ),
+                IfBlockBranch(
+                    condition=Variable("x"),
+                    statements=[Operation(var_name="y", expr=Integer(2))],
+                ),
+                IfBlockBranch(
+                    condition=None,
+                    statements=[Operation(var_name="y", expr=Integer(3))],
+                ),
+            ]
+        )
+        x = z3.Int("x")
+        y = z3.Int("y")
+        w = z3.Int("w")
+
+        execution = execute_operations_domain(statement, {"x": x, "y": y, "w": w})
+
+        assert execution.failure is not None
+        assert execution.failure.kind == "non_bool_condition"
+        assert execution.failure.translation_failure is None
+        assert len(execution.steps) == 1
+        assert len(execution.branches) == 1
+        assert execution.branches[0].failure is None
+        assert_z3_expr_equal(execution.branches[0].result_env["y"], z3.IntVal(1))
+        assert_constraints_reject((x > 0,), execution.env["y"] != 1)
+        assert_constraints_reject((x <= 0,), execution.env["y"] != y)
+        assert_z3_expr_equal(execution.env["w"], w)
 
     def test_unsupported_statement_is_operation_failure_kind(self):
         """Unknown operation statements use the stable operation-layer kind."""


### PR DESCRIPTION
## PR-A5c 定位

本 PR 是第 3 层议题 [#114](https://github.com/HansBug/pyfcstm/issues/114) 下 PR-A5 总控计划 [#142](https://github.com/HansBug/pyfcstm/pull/142) 的第三个实现子 PR，归属 PR-A 总伞 [#127](https://github.com/HansBug/pyfcstm/pull/127)。

- 基准分支：`dev/issue114-pr-a-verify`
- 来源分支：`dev/issue114-pr-a5c-operation-domain`
- 当前进度：✅ ready，等待用户验收，不 merge
- 上游依赖：PR-A5a [#169](https://github.com/HansBug/pyfcstm/pull/169) 已合入 #127，merge commit `82308d78165eb4a8b0dc2547e22cfaf3c7b31051`；PR-A5b [#171](https://github.com/HansBug/pyfcstm/pull/171) 已合入 #127，merge commit `5b3e546c4d4faff091ade67ba3b36172630ed285`
- 本 PR 目标：扩展 `pyfcstm/solver/operation.py`，提供带路径条件、前后快照和定义域约束的操作块符号执行结果，供后续 PR-A5d 验证层重接线消费

本 PR 不接线验证层、不返回 `AlgorithmResult`、不理解状态机生命周期或迁移声明顺序。`pyfcstm.solver.operation` 只能产出纯求解器层数据；验证层如何解释失败、如何生成原始算法结果，留给 PR-A5d。

---

## 子项表

| 子项 | 进度 | 目标 | 依赖项目 | 依赖关系 | 合入条件 | 写入范围 | 禁止范围 | 验收重点 |
|---|---|---|---|---|---|---|---|---|
| PR-A5c | ✅ ready，等待用户验收 | 扩展 `solver.operation`：带路径条件的操作块符号执行 | PR-A4 [#132] 已合入结果；PR-A5b [#171] 已合入结果；现有 `pyfcstm/solver/operation.py`；现有 `pyfcstm/solver/domain.py`；现有 `test/solver/test_operation.py` | 依赖 PR-A5b 已合入的定义域接口；PR-A5d 对本 PR 是硬依赖；本 PR 不依赖 PR-A5d | 三路计划复审 C/I 写回正文；TDD 用例先红后绿；CI 全绿；Codecov 修改行覆盖达标；三路代码复审 C=0 / I=0；操作执行接口冻结表与实际实现一致 | `pyfcstm/solver/operation.py`、`test/solver/test_operation.py`；必要时小改 `pyfcstm/solver/domain.py` 的纯数据 helper，但不得改变 PR-A5b 已冻结公共语义 | 不改 `pyfcstm/verify/**`；不改 `test/verify/**`；不导入验证层、诊断层、注册表或检查策略；不承载根初始路径、状态机生命周期、迁移触发、声明顺序；不返回验证算法证据字段；不改模型层、DSL、编辑器、`codes.yaml`、`schema.json` | 覆盖顺序赋值、临时变量、`if` / `else if` / `else` 累积路径条件、不可达分支裁剪、条件表达式选中分支语义、嵌套路径前缀条件、前后变量快照、表达式定义域约束和失败传播 |

---

## 依赖图

图中颜色按本 PR 视角维护：#127 / #142 是上游节点，所以用蓝色；已合入子 PR 用绿色；未完成子 PR 用黄色。

```mermaid
flowchart TD
    PRA["PR-A 总伞 #127<br/>上游总伞，承载 PR-A1 到 PR-A5 的合入判断<br/>🟦 上游打开中"]
    PRA5["PR-A5 #142<br/>上游总控迁移计划，拆分 PR-A5a 到 PR-A5d<br/>🟦 上游计划"]
    PRA5a["PR-A5a #169<br/>已修复初始值表达式运行时有定义性问题<br/>✅ 已合入"]
    PRA5b["PR-A5b #171<br/>已建立求解器层表达式定义域接口<br/>✅ 已合入"]
    PRA5c["PR-A5c<br/>扩展求解器层操作块路径敏感执行<br/>✅ ready，等待用户验收"]
    PRA5d["PR-A5d<br/>验证层接线、清理和内部拆分<br/>🟨 待启动"]

    PRA --> PRA5
    PRA5 --> PRA5a
    PRA5a --> PRA5b
    PRA5b --> PRA5c
    PRA5a --> PRA5d
    PRA5b --> PRA5d
    PRA5c --> PRA5d

    classDef u fill:#dbeafe,stroke:#2563eb,color:#111827
    classDef g fill:#dcfce7,stroke:#16a34a,color:#111827
    classDef y fill:#fef3c7,stroke:#d97706,color:#111827
    class PRA,PRA5 u
    class PRA5a,PRA5b,PRA5c g
    class PRA5d y
```

后续维护规则：表格必须保留“进度”和“依赖关系”列；依赖图节点必须包含一句话说明和同款进度行；颜色按上游蓝色、已完成绿色、未完成黄色维护。

---

## 首轮计划复审处理表

| reviewer | 首轮结论 | 处理状态 | 写回正文的处理 |
|---|---|---|---|
| `claude reviewer` | C=0 / I=6 / M=4 | ✅ 已写回 | 明确 `OperationSource` 与 `DomainSource` 关系、`OperationFailure` 与 `TranslationFailure` 关系、分支状态维度、临时变量两层作用域、`expr_constraints` 当前恒空、merge helper 与 PR-A5b helper 的关系 |
| `codex reviewer` | C=0 / I=2 / M=2 | ✅ 已写回 | 明确 `else` 分支也有有效 selector 和三态可达性；明确全局定义域约束必须已受路径保护，可直接作为硬约束加入 solver |
| `deepseek reviewer` | C=2 / I=5 / M=3 | ✅ 已写回 | 明确来源映射、定义域约束包装时机、旧 `execute_operations()` 兼容策略、失败后停止执行、嵌套 if TDD、`unknown` 合并语义、路径前缀定义和 `test/verify/**` 禁止范围 |

当前处理规则：三轮计划复审若仍有 C/I，继续先修正文，不进入 TDD；M 级不阻塞，但可低成本修正。

---

## 二轮计划复审处理表

| reviewer | 二轮结论 | 处理状态 | 写回正文的处理 |
|---|---|---|---|
| `codex reviewer` | C=0 / I=2 / M=2 | ✅ 已写回 | 明确 `else if` 条件表达式自身定义域按到达该条件的前序 selector 保护；明确 `unsat` 分支保留记录且 `result_env=None` |
| `deepseek reviewer` | C=0 / I=3 / M=2 | ✅ 已写回 | 明确 `result_env` key 集合只等于进入分支前的合并域；明确不可达分支仍出现在 `branches`；明确非表达式失败 `kind` 最小集合；明确 `OperationSource` 仅为 `DomainSource` 别名；补充路径前缀正式定义 |
| `claude reviewer` | C=0 / I=0 / M=3 | ✅ 已复核 | 保留其已确认通过的首轮 C/I 消化结论；顺手吸收来源类型措辞、嵌套 if 扁平表达等 M 级细化 |

当前处理规则：三轮计划复审 C/I 已清零，进入 TDD 实现；实现阶段若发现接口冻结表与代码冲突，先同步正文再继续。


---

## 三轮计划复审处理表

| reviewer | 三轮结论 | 处理状态 | 评论链接 | 处理结论 |
|---|---|---|---|---|
| `claude reviewer` | C=0 / I=0 / M=3 | ✅ 已通过 | [comment](https://github.com/HansBug/pyfcstm/pull/172#issuecomment-4659634208) | 可进入 TDD；M 级仅为字段语义边界，不阻塞 |
| `deepseek reviewer` | C=0 / I=0 / M=2 | ✅ 已通过 | [comment](https://github.com/HansBug/pyfcstm/pull/172#issuecomment-4659642582) | 可进入 TDD；七项强对抗检查均与 PR-A5b 白盒字段对齐 |
| `codex reviewer` | C=0 / I=0 / M=2 | ✅ 已通过 | [comment](https://github.com/HansBug/pyfcstm/pull/172#issuecomment-4659644784) | 可进入 TDD；上游一致性、接口冻结表和验收计划均可执行 |

当前处理规则：三轮计划复审 C/I=0；head `7c836613` 的 CI 与 Codecov 已通过，最终三路代码复审 C/I=0。M 级不阻塞，保持不 merge，等待用户验收。

---

## 操作执行接口冻结草案

本表已按当前实现同步；后续代码复审如需调整，必须同步本表和测试验收。

| 接口项 | 进度 | 冻结草案 | 依赖项目 | 依赖关系 | 验收方式 |
|---|---|---|---|---|---|
| 求解器层来源类型 | ✅ 已实现 | 本 PR 不新增同构来源 dataclass；操作来源直接使用 PR-A5b 的 `DomainSource`。若实现为了阅读保留 `OperationSource` 名称，只能写成 `OperationSource = DomainSource` 别名。`DomainSource` 字段固定为 `label: Optional[str]`、`step: Optional[int]`、`snapshot: Optional[str]`、`prefix_id: Optional[str]`；`label` 只是人读标识，不参与自动化判断。分支身份不塞进来源类型，单独放在 `OperationBranch.branch_id` | PR-A5b `DomainSource` | 传给 `translate_expr_domain(source=...)` 时无需猜测映射；字段固定同名一对一：`label`、`step`、`snapshot`、`prefix_id`；不得维护 `path_id` / `branch_id` 到来源字段的隐式映射 | 单测断言来源字段可传入、可保留、不会导入验证层；不得新增与 `DomainSource` 冲突的同构来源类型 |
| `OperationFailure` | ✅ 已实现 | 纯操作执行失败：`kind: str`、`reason: str`、`source: Optional[DomainSource]`、`translation_failure: Optional[TranslationFailure]`。表达式翻译失败由 `TranslationFailure` 一对一升级，`kind` / `reason` 沿用 PR-A5b 的 `not_implemented` / `value_error` / `type_error` / `z3_error`，不新增 `unknown_variable` 等平行分类；操作层非表达式失败最小集合固定为 `unsupported_statement`（未知操作语句类型）和 `non_bool_condition`（`if` / `elif` 条件翻译成功但不是布尔 Z3 表达式）。后续若要扩展新的操作层 `kind`，必须先写入冻结表和测试 | PR-A5b `TranslationFailure`；现有 `expr_to_z3()` 已知失败类型 | 被 `OperationExecution.failure` 和 `OperationBranch.failure` 持有；验证层在 PR-A5d 再转成原始算法结果；表达式失败看 `translation_failure`，操作层失败看固定 `kind` | 单测覆盖未知变量、不支持函数、非布尔条件、未知语句类型；表达式失败保留原 `TranslationFailure.kind`；操作层失败 `kind` 必须落在冻结集合内；未列明异常继续暴露 |
| `OperationStep` | ✅ 已实现 | 单个成功赋值步骤记录：`source: Optional[DomainSource]`、`before: Mapping[str, z3.ExprRef]`、`after: Mapping[str, z3.ExprRef]`、`path_conditions: Tuple[z3.ExprRef, ...]`、`definedness_constraints: Tuple[DomainConstraint, ...]`。`before` / `after` 是该执行点完整工作环境快照，包含当前已可见的临时变量；失败语句不产生成功步骤 | Z3 表达式、PR-A5b `DomainConstraint` | 用于解释顺序赋值、临时变量和分支内更新；不携带验证证据字段；`definedness_constraints` 中的约束已经按本步 `path_conditions` 包装，可直接上升到全局硬约束 | 单测覆盖前后快照、临时变量不泄漏、顺序赋值使用最新值、失败后不产生成功步骤 |
| `OperationBranch` | ✅ 已实现 | 分支执行记录：`branch_id: Optional[str]`、`branch_kind: str`、`selector: z3.ExprRef`、`path_conditions: Tuple[z3.ExprRef, ...]`、`status: str`、`result_env: Optional[Mapping[str, z3.ExprRef]]`、`definedness_constraints: Tuple[DomainConstraint, ...]`、`failure: Optional[OperationFailure]`。`branch_kind` 只允许 `if` / `elif` / `else`；`status` 只允许 `sat` / `unsat` / `unknown`，不再使用 `else` 作为状态。`selector` 是当前分支的有效 selector，`else` 也必须有 selector：所有前序分支 selector 取反后合取。`status == "unsat"` 的分支仍保留记录，但不执行语句，`result_env=None`、`definedness_constraints=()`、`failure=None`。`status` 为 `sat` 或 `unknown` 时，`result_env` 的 key 集合严格等于进入该 `if` 前的合并域名字集合，不包含分支内部新建临时变量 | PR-A5b 分支可达性查询；`solver.logical.is_sat()` | 用于解释 `if` / `else if` / `else` 的路径裁剪和合并来源；`unknown` 不裁剪；`status` 是元数据，不改变 Z3 合并语义；`branches` 保留源代码分支顺序，便于 PR-A5d 审计 | 单测覆盖可达、不可达、`unknown` 不裁剪、`else` 可被证明不可达、`else if` / `else` selector 与前序条件互斥；断言 `unsat` 分支保留记录且 `result_env is None`；断言可达分支 `result_env` 不含分支内部临时变量 |
| `OperationExecution` | ✅ 已实现 | 操作块执行结果：`env: Mapping[str, z3.ExprRef]`、`visible_names: Tuple[str, ...]`、`expr_constraints: Tuple[z3.ExprRef, ...]`、`definedness_constraints: Tuple[DomainConstraint, ...]`、`steps: Tuple[OperationStep, ...]`、`branches: Tuple[OperationBranch, ...]`、`failure: Optional[OperationFailure]`。`visible_names` 严格等于调用方传入的 `var_exprs.keys()`，`env` 只返回这些原始可见变量；工作环境可包含临时变量，但只出现在步骤 / 分支快照里。`branches` 是扁平执行记录：嵌套 `if` 不在 `OperationBranch` 中递归挂子节点，嵌套关系通过 `path_conditions` 体现；不可达源分支仍以 `status="unsat"` 保留占位。`expr_constraints` 本 PR固定为 `()`，只作为与 PR-A5b 对齐的预留字段 | 现有 `execute_operations()` 语义；PR-A5b `ExprDomain` | 新入口唯一返回类型；PR-A5d 只读消费纯数据；全局 `definedness_constraints` 全部是已受路径保护、可直接加入 solver 的约束 | 单测断言字段稳定；`expr_constraints == ()`；`branches` 对不可达分支保留占位；不得出现验证层结果类型、诊断字段或策略字段 |
| `execute_operations_domain(operations, var_exprs, *, assumptions=(), path_conditions=(), source=None, prune_unreachable=True, timeout_ms=None)` | ✅ 已实现 | 新增定义域感知入口；返回 `OperationExecution`。`assumptions` 和 `path_conditions` 只影响分支可达性，不存入结果顶层；`timeout_ms` 只影响裁剪查询；默认不裁剪 `unknown`。遇到第一个运行时可达的翻译 / 执行失败时立即停止，不执行后续语句；返回失败发生前的部分工作环境，过滤成原始可见变量作为 `env` | PR-A5b `translate_expr_domain()`；现有 `execute_operations()` | PR-A5d 的效果类算法应消费本函数；现有 `execute_operations()` 公共签名和返回类型保持兼容。实现可以让旧 `execute_operations()` 成为新入口的薄包装，但必须用等价性测试证明旧行为不回退 | 覆盖赋值、临时变量、条件块、不可达分支、定义域约束、失败传播、旧 `execute_operations()` 等价性 |
| `merge_operation_definedness(*items)` | ✅ 已实现 | 操作层便捷合并函数；接受 `OperationExecution`、`OperationStep`、`OperationBranch`、`DomainConstraint` 或这些对象的序列，提取各对象 `definedness_constraints` 后委托 PR-A5b `merge_definedness_constraints()` 做最终扁平化。合并语义是“当前路径全部必须有定义”；本函数不做可满足性判断，不吞矛盾，不去重 | PR-A5b `merge_definedness_constraints()` | 这是操作层对象的规范入口；只有 `ExprDomain` / `DomainConstraint` 时继续直接用 PR-A5b helper。不得维护第二套合并语义；调用方应传 `OperationExecution` 或其子对象，不要同时传父对象和子对象来制造重复约束 | 单测覆盖多来源、来源保留、矛盾约束不被删除、非法输入拒绝；断言内部语义与 PR-A5b helper 一致；重复输入不改变 SAT 语义但不会被自动去重 |

接口约束：

- `execute_operations()` 的公共签名和返回类型在本 PR 保持不变；新增定义域感知逻辑只能通过 `execute_operations_domain()` 暴露。
- `pyfcstm/solver/__init__.py` 本 PR 不强制再导出新接口；消费路径先冻结为 `from pyfcstm.solver.operation import execute_operations_domain`。
- 新执行器必须复用 PR-A5b 的 `translate_expr_domain()`，不得在 `operation.py` 中复制第三套表达式定义域规则。
- 新执行器只能处理操作块语义：赋值、临时变量、条件分支、路径前缀和前后快照。状态机生命周期、迁移触发、声明顺序、根初始路径不属于本 PR。
- `path_conditions` 的范围只包含调用方传入的求解器前缀、外层 `if` 分支有效 selector、当前分支有效 selector，以及当前执行路径已经确认必须成立的运行时定义域约束；不包含 transition guard、状态机生命周期或验证层语义。
- 路径前缀定义为当前执行点之前所有已激活 `if` / `elif` 有效 selector 与调用方传入 `path_conditions` 的合取；它不是 transition guard，也不是状态机生命周期条件。
- 每个 `if` / `elif` 条件表达式本身也必须通过 `translate_expr_domain()` 翻译；条件定义域约束按“到达该条件的前序 selector”保护，分支体定义域约束按“当前分支有效 selector”保护。
- 被前序 selector 证明不可达的 `elif` 条件不翻译、不产生失败；运行时可达的条件翻译失败立即停止，遵守与分支体相同的失败传播规则。
- 可以适度重构 `solver.operation` 内部实现，旧门面不是硬约束；但事实上的 `execute_operations()` 行为、现有测试和生成的 Z3 表达式不能回退。

---

## 条件分支与路径语义

| 场景 | 冻结规则 | 验收重点 |
|---|---|---|
| 顺序赋值 | 后续语句读取前序语句更新后的工作环境；定义域约束按运行时求值顺序累积，并作为后续表达式可达性判断的路径前缀 | `x = 1 / y; z = (y == 0) ? sin(a) : x;` 中前序 `y != 0` 应剪掉后续不可达分支 |
| 临时变量 | 工作环境包含原始变量和块内已经赋值的临时变量；最终 `OperationExecution.env` 只返回原始 `var_exprs.keys()`；步骤 / 分支快照可以包含临时变量 | `tmp = x + 1; y = tmp;` 中 `tmp` 不泄漏到最终 `env`，但可在步骤快照解释 |
| `if` 合并域 | 每个分支从进入 `if` 前的同一工作环境执行；分支合并域是进入 `if` 时工作环境中的所有名字，包括此前已赋值的顶层临时变量；分支内部新建的临时变量不参与外层合并 | `tmp = x + 1; if [x > 0] { tmp = tmp + 1; } y = tmp;` 中 `tmp` 可合并并供后续 `y = tmp` 使用，但最终 `env` 不含 `tmp` |
| `else if` / `else` selector | 第 1 分支有效 selector 是 `c1`；第 2 分支是 `And(Not(c1), c2)`；`else` 是所有前序分支 selector 取反后的合取。`branch_kind` 表示语法身份，`status` 只表示可达性三态 | `mode == 0 / mode == 1 / else` 的 selector 两两互斥，并可由 Z3 证明 |
| 分支条件定义域 | 每个 `if` / `elif` 条件表达式自身也有运行时定义域。条件定义域约束按到达该条件的前序 selector 保护：首个条件按外层路径保护，第二个条件按 `Not(c1)` 加外层路径保护，依此类推；分支体定义域再按当前有效 selector 保护 | `if [x == 0] { y = 0; } else if [1 / x > 0] { y = 1; }` 中第二条件的 `x != 0` 受 `Not(x == 0)` 保护；`if [x > 0] ... else if [1 / x > 0] ...` 在 `x == 0` 下必须返回可达条件失败 |
| 不可达分支裁剪 | 若 `assumptions + path_conditions + 已有定义域 + 当前有效 selector` 被证明 `unsat`，该分支不执行、不产生失败、不产生定义域约束，但仍在 `OperationExecution.branches` 中保留 `status="unsat"` 记录；该记录固定 `result_env=None`、`definedness_constraints=()`、`failure=None` | 前序定义域或调用方 path condition 能剪掉不可达 `sin()` 或除零分支；不可达分支记录仍可用于审计源分支数量和顺序 |
| `unknown` / 超时 | 分支可达性查询返回 `unknown` 时，不裁剪分支；保留 `selector`、`result_env` 和分支定义域；最终值合并仍使用标准 `z3.If(selector, branch_result, fallback)`，`status` 只作为元数据 | 用 monkeypatch 或稳定等价方式覆盖 `unknown` 不裁剪，并断言 selector 仍参与合并 |
| 失败传播 | 运行时可达路径上的表达式翻译失败返回 `OperationFailure` 并立即停止执行后续语句；不可达路径上的失败不污染结果；失败前已经成功执行的步骤和定义域约束保留 | 不支持函数只在可达分支阻塞；不可达分支被裁剪时成功；失败后的语句不出现在 steps 中 |
| 定义域约束保护 | `OperationStep`、`OperationBranch`、`OperationExecution` 中的 `definedness_constraints` 全部存放已受当前执行路径保护的约束，可直接作为全局硬约束加入 solver。保护形态与 PR-A5b 一致，用 `Implies(And(*path_conditions), raw_constraint)` 或等价 Z3 公式表达 | `if [x != 0] { y = 1 / x; } else { y = 0; }` 的全局定义域约束在 `x == 0` 下仍可满足 |
| 嵌套路径前缀 | 内层 `if` 的路径前缀必须包含所有外层有效 selector；嵌套分支不在 `OperationBranch` 中递归挂子节点，而是通过 `OperationStep.path_conditions` / `OperationBranch.path_conditions` 的扁平记录表达 | `if [x > 0] { if [y > 0] { z = 1 / (x - y); } }` 的定义域约束受 `x > 0 && y > 0` 保护，执行记录可按扁平 path conditions 审计 |

---

## 明确不做

| 不做项 | 原因 |
|---|---|
| 不改 `pyfcstm.verify.smt_local` 接线 | 验证层接线和重复包装清理属于 PR-A5d |
| 不改 `test/verify/**` | 本 PR 只提供求解器层纯接口，验证层回归由 PR-A5d 处理 |
| 不接入 `inspect_model()` 或诊断适配层 | 诊断策略由后续诊断层 PR 统一处理 |
| 不修改 `codes.yaml` / `schema.json` / `editors/**` | 这些属于诊断层和编辑器范围，不属于求解器层操作执行接口 |
| 不创建 `pyfcstm/verify/search.py` / `pyfcstm/verify/reachability.py` | 文件名继续留给第 3 组 / dev/verify 集成 |
| 不让 `solver.operation` 返回 `AlgorithmResult` | 求解器层只返回纯数据结果，验证层负责原始算法结果 |
| 不承载 FCSTM 生命周期或迁移顺序语义 | 根初始路径、首次周期、迁移触发和声明顺序属于 `pyfcstm.verify.encoding.*` |
| 不为了保留旧门面牺牲清晰架构 | 当前没有外部历史包袱；确认事实执行逻辑不回退时允许大胆重构，但本 PR 仍只做求解器层接口 |

---

## TDD 验收计划

| 用例 | 当前风险 | 预期结果 |
|---|---|---|
| 顺序定义域传播 | 前序赋值的定义域没有加入后续表达式路径判断 | `x = 1 / y; z = (y == 0) ? sin(a) : x;` 不因不可达 `sin(a)` 失败，结果携带 `y != 0` |
| 右侧失败保留前序约束 | 后续语句失败时丢失此前已求值语句的定义域，或失败后继续执行导致结果不可解释 | `x = 1 / y; z = missing; w = 1;` 返回失败，同时保留 `y != 0`；`w = 1` 不执行、不出现在成功步骤中 |
| 条件分支定义域保护 | 分支内除零约束无条件泄漏，导致外层路径误判 | `if [x != 0] { y = 1 / x; } else { y = 0; }` 的全局定义域约束在 `x == 0` 下仍可满足，并且可证明 `y == 0` |
| `else if` 路径互斥 | 第 2 分支没有带上第 1 分支取反条件，或 `else` 没有有效 selector | `mode == 1` 分支 selector 包含 `mode != 0 && mode == 1`；`else` selector 是所有前序条件取反；三者两两互斥 |
| 不可达分支裁剪 | 不可达分支里的不支持函数污染结果，或不可达分支记录丢失导致审计信息不完整 | assumptions 或 path_conditions 证明分支不可达时，不翻译该分支，不返回失败；对应 `OperationBranch` 仍保留，`status == "unsat"`、`result_env is None`、定义域约束为空 |
| 分支条件定义域 | 只处理分支体定义域，漏掉 `if` / `elif` 条件表达式本身定义域 | `if [x == 0] { y = 0; } else if [1 / x > 0] { y = 1; }` 中第二条件的 `x != 0` 受 `Not(x == 0)` 保护；`if [x > 0] ... else if [1 / x > 0] ...` 在 `x == 0` 下返回条件失败，不静默落入 `else` |
| `unknown` 不裁剪 | 求解器超时被误当成不可达，或 selector 未参与最终合并 | `unknown` 记录在分支信息中，分支仍执行，最终值表达式仍含该 selector |
| 临时变量两层作用域 | 分支内临时变量泄漏到最终环境，或外层临时变量无法参与 if 合并 | 分支内临时不泄漏；`tmp = x + 1; if [...] { tmp = tmp + 1; } y = tmp;` 可合并；最终 `env` 不含 `tmp`；可达分支 `result_env` key 集合等于进入 if 前的合并域，不包含分支内部新建临时 |
| 前后快照 | 调用方无法解释某一步使用的是旧值还是新值，或快照漏掉临时变量 | 每个成功 `OperationStep` 有完整工作环境 `before` / `after`，包含当时可见临时变量 |
| 嵌套 if 路径前缀 | 内层定义域约束没有带外层 selector | `if [x > 0] { if [y > 0] { z = 1 / (x - y); } }` 返回受 `x > 0 && y > 0` 保护的 `x - y != 0` |
| `expr_constraints` 预留字段 | 实现者误填未冻结的表达式值约束 | `OperationExecution.expr_constraints == ()`，与 PR-A5b 当前预留字段保持一致 |
| 非表达式失败 kind | 操作层失败字符串随实现漂移，导致 PR-A5d 无法稳定消费 | 未知语句类型返回 `unsupported_statement`；非布尔条件返回 `non_bool_condition`；表达式翻译失败仍沿用 PR-A5b `TranslationFailure.kind` |
| 旧入口等价性 | 新实现破坏现有 `execute_operations()` 行为 | 现有 if/else、顺序赋值、临时变量测试继续通过；新增等价性测试证明旧入口返回值与新入口 `env` 对齐 |
| 纯求解器边界 | `solver.operation` 反向导入验证层或诊断层 | 边界检查命令输出为空 |

必跑命令：

```bash
pytest test/solver/test_operation.py -q
pytest test/solver/test_domain.py -q
pytest test/solver/ -q
pytest test/verify/test_smt_local.py -q
SKIP_SLOW_TESTS=1 make unittest
git diff --check
```

`test/verify/test_smt_local.py` 是回归 guard：PR-A5c 不改验证层，但不能让新求解器接口破坏 PR-A5a / PR-A5b 已修复的语义。

边界检查：

```bash
BASE=$(git merge-base HEAD origin/dev/issue114-pr-a-verify)
git diff --name-only "$BASE" | rg '^(pyfcstm/diagnostics/|codes\.yaml|schema\.json|editors/|pyfcstm/verify/|test/verify/|pyfcstm/model/|pyfcstm/dsl/)'
rg 'pyfcstm\.verify|pyfcstm\.diagnostics|pyfcstm\.verify\.registry|from pyfcstm import .*\b(verify|diagnostics)\b|from \.+(verify|diagnostics)\b|from \.+ import .*\b(verify|diagnostics)\b|import \.+(verify|diagnostics)\b|inspect_model|diagnostics\.inspect|AlgorithmResult|ResultKind' pyfcstm/solver
rg 'solver\.safety|check_expr_safety' pyfcstm/verify
```

最后一条是 #114 / #142 的全程门禁，在 PR-A5c 中只作为回归 guard，避免原始验证默认接入 `solver.safety`。

---

## 当前实现与验证结果

| 项目 | 结果 |
|---|---|
| 初始提交 | `b8687ee2`：`PR-A5c 创建操作块路径敏感执行空提交 [skip-slow]` |
| 实现提交 | `389cb9e0`：`PR-A5c 实现操作块路径敏感执行 [skip-slow]` |
| 覆盖率补强提交 | `646c0142`：`PR-A5c 补齐操作块执行覆盖率 [skip-slow]` |
| 不可达执行裁剪提交 | `c36a79c8`：`PR-A5c 修复不可达操作执行裁剪 [skip-slow]` |
| 分支失败部分环境提交 | `85458ac8`：`PR-A5c 修复分支失败部分环境 [skip-slow]` |
| `elif` 条件失败环境合并提交 | `7c836613`：`PR-A5c 修复 elif 条件失败环境合并 [skip-slow]` |
| CI / Codecov | ✅ GitHub checks 33/33 全部通过；✅ Codecov：所有修改且可覆盖行都已被测试覆盖，head `7c836613` |
| 写入范围 | `pyfcstm/solver/operation.py`、`test/solver/test_operation.py` |
| 本地测试 | ✅ `pytest test/solver/test_operation.py -q`：71 passed；✅ `pytest test/solver/test_operation.py --cov=pyfcstm.solver.operation --cov-report=term-missing -q`：71 passed，`operation.py` 100%；✅ `pytest test/solver/test_domain.py -q`：47 passed；✅ `pytest test/solver/ -q`：260 passed；✅ `pytest test/verify/test_smt_local.py -q`：226 passed；✅ `SKIP_SLOW_TESTS=1 make unittest`：9271 passed, 164 skipped, 63 deselected；✅ `git diff --check`；✅ `ruff format --check pyfcstm/solver/operation.py test/solver/test_operation.py` |
| 当前待办 | ✅ 最终三路强对抗代码复审 C=0 / I=0；M 级不阻塞；保持不 merge，等待用户验收指示 |

---

## 最终代码复审结论

| reviewer | 进度 | head | 结论 | 评论链接 | 处理结论 |
|---|---|---|---|---|---|
| `claude reviewer` | ✅ 已完成 | `7c836613` | C=0 / I=0 / M=4 | [comment](https://github.com/HansBug/pyfcstm/pull/172#issuecomment-4661681601) | 建议放行；M 级为元数据、入口校验和内部不变量说明，不阻塞 |
| `deepseek reviewer` | ✅ 已完成 | `7c836613` | C=0 / I=0 / M=3 | [comment](https://github.com/HansBug/pyfcstm/pull/172#issuecomment-4661700391) | 上一轮 I 级已验证修复；额外 8 个白盒边界场景通过，建议 ready |
| `codex reviewer` | ✅ 已完成 | `7c836613` | C=0 / I=0 / M=3 | [comment](https://github.com/HansBug/pyfcstm/pull/172#issuecomment-4661707496) | 历史 I 级均已修复；本轮未发现阻塞 ready 的语义问题 |

当前处理结论：最终代码复审 C/I 已清零；CI 33/33 全部通过；Codecov 确认所有修改且可覆盖行都已被测试覆盖。M 级不阻塞，本 PR 保持不 merge，等待用户验收。

---

## 三路计划复审结论

| reviewer | 进度 | 首轮结论 | 已写回正文的处理 |
|---|---|---|---|
| `claude reviewer` | ✅ 已完成 | C=0 / I=6 / M=4 | 补充来源字段同构、失败类型升级、分支状态拆维度、临时变量两层作用域、`expr_constraints` 恒空、merge helper 委托关系 |
| `codex reviewer` | ✅ 已完成 | C=0 / I=2 / M=2 | 补充 `else` 有有效 selector、`status` 只表达三态可达性、分支定义域约束必须已保护且可直接作为全局硬约束 |
| `deepseek reviewer` | ✅ 已完成 | C=2 / I=5 / M=3 | 补充 `OperationSource` 与 `DomainSource` 一对一关系、定义域包装时机、旧入口兼容、失败后停止、嵌套 if 用例、`unknown` selector 合并语义 |

当前处理结论：三轮计划复审 C/I=0；head `7c836613` 的 CI 与 Codecov 已通过；最终三路强对抗代码复审 C=0 / I=0；PR-A5c 已 ready，保持不 merge，等待用户验收。
















