### PR TITLE
发布准备：v0.5.0 发布前收口

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,7 +726,7 @@ Every code is reachable from the minimal DSL snippet in the right-hand column; s
 [`pyfcstm/diagnostics/codes.yaml`](pyfcstm/diagnostics/codes.yaml) for full per-code metadata (refs schema,
 `for_llm` payload, suggested-fix template, parity flags).
 
-#### Errors (`E_*`) — model is invalid, must fix (19)
+#### Errors (`E_*`) — model is invalid, must fix (20)
 
 | Code | What it catches | Minimal DSL example |
 |------|-----------------|---------------------|
@@ -743,6 +743,7 @@ Every code is reachable from the minimal DSL snippet in the right-hand column; s
 | `E_DUPLICATE_FUNCTION_NAME` | Two named lifecycle actions within the same state share the same name. | `state Root { state A { enter Foo { } enter Foo { } } }` |
 | `E_DURING_ASPECT_INVALID` | A `during` block is declared inconsistently with the host state's leaf/composite kind. | `state Root { state A { during before { } } }` |
 | `E_PSEUDO_NOT_LEAF` | A state was declared with the `pseudo` keyword but has nested substates. | `state Root { pseudo state Outer { state Inner; [*] -> Inner; } }` |
+| `E_NAMED_FUNCTION_REF_CYCLE` | A lifecycle action `ref` chain forms a cycle and never reaches a concrete or abstract action. | `state Root { state A { enter First ref Second; enter Second ref First; } [*] -> A; }` |
 | `E_NAMED_FUNCTION_REF_NOT_FOUND` | A `ref` lifecycle action could not resolve its target named action. | `state Root { state A { enter ref NoSuch.NoSuch; } }` |
 | `E_IMPORT_NOT_FOUND` | An `import` statement points at a source file that cannot be found, read, or parsed. | `state System { import "missing.fcstm" as Sub; }` |
 | `E_IMPORT_CIRCULAR` | A cycle was detected while resolving `import` statements between two or more state-machine source files. | `# a.fcstm state A { import "b.fcstm" as B; } # b.fcstm state B { import "a.fcstm" as A; }` |
@@ -750,7 +751,7 @@ Every code is reachable from the minimal DSL snippet in the right-hand column; s
 | `E_IMPORT_DUPLICATE_MAPPING` | Two or more mapping clauses under the same `import { ... }` block target the same imported name. | `state System { import "sub.fcstm" as Sub { def x = a; def x = b; } }` |
 | `E_IMPORT_MAPPING_INVALID` | An import-mapping clause refers to a source name that does not exist in the imported machine. | `state System { import "sub.fcstm" as Sub { def x = no_such_var; } }` |
 
-#### Warnings (`W_*`) — high-confidence design-health issues (24)
+#### Warnings (`W_*`) — high-confidence design-health issues (32)
 
 | Code | What it catches | Minimal DSL example |
 |------|-----------------|---------------------|
@@ -778,14 +779,26 @@ Every code is reachable from the minimal DSL snippet in the right-hand column; s
 | `W_HIGH_VAR_TO_LEAF_RATIO` | The number of variables is high relative to the number of non-pseudo leaf states (fact-flag bloat heuristic). | `def int a = 0; def int b = 0; def int c = 0; state Root { state A; [*] -> A; }` |
 | `W_DEEP_HIERARCHY` | The state hierarchy exceeds the configured maximum depth. | `state Root { state A { state B { state C; [*] -> C; } [*] -> B; } [*] -> A; }` |
 | `W_LARGE_COMPOSITE` | A composite state has more direct children than the configured threshold. | `state Root { state A; state B; state C; [*] -> A; }` |
