### PR TITLE
PR-0：建立 pyfcstm.simulate 语义 fixture 与诊断契约基线

### DIFF
--- a/test/fixtures/simulate_semantics/cases/abstract_handler_context_metadata.fcstm
+++ b/test/fixtures/simulate_semantics/cases/abstract_handler_context_metadata.fcstm
@@ -1,0 +1,9 @@
+def int x = 0;
+
+state Root {
+    state Active {
+        during abstract Touch;
+    }
+
+    [*] -> Active;
+}

--- a/test/fixtures/simulate_semantics/cases/abstract_handler_context_metadata.yaml
+++ b/test/fixtures/simulate_semantics/cases/abstract_handler_context_metadata.yaml
@@ -1,0 +1,55 @@
+schema_version: 1
+id: abstract_handler_context_metadata
+title: Abstract handler context metadata fixture
+source:
+  fcstm: abstract_handler_context_metadata.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  assertion_types:
+  - handler_calls
+  - history
+  - vars
+  notes:
+  - Minimal fixture proving optional context metadata fields are accepted and asserted.
+categories:
+- runtime
+- abstract
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+handlers:
+- action: Root.Active.Touch
+  behavior: record_call
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - Active
+    vars:
+      x: 0
+    ended: false
+    cycle_result:
+      value: null
+    history_length: 1
+    history_tail:
+    - cycle: 1
+      state: Root.Active
+      vars:
+        x: 0
+      events: []
+    handler_calls:
+    - action: Root.Active.Touch
+      state: Root.Active
+      stage: during
+      vars:
+        x: 0
+      active_leaf:
+      - Root
+      - Active
+      call_stage: during
+      abstract_target: Root.Active.Touch
+      named_ref: null

--- a/test/fixtures/simulate_semantics/cases/cycle_result_history_event_transition.fcstm
+++ b/test/fixtures/simulate_semantics/cases/cycle_result_history_event_transition.fcstm
@@ -1,0 +1,15 @@
+def int counter = 0;
+
+state Root {
+    state Idle;
+    state Active {
+        enter {
+            counter = counter + 3;
+        }
+    }
+
+    [*] -> Idle;
+    Idle -> Active :: Start effect {
+        counter = counter + 2;
+    };
+}

--- a/test/fixtures/simulate_semantics/cases/cycle_result_history_event_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/cycle_result_history_event_transition.yaml
@@ -1,0 +1,66 @@
+schema_version: 1
+id: cycle_result_history_event_transition
+title: Cycle result and history assertions for event transition
+source:
+  fcstm: cycle_result_history_event_transition.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  assertion_types:
+  - cycle_result
+  - events
+  - history
+  - stack
+  - state
+  - vars
+  notes:
+  - Minimal fixture proving event input is reflected in history and cycle_result stays compatible.
+categories:
+- runtime
+- event_paths
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - Idle
+    vars:
+      counter: 0
+    ended: false
+    cycle_result:
+      value: null
+    history_length: 1
+- cycle:
+    events:
+    - Root.Idle.Start
+  expect:
+    state:
+    - Root
+    - Active
+    vars:
+      counter: 5
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    - path:
+      - Root
+      - Active
+      mode: active
+    cycle_count: 2
+    cycle_result:
+      value: null
+    history_length: 2
+    history_tail:
+    - cycle: 2
+      state: Root.Active
+      vars:
+        counter: 5
+      events:
+      - Root.Idle.Start

--- a/test/fixtures/simulate_semantics/cases/cycle_result_history_stable_leaf.fcstm
+++ b/test/fixtures/simulate_semantics/cases/cycle_result_history_stable_leaf.fcstm
@@ -1,0 +1,11 @@
+def int counter = 0;
+
+state Root {
+    state Counting {
+        during {
+            counter = counter + 1;
+        }
+    }
+
+    [*] -> Counting;
+}

--- a/test/fixtures/simulate_semantics/cases/cycle_result_history_stable_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/cycle_result_history_stable_leaf.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+id: cycle_result_history_stable_leaf
+title: Cycle result and history assertions for a stable leaf
+source:
+  fcstm: cycle_result_history_stable_leaf.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  assertion_types:
+  - cycle_result
+  - history
+  - stack
+  - state
+  - vars
+  notes:
+  - Minimal fixture proving that cycle_result and history assertions are executable.
+categories:
+- runtime
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - Counting
+    vars:
+      counter: 1
+    ended: false
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    - path:
+      - Root
+      - Counting
+      mode: active
+    cycle_count: 1
+    cycle_result:
+      value: null
+    history_length: 1
+    history_tail:
+    - cycle: 1
+      state: Root.Counting
+      vars:
+        counter: 1
+      events: []

--- a/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.fcstm
+++ b/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.fcstm
@@ -1,0 +1,11 @@
+def int x = 0;
+
+state Root {
+    state Faulty {
+        during {
+            x = 1 / x;
+        }
+    }
+
+    [*] -> Faulty;
+}

--- a/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.yaml
@@ -1,0 +1,38 @@
+schema_version: 1
+id: expression_error_preserves_runtime_snapshot
+title: Expression errors preserve runtime snapshot assertions
+source:
+  fcstm: expression_error_preserves_runtime_snapshot.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  assertion_types:
+  - raises
+  - stack
+  - vars
+  notes:
+  - Minimal fixture proving exception assertions can be combined with rollback snapshot assertions.
+categories:
+- runtime
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    raises:
+      type: SimulationRuntimeExpressionError
+      match: division by zero
+      match_kind: substring
+      cause_type: ZeroDivisionError
+      cause_match: division by zero
+      cause_match_kind: substring
+    vars_exact:
+      x: 0
+    stack:
+    - path:
+      - Root
+      mode: init_wait
+    history_length: 0

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -219,6 +219,12 @@ for richer execution-context checks:
   invoked through a named reference. Current fixtures may use `null`; richer
   named-reference distinctions are reserved for later context-metadata work.
 
+The fixture helper may synthesize these optional metadata fields from the
+original `action`, `state`, and `stage` record when a handler does not provide
+them. That keeps older handler records compatible while reserving stable schema
+slots for later runtime-context work. Once concrete metadata is collected by a
+handler, the helper preserves the provided values instead of overwriting them.
+
 ## Runtime steps
 
 A runtime step is either an initial assertion or a cycle call:

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -9,8 +9,9 @@ built-in Python runtime alignment tests.  A fixture is a pair of files under
 
 The schema is intentionally strict. Unknown top-level fields, unknown runner
 names, unknown categories, unknown expectation fields, and unknown nested fields
-inside `cycle`, `raises`, `logs`, `stack`, and CLI expectations must fail fast
-with a diagnostic containing the case id and YAML path.
+inside `cycle`, `cycle_result`, `history`, `raises`, `logs`, `stack`, handler
+calls, and CLI expectations must fail fast with a diagnostic containing the case
+id and YAML path.
 
 ## Top-level fields
 
@@ -186,6 +187,10 @@ state: Root
 stage: enter
 vars:
   x: 0
+active_leaf: [Root]
+call_stage: enter
+abstract_target: Root.RootInit
+named_ref: null
 write_attempt:
   name: x
   value: 999
@@ -199,6 +204,20 @@ Only `ValueError` is currently supported for `raise_error`, because the fixture
 corpus only needs a deterministic user-handler exception class for simulator
 rollback semantics. If another exception family is needed, extend the allowed
 set together with schema-negative tests.
