### PR TITLE
PR-B2：实现 inspect adapter 执行闭环（#114）

### DIFF
--- a/docs/source/api_doc/verify/inspect_adapter.rst
+++ b/docs/source/api_doc/verify/inspect_adapter.rst
@@ -12,6 +12,13 @@ pyfcstm.verify.inspect\_adapter
 .. autodata:: __all__
 
 
+InspectRunResult
+-----------------------------------------------------
+
+.. autoclass:: InspectRunResult
+    :members: algorithm_name,complexity_tier,smt_logic,verification_scope,diagnostic_codes,result_kind,diagnostics,reason,raw_result
+
+
 InspectAccessForbiddenError
 -----------------------------------------------------
 
@@ -28,3 +35,9 @@ iter\_inspect\_eligible
 -----------------------------------------------------
 
 .. autofunction:: iter_inspect_eligible
+
+
+run\_inspect\_algorithms
+-----------------------------------------------------
+
+.. autofunction:: run_inspect_algorithms

--- a/pyfcstm/verify/__init__.py
+++ b/pyfcstm/verify/__init__.py
@@ -37,7 +37,7 @@ Module map:
      - Shared FCSTM-to-SMT encoding helpers used by algorithm implementations;
        callers normally should not import this package directly.
 
-Example::
+Examples::
 
     >>> from pyfcstm.verify import REGISTRY, dead_guard
     >>> # The public top-level algorithm is the same callable registered here.

--- a/pyfcstm/verify/__init__.py
+++ b/pyfcstm/verify/__init__.py
@@ -25,6 +25,10 @@ Module map:
    * - Inspect gating
      - :func:`eligible_for_inspect`, :func:`iter_inspect_eligible`
      - Decide which raw algorithms may be used by automatic inspect workflows.
+   * - Inspect execution
+     - :class:`InspectRunResult`, :func:`run_inspect_algorithms`
+     - Execute inspect-eligible algorithms and preserve normalized raw results
+       for later diagnostics conversion.
    * - Taxonomy
      - :class:`VerifyAlgorithmMeta` and the ``Literal`` aliases
      - Describe algorithm complexity, theory, scope, and fallback risk.
@@ -52,9 +56,11 @@ from .algorithms import (
     transition_shadowed_by_predecessor,
 )
 from .inspect_adapter import (
+    InspectRunResult,
     InspectAccessForbiddenError,
     eligible_for_inspect,
     iter_inspect_eligible,
+    run_inspect_algorithms,
 )
 from .registry import REGISTRY
 from .result import AlgorithmResult, ResultKind