+| `W_TOPOLOGICAL_NOEXIT` | A root-reachable leaf or cycle has no guard-agnostic route to the root exit sink. | `state System { state A; state B; [*] -> A; A -> B; }` |
+| `W_EVENT_UNREACHABLE_EMIT` | A used event has no consumer source that is reachable in the guard-agnostic topology graph. | `state System { event Panic; state A; state LostA; state LostB; [*] -> A; LostA -> A : Panic; LostB -> A : Panic; }` |
+| `W_DEAD_GUARD` | SMT proves a transition guard is unsatisfiable under model variable type and runtime-definedness constraints. | `def int x = 0; state System { state A; state B; [*] -> A; A -> B : if [x > 1 && x < 0]; }` |
+| `W_GUARD_TAUTOLOGY` | SMT proves a transition guard is true for every valid variable valuation. | `def int x = 0; state System { state A; state B; [*] -> A; A -> B : if [x >= 0 || x < 0]; }` |
+| `W_FORCED_GUARD_UNSAT` | A forced-transition guard cannot be satisfied under declaration initializer values. | `def int x = 0; state System { state A; state B; [*] -> A; !A -> B : if [x > 0]; }` |
+| `W_EFFECT_SMT_NO_OP` | SMT proves a transition effect leaves all persistent model variables unchanged whenever the transition can run. | `def int x = 0; state System { state A; state B; [*] -> A; A -> B : if [x >= 0] effect { x = x + 0; }; }` |
+| `W_TRANSITION_SHADOWED` | A later outgoing transition is fully covered by earlier same-source triggers and therefore cannot be selected. | `state System { state A; state B; state C; [*] -> A; A -> B; A -> C; }` |
+| `W_COMPOSITE_INIT_INCOMPLETE` | A composite state's initial transitions do not jointly cover all variable and event inputs. | `def int x = 0; state System { state A; state B; [*] -> A : if [x > 0]; [*] -> B : if [x < 0]; }` |
 
-#### Infos (`I_*`) — observations that may be intentional (3)
+#### Infos (`I_*`) — observations that may be intentional (7)
 
 | Code | What it observes | Minimal DSL example |
 |------|------------------|---------------------|
 | `I_UNREFERENCED_VAR_MAYBE_ABSTRACT` | A variable cannot affect any transition guard through DSL data-flow, but at least one visible abstract action may use it externally. | `def int maybe_external = 0; def int ready = 0; state Root { state A { enter abstract ExternalHook; } state B; [*] -> A; A -> B : if [ready > 0]; }` |
 | `I_TRANSITION_TO_SELF_VIA_PARENT` | A composite state transitions to itself, intentionally forcing a re-entry through child initialization. | `state Root { state Active { state Leaf; [*] -> Leaf; } [*] -> Active; Active -> Active; }` |
 | `I_TRANSITION_NEVER_EVENT_TRIGGERED` | A normal transition has no event and no guard — an unconditional fall-through. | `state Root { state A; state B; [*] -> A; A -> B; }` |
