### PR TITLE
PR-B4：对齐拓扑 reachability 并整理重复诊断（#114）

### DIFF
--- a/docs/source/api_doc/diagnostics/inspect.rst
+++ b/docs/source/api_doc/diagnostics/inspect.rst
@@ -30,6 +30,12 @@ KNOWN\_SPANLESS\_CODES
 .. autodata:: KNOWN_SPANLESS_CODES
 
 
+VERIFY\_SHARED\_STATIC\_CODES
+-----------------------------------------------------
+
+.. autodata:: VERIFY_SHARED_STATIC_CODES
+
+
 StateInfo
 -----------------------------------------------------
 

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -108,7 +108,7 @@ def _unreachable_state_diagnostics(states, reachability_graph, root_state_path) 
     reachable.add(root_state_path)
     diagnostics: List[ModelDiagnostic] = []
     for state in states:
-        if state.is_pseudo or state.path in reachable:
+        if not state.is_leaf or state.is_pseudo or state.path in reachable:
             continue
         diagnostics.append(
             ModelDiagnostic(

--- a/pyfcstm/diagnostics/analyzers/structural.py
+++ b/pyfcstm/diagnostics/analyzers/structural.py
@@ -175,10 +175,14 @@ def _dead_named_action_warnings(
     root_path = root_state_path or states[0].path
     reachable = set(reachability_graph.get(root_path, ()))
     reachable.add(root_path)
+    reachable_action_states = _expand_leaf_reachability_to_action_states(
+        states,
+        reachable,
+    )
     referenced: Set[str] = {
         action.ref_target
         for action in actions
-        if action.ref_target is not None and action.state_path in reachable
+        if action.ref_target is not None and action.state_path in reachable_action_states
     }
     diagnostics: List[ModelDiagnostic] = []
     for action in actions:
@@ -186,7 +190,7 @@ def _dead_named_action_warnings(
             continue
         if action.signature in referenced:
             continue
-        if action.state_path in reachable:
+        if action.state_path in reachable_action_states:
             continue
         diagnostics.append(ModelDiagnostic(
             code='W_DEAD_NAMED_ACTION',
@@ -199,3 +203,65 @@ def _dead_named_action_warnings(
             },
         ))
     return diagnostics
+
+
+def _expand_leaf_reachability_to_action_states(states, reachable):
+    """Expand leaf-only reachability to states that can host actions.
+
+    Inspect reachability values are leaf-only, but actions can be declared on
+    composite states. A composite is action-reachable when any reachable leaf
+    sits below it in the hierarchy.
+
+    :param states: Inspect state payloads.
+    :type states: Iterable[StateInfo]
+    :param reachable: Reachable state paths from the root topology view.
+    :type reachable: Iterable[str]
+    :return: Reachable paths including ancestor composites of reachable leaves.
+    :rtype: Set[str]
+
+    Examples::
+
+        >>> from pyfcstm.diagnostics import StateInfo
+        >>> root = StateInfo(
+        ...     path='Root',
+        ...     name='Root',
+        ...     parent_path=None,
+        ...     is_leaf=False,
+        ...     is_pseudo=False,
+        ...     is_composite=True,
+        ...     substates=('Root.A',),
+        ...     initial_targets=(),
+        ...     entry_actions=(),
+        ...     during_actions=(),
+        ...     exit_actions=(),
+        ...     aspect_before=(),
+        ...     aspect_after=(),
+        ...     has_abstract_action=False,
+        ... )
+        >>> leaf = StateInfo(
+        ...     path='Root.A',
+        ...     name='A',
+        ...     parent_path='Root',
+        ...     is_leaf=True,
+        ...     is_pseudo=False,
+        ...     is_composite=False,
+        ...     substates=(),
+        ...     initial_targets=(),
+        ...     entry_actions=(),
+        ...     during_actions=(),
+        ...     exit_actions=(),
+        ...     aspect_before=(),
+        ...     aspect_after=(),
+        ...     has_abstract_action=False,
+        ... )
+        >>> sorted(_expand_leaf_reachability_to_action_states((root, leaf), {'Root.A'}))
+        ['Root', 'Root.A']
+    """
+    reachable_states = set(reachable)
+    for state in states:
+        if state.path in reachable_states:
+            continue
+        prefix = state.path + '.'
+        if any(path.startswith(prefix) for path in reachable):
+            reachable_states.add(state.path)
+    return reachable_states

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -427,9 +427,10 @@ class ModelInspect:
     :type events: Tuple[EventInfo, ...]
     :param metrics: Aggregate model metrics.
     :type metrics: ModelMetrics
-    :param reachability_graph: Mapping state path → list of state paths
-        reachable through normal transitions (BFS closure, ignoring
-        guards).
+    :param reachability_graph: Mapping from every state path to leaf state
+        paths reachable in the guard-agnostic topology projection. Keys include
+        composite states, but values are leaf-only and never expose the
+        topology package's synthetic root-exit sink.
     :type reachability_graph: Dict[str, Tuple[str, ...]]
     :param event_emission_map: Mapping event qualified name → list of
         source state paths that can emit it.
@@ -1291,49 +1292,40 @@ def _build_metrics(
     )
 
 
-def _build_reachability_graph(
-        states: Tuple[StateInfo, ...],
-        transitions: Tuple[TransitionInfo, ...],
-) -> Dict[str, Tuple[str, ...]]:
-    """BFS reachability over normal transitions, ignoring guards."""
-    # Adjacency list keyed by state path. ``[*]`` markers are skipped.
-    adjacency: Dict[str, set] = {s.path: set() for s in states}
-    initial_edges: Dict[str, set] = {s.path: set() for s in states}
-    for t in transitions:
-        if t.from_path == _INIT_MARK or t.to_path == _EXIT_MARK:
-            # Initial / exit pseudo edges feed reachability from the
-            # parent composite (the parent's "active" implies traversing
-            # the initial transition).
-            continue
-        if t.from_path not in adjacency:  # pragma: no cover
-            # Defensive: transitions emitted by the model layer always
-            # have from_path equal to a known state path (or the INIT
-            # marker caught above). Unreachable through grammar-driven
-            # input; kept as a safety net so a future synthesizer that
-            # invents from_paths doesn't crash here.
-            continue
-        adjacency[t.from_path].add(t.to_path)
+def _build_reachability_graph(machine: 'StateMachine') -> Dict[str, Tuple[str, ...]]:
+    """Return inspect reachability using the verify topology projection.
 
-    for s in states:
-        if s.is_composite and s.initial_targets:
-            for it in s.initial_targets:
-                target = it['target']
-                if target != _EXIT_MARK:
-                    initial_edges[s.path].add(target)
+    The public inspect JSON contract keeps one key for every state path, while
+    values are the leaf-only, guard-agnostic topology closure computed by
+    :func:`pyfcstm.verify.topology.topological_reachable_set`. This keeps
+    inspect, design-health diagnostics, and verify diagnostics on one
+    hierarchy-aware source of truth.
 
-    out: Dict[str, Tuple[str, ...]] = {}
-    for s in states:
-        seen = set()
-        queue = [s.path]
-        while queue:
-            cur = queue.pop(0)
-            for nxt in sorted(adjacency.get(cur, set()) | initial_edges.get(cur, set())):
-                if nxt in seen or nxt == s.path:
-                    continue
-                seen.add(nxt)
-                queue.append(nxt)
-        out[s.path] = tuple(sorted(seen))
-    return out
+    :param machine: State machine whose topology should be projected.
+    :type machine: pyfcstm.model.StateMachine
+    :return: Mapping from every state path to reachable leaf paths.
+    :rtype: Dict[str, Tuple[str, ...]]
+
+    Examples::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... state Root {
+        ...     state A;
+        ...     state B;
+        ...     [*] -> A;
+        ...     A -> B;
+        ... }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, 'state_machine_dsl')
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> _build_reachability_graph(machine)['Root.A']
+        ('Root.B',)
+    """
+    from ..verify.topology import topological_reachable_set
+
+    return topological_reachable_set(machine)
 
 
 def _build_event_emission_map(
@@ -2062,6 +2054,16 @@ def _structural_verify_diagnostics(
             )
             if diagnostic is not None:
                 diagnostics.append(diagnostic)
+    elif result.algorithm_name == 'unreachable_states':
+        for state_path in result.raw_result or ():
+            refs = {'state_path': state_path}
+            diagnostic = _make_verify_diagnostic(
+                'W_UNREACHABLE_STATE',
+                refs,
+                _state_span_by_path(states, state_path),
+            )
+            if diagnostic is not None:
+                diagnostics.append(diagnostic)
     elif result.algorithm_name == 'topological_finite':
         counterexamples = getattr(result.raw_result, 'counterexamples', ())
         for kind, payload in counterexamples:
@@ -2366,6 +2368,46 @@ def _verify_diagnostics_from_results(
     return tuple(diagnostics)
 
 
+def _deduplicate_model_diagnostics(
+        diagnostics: Sequence[ModelDiagnostic],
+) -> Tuple[ModelDiagnostic, ...]:
+    """Remove semantic duplicates while preserving diagnostic order.
+
+    The inspect surface may combine legacy design-health warnings with optional
+    verify-pipeline diagnostics. When both paths report the same unreachable
+    state, callers should see one diagnostic rather than two equivalent
+    warnings. Other diagnostics are left untouched because repeated findings on
+    one state can represent distinct source occurrences.
+
+    :param diagnostics: Diagnostics in emission order.
+    :type diagnostics: Sequence[ModelDiagnostic]
+    :return: Diagnostics with duplicate state-scoped entries removed.
+    :rtype: Tuple[ModelDiagnostic, ...]
+
+    Examples::
+
+        >>> diag = ModelDiagnostic(
+        ...     code='W_UNREACHABLE_STATE',
+        ...     severity='warning',
+        ...     message='unreachable',
+        ...     refs={'state_path': 'Root.Orphan'},
+        ... )
+        >>> len(_deduplicate_model_diagnostics((diag, diag)))
+        1
+    """
+    out: List[ModelDiagnostic] = []
+    seen_state_scoped = set()
+    for diagnostic in diagnostics:
+        state_path = diagnostic.refs.get('state_path')
+        if diagnostic.code == 'W_UNREACHABLE_STATE' and isinstance(state_path, str):
+            key = (diagnostic.code, state_path)
+            if key in seen_state_scoped:
+                continue
+            seen_state_scoped.add(key)
+        out.append(diagnostic)
+    return tuple(out)
+
+
 def inspect_model(
         machine: 'StateMachine',
         *,
@@ -2452,7 +2494,7 @@ def inspect_model(
     actions = _build_action_infos(machine)
     forced_transitions = _build_forced_transition_infos(machine)
     metrics = _build_metrics(states, transitions, variables, events)
-    reachability_graph = _build_reachability_graph(states, transitions)
+    reachability_graph = _build_reachability_graph(machine)
     root_state_path = _state_path(machine.root_state)
     diagnostics = list(collect_design_health_warnings(
         states,
@@ -2483,6 +2525,7 @@ def inspect_model(
             events,
             actions,
         ))
+    diagnostics = list(_deduplicate_model_diagnostics(diagnostics))
     return ModelInspect(
         root_state_path=root_state_path,
         states=states,

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -79,6 +79,14 @@ DEFAULT_VAR_TO_LEAF_RATIO_THRESHOLD = 2.0
 # test/diagnostics/test_inspect_span_contract.py.
 KNOWN_SPANLESS_CODES = frozenset()
 
+# Some structural verify algorithms intentionally reuse a legacy static
+# diagnostic code so callers see one stable public code for the same model
+# problem, regardless of whether it came from design-health analysis or the
+# optional verify adapter.
+VERIFY_SHARED_STATIC_CODES = frozenset({
+    'W_UNREACHABLE_STATE',
+})
+
 
 _OP_PRECEDENCE = {
     'function_call': 90,
@@ -2199,18 +2207,21 @@ def _type_matches_schema(value: Any, field_spec: CodeFieldSpec) -> bool:
 
 
 def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
-    """Return whether refs satisfy the declared verify diagnostic schema.
+    """Return whether refs satisfy the declared verify-adapter schema.
 
     The conversion layer uses this as a fail-closed guard: raw verify findings
     are emitted only after their refs are declared, complete, enum-safe, and
-    type-compatible with ``codes.yaml``.
+    type-compatible with ``codes.yaml``. Most accepted codes are declared as
+    ``emit_tier: verify_pipeline``; codes in
+    :data:`VERIFY_SHARED_STATIC_CODES` are legacy static diagnostics that a
+    structural verify algorithm may also emit.
 
     :param code: Diagnostic code to validate.
     :type code: str
     :param refs: Candidate refs payload.
     :type refs: Mapping[str, Any]
-    :return: ``True`` when the code is a verify-pipeline code and refs match
-        its schema.
+    :return: ``True`` when the code may be emitted by the verify adapter and
+        refs match its schema.
     :rtype: bool
 
     Examples::
@@ -2226,9 +2237,15 @@ def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
         ...     'transition_summary': 'Root:A->B',
         ... })
         True
+        >>> _refs_match_code_schema('W_UNREACHABLE_STATE', {
+        ...     'state_path': 'Root.Orphan',
+        ... })
+        True
     """
     spec = CODE_REGISTRY.get(code)
-    if spec is None or spec.emit_tier != 'verify_pipeline':
+    if spec is None:
+        return False
+    if spec.emit_tier != 'verify_pipeline' and code not in VERIFY_SHARED_STATIC_CODES:
         return False
     declared = set(spec.refs_schema.keys())
     if set(refs.keys()) - declared:

--- a/pyfcstm/diagnostics/schema.json
+++ b/pyfcstm/diagnostics/schema.json
@@ -53,7 +53,7 @@
     "metrics": { "$ref": "#/definitions/ModelMetrics" },
     "reachability_graph": {
       "type": "object",
-      "description": "Mapping state path -> reachable state paths via normal transitions (BFS closure, guards ignored).",
+      "description": "Mapping state path -> reachable leaf state paths in the guard-agnostic topology projection. Keys include every state path; values are leaf-only paths and do not expose the synthetic root-exit sink.",
       "additionalProperties": {
         "type": "array",
         "items": { "type": "string" }

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -1030,6 +1030,13 @@ DESIGN_HEALTH_INSPECT_FIXTURES = [
                 },
             },
             {
+                'code': 'W_UNREACHABLE_STATE',
+                'severity': 'warning',
+                'refs': {
+                    'state_path': 'Root.B',
+                },
+            },
+            {
                 'code': 'W_UNREFERENCED_VAR',
                 'severity': 'warning',
                 'refs': {

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -2277,6 +2277,88 @@ class TestInspectModelVerifyIntegration:
             context='verify-unreachable-dedup',
         )
 
+    def test_structural_verify_converts_unreachable_shared_static_code(self):
+        from pyfcstm.verify import InspectRunResult
+
+        state = StateInfo(
+            path='Root.Orphan',
+            name='Orphan',
+            parent_path='Root',
+            is_leaf=True,
+            is_pseudo=False,
+            is_composite=False,
+            substates=(),
+            initial_targets=(),
+            entry_actions=(),
+            during_actions=(),
+            exit_actions=(),
+            aspect_before=(),
+            aspect_after=(),
+            has_abstract_action=False,
+            span=inspect_module.Span(line=3, column=5),
+        )
+        result = InspectRunResult(
+            algorithm_name='unreachable_states',
+            complexity_tier='structural',
+            smt_logic=None,
+            verification_scope='topological_only',
+            diagnostic_codes=('W_UNREACHABLE_STATE',),
+            result_kind='sat',
+            diagnostics=(),
+            reason=None,
+            raw_result=('Root.Orphan',),
+        )
+
+        diagnostics = inspect_module._structural_verify_diagnostics(
+            result,
+            (state,),
+            (),
+        )
+
+        assert [(diag.code, diag.refs) for diag in diagnostics] == [
+            ('W_UNREACHABLE_STATE', {'state_path': 'Root.Orphan'}),
+        ]
+        assert diagnostics[0].span == state.span
+        assert_all_diags_match_schema(
+            diagnostics,
+            context='verify-unreachable-structural',
+        )
+
+    def test_deduplicates_only_unreachable_state_duplicates(self):
+        unreachable = inspect_module.ModelDiagnostic(
+            code='W_UNREACHABLE_STATE',
+            severity='warning',
+            message='unreachable',
+            refs={'state_path': 'Root.Orphan'},
+        )
+        distinct_state = inspect_module.ModelDiagnostic(
+            code='W_UNREACHABLE_STATE',
+            severity='warning',
+            message='unreachable',
+            refs={'state_path': 'Root.Other'},
+        )
+        repeated_other_code = inspect_module.ModelDiagnostic(
+            code='W_DEAD_NAMED_ACTION',
+            severity='warning',
+            message='dead action',
+            refs={'state_path': 'Root.Orphan'},
+        )
+
+        diagnostics = inspect_module._deduplicate_model_diagnostics((
+            unreachable,
+            unreachable,
+            distinct_state,
+            repeated_other_code,
+            repeated_other_code,
+        ))
+
+        assert diagnostics == (
+            unreachable,
+            distinct_state,
+            repeated_other_code,
+            repeated_other_code,
+        )
+
     def test_enable_verify_converts_smt_raw_diagnostics(self):
         dsl = """
         def int x = 0;

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -2648,6 +2648,10 @@ class TestInspectModelVerifyIntegration:
 
         assert inspect_module._refs_match_code_schema('W_DEAD_GUARD', valid_refs)
         assert not inspect_module._refs_match_code_schema(
+            'X_UNKNOWN_CODE',
+            {'state_path': 'Root.Missing'},
+        )
+        assert not inspect_module._refs_match_code_schema(
             'E_UNDEFINED_VAR',
             dict(valid_refs),
         )

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -31,6 +31,11 @@ from pyfcstm.diagnostics import (
 )
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.verify.topology import (
+    EXIT_ROOT_SINK,
+    topological_reachable_set,
+    unreachable_states,
+)
 
 from ._schema_check import assert_all_diags_match_schema
 
@@ -201,6 +206,56 @@ class TestInspectModelViews:
     def test_reachability_leaf_to_leaf(self, report):
         assert 'Root.Active' in report.reachability_graph['Root.Idle']
         assert 'Root.Idle' in report.reachability_graph['Root.Active']
+
+    def test_reachability_uses_leaf_only_topology_semantics(self):
+        dsl = """
+        state System {
+            state Working {
+                state Active;
+                state Idle;
+                [*] -> Active;
+                Active -> Idle;
+                Idle -> [*];
+            }
+            state Done;
+            state Orphan;
+            [*] -> Working;
+            Working -> Done;
+            Done -> [*];
+        }
+        """
+        machine = _parse(dsl)
+        report = inspect_model(machine)
+
+        assert report.reachability_graph == topological_reachable_set(machine)
+        assert report.reachability_graph['System'] == (
+            'System.Done',
+            'System.Working.Active',
+            'System.Working.Idle',
+        )
+        assert 'System.Working' not in report.reachability_graph['System']
+        assert report.reachability_graph['System.Working.Idle'] == ('System.Done',)
+        assert EXIT_ROOT_SINK not in report.reachability_graph['System.Done']
+
+    def test_unreachable_diagnostics_match_verify_topology(self):
+        dsl = """
+        state Root {
+            state A;
+            pseudo state PseudoOnly;
+            state Orphan;
+            [*] -> A;
+        }
+        """
+        machine = _parse(dsl)
+        report = inspect_model(machine)
+
+        assert tuple(
+            sorted(
+                diag.refs['state_path']
+                for diag in report.diagnostics
+                if diag.code == 'W_UNREACHABLE_STATE'
+            )
+        ) == unreachable_states(machine)
 
     def test_event_emission_map(self, report):
         assert report.event_emission_map == {
@@ -391,6 +446,12 @@ class TestSchemaJsonValidates:
         refs_text = json.dumps(refs_schema, sort_keys=True)
         assert '<object>_span' in refs_text
         assert 'list[Span]' in refs_text
+
+    def test_schema_documents_leaf_only_reachability(self):
+        schema = self._load_schema()
+        description = schema['properties']['reachability_graph']['description']
+        assert 'leaf' in description
+        assert 'topology' in description
 
     def test_diagnostics_readme_documents_range_layers(self):
         readme_path = os.path.join(
@@ -690,6 +751,31 @@ state Root {
             d.refs for d in report.diagnostics
             if d.code == 'W_DEAD_NAMED_ACTION'
         ] == [{'function_name': 'Target', 'defined_in': 'Root.Orphan'}]
+
+    def test_dead_named_action_uses_topology_reachability(self):
+        dsl = """
+        state Root {
+            state Flow {
+                state A { enter Live {} }
+                state B { enter AlsoLive {} }
+                [*] -> A;
+                A -> B;
+                B -> [*];
+            }
+            state Done;
+            state Orphan { enter Dead {} }
+            [*] -> Flow;
+            Flow -> Done;
+            Done -> [*];
+        }
+        """
+        report = inspect_model(_parse(dsl))
+
+        assert [
+            diag.refs
+            for diag in report.diagnostics
+            if diag.code == 'W_DEAD_NAMED_ACTION'
+        ] == [{'function_name': 'Dead', 'defined_in': 'Root.Orphan'}]
 
     def test_nested_chain_event_keeps_chain_scope(self):
         dsl = """
@@ -2167,6 +2253,29 @@ class TestInspectModelVerifyIntegration:
         assert_all_diags_match_schema([noexit_diag], context='verify-deadlock')
         _assert_has_span(noexit_diag.span)
         assert 'state B' in _slice_by_span(dsl, noexit_diag.span)
+
+    def test_enable_verify_deduplicates_unreachable_state_diagnostics(self):
+        dsl = """
+        state System {
+            state A;
+            state Orphan;
+            [*] -> A;
+        }
+        """
+
+        report = inspect_model(_parse(dsl), enable_verify=True)
+        unreachable_diags = [
+            diag for diag in report.diagnostics
+            if diag.code == 'W_UNREACHABLE_STATE'
+        ]
+
+        assert [diag.refs['state_path'] for diag in unreachable_diags] == [
+            'System.Orphan',
+        ]
+        assert_all_diags_match_schema(
+            unreachable_diags,
+            context='verify-unreachable-dedup',
+        )
 
     def test_enable_verify_converts_smt_raw_diagnostics(self):
         dsl = """


### PR DESCRIPTION
## 上游依据

关联上游 issue：#114，依赖 PR-B 总伞 #174。

本 PR 是 Track B 的 PR-B4，base 固定为 PR-B 总伞分支 `dev/issue114-pr-b-inspect`，不是 `main`。当前前置依赖状态：

| 依赖项 | 状态 | 本 PR 使用方式 |
|---|---|---|
| PR-B2 #176 | 🟢 已合入 PR-B | 使用已落地的 verify inspect adapter 与 topology 算法入口。 |
| PR-B3 #178 | 🟢 已合入 PR-B | 在 `inspect_model()` 已可选接入 verify 的基础上，继续整理 inspect reachability 与 verify topology 的同源关系。 |
| PR-B 总伞 #174 | 🟨 推进中 | 本 PR 只完成其中“拓扑图同源化与重复诊断整理”这一行。 |
| issue #114 | 🔵 上游基线 | 遵守组 1 拓扑算法规范，尤其是多层初始进入、leaf exit bubble、root exit sink、parent boundary 与 `topological_only` 边界声明。 |

## 本 PR 目标

把 `inspect_model()` 里的 reachability 语义与 `pyfcstm.verify.topology` 的拓扑算法保持同源，避免 inspect 与 verify 对同一个层次模型给出互相矛盾的结构结论。

必须达成：

1. `inspect_model(machine).reachability_graph` 保持现有 JSON 字段名和序列化类型形状不变：key 仍是全部 state path，value 仍是 path 列表；但 value 的语义明确调整为 **leaf-only topology reachable paths**，与 `topological_reachable_set(machine)` 对齐，不再把 composite state path 混入可达值。
2. 多层初始进入、进入 composite 后继续下钻到 leaf、leaf `-> [*]` bubble 到父级 outgoing、root exit sink、parent boundary 等用例必须与 `pyfcstm.verify.topology` 一致。
3. `W_UNREACHABLE_STATE` 仍只报告非 pseudo leaf 状态，并与 `unreachable_states(machine)` 的结果一致。
4. 当 `enable_verify=True` 时，不得因为 inspect 静态诊断和 verify 拓扑诊断同时运行而重复发射语义等价的 `W_UNREACHABLE_STATE`。
5. 不修改 raw verify 算法数学语义；如需要共享逻辑，应从 inspect 调用 verify topology 的公开入口，而不是复制一份平行算法。
6. 同步更新 schema / pydoc 中对 `reachability_graph` 的描述，避免继续写成泛化的 reachable state paths。

## reachability_graph 契约消歧

| 项目 | B4 后契约 | 说明 |
|---|---|---|
| JSON 字段名 | 保持 `reachability_graph` | 不改 downstream 读取字段。 |
| key 集合 | 全部 state path | root、composite、leaf 都保留 key，方便既有消费者按任意状态查图。 |
| value 类型 | path 列表 | JSON 仍是 array，Python 仍是 tuple/list 序列化形状。 |
| value 语义 | leaf-only topology reachable paths | 与 `topological_reachable_set(machine)` 相同，值里不再包含 composite path。 |
| root exit sink | 不进入 JSON value | verify 内部的 synthetic sink 只用于算法，不暴露到 inspect JSON。 |
| schema / pydoc | 同步说明 leaf-only | 避免“字段名不变”被误解成“值语义完全不变”。 |

## 实施范围

| 模块 / 文件 | 计划内容 | 验收口径 |
|---|---|---|
| `pyfcstm.diagnostics.inspect` | 将 reachability 计算切换到与 `pyfcstm.verify.topology.topological_reachable_set()` 同源的路径，保留 `ModelInspect.reachability_graph` 字段、key 集合和 JSON 类型形状。 | 复杂层次模型中，`inspect_model(machine).reachability_graph` 与 `topological_reachable_set(machine)` 对同一状态返回同一 leaf 集合。 |
| `pyfcstm.diagnostics.analyzers.design_health` | 整理 `W_UNREACHABLE_STATE` 的来源，使默认 inspect 仍发该诊断，但开启 verify 后不重复发同一状态的同类诊断。 | 同一不可达 leaf 在 `enable_verify=True` 下只出现一条 `W_UNREACHABLE_STATE`，refs 仍通过 schema。 |
| `pyfcstm.diagnostics.analyzers.structural` | 复核 `_dead_named_action_warnings()` 对 `reachability_graph` 的消费，确保 leaf-only value 后仍能正确判断不可达命名动作。 | 可达 leaf 上的命名动作不误报；不可达 leaf 上未引用命名动作仍报告。 |
| `pyfcstm/diagnostics/schema.json` | 如 schema 描述 reachability value，需要同步改成 leaf-only topology reachable paths。 | JSON schema 仍验证真实 inspect 输出，描述与 B4 契约一致。 |
| `test/diagnostics` | 增加多层 init、bubble、root exit、parent boundary、pseudo leaf、重复诊断去重、structural 消费方的回归测试。 | 新测试能在 B4 实现前暴露当前 inspect/verify 拓扑差异，实装后通过。 |
| `test/verify` | 如发现 verify topology 覆盖缺口，只补充验证现有公开算法行为的测试，不改变算法边界。 | verify topology 原有测试继续通过；新增测试不要求 Z3 或 CLI。 |
| 文档与 pydoc | 若新增或修改公开 helper，按 CLAUDE.md 维护 reST pydoc、`:param:`、`:type:`、`:return:`、`:rtype:` 与 `Examples::`。提交前运行 `make rst_auto`。 | pydoc 示例真实可运行；API RST 生成正常。 |

## 重复诊断策略

| 场景 | 默认 inspect | `enable_verify=True` | 期望 |
|---|---|---|---|
| 不可达 leaf | 发 `W_UNREACHABLE_STATE` | verify adapter 也可能返回同 code | 最终只保留一条，优先保留 refs/schema 更完整且 span 可靠的诊断。 |
| 非平凡 SCC | 默认不由旧 inspect 发 | verify topology 可发 `I_NONTRIVIAL_SCC` | 保持 PR-B3 行为，不在 B4 新增静态重复源。 |
| 拓扑 no-exit / non-terminating | 默认不由旧 inspect 发 | verify topology 可发对应 code | 保持 PR-B3 行为，不在 B4 混入 CLI 或新开关。 |
| pseudo leaf 不可达 | 不发 `W_UNREACHABLE_STATE` | verify topology 同样不应作为 unreachable leaf 发 | 两边一致跳过。 |

## 不在本 PR 范围

| 项目 | 原因 | 后续入口 |
|---|---|---|
| CLI 参数与用户文档收口 | 属于 PR-B5。 | PR-B5 |
| 新增 verify 诊断码 | PR-B1 已完成本轮公开 code 契约；B4 只整理发射策略。 | 独立契约 PR 或后续 issue |
| BMC / queried 算法 | #114 明确禁止进入自动 inspect。 | dev/verify #50 或独立 issue |
| jsfcstm 端 verify 实装 | 本 PR 不修改 `editors/jsfcstm/`；如 inspect JSON 值语义影响浏览器端 consumer，需要在 PR 说明中明确。 | 后续单独评估 |
| 修改 SMT 局部算法 | B4 是 structural topology 同源化，不改 SMT 算法。 | 算法 bug 另开修复 PR |

## 测试计划

| 阶段 | 命令 / 检查 | 目标 |
|---|---|---|
| 快速单测 | `SKIP_SLOW_TESTS=1 pytest test/diagnostics test/verify -q` | 覆盖 inspect + verify topology 主路径。 |
| 精准测试 | `SKIP_SLOW_TESTS=1 pytest test/diagnostics/test_inspect_model.py test/verify/test_topology.py -q` | 覆盖 reachability 同源化与重复诊断策略。 |
| doctest | `pytest --doctest-modules pyfcstm/diagnostics/inspect.py pyfcstm/verify/topology.py -q` | 确认相关 pydoc 示例真实可运行。 |
| 文档生成 | `make rst_auto` | API RST 与 pydoc 同步。 |
| jsfcstm 边界 | `git diff --name-only origin/dev/issue114-pr-b-inspect...HEAD -- editors/jsfcstm` | 默认期望为空；若不为空必须说明为何不要求浏览器端发射 verify-only 诊断。 |
| 全量快速回归 | `SKIP_SLOW_TESTS=1 make unittest` | 合并前本地快速全量通过。 |
| CI | GitHub Actions 全部通过 | Python matrix、CLI、jsfcstm、release 相关检查均收敛。 |

## pydoc / 文档规则

- 新增或修改的 module / class / function pydoc 必须使用 reST 风格，说明功能和效果。
- 函数必须包含 `:param:`、`:type:`、`:return:`、`:rtype:`；可能抛出的受控异常必须包含 `:raises:`。
- 类或 dataclass 必须说明字段含义和类型。
- 公开入口必须包含真实可运行的 `Examples::`，示例不能是伪代码。
- 触及 `__init__.py` 时，module pydoc 必须以表格形式提供模块地图。
- 不得把 PR 号、阶段名、review round 等工作流标签写入代码标识符、runtime message 或 pydoc 语义描述。

## PR body 一致性审查要求

三路 reviewer 需要重点检查：

| 检查项 | 期望 |
|---|---|
| 与 #114 一致性 | 多层 hierarchy、bubble、root exit、parent boundary、`topological_only` 边界均一致。 |
| 与 #174 一致性 | PR-B4 只做 reachability 同源化与重复诊断整理，不越界到 PR-B5。 |
| 与 #176 / #178 一致性 | 复用 verify topology 与 inspect adapter 接入成果，不绕过 PR-B3 的 enable_verify 策略。 |
| 可执行性 | TDD 切入点清晰，能先写当前 inspect 与 verify topology 不一致的失败测试。 |
| 可验收性 | 每个目标都有对应测试、文档或 CI 证据。 |