@@ -82,6 +88,7 @@ __all__ = [
     "FallbackUnknownRisk",
     "FormulaSizeScaling",
     "InspectAccessForbiddenError",
+    "InspectRunResult",
     "SMTLogic",
     "ResultKind",
     "VerificationScope",
@@ -95,5 +102,6 @@ __all__ = [
     "forced_guard_unsat_under_init",
     "guard_tautology",
     "iter_inspect_eligible",
+    "run_inspect_algorithms",
     "transition_shadowed_by_predecessor",
 ]

--- a/pyfcstm/verify/inspect_adapter.py
+++ b/pyfcstm/verify/inspect_adapter.py
@@ -488,9 +488,10 @@ def _aggregate_algorithm_results(results: Sequence[AlgorithmResult]) -> Algorith
     diagnostics conversion must be able to disclose that at least one checked
     element could not be decided.
     When all checked elements are definite, diagnostics decide whether the
-    aggregate is ``sat`` or ``unsat``: emitting algorithms use ``unsat`` or
-    ``sat`` according to their own raw contract, while an empty run is a
-    successful ``sat`` no-finding result.
+    aggregate is ``sat`` or ``unsat``: any ``unsat`` result with diagnostics
+    dominates ``sat`` diagnostics, otherwise emitting algorithms use ``sat``
+    according to their own raw contract.  An empty run is a successful ``sat``
+    no-finding result.
 
     :param results: Per-element raw algorithm results.
     :type results: Sequence[AlgorithmResult]
@@ -503,6 +504,12 @@ def _aggregate_algorithm_results(results: Sequence[AlgorithmResult]) -> Algorith
         'sat'
         >>> _aggregate_algorithm_results((AlgorithmResult("timeout", reason="t"),)).reason
         't'
+        >>> mixed = (
+        ...     AlgorithmResult("sat", diagnostics=({"code": "I_FAKE"},)),
+        ...     AlgorithmResult("unsat", diagnostics=({"code": "W_FAKE"},)),
+        ... )
+        >>> _aggregate_algorithm_results(mixed).kind
+        'unsat'
     """
     if not results:
         return AlgorithmResult(kind="sat")
@@ -519,6 +526,8 @@ def _aggregate_algorithm_results(results: Sequence[AlgorithmResult]) -> Algorith
         )
 
     if diagnostics:
+        if any(result.kind == "unsat" and result.diagnostics for result in results):
+            return AlgorithmResult(kind="unsat", diagnostics=diagnostics)
         for result in results:
             if result.diagnostics:
                 return AlgorithmResult(kind=result.kind, diagnostics=diagnostics)

--- a/pyfcstm/verify/inspect_adapter.py
+++ b/pyfcstm/verify/inspect_adapter.py
@@ -5,7 +5,7 @@ automatic inspect runs under a bounded complexity and call-count policy.  It
 also executes eligible algorithms and normalizes their raw results without
 importing diagnostics presentation code.
 
-Example::
+Examples::
 
     >>> from pyfcstm.dsl import parse_with_grammar_entry
     >>> from pyfcstm.model import parse_dsl_node_to_state_machine
@@ -84,10 +84,12 @@ class InspectRunResult:
     """Normalized output for one inspect-adapter algorithm run.
 
     The adapter returns one instance per registry algorithm, not one instance
-    per raw diagnostic.  Structural algorithms keep their graph-oriented raw
-    payload in :attr:`raw_result`.  SMT-local algorithms expose raw diagnostic
-    dictionaries through :attr:`diagnostics` while preserving their original
-    :class:`AlgorithmResult` or per-element result tuple.
+    per raw diagnostic. Structural algorithms keep their graph-oriented raw
+    payload in :attr:`raw_result`; their :attr:`result_kind` records that the
+    structural run completed rather than replacing the structural payload.
+    SMT-local algorithms expose raw diagnostic dictionaries through
+    :attr:`diagnostics` while preserving their original :class:`AlgorithmResult`
+    or per-element result tuple.
 
     :param algorithm_name: Registry name of the executed algorithm.
     :type algorithm_name: str
@@ -113,7 +115,7 @@ class InspectRunResult:
         inspect or diagnostics conversion.
     :type raw_result: object
 
-    Example::
+    Examples::
 
         >>> result = InspectRunResult(
         ...     algorithm_name="topological_reachable_set",
@@ -144,7 +146,7 @@ class InspectRunResult:
 class InspectAccessForbiddenError(ValueError):
     """Raised when a forbidden inspect complexity tier is requested.
 
-    Example::
+    Examples::
 
         >>> raise InspectAccessForbiddenError("blocked")
         Traceback (most recent call last):
@@ -170,7 +172,7 @@ def _order_allows(order, value, maximum):
         ``maximum``.
     :rtype: bool
 
-    Example::
+    Examples::
 
         >>> _order_allows(("low", "high"), "low", "high")
         True
@@ -197,7 +199,7 @@ def _validate_max_complexity_tier(maximum: ComplexityTier) -> None:
     :raises InspectAccessForbiddenError: If ``maximum`` is unknown or requests
         the forbidden ``"bmc_search"`` tier.
 
-    Example::
+    Examples::
 
         >>> _validate_max_complexity_tier("structural")
         >>> _validate_max_complexity_tier("bmc_search")
@@ -225,7 +227,7 @@ def _validate_max_call_count_scaling(maximum: CallCountScaling) -> None:
     :raises InspectAccessForbiddenError: If ``maximum`` is outside the automatic
         inspect ordering.
 
-    Example::
+    Examples::
 
         >>> _validate_max_call_count_scaling("linear_in_transitions")
         >>> _validate_max_call_count_scaling("k_unrollings")
@@ -256,7 +258,7 @@ def _call_count_allows(value: CallCountScaling, maximum: CallCountScaling) -> bo
     :return: ``True`` if the scaling class is allowed by the inspect budget.
     :rtype: bool
 
-    Example::
+    Examples::
 
         >>> _call_count_allows("linear_in_leaves", "linear_in_transitions")
         True
@@ -292,7 +294,7 @@ def eligible_for_inspect(
         ``'bmc_search'`` or if either inspect limit is outside the automatic
         inspect ordering.
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.verify.registry import REGISTRY
         >>> eligible_for_inspect(REGISTRY["topological_reachable_set"])
@@ -333,7 +335,7 @@ def iter_inspect_eligible(
     :yield: Eligible metadata entries in registry order.
     :rtype: Iterator[VerifyAlgorithmMeta]
 
-    Example::
+    Examples::
 
         >>> names = [meta.name for meta in iter_inspect_eligible()]
         >>> names[:2]
@@ -359,7 +361,7 @@ def _variables_for(machine) -> Tuple[object, ...]:
     :return: Variable definitions in source order.
     :rtype: Tuple[object, ...]
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.dsl import parse_with_grammar_entry
         >>> from pyfcstm.model import parse_dsl_node_to_state_machine
@@ -380,7 +382,7 @@ def _iter_model_transitions(machine) -> Iterator[object]:
     :yield: Transition objects in model traversal order.
     :rtype: Iterator[object]
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.dsl import parse_with_grammar_entry
         >>> from pyfcstm.model import parse_dsl_node_to_state_machine
@@ -409,7 +411,7 @@ def _iter_model_leaf_states(machine) -> Iterator[object]:
     :yield: Leaf state objects in model traversal order.
     :rtype: Iterator[object]
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.dsl import parse_with_grammar_entry
         >>> from pyfcstm.model import parse_dsl_node_to_state_machine
@@ -437,7 +439,7 @@ def _missing_impl_result(meta: VerifyAlgorithmMeta) -> InspectRunResult:
     :return: Normalized skip result.
     :rtype: InspectRunResult
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.verify.registry import REGISTRY
         >>> result = _missing_impl_result(REGISTRY["bounded_reachability"])
@@ -468,7 +470,7 @@ def _first_indeterminate(results: Sequence[AlgorithmResult]) -> Optional[Algorit
         ``None`` when all results are definite.
     :rtype: Optional[AlgorithmResult]
 
-    Example::
+    Examples::
 
         >>> _first_indeterminate((AlgorithmResult("sat"), AlgorithmResult("unknown", reason="u"))).reason
         'u'
@@ -482,8 +484,9 @@ def _first_indeterminate(results: Sequence[AlgorithmResult]) -> Optional[Algorit
 def _aggregate_algorithm_results(results: Sequence[AlgorithmResult]) -> AlgorithmResult:
     """Aggregate per-element raw results into one algorithm-level result.
 
-    Inconclusive outcomes dominate deterministic outcomes because PR-B3 must be
-    able to disclose that at least one checked element could not be decided.
+    Inconclusive outcomes dominate deterministic outcomes because later
+    diagnostics conversion must be able to disclose that at least one checked
+    element could not be decided.
     When all checked elements are definite, diagnostics decide whether the
     aggregate is ``sat`` or ``unsat``: emitting algorithms use ``unsat`` or
     ``sat`` according to their own raw contract, while an empty run is a
@@ -494,7 +497,7 @@ def _aggregate_algorithm_results(results: Sequence[AlgorithmResult]) -> Algorith
     :return: Aggregated raw result.
     :rtype: AlgorithmResult
 
-    Example::
+    Examples::
 
         >>> _aggregate_algorithm_results((AlgorithmResult("sat"),)).kind
         'sat'
@@ -516,8 +519,9 @@ def _aggregate_algorithm_results(results: Sequence[AlgorithmResult]) -> Algorith
         )
 
     if diagnostics:
-        finding = next(result for result in results if result.diagnostics)
-        return AlgorithmResult(kind=finding.kind, diagnostics=diagnostics)
+        for result in results:
+            if result.diagnostics:
+                return AlgorithmResult(kind=result.kind, diagnostics=diagnostics)
 
     if all(result.kind == "unsat" for result in results):
         return AlgorithmResult(kind="unsat")
@@ -536,8 +540,12 @@ def _normalize_algorithm_result(
     :type raw_result: object
     :return: Normalized inspect-adapter result.
     :rtype: InspectRunResult
+    :raises TypeError: If an SMT-local algorithm returns a payload that is not
+        an :class:`AlgorithmResult` or a tuple of :class:`AlgorithmResult`
+        values. Structural algorithms may return plain topology payloads and
+        keep them in ``raw_result``.
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.verify.registry import REGISTRY
         >>> result = _normalize_algorithm_result(
@@ -549,13 +557,28 @@ def _normalize_algorithm_result(
     """
     if isinstance(raw_result, AlgorithmResult):
         algorithm_result = raw_result
-    elif (
-        isinstance(raw_result, tuple)
-        and all(isinstance(item, AlgorithmResult) for item in raw_result)
-    ):
+    elif meta.complexity_tier == "structural":
+        algorithm_result = AlgorithmResult(kind="sat")
+    elif isinstance(raw_result, tuple):
+        for index, item in enumerate(raw_result):
+            if not isinstance(item, AlgorithmResult):
+                raise TypeError(
+                    "algorithm {name!r} returned tuple item {index} with "
+                    "unexpected type {actual!r}; expected AlgorithmResult".format(
+                        name=meta.name,
+                        index=index,
+                        actual=type(item).__name__,
+                    )
+                )
         algorithm_result = _aggregate_algorithm_results(raw_result)
     else:
-        algorithm_result = AlgorithmResult(kind="sat")
+        raise TypeError(
+            "algorithm {name!r} returned unexpected raw result type {actual!r}; "
+            "expected AlgorithmResult or Tuple[AlgorithmResult, ...]".format(
+                name=meta.name,
+                actual=type(raw_result).__name__,
+            )
+        )
 
     return InspectRunResult(
         algorithm_name=meta.name,
@@ -581,8 +604,9 @@ def _run_smt_algorithm(meta: VerifyAlgorithmMeta, machine, smt_timeout_ms):
     :type smt_timeout_ms: Optional[int]
     :return: Raw result value from the algorithm or per-element aggregate input.
     :rtype: object
+    :raises ValueError: If an SMT-local algorithm has no inspect dispatch rule.
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.dsl import parse_with_grammar_entry
         >>> from pyfcstm.model import parse_dsl_node_to_state_machine
@@ -617,7 +641,11 @@ def _run_smt_algorithm(meta: VerifyAlgorithmMeta, machine, smt_timeout_ms):
             variables,
             smt_timeout_ms=smt_timeout_ms,
         )
-    return meta.impl(machine, variables, smt_timeout_ms=smt_timeout_ms)
+    raise ValueError(
+        "algorithm {name!r} has no inspect dispatch rule; register it as "
+        "transition-level, lifecycle-leaf-level, or machine-level before "
+        "enabling automatic inspect execution".format(name=meta.name)
+    )
 
 
 def _run_algorithm(meta: VerifyAlgorithmMeta, machine, smt_timeout_ms):
@@ -631,8 +659,9 @@ def _run_algorithm(meta: VerifyAlgorithmMeta, machine, smt_timeout_ms):
     :type smt_timeout_ms: Optional[int]
     :return: Raw algorithm return value.
     :rtype: object
+    :raises ValueError: If an SMT-local algorithm has no inspect dispatch rule.
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.dsl import parse_with_grammar_entry
         >>> from pyfcstm.model import parse_dsl_node_to_state_machine
@@ -682,8 +711,11 @@ def run_inspect_algorithms(
     :rtype: Tuple[InspectRunResult, ...]
     :raises InspectAccessForbiddenError: If either inspect limit is outside the
         automatic inspect ordering.
+    :raises TypeError: If an SMT-local algorithm returns an unexpected raw
+        result payload.
+    :raises ValueError: If an SMT-local algorithm has no inspect dispatch rule.
 
-    Example::
+    Examples::
 
         >>> from pyfcstm.dsl import parse_with_grammar_entry
         >>> from pyfcstm.model import parse_dsl_node_to_state_machine

--- a/pyfcstm/verify/inspect_adapter.py
+++ b/pyfcstm/verify/inspect_adapter.py
@@ -1,28 +1,144 @@
-"""Inspect gating helpers for verify algorithm metadata.
+"""Inspect gating and execution helpers for verify algorithm metadata.
 
 This module decides which raw verification algorithms are eligible for
 automatic inspect runs under a bounded complexity and call-count policy.  It
-does not execute algorithms and does not import diagnostics presentation code.
+also executes eligible algorithms and normalizes their raw results without
+importing diagnostics presentation code.
 
 Example::
 
-    >>> from pyfcstm.verify.inspect_adapter import iter_inspect_eligible
-    >>> names = [meta.name for meta in iter_inspect_eligible()]
+    >>> from pyfcstm.dsl import parse_with_grammar_entry
+    >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+    >>> from pyfcstm.verify.inspect_adapter import run_inspect_algorithms
+    >>> source = '''
+    ... state Root {
+    ...     state A;
+    ...     [*] -> A;
+    ... }
+    ... '''
+    >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+    >>> machine = parse_dsl_node_to_state_machine(ast)
+    >>> names = [result.algorithm_name for result in run_inspect_algorithms(machine)]
     >>> "topological_reachable_set" in names
     True
     >>> "bounded_reachability" in names
     False
+
+Module map:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Entry
+     - Purpose
+   * - :class:`InspectRunResult`
+     - Carries one normalized inspect-adapter result while preserving the raw
+       verification payload.
+   * - :func:`eligible_for_inspect`
+     - Decides whether one metadata entry is allowed by inspect policy.
+   * - :func:`iter_inspect_eligible`
+     - Iterates eligible registry metadata entries in stable registry order.
+   * - :func:`run_inspect_algorithms`
+     - Executes eligible algorithms and returns normalized results for later
+       diagnostics conversion.
 """
 
-from typing import Iterator
+from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any, Iterator, Mapping, Optional, Sequence, Tuple
+
+from .result import AlgorithmResult, ResultKind
 from .taxonomy import (
     CALL_COUNT_SCALING_ORDER,
     COMPLEXITY_TIER_ORDER,
     CallCountScaling,
     ComplexityTier,
+    SMTLogic,
+    VerificationScope,
     VerifyAlgorithmMeta,
 )
+
+
+_RawResult = Any
+_TRANSITION_ALGORITHMS = frozenset(
+    (
+        "dead_guard",
+        "guard_tautology",
+        "forced_guard_unsat_under_init",
+        "effect_no_op_under_guard",
+        "effect_contradicts_guard",
+    )
+)
+_MACHINE_SMT_ALGORITHMS = frozenset(
+    (
+        "transition_shadowed_by_predecessor",
+        "composite_init_guards_incomplete",
+    )
+)
+_INDETERMINATE_KINDS = ("timeout", "unknown", "undecidable_skip")
+
+
+@dataclass(frozen=True)
+class InspectRunResult:
+    """Normalized output for one inspect-adapter algorithm run.
+
+    The adapter returns one instance per registry algorithm, not one instance
+    per raw diagnostic.  Structural algorithms keep their graph-oriented raw
+    payload in :attr:`raw_result`.  SMT-local algorithms expose raw diagnostic
+    dictionaries through :attr:`diagnostics` while preserving their original
+    :class:`AlgorithmResult` or per-element result tuple.
+
+    :param algorithm_name: Registry name of the executed algorithm.
+    :type algorithm_name: str
+    :param complexity_tier: Algorithm complexity tier from registry metadata.
+    :type complexity_tier: ComplexityTier
+    :param smt_logic: SMT logic from registry metadata, or ``None`` for
+        structural algorithms.
+    :type smt_logic: Optional[SMTLogic]
+    :param verification_scope: Downstream boundary label from registry
+        metadata.
+    :type verification_scope: Optional[VerificationScope]
+    :param diagnostic_codes: Diagnostic codes advertised by registry metadata.
+    :type diagnostic_codes: Tuple[str, ...]
+    :param result_kind: Normalized result kind for the whole algorithm run.
+    :type result_kind: ResultKind
+    :param diagnostics: Raw verify diagnostic dictionaries collected from
+        :class:`AlgorithmResult` values.
+    :type diagnostics: Tuple[dict, ...]
+    :param reason: Optional reason from the raw result when the run is
+        inconclusive or skipped.
+    :type reason: Optional[str]
+    :param raw_result: Original raw algorithm return value kept for later
+        inspect or diagnostics conversion.
+    :type raw_result: object
+
+    Example::
+
+        >>> result = InspectRunResult(
+        ...     algorithm_name="topological_reachable_set",
+        ...     complexity_tier="structural",
+        ...     smt_logic=None,
+        ...     verification_scope="topological_only",
+        ...     diagnostic_codes=(),
+        ...     result_kind="sat",
+        ...     diagnostics=(),
+        ...     reason=None,
+        ...     raw_result={"Root.A": ()},
+        ... )
+        >>> result.algorithm_name
+        'topological_reachable_set'
+    """
+
+    algorithm_name: str
+    complexity_tier: ComplexityTier
+    smt_logic: Optional[SMTLogic]
+    verification_scope: Optional[VerificationScope]
+    diagnostic_codes: Tuple[str, ...]
+    result_kind: ResultKind
+    diagnostics: Tuple[dict, ...]
+    reason: Optional[str]
+    raw_result: _RawResult
 
 
 class InspectAccessForbiddenError(ValueError):
@@ -234,8 +350,376 @@ def iter_inspect_eligible(
             yield meta
 
 
+def _variables_for(machine) -> Tuple[object, ...]:
+    """Return model variables in stable declaration order.
+
+    :param machine: State machine whose variable definitions should be passed
+        to SMT-local algorithms.
+    :type machine: StateMachine
+    :return: Variable definitions in source order.
+    :rtype: Tuple[object, ...]
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> ast = parse_with_grammar_entry("def int x = 0; state Root;", "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> _variables_for(machine)[0].name
+        'x'
+    """
+    return tuple(machine.defines.values())
+
+
+def _iter_model_transitions(machine) -> Iterator[object]:
+    """Iterate transitions from all states in model order.
+
+    :param machine: State machine to scan.
+    :type machine: StateMachine
+    :return: Iterator over transitions owned by each walked state.
+    :yield: Transition objects in model traversal order.
+    :rtype: Iterator[object]
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     [*] -> A;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> len(tuple(_iter_model_transitions(machine)))
+        1
+    """
+    for state in machine.walk_states():
+        for transition in state.transitions:
+            yield transition
+
+
+def _iter_model_leaf_states(machine) -> Iterator[object]:
+    """Iterate non-pseudo leaf states in model order.
+
+    :param machine: State machine to scan.
+    :type machine: StateMachine
+    :return: Iterator over non-pseudo leaf states.
+    :yield: Leaf state objects in model traversal order.
+    :rtype: Iterator[object]
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     [*] -> A;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> [state.path[-1] for state in _iter_model_leaf_states(machine)]
+        ['A']
+    """
+    for state in machine.walk_states():
+        if state.is_leaf_state and not state.is_pseudo:
+            yield state
+
+
+def _missing_impl_result(meta: VerifyAlgorithmMeta) -> InspectRunResult:
+    """Return a normalized skip result for an unimplemented registry entry.
+
+    :param meta: Metadata whose implementation is absent.
+    :type meta: VerifyAlgorithmMeta
+    :return: Normalized skip result.
+    :rtype: InspectRunResult
+
+    Example::
+
+        >>> from pyfcstm.verify.registry import REGISTRY
+        >>> result = _missing_impl_result(REGISTRY["bounded_reachability"])
+        >>> result.result_kind
+        'undecidable_skip'
+    """
+    reason = "algorithm implementation is not registered"
+    raw_result = AlgorithmResult(kind="undecidable_skip", reason=reason)
+    return InspectRunResult(
+        algorithm_name=meta.name,
+        complexity_tier=meta.complexity_tier,
+        smt_logic=meta.smt_logic,
+        verification_scope=meta.verification_scope,
+        diagnostic_codes=meta.diagnostic_codes,
+        result_kind=raw_result.kind,
+        diagnostics=(),
+        reason=raw_result.reason,
+        raw_result=raw_result,
+    )
+
+
+def _first_indeterminate(results: Sequence[AlgorithmResult]) -> Optional[AlgorithmResult]:
+    """Return the first inconclusive raw result, if any.
+
+    :param results: Raw algorithm results to scan.
+    :type results: Sequence[AlgorithmResult]
+    :return: First ``timeout``, ``unknown``, or ``undecidable_skip`` result, or
+        ``None`` when all results are definite.
+    :rtype: Optional[AlgorithmResult]
+
+    Example::
+
+        >>> _first_indeterminate((AlgorithmResult("sat"), AlgorithmResult("unknown", reason="u"))).reason
+        'u'
+    """
+    for result in results:
+        if result.kind in _INDETERMINATE_KINDS:
+            return result
+    return None
+
+
+def _aggregate_algorithm_results(results: Sequence[AlgorithmResult]) -> AlgorithmResult:
+    """Aggregate per-element raw results into one algorithm-level result.
+
+    Inconclusive outcomes dominate deterministic outcomes because PR-B3 must be
+    able to disclose that at least one checked element could not be decided.
+    When all checked elements are definite, diagnostics decide whether the
+    aggregate is ``sat`` or ``unsat``: emitting algorithms use ``unsat`` or
+    ``sat`` according to their own raw contract, while an empty run is a
+    successful ``sat`` no-finding result.
+
+    :param results: Per-element raw algorithm results.
+    :type results: Sequence[AlgorithmResult]
+    :return: Aggregated raw result.
+    :rtype: AlgorithmResult
+
+    Example::
+
+        >>> _aggregate_algorithm_results((AlgorithmResult("sat"),)).kind
+        'sat'
+        >>> _aggregate_algorithm_results((AlgorithmResult("timeout", reason="t"),)).reason
+        't'
+    """
+    if not results:
+        return AlgorithmResult(kind="sat")
+
+    diagnostics = tuple(
+        diagnostic for result in results for diagnostic in result.diagnostics
+    )
+    indeterminate = _first_indeterminate(results)
+    if indeterminate is not None:
+        return AlgorithmResult(
+            kind=indeterminate.kind,
+            diagnostics=diagnostics,
+            reason=indeterminate.reason,
+        )
+
+    if diagnostics:
+        finding = next(result for result in results if result.diagnostics)
+        return AlgorithmResult(kind=finding.kind, diagnostics=diagnostics)
+
+    if all(result.kind == "unsat" for result in results):
+        return AlgorithmResult(kind="unsat")
+    return AlgorithmResult(kind="sat")
+
+
+def _normalize_algorithm_result(
+    meta: VerifyAlgorithmMeta,
+    raw_result: _RawResult,
+) -> InspectRunResult:
+    """Convert one raw return value into :class:`InspectRunResult`.
+
+    :param meta: Metadata for the algorithm that produced ``raw_result``.
+    :type meta: VerifyAlgorithmMeta
+    :param raw_result: Raw algorithm return value.
+    :type raw_result: object
+    :return: Normalized inspect-adapter result.
+    :rtype: InspectRunResult
+
+    Example::
+
+        >>> from pyfcstm.verify.registry import REGISTRY
+        >>> result = _normalize_algorithm_result(
+        ...     REGISTRY["dead_guard"],
+        ...     AlgorithmResult("sat"),
+        ... )
+        >>> result.algorithm_name
+        'dead_guard'
+    """
+    if isinstance(raw_result, AlgorithmResult):
+        algorithm_result = raw_result
+    elif (
+        isinstance(raw_result, tuple)
+        and all(isinstance(item, AlgorithmResult) for item in raw_result)
+    ):
+        algorithm_result = _aggregate_algorithm_results(raw_result)
+    else:
+        algorithm_result = AlgorithmResult(kind="sat")
+
+    return InspectRunResult(
+        algorithm_name=meta.name,
+        complexity_tier=meta.complexity_tier,
+        smt_logic=meta.smt_logic,
+        verification_scope=meta.verification_scope,
+        diagnostic_codes=meta.diagnostic_codes,
+        result_kind=algorithm_result.kind,
+        diagnostics=algorithm_result.diagnostics,
+        reason=algorithm_result.reason,
+        raw_result=raw_result,
+    )
+
+
+def _run_smt_algorithm(meta: VerifyAlgorithmMeta, machine, smt_timeout_ms):
+    """Execute one SMT-local algorithm according to its registry scope.
+
+    :param meta: Metadata with an implementation callable.
+    :type meta: VerifyAlgorithmMeta
+    :param machine: State machine to verify.
+    :type machine: StateMachine
+    :param smt_timeout_ms: Optional solver timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int]
+    :return: Raw result value from the algorithm or per-element aggregate input.
+    :rtype: object
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> from pyfcstm.verify.registry import REGISTRY
+        >>> ast = parse_with_grammar_entry("state Root;", "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> _run_smt_algorithm(REGISTRY["composite_init_guards_incomplete"], machine, None).kind
+        'unsat'
+    """
+    variables = _variables_for(machine)
+    if meta.name in _TRANSITION_ALGORITHMS:
+        return tuple(
+            meta.impl(
+                transition,
+                variables,
+                smt_timeout_ms=smt_timeout_ms,
+            )
+            for transition in _iter_model_transitions(machine)
+        )
+    if meta.name == "enter_postcondition_implies_during_precondition":
+        return tuple(
+            meta.impl(
+                state,
+                variables,
+                smt_timeout_ms=smt_timeout_ms,
+            )
+            for state in _iter_model_leaf_states(machine)
+        )
+    if meta.name in _MACHINE_SMT_ALGORITHMS:
+        return meta.impl(
+            machine,
+            variables,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+    return meta.impl(machine, variables, smt_timeout_ms=smt_timeout_ms)
+
+
+def _run_algorithm(meta: VerifyAlgorithmMeta, machine, smt_timeout_ms):
+    """Execute one eligible algorithm and return its raw value.
+
+    :param meta: Metadata with an implementation callable.
+    :type meta: VerifyAlgorithmMeta
+    :param machine: State machine to verify.
+    :type machine: StateMachine
+    :param smt_timeout_ms: Optional SMT timeout in milliseconds.
+    :type smt_timeout_ms: Optional[int]
+    :return: Raw algorithm return value.
+    :rtype: object
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> from pyfcstm.verify.registry import REGISTRY
+        >>> ast = parse_with_grammar_entry("state Root;", "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> isinstance(_run_algorithm(REGISTRY["topological_reachable_set"], machine, None), dict)
+        True
+    """
+    if meta.complexity_tier == "structural":
+        return meta.impl(machine)
+    return _run_smt_algorithm(meta, machine, smt_timeout_ms)
+
+
+def run_inspect_algorithms(
+    machine,
+    *,
+    max_complexity_tier: ComplexityTier = "structural",
+    max_call_count_scaling: CallCountScaling = "linear_in_transitions",
+    smt_timeout_ms: Optional[int] = None,
+    registry: Optional[Mapping[str, VerifyAlgorithmMeta]] = None,
+) -> Tuple[InspectRunResult, ...]:
+    """Run inspect-eligible verify algorithms and normalize their outputs.
+
+    The function is the execution half of the inspect adapter.  It reuses
+    :func:`eligible_for_inspect` as the only admission policy, runs algorithms
+    in registry order, keeps planned ``impl=None`` entries as controlled skip
+    results when they are otherwise eligible, and never emits diagnostics-layer
+    objects directly.
+
+    :param machine: State machine to verify.
+    :type machine: StateMachine
+    :param max_complexity_tier: Maximum non-BMC complexity tier allowed by the
+        inspect policy, defaults to ``"structural"``.
+    :type max_complexity_tier: ComplexityTier, optional
+    :param max_call_count_scaling: Maximum call-count scaling allowed by the
+        inspect policy, defaults to ``"linear_in_transitions"``.
+    :type max_call_count_scaling: CallCountScaling, optional
+    :param smt_timeout_ms: Optional solver timeout passed to SMT-local
+        algorithms as ``smt_timeout_ms``.  ``None`` preserves the raw algorithm
+        default of no configured solver timeout.
+    :type smt_timeout_ms: Optional[int], optional
+    :param registry: Optional metadata registry for tests or alternate
+        consumers.  ``None`` uses :data:`pyfcstm.verify.registry.REGISTRY`.
+    :type registry: Optional[Mapping[str, VerifyAlgorithmMeta]], optional
+    :return: Normalized results in registry order.
+    :rtype: Tuple[InspectRunResult, ...]
+    :raises InspectAccessForbiddenError: If either inspect limit is outside the
+        automatic inspect ordering.
+
+    Example::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> ast = parse_with_grammar_entry("state Root;", "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> [result.algorithm_name for result in run_inspect_algorithms(machine)][:2]
+        ['topological_reachable_set', 'unreachable_states']
+    """
+    _validate_max_complexity_tier(max_complexity_tier)
+    _validate_max_call_count_scaling(max_call_count_scaling)
+
+    if registry is None:
+        from .registry import REGISTRY
+
+        registry = REGISTRY
+
+    results = []
+    for meta in registry.values():
+        if not eligible_for_inspect(
+            meta,
+            max_complexity_tier=max_complexity_tier,
+            max_call_count_scaling=max_call_count_scaling,
+        ):
+            continue
+        if meta.impl is None:
+            results.append(_missing_impl_result(meta))
+            continue
+        raw_result = _run_algorithm(meta, machine, smt_timeout_ms)
+        results.append(_normalize_algorithm_result(meta, raw_result))
+    return tuple(results)
+
+
 __all__ = [
+    "InspectRunResult",
     "InspectAccessForbiddenError",
     "eligible_for_inspect",
     "iter_inspect_eligible",
+    "run_inspect_algorithms",
 ]

--- a/test/verify/test_inspect_adapter.py
+++ b/test/verify/test_inspect_adapter.py
@@ -548,6 +548,117 @@ def test_run_inspect_algorithms_aggregates_all_unsat_transition_results():
     assert result.diagnostics == ()
 
 
+def test_run_inspect_algorithms_treats_empty_per_element_run_as_no_finding():
+    def smt_impl(transition, variables, *, smt_timeout_ms=None):
+        raise AssertionError("transition-level algorithm should not run")
+
+    registry = {
+        "dead_guard": _meta(
+            name="dead_guard",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            impl=smt_impl,
+        )
+    }
+
+    result = run_inspect_algorithms(
+        _machine("state Root;"),
+        max_complexity_tier="smt_linear",
+        registry=registry,
+    )[0]
+
+    assert result.result_kind == "sat"
+    assert result.diagnostics == ()
+    assert result.raw_result == ()
+
+
+def test_run_inspect_algorithms_aggregates_unsat_findings_before_sat_diagnostics():
+    calls = []
+
+    def smt_impl(transition, variables, *, smt_timeout_ms=None):
+        calls.append(str(transition.from_state))
+        if len(calls) == 1:
+            return AlgorithmResult(
+                kind="sat",
+                diagnostics=({"code": "I_FAKE", "data": {"state": "Root"}},),
+            )
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=({"code": "W_FAKE", "data": {"state": "Root.A"}},),
+        )
+
+    registry = {
+        "dead_guard": _meta(
+            name="dead_guard",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            diagnostic_codes=("I_FAKE", "W_FAKE"),
+            impl=smt_impl,
+        )
+    }
+    machine = _machine(
+        """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+    )
+
+    result = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        registry=registry,
+    )[0]
+
+    assert calls == ["INIT_STATE", "A"]
+    assert result.result_kind == "unsat"
+    assert result.diagnostics == (
+        {"code": "I_FAKE", "data": {"state": "Root"}},
+        {"code": "W_FAKE", "data": {"state": "Root.A"}},
+    )
+
+
+def test_run_inspect_algorithms_preserves_sat_diagnostic_kind_without_unsat_findings():
+    def smt_impl(transition, variables, *, smt_timeout_ms=None):
+        return AlgorithmResult(
+            kind="sat",
+            diagnostics=({"code": "I_FAKE", "data": {"state": "Root"}},),
+        )
+
+    registry = {
+        "dead_guard": _meta(
+            name="dead_guard",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            diagnostic_codes=("I_FAKE",),
+            impl=smt_impl,
+        )
+    }
+    machine = _machine(
+        """
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+
+    result = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        registry=registry,
+    )[0]
+
+    assert result.result_kind == "sat"
+    assert result.diagnostics == ({"code": "I_FAKE", "data": {"state": "Root"}},)
+
+
 def test_run_inspect_algorithms_dispatches_leaf_lifecycle_algorithm():
     seen = []
 

--- a/test/verify/test_inspect_adapter.py
+++ b/test/verify/test_inspect_adapter.py
@@ -258,8 +258,8 @@ def test_run_inspect_algorithms_passes_timeout_only_to_smt_algorithms():
             diagnostic_codes=("W_STRUCT",),
             impl=structural_impl,
         ),
-        "smt_demo": _meta(
-            name="smt_demo",
+        "composite_init_guards_incomplete": _meta(
+            name="composite_init_guards_incomplete",
             complexity_tier="smt_linear",
             smt_logic="QF_LIRA",
             verification_scope="smt_local",
@@ -282,7 +282,7 @@ def test_run_inspect_algorithms_passes_timeout_only_to_smt_algorithms():
     ]
     assert tuple(result.algorithm_name for result in results) == (
         "structural_demo",
-        "smt_demo",
+        "composite_init_guards_incomplete",
     )
     smt_result = results[1]
     assert smt_result.result_kind == "timeout"
@@ -303,8 +303,8 @@ def test_run_inspect_algorithms_none_timeout_is_preserved_for_smt_algorithms():
         return AlgorithmResult(kind="unknown", reason="solver said unknown")
 
     registry = {
-        "smt_demo": _meta(
-            name="smt_demo",
+        "composite_init_guards_incomplete": _meta(
+            name="composite_init_guards_incomplete",
             complexity_tier="smt_linear",
             smt_logic="QF_LIRA",
             verification_scope="smt_local",
@@ -322,6 +322,101 @@ def test_run_inspect_algorithms_none_timeout_is_preserved_for_smt_algorithms():
     assert seen == [None]
     assert result.result_kind == "unknown"
     assert result.reason == "solver said unknown"
+
+
+def test_run_inspect_algorithms_keeps_structural_plain_payloads():
+    raw_payload = ("Root", "Root.A")
+
+    def structural_impl(machine):
+        return raw_payload
+
+    registry = {
+        "structural_demo": _meta(
+            name="structural_demo",
+            complexity_tier="structural",
+            smt_logic=None,
+            verification_scope="topological_only",
+            impl=structural_impl,
+        )
+    }
+
+    result = run_inspect_algorithms(_machine(), registry=registry)[0]
+
+    assert result.result_kind == "sat"
+    assert result.raw_result is raw_payload
+
+
+def test_run_inspect_algorithms_rejects_invalid_machine_level_smt_payload():
+    def smt_impl(machine, variables, *, smt_timeout_ms=None):
+        return "bad"
+
+    registry = {
+        "composite_init_guards_incomplete": _meta(
+            name="composite_init_guards_incomplete",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            impl=smt_impl,
+        )
+    }
+
+    with pytest.raises(TypeError, match="unexpected raw result type 'str'"):
+        run_inspect_algorithms(
+            _machine(),
+            max_complexity_tier="smt_linear",
+            registry=registry,
+        )
+
+
+def test_run_inspect_algorithms_rejects_invalid_smt_tuple_item():
+    def smt_impl(machine, variables, *, smt_timeout_ms=None):
+        return (
+            AlgorithmResult(
+                kind="unsat",
+                diagnostics=({"code": "W_FAKE", "data": {"state": "Root"}},),
+            ),
+            "bad",
+        )
+
+    registry = {
+        "composite_init_guards_incomplete": _meta(
+            name="composite_init_guards_incomplete",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            diagnostic_codes=("W_FAKE",),
+            impl=smt_impl,
+        )
+    }
+
+    with pytest.raises(TypeError, match="tuple item 1"):
+        run_inspect_algorithms(
+            _machine(),
+            max_complexity_tier="smt_linear",
+            registry=registry,
+        )
+
+
+def test_run_inspect_algorithms_rejects_unknown_smt_dispatch_rule():
+    def smt_impl(machine, variables, *, smt_timeout_ms=None):
+        return AlgorithmResult(kind="sat")
+
+    registry = {
+        "custom_smt": _meta(
+            name="custom_smt",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            impl=smt_impl,
+        )
+    }
+
+    with pytest.raises(ValueError, match="no inspect dispatch rule"):
+        run_inspect_algorithms(
+            _machine(),
+            max_complexity_tier="smt_linear",
+            registry=registry,
+        )
 
 
 def test_run_inspect_algorithms_keeps_diagnostics_when_one_element_times_out():

--- a/test/verify/test_inspect_adapter.py
+++ b/test/verify/test_inspect_adapter.py
@@ -2,11 +2,16 @@ from typing import cast
 
 import pytest
 
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.verify import (
     REGISTRY,
+    AlgorithmResult,
+    InspectRunResult,
     InspectAccessForbiddenError,
     eligible_for_inspect,
     iter_inspect_eligible,
+    run_inspect_algorithms,
 )
 from pyfcstm.verify.taxonomy import (
     CallCountScaling,
@@ -16,6 +21,11 @@ from pyfcstm.verify.taxonomy import (
 
 
 pytestmark = pytest.mark.unittest
+
+
+def _machine(source="state Root;"):
+    ast = parse_with_grammar_entry(source, "state_machine_dsl")
+    return parse_dsl_node_to_state_machine(ast)
 
 
 def _meta(**overrides):
@@ -193,3 +203,384 @@ def test_iter_inspect_eligible_preserves_registry_order():
         "topological_inevitable_terminator",
         "composite_init_guards_incomplete",
     )
+
+
+def test_run_inspect_algorithms_executes_default_eligible_registry_set():
+    machine = _machine(
+        """
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+
+    results = run_inspect_algorithms(machine)
+
+    assert isinstance(results, tuple)
+    assert all(isinstance(result, InspectRunResult) for result in results)
+    assert tuple(result.algorithm_name for result in results) == tuple(
+        meta.name for meta in iter_inspect_eligible()
+    )
+    first = results[0]
+    assert first.algorithm_name == "topological_reachable_set"
+    assert first.complexity_tier == "structural"
+    assert first.smt_logic is None
+    assert first.verification_scope == "topological_only"
+    assert first.diagnostic_codes == ()
+    assert first.result_kind == "sat"
+    assert first.reason is None
+    assert first.diagnostics == ()
+    assert first.raw_result["Root.A"] == ()
+
+
+def test_run_inspect_algorithms_passes_timeout_only_to_smt_algorithms():
+    calls = []
+
+    def structural_impl(machine):
+        calls.append(("structural", machine))
+        return {"ok": True}
+
+    def smt_impl(machine, variables, *, smt_timeout_ms=None):
+        calls.append(("smt", machine, tuple(variables), smt_timeout_ms))
+        return AlgorithmResult(
+            kind="timeout",
+            diagnostics=({"code": "W_FAKE", "data": {"target": "Root"}},),
+            reason="forced timeout",
+        )
+
+    registry = {
+        "structural_demo": _meta(
+            name="structural_demo",
+            complexity_tier="structural",
+            smt_logic=None,
+            verification_scope="topological_only",
+            diagnostic_codes=("W_STRUCT",),
+            impl=structural_impl,
+        ),
+        "smt_demo": _meta(
+            name="smt_demo",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            diagnostic_codes=("W_FAKE",),
+            impl=smt_impl,
+        ),
+    }
+    machine = _machine("def int x = 0; state Root;")
+
+    results = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=250,
+        registry=registry,
+    )
+
+    assert calls == [
+        ("structural", machine),
+        ("smt", machine, tuple(machine.defines.values()), 250),
+    ]
+    assert tuple(result.algorithm_name for result in results) == (
+        "structural_demo",
+        "smt_demo",
+    )
+    smt_result = results[1]
+    assert smt_result.result_kind == "timeout"
+    assert smt_result.reason == "forced timeout"
+    assert smt_result.diagnostics == ({"code": "W_FAKE", "data": {"target": "Root"}},)
+    assert smt_result.raw_result == AlgorithmResult(
+        kind="timeout",
+        diagnostics=({"code": "W_FAKE", "data": {"target": "Root"}},),
+        reason="forced timeout",
+    )
+
+
+def test_run_inspect_algorithms_none_timeout_is_preserved_for_smt_algorithms():
+    seen = []
+
+    def smt_impl(machine, variables, *, smt_timeout_ms=None):
+        seen.append(smt_timeout_ms)
+        return AlgorithmResult(kind="unknown", reason="solver said unknown")
+
+    registry = {
+        "smt_demo": _meta(
+            name="smt_demo",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            impl=smt_impl,
+        )
+    }
+
+    result = run_inspect_algorithms(
+        _machine(),
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=None,
+        registry=registry,
+    )[0]
+
+    assert seen == [None]
+    assert result.result_kind == "unknown"
+    assert result.reason == "solver said unknown"
+
+
+def test_run_inspect_algorithms_keeps_diagnostics_when_one_element_times_out():
+    def first_impl(machine, variables, *, smt_timeout_ms=None):
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=({"code": "W_FAKE", "data": {"state": "Root.A"}},),
+        )
+
+    def second_impl(machine, variables, *, smt_timeout_ms=None):
+        return AlgorithmResult(kind="timeout", reason="second transition timed out")
+
+    calls = [first_impl, second_impl]
+
+    def smt_impl(machine, variables, *, smt_timeout_ms=None):
+        return calls.pop(0)(machine, variables, smt_timeout_ms=smt_timeout_ms)
+
+    registry = {
+        "dead_guard": _meta(
+            name="dead_guard",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            diagnostic_codes=("W_FAKE",),
+            impl=smt_impl,
+        )
+    }
+    machine = _machine(
+        """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+    )
+
+    result = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        registry=registry,
+    )[0]
+
+    assert result.result_kind == "timeout"
+    assert result.reason == "second transition timed out"
+    assert result.diagnostics == ({"code": "W_FAKE", "data": {"state": "Root.A"}},)
+
+
+def test_run_inspect_algorithms_aggregates_definite_transition_findings():
+    calls = []
+
+    def smt_impl(transition, variables, *, smt_timeout_ms=None):
+        source = str(transition.from_state)
+        calls.append(source)
+        if source in ("INIT_STATE", "A"):
+            return AlgorithmResult(kind="sat")
+        return AlgorithmResult(
+            kind="unsat",
+            diagnostics=({"code": "W_FAKE", "data": {"state": "Root.B"}},),
+        )
+
+    registry = {
+        "dead_guard": _meta(
+            name="dead_guard",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            diagnostic_codes=("W_FAKE",),
+            impl=smt_impl,
+        )
+    }
+    machine = _machine(
+        """
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B;
+            B -> C;
+        }
+        """
+    )
+
+    result = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        registry=registry,
+    )[0]
+
+    assert calls == ["INIT_STATE", "A", "B"]
+    assert result.result_kind == "unsat"
+    assert result.reason is None
+    assert result.diagnostics == ({"code": "W_FAKE", "data": {"state": "Root.B"}},)
+
+
+def test_run_inspect_algorithms_aggregates_all_unsat_transition_results():
+    def smt_impl(transition, variables, *, smt_timeout_ms=None):
+        return AlgorithmResult(kind="unsat")
+
+    registry = {
+        "dead_guard": _meta(
+            name="dead_guard",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            impl=smt_impl,
+        )
+    }
+    machine = _machine(
+        """
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+    )
+
+    result = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        registry=registry,
+    )[0]
+
+    assert result.result_kind == "unsat"
+    assert result.diagnostics == ()
+
+
+def test_run_inspect_algorithms_dispatches_leaf_lifecycle_algorithm():
+    seen = []
+
+    def lifecycle_impl(state, variables, *, smt_timeout_ms=None):
+        seen.append((state.name, tuple(variables), smt_timeout_ms))
+        return AlgorithmResult(kind="sat")
+
+    registry = {
+        "enter_postcondition_implies_during_precondition": _meta(
+            name="enter_postcondition_implies_during_precondition",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            call_count_scaling="linear_in_leaves",
+            verification_scope="smt_local",
+            impl=lifecycle_impl,
+        )
+    }
+    machine = _machine(
+        """
+        state Root {
+            state A;
+            pseudo state Probe;
+            [*] -> A;
+        }
+        """
+    )
+
+    result = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=75,
+        registry=registry,
+    )[0]
+
+    assert seen == [("A", (), 75)]
+    assert result.result_kind == "sat"
+
+
+def test_run_inspect_algorithms_dispatches_machine_level_smt_algorithm():
+    seen = []
+
+    def machine_impl(machine, variables, *, smt_timeout_ms=None):
+        seen.append(
+            (
+                machine.root_state.name,
+                tuple(variable.name for variable in variables),
+                smt_timeout_ms,
+            )
+        )
+        return AlgorithmResult(kind="unknown", reason="machine-level check")
+
+    registry = {
+        "composite_init_guards_incomplete": _meta(
+            name="composite_init_guards_incomplete",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            impl=machine_impl,
+        )
+    }
+
+    result = run_inspect_algorithms(
+        _machine("def int x = 0; state Root;"),
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=125,
+        registry=registry,
+    )[0]
+
+    assert seen == [("Root", ("x",), 125)]
+    assert result.result_kind == "unknown"
+    assert result.reason == "machine-level check"
+
+
+def test_run_inspect_algorithms_skips_missing_impl_without_crashing():
+    registry = {
+        "missing_demo": _meta(
+            name="missing_demo",
+            complexity_tier="structural",
+            verification_scope="topological_only",
+            impl=None,
+        )
+    }
+
+    result = run_inspect_algorithms(_machine(), registry=registry)[0]
+
+    assert result.algorithm_name == "missing_demo"
+    assert result.result_kind == "undecidable_skip"
+    assert result.diagnostics == ()
+    assert "implementation is not registered" in result.reason
+    assert result.raw_result == AlgorithmResult(
+        kind="undecidable_skip",
+        reason="algorithm implementation is not registered",
+    )
+
+
+def test_run_inspect_algorithms_does_not_execute_excluded_metadata():
+    calls = []
+
+    def impl(machine):
+        calls.append(machine)
+        return {"unexpected": True}
+
+    registry = {
+        "queried_demo": _meta(
+            name="queried_demo",
+            closedness="queried",
+            complexity_tier="structural",
+            impl=impl,
+        ),
+        "too_expensive_demo": _meta(
+            name="too_expensive_demo",
+            complexity_tier="smt_linear",
+            smt_logic="QF_LIRA",
+            verification_scope="smt_local",
+            impl=impl,
+        ),
+    }
+
+    results = run_inspect_algorithms(_machine(), registry=registry)
+
+    assert results == ()
+    assert calls == []
+
+
+def test_run_inspect_algorithms_rejects_bmc_complexity_limit():
+    with pytest.raises(InspectAccessForbiddenError, match="bmc_search"):
+        run_inspect_algorithms(
+            _machine(),
+            max_complexity_tier="bmc_search",
+            registry={},
+        )


### PR DESCRIPTION
## 上游依据

本 PR 是 Track B 伞 PR #174 的第二个子 PR，关联上游 issue #114。

#174 对 PR-B2 的定义是：在 `pyfcstm.verify.inspect_adapter` 中实现 `run_inspect_algorithms(...)`，按算法登记表、复杂度门限、调用次数门限和 timeout 策略执行 eligible 算法，并把 raw result 归一化为可转换结构；明确 `unknown`、`timeout`、`undecidable_skip` 的处理。

PR-B1 #175 已合入本伞分支，已经补齐 verify 诊断码与 refs 契约。本 PR 只做 adapter 执行闭环，不把结果接入 `inspect_model()`，不改 CLI，不实装 BMC 算法本体，也不让 BMC / queried 算法进入 inspect 自动执行路径，不修改 jsfcstm。

说明：#114 正文中较早的 Track B PR-B1/B2 草案已由伞 PR #174 重新细化；本 PR 的可执行范围以 #174 的 PR-B2 定义为准。旧草案中的 `inspect_model()` 接入归 PR-B3，拓扑 reachability 同源化归 PR-B4，CLI 归 PR-B5。

## 目标

把 Track A 已落地的 verify 算法登记表从“可枚举 eligible 算法”推进到“inspect 策略层可受控执行算法并拿到统一结果”。

必须达成：

1. `iter_inspect_eligible(...)` 的筛选规则继续作为唯一准入来源。
2. `run_inspect_algorithms(...)` 只运行 `closed` 且通过复杂度门限、调用次数门限的算法。
3. `bmc_search` 和 `queried` 算法不能进入自动 inspect 执行路径。
4. `impl is None` 的 registry 项必须受控跳过，不得崩溃。
5. `smt_timeout_ms` 只作为 adapter 策略参数向 raw verify 算法的同名 `smt_timeout_ms` 参数透传；raw 算法内部再按既有 solver helper 契约处理 `timeout_ms`，本 PR 不反向修改 raw verify 算法默认契约。
6. raw `AlgorithmResult` 必须被归一化为稳定结构，保留 PR-B3 转换为 `ModelDiagnostic` 所需的 registry metadata：`algorithm_name`、`complexity_tier`、`smt_logic`、`verification_scope`、`diagnostic_codes`、`result_kind`、`reason` 和原始 diagnostics；本 PR 只保存这些字段，不发射 `ModelDiagnostic`。
7. 本 PR 不发射 `ModelDiagnostic`，不改变 `inspect_model()` 默认输出。

## 最小接口契约

草拟签名如下，最终以本 PR 实现为准：

```python
def run_inspect_algorithms(
    machine: StateMachine,
    *,
    max_complexity_tier: ComplexityTier = "structural",
    max_call_count_scaling: CallCountScaling = "linear_in_transitions",
    smt_timeout_ms: Optional[int] = None,
    registry: Optional[Mapping[str, VerifyAlgorithmMeta]] = None,
) -> Tuple[InspectRunResult, ...]: ...
```

归一化结果结构草拟如下：

```python
@dataclass(frozen=True)
class InspectRunResult:
    algorithm_name: str
    complexity_tier: ComplexityTier
    smt_logic: Optional[SMTLogic]
    verification_scope: Optional[VerificationScope]
    diagnostic_codes: Tuple[str, ...]
    result_kind: ResultKind
    diagnostics: Tuple[dict, ...]
    reason: Optional[str]
```

timeout 映射规则：

- `run_inspect_algorithms(..., smt_timeout_ms=None)` 表示不配置 solver timeout，与 Track A 的 `timeout_ms: Optional[int] = None` 契约一致。
- 非 `None` 的 `smt_timeout_ms` 原样以 `smt_timeout_ms=<value>` 传给 SMT-local raw verify 算法。
- `complexity_tier == "structural"` 的算法不接 Z3 timeout，adapter 不向其传 `smt_timeout_ms`。
- 本 PR 不在 raw verify 层校验 finite positive policy；后续 inspect/CLI 策略层如需限制，由上层负责。

## 实施范围

| 文件或模块 | 工作内容 | 验收口径 |
|---|---|---|
| `pyfcstm.verify.inspect_adapter` | 新增执行结果数据结构和 `run_inspect_algorithms(...)` | 可按 registry 顺序执行 eligible 算法；skip、unknown、timeout 有稳定表达；执行算法集合等于 `iter_inspect_eligible(...)` 返回集合 |
| `pyfcstm.verify.__init__` | 重导出新增公开入口 | 用户不需要 import 三级内部模块；module pydoc 的 reST 表格模块地图同步新增入口 |
| `test/verify/test_inspect_adapter.py` | TDD 覆盖执行闭环 | 覆盖 structural、`smt_linear`、拒绝 `bmc_search`、跳过 `impl=None`、timeout 透传、unknown/skip 不误报、归一化结果字段完整 |
| `docs/source/api_doc/verify/inspect_adapter.rst` | 由 `make rst_auto` 自动同步 | 文档构建入口不缺新增公开对象；只提交本 PR 相关 RST diff |

## pydoc / API 文档约束

| 对象 | 要求 | 验收口径 |
|---|---|---|
| 新增 module / class / function / dataclass docstring | 使用 reST 格式说明功能与效果、参数信息和类型 | 函数/方法包含 `:param:`、`:type:`、`:return:`、`:rtype:`；可抛异常包含 `:raises:`；dataclass field 用 `:param:`、`:type:` 描述 |
| `Examples::` | 示例必须真实可运行 | import 路径正确，不依赖未声明 fixture，不抛 `NameError` / `AttributeError` |
| `pyfcstm.verify.__init__` | module pydoc 继续使用 reST 表格提供模块地图 | 表格列出 public entry、来源模块和一句话用途；新增入口有对应行 |
| 工作流标签 | 不写入代码/API/pydoc 语义 | 不把 PR-B2、review round、issue 阶段写进函数名、类名、测试名、runtime message 或 pydoc 语义描述 |

## 明确不做

| 项目 | 原因 |
|---|---|
| 接入 `inspect_model()` | 留给 PR-B3，避免和本 PR 的 adapter 执行闭环混在一起 |
| 生成 `ModelDiagnostic` | 留给 PR-B3，PR-B1 只提供诊断契约，本 PR 只提供 raw result 归一化 |
| 改 CLI | 留给 PR-B5 |
| 运行 BMC / queried 算法 | #114 和 #174 明确禁止进入 inspect 自动路径 |
| 修改 jsfcstm | Track B 为 py-only verify 接入；默认跨端 parity 不应被本 PR 影响 |

## 测试计划

- `SKIP_SLOW_TESTS=1 pytest test/verify/test_inspect_adapter.py -v`
- `SKIP_SLOW_TESTS=1 make unittest`
- `make rst_auto`
- `READTHEDOCS_LANGUAGE=zh sphinx-build -b html docs/source /tmp/pyfcstm-pr-b2-html-zh`
- `rg -n 'class="problematic"' /tmp/pyfcstm-pr-b2-html-zh -g '*.html'` 必须无命中

测试必须证明：

1. 给定门限下，`run_inspect_algorithms(...)` 覆盖的算法名集合等于 `iter_inspect_eligible(...)` 返回的集合。
2. `structural` 算法不会收到 `smt_timeout_ms`。
3. `smt_linear` 算法会收到 `smt_timeout_ms=<smt_timeout_ms>`，`None` 和非 `None` 都原样透传。
4. 请求 `max_complexity_tier="bmc_search"` 受控失败。
5. `impl is None` 或被 registry metadata 排除的算法不会被执行。
6. `unknown`、`timeout`、`undecidable_skip` 只进入归一化结果，不在本 PR 发射 `ModelDiagnostic`。
7. 归一化结果包含 `algorithm_name`、`complexity_tier`、`smt_logic`、`verification_scope`、`diagnostic_codes`、`result_kind`、`reason`、raw diagnostics 和 `raw_result`。

## PR body 一致性审查状态

三路 reviewer 已完成计划一致性审查：

| reviewer | 结论 | 后续处理 |
|---|---|---|
| codex reviewer | C=0，I=2，M=2 | 已补充 `verification_scope` 等结果字段，以及 `__init__.py` 模块地图要求 |
| claude reviewer | C=0，I=4，M=3 | 已补充 reST pydoc、timeout 映射、函数签名草案、Sphinx HTML 验证 |
| deepseek reviewer | C=0，I=4，M=2 | 已补充函数签名、结果结构、模块地图和 eligible 集合一致性验收 |

## 当前状态

| 项目 | 状态 | 说明 |
|---|---|---|
| PR-B2 | 🟨 计划已按三路 review 修正，进入 TDD 实现 | 先写测试，再实现 adapter 执行闭环 |
| 依赖 | 🟢 PR-B1 已合入 | 可消费 verify 诊断契约，但本 PR 暂不发射诊断 |
| 合并策略 | 🟨 等维护者指示 | 本 PR ready 后不自行 merge |