### PR TITLE
PR-B3：把 verify 可选接入 inspect_model（#114）

### DIFF
--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -27,7 +27,7 @@ The module exposes the following dataclasses:
 Examples::
 
     >>> from pyfcstm.dsl import parse_with_grammar_entry
-    >>> from pyfcstm.model.parse import parse_dsl_node_to_state_machine
+    >>> from pyfcstm.model import parse_dsl_node_to_state_machine
     >>> from pyfcstm.diagnostics import inspect_model
     >>> source = '''
     ... def int counter = 0;
@@ -478,6 +478,11 @@ class ModelInspect:
 
         Examples::
 
+            >>> from pyfcstm.dsl import parse_with_grammar_entry
+            >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+            >>> ast = parse_with_grammar_entry('state Root;', 'state_machine_dsl')
+            >>> machine = parse_dsl_node_to_state_machine(ast)
+            >>> report = inspect_model(machine)
             >>> report.to_json()['root_state_path']
             'Root'
         """
@@ -2247,6 +2252,10 @@ def _make_verify_diagnostic(
 ) -> Optional[ModelDiagnostic]:
     """Create one ``ModelDiagnostic`` from verified refs.
 
+    Verify diagnostics must bind back to the source object declared by the
+    code registry. A raw verify finding with valid refs but no source object
+    is dropped instead of becoming a public spanless diagnostic.
+
     :param code: Verify-pipeline diagnostic code.
     :type code: str
     :param refs: Candidate refs payload.
@@ -2271,6 +2280,12 @@ def _make_verify_diagnostic(
     if not _refs_match_code_schema(code, refs):
         return None
     spec = CODE_REGISTRY[code]
+    if (
+            spec.span_object is not None
+            and code not in KNOWN_SPANLESS_CODES
+            and span is None
+    ):
+        return None
     return ModelDiagnostic(
         code=code,
         severity=spec.severity,

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -24,7 +24,7 @@ The module exposes the following dataclasses:
 * :class:`ModelMetrics` — aggregate counts and ratios
 * :class:`ModelInspect` — top-level container including diagnostics
 
-Example::
+Examples::
 
     >>> from pyfcstm.dsl import parse_with_grammar_entry
     >>> from pyfcstm.model.parse import parse_dsl_node_to_state_machine
@@ -47,13 +47,14 @@ Example::
 
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from .analyzers import (
     build_use_def_graph,
     collect_design_health_warnings,
     collect_expr_variables,
 )
+from .codes import CODE_REGISTRY, CodeFieldSpec
 from ..utils.validate import ModelDiagnostic, Span
 
 if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
@@ -65,6 +66,7 @@ if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
         StateMachine,
         Transition,
     )
+    from ..verify.inspect_adapter import InspectRunResult
 
 
 DEFAULT_DEEP_HIERARCHY_THRESHOLD = 6
@@ -474,7 +476,7 @@ class ModelInspect:
             without loss.
         :rtype: Dict[str, Any]
 
-        Example::
+        Examples::
 
             >>> report.to_json()['root_state_path']
             'Root'
@@ -1412,12 +1414,859 @@ def _function_signature(state: Any, default_path: Optional[str], action: Any) ->
     return f'{normalized}:{leaf}' if normalized else leaf
 
 
+def _run_verify_inspect_algorithms(machine: 'StateMachine', **kwargs):
+    """Run the verify inspect adapter lazily.
+
+    Keeping this import behind the ``enable_verify`` branch preserves the
+    default inspect path for users that only need structural diagnostics.
+
+    :param machine: State machine to verify.
+    :type machine: pyfcstm.model.StateMachine
+    :param kwargs: Inspect-adapter policy arguments.
+    :type kwargs: object
+    :return: Adapter results in registry order.
+    :rtype: Tuple[pyfcstm.verify.inspect_adapter.InspectRunResult, ...]
+
+    Examples::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> ast = parse_with_grammar_entry("state Root;", "state_machine_dsl")
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> bool(_run_verify_inspect_algorithms(machine))
+        True
+    """
+    from ..verify.inspect_adapter import run_inspect_algorithms
+
+    return run_inspect_algorithms(machine, **kwargs)
+
+
+def _transition_summary(payload: Mapping[str, Any]) -> str:
+    """Render a raw verify transition payload as a compact label.
+
+    :param payload: Raw transition payload produced by
+        :mod:`pyfcstm.verify.encoding`.
+    :type payload: Mapping[str, Any]
+    :return: ``parent:from->to`` transition label.
+    :rtype: str
+
+    Examples::
+
+        >>> _transition_summary({
+        ...     'parent': 'Root',
+        ...     'from_state': 'A',
+        ...     'to_state': 'B',
+        ... })
+        'Root:A->B'
+    """
+    return '{parent}:{from_state}->{to_state}'.format(**payload)
+
+
+def _state_span_by_path(states: Sequence[StateInfo], state_path: Optional[str]) -> Optional[Span]:
+    """Return the source span for a state path.
+
+    :param states: Inspect state payloads.
+    :type states: Sequence[StateInfo]
+    :param state_path: Dotted state path to locate.
+    :type state_path: Optional[str]
+    :return: Matching state span, or ``None`` when the path is absent.
+    :rtype: Optional[Span]
+
+    Examples::
+
+        >>> state = StateInfo(
+        ...     path='Root',
+        ...     name='Root',
+        ...     parent_path=None,
+        ...     is_leaf=True,
+        ...     is_pseudo=False,
+        ...     is_composite=False,
+        ...     substates=(),
+        ...     initial_targets=(),
+        ...     entry_actions=(),
+        ...     during_actions=(),
+        ...     exit_actions=(),
+        ...     aspect_before=(),
+        ...     aspect_after=(),
+        ...     has_abstract_action=False,
+        ...     span=Span(line=1, column=1),
+        ... )
+        >>> _state_span_by_path((state,), 'Root').line
+        1
+    """
+    if state_path is None:
+        return None
+    for state in states:
+        if state.path == state_path:
+            return state.span
+    return None
+
+
+def _event_span_by_name(events: Sequence[EventInfo], event_name: Optional[str]) -> Optional[Span]:
+    """Return the source span for a qualified event name.
+
+    :param events: Inspect event payloads.
+    :type events: Sequence[EventInfo]
+    :param event_name: Qualified event name to locate.
+    :type event_name: Optional[str]
+    :return: Matching event declaration span, or ``None``.
+    :rtype: Optional[Span]
+
+    Examples::
+
+        >>> event = EventInfo(
+        ...     qualified_name='Root.Tick',
+        ...     scope='chain',
+        ...     used_by=(),
+        ...     is_declared=True,
+        ...     is_used=False,
+        ...     span=Span(line=2, column=5),
+        ... )
+        >>> _event_span_by_name((event,), 'Root.Tick').column
+        5
+    """
+    if event_name is None:
+        return None
+    for event in events:
+        if event.qualified_name == event_name:
+            return event.span
+    return None
+
+
+def _transition_matches_payload(info: TransitionInfo, payload: Mapping[str, Any]) -> bool:
+    """Return whether inspect transition data matches raw verify payload.
+
+    :param info: Inspect transition payload.
+    :type info: TransitionInfo
+    :param payload: Raw verify transition payload.
+    :type payload: Mapping[str, Any]
+    :return: ``True`` when endpoints, event, guard, and forced flag match.
+    :rtype: bool
+
+    Examples::
+
+        >>> info = TransitionInfo(
+        ...     from_path='Root.A',
+        ...     to_path='Root.B',
+        ...     event=None,
+        ...     event_scope=None,
+        ...     guard='x > 0',
+        ...     effect=None,
+        ...     effect_self_assigns=(),
+        ...     is_forced=False,
+        ...     forced_origin=None,
+        ...     transition_index=0,
+        ... )
+        >>> _transition_matches_payload(info, {
+        ...     'parent': 'Root',
+        ...     'from_state': 'A',
+        ...     'to_state': 'B',
+        ...     'event': None,
+        ...     'guard': 'x > 0',
+        ...     'is_forced': False,
+        ... })
+        True
+    """
+    parent = payload.get('parent')
+    from_state = payload.get('from_state')
+    to_state = payload.get('to_state')
+    from_path = '[*]' if from_state == '[*]' else (
+        f'{parent}.{from_state}' if parent else from_state
+    )
+    to_path = '[*]' if to_state == '[*]' else (
+        f'{parent}.{to_state}' if parent else to_state
+    )
+    return (
+        info.from_path == from_path
+        and info.to_path == to_path
+        and info.event == payload.get('event')
+        and info.guard == payload.get('guard')
+        and info.is_forced == bool(payload.get('is_forced'))
+    )
+
+
+def _transition_span_by_payload(
+        transitions: Sequence[TransitionInfo],
+        payload: Optional[Mapping[str, Any]],
+) -> Optional[Span]:
+    """Return the transition span for a raw verify transition payload.
+
+    :param transitions: Inspect transition payloads.
+    :type transitions: Sequence[TransitionInfo]
+    :param payload: Raw verify transition payload.
+    :type payload: Optional[Mapping[str, Any]]
+    :return: Matching transition source span, or ``None``.
+    :rtype: Optional[Span]
+
+    Examples::
+
+        >>> transition = TransitionInfo(
+        ...     from_path='Root.A',
+        ...     to_path='Root.B',
+        ...     event=None,
+        ...     event_scope=None,
+        ...     guard=None,
+        ...     effect=None,
+        ...     effect_self_assigns=(),
+        ...     is_forced=False,
+        ...     forced_origin=None,
+        ...     transition_index=0,
+        ...     span=Span(line=3, column=5),
+        ... )
+        >>> _transition_span_by_payload((transition,), {
+        ...     'parent': 'Root',
+        ...     'from_state': 'A',
+        ...     'to_state': 'B',
+        ...     'event': None,
+        ...     'guard': None,
+        ...     'is_forced': False,
+        ... }).line
+        3
+    """
+    if payload is None:
+        return None
+    for transition in transitions:
+        if _transition_matches_payload(transition, payload):
+            return transition.span
+    return None
+
+
+def _effect_span_by_payload(
+        transitions: Sequence[TransitionInfo],
+        payload: Optional[Mapping[str, Any]],
+) -> Optional[Span]:
+    """Return the most specific effect span for a raw transition payload.
+
+    :param transitions: Inspect transition payloads.
+    :type transitions: Sequence[TransitionInfo]
+    :param payload: Raw verify transition payload.
+    :type payload: Optional[Mapping[str, Any]]
+    :return: First effect span when present, otherwise the transition span.
+    :rtype: Optional[Span]
+
+    Examples::
+
+        >>> span = Span(line=4, column=10)
+        >>> transition = TransitionInfo(
+        ...     from_path='Root.A',
+        ...     to_path='Root.B',
+        ...     event=None,
+        ...     event_scope=None,
+        ...     guard=None,
+        ...     effect='x = x + 0',
+        ...     effect_self_assigns=(),
+        ...     is_forced=False,
+        ...     forced_origin=None,
+        ...     transition_index=0,
+        ...     effect_spans=(span,),
+        ... )
+        >>> _effect_span_by_payload((transition,), {
+        ...     'parent': 'Root',
+        ...     'from_state': 'A',
+        ...     'to_state': 'B',
+        ...     'event': None,
+        ...     'guard': None,
+        ...     'is_forced': False,
+        ... }).column
+        10
+    """
+    if payload is None:
+        return None
+    for transition in transitions:
+        if _transition_matches_payload(transition, payload):
+            if transition.effect_spans:
+                return transition.effect_spans[0]
+            return transition.span
+    return None
+
+
+def _action_span_by_state_and_condition(
+        actions: Sequence[ActionInfo],
+        state_path: Optional[str],
+        condition_source: Optional[str],
+) -> Optional[Span]:
+    """Return the lifecycle action span associated with a verify condition.
+
+    :param actions: Inspect action payloads.
+    :type actions: Sequence[ActionInfo]
+    :param state_path: State path reported by the raw verify diagnostic.
+    :type state_path: Optional[str]
+    :param condition_source: Condition source label, such as
+        ``"during:0"``.
+    :type condition_source: Optional[str]
+    :return: Matching action span, or ``None``.
+    :rtype: Optional[Span]
+
+    Examples::
+
+        >>> action = ActionInfo(
+        ...     signature='Root.A:<inline>',
+        ...     state_path='Root.A',
+        ...     name=None,
+        ...     stage='during',
+        ...     aspect=None,
+        ...     is_ref=False,
+        ...     ref_target=None,
+        ...     is_attached=True,
+        ...     span=Span(line=5, column=9),
+        ... )
+        >>> _action_span_by_state_and_condition(
+        ...     (action,),
+        ...     'Root.A',
+        ...     'during:0',
+        ... ).line
+        5
+    """
+    if state_path is None:
+        return None
+    if condition_source and ':' in condition_source:
+        stage = condition_source.split(':', 1)[0]
+        for action in actions:
+            if action.state_path == state_path and action.stage == stage:
+                return action.span
+    for action in actions:
+        if action.state_path == state_path and action.stage == 'during':
+            return action.span
+    return None
+
+
+def _verify_smt_refs(raw: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    """Build inspect diagnostic refs from one raw SMT-local finding.
+
+    Raw verify algorithms deliberately return dictionaries so they do not
+    depend on the diagnostics package. This helper translates the shared raw
+    fields into the refs vocabulary declared in ``codes.yaml``.
+
+    :param raw: Raw diagnostic dictionary with ``code``, ``algorithm_name``,
+        and ``data`` keys.
+    :type raw: Mapping[str, Any]
+    :return: Refs payload candidate, or ``None`` when ``raw`` is not shaped
+        like a verify diagnostic.
+    :rtype: Optional[Dict[str, Any]]
+
+    Examples::
+
+        >>> raw = {
+        ...     'code': 'W_DEAD_GUARD',
+        ...     'algorithm_name': 'dead_guard',
+        ...     'data': {
+        ...         'transition': {
+        ...             'parent': 'Root',
+        ...             'from_state': 'A',
+        ...             'to_state': 'B',
+        ...             'event': None,
+        ...             'guard': 'x > 0',
+        ...             'is_forced': False,
+        ...         },
+        ...         'verification_scope': 'smt_local',
+        ...     },
+        ... }
+        >>> refs = _verify_smt_refs(raw)
+        >>> refs['transition_summary']
+        'Root:A->B'
+    """
+    code = raw.get('code')
+    data = raw.get('data')
+    if not isinstance(code, str) or not isinstance(data, Mapping):
+        return None
+    refs: Dict[str, Any] = {
+        'algorithm_name': raw.get('algorithm_name'),
+        'verification_scope': data.get('verification_scope'),
+    }
+
+    transition = data.get('transition')
+    if isinstance(transition, Mapping):
+        transition_dict = dict(transition)
+        refs['transition'] = transition_dict
+        refs['transition_summary'] = _transition_summary(transition_dict)
+
+    if code == 'W_FORCED_GUARD_UNSAT':
+        refs['scope'] = data.get('scope')
+    elif code == 'W_TRANSITION_SHADOWED':
+        shadowed_by = data.get('shadowed_by') or ()
+        refs.update({
+            'source_state_path': data.get('source'),
+            'reason': data.get('reason'),
+            'shadowed_by_count': len(shadowed_by),
+            'shadowed_by': [
+                _transition_summary(item) for item in shadowed_by
+                if isinstance(item, Mapping)
+            ],
+        })
+    elif code == 'I_ENTER_DURING_CONTRADICT':
+        refs.update({
+            'state_path': data.get('state'),
+            'condition': data.get('condition'),
+            'condition_source': data.get('condition_source'),
+            'branch_taken': data.get('branch_taken'),
+        })
+    elif code == 'W_COMPOSITE_INIT_INCOMPLETE':
+        init_transitions = data.get('init_transitions') or ()
+        refs.update({
+            'composite_path': data.get('state'),
+            'init_transition_count': len(init_transitions),
+            'init_transitions': [
+                _transition_summary(item) for item in init_transitions
+                if isinstance(item, Mapping)
+            ],
+            'witness': data.get('witness'),
+        })
+    return refs
+
+
+def _verify_smt_span(
+        code: str,
+        raw: Mapping[str, Any],
+        states: Sequence[StateInfo],
+        transitions: Sequence[TransitionInfo],
+        actions: Sequence[ActionInfo],
+) -> Optional[Span]:
+    """Choose a source span for an SMT-local verify diagnostic.
+
+    The span follows the semantic object declared for each verify code:
+    guard/transition findings point at the transition, effect findings prefer
+    the effect statement, lifecycle findings point at the relevant action, and
+    composite-init findings point at the composite state.
+
+    :param code: Diagnostic code.
+    :type code: str
+    :param raw: Raw verify diagnostic dictionary.
+    :type raw: Mapping[str, Any]
+    :param states: Inspect state payloads.
+    :type states: Sequence[StateInfo]
+    :param transitions: Inspect transition payloads.
+    :type transitions: Sequence[TransitionInfo]
+    :param actions: Inspect action payloads.
+    :type actions: Sequence[ActionInfo]
+    :return: Best-effort source span, or ``None`` when no source object can
+        be matched.
+    :rtype: Optional[Span]
+
+    Examples::
+
+        >>> transition = TransitionInfo(
+        ...     from_path='Root.A',
+        ...     to_path='Root.B',
+        ...     event=None,
+        ...     event_scope=None,
+        ...     guard='x > 0',
+        ...     effect=None,
+        ...     effect_self_assigns=(),
+        ...     is_forced=False,
+        ...     forced_origin=None,
+        ...     transition_index=0,
+        ...     span=Span(line=3, column=5),
+        ... )
+        >>> raw = {'data': {'transition': {
+        ...     'parent': 'Root',
+        ...     'from_state': 'A',
+        ...     'to_state': 'B',
+        ...     'event': None,
+        ...     'guard': 'x > 0',
+        ...     'is_forced': False,
+        ... }}}
+        >>> _verify_smt_span('W_DEAD_GUARD', raw, (), (transition,), ()).line
+        3
+    """
+    data = raw.get('data')
+    if not isinstance(data, Mapping):
+        return None
+    transition = data.get('transition')
+    if code in {
+            'W_DEAD_GUARD',
+            'W_GUARD_TAUTOLOGY',
+            'W_FORCED_GUARD_UNSAT',
+            'W_TRANSITION_SHADOWED',
+    }:
+        return _transition_span_by_payload(transitions, transition)
+    if code in {'W_EFFECT_SMT_NO_OP', 'I_EFFECT_GUARD_CONTRADICT'}:
+        return _effect_span_by_payload(transitions, transition)
+    if code == 'I_ENTER_DURING_CONTRADICT':
+        return _action_span_by_state_and_condition(
+            actions,
+            data.get('state'),
+            data.get('condition_source'),
+        )
+    if code == 'W_COMPOSITE_INIT_INCOMPLETE':
+        return _state_span_by_path(states, data.get('state'))
+    return None
+
+
+def _structural_verify_diagnostics(
+        result: 'InspectRunResult',
+        states: Sequence[StateInfo],
+        events: Sequence[EventInfo],
+) -> List[ModelDiagnostic]:
+    """Convert structural verify payloads into model diagnostics.
+
+    Structural algorithms return graph-oriented payloads rather than raw
+    diagnostic dictionaries. This helper maps the known structural adapter
+    results onto the verify-pipeline codes declared in ``codes.yaml``.
+
+    :param result: One normalized inspect-adapter result.
+    :type result: pyfcstm.verify.inspect_adapter.InspectRunResult
+    :param states: Inspect state payloads for source-span lookup.
+    :type states: Sequence[StateInfo]
+    :param events: Inspect event payloads for event-span and consumer lookup.
+    :type events: Sequence[EventInfo]
+    :return: Diagnostics converted from ``result``.
+    :rtype: List[ModelDiagnostic]
+
+    Examples::
+
+        >>> from pyfcstm.verify.inspect_adapter import InspectRunResult
+        >>> state = StateInfo(
+        ...     path='Root.A',
+        ...     name='A',
+        ...     parent_path='Root',
+        ...     is_leaf=True,
+        ...     is_pseudo=False,
+        ...     is_composite=False,
+        ...     substates=(),
+        ...     initial_targets=(),
+        ...     entry_actions=(),
+        ...     during_actions=(),
+        ...     exit_actions=(),
+        ...     aspect_before=(),
+        ...     aspect_after=(),
+        ...     has_abstract_action=False,
+        ...     span=Span(line=2, column=5),
+        ... )
+        >>> result = InspectRunResult(
+        ...     algorithm_name='strongly_connected_components',
+        ...     complexity_tier='structural',
+        ...     smt_logic=None,
+        ...     verification_scope='topological_only',
+        ...     diagnostic_codes=('I_NONTRIVIAL_SCC',),
+        ...     result_kind='sat',
+        ...     diagnostics=(),
+        ...     reason=None,
+        ...     raw_result=(('Root.A',),),
+        ... )
+        >>> _structural_verify_diagnostics(result, (state,), ())[0].code
+        'I_NONTRIVIAL_SCC'
+    """
+    diagnostics: List[ModelDiagnostic] = []
+    if result.algorithm_name == 'strongly_connected_components':
+        for component in result.raw_result or ():
+            scc = list(component)
+            if not scc:
+                continue
+            refs = {
+                'algorithm_name': result.algorithm_name,
+                'verification_scope': result.verification_scope,
+                'representative_state_path': scc[0],
+                'scc': scc,
+            }
+            diagnostic = _make_verify_diagnostic(
+                'I_NONTRIVIAL_SCC',
+                refs,
+                _state_span_by_path(states, scc[0]),
+            )
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+    elif result.algorithm_name == 'topological_finite':
+        counterexamples = getattr(result.raw_result, 'counterexamples', ())
+        for kind, payload in counterexamples:
+            representative = payload[0] if isinstance(payload, tuple) else payload
+            refs = {
+                'algorithm_name': result.algorithm_name,
+                'verification_scope': result.verification_scope,
+                'representative_state_path': representative,
+                'counterexample_kind': kind,
+                'scc': list(payload) if isinstance(payload, tuple) else [],
+            }
+            diagnostic = _make_verify_diagnostic(
+                'W_TOPOLOGICAL_NOEXIT',
+                refs,
+                _state_span_by_path(states, representative),
+            )
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+    elif result.algorithm_name == 'topological_inevitable_terminator':
+        path = list(getattr(result.raw_result, 'counterexample_path', ()) or ())
+        if path:
+            refs = {
+                'algorithm_name': result.algorithm_name,
+                'verification_scope': result.verification_scope,
+                'representative_state_path': path[0],
+                'counterexample_path': path,
+            }
+            diagnostic = _make_verify_diagnostic(
+                'I_TOPOLOGICAL_NON_TERMINATING',
+                refs,
+                _state_span_by_path(states, path[0]),
+            )
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+    elif result.algorithm_name == 'event_emission_to_consumer_reachable':
+        for event_name in result.raw_result or ():
+            refs = {
+                'algorithm_name': result.algorithm_name,
+                'verification_scope': result.verification_scope,
+                'event_name': event_name,
+                'consumer_count': _event_consumer_count(events, event_name),
+            }
+            diagnostic = _make_verify_diagnostic(
+                'W_EVENT_UNREACHABLE_EMIT',
+                refs,
+                _event_span_by_name(events, event_name),
+            )
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
+    return diagnostics
+
+
+def _event_consumer_count(events: Sequence[EventInfo], event_name: str) -> int:
+    """Return how many inspect transitions consume an event.
+
+    :param events: Inspect event payloads.
+    :type events: Sequence[EventInfo]
+    :param event_name: Qualified event name.
+    :type event_name: str
+    :return: Number of transition consumers recorded for the event.
+    :rtype: int
+
+    Examples::
+
+        >>> event = EventInfo(
+        ...     qualified_name='Root.Panic',
+        ...     scope='chain',
+        ...     used_by=(('Root.Lost', 'Root.A'),),
+        ...     is_declared=True,
+        ...     is_used=True,
+        ... )
+        >>> _event_consumer_count((event,), 'Root.Panic')
+        1
+    """
+    for event in events:
+        if event.qualified_name == event_name:
+            return len(event.used_by)
+    return 0
+
+
+def _type_matches_schema(value: Any, field_spec: CodeFieldSpec) -> bool:
+    """Return whether a runtime value fits a ``codes.yaml`` type token.
+
+    :param value: Runtime value from a diagnostic refs payload.
+    :type value: Any
+    :param field_spec: Field schema loaded from ``codes.yaml``.
+    :type field_spec: CodeFieldSpec
+    :return: ``True`` when ``value`` fits the field type.
+    :rtype: bool
+
+    Examples::
+
+        >>> spec = CodeFieldSpec(
+        ...     name='count',
+        ...     type='int',
+        ...     required=True,
+        ...     description='Count value.',
+        ... )
+        >>> _type_matches_schema(3, spec)
+        True
+        >>> _type_matches_schema(True, spec)
+        False
+    """
+    type_token = field_spec.type
+    if type_token == 'str':
+        return isinstance(value, str)
+    if type_token == 'int':
+        return isinstance(value, int) and not isinstance(value, bool)
+    if type_token == 'float':
+        return isinstance(value, float)
+    if type_token == 'number':
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    if type_token == 'bool':
+        return isinstance(value, bool)
+    if type_token == 'dict':
+        return isinstance(value, dict)
+    if type_token == 'list[str]':
+        return isinstance(value, list) and all(isinstance(item, str) for item in value)
+    if type_token == 'list[Span]':
+        return isinstance(value, list) and all(
+            item is None or hasattr(item, 'line') for item in value
+        )
+    if type_token == 'Span':
+        return value is None or hasattr(value, 'line')
+    if type_token == 'str_or_null':
+        return value is None or isinstance(value, str)
+    if type_token == 'int_or_null':
+        return value is None or (
+            isinstance(value, int) and not isinstance(value, bool)
+        )
+    return True
+
+
+def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
+    """Return whether refs satisfy the declared verify diagnostic schema.
+
+    The conversion layer uses this as a fail-closed guard: raw verify findings
+    are emitted only after their refs are declared, complete, enum-safe, and
+    type-compatible with ``codes.yaml``.
+
+    :param code: Diagnostic code to validate.
+    :type code: str
+    :param refs: Candidate refs payload.
+    :type refs: Mapping[str, Any]
+    :return: ``True`` when the code is a verify-pipeline code and refs match
+        its schema.
+    :rtype: bool
+
+    Examples::
+
+        >>> _refs_match_code_schema('W_DEAD_GUARD', {
+        ...     'algorithm_name': 'dead_guard',
+        ...     'verification_scope': 'smt_local',
+        ...     'transition': {
+        ...         'parent': 'Root',
+        ...         'from_state': 'A',
+        ...         'to_state': 'B',
+        ...     },
+        ...     'transition_summary': 'Root:A->B',
+        ... })
+        True
+    """
+    spec = CODE_REGISTRY.get(code)
+    if spec is None or spec.emit_tier != 'verify_pipeline':
+        return False
+    declared = set(spec.refs_schema.keys())
+    if set(refs.keys()) - declared:
+        return False
+    for field_name in spec.required_fields():
+        if field_name not in refs or refs[field_name] is None:
+            return False
+    for field_name, field_spec in spec.refs_schema.items():
+        if field_name not in refs:
+            continue
+        value = refs[field_name]
+        if field_spec.enum and value not in set(field_spec.enum):
+            return False
+        if not _type_matches_schema(value, field_spec):
+            return False
+    return True
+
+
+def _make_verify_diagnostic(
+        code: str,
+        refs: Mapping[str, Any],
+        span: Optional[Span],
+) -> Optional[ModelDiagnostic]:
+    """Create one ``ModelDiagnostic`` from verified refs.
+
+    :param code: Verify-pipeline diagnostic code.
+    :type code: str
+    :param refs: Candidate refs payload.
+    :type refs: Mapping[str, Any]
+    :param span: Best-effort source span for the diagnostic.
+    :type span: Optional[Span]
+    :return: ``ModelDiagnostic`` when refs pass schema validation, otherwise
+        ``None``.
+    :rtype: Optional[ModelDiagnostic]
+
+    Examples::
+
+        >>> diag = _make_verify_diagnostic('I_NONTRIVIAL_SCC', {
+        ...     'algorithm_name': 'strongly_connected_components',
+        ...     'verification_scope': 'topological_only',
+        ...     'representative_state_path': 'Root.A',
+        ...     'scc': ['Root.A'],
+        ... }, Span(line=2, column=5))
+        >>> diag.code
+        'I_NONTRIVIAL_SCC'
+    """
+    if not _refs_match_code_schema(code, refs):
+        return None
+    spec = CODE_REGISTRY[code]
+    return ModelDiagnostic(
+        code=code,
+        severity=spec.severity,
+        message=spec.description,
+        span=span,
+        refs=dict(refs),
+    )
+
+
+def _verify_diagnostics_from_results(
+        results: Sequence['InspectRunResult'],
+        states: Sequence[StateInfo],
+        transitions: Sequence[TransitionInfo],
+        events: Sequence[EventInfo],
+        actions: Sequence[ActionInfo],
+) -> Tuple[ModelDiagnostic, ...]:
+    """Convert inspect-adapter results into public model diagnostics.
+
+    SMT-local raw diagnostic dictionaries are consumed directly. Structural
+    results are interpreted only for algorithms whose payloads have an
+    explicit conversion. Indeterminate results without raw diagnostics are
+    skipped so ``unknown`` or ``timeout`` does not become a false warning.
+
+    :param results: Normalized inspect-adapter results.
+    :type results: Sequence[pyfcstm.verify.inspect_adapter.InspectRunResult]
+    :param states: Inspect state payloads.
+    :type states: Sequence[StateInfo]
+    :param transitions: Inspect transition payloads.
+    :type transitions: Sequence[TransitionInfo]
+    :param events: Inspect event payloads.
+    :type events: Sequence[EventInfo]
+    :param actions: Inspect action payloads.
+    :type actions: Sequence[ActionInfo]
+    :return: Converted verify diagnostics.
+    :rtype: Tuple[ModelDiagnostic, ...]
+
+    Examples::
+
+        >>> from pyfcstm.verify.inspect_adapter import InspectRunResult
+        >>> result = InspectRunResult(
+        ...     algorithm_name='dead_guard',
+        ...     complexity_tier='smt_linear',
+        ...     smt_logic='QF_LIRA',
+        ...     verification_scope='smt_local',
+        ...     diagnostic_codes=('W_DEAD_GUARD',),
+        ...     result_kind='unknown',
+        ...     diagnostics=(),
+        ...     reason='solver said unknown',
+        ...     raw_result=None,
+        ... )
+        >>> _verify_diagnostics_from_results((result,), (), (), (), ())
+        ()
+    """
+    diagnostics: List[ModelDiagnostic] = []
+    for result in results:
+        if result.diagnostics:
+            for raw in result.diagnostics:
+                if not isinstance(raw, Mapping):
+                    continue
+                code = raw.get('code')
+                if not isinstance(code, str):
+                    continue
+                refs = _verify_smt_refs(raw)
+                if refs is None:
+                    continue
+                diagnostic = _make_verify_diagnostic(
+                    code,
+                    refs,
+                    _verify_smt_span(code, raw, states, transitions, actions),
+                )
+                if diagnostic is not None:
+                    diagnostics.append(diagnostic)
+            continue
+        if result.result_kind in {'unknown', 'timeout', 'undecidable_skip'}:
+            continue
+        diagnostics.extend(_structural_verify_diagnostics(result, states, events))
+    return tuple(diagnostics)
+
+
 def inspect_model(
         machine: 'StateMachine',
         *,
         deep_hierarchy_threshold: int = DEFAULT_DEEP_HIERARCHY_THRESHOLD,
         large_composite_threshold: int = DEFAULT_LARGE_COMPOSITE_THRESHOLD,
         var_to_leaf_ratio_threshold: float = DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD,
+        enable_verify: bool = False,
+        max_complexity_tier: str = 'structural',
+        max_call_count_scaling: str = 'linear_in_transitions',
+        smt_timeout_ms: Optional[int] = None,
 ) -> ModelInspect:
     """
     Build a structured inspection report for a state machine model.
@@ -1436,14 +2285,44 @@ def inspect_model(
     :param var_to_leaf_ratio_threshold: Maximum accepted variable to
         non-pseudo leaf-state ratio.
     :type var_to_leaf_ratio_threshold: float
+    :param enable_verify: Whether to run inspect-eligible
+        :mod:`pyfcstm.verify` algorithms and append their diagnostics.
+        The default ``False`` preserves the Layer 2 inspect contract.
+    :type enable_verify: bool, optional
+    :param max_complexity_tier: Maximum verify complexity tier accepted by
+        the inspect adapter when ``enable_verify`` is true.
+        ``"structural"`` keeps the default to graph-only verification.
+    :type max_complexity_tier: str, optional
+    :param max_call_count_scaling: Maximum verify call-count scaling accepted
+        by the inspect adapter when ``enable_verify`` is true.
+    :type max_call_count_scaling: str, optional
+    :param smt_timeout_ms: Optional solver timeout forwarded to SMT-local
+        verify algorithms. ``None`` preserves the raw verify default of no
+        configured timeout.
+    :type smt_timeout_ms: Optional[int], optional
     :return: Structured view of the model.
     :rtype: ModelInspect
 
-    Example::
+    Examples::
 
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     state B;
+        ...     [*] -> A;
+        ...     A -> B;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, 'state_machine_dsl')
+        >>> machine = parse_dsl_node_to_state_machine(ast)
         >>> report = inspect_model(machine)
-        >>> sorted(report.reachability_graph['Root.Sub.A'])
-        ['Root.Sub.B']
+        >>> report.reachability_graph['Root.A']
+        ('Root.B',)
+        >>> verify_report = inspect_model(machine, enable_verify=True)
+        >>> len(verify_report.diagnostics) >= len(report.diagnostics)
+        True
     """
     deep_hierarchy_threshold = _normalize_int_threshold(
         'deep_hierarchy_threshold',
@@ -1466,6 +2345,35 @@ def inspect_model(
     metrics = _build_metrics(states, transitions, variables, events)
     reachability_graph = _build_reachability_graph(states, transitions)
     root_state_path = _state_path(machine.root_state)
+    diagnostics = list(collect_design_health_warnings(
+        states,
+        transitions,
+        variables,
+        events,
+        actions,
+        forced_transitions,
+        metrics,
+        reachability_graph,
+        root_state_path=root_state_path,
+        deep_hierarchy_threshold=deep_hierarchy_threshold,
+        large_composite_threshold=large_composite_threshold,
+        var_to_leaf_ratio_threshold=var_to_leaf_ratio_threshold,
+        machine=machine,
+    ))
+    if enable_verify:
+        verify_results = _run_verify_inspect_algorithms(
+            machine,
+            max_complexity_tier=max_complexity_tier,
+            max_call_count_scaling=max_call_count_scaling,
+            smt_timeout_ms=smt_timeout_ms,
+        )
+        diagnostics.extend(_verify_diagnostics_from_results(
+            verify_results,
+            states,
+            transitions,
+            events,
+            actions,
+        ))
     return ModelInspect(
         root_state_path=root_state_path,
         states=states,
@@ -1480,21 +2388,7 @@ def inspect_model(
         var_dataflow=_build_var_dataflow(variables),
         aspect_impact_map=_build_aspect_impact_map(states),
         action_ref_graph=_build_action_ref_graph(machine),
-        diagnostics=tuple(collect_design_health_warnings(
-            states,
-            transitions,
-            variables,
-            events,
-            actions,
-            forced_transitions,
-            metrics,
-            reachability_graph,
-            root_state_path=root_state_path,
-            deep_hierarchy_threshold=deep_hierarchy_threshold,
-            large_composite_threshold=large_composite_threshold,
-            var_to_leaf_ratio_threshold=var_to_leaf_ratio_threshold,
-            machine=machine,
-        )),
+        diagnostics=tuple(diagnostics),
     )
 
 

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -1462,6 +1462,96 @@ def _transition_summary(payload: Mapping[str, Any]) -> str:
     return '{parent}:{from_state}->{to_state}'.format(**payload)
 
 
+def _verify_transition_payload(payload: Any) -> Optional[Dict[str, Any]]:
+    """Return a validated raw verify transition payload.
+
+    Verify algorithms return diagnostics-layer-free dictionaries. The
+    inspect conversion layer must fail closed when a raw payload is malformed,
+    because the public ``ModelDiagnostic.refs`` schema can only validate the
+    outer ``dict`` type for transition refs.
+
+    :param payload: Raw transition payload to validate.
+    :type payload: Any
+    :return: A defensive copy when the payload is shaped like
+        ``pyfcstm.verify.encoding`` transition data, otherwise ``None``.
+    :rtype: Optional[Dict[str, Any]]
+
+    Examples::
+
+        >>> _verify_transition_payload({
+        ...     'parent': 'Root',
+        ...     'from_state': 'A',
+        ...     'to_state': 'B',
+        ...     'event': None,
+        ...     'guard': 'x > 0',
+        ...     'is_forced': False,
+        ... })['from_state']
+        'A'
+        >>> _verify_transition_payload({'parent': 'Root'}) is None
+        True
+    """
+    if not isinstance(payload, Mapping):
+        return None
+    parent = payload.get('parent')
+    from_state = payload.get('from_state')
+    to_state = payload.get('to_state')
+    event = payload.get('event')
+    guard = payload.get('guard')
+    is_forced = payload.get('is_forced')
+    if not all(isinstance(item, str) for item in (parent, from_state, to_state)):
+        return None
+    if event is not None and not isinstance(event, str):
+        return None
+    if guard is not None and not isinstance(guard, str):
+        return None
+    if not isinstance(is_forced, bool):
+        return None
+    return {
+        'parent': parent,
+        'from_state': from_state,
+        'to_state': to_state,
+        'event': event,
+        'guard': guard,
+        'is_forced': is_forced,
+    }
+
+
+def _verify_transition_summaries(payloads: Any) -> Optional[List[str]]:
+    """Return summaries for a sequence of raw verify transition payloads.
+
+    The conversion fails closed: one malformed item invalidates the entire
+    sequence so the diagnostic cannot present partial evidence as complete.
+
+    :param payloads: Raw transition payload sequence.
+    :type payloads: Any
+    :return: Transition summaries, or ``None`` when the sequence is malformed.
+    :rtype: Optional[List[str]]
+
+    Examples::
+
+        >>> _verify_transition_summaries(({
+        ...     'parent': 'Root',
+        ...     'from_state': 'A',
+        ...     'to_state': 'B',
+        ...     'event': None,
+        ...     'guard': None,
+        ...     'is_forced': False,
+        ... },))
+        ['Root:A->B']
+        >>> _verify_transition_summaries(({'parent': 'Root'},)) is None
+        True
+    """
+    if not isinstance(payloads, (list, tuple)):
+        return None
+    summaries: List[str] = []
+    for raw_item in payloads:
+        item = _verify_transition_payload(raw_item)
+        if item is None:
+            return None
+        summaries.append(_transition_summary(item))
+    return summaries
+
+
 def _state_span_by_path(states: Sequence[StateInfo], state_path: Optional[str]) -> Optional[Span]:
     """Return the source span for a state path.
 
@@ -1567,9 +1657,12 @@ def _transition_matches_payload(info: TransitionInfo, payload: Mapping[str, Any]
         ... })
         True
     """
-    parent = payload.get('parent')
-    from_state = payload.get('from_state')
-    to_state = payload.get('to_state')
+    transition_payload = _verify_transition_payload(payload)
+    if transition_payload is None:
+        return False
+    parent = transition_payload['parent']
+    from_state = transition_payload['from_state']
+    to_state = transition_payload['to_state']
     from_path = '[*]' if from_state == '[*]' else (
         f'{parent}.{from_state}' if parent else from_state
     )
@@ -1579,9 +1672,9 @@ def _transition_matches_payload(info: TransitionInfo, payload: Mapping[str, Any]
     return (
         info.from_path == from_path
         and info.to_path == to_path
-        and info.event == payload.get('event')
-        and info.guard == payload.get('guard')
-        and info.is_forced == bool(payload.get('is_forced'))
+        and info.event == transition_payload['event']
+        and info.guard == transition_payload['guard']
+        and info.is_forced == transition_payload['is_forced']
     )
 
 
@@ -1774,9 +1867,8 @@ def _verify_smt_refs(raw: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
         'verification_scope': data.get('verification_scope'),
     }
 
-    transition = data.get('transition')
-    if isinstance(transition, Mapping):
-        transition_dict = dict(transition)
+    transition_dict = _verify_transition_payload(data.get('transition'))
+    if transition_dict is not None:
         refs['transition'] = transition_dict
         refs['transition_summary'] = _transition_summary(transition_dict)
 
@@ -1784,14 +1876,14 @@ def _verify_smt_refs(raw: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
         refs['scope'] = data.get('scope')
     elif code == 'W_TRANSITION_SHADOWED':
         shadowed_by = data.get('shadowed_by') or ()
+        shadowed_by_summaries = _verify_transition_summaries(shadowed_by)
+        if shadowed_by_summaries is None:
+            return None
         refs.update({
             'source_state_path': data.get('source'),
             'reason': data.get('reason'),
-            'shadowed_by_count': len(shadowed_by),
-            'shadowed_by': [
-                _transition_summary(item) for item in shadowed_by
-                if isinstance(item, Mapping)
-            ],
+            'shadowed_by_count': len(shadowed_by_summaries),
+            'shadowed_by': shadowed_by_summaries,
         })
     elif code == 'I_ENTER_DURING_CONTRADICT':
         refs.update({
@@ -1802,13 +1894,13 @@ def _verify_smt_refs(raw: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
         })
     elif code == 'W_COMPOSITE_INIT_INCOMPLETE':
         init_transitions = data.get('init_transitions') or ()
+        init_transition_summaries = _verify_transition_summaries(init_transitions)
+        if init_transition_summaries is None:
+            return None
         refs.update({
             'composite_path': data.get('state'),
-            'init_transition_count': len(init_transitions),
-            'init_transitions': [
-                _transition_summary(item) for item in init_transitions
-                if isinstance(item, Mapping)
-            ],
+            'init_transition_count': len(init_transition_summaries),
+            'init_transitions': init_transition_summaries,
             'witness': data.get('witness'),
         })
     return refs
@@ -1969,12 +2061,13 @@ def _structural_verify_diagnostics(
         counterexamples = getattr(result.raw_result, 'counterexamples', ())
         for kind, payload in counterexamples:
             representative = payload[0] if isinstance(payload, tuple) else payload
+            scc = list(payload) if isinstance(payload, tuple) else [payload]
             refs = {
                 'algorithm_name': result.algorithm_name,
                 'verification_scope': result.verification_scope,
                 'representative_state_path': representative,
                 'counterexample_kind': kind,
-                'scc': list(payload) if isinstance(payload, tuple) else [],
+                'scc': scc,
             }
             diagnostic = _make_verify_diagnostic(
                 'W_TOPOLOGICAL_NOEXIT',
@@ -2198,8 +2291,9 @@ def _verify_diagnostics_from_results(
 
     SMT-local raw diagnostic dictionaries are consumed directly. Structural
     results are interpreted only for algorithms whose payloads have an
-    explicit conversion. Indeterminate results without raw diagnostics are
-    skipped so ``unknown`` or ``timeout`` does not become a false warning.
+    explicit conversion. Indeterminate results are skipped even when partial
+    raw diagnostics are attached, so ``unknown`` or ``timeout`` does not
+    become a false warning.
 
     :param results: Normalized inspect-adapter results.
     :type results: Sequence[pyfcstm.verify.inspect_adapter.InspectRunResult]
@@ -2233,6 +2327,8 @@ def _verify_diagnostics_from_results(
     """
     diagnostics: List[ModelDiagnostic] = []
     for result in results:
+        if result.result_kind in {'unknown', 'timeout', 'undecidable_skip'}:
+            continue
         if result.diagnostics:
             for raw in result.diagnostics:
                 if not isinstance(raw, Mapping):
@@ -2250,8 +2346,6 @@ def _verify_diagnostics_from_results(
                 )
                 if diagnostic is not None:
                     diagnostics.append(diagnostic)
-            continue
-        if result.result_kind in {'unknown', 'timeout', 'undecidable_skip'}:
             continue
         diagnostics.extend(_structural_verify_diagnostics(result, states, events))
     return tuple(diagnostics)

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -10,6 +10,7 @@ that inspect surface.
 
 import json
 import os
+import inspect
 
 import pytest
 
@@ -2001,6 +2002,228 @@ def test_inspect_guard_text_is_shared_normalized_format():
 
     assert transition.guard == '15 & 240 != 0'
     assert diagnostic.refs['guard_text'] == '15 & 240 != 0'
+
+
+@pytest.mark.unittest
+class TestInspectModelVerifyIntegration:
+    """Optional verify integration for inspect_model."""
+
+    def test_verify_parameters_keep_expected_defaults(self):
+        signature = inspect.signature(inspect_model)
+
+        assert signature.parameters['enable_verify'].default is False
+        assert signature.parameters['max_complexity_tier'].default == 'structural'
+        assert (
+            signature.parameters['max_call_count_scaling'].default
+            == 'linear_in_transitions'
+        )
+        assert signature.parameters['smt_timeout_ms'].default is None
+
+    def test_default_inspect_path_does_not_call_verify_adapter(self, monkeypatch):
+        def fail_if_called(*args, **kwargs):
+            raise AssertionError('verify adapter must stay disabled by default')
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fail_if_called,
+        )
+
+        report = inspect_model(_parse(SIMPLE_DSL))
+
+        assert isinstance(report, ModelInspect)
+
+    def test_enable_verify_passes_default_policy_to_adapter(self, monkeypatch):
+        calls = []
+
+        def fake_adapter(machine, **kwargs):
+            calls.append((machine, kwargs))
+            return ()
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fake_adapter,
+        )
+        machine = _parse(SIMPLE_DSL)
+
+        inspect_model(machine, enable_verify=True)
+
+        assert calls == [
+            (
+                machine,
+                {
+                    'max_complexity_tier': 'structural',
+                    'max_call_count_scaling': 'linear_in_transitions',
+                    'smt_timeout_ms': None,
+                },
+            ),
+        ]
+
+    def test_enable_verify_passes_explicit_policy_to_adapter(self, monkeypatch):
+        calls = []
+
+        def fake_adapter(machine, **kwargs):
+            calls.append(kwargs)
+            return ()
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fake_adapter,
+        )
+
+        inspect_model(
+            _parse(SIMPLE_DSL),
+            enable_verify=True,
+            max_complexity_tier='smt_linear',
+            max_call_count_scaling='linear_in_states',
+            smt_timeout_ms=250,
+        )
+
+        assert calls == [
+            {
+                'max_complexity_tier': 'smt_linear',
+                'max_call_count_scaling': 'linear_in_states',
+                'smt_timeout_ms': 250,
+            },
+        ]
+
+    def test_enable_verify_converts_structural_findings(self):
+        dsl = """
+        state System {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+            B -> A;
+        }
+        """
+
+        report = inspect_model(_parse(dsl), enable_verify=True)
+
+        verify_diagnostics = [
+            diag for diag in report.diagnostics
+            if diag.code in {
+                'I_NONTRIVIAL_SCC',
+                'W_TOPOLOGICAL_NOEXIT',
+                'I_TOPOLOGICAL_NON_TERMINATING',
+            }
+        ]
+        assert verify_diagnostics
+        assert_all_diags_match_schema(verify_diagnostics, context='verify-structural')
+        by_code = {diag.code: diag for diag in verify_diagnostics}
+
+        scc_diag = by_code['I_NONTRIVIAL_SCC']
+        assert scc_diag.severity == 'info'
+        assert scc_diag.refs == {
+            'algorithm_name': 'strongly_connected_components',
+            'verification_scope': 'topological_only',
+            'representative_state_path': 'System.A',
+            'scc': ['System.A', 'System.B'],
+        }
+        _assert_has_span(scc_diag.span)
+        assert 'state A' in _slice_by_span(dsl, scc_diag.span)
+
+        noexit_diag = by_code['W_TOPOLOGICAL_NOEXIT']
+        assert noexit_diag.refs['algorithm_name'] == 'topological_finite'
+        assert noexit_diag.refs['counterexample_kind'] == 'trap_cycle'
+        assert noexit_diag.refs['scc'] == ['System.A', 'System.B']
+
+        nonterminating_diag = by_code['I_TOPOLOGICAL_NON_TERMINATING']
+        assert (
+            nonterminating_diag.refs['algorithm_name']
+            == 'topological_inevitable_terminator'
+        )
+        assert nonterminating_diag.refs['counterexample_path'] == [
+            'System.A',
+            'System.B',
+        ]
+
+    def test_enable_verify_converts_smt_raw_diagnostics(self):
+        dsl = """
+        def int x = 0;
+        state System {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : if [x > 1 && x < 0];
+        }
+        """
+
+        report = inspect_model(
+            _parse(dsl),
+            enable_verify=True,
+            max_complexity_tier='smt_linear',
+        )
+
+        dead_guard = next(
+            diag for diag in report.diagnostics
+            if diag.code == 'W_DEAD_GUARD'
+        )
+        assert dead_guard.severity == 'warning'
+        assert dead_guard.refs == {
+            'algorithm_name': 'dead_guard',
+            'verification_scope': 'smt_local',
+            'transition': {
+                'parent': 'System',
+                'from_state': 'A',
+                'to_state': 'B',
+                'event': None,
+                'guard': 'x > 1 && x < 0',
+                'is_forced': False,
+            },
+            'transition_summary': 'System:A->B',
+        }
+        assert_all_diags_match_schema([dead_guard], context='verify-smt')
+        _assert_has_span(dead_guard.span)
+        assert 'x > 1 && x < 0' in _slice_by_span(dsl, dead_guard.span)
+
+    @pytest.mark.parametrize(
+        'kind',
+        ['unknown', 'timeout', 'undecidable_skip'],
+    )
+    def test_indeterminate_verify_results_do_not_emit_without_diagnostics(
+            self,
+            monkeypatch,
+            kind,
+    ):
+        from pyfcstm.verify import InspectRunResult
+
+        def fake_adapter(machine, **kwargs):
+            return (
+                InspectRunResult(
+                    algorithm_name='dead_guard',
+                    complexity_tier='smt_linear',
+                    smt_logic='QF_LIRA',
+                    verification_scope='smt_local',
+                    diagnostic_codes=('W_DEAD_GUARD',),
+                    result_kind=kind,
+                    diagnostics=(),
+                    reason='not decidable in this test',
+                    raw_result=None,
+                ),
+            )
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fake_adapter,
+        )
+
+        report = inspect_model(_parse(SIMPLE_DSL), enable_verify=True)
+
+        assert 'W_DEAD_GUARD' not in {diag.code for diag in report.diagnostics}
+
+    def test_invalid_verify_complexity_tier_raises_controlled_error(self):
+        from pyfcstm.verify import InspectAccessForbiddenError
+
+        with pytest.raises(InspectAccessForbiddenError, match='bmc_search'):
+            inspect_model(
+                _parse(SIMPLE_DSL),
+                enable_verify=True,
+                max_complexity_tier='bmc_search',
+            )
 
 
 @pytest.mark.unittest

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -2240,6 +2240,36 @@ class TestInspectModelVerifyIntegration:
                 },
             },
             {
+                'code': 'W_DEAD_GUARD',
+                'algorithm_name': 'dead_guard',
+                'data': {
+                    'transition': {
+                        'parent': 'Root',
+                        'from_state': 'Idle',
+                        'to_state': 'Active',
+                        'event': 123,
+                        'guard': 'counter > 0',
+                        'is_forced': False,
+                    },
+                    'verification_scope': 'smt_local',
+                },
+            },
+            {
+                'code': 'W_DEAD_GUARD',
+                'algorithm_name': 'dead_guard',
+                'data': {
+                    'transition': {
+                        'parent': 'Root',
+                        'from_state': 'Idle',
+                        'to_state': 'Active',
+                        'event': None,
+                        'guard': 123,
+                        'is_forced': False,
+                    },
+                    'verification_scope': 'smt_local',
+                },
+            },
+            {
                 'code': 'W_TRANSITION_SHADOWED',
                 'algorithm_name': 'transition_shadowed_by_predecessor',
                 'data': {
@@ -2292,6 +2322,203 @@ class TestInspectModelVerifyIntegration:
         assert raw_diagnostic['code'] not in {
             diag.code for diag in report.diagnostics
         }
+
+    def test_unmatched_verify_transition_payloads_fail_closed(self, monkeypatch):
+        from pyfcstm.verify import InspectRunResult
+
+        def fake_adapter(machine, **kwargs):
+            return (
+                InspectRunResult(
+                    algorithm_name='dead_guard',
+                    complexity_tier='smt_linear',
+                    smt_logic='QF_LIRA',
+                    verification_scope='smt_local',
+                    diagnostic_codes=('W_DEAD_GUARD',),
+                    result_kind='sat',
+                    diagnostics=({
+                        'code': 'W_DEAD_GUARD',
+                        'algorithm_name': 'dead_guard',
+                        'data': {
+                            'transition': {
+                                'parent': 'Root',
+                                'from_state': 'Idle',
+                                'to_state': 'Missing',
+                                'event': None,
+                                'guard': 'counter > 0',
+                                'is_forced': False,
+                            },
+                            'verification_scope': 'smt_local',
+                        },
+                    },),
+                    reason=None,
+                    raw_result=None,
+                ),
+            )
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fake_adapter,
+        )
+
+        report = inspect_model(_parse(SIMPLE_DSL), enable_verify=True)
+
+        assert 'W_DEAD_GUARD' not in {diag.code for diag in report.diagnostics}
+
+    def test_structural_verify_payloads_without_source_span_fail_closed(
+            self,
+            monkeypatch,
+    ):
+        from pyfcstm.verify import InspectRunResult
+
+        class FinitenessRawResult:
+            counterexamples = (('deadlock', 'Root.Missing'),)
+
+        class InevitabilityRawResult:
+            counterexample_path = ('Root.Missing',)
+
+        def fake_adapter(machine, **kwargs):
+            return (
+                InspectRunResult(
+                    algorithm_name='strongly_connected_components',
+                    complexity_tier='structural',
+                    smt_logic=None,
+                    verification_scope='topological_only',
+                    diagnostic_codes=('I_NONTRIVIAL_SCC',),
+                    result_kind='sat',
+                    diagnostics=(),
+                    reason=None,
+                    raw_result=(('Root.Missing',),),
+                ),
+                InspectRunResult(
+                    algorithm_name='topological_finite',
+                    complexity_tier='structural',
+                    smt_logic=None,
+                    verification_scope='topological_only',
+                    diagnostic_codes=('W_TOPOLOGICAL_NOEXIT',),
+                    result_kind='sat',
+                    diagnostics=(),
+                    reason=None,
+                    raw_result=FinitenessRawResult(),
+                ),
+                InspectRunResult(
+                    algorithm_name='topological_inevitable_terminator',
+                    complexity_tier='structural',
+                    smt_logic=None,
+                    verification_scope='topological_only',
+                    diagnostic_codes=('I_TOPOLOGICAL_NON_TERMINATING',),
+                    result_kind='sat',
+                    diagnostics=(),
+                    reason=None,
+                    raw_result=InevitabilityRawResult(),
+                ),
+                InspectRunResult(
+                    algorithm_name='event_emission_to_consumer_reachable',
+                    complexity_tier='structural',
+                    smt_logic=None,
+                    verification_scope='topological_only',
+                    diagnostic_codes=('W_EVENT_UNREACHABLE_EMIT',),
+                    result_kind='sat',
+                    diagnostics=(),
+                    reason=None,
+                    raw_result=('Root.MissingEvent',),
+                ),
+            )
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fake_adapter,
+        )
+
+        report = inspect_model(_parse(SIMPLE_DSL), enable_verify=True)
+
+        assert {
+            'I_NONTRIVIAL_SCC',
+            'W_TOPOLOGICAL_NOEXIT',
+            'I_TOPOLOGICAL_NON_TERMINATING',
+            'W_EVENT_UNREACHABLE_EMIT',
+        }.isdisjoint({diag.code for diag in report.diagnostics})
+
+    def test_verify_schema_rejects_undeclared_enum_and_type_mismatch(self):
+        valid_refs = {
+            'algorithm_name': 'dead_guard',
+            'verification_scope': 'smt_local',
+            'transition': {
+                'parent': 'Root',
+                'from_state': 'Idle',
+                'to_state': 'Active',
+                'event': None,
+                'guard': 'counter > 0',
+                'is_forced': False,
+            },
+            'transition_summary': 'Root:Idle->Active',
+        }
+
+        assert inspect_module._refs_match_code_schema('W_DEAD_GUARD', valid_refs)
+        assert not inspect_module._refs_match_code_schema(
+            'E_UNDEFINED_VAR',
+            dict(valid_refs),
+        )
+        assert not inspect_module._refs_match_code_schema(
+            'W_DEAD_GUARD',
+            dict(valid_refs, extra='not declared'),
+        )
+        assert not inspect_module._refs_match_code_schema(
+            'W_DEAD_GUARD',
+            dict(valid_refs, verification_scope='topological_only'),
+        )
+        assert not inspect_module._refs_match_code_schema(
+            'W_DEAD_GUARD',
+            dict(valid_refs, transition_summary=123),
+        )
+
+    def test_verify_type_schema_covers_all_declared_tokens(self):
+        true_cases = {
+            'str': 'value',
+            'int': 1,
+            'float': 1.5,
+            'number': 1,
+            'bool': False,
+            'dict': {},
+            'list[str]': ['a', 'b'],
+            'list[Span]': [None],
+            'Span': None,
+            'str_or_null': None,
+            'int_or_null': None,
+            'unknown_future_type': object(),
+        }
+
+        for type_token, value in true_cases.items():
+            field_spec = inspect_module.CodeFieldSpec(
+                name='field',
+                type=type_token,
+                required=True,
+                description='test field',
+            )
+            assert inspect_module._type_matches_schema(value, field_spec)
+
+        false_cases = {
+            'int': True,
+            'float': 1,
+            'number': True,
+            'bool': 0,
+            'dict': [],
+            'list[str]': ['ok', 1],
+            'list[Span]': [object()],
+            'Span': object(),
+            'str_or_null': 1,
+            'int_or_null': True,
+        }
+
+        for type_token, value in false_cases.items():
+            field_spec = inspect_module.CodeFieldSpec(
+                name='field',
+                type=type_token,
+                required=True,
+                description='test field',
+            )
+            assert not inspect_module._type_matches_schema(value, field_spec)
 
     @pytest.mark.parametrize(
         'kind',

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -2140,6 +2140,34 @@ class TestInspectModelVerifyIntegration:
             'System.B',
         ]
 
+    def test_enable_verify_reports_deadlock_noexit_with_single_node_scc(self):
+        dsl = """
+        state System {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B;
+        }
+        """
+
+        report = inspect_model(_parse(dsl), enable_verify=True)
+
+        noexit_diag = next(
+            diag for diag in report.diagnostics
+            if diag.code == 'W_TOPOLOGICAL_NOEXIT'
+            and diag.refs['counterexample_kind'] == 'deadlock'
+        )
+        assert noexit_diag.refs == {
+            'algorithm_name': 'topological_finite',
+            'verification_scope': 'topological_only',
+            'representative_state_path': 'System.B',
+            'counterexample_kind': 'deadlock',
+            'scc': ['System.B'],
+        }
+        assert_all_diags_match_schema([noexit_diag], context='verify-deadlock')
+        _assert_has_span(noexit_diag.span)
+        assert 'state B' in _slice_by_span(dsl, noexit_diag.span)
+
     def test_enable_verify_converts_smt_raw_diagnostics(self):
         dsl = """
         def int x = 0;
@@ -2180,6 +2208,92 @@ class TestInspectModelVerifyIntegration:
         assert 'x > 1 && x < 0' in _slice_by_span(dsl, dead_guard.span)
 
     @pytest.mark.parametrize(
+        'raw_diagnostic',
+        [
+            {
+                'code': 'W_DEAD_GUARD',
+                'algorithm_name': 'dead_guard',
+                'data': {
+                    'transition': {
+                        'parent': 'Root',
+                        'from_state': 'Idle',
+                        'event': None,
+                        'guard': 'counter > 0',
+                        'is_forced': False,
+                    },
+                    'verification_scope': 'smt_local',
+                },
+            },
+            {
+                'code': 'W_DEAD_GUARD',
+                'algorithm_name': 'dead_guard',
+                'data': {
+                    'transition': {
+                        'parent': 'Root',
+                        'from_state': 'Idle',
+                        'to_state': 'Active',
+                        'event': None,
+                        'guard': 'counter > 0',
+                        'is_forced': 'false',
+                    },
+                    'verification_scope': 'smt_local',
+                },
+            },
+            {
+                'code': 'W_TRANSITION_SHADOWED',
+                'algorithm_name': 'transition_shadowed_by_predecessor',
+                'data': {
+                    'transition': {
+                        'parent': 'Root',
+                        'from_state': 'Idle',
+                        'to_state': 'Active',
+                        'event': None,
+                        'guard': 'counter > 0',
+                        'is_forced': False,
+                    },
+                    'shadowed_by': ({'parent': 'Root'},),
+                    'reason': 'guard_shadow',
+                    'source': 'Root.Idle',
+                    'verification_scope': 'smt_local',
+                },
+            },
+        ],
+    )
+    def test_malformed_verify_transition_payloads_fail_closed(
+            self,
+            monkeypatch,
+            raw_diagnostic,
+    ):
+        from pyfcstm.verify import InspectRunResult
+
+        def fake_adapter(machine, **kwargs):
+            return (
+                InspectRunResult(
+                    algorithm_name='dead_guard',
+                    complexity_tier='smt_linear',
+                    smt_logic='QF_LIRA',
+                    verification_scope='smt_local',
+                    diagnostic_codes=(raw_diagnostic['code'],),
+                    result_kind='sat',
+                    diagnostics=(raw_diagnostic,),
+                    reason=None,
+                    raw_result=None,
+                ),
+            )
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fake_adapter,
+        )
+
+        report = inspect_model(_parse(SIMPLE_DSL), enable_verify=True)
+
+        assert raw_diagnostic['code'] not in {
+            diag.code for diag in report.diagnostics
+        }
+
+    @pytest.mark.parametrize(
         'kind',
         ['unknown', 'timeout', 'undecidable_skip'],
     )
@@ -2215,6 +2329,56 @@ class TestInspectModelVerifyIntegration:
 
         assert 'W_DEAD_GUARD' not in {diag.code for diag in report.diagnostics}
 
+    @pytest.mark.parametrize(
+        'kind',
+        ['unknown', 'timeout', 'undecidable_skip'],
+    )
+    def test_indeterminate_verify_results_do_not_emit_with_diagnostics(
+            self,
+            monkeypatch,
+            kind,
+    ):
+        from pyfcstm.verify import InspectRunResult
+
+        def fake_adapter(machine, **kwargs):
+            return (
+                InspectRunResult(
+                    algorithm_name='dead_guard',
+                    complexity_tier='smt_linear',
+                    smt_logic='QF_LIRA',
+                    verification_scope='smt_local',
+                    diagnostic_codes=('W_DEAD_GUARD',),
+                    result_kind=kind,
+                    diagnostics=({
+                        'code': 'W_DEAD_GUARD',
+                        'algorithm_name': 'dead_guard',
+                        'data': {
+                            'transition': {
+                                'parent': 'Root',
+                                'from_state': 'Idle',
+                                'to_state': 'Active',
+                                'event': None,
+                                'guard': 'counter > 0',
+                                'is_forced': False,
+                            },
+                            'verification_scope': 'smt_local',
+                        },
+                    },),
+                    reason='partially explored before the solver stopped',
+                    raw_result=None,
+                ),
+            )
+
+        monkeypatch.setattr(
+            inspect_module,
+            '_run_verify_inspect_algorithms',
+            fake_adapter,
+        )
+
+        report = inspect_model(_parse(SIMPLE_DSL), enable_verify=True)
+
+        assert 'W_DEAD_GUARD' not in {diag.code for diag in report.diagnostics}
+
     def test_invalid_verify_complexity_tier_raises_controlled_error(self):
         from pyfcstm.verify import InspectAccessForbiddenError
 
@@ -2223,6 +2387,24 @@ class TestInspectModelVerifyIntegration:
                 _parse(SIMPLE_DSL),
                 enable_verify=True,
                 max_complexity_tier='bmc_search',
+            )
+
+    @pytest.mark.parametrize(
+        ('kwargs', 'message'),
+        [
+            ({'max_complexity_tier': 'unknown_tier'}, 'unknown inspect complexity tier'),
+            ({'max_call_count_scaling': 'k_unrollings'}, 'call-count scaling'),
+            ({'max_call_count_scaling': 'unknown_scaling'}, 'call-count scaling'),
+        ],
+    )
+    def test_invalid_verify_policy_raises_controlled_error(self, kwargs, message):
+        from pyfcstm.verify import InspectAccessForbiddenError
+
+        with pytest.raises(InspectAccessForbiddenError, match=message):
+            inspect_model(
+                _parse(SIMPLE_DSL),
+                enable_verify=True,
+                **kwargs,
             )
 
 


### PR DESCRIPTION
## 上游依据

关联上游 issue：#114。

本 PR 是 Track B 的 PR-B3，base 固定为 PR-B 总伞分支 `dev/issue114-pr-b-inspect`，不是 `main`。PR-B3 依赖：

| 依赖项 | 状态 | 本 PR 使用方式 |
|---|---|---|
| PR-B1 #175 | 🟢 已合入 PR-B | 使用已补齐的 verify 诊断码、refs 契约和 schema 约束。 |
| PR-B2 #176 | 🟢 已合入 PR-B | 使用 `run_inspect_algorithms(...)` 和 `InspectRunResult` 作为 verify 自动执行入口。 |
| PR-B 总伞 #174 | 🟨 推进中 | 本 PR 只完成其中“把 verify 可选接入 `inspect_model()`”这一行。 |
| issue #114 | 🔵 上游基线 | 遵守 `enable_verify`、复杂度门限、调用次数门限、`smt_timeout_ms` 和禁止 `bmc_search` 自动 inspect 的裁定。 |

## 本 PR 目标

给 `inspect_model()` 增加 verify 可选接入能力，并保持默认行为完全不变。

必须达成：

1. 不传新参数时，`inspect_model(machine)` 的诊断、返回结构、JSON 可序列化形状和现有测试语义保持不变。
2. 只有显式传入 `enable_verify=True` 时，才调用 PR-B2 的 `run_inspect_algorithms(...)`。
3. `max_complexity_tier`、`max_call_count_scaling` 和 `smt_timeout_ms` 只作为 inspect 策略参数传给 adapter，不反向修改 raw verify 算法默认契约。
4. `inspect_model(enable_verify=True)` 在未显式传入 verify 策略参数时，必须等价于把 `max_complexity_tier="structural"`、`max_call_count_scaling="linear_in_transitions"`、`smt_timeout_ms=None` 透传给 `run_inspect_algorithms(...)`；默认只放行 structural 拓扑算法，不默认放宽到 `smt_linear`，也不默认强加 Z3 timeout。
5. `bmc_search` 和 queried 算法仍不得进入自动 inspect 路径；非法门限必须受控失败。
6. verify raw diagnostics 进入 `ModelDiagnostic` 前必须经过 PR-B1 的 code、refs、span 和 schema 契约。
7. jsfcstm 本 PR 不实装 verify 算法，默认 parity 路径不能被破坏。

## 实施范围

| 模块 / 文件 | 计划内容 | 验收口径 |
|---|---|---|
| `pyfcstm.diagnostics.inspect` | 扩展 `inspect_model(...)` 参数：`enable_verify=False`、`max_complexity_tier="structural"`、`max_call_count_scaling="linear_in_transitions"`、`smt_timeout_ms=None`；默认路径不调用 verify。 | 现有默认 inspect 测试不改期望仍通过；新增 spy 测试证明默认不调用 `run_inspect_algorithms(...)`；新增 spy 测试证明 `inspect_model(machine, enable_verify=True)` 未显式传参时向 adapter 透传 `structural`、`linear_in_transitions` 和 `None`。 |
| `pyfcstm.diagnostics.inspect` | 增加 verify result 到 `ModelDiagnostic` 的转换层，只消费 PR-B2 的 `InspectRunResult`，raw diagnostic 字典结构按 `{'code': str, 'algorithm_name': str, 'data': dict}` 处理。 | 至少一个真实 verify finding 能被转换成已声明 code 的 `ModelDiagnostic`；优先选择 structural 档能稳定触发的 verify code 作为 smoke 样本。 |
| `pyfcstm.diagnostics.codes.yaml` / schema 相关测试 | 如发现 PR-B1 仍缺少必要字段，只补契约，不新增无上游依据的诊断码。 | 新增或触达的 code 均能被 registry 加载，并通过 refs schema；本 PR 不新增 PR-B1 之外的新诊断 code，除非先在 PR body 和评论中说明上游依据。 |
| `pyfcstm.diagnostics.__init__` | 如转换层新增公开 helper，则同步顶层导出和 module pydoc 地图；若 helper 保持内部私有，则不改公开 API。 | 触及公开入口时，`__init__.py` module pydoc 仍以表格形式说明模块地图。 |
| `test/diagnostics` / `test/verify` | 增加默认不变、开启 verify、非法门限、skip/unknown/timeout 处理、refs/schema 的回归测试。 | `SKIP_SLOW_TESTS=1 pytest test/diagnostics test/verify -q` 通过。 |
| 文档与 API RST | 如新增公开 helper，补 reST pydoc；提交前运行 `make rst_auto`。 | Sphinx 本地构建通过，HTML 中无 `class="problematic"`。 |

## 结果转换规则

| adapter 结果 | inspect 行为 | 诊断策略 |
|---|---|---|
| `result_kind="sat"` 且有 raw diagnostics | 转成对应 `ModelDiagnostic` | 使用 raw diagnostic 的 code/data/refs，并补齐算法元数据。 |
| `result_kind="sat"` 且无 raw diagnostics | 不发诊断 | 代表无发现或 structural payload 暂不直接发射。 |
| `result_kind="unsat"` 且有 raw diagnostics | 转成对应 `ModelDiagnostic` | 保留 raw diagnostic 语义，不按 result kind 反转。 |
| `result_kind="unsat"` 且无 raw diagnostics | 不发诊断 | 代表算法证明某类性质成立或无对外发现。 |
| `result_kind="unknown"` / `"timeout"` / `"undecidable_skip"` | 默认不误报 warning | 如 PR-B1 已有对应 informational code 且 refs 完整，可发受控信息；否则仅保守跳过，不进入 `ModelDiagnostic`。 |
| adapter 抛出 `InspectAccessForbiddenError` | 受控失败 | 非法门限或 `bmc_search` 请求应给出清晰异常，不静默吞掉。 |

## 不在本 PR 范围

| 项目 | 原因 | 后续入口 |
|---|---|---|
| CLI 参数 | 属于 PR-B5。 | PR-B5 |
| inspect reachability 与 verify topology 同源化 | 属于 PR-B4，避免同时大改 `inspect.py`。 | PR-B4 |
| BMC / queried 算法实现或自动运行 | #114 明确禁止进入自动 inspect。 | dev/verify #50 或独立 issue |
| jsfcstm 端 verify 实装 | Track B 是 py-only verify 接入；本 PR 只保护默认 parity。 | 后续单独评估 |
| 修改 raw verify 算法数学语义 | Track B 只消费 PR-B2 adapter 结果。 | 算法 bug 另开修复 PR |

## 测试计划

| 阶段 | 命令 / 检查 | 目标 |
|---|---|---|
| 快速单测 | `SKIP_SLOW_TESTS=1 pytest test/diagnostics test/verify -q` | 覆盖 inspect + verify 接入主路径。 |
| 精准覆盖 | 根据 Codecov comment 补测 modified lines | PR patch modified lines 必须全覆盖或有明确不可覆盖理由。 |
| 签名默认值 | `python - <<'PY'` 检查 `inspect_model` 四个新增参数默认值 | `enable_verify` 为 `False`，`max_complexity_tier` 为 `"structural"`，`max_call_count_scaling` 为 `"linear_in_transitions"`，`smt_timeout_ms` 为 `None`。 |
| jsfcstm 边界 | `git diff --name-only origin/dev/issue114-pr-b-inspect...HEAD -- editors/jsfcstm` | 默认期望为空；若不为空必须说明为何不要求浏览器端发射 verify-only 诊断。 |
| 诊断码边界 | 检查 `pyfcstm/diagnostics/codes.yaml` code 集合 | 默认不新增 PR-B1 之外的 verify code；若新增必须有上游依据、refs schema 和测试。 |
| 文档生成 | `make rst_auto` | API RST 与 pydoc 同步。 |
| 文档构建 | `READTHEDOCS_LANGUAGE=zh sphinx-build -b html docs/source /tmp/pyfcstm-inspect-verify-html-zh` | 确认 reST 不炸，且无 `class="problematic"`。 |
| 全量快速回归 | `SKIP_SLOW_TESTS=1 make unittest` | 合并前本地快速全量通过。 |
| CI | GitHub Actions 全部通过 | Python matrix、CLI、jsfcstm、release 相关检查均收敛。 |

## pydoc / 文档规则

- 新增或修改的 module / class / function pydoc 必须使用 reST 风格，说明功能和效果。
- 函数必须包含 `:param:`、`:type:`、`:return:`、`:rtype:`；可能抛出的受控异常必须包含 `:raises:`。
- 类或 dataclass 必须说明字段含义和类型。
- 公开入口必须包含真实可运行的 `Examples::`，示例不能是伪代码。
- 触及 `__init__.py` 时，module pydoc 必须以表格形式提供模块地图。
- 不得把 PR 号、阶段名、review round 等工作流标签写入代码标识符、runtime message 或 pydoc 语义描述。

## PR body 一致性审查要求

三路 reviewer 需要重点检查：

| 检查项 | 期望 |
|---|---|
| 与 #114 一致性 | 参数名、默认行为、`bmc_search` 禁止自动 inspect、jsfcstm 边界均一致。 |
| 与 #174 一致性 | PR-B3 只做 `inspect_model()` 可选接入，不越界到 PR-B4/PR-B5。 |
| 与 #175 / #176 一致性 | 只消费已有诊断契约和 adapter 结果，不绕过 refs/schema，不重复实现算法执行。 |
| 可执行性 | TDD 切入点清晰，能先写默认不变和开启 verify 的失败测试。 |
| 可验收性 | 每个目标都有对应测试、文档或 CI 证据。 |