+
+Optional handler-call metadata fields are assertion-only compatibility slots
+for richer execution-context checks:
+
+- `active_leaf`: Active leaf path segments observed by the handler. The current
+  fixture helper derives this from `state`; later runtime context work can make
+  it more precise for reference callsites.
+- `call_stage`: Lifecycle stage observed at the callsite. When both `stage` and
+  `call_stage` are present they should match unless a later schema extension
+  documents a more precise distinction.
+- `abstract_target`: Abstract action path observed by the handler.
+- `named_ref`: Named reference callsite path, or `null` when the action is not
+  invoked through a named reference. Current fixtures may use `null`; richer
+  named-reference distinctions are reserved for later context-metadata work.
 
 ## Runtime steps
 
@@ -223,7 +242,14 @@ steps:
       vars:
         counter: 10
       ended: false
-      return: null
+      cycle_result:
+        value: null
+      history_tail:
+        - cycle: 1
+          state: Root.B
+          vars:
+            counter: 10
+          events: [Root.A.Go]
 ```
 
 `cycle` may be `{}`, `null`, a bare event-path string, or a mapping with
@@ -253,7 +279,11 @@ parent-relative paths (`.go`), and root-relative paths (`/go`).
 | `ended` | Expected `runtime.is_ended`. |
 | `stack` | Expected `brief_stack`, with `path` list and `mode`. |
 | `cycle_count` | Runtime cycle count assertion. For generated alignment cases the generated runtime must expose the same count. |
-| `return` | Expected `cycle()` return value. |
+| `return` | Legacy expected `cycle()` return value. Existing fixtures may keep it; new fixtures should prefer `cycle_result`. |
+| `cycle_result` | Standardized `cycle()` result object. Current minimum shape is `value`; later event-consumption metadata can extend the same object. |
+| `history_length` | Expected length of `runtime.history`. |
+| `history` | Expected full `runtime.history` sequence after the step. |
+| `history_tail` | Expected non-empty suffix of `runtime.history` after the step. Use `history_length: 0` or `history: []` to assert no history entries. |
 | `raises` | Expected exception class name and optional message match. |
 | `logs` | Step-local `caplog` assertions. |
 | `warnings` | Step-local Python warning assertions. Simulation-only. |
@@ -266,7 +296,37 @@ Allowed stack modes are `active` and `init_wait`.
 
 `vars` and `vars_exact` may both be present only when the partial `vars` mapping
 is consistent with `vars_exact`. `vars_keys` and `vars_absent` must not overlap.
-`raises` and `return` are mutually exclusive.
+`raises`, `return`, and `cycle_result` are mutually exclusive where their
+meanings overlap: `raises` cannot be combined with either return assertion, and
+`return` cannot be combined with `cycle_result`. `cycle_result` must be a
+mapping with a `value` field; use `cycle_result: {value: null}` for the current
+`SimulationRuntime.cycle()` return value rather than a top-level
+`cycle_result: null`.
+
+`cycle_result` allows these fields:
+
+| Field | Required | Description |
+|---|---:|---|
+| `value` | yes | Standardized `cycle()` return value. |
+| `input_events` | no | Reserved list of normalized input event names. |
+| `consumed_events` | no | Reserved list of consumed event names. |
+| `unconsumed_events` | no | Reserved list of unconsumed event names. |
+
+The current simulator returns `None`, so representative fixtures use only
+`cycle_result.value`. Event-consumption fields are reserved for later
+cycle-result work and remain strict lists of strings.
+
+`history`, `history_tail`, and history entries use the current
+`SimulationRuntime.history` shape:
+
+| Field | Description |
+|---|---|
+| `cycle` | Successful runtime cycle index. |
+| `state` | Dot-separated current state path, or `(terminated)`. |
+| `vars` | Deep-copied variable snapshot. |
+| `events` | List of normalized input event path names. |
+
+`history_tail` must be non-empty and compares the same number of entries from the end of `runtime.history`.
 
 ## Exceptions
 

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -464,6 +464,18 @@ def _set_model_build_expectation(data, raises):
         (
             lambda data: (
                 data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update(
+                    {
+                        "raises": {"type": "ValueError"},
+                        "cycle_result": {"value": None},
+                    }
+                )
+            ),
+            "cannot combine raises and cycle_result",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
                 or data["steps"][0]["expect"].update({"cycle_result": None})
             ),
             "cycle_result must be a mapping",

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -21,6 +21,91 @@ def test_all_semantic_fixtures_load():
 
 
 @pytest.mark.unittest
+def test_semantic_fixture_assertion_families_are_executable():
+    cases = iter_semantic_cases(runners=["simulation"])
+    covered = set()
+    for case in cases:
+        if case.data.get("model_build"):
+            continue
+        for step in case.data.get("steps") or []:
+            expect = step.get("expect_initial") or step.get("expect") or {}
+            if "stack" in expect:
+                covered.add("stack")
+            if "state" in expect:
+                covered.add("current_state")
+            if any(
+                field in expect
+                for field in ("vars", "vars_exact", "vars_keys", "vars_absent")
+            ):
+                covered.add("vars")
+            if any(
+                field in expect
+                for field in ("history", "history_length", "history_tail")
+            ):
+                covered.add("history")
+            if step.get("cycle") not in (None, {}) and "events" in step.get(
+                "cycle", {}
+            ):
+                covered.add("events")
+            if "cycle_result" in expect:
+                covered.add("cycle_result")
+            if "raises" in expect:
+                covered.add("exception")
+            if "handler_calls" in expect:
+                covered.add("context")
+
+    assert {
+        "stack",
+        "current_state",
+        "vars",
+        "history",
+        "events",
+        "cycle_result",
+        "exception",
+        "context",
+    }.issubset(covered)
+
+
+@pytest.mark.unittest
+def test_semantic_fixture_origin_files_cover_existing_simulate_tests():
+    expected_files = {
+        "test_abstract_handlers.py",
+        "test_cli_init.py",
+        "test_completer_init.py",
+        "test_decorators.py",
+        "test_event_inputs.py",
+        "test_handler_decorator.py",
+        "test_hot_start.py",
+        "test_hot_start_edge_cases.py",
+        "test_semantic_fixtures.py",
+        "test_utils.py",
+    }
+    actual_files = {
+        name
+        for name in os.listdir(os.path.dirname(__file__))
+        if name.startswith("test_") and name.endswith(".py")
+    }
+    assert expected_files.issubset(actual_files)
+
+    representative_cases = {
+        "cycle_result_history_stable_leaf",
+        "cycle_result_history_event_transition",
+        "expression_error_preserves_runtime_snapshot",
+        "abstract_handler_context_metadata",
+    }
+    cases = [case for case in iter_semantic_cases() if case.id in representative_cases]
+    assert {case.id for case in cases} == representative_cases
+    origin_files = {
+        origin
+        for case in cases
+        for origin in case.data.get("origin", {}).get("files", [])
+    }
+    assert origin_files == {
+        "test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture"
+    }
+
+
+@pytest.mark.unittest
 @pytest.mark.parametrize(
     "case",
     [case for case in iter_semantic_cases(runners=["simulation"])],
@@ -371,6 +456,49 @@ def _set_model_build_expectation(data, raises):
             "cannot combine raises and return",
         ),
         (
+            lambda data: data["steps"][0]["expect"].update(
+                {"cycle_result": {"value": None}}
+            ),
+            "cannot combine return and cycle_result",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update({"cycle_result": None})
+            ),
+            "cycle_result must be a mapping",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update({"cycle_result": {}})
+            ),
+            "cycle_result.value is required",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update(
+                    {"cycle_result": {"value": None, "extra": []}}
+                )
+            ),
+            "cycle_result has unknown fields",
+        ),
+        (
+            lambda data: (
+                data["steps"][0]["expect"].pop("return")
+                or data["steps"][0]["expect"].update(
+                    {
+                        "cycle_result": {
+                            "value": None,
+                            "input_events": "Root.A.Go",
+                        }
+                    }
+                )
+            ),
+            "cycle_result.input_events must be a list of strings",
+        ),
+        (
             lambda data: (
                 data["steps"][0]["expect"].pop("return")
                 or data["steps"][0]["expect"].update(
@@ -416,6 +544,51 @@ def _set_model_build_expectation(data, raises):
         (
             lambda data: data["steps"][0]["expect"].update({"warnings": {"count": -1}}),
             "warnings.count must be a non-negative integer",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"history_length": -1}),
+            "history_length must be a non-negative integer",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"history": {}}),
+            "history must be a list",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {
+                    "history_tail": [
+                        {"cycle": "1", "state": "Root.A", "vars": {}, "events": []}
+                    ]
+                }
+            ),
+            "history_tail\\[0\\].cycle must be an integer",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {
+                    "history_tail": [
+                        {
+                            "cycle": 1,
+                            "state": "Root.A",
+                            "vars": {},
+                            "events": "Root.A.Go",
+                        }
+                    ]
+                }
+            ),
+            "history_tail\\[0\\].events must be a list of strings",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"history_tail": [{"unknown": True}]}
+            ),
+            "history_tail\\[0\\] has unknown fields",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"history_tail": [{"cycle": 1, "state": "Root.A", "events": []}]}
+            ),
+            "history_tail\\[0\\] missing fields",
         ),
         (
             lambda data: data["steps"][0]["expect"].update(
@@ -466,6 +639,38 @@ def _set_model_build_expectation(data, raises):
                 }
             ),
             "write_attempt.succeeded must be a boolean",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {
+                    "handler_calls": [
+                        {
+                            "action": "Root.Init",
+                            "state": "Root",
+                            "stage": "enter",
+                            "vars": {},
+                            "active_leaf": "Root",
+                        }
+                    ]
+                }
+            ),
+            "handler_calls\\[0\\].active_leaf must be a list",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {
+                    "handler_calls": [
+                        {
+                            "action": "Root.Init",
+                            "state": "Root",
+                            "stage": "enter",
+                            "vars": {},
+                            "abstract_target": 7,
+                        }
+                    ]
+                }
+            ),
+            "handler_calls\\[0\\].abstract_target must be a string or null",
         ),
         (
             lambda data: data["steps"][0]["expect"].update({"error_state": "true"}),

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -403,6 +403,10 @@ def _assert_cycle_result(
 def _handler_call_comparable_record(actual: Mapping[str, Any]) -> Dict[str, Any]:
     result = dict(actual)
     state = actual.get("state")
+    # Handler records originally carried only action/state/stage/vars. These
+    # compatibility defaults reserve optional metadata slots for richer fixture
+    # assertions while preserving old records; handlers that collect concrete
+    # metadata can provide these keys directly and they will not be overwritten.
     result.setdefault(
         "active_leaf", state.split(".") if isinstance(state, str) else None
     )

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -1,4 +1,29 @@
-"""Shared helpers for simulate semantic fixture tests."""
+"""
+Shared helpers for simulate semantic fixture tests.
+
+This module loads YAML/FCSTM semantic fixtures from
+``test/fixtures/simulate_semantics`` and runs them against
+:class:`pyfcstm.simulate.SimulationRuntime`, the generated Python alignment
+runtime, or the simulate command processor. It owns the strict fixture schema,
+runtime assertion helpers, and callback fixtures used by Python-side simulation
+tests.
+
+The module contains:
+
+* :class:`SemanticCase` - Loaded fixture data and source paths.
+* :class:`SemanticCaseError` - Schema and fixture-shape diagnostics.
+* :func:`load_semantic_case` - Load one fixture by id or YAML path.
+* :func:`iter_semantic_cases` - Enumerate fixture cases with optional filters.
+* :func:`run_simulation_case` - Execute one case against
+  :class:`pyfcstm.simulate.SimulationRuntime`.
+* :func:`run_cli_command_case` - Execute one CLI-command fixture.
+
+Example::
+
+    >>> case = load_semantic_case("design_basic_simple_transition")
+    >>> case.id
+    'design_basic_simple_transition'
+"""
 
 import importlib.util
 import logging
@@ -75,6 +100,10 @@ _ALLOWED_EXPECT_FIELDS = {
     "stack",
     "cycle_count",
     "return",
+    "cycle_result",
+    "history",
+    "history_length",
+    "history_tail",
     "raises",
     "logs",
     "warnings",
@@ -136,10 +165,24 @@ _ALLOWED_WARNING_FIELDS = {"contains", "not_contains", "count"}
 _ALLOWED_WARNING_ITEM_FIELDS = {"category", "message", "match_kind"}
 _ALLOWED_WARNING_CATEGORIES = {"UserWarning"}
 _REQUIRED_HANDLER_CALL_FIELDS = {"action", "state", "stage", "vars"}
-_ALLOWED_HANDLER_CALL_FIELDS = _REQUIRED_HANDLER_CALL_FIELDS | {"write_attempt"}
+_ALLOWED_HANDLER_CALL_FIELDS = _REQUIRED_HANDLER_CALL_FIELDS | {
+    "active_leaf",
+    "call_stage",
+    "abstract_target",
+    "named_ref",
+    "write_attempt",
+}
 _ALLOWED_WRITE_ATTEMPT_FIELDS = {"name", "value", "succeeded", "error_type", "vars"}
 _ALLOWED_ABSTRACT_HANDLER_ERROR_FIELDS = {"action", "type", "message", "match_kind"}
 _ALLOWED_ERROR_INFO_FIELDS = {"action", "type", "message", "match_kind"}
+_ALLOWED_CYCLE_RESULT_FIELDS = {
+    "value",
+    "input_events",
+    "consumed_events",
+    "unconsumed_events",
+}
+_ALLOWED_HISTORY_FIELDS = {"cycle", "state", "vars", "events"}
+_REQUIRED_HISTORY_FIELDS = _ALLOWED_HISTORY_FIELDS
 _CLI_OUTPUT_FIELDS = ("output_contains", "output_not_contains", "error_contains")
 _EXCEPTION_TYPES = {
     "ModelValidationError": ModelValidationError,
@@ -153,12 +196,50 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class SemanticCaseError(ValueError):
-    """Raised when a semantic fixture is malformed."""
+    """
+    Raised when a semantic fixture is malformed.
+
+    The exception message includes the fixture case id and YAML path whenever
+    that information is available, so loader failures can be traced back to the
+    source fixture without inspecting the pytest parameter id.
+
+    :param args: Positional message arguments accepted by
+        :class:`ValueError`.
+    :type args: object
+
+    Example::
+
+        >>> err = SemanticCaseError("sample (/tmp/sample.yaml): bad field")
+        >>> "sample" in str(err)
+        True
+    """
 
 
 @dataclass(frozen=True)
 class SemanticCase:
-    """Loaded simulate semantic fixture."""
+    """
+    Loaded simulate semantic fixture.
+
+    A semantic case bundles the parsed YAML metadata, source file locations, and
+    FCSTM DSL text needed by fixture runners. The object is immutable so tests
+    can safely reuse it across parametrized simulation, generated-runtime
+    alignment, and CLI-command runners.
+
+    :param data: Parsed fixture YAML mapping.
+    :type data: typing.Mapping[str, typing.Any]
+    :param yaml_path: Absolute path to the fixture YAML file.
+    :type yaml_path: str
+    :param fcstm_path: Absolute path to the paired FCSTM source file.
+    :type fcstm_path: str
+    :param dsl_code: FCSTM DSL source text.
+    :type dsl_code: str
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
 
     data: Mapping[str, Any]
     yaml_path: str
@@ -247,6 +328,90 @@ def _runtime_stack(runtime: Any) -> List[Tuple[Tuple[str, ...], str]]:
     return [(tuple(path), mode) for path, mode in runtime.brief_stack]
 
 
+def _standardize_cycle_result(value: Any) -> Dict[str, Any]:
+    return {"value": value}
+
+
+def _normalize_history_entries(
+    value: Any, case: SemanticCase, field_path: str
+) -> List[Dict[str, Any]]:
+    if not isinstance(value, list):
+        raise _case_error(case.id, case.yaml_path, "%s must be a list" % field_path)
+    result = []
+    for index, item in enumerate(value):
+        item_path = "%s[%d]" % (field_path, index)
+        if not isinstance(item, dict):
+            raise _case_error(
+                case.id, case.yaml_path, "%s must be a mapping" % item_path
+            )
+        result.append(dict(item))
+    return result
+
+
+def _runtime_history(runtime: Any) -> List[Dict[str, Any]]:
+    return [dict(item) for item in getattr(runtime, "history")]
+
+
+def _assert_history(
+    runtime: Any, expect: Mapping[str, Any], case: SemanticCase, field_path: str
+) -> None:
+    actual_history = None
+    if "history_length" in expect:
+        actual_history = _runtime_history(runtime)
+        assert len(actual_history) == expect["history_length"], (
+            "%s %s history_length mismatch: %r != %r"
+            % (case.id, field_path, len(actual_history), expect["history_length"])
+        )
+    if "history" in expect:
+        actual_history = _runtime_history(runtime)
+        expected_history = _normalize_history_entries(
+            expect["history"], case, field_path + ".history"
+        )
+        assert actual_history == expected_history, (
+            "%s %s history mismatch: %r != %r"
+            % (case.id, field_path, actual_history, expected_history)
+        )
+    if "history_tail" in expect:
+        actual_history = _runtime_history(runtime)
+        expected_tail = _normalize_history_entries(
+            expect["history_tail"], case, field_path + ".history_tail"
+        )
+        actual_tail = actual_history[-len(expected_tail) :] if expected_tail else []
+        assert actual_tail == expected_tail, "%s %s history_tail mismatch: %r != %r" % (
+            case.id,
+            field_path,
+            actual_tail,
+            expected_tail,
+        )
+
+
+def _assert_cycle_result(
+    result: Any, expect: Mapping[str, Any], case: SemanticCase, field_path: str
+) -> None:
+    if "cycle_result" not in expect:
+        return
+    actual_result = _standardize_cycle_result(result)
+    expected_result = dict(expect["cycle_result"])
+    assert actual_result == expected_result, "%s %s cycle_result mismatch: %r != %r" % (
+        case.id,
+        field_path,
+        actual_result,
+        expected_result,
+    )
+
+
+def _handler_call_comparable_record(actual: Mapping[str, Any]) -> Dict[str, Any]:
+    result = dict(actual)
+    state = actual.get("state")
+    result.setdefault(
+        "active_leaf", state.split(".") if isinstance(state, str) else None
+    )
+    result.setdefault("call_stage", actual.get("stage"))
+    result.setdefault("abstract_target", actual.get("action"))
+    result.setdefault("named_ref", None)
+    return result
+
+
 def _assert_handler_calls(
     expect: Mapping[str, Any],
     handler_calls: Optional[Sequence[Mapping[str, Any]]],
@@ -262,13 +427,26 @@ def _assert_handler_calls(
             "%s.handler_calls requires registered fixture handlers" % field_path,
         )
     expected_calls = [dict(item) for item in expect["handler_calls"]]
-    actual_calls = [dict(item) for item in handler_calls]
-    assert actual_calls == expected_calls, "%s %s handler_calls mismatch: %r != %r" % (
-        case.id,
-        field_path,
-        actual_calls,
-        expected_calls,
+    actual_calls = [_handler_call_comparable_record(item) for item in handler_calls]
+    assert len(actual_calls) == len(expected_calls), (
+        "%s %s handler_calls length mismatch: %r != %r"
+        % (case.id, field_path, actual_calls, expected_calls)
     )
+    for index, expected in enumerate(expected_calls):
+        actual = actual_calls[index]
+        for key, expected_value in expected.items():
+            actual_value = actual.get(key)
+            assert actual_value == expected_value, (
+                "%s %s handler_calls[%d].%s mismatch: %r != %r"
+                % (
+                    case.id,
+                    field_path,
+                    index,
+                    key,
+                    actual_value,
+                    expected_value,
+                )
+            )
 
 
 def _assert_abstract_handler_errors(
@@ -490,6 +668,7 @@ def _assert_runtime_expectation(
             )
         )
 
+    _assert_history(runtime, expect, case, field_path)
     _assert_handler_calls(expect, handler_calls, case, field_path)
     _assert_abstract_handler_errors(runtime, expect, case, field_path)
     _assert_error_info(runtime, expect, case, field_path)
@@ -811,6 +990,12 @@ def _run_step(
                             expect["return"],
                         )
                     )
+                _assert_cycle_result(
+                    result,
+                    expect,
+                    case,
+                    field_path + ".expect.cycle_result",
+                )
     _assert_runtime_expectation(
         runtime,
         expect,
@@ -832,12 +1017,54 @@ def _parse_dsl(dsl_code: str):
 
 
 def build_state_machine_from_case(case: SemanticCase):
-    """Build a state machine model for a semantic fixture."""
+    """
+    Build a state machine model for a semantic fixture.
+
+    The helper parses the case DSL with the normal FCSTM grammar entry and then
+    converts the AST into the production model object used by the simulator and
+    generated-runtime alignment runner.
+
+    :param case: Semantic fixture to parse.
+    :type case: SemanticCase
+    :return: Parsed state machine model for the case DSL.
+    :rtype: pyfcstm.model.StateMachine
+    :raises pyfcstm.dsl.error.GrammarParseError: If the fixture DSL is invalid.
+    :raises pyfcstm.utils.validate.ModelValidationError: If model validation
+        rejects the parsed DSL.
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> model = build_state_machine_from_case(case)
+        >>> model.root_state.name
+        'Root'
+    """
     return _parse_dsl(case.dsl_code)
 
 
 def run_model_build_case(case: SemanticCase) -> None:
-    """Run a semantic fixture that expects model construction diagnostics."""
+    """
+    Run a semantic fixture that expects model construction diagnostics.
+
+    Model-build cases assert failures that happen before a
+    :class:`pyfcstm.simulate.SimulationRuntime` can be constructed. The expected
+    exception is matched through the same ``raises`` schema used by executable
+    runtime steps.
+
+    :param case: Semantic fixture with a ``model_build`` expectation.
+    :type case: SemanticCase
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If model construction succeeds unexpectedly or the
+        diagnostic does not match the fixture expectation.
+    :raises SemanticCaseError: If the fixture expectation is malformed at
+        assertion time.
+
+    Example::
+
+        >>> case = load_semantic_case("validation_action_reference_cycle")
+        >>> run_model_build_case(case)
+    """
     model_build = case.data["model_build"]
     expect = model_build["expect"]
     try:
@@ -1235,7 +1462,31 @@ def _build_simulation_runtime(case: SemanticCase) -> SimulationRuntime:
 
 
 def run_simulation_case(case: SemanticCase, caplog: Any = None) -> None:
-    """Run a semantic fixture against :class:`SimulationRuntime`."""
+    """
+    Run a semantic fixture against :class:`SimulationRuntime`.
+
+    The runner builds the production simulator, installs any fixture-defined
+    abstract handlers, executes each step, and applies the strict YAML
+    expectations for state, variables, stack, history, cycle result, logs,
+    warnings, and handler calls.
+
+    :param case: Semantic fixture to execute with the simulation runner.
+    :type case: SemanticCase
+    :param caplog: Optional pytest log-capture fixture used when a step asserts
+        log output, defaults to ``None``.
+    :type caplog: typing.Any, optional
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If runtime behavior differs from the fixture
+        expectation.
+    :raises SemanticCaseError: If a runtime-only assertion is requested without
+        the supporting fixture setup.
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> run_simulation_case(case)
+    """
     if "model_build" in case.data:
         run_model_build_case(case)
         return
@@ -1261,7 +1512,29 @@ def run_simulation_case(case: SemanticCase, caplog: Any = None) -> None:
 
 
 def run_generated_python_alignment_case(case: SemanticCase, caplog: Any = None) -> None:
-    """Run a semantic fixture against simulation and generated Python runtimes."""
+    """
+    Run a semantic fixture against simulation and generated Python runtimes.
+
+    The alignment runner generates the built-in Python runtime for the case DSL,
+    executes it beside :class:`SimulationRuntime`, and asserts that state,
+    variables, stack, cycle counts, returns, exceptions, and handler calls remain
+    aligned after every fixture step.
+
+    :param case: Semantic fixture that includes the
+        ``generated_python_alignment`` runner.
+    :type case: SemanticCase
+    :param caplog: Optional pytest log-capture fixture, defaults to ``None``.
+    :type caplog: typing.Any, optional
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If generated runtime behavior diverges from the
+        simulator or the fixture expectation.
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> run_generated_python_alignment_case(case)
+    """
     if _initial_constructor_expect(case) is not None:
         _assert_aligned_constructor_failure(case)
         return
@@ -1291,7 +1564,25 @@ def run_generated_python_alignment_case(case: SemanticCase, caplog: Any = None) 
 
 
 def run_cli_command_case(case: SemanticCase) -> None:
-    """Run a semantic fixture against the simulate CLI command processor."""
+    """
+    Run a semantic fixture against the simulate CLI command processor.
+
+    CLI-command cases exercise :class:`pyfcstm.entry.simulate.commands.CommandProcessor`
+    directly. Each command expectation may assert output text, exit behavior,
+    and the backing runtime state after the command has executed.
+
+    :param case: Semantic fixture that uses the ``cli_command`` runner.
+    :type case: SemanticCase
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If command output, exit flags, or runtime state do
+        not match the fixture expectation.
+
+    Example::
+
+        >>> case = load_semantic_case("cli_init_full_state")
+        >>> run_cli_command_case(case)
+    """
     state_machine = build_state_machine_from_case(case)
     runtime = SimulationRuntime(state_machine)
     processor = CommandProcessor(runtime, state_machine=state_machine, use_color=False)
@@ -1428,6 +1719,12 @@ def _validate_raises(
         raise _case_error(
             case_id, yaml_path, "%s cannot combine raises and return" % field_path
         )
+    if "cycle_result" in expect:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s cannot combine raises and cycle_result" % field_path,
+        )
     raises = expect["raises"]
     if not isinstance(raises, dict):
         raise _case_error(
@@ -1470,6 +1767,105 @@ def _validate_raises(
             case_id,
             yaml_path,
             "%s.raises.cause_match_kind requires cause_match" % field_path,
+        )
+
+
+def _validate_cycle_result(
+    expect: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if "cycle_result" not in expect:
+        return
+    if "return" in expect:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s cannot combine return and cycle_result" % field_path,
+        )
+    cycle_result = expect["cycle_result"]
+    if not isinstance(cycle_result, dict):
+        raise _case_error(
+            case_id, yaml_path, "%s.cycle_result must be a mapping" % field_path
+        )
+    unknown = set(cycle_result.keys()) - _ALLOWED_CYCLE_RESULT_FIELDS
+    if unknown:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.cycle_result has unknown fields: %r" % (field_path, sorted(unknown)),
+        )
+    if "value" not in cycle_result:
+        raise _case_error(
+            case_id, yaml_path, "%s.cycle_result.value is required" % field_path
+        )
+    for event_field in ("input_events", "consumed_events", "unconsumed_events"):
+        if event_field in cycle_result:
+            _validate_string_list(
+                cycle_result[event_field],
+                case_id,
+                yaml_path,
+                "%s.cycle_result.%s" % (field_path, event_field),
+            )
+
+
+def _validate_history_entries(
+    value: Any, case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if not isinstance(value, list):
+        raise _case_error(case_id, yaml_path, "%s must be a list" % field_path)
+    for index, item in enumerate(value):
+        item_path = "%s[%d]" % (field_path, index)
+        if not isinstance(item, dict):
+            raise _case_error(case_id, yaml_path, "%s must be a mapping" % item_path)
+        unknown = set(item.keys()) - _ALLOWED_HISTORY_FIELDS
+        if unknown:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s has unknown fields: %r" % (item_path, sorted(unknown)),
+            )
+        missing = _REQUIRED_HISTORY_FIELDS - set(item.keys())
+        if missing:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s missing fields: %r" % (item_path, sorted(missing)),
+            )
+        if not isinstance(item["cycle"], int):
+            raise _case_error(
+                case_id, yaml_path, "%s.cycle must be an integer" % item_path
+            )
+        if not isinstance(item["state"], str):
+            raise _case_error(
+                case_id, yaml_path, "%s.state must be a string" % item_path
+            )
+        _validate_vars_mapping(item["vars"], case_id, yaml_path, item_path + ".vars")
+        _validate_string_list(item["events"], case_id, yaml_path, item_path + ".events")
+
+
+def _validate_history(
+    expect: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if "history_length" in expect and (
+        not isinstance(expect["history_length"], int) or expect["history_length"] < 0
+    ):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.history_length must be a non-negative integer" % field_path,
+        )
+    if "history" in expect:
+        _validate_history_entries(
+            expect["history"], case_id, yaml_path, field_path + ".history"
+        )
+    if "history_tail" in expect:
+        if not expect["history_tail"]:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.history_tail must be a non-empty list" % field_path,
+            )
+        _validate_history_entries(
+            expect["history_tail"], case_id, yaml_path, field_path + ".history_tail"
         )
 
 
@@ -1712,6 +2108,25 @@ def _validate_handler_calls(
                 yaml_path,
                 "%s.handler_calls[%d].write_attempt" % (field_path, index),
             )
+        if "active_leaf" in item:
+            _validate_path_segments(
+                item["active_leaf"],
+                case_id,
+                yaml_path,
+                "%s.handler_calls[%d].active_leaf" % (field_path, index),
+            )
+        for field_name in ("call_stage", "abstract_target", "named_ref"):
+            if (
+                field_name in item
+                and item[field_name] is not None
+                and not isinstance(item[field_name], str)
+            ):
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s.handler_calls[%d].%s must be a string or null"
+                    % (field_path, index, field_name),
+                )
 
 
 def _validate_write_attempt(
@@ -1914,6 +2329,8 @@ def _validate_expect(
     _validate_vars_contract(expect, case_id, yaml_path, field_path)
     _validate_stack(expect, case_id, yaml_path, field_path)
     _validate_raises(expect, case_id, yaml_path, field_path)
+    _validate_cycle_result(expect, case_id, yaml_path, field_path)
+    _validate_history(expect, case_id, yaml_path, field_path)
     _validate_logs(expect, case_id, yaml_path, field_path)
     _validate_warnings(expect, case_id, yaml_path, field_path)
     _validate_handler_calls(expect, case_id, yaml_path, field_path)
@@ -2476,7 +2893,26 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
 
 
 def load_semantic_case(path_or_id: str) -> SemanticCase:
-    """Load a semantic fixture by case id or YAML path."""
+    """
+    Load a semantic fixture by case id or YAML path.
+
+    A bare case id is resolved under ``test/fixtures/simulate_semantics/cases``.
+    A path ending in ``.yaml`` is loaded directly. The loader validates the
+    strict schema before reading the paired FCSTM source file.
+
+    :param path_or_id: Fixture id or path to a YAML fixture file.
+    :type path_or_id: str
+    :return: Loaded semantic fixture.
+    :rtype: SemanticCase
+    :raises SemanticCaseError: If the YAML shape, schema fields, or paired FCSTM
+        path are invalid.
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.yaml_path.endswith("design_basic_simple_transition.yaml")
+        True
+    """
     yaml_path = path_or_id
     if (
         not yaml_path.endswith(".yaml")
@@ -2505,7 +2941,29 @@ def load_semantic_case(path_or_id: str) -> SemanticCase:
 def iter_semantic_cases(
     categories: Optional[Iterable[str]] = None, runners: Optional[Iterable[str]] = None
 ) -> List[SemanticCase]:
-    """Iterate semantic fixtures, optionally filtered by categories or runners."""
+    """
+    Iterate semantic fixtures, optionally filtered by categories or runners.
+
+    Filters are subset matches: a case is returned only when it contains every
+    requested category and every requested runner. Cases are loaded in sorted
+    YAML filename order to keep pytest parametrization stable.
+
+    :param categories: Optional category names that each returned case must
+        contain, defaults to ``None``.
+    :type categories: typing.Optional[typing.Iterable[str]], optional
+    :param runners: Optional runner names that each returned case must contain,
+        defaults to ``None``.
+    :type runners: typing.Optional[typing.Iterable[str]], optional
+    :return: Loaded semantic fixtures matching the filters.
+    :rtype: typing.List[SemanticCase]
+    :raises SemanticCaseError: If any loaded fixture is malformed.
+
+    Example::
+
+        >>> cases = iter_semantic_cases(runners=["simulation"])
+        >>> all("simulation" in case.runners for case in cases)
+        True
+    """
     category_set = set(categories or [])
     runner_set = set(runners or [])
     result = []


### PR DESCRIPTION
# PR-0：建立 `pyfcstm.simulate` 语义 fixture 与诊断契约基线

上游伞 PR：[PR #186](https://github.com/HansBug/pyfcstm/pull/186)  
上游问题集合：[issue #156](https://github.com/HansBug/pyfcstm/issues/156)

本 PR 是 [PR #186](https://github.com/HansBug/pyfcstm/pull/186) 的 PR-0。目标不是修复 [issue #156](https://github.com/HansBug/pyfcstm/issues/156) 中的具体 runtime bug，而是先把后续 sub PR 复用的 `pyfcstm.simulate` 语义 fixture、断言 schema、迁移清单和最小样例打牢，避免后续修复 PR 各自发明测试结构、导致测试语义漂移或覆盖线丢失。

## 当前 fixture 体系事实

PR-0 必须扩展现有 semantic fixture 体系，不新建并行体系：

| 角色 | 现有 canonical 路径 | PR-0 要求 |
|---|---|---|
| fixture 根目录 | `test/fixtures/simulate_semantics/` | 继续使用这个根目录。 |
| schema 文档 | `test/fixtures/simulate_semantics/schema.md` | 在这里补齐 schema、字段语义和样例。 |
| YAML / FCSTM case | `test/fixtures/simulate_semantics/cases/<id>.yaml` 与 `<id>.fcstm` | 新增最小样例必须放这里。 |
| pytest 入口 | `test/simulate/test_semantic_fixtures.py` | 保持为语义 fixture 主入口。 |
| loader / runner helper | `test/testings/simulate_semantics.py` | 扩展字段校验与执行断言。 |

不得创建与 `test/fixtures/simulate_semantics/` 并行的 fixture 根目录。若未来确需迁移目录，必须在同一 PR 中更新 loader、schema 文档、所有引用，并证明现有 corpus 覆盖线没有丢失；本 PR 不做目录迁移。

## 范围

### 纳入范围

- 仅新增/调整 Python 测试侧 fixture、runner、helper 和相关测试：
  - `test/fixtures/simulate_semantics/schema.md`
  - `test/fixtures/simulate_semantics/cases/*.yaml`
  - `test/fixtures/simulate_semantics/cases/*.fcstm`
  - `test/simulate/test_semantic_fixtures.py`
  - `test/testings/simulate_semantics.py`
- 可增加 fixture schema 的负例/正例单测，确保未知字段、错误类型、断言类型不合法时给出可读错误。
- 可运行 `make rst_auto`，但本 PR 不应为了文档生成而修改生产语义。

### 排除范围

- 不修改 `pyfcstm/simulate/` 生产代码以修复具体 bug。
- 不修改 template / generated runtime / CLI / entry / editor / jsfcstm / solver / render。
- 不修改 `Makefile`。
- 不把 PR 编号、issue 编号、排查轮次等工作流元数据写进代码标识符、fixture id、runtime message、docstring 或 pydoc。Markdown 中引用具体工作项时必须使用超链接，例如 `[PR #186](https://github.com/HansBug/pyfcstm/pull/186)`。

## 与上游 PR 的一致性

| 上游 PR-0 要求 | 本 PR 落地计划 | 验收方式 | 状态 |
|---|---|---|---|
| 扩展现有 semantic fixture schema 文档/示例 | 更新 `test/fixtures/simulate_semantics/schema.md` 和 `cases/`，字段可表达 DSL、初始状态、`initial_vars`、事件序列、期望 stack/state、vars、history/events、异常类型、context metadata。 | 文档/示例被测试读取或与 runner 字段一致；review 检查不依赖外部目录。 | 🟦 已明确 |
| fixture runner 可机械解析 | 扩展 `test/testings/simulate_semantics.py` 与 `test/simulate/test_semantic_fixtures.py`，保持 strict schema。 | `pytest test/simulate/test_semantic_fixtures.py -v`。 | 🟦 已明确 |
| 七类断言：`stack/current_state/vars/history/events/exception/context` | 保持既有字段兼容；新增缺失字段；各类至少一条最小 fixture。 | 新增 schema tests 与 fixture corpus 覆盖每类断言。 | 🟦 已明确 |
| 迁移后的现有 simulate 语义测试清单 | 本 PR body 先列出现有文件清单，代码实现时补充 case `origin.files` 和测试侧覆盖检查。 | PR review 可逐项确认覆盖没有缩水；未迁移测试不得删除。 | 🟦 已明确 |
| 最小样例 | 新增四个独立 fixture：成功 cycle、transition、异常断言、context metadata。 | fixture runner 参数化测试通过。 | 🟦 已明确 |
| 本地命令 | `pytest test/simulate/test_semantic_fixtures.py -v`、`SKIP_SLOW_TESTS=1 make unittest`、`make rst_auto`。 | 本地执行并在 PR comment 汇报；CI 通过。 | 🟦 已明确 |

## 现状 schema 与目标 schema delta

PR-0 只扩展测试契约，不破坏现有 case。现有 `schema_version: 1` 继续有效；新增字段是 version 1 的向后兼容扩展。旧 fixture 不需要批量 bump。新增字段仍遵守 strict schema：未列入白名单的字段必须报错。

| Assertion family | YAML 字段 | 现状 | PR-0 目标 | Runtime source | 最小验收 |
|---|---|---|---|---|---|
| `stack` | `expect.stack` | ✅ 已有 | 保持兼容，不改字段形态。 | `runtime.brief_stack` | 精确断言每帧 `path` 与 `mode`。 |
| `current_state` | `expect.state` | ✅ 已有，schema 名为 `state` | 保持兼容；PR body 中的 `current_state` 仅是语义族名。 | `runtime.current_state.path`，ended 时为 `null` | 支持路径 list 与 `null`。 |
| `vars` | `expect.vars`、`expect.vars_exact`、`expect.vars_keys`、`expect.vars_absent` | ✅ 已有 | 保持兼容。 | `dict(runtime.vars)` | 支持部分、精确、key-set、缺席断言。 |
| `history` | `expect.history`、`expect.history_length`、`expect.history_tail` | ❌ 新增 | 新增机器可解析断言。 | `runtime.history` | 至少可断言总长度、完整列表或尾部事件，条目字段按现有 runtime history 序列化。 |
| `events` | `cycle.events` 输入；`expect.return` 保持旧返回值断言；`expect.cycle_result` 作为新结果断言超集 | ⚠️ 仅有输入端和 `return` | PR-0 保持 `cycle.events` 输入校验；新增 `cycle_result` 字段契约。`cycle_result` 是 `return` 的超集：旧 fixture 继续允许 `return`，新 fixture 优先使用 `cycle_result`。同一个 `expect` 中 `return` 与 `cycle_result` 互斥，避免双轨断言漂移。PR-3 在 `cycle_result` 内填充实际 `input_events` / `consumed_events` / `unconsumed_events`。 | `runtime.cycle(...)` 返回值与 history 记录 | PR-0 至少断言当前返回值和 history 中事件记录；PR-3 在同字段内扩展事件消费结果。 |
| `exception` | `expect.raises` | ✅ 已有 | 保持兼容；PR body 中的 `exception` 仅是语义族名。 | constructor / cycle / model-build exception | 断言类型、message、cause 类型/message。 |
| `context` | `handlers` + `expect.handler_calls` 扩展字段 | ⚠️ 已有 `action/state/stage/vars`，缺少更明确 metadata | 扩展 handler call schema，允许断言 `active_leaf`、`call_stage`、`abstract_target`、`named_ref` 等字段；已有 case 不必提供这些字段。 | `ReadOnlyExecutionContext` 与 fixture handler 记录 | 至少覆盖 action、active state、stage、vars；为 named ref / target action 字段提供稳定名称。 |

### 新增字段草案

字段名称必须是领域语义，不使用 PR 阶段或 issue 编号命名。

| 字段 | 类型 | 语义 | 下游依赖 |
|---|---|---|---|
| `expect.history_length` | integer | 断言 `len(runtime.history)`。 | PR-4 `HIST-3`。 |
| `expect.history` | list | 断言完整 history 序列的标准化表示。 | PR-4 与全集回归。 |
| `expect.history_tail` | list | 断言尾部若干条 history，避免测试过度绑定无关前缀。 | PR-1/PR-3/PR-4。 |
| `expect.cycle_result` | mapping/null | 断言 `cycle()` 返回值的标准化表示；作为既有 `expect.return` 的超集。旧 fixture 可继续使用 `return`；新 fixture 应优先使用 `cycle_result`；同一 step 不允许同时写 `return` 和 `cycle_result`。当前可断言 `value: null`，未来可包含 `input_events`、`consumed_events`、`unconsumed_events`。 | PR-3。 |
| `expect.handler_calls[].active_leaf` | list/null | handler 调用时 active leaf 路径。 | PR-5。 |
| `expect.handler_calls[].call_stage` | string | handler 调用阶段；与既有 `stage` 兼容时二者应一致。 | PR-5/PR-6。 |
| `expect.handler_calls[].abstract_target` | string/null | 当前 abstract action 的声明目标。 | PR-5。 |
| `expect.handler_calls[].named_ref` | string/null | 通过 named ref 触发时的 ref callsite；非 ref 调用为 `null`。 | PR-5。 |

### 最小样例与七类断言映射

四个最小 fixture 必须是独立 case，fixture id 使用领域行为名，不使用 PR / issue / 阶段名。每个 case 的 `origin.files` 指向被覆盖的既有测试文件或 schema 测试入口。

| 最小样例 | 主要目标 | 必须覆盖的断言族 | 建议 fixture 形态 |
|---|---|---|---|
| 成功 cycle 样例 | 证明无事件 cycle 后状态保持、变量更新和 history 记录稳定 | `current_state`、`vars`、`stack`、`history`、`events`、`cycle_result` | leaf state `during` 修改变量；`expect.cycle_result.value: null`；`history_length` / `history_tail` 断言本轮记录。 |
| transition 样例 | 证明事件驱动 transition、effect、enter/exit 后 stack 与变量一致 | `current_state`、`vars`、`stack`、`history`、`events`、`cycle_result` | `A -> B :: Go`；`cycle.events: [Root.A.Go]`；`history_tail` 断言事件输入；`cycle_result.value: null`。 |
| 异常断言样例 | 证明 fixture 可表达 runtime / expression / event 诊断 | `exception`、`vars`、`stack` | 使用现有 simulate exception 类型；`expect.raises` 断言 type/message/cause；同时断言失败后 vars/stack 不漂移。 |
| context metadata 样例 | 证明 fixture 可表达 handler context 与后续 ref callsite 扩展字段 | `context`、`vars`、`history` | abstract handler `record_call`；`expect.handler_calls` 断言既有 `action/state/stage/vars` 和新增可用 metadata 字段；PR-5 再补 `abstract_target` / `named_ref` 具体差异。 |

验收时需要机械检查：七类断言族至少各由一个新增或既有 fixture 真实触发；不能只在 schema 文档中声明字段而没有 fixture 断言。

## 现存 simulate 测试覆盖清单与迁移策略

本 PR 不为了“迁移”而删除旧测试。迁移完成的判断标准是：同一语义可以由 `test/fixtures/simulate_semantics/cases/` 中自包含 fixture 表达，且原测试覆盖的断言线没有丢失。未迁移项必须保留原测试。

| 文件 | 当前覆盖主题 | PR-0 策略 | 验收目标 |
|---|---|---|---|
| `test/simulate/test_semantic_fixtures.py` | semantic fixture loader/runner/schema 正负例 | 直接扩展 | 新字段和四个最小样例由此入口覆盖。 |
| `test/simulate/test_hot_start.py` | hot start 语义、栈、初始化、pseudo 相关行为 | 不删除旧测试；为 PR-1 提供 fixture 表达能力 | PR-1 可逐步补 fixture；PR-0 只保证 schema 能表达。 |
| `test/simulate/test_hot_start_edge_cases.py` | hot start 边界和失败诊断 | 不删除旧测试；为 PR-1 提供 fixture 表达能力 | 旧覆盖继续存在；新增 schema 可表达异常和 stack。 |
| `test/simulate/test_event_inputs.py` | event 输入解析与非法输入 | 不删除旧测试；为 PR-3 提供 event/cycle_result 字段 | PR-0 增强输入/返回断言能力。 |
| `test/simulate/test_abstract_handlers.py` | handler 调用、错误模式、rollback、warning/error metadata | 不删除旧测试；扩展 `handler_calls` metadata | PR-5/PR-6 可用 fixture 表达 context metadata。 |
| `test/simulate/test_handler_decorator.py` | decorator 注册与多路径行为 | 不删除旧测试；PR-7 再考虑 fixture 化 | PR-0 不引入 scanner/decorator 生产行为修改。 |
| `test/simulate/test_decorators.py` | decorator helper 单元行为 | 不迁移 | 保持单元测试形态。 |
| `test/simulate/test_cli_init.py` | simulate CLI init 命令行为 | 不迁移到本轮 runtime-only 修复；保留旧测试 | 本轮不新增 CLI 依赖。 |
| `test/simulate/test_completer_init.py` | REPL completer 行为 | 不迁移 | 非 `pyfcstm.simulate` runtime 语义，保留单元测试。 |
| `test/simulate/test_utils.py` | simulate 相关工具函数 | 不迁移 | 保留单元测试。 |

## PR-0 内部执行计划

| 步骤 | 工作内容 | 验收目标 | 状态 |
|---|---|---|---|
| TDD-1 | 先写 schema / runner 失败测试：新增字段未知时失败、字段类型错误失败、history/context/cycle_result 断言不合法失败。 | 失败测试已覆盖新增字段互斥、未知字段、类型错误、history 完整条目、context metadata 类型错误。 | ✅ 已完成 |
| TDD-2 | 扩展 schema 文档、loader validation 和标准化 helper。 | `schema.md`、loader validation、history/cycle_result/helper 标准化已完成；旧 `schema_version: 1` fixture 保持兼容。 | ✅ 已完成 |
| TDD-3 | 扩展 simulation fixture runner 七类断言。 | `stack/current_state/vars/history/events/exception/context` 均可通过 YAML 表达并由 corpus 覆盖检查确认。 | ✅ 已完成 |
| TDD-4 | 增加四个独立最小样例：成功 cycle、transition、异常、context metadata。 | 已新增四组自包含 YAML/FCSTM fixture，全部位于 `test/fixtures/simulate_semantics/cases/`。 | ✅ 已完成 |
| TDD-5 | 补齐迁移/覆盖清单检查，不删除未迁移旧测试。 | 已新增 test 文件清单 smoke check 与代表 fixture `origin.files` 检查；未删除旧测试。 | ✅ 已完成 |
| 验证 | 运行 `make rst_auto`、精准 pytest、slow-skip unittest。 | 本地命令已通过；CI 正在等待/轮询。 | 🟦 本地通过 |


## 实现摘要

本 PR 当前实现 commit：[86250abf](https://github.com/HansBug/pyfcstm/pull/187/commits/86250abf)。

已落地内容：

- 扩展 `test/testings/simulate_semantics.py`：新增 `cycle_result`、`history` / `history_length` / `history_tail`、handler call metadata 的 strict schema 校验与运行时断言。
- 扩展 `test/simulate/test_semantic_fixtures.py`：新增断言族覆盖检查、既有 simulate 测试文件清单 smoke check、schema 负例测试。
- 扩展 `test/fixtures/simulate_semantics/schema.md`：补齐新增字段、history entry、cycle result、handler metadata 的契约说明。
- 新增四组自包含 fixture：
  - `cycle_result_history_stable_leaf`
  - `cycle_result_history_event_transition`
  - `expression_error_preserves_runtime_snapshot`
  - `abstract_handler_context_metadata`

本 PR 没有修改 `pyfcstm/simulate/` 生产行为，没有修改 `Makefile`，没有新增与 `test/fixtures/simulate_semantics/` 并行的 fixture 根目录。

## 本地验证记录

```bash
ruff check test/testings/simulate_semantics.py test/simulate/test_semantic_fixtures.py
pytest test/simulate/test_semantic_fixtures.py -q
pytest test/simulate/ -q --ignore=test/simulate/test_semantic_fixtures.py
SKIP_SLOW_TESTS=1 make unittest
make rst_auto
```

结果：

- `ruff check ...`：通过。
- `pytest test/simulate/test_semantic_fixtures.py -q`：`198 passed`。
- `pytest test/simulate/ -q --ignore=test/simulate/test_semantic_fixtures.py`：`126 passed`。
- `SKIP_SLOW_TESTS=1 make unittest`：`40898 passed, 164 skipped, 63 deselected`。
- `make rst_auto`：通过，未产生需要提交的 API doc diff。

## Mermaid 依赖图

```mermaid
flowchart TD
    U["PR #186<br/>simulate 修复拆分伞 PR<br/>🟦 已开启"]:::active
    P0["PR-0<br/>语义 fixture 与诊断契约基线<br/>🟦 本 PR"]:::active
    P1["PR-1..PR-7<br/>后续具体 runtime bug 修复<br/>⏳ 等待 PR-0"]:::planned
    P8["PR-8<br/>全集回归与 issue 收口<br/>⏳ 等待前序"]:::planned

    U --> P0
    P0 --> P1
    P1 --> P8

    classDef active fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef planned fill:#f3f4f6,stroke:#6b7280,color:#111827;
    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
    classDef blocked fill:#fee2e2,stroke:#dc2626,color:#111827;
```

## 下游 sub PR 自包含要求

PR-0 完成后，PR-1 到 PR-7 的 PR body 必须能复制本 PR 提供的 fixture/schema 能力，并在各自 body 内自包含：

1. 问题 ID 与上游 comment URL。
2. 最小 DSL / Python 复现代码。
3. 复现命令。
4. 期望结果与实际结果。
5. 白盒原因解释。
6. 修复设计与兼容性说明。
7. 验收目标、测试路径、覆盖不丢线说明。
8. 自己的 Mermaid 依赖图和状态表。

## Docstring / 文档要求

- 新增 Python module / class / public function 必须使用 reST docstring。
- 新增 helper 模块不得引入跨 test tree 引用：不 import jsfcstm，不依赖 `editors/`、Node.js 或 JavaScript 测试资源。
- public function / class docstring 必须包含 `:param:`、`:type:`、`:return:`、`:rtype:`、必要的 `:raises:`，并提供 `Example::`。
- module docstring 需要说明模块职责、主要入口和与 fixture runner 的关系。
- 如果新增 `__init__.py` 导出内容，应保持表格/roadmap 形态，能说明本测试 helper module 的入口和职责。
- 提交前运行 `make rst_auto`，review 时检查 pydoc 是否符合 `CLAUDE.md`。

## 本地验收命令

```bash
pytest test/simulate/test_semantic_fixtures.py -v
pytest test/simulate/ -q --ignore=test/simulate/test_semantic_fixtures.py
SKIP_SLOW_TESTS=1 make unittest
make rst_auto
```

## 当前状态

- [x] PR body 初审问题已吸收进 v2/v3 body。
- [x] PR body 复审 C/I=0。
- [ ] 本 PR merge 后再按上游 PR 开启实现型 sub PR。
- [x] TDD 失败测试已提交。
- [x] fixture/schema/runner 实现完成。
- [x] 本地验收命令通过。
- [ ] CI 通过。
- [ ] 多 agent 强对抗 review C/I=0。