+| `I_NONTRIVIAL_SCC` | A non-trivial strongly connected component exists in the guard-agnostic leaf-level topology graph. | `state System { state A; state B; [*] -> A; A -> B; B -> A; }` |
+| `I_TOPOLOGICAL_NON_TERMINATING` | The topology does not force all root-reachable executions to eventually reach the root terminator. | `state System { state A; [*] -> A; A -> A; A -> [*]; }` |
+| `I_EFFECT_GUARD_CONTRADICT` | A transition effect makes the same transition guard false after every guarded, runtime-defined execution. | `def int x = 0; state System { state A; state B; [*] -> A; A -> B : if [x > 0] effect { x = 0; }; }` |
+| `I_ENTER_DURING_CONTRADICT` | Entry-time assignments make a first-cycle `during` branch condition predetermined. | `def int x = 0; state System { state A { enter { x = 1; } during { if [x > 0] { x = x + 1; } else { x = x - 1; } } } [*] -> A; }` |
 
 > **Configurable thresholds.** `inspect_model(machine, *, deep_hierarchy_threshold=6, large_composite_threshold=12, var_to_leaf_ratio_threshold=2.0)` accepts override knobs for the three threshold-based warnings (`W_DEEP_HIERARCHY` / `W_LARGE_COMPOSITE` / `W_HIGH_VAR_TO_LEAF_RATIO`). jsfcstm `inspectModel(model, { deepHierarchyThreshold, largeCompositeThreshold, varToLeafRatioThreshold })` mirrors the same defaults.
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ target languages. It specializes in modeling **Hierarchical State Machines (Hare
 Jinja2-based template system, making it ideal for embedded systems, protocol implementations, game AI, workflow
 engines, and complex control logic.
 
-Out of the box, pyfcstm can parse, visualize, and simulate FCSTM state machines. For source-code generation, pyfcstm
-provides the rendering engine and model API, while you provide the target-language template directory.
+Out of the box, pyfcstm can parse, visualize, simulate, inspect, and generate code from FCSTM state machines. For
+source-code generation, pyfcstm ships packaged built-in templates for common starting points and still supports fully
+custom target-language template directories.
 
 ## Table of Contents
 
@@ -68,7 +69,7 @@ pyfcstm aims to provide a complete solution from conceptual design to code imple
 | **FSM DSL**                     | A concise and readable DSL syntax for defining states, nesting, transitions, events, conditions, and effects.                         | Focus on state machine logic, not programming language details.                                                | [DSL Syntax Tutorial](https://pyfcstm.readthedocs.io/en/latest/tutorials/dsl/index.html)                      |
 | **Hierarchical State Machines** | Supports **nested states** and **composite state** lifecycles (`enter`, `during`, `exit`).                                            | Capable of modeling complex real-time systems and protocols, enhancing maintainability.                        | [DSL Syntax Tutorial - State Definitions](https://pyfcstm.readthedocs.io/en/latest/tutorials/dsl/index.html)  |
 | **Expression System**           | Built-in mathematical and logical expression parser supporting variable definition, conditional guards, and state effects (`effect`). | Allows defining the state machine's internal data and behavior at the DSL level.                               | [DSL Syntax Tutorial - Expression System](https://pyfcstm.readthedocs.io/en/latest/tutorials/dsl/index.html)  |
-| **Templated Code Generation**   | Based on the **Jinja2** template engine, rendering the state machine model into target code (e.g., C/C++, Python, Rust).              | Extremely high flexibility, supporting code generation for virtually any programming language.                 | [Template Tutorial](https://pyfcstm.readthedocs.io/en/latest/tutorials/render/index.html)                     |
+| **Templated Code Generation**   | Based on the **Jinja2** template engine, rendering the state machine model into target code through packaged built-in templates or custom template directories. | Use built-in `python`, `c`, and `c_poll` templates as starting points, or generate for virtually any language with your own templates. | [Template Tutorial](https://pyfcstm.readthedocs.io/en/latest/tutorials/render/index.html)                     |
 | **Cross-Language Support**      | Easily enables state machine code generation for embedded or high-performance languages like **C/C++** through the template system.   | Suitable for scenarios where state machine logic needs to be deployed across different platforms or languages. | [Template Tutorial - Expression Styles](https://pyfcstm.readthedocs.io/en/latest/tutorials/render/index.html) |
 | **PlantUML Integration**        | Directly converts DSL files into **PlantUML** code, with preset detail levels and fine-grained visualization options.                | Facilitates design review and documentation generation.                                                        | [Visualization Guide](https://pyfcstm.readthedocs.io/en/latest/tutorials/visualization/index.html)            |
 | **Simulation Runtime**          | Runs FCSTM models directly in Python or from an interactive CLI REPL / batch executor.                                                | Lets you validate behavior before committing to generated code.                                                | [Simulation Guide](https://pyfcstm.readthedocs.io/en/latest/tutorials/simulation/index.html)                  |
@@ -76,8 +77,8 @@ pyfcstm aims to provide a complete solution from conceptual design to code imple
 | **Structured Diagnostics**      | `pyfcstm.diagnostics` ships **59 diagnostic codes** (20 errors / 32 warnings / 7 infos) covering parse errors, design-health issues (deadlock, unreachable, redundant transitions, const-folded guards, etc.), Layer 0 use-def dataflow analysis, and optional verify-backed checks. | Replace ad-hoc regex / message scraping with a stable structured API; codes carry `for_llm` payloads to drive LLM-assisted repair. | [Diagnostics Code List](#static-diagnostics-codes) |
 | **`inspect_model()` API**       | One-call structured view of a state machine: states / transitions / variables / events / metrics + reachability graph + var dataflow + aspect impact map + diagnostics. Round-trippable via `to_json()` against a published JSON schema. | Drop-in replacement for hand-written model walkers; single source of truth for downstream tooling.             | [inspect_model API](https://pyfcstm.readthedocs.io/en/latest/api_doc/diagnostics/inspect.html)                |
 | **`pyfcstm inspect` CLI**       | Emits the same structured inspect report as stable JSON; verify-backed diagnostics stay disabled unless `--enable-verify` is passed. | Makes diagnostics usable in CI, scripts, and editor tooling without writing Python glue.                       | [CLI Guide](https://pyfcstm.readthedocs.io/en/latest/tutorials/cli/index.html)                                |
-| **Suggested-Fix + VS Code Quick-Fix** | Selected diagnostics carry a `suggested_fix` payload (kind / anchor / text template) that the VS Code extension consumes as auto-apply quick-fixes; each fix is parse-back-verified. | Auto-fix loop for both humans and LLM agents; no regex patching. | [VS Code Extension](https://pyfcstm.readthedocs.io/en/latest/tutorials/editor/index.html) |
-| **Cross-End Parity (py / js)**  | Python `inspect_model().diagnostics` and `@pyfcstm/jsfcstm` `inspectModel().diagnostics` emit byte-equivalent sets (normalized `code + severity + refs`), locked by cross-end parity tests. | Same diagnostics surface in CLI tooling, server-side processors, and browser-based editors / language servers. | [Cross-End Parity](https://pyfcstm.readthedocs.io/en/latest/api_doc/diagnostics/parity.html) |
+| **Suggested-Fix + VS Code Quick-Fix** | Selected diagnostics carry a `suggested_fix` payload (kind / anchor / text template) that the VS Code extension consumes as auto-apply quick-fixes; each fix is parse-back-verified. | Auto-fix loop for both humans and LLM agents; no regex patching. | [VS Code Extension](https://pyfcstm.readthedocs.io/en/latest/tutorials/grammar/index.html) |
+| **Cross-End Parity (py / js)**  | Python `inspect_model().diagnostics` and `@pyfcstm/jsfcstm` `inspectModel().diagnostics` emit byte-equivalent sets (normalized `code + severity + refs`), locked by cross-end parity tests. | Same diagnostics surface in CLI tooling, server-side processors, and browser-based editors / language servers. | [Diagnostics Code List](#static-diagnostics-codes) |
 
 ## Installation
 
@@ -213,13 +214,22 @@ In interactive mode, useful commands include `cycle`, `current`, `events`, `hist
 
 #### Templated Code Generation
 
-Use the `generate` subcommand, along with a template directory, to generate target language code:
+Use the `generate` subcommand with either a packaged built-in template or a custom template directory.
+
+Built-in templates are selected with `--template`:
+
+```shell
+pyfcstm generate -i traffic_light.fcstm --template python -o ./generated/python --clear
+```
+
+Custom templates are still supported with `-t/--template-dir`:
 
 ```shell
 pyfcstm generate -i traffic_light.fcstm -t ./templates/c -o ./generated/c --clear
 ```
 
-**Important**: `generate` expects a template directory that you provide. At minimum, that directory should contain a
+Built-in templates currently include `python`, `c`, and `c_poll`; they are packaged from the repository
+`templates/` tree and exposed through `pyfcstm generate --template ...`. A custom template directory must contain a
 `config.yaml`; any `.j2` files are rendered, and non-template files are copied as-is.
 
 ### 2. Using the Python API
@@ -636,8 +646,19 @@ template_directory/
 └── ...                  # Directory structure is preserved
 ```
 
-pyfcstm does not ship a universal built-in code template set. In practice, you prepare a template directory for your
-own runtime/framework and pass it to `pyfcstm generate`.
+pyfcstm ships packaged built-in templates declared in `pyfcstm/template/index.json`, currently `python`, `c`, and
+`c_poll`. Use them when you want a ready reference runtime:
+
+```shell
+pyfcstm generate -i machine.fcstm --template python -o ./out --clear
+```
+
+For project-specific runtime/framework integration, prepare a custom template directory and pass it to
+`pyfcstm generate -t`:
+
+```shell
+pyfcstm generate -i machine.fcstm -t ./template_directory -o ./out --clear
+```
 
 **More Information**:
 See [Template System Architecture Details](https://pyfcstm.readthedocs.io/en/latest/tutorials/render/index.html) for a

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -1,8 +1,75 @@
 Release Notes
 =============
 
+v0.5.0
+------
+
+This release is a minor release rather than a ``v0.4.2`` patch release. It adds
+new user-facing APIs, CLI surfaces, packaged LLM resources, verification-backed
+diagnostics, DSL condition operators, and simulator semantic fixes. Existing
+models should review the compatibility notes before upgrading.
+
+Verification and Inspect
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Added the :mod:`pyfcstm.verify` package as the public entry point for raw
+  verification algorithms, registry metadata, complexity taxonomy, and inspect
+  gating helpers.
+- Added SMT-local verification algorithms for guards, effects, lifecycle
+  relations, transition shadowing, and composite initialization checks.
+- Integrated inspect-eligible verification algorithms into
+  :func:`pyfcstm.diagnostics.inspect_model` and the ``pyfcstm inspect`` CLI.
+  Verify-backed checks stay opt-in through ``enable_verify=True`` or
+  ``pyfcstm inspect --enable-verify``.
+- Added inspect safety gates for complexity tier, call-count scaling, and SMT
+  timeout forwarding. BMC-style search remains outside the automatic inspect
+  path.
+
+Diagnostics and CLI
+~~~~~~~~~~~~~~~~~~~
+
+- Expanded the structured diagnostics catalog to 59 codes: 20 errors,
+  32 warnings, and 7 infos.
+- Added verify-backed diagnostic coverage while keeping the default inspect path
+  static unless verification is explicitly enabled.
+- Added ``pyfcstm inspect`` for stable JSON output matching
+  ``inspect_model(model).to_json()``.
+- Preserved Python / jsfcstm diagnostic-surface parity for normalized code,
+  severity, and reference payloads used by editor integrations.
+
+LLM Grammar Guide
+~~~~~~~~~~~~~~~~~
+
+- Added :mod:`pyfcstm.llm` with
+  :func:`pyfcstm.llm.get_grammar_guide_prompt_for_llm`,
+  :func:`pyfcstm.llm.get_grammar_guide_prompt_path_for_llm`, and
+  :func:`pyfcstm.llm.get_grammar_guide_prompt_metadata_for_llm`.
+- Packaged the official LLM-facing FCSTM grammar guide as
+  ``pyfcstm/llm/fcstm_grammar_guide.md``.
+- Added a packaged SHA-256 sidecar and runtime integrity verification for the
+  grammar guide prompt. Callers may downgrade integrity failures to warnings
+  when they intentionally need to inspect a damaged or development resource.
+- Added standalone ``llm_eval/`` fixtures and reports for prompt-quality
+  validation. These files are repository evaluation assets and are not packaged
+  into PyPI distributions.
+
+Simulation and Built-In Templates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Hardened simulator semantics around speculative rollback, hot-start
+  initialization, event normalization, lifecycle action references, abstract
+  handler contracts, and cycle boundary behavior.
+- Added a semantic fixture corpus for simulator and generated-runtime alignment.
+- Stabilized generated Python runtime metadata, callback rollback behavior, and
+  expression-error wrapping.
+- The packaged built-in template flow remains available through
+  ``pyfcstm generate --template ...``. Current packaged templates are
+  ``python``, ``c``, and ``c_poll``; the VSCode extension has its own
+  independent version line and is not versioned as ``0.5.0`` by this Python
+  package release.
+
 DSL Expression Operators
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 This release extends ``cond_expression`` with three boolean operators for guard
 conditions and other boolean expression sites:
@@ -17,7 +84,7 @@ conditions and other boolean expression sites:
   precedence layer as ``==`` and ``!=``.
 
 Compatibility Notes
--------------------
+~~~~~~~~~~~~~~~~~~~
 
 ``implies``, ``xor``, and ``iff`` are now reserved DSL keywords. Existing
 machines that used these names for variables, states, or events must rename
@@ -40,3 +107,8 @@ It is not a boolean XOR spelling:
    StateA -> StateB : if [a > 0 xor b > 0];   // valid
    StateA -> StateB : if [(a > 0) ^ (b > 0)]; // invalid
    StateA -> StateB : if [true ^ false];      // invalid
+
+The verification and inspect APIs are new public surfaces in this release. They
+are intended to be stable at the function and JSON-contract level, but callers
+should still treat precise diagnostic wording and solver evidence text as
+diagnostic payloads rather than hard-coded parsing targets.

--- a/docs/source/release_notes_zh.rst
+++ b/docs/source/release_notes_zh.rst
@@ -1,8 +1,67 @@
 版本说明
 ========
 
+v0.5.0
+------
+
+本版本应作为 minor release 发布，而不是 ``v0.4.2`` 这类 patch release。
+它增加了新的用户可见 API、CLI 能力、打包的 LLM 资源、接入验证能力的诊断、
+DSL 条件表达式运算符，以及模拟器语义修复。已有模型升级前应先阅读兼容性说明。
+
+验证与 inspect
+~~~~~~~~~~~~~~
+
+- 新增 :mod:`pyfcstm.verify` 包，作为原始验证算法、注册表元数据、复杂度分类
+  和 inspect 接入门控的公开入口。
+- 新增面向 guard、effect、生命周期关系、transition shadowing 和 composite
+  initialization 的 SMT 局部验证算法。
+- 将 inspect 允许调用的验证算法接入
+  :func:`pyfcstm.diagnostics.inspect_model` 和 ``pyfcstm inspect`` CLI。
+  默认 inspect 路径仍不运行验证；需要通过 ``enable_verify=True`` 或
+  ``pyfcstm inspect --enable-verify`` 显式启用。
+- 增加复杂度层级、调用次数扩展方式和 SMT timeout 转发的安全门控。BMC 风格
+  搜索仍不进入自动 inspect 路径。
+
+诊断与 CLI
+~~~~~~~~~~
+
+- 结构化诊断目录扩展到 59 个代码：20 个 error、32 个 warning、7 个 info。
+- 增加 verify-backed diagnostics，同时保持默认 inspect 路径为静态分析。
+- 新增 ``pyfcstm inspect``，输出与 ``inspect_model(model).to_json()`` 对齐的
+  稳定 JSON 报告。
+- 保持 Python / jsfcstm 在 normalized code、severity 和 refs payload 上的
+  诊断表面一致性，供编辑器集成复用。
+
+LLM 语法指南
+~~~~~~~~~~~~
+
+- 新增 :mod:`pyfcstm.llm`，提供
+  :func:`pyfcstm.llm.get_grammar_guide_prompt_for_llm`、
+  :func:`pyfcstm.llm.get_grammar_guide_prompt_path_for_llm` 和
+  :func:`pyfcstm.llm.get_grammar_guide_prompt_metadata_for_llm`。
+- 将官方 LLM-facing FCSTM grammar guide 打包为
+  ``pyfcstm/llm/fcstm_grammar_guide.md``。
+- 为 grammar guide prompt 增加打包的 SHA-256 sidecar 和运行时完整性校验。
+  调用方如果确实需要检查损坏资源或开发态资源，可以选择将完整性失败降级为
+  warning。
+- 新增独立的 ``llm_eval/`` fixtures 和 reports，用于 prompt 质量验证。这些
+  是仓库评测资料，不会打包进 PyPI 分发物。
+
+模拟器与内置模板
+~~~~~~~~~~~~~~~~
+
+- 强化模拟器在 speculative rollback、hot-start initialization、event
+  normalization、lifecycle action refs、abstract handler contracts 和 cycle
+  boundary 行为上的语义。
+- 增加模拟器与生成运行时对齐的 semantic fixture corpus。
+- 稳定生成的 Python runtime metadata、callback rollback 行为和 expression
+  error wrapping。
+- 打包内置模板仍通过 ``pyfcstm generate --template ...`` 使用。当前打包模板为
+  ``python``、``c`` 和 ``c_poll``；VSCode 扩展有独立版本线，本 Python 包
+  发布不会把 VSCode 扩展版本改为 ``0.5.0``。
+
 DSL 表达式运算符
-----------------
+~~~~~~~~~~~~~~~~
 
 本版本为 ``cond_expression`` 增加三组可用于守卫条件和其他布尔表达式位置的
 布尔运算符：
@@ -15,7 +74,7 @@ DSL 表达式运算符
   ``==``、``!=`` 使用同一相等关系优先级层。
 
 兼容性说明
-----------
+~~~~~~~~~~
 
 ``implies``、``xor`` 和 ``iff`` 现在是 DSL 保留关键字。已有状态机如果把这些
 名字用作变量、状态或事件名，需要在使用本版本前先重命名。
@@ -36,3 +95,7 @@ DSL 表达式运算符
    StateA -> StateB : if [a > 0 xor b > 0];   // 有效
    StateA -> StateB : if [(a > 0) ^ (b > 0)]; // 无效
    StateA -> StateB : if [true ^ false];      // 无效
+
+验证与 inspect API 是本版本新增的公开能力。函数入口和 JSON 契约会作为稳定
+接口维护，但精确诊断文案和 solver evidence 文本应视为诊断 payload，不建议
+下游用字符串解析方式硬编码依赖。

--- a/pyfcstm/config/meta.py
+++ b/pyfcstm/config/meta.py
@@ -19,7 +19,7 @@ Example::
     >>> meta.__TITLE__
     'pyfcstm'
     >>> meta.__VERSION__
-    '0.3.0'
+    '0.5.0'
 
 .. note::
    These values are intended to be constants and should not be modified at
@@ -31,7 +31,7 @@ Example::
 __TITLE__: str = 'pyfcstm'
 
 #: Version of this project.
-__VERSION__: str = '0.4.1'
+__VERSION__: str = '0.5.0'
 
 #: Short description of the project, will be included in ``setup.py``.
 __DESCRIPTION__: str = (

--- a/test/config/test_meta.py
+++ b/test/config/test_meta.py
@@ -1,9 +1,14 @@
 import pytest
 
-from pyfcstm.config.meta import __TITLE__
+import pyfcstm
+from pyfcstm.config.meta import __TITLE__, __VERSION__
 
 
 @pytest.mark.unittest
 class TestConfigMeta:
     def test_title(self):
         assert __TITLE__ == "pyfcstm"
+
+    def test_package_version_export_matches_release_version(self):
+        assert __VERSION__ == "0.5.0"
+        assert pyfcstm.__version__ == __VERSION__


### PR DESCRIPTION
## 背景与目标

关联 issue：Addresses #183。

本 PR 用于完成 `v0.5.0` 发布前的剩余收口工作。当前最新正式版是 `v0.4.1`，但 `main` 已经包含 verify、inspect CLI、diagnostics 扩展、条件表达式新增运算符、LLM grammar guide、simulator 语义修复、jsfcstm / VSCode 同步等多类变化，因此本轮发布应按 minor release 定为 `v0.5.0`，不适合作为 `v0.4.2` patch release。

本 PR 不负责真正发布，不打 tag，不创建 GitHub Release，不上传 PyPI。完成后保持 ready to merge，等待维护者下一步指示。

## 必须完成的工作项

| 状态 | 工作项 | 具体要求 | 验收方式 |
|---|---|---|---|
| ⬜ | 版本号更新 | 将 `pyfcstm.config.meta.__VERSION__` 更新为 `0.5.0`，确认 `setup.py`、源码树入口、安装后 console script、docs 均从同一版本来源读取 | `python -c 'import pyfcstm; print(pyfcstm.__version__)'`、源码树 `python -m pyfcstm --version`、安装后 `pyfcstm --version` 口径一致 |
| ⬜ | Release notes 扩写 | 中英文 release notes 覆盖 verify、inspect CLI、diagnostics 59 codes、LLM grammar guide、simulation semantics、DSL 兼容性变化 | `docs/source/release_notes*.rst` 内容完整，并通过 `make docs_en` / `make docs_zh` 或等价 Sphinx 构建检查 |
| ⬜ | README 模板说明修正 | 移除“pyfcstm 不提供内置模板 / 必须用户提供模板目录”的旧说法，改为同时说明 `--template python` 等 packaged built-in templates 与 `-t/--template-dir` | README 中可看到内置模板和自定义模板两条路径 |
| ⬜ | README 链接修正 | 修正 README 中疑似不存在的 docs 链接，例如 editor tutorial / diagnostics parity 这类路径，避免发布后 404 | 链接指向当前 docs 树存在页面或明确稳定锚点 |
| ⬜ | LLM 路径一致性 | 确认 `CLAUDE.md` / `AGENTS.md` / docs 中不再引用旧目录 `llm_grammar_guide_evals/`，并且需要引用评测材料的位置正向指向 `llm_eval/` | `rg 'llm_grammar_guide_evals'` 无结果，且 `rg 'llm_eval' CLAUDE.md AGENTS.md llm_eval/README.md tools/evaluate_llm_grammar_guide.py` 能看到正确路径 |
| ⬜ | VSCode 版本线说明 | 明确 VSCode extension 版本线独立于 Python package，本 PR 不强行把 VSIX 版本改成 `0.5.0`，除非发现 release workflow 必须同步 | PR / release notes / README 不产生版本线误导 |
| ⬜ | 包资源抽检 | 确认 wheel/sdist 包含 LLM guide、`.sha256`、以及 `pyfcstm/template/index.json` 声明的全部 built-in template zip 资源 | `make package` 后按 `index.json` 全量抽检 `dist/*.whl` / `dist/*.tar.gz` 内容 |
| ⬜ | pydoc / RST 收口 | 每次 commit 前执行 `make rst_auto`；如改 Python public API，pydoc 必须符合 `CLAUDE.md` reST 指引 | `make rst_auto` 后无遗漏生成文件，reviewer 检查 pydoc 清晰度 |
| ⬜ | 测试与 CI | 本地快速测试通过并观察 GitHub CI 全绿；CI 会覆盖全量矩阵，本地迭代使用 skip slow | `SKIP_SLOW_TESTS=1 make unittest`、`make package`、PR CI 全 passed |

## 实施顺序

1. 更新版本号到 `0.5.0`，确认没有其他 Python 包版本来源需要同步。
2. 修正文档一致性问题：README 内置模板描述、README docs 链接，并确认 LLM eval 路径无旧目录残留且新目录引用正确。
3. 扩写中英文 release notes，按功能域写清楚本次发布内容和兼容性影响。verify、inspect CLI、diagnostics、LLM grammar guide、simulation semantics、DSL 兼容性说明均属于发布阻塞项，不能遗漏。
4. 运行 `make rst_auto`，检查生成的 API 文档是否只包含必要变化。
5. 执行本地验证：

```bash
python -c 'import pyfcstm; print(pyfcstm.__version__)'
python -m pyfcstm --version
rg 'llm_grammar_guide_evals'
rg 'llm_eval' CLAUDE.md AGENTS.md llm_eval/README.md tools/evaluate_llm_grammar_guide.py
SKIP_SLOW_TESTS=1 make unittest
make docs_en
make docs_zh
make package
```

安装后 console script 版本口径在 wheel 安装 smoke 中确认：

```bash
python -m venv /tmp/pyfcstm-release-smoke
/tmp/pyfcstm-release-smoke/bin/python -m pip install dist/pyfcstm-0.5.0-py3-none-any.whl
/tmp/pyfcstm-release-smoke/bin/pyfcstm --version
/tmp/pyfcstm-release-smoke/bin/python -c 'import pyfcstm; print(pyfcstm.__version__)'
```

6. 按模板索引全量抽检发布包资源：

```bash
python - <<'PY'
import json
import tarfile
import zipfile
from pathlib import Path

index = json.loads(Path('pyfcstm/template/index.json').read_text(encoding='utf-8'))
required_suffixes = [
    'pyfcstm/llm/fcstm_grammar_guide.md',
    'pyfcstm/llm/fcstm_grammar_guide.md.sha256',
    'pyfcstm/template/index.json',
]
required_suffixes.extend(
    f"pyfcstm/template/{item['archive']}" for item in index['templates']
)

for path in sorted(Path('dist').glob('*')):
    print(path)
    if path.suffix == '.whl':
        with zipfile.ZipFile(path) as zf:
            names = set(zf.namelist())
    elif path.suffixes[-2:] == ['.tar', '.gz']:
        with tarfile.open(path) as tf:
            names = set(tf.getnames())
    else:
        continue

    missing = [suffix for suffix in required_suffixes if not any(name.endswith(suffix) for name in names)]
    if missing:
        raise SystemExit(f'{path} missing required packaged resources: {missing}')
    print('  ok')
PY
```

7. 推送后等待 GitHub CI 全部通过。
8. 发起三路 reviewer 对抗审查，C/I 级问题必须修复，M 级尽量处理但不因 M 级反复卡住。

## Reviewer 必查点

| 级别 | 检查点 |
|---|---|
| C | 版本号不是 `0.5.0`，或源码树入口、安装后 console script、包元数据 / docs 版本不一致 |
| C | wheel/sdist 缺少 LLM guide、checksum、template index，或缺少 `index.json` 声明的任一 built-in template zip |
| C | README 仍明确声称没有 built-in templates 或只能使用用户模板目录 |
| I | release notes 遗漏 verify / inspect CLI / diagnostics / LLM guide / simulation semantics / DSL 兼容性说明中任一核心发布内容 |
| I | README 中新增或保留明显不存在的 docs 链接 |
| I | `llm_grammar_guide_evals/` 旧路径仍残留在维护者文档或用户文档里，或应指向评测材料的位置没有正向指到 `llm_eval/` |
| I | 修改了 public API 但 pydoc / RST 没有同步 |
| M | 文字表述不够清楚、示例还可以更短、更直接 |

## 不做事项

- 不创建 tag。
- 不发布 GitHub Release。
- 不上传 PyPI。
- 不 merge 本 PR，等待维护者指示。
- 不引入新的 DSL assumption / predicate logic 设计。
