### PR TITLE
PR-1：修复 hot start、pseudo 候选、DFS safety 与 stack 稳定化

### DIFF
--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -773,6 +773,7 @@ class SimulationRuntime:
 
         validation_stack = self._clone_stack(self.stack)
         validation_vars = copy.deepcopy(self.vars)
+        dfs_error = None
         try:
             success, _ = self._run_cycle_on_context(
                 validation_stack,
@@ -780,10 +781,15 @@ class SimulationRuntime:
                 {},
                 is_validation_mode=True,
             )
-        except SimulationRuntimeDfsError:
+        except SimulationRuntimeDfsError as e:
+            # _run_cycle_on_context preflight can hit DFS limits while proving
+            # that a hot-start target has no empty-event stable path.
+            dfs_error = e
             success = False
         if not success:
             if self._can_hot_start_wait_for_evented_initial(target_state):
+                if dfs_error is not None:
+                    raise dfs_error
                 return
             target_path = ".".join(target_state.path)
             raise ValueError(
@@ -796,22 +802,83 @@ class SimulationRuntime:
 
         Constructor preflight runs without user events, so an initial transition
         guarded by an event may be legitimately disabled until the first
-        :meth:`cycle` call. Such targets should remain in ``init_wait`` instead
-        of being rejected during construction.
+        :meth:`cycle` call. The event gate can appear directly on the target
+        composite or after an eventless initial-transition chain. Such targets
+        should remain in ``init_wait`` instead of being rejected during
+        construction.
 
         :param target_state: Hot-start target state to inspect.
         :type target_state: State
         :return: ``True`` when the target has an event-gated initial transition
-            whose non-event guard is currently satisfiable.
+            boundary whose non-event guard is currently satisfiable.
         :rtype: bool
+        :raises SimulationRuntimeDfsError: If the eventless initial-chain search
+            exceeds the runtime safety limits.
         """
         if target_state.is_leaf_state:
             return False
-        for transition in target_state.init_transitions:
-            if transition.event is None:
+
+        worklist = [(self._clone_stack(self.stack), copy.deepcopy(self.vars))]
+        seen_signatures = set()
+        steps_taken = 0
+
+        while worklist:
+            current_stack, current_vars = worklist.pop()
+            if not current_stack:
                 continue
-            if self._transition_matches_guard(transition, self.vars):
-                return True
+
+            structural_signature = self._create_structural_signature(current_stack)
+            if len(structural_signature) > self._DFS_STRUCTURAL_DEPTH_LIMIT:
+                raise SimulationRuntimeDfsError(
+                    "Hot start event-gated initial-chain search exceeded the "
+                    "structural stack-depth safety limit "
+                    f"({self._DFS_STRUCTURAL_DEPTH_LIMIT}); "
+                    "choose a shallower target state or simplify the state hierarchy."
+                )
+
+            signature = self._create_execution_signature(current_stack, current_vars)
+            if signature in seen_signatures:
+                continue
+            seen_signatures.add(signature)
+
+            if steps_taken >= self._DFS_STEP_LIMIT:
+                raise SimulationRuntimeDfsError(
+                    "Hot start event-gated initial-chain search exceeded the "
+                    f"step safety limit ({self._DFS_STEP_LIMIT}); "
+                    "the state machine likely contains an invalid unbounded "
+                    "initial-transition chain."
+                )
+            steps_taken += 1
+
+            frame = current_stack[-1]
+            state = frame.state
+            if state.is_leaf_state or frame.mode != "init_wait":
+                continue
+
+            for transition in state.init_transitions:
+                if transition.event is None:
+                    continue
+                if self._transition_matches_guard(transition, current_vars):
+                    return True
+
+            for transition in reversed(state.init_transitions):
+                if transition.event is not None:
+                    continue
+                if not self._transition_matches_guard(transition, current_vars):
+                    continue
+
+                next_stack = self._clone_stack(current_stack)
+                next_vars = copy.deepcopy(current_vars)
+                self._execute_initial_transition_on_context(
+                    next_stack,
+                    next_vars,
+                    transition,
+                    {},
+                    is_validation_mode=True,
+                    attempt_initial_transition=False,
+                )
+                worklist.append((next_stack, next_vars))
+
         return False
 
     def _parse_event(self, event: Any) -> Event:
@@ -1546,6 +1613,8 @@ class SimulationRuntime:
         :type attempt_initial_transition: bool, optional
         :return: ``None``.
         :rtype: None
+        :raises SimulationRuntimeDfsError: If initial-transition validation
+            exceeds runtime safety limits.
         """
         stack.append(_Frame(state, "active"))
         for on_enter in state.on_enters:

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -366,6 +366,9 @@ class SimulationRuntime:
         11
     """
 
+    _DFS_STEP_LIMIT = 1000
+    _DFS_STRUCTURAL_DEPTH_LIMIT = 64
+
     def __init__(
         self,
         state_machine: StateMachine,
@@ -755,23 +758,61 @@ class SimulationRuntime:
         :return: ``None``.
         :rtype: None
         :raises ValueError: If the target cannot reach a stoppable state or end.
+        :raises SimulationRuntimeDfsError: If the constructed hot-start stack
+            already exceeds the structural depth safety limit.
         """
+        if len(self.stack) > self._DFS_STRUCTURAL_DEPTH_LIMIT:
+            raise SimulationRuntimeDfsError(
+                "Hot start target exceeds the structural stack-depth safety limit "
+                f"({self._DFS_STRUCTURAL_DEPTH_LIMIT}) before execution; "
+                "choose a shallower target state or simplify the state hierarchy."
+            )
+
         if target_state.is_stoppable:
             return
 
         validation_stack = self._clone_stack(self.stack)
         validation_vars = copy.deepcopy(self.vars)
-        success, _ = self._run_cycle_on_context(
-            validation_stack,
-            validation_vars,
-            {},
-            is_validation_mode=True,
-        )
+        try:
+            success, _ = self._run_cycle_on_context(
+                validation_stack,
+                validation_vars,
+                {},
+                is_validation_mode=True,
+            )
+        except SimulationRuntimeDfsError:
+            success = False
         if not success:
+            if self._can_hot_start_wait_for_evented_initial(target_state):
+                return
             target_path = ".".join(target_state.path)
             raise ValueError(
                 f"Hot start target '{target_path}' cannot reach a stoppable state"
             )
+
+    def _can_hot_start_wait_for_evented_initial(self, target_state: State) -> bool:
+        """
+        Return whether a composite hot-start target can wait for an evented init.
+
+        Constructor preflight runs without user events, so an initial transition
+        guarded by an event may be legitimately disabled until the first
+        :meth:`cycle` call. Such targets should remain in ``init_wait`` instead
+        of being rejected during construction.
+
+        :param target_state: Hot-start target state to inspect.
+        :type target_state: State
+        :return: ``True`` when the target has an event-gated initial transition
+            whose non-event guard is currently satisfiable.
+        :rtype: bool
+        """
+        if target_state.is_leaf_state:
+            return False
+        for transition in target_state.init_transitions:
+            if transition.event is None:
+                continue
+            if self._transition_matches_guard(transition, self.vars):
+                return True
+        return False
 
     def _parse_event(self, event: Any) -> Event:
         """
@@ -1478,6 +1519,7 @@ class SimulationRuntime:
         vars_: Dict[str, Union[int, float]],
         d_events: Dict[str, Event],
         is_validation_mode: bool = False,
+        attempt_initial_transition: bool = True,
     ) -> None:
         """
         Enter a state and perform its immediate entry-time semantics.
@@ -1499,6 +1541,9 @@ class SimulationRuntime:
         :type d_events: Dict[str, Event]
         :param is_validation_mode: Whether this is validation mode (handlers not executed).
         :type is_validation_mode: bool
+        :param attempt_initial_transition: Whether composite entry should
+            immediately try its initial transition chain, defaults to ``True``.
+        :type attempt_initial_transition: bool, optional
         :return: ``None``.
         :rtype: None
         """
@@ -1515,9 +1560,10 @@ class SimulationRuntime:
                     on_during_before, vars_, is_validation_mode=is_validation_mode
                 )
             stack[-1].mode = "init_wait"
-            self._attempt_init_transition(
-                stack, vars_, d_events, is_validation_mode=is_validation_mode
-            )
+            if attempt_initial_transition:
+                self._attempt_init_transition(
+                    stack, vars_, d_events, is_validation_mode=is_validation_mode
+                )
 
     def _attempt_init_transition(
         self,
@@ -1572,6 +1618,7 @@ class SimulationRuntime:
                     transition,
                     d_events,
                     is_validation_mode=is_validation_mode,
+                    attempt_initial_transition=not is_validation_mode,
                 )
                 return True
         return False
@@ -1583,6 +1630,7 @@ class SimulationRuntime:
         transition: Transition,
         d_events: Dict[str, Event],
         is_validation_mode: bool = False,
+        attempt_initial_transition: bool = True,
     ) -> None:
         """
         Execute one enabled initial transition on the supplied context.
@@ -1601,10 +1649,15 @@ class SimulationRuntime:
         :type d_events: Dict[str, Event]
         :param is_validation_mode: Whether this is validation mode.
         :type is_validation_mode: bool
+        :param attempt_initial_transition: Whether entering a composite target
+            should immediately try its own initial transition, defaults to
+            ``True``.
+        :type attempt_initial_transition: bool, optional
         :return: ``None``.
         :rtype: None
         """
-        state = stack[-1].state
+        composite_frame = stack[-1]
+        state = composite_frame.state
         self._execute_transition_effect(
             transition,
             vars_,
@@ -1617,7 +1670,10 @@ class SimulationRuntime:
             vars_,
             d_events,
             is_validation_mode=is_validation_mode,
+            attempt_initial_transition=attempt_initial_transition,
         )
+        if composite_frame in stack:
+            composite_frame.mode = "active"
 
     def _validate_initial_transition(
         self,
@@ -1654,14 +1710,9 @@ class SimulationRuntime:
             transition,
             d_events,
             is_validation_mode=True,
+            attempt_initial_transition=False,
         )
-        success, _ = self._run_cycle_on_context(
-            sim_stack,
-            sim_vars,
-            d_events,
-            is_validation_mode=True,
-        )
-        return success
+        return self._validation_search_reaches_stable(sim_stack, sim_vars, d_events)
 
     def _finalize_exit_to_parent(
         self,
@@ -1906,13 +1957,12 @@ class SimulationRuntime:
             )
             return True
 
-        success, _ = self._run_cycle_on_context(
+        success = self._validation_search_reaches_stable(
             sim_stack,
             sim_vars,
             d_events,
             ended=ended,
             validate_post_child_exit=True,
-            is_validation_mode=True,
         )
         sim_stack_repr = [
             (".".join(frame.state.path), frame.mode) for frame in sim_stack
@@ -1922,6 +1972,174 @@ class SimulationRuntime:
             f"success={success}, stack={sim_stack_repr}, vars={sim_vars}"
         )
         return success
+
+    def _validation_search_reaches_stable(
+        self,
+        stack: List[_Frame],
+        vars_: Dict[str, Union[int, float]],
+        d_events: Dict[str, Event],
+        *,
+        ended: bool = False,
+        validate_post_child_exit: bool = True,
+    ) -> bool:
+        """
+        Search for a stable continuation without recursive Python calls.
+
+        Speculative transition and initial-transition checks need to decide
+        whether at least one enabled continuation reaches a stoppable state or
+        termination. This helper performs that search with an explicit worklist
+        so unbounded pseudo chains hit the runtime's own DFS safety limits
+        instead of Python's call-stack limit.
+
+        :param stack: Starting validation stack. Mutated to the stable path on
+            success.
+        :type stack: List[_Frame]
+        :param vars_: Starting variable mapping. Mutated to the stable path on
+            success.
+        :type vars_: Dict[str, Union[int, float]]
+        :param d_events: Active events for this validation attempt.
+        :type d_events: Dict[str, Event]
+        :param ended: Whether the starting context has already ended, defaults
+            to ``False``.
+        :type ended: bool, optional
+        :param validate_post_child_exit: Whether post-child-exit transitions
+            should be considered during search, defaults to ``True``.
+        :type validate_post_child_exit: bool, optional
+        :return: ``True`` if a stable continuation is reachable.
+        :rtype: bool
+        :raises SimulationRuntimeDfsError: If the worklist exceeds safety
+            limits before reaching a stable continuation.
+        """
+        if ended:
+            stack.clear()
+            vars_.clear()
+            return True
+
+        worklist = [(self._clone_stack(stack), copy.deepcopy(vars_), False)]
+        seen_signatures = set()
+        steps_taken = 0
+
+        while worklist:
+            current_stack, current_vars, current_ended = worklist.pop()
+            if current_ended:
+                stack.clear()
+                vars_.clear()
+                vars_.update(current_vars)
+                return True
+            if not current_stack:
+                stack.clear()
+                vars_.clear()
+                vars_.update(current_vars)
+                return True
+
+            structural_signature = self._create_structural_signature(current_stack)
+            if len(structural_signature) > self._DFS_STRUCTURAL_DEPTH_LIMIT:
+                raise SimulationRuntimeDfsError(
+                    "Speculative DFS exceeded the structural stack-depth safety limit "
+                    f"({self._DFS_STRUCTURAL_DEPTH_LIMIT}) without reaching a stoppable state or pruning; "
+                    "the state machine likely contains an invalid unbounded nesting chain."
+                )
+
+            signature = self._create_execution_signature(current_stack, current_vars)
+            if signature in seen_signatures:
+                continue
+            seen_signatures.add(signature)
+
+            if steps_taken >= self._DFS_STEP_LIMIT:
+                raise SimulationRuntimeDfsError(
+                    "Speculative DFS exceeded the step safety limit "
+                    f"({self._DFS_STEP_LIMIT}) without reaching a stoppable state or pruning; "
+                    "the state machine likely contains an invalid unbounded pseudo-state "
+                    "or transition chain."
+                )
+            steps_taken += 1
+
+            frame = current_stack[-1]
+            state = frame.state
+
+            if state.is_leaf_state and frame.mode == "after_entry":
+                next_stack = self._clone_stack(current_stack)
+                next_vars = copy.deepcopy(current_vars)
+                next_stack[-1].mode = "active"
+                if state.is_stoppable:
+                    stack[:] = next_stack
+                    vars_.clear()
+                    vars_.update(next_vars)
+                    return True
+                worklist.append((next_stack, next_vars, False))
+                continue
+
+            if state.is_leaf_state:
+                progressed = False
+                for transition in reversed(state.transitions_from):
+                    if not self._transition_is_enabled(transition, d_events, current_vars):
+                        continue
+                    next_stack = self._clone_stack(current_stack)
+                    next_vars = copy.deepcopy(current_vars)
+                    next_ended = self._execute_transition_on_context(
+                        next_stack,
+                        next_vars,
+                        transition,
+                        d_events,
+                        is_validation_mode=True,
+                    )
+                    worklist.append((next_stack, next_vars, next_ended))
+                    progressed = True
+                if progressed:
+                    continue
+
+                if not state.is_stoppable:
+                    continue
+
+                next_stack = self._clone_stack(current_stack)
+                next_vars = copy.deepcopy(current_vars)
+                self._run_leaf_during(
+                    state, next_vars, is_validation_mode=True
+                )
+                next_stack[-1].mode = "after_entry"
+                worklist.append((next_stack, next_vars, False))
+                continue
+
+            if frame.mode == "init_wait":
+                progressed = False
+                for transition in reversed(state.init_transitions):
+                    if not self._transition_is_enabled(transition, d_events, current_vars):
+                        continue
+                    next_stack = self._clone_stack(current_stack)
+                    next_vars = copy.deepcopy(current_vars)
+                    self._execute_initial_transition_on_context(
+                        next_stack,
+                        next_vars,
+                        transition,
+                        d_events,
+                        is_validation_mode=True,
+                        attempt_initial_transition=False,
+                    )
+                    worklist.append((next_stack, next_vars, False))
+                    progressed = True
+                if not progressed:
+                    continue
+                continue
+
+            if frame.mode == "post_child_exit":
+                if not validate_post_child_exit:
+                    continue
+                for transition in reversed(state.transitions_from):
+                    if not self._transition_is_enabled(transition, d_events, current_vars):
+                        continue
+                    next_stack = self._clone_stack(current_stack)
+                    next_vars = copy.deepcopy(current_vars)
+                    next_ended = self._execute_transition_on_context(
+                        next_stack,
+                        next_vars,
+                        transition,
+                        d_events,
+                        is_validation_mode=True,
+                    )
+                    worklist.append((next_stack, next_vars, next_ended))
+                continue
+
+        return False
 
     def _initialize_context(
         self,
@@ -2057,9 +2275,9 @@ class SimulationRuntime:
             return True, True
 
         steps_taken = 0
-        max_steps = 1000
+        max_steps = self._DFS_STEP_LIMIT
         seen_signatures = set()
-        max_structural_depth = 64
+        max_structural_depth = self._DFS_STRUCTURAL_DEPTH_LIMIT
 
         while not ended:
             if is_validation_mode:
@@ -2091,12 +2309,12 @@ class SimulationRuntime:
                 )
 
             if steps_taken >= max_steps:
-                self.logger.debug(
-                    "[VALIDATION] Speculative DFS reached the step safety limit (%s) without convergence; "
-                    "treating the path as invalid continuation.",
-                    max_steps,
+                raise SimulationRuntimeDfsError(
+                    "Speculative DFS exceeded the step safety limit "
+                    f"({max_steps}) without reaching a stoppable state or pruning; "
+                    "the state machine likely contains an invalid unbounded pseudo-state "
+                    "or transition chain."
                 )
-                return False, False
 
             frame = stack[-1]
             state = frame.state
@@ -2109,7 +2327,12 @@ class SimulationRuntime:
                     steps_taken += 1
                     continue
 
-                transition = self._select_transition(stack, vars_, d_events)
+                transition = self._select_transition(
+                    stack,
+                    vars_,
+                    d_events,
+                    force_validate=not state.is_stoppable,
+                )
                 if transition is not None:
                     ended = self._execute_transition_on_context(
                         stack,

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -767,6 +767,7 @@ class {{ machine_class_name(model) }}:
     def _execute_initial_transition_on_context(
         self, stack, vars_, transition_id, event_names, is_validation_mode=False
     ):
+        composite_frame = stack[-1]
         transition = self._TRANSITIONS[transition_id]
         self._execute_transition_effect(
             transition, vars_, is_validation_mode=is_validation_mode
@@ -778,6 +779,8 @@ class {{ machine_class_name(model) }}:
             event_names,
             is_validation_mode=is_validation_mode,
         )
+        if composite_frame in stack:
+            composite_frame["mode"] = "active"
 
     def _validate_initial_transition(self, stack, vars_, transition_id, event_names):
         sim_stack = self._clone_stack(stack)

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -779,7 +779,7 @@ class {{ machine_class_name(model) }}:
             event_names,
             is_validation_mode=is_validation_mode,
         )
-        if composite_frame in stack:
+        if any(frame is composite_frame for frame in stack):
             composite_frame["mode"] = "active"
 
     def _validate_initial_transition(self, stack, vars_, transition_id, event_names):

--- a/test/fixtures/simulate_semantics/cases/abstract_handler_context_vars_are_read_only.yaml
+++ b/test/fixtures/simulate_semantics/cases/abstract_handler_context_vars_are_read_only.yaml
@@ -44,7 +44,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/fixtures/simulate_semantics/cases/cold_initial_chain_stack_modes_are_active.fcstm
+++ b/test/fixtures/simulate_semantics/cases/cold_initial_chain_stack_modes_are_active.fcstm
@@ -1,0 +1,11 @@
+def int x = 0;
+
+state Root {
+    state Parent {
+        state A {
+            during { x = x + 1; }
+        }
+        [*] -> A;
+    }
+    [*] -> Parent;
+}

--- a/test/fixtures/simulate_semantics/cases/cold_initial_chain_stack_modes_are_active.yaml
+++ b/test/fixtures/simulate_semantics/cases/cold_initial_chain_stack_modes_are_active.yaml
@@ -1,21 +1,23 @@
 schema_version: 1
-id: cycle_result_history_stable_leaf
-title: Cycle result and history assertions for a stable leaf
+id: cold_initial_chain_stack_modes_are_active
+title: Cold initial chain stack modes become active after stabilization
 source:
-  fcstm: cycle_result_history_stable_leaf.fcstm
+  fcstm: cold_initial_chain_stack_modes_are_active.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633126858
   assertion_types:
-  - cycle_result
-  - history
-  - stack
   - state
   - vars
-  notes:
-  - Minimal fixture proving that cycle_result and history assertions are executable.
+  - stack
+  - return
+  - history
 categories:
 - runtime
+- validation
+- lifecycle
 runners:
 - simulation
 initial:
@@ -26,25 +28,29 @@ steps:
   expect:
     state:
     - Root
-    - Counting
+    - Parent
+    - A
     vars:
-      counter: 1
-    ended: false
+      x: 1
     stack:
     - path:
       - Root
       mode: active
     - path:
       - Root
-      - Counting
+      - Parent
       mode: active
-    cycle_count: 1
+    - path:
+      - Root
+      - Parent
+      - A
+      mode: active
+    ended: false
     cycle_result:
       value: null
-    history_length: 1
     history_tail:
     - cycle: 1
-      state: Root.Counting
+      state: Root.Parent.A
       vars:
-        counter: 1
+        x: 1
       events: []

--- a/test/fixtures/simulate_semantics/cases/composite_initial_skips_unstable_candidates_root_entry.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_skips_unstable_candidates_root_entry.yaml
@@ -37,7 +37,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Good

--- a/test/fixtures/simulate_semantics/cases/cycle_result_history_event_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/cycle_result_history_event_transition.yaml
@@ -48,7 +48,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Active

--- a/test/fixtures/simulate_semantics/cases/design_explicit_exit_to_root_ends_runtime.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_explicit_exit_to_root_ends_runtime.yaml
@@ -38,7 +38,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A
@@ -56,7 +56,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/fixtures/simulate_semantics/cases/design_speculative_dfs_safety_limit.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_speculative_dfs_safety_limit.yaml
@@ -52,7 +52,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.yaml
+++ b/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.yaml
@@ -39,7 +39,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
@@ -54,7 +54,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/fixtures/simulate_semantics/cases/hot_start_composite_state_with_init.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_composite_state_with_init.yaml
@@ -56,7 +56,7 @@ steps:
     - path:
       - Root
       - System
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - System

--- a/test/fixtures/simulate_semantics/cases/hot_start_composite_waits_for_initial_event.fcstm
+++ b/test/fixtures/simulate_semantics/cases/hot_start_composite_waits_for_initial_event.fcstm
@@ -1,0 +1,11 @@
+def int x = 0;
+
+state Root {
+    state Locked {
+        state Ready {
+            during { x = x + 1; }
+        }
+        [*] -> Ready :: Unlock;
+    }
+    [*] -> Locked;
+}

--- a/test/fixtures/simulate_semantics/cases/hot_start_composite_waits_for_initial_event.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_composite_waits_for_initial_event.yaml
@@ -1,0 +1,76 @@
+schema_version: 1
+id: hot_start_composite_waits_for_initial_event
+title: Hot start composite waits for an initial transition event
+source:
+  fcstm: hot_start_composite_waits_for_initial_event.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631746763
+  assertion_types:
+  - initial
+  - state
+  - vars
+  - stack
+  - return
+  - history
+categories:
+- runtime
+- hot_start
+- validation
+runners:
+- simulation
+initial:
+  state: Root.Locked
+  vars:
+    x: 0
+steps:
+- expect_initial:
+    state:
+    - Root
+    - Locked
+    vars:
+      x: 0
+    stack:
+    - path:
+      - Root
+      mode: active
+    - path:
+      - Root
+      - Locked
+      mode: init_wait
+    ended: false
+- cycle:
+    events:
+    - Root.Locked.Unlock
+  expect:
+    state:
+    - Root
+    - Locked
+    - Ready
+    vars:
+      x: 1
+    stack:
+    - path:
+      - Root
+      mode: active
+    - path:
+      - Root
+      - Locked
+      mode: active
+    - path:
+      - Root
+      - Locked
+      - Ready
+      mode: active
+    ended: false
+    cycle_result:
+      value: null
+    history_tail:
+    - cycle: 1
+      state: Root.Locked.Ready
+      vars:
+        x: 1
+      events:
+      - Root.Locked.Unlock

--- a/test/fixtures/simulate_semantics/cases/post_child_exit_continuation_skips_unstable_candidates.yaml
+++ b/test/fixtures/simulate_semantics/cases/post_child_exit_continuation_skips_unstable_candidates.yaml
@@ -37,11 +37,11 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - System
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - System
@@ -63,11 +63,11 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Good
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Good

--- a/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.fcstm
+++ b/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.fcstm
@@ -1,0 +1,34 @@
+def int trace = 0;
+
+state Root {
+    >> during before { trace = trace + 1000; }
+    >> during after { trace = trace + 100000; }
+
+    state A {
+        during { trace = trace + 1; }
+    }
+
+    state Target {
+        >> during before { trace = trace + 100; }
+        >> during after { trace = trace + 10000; }
+
+        pseudo state Gate {
+            enter { trace = trace + 10; }
+        }
+        state Bad {
+            enter { trace = trace + 20; }
+            state Dead;
+            [*] -> Dead : if [false];
+        }
+        state Good {
+            during { trace = trace + 2; }
+        }
+
+        [*] -> Gate;
+        Gate -> Bad :: Go;
+        Gate -> Good :: Go;
+    }
+
+    [*] -> A;
+    A -> Target :: Go;
+}

--- a/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.yaml
@@ -1,0 +1,81 @@
+schema_version: 1
+id: pseudo_candidate_skips_unstable_branch
+title: Pseudo candidate selection skips an unstable branch
+source:
+  fcstm: pseudo_candidate_skips_unstable_branch.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631750074
+  assertion_types:
+  - state
+  - vars
+  - stack
+  - return
+  - history
+categories:
+- runtime
+- pseudo_chain
+- validation
+- lifecycle
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      trace: 101001
+    stack:
+    - path:
+      - Root
+      mode: active
+    - path:
+      - Root
+      - A
+      mode: active
+    ended: false
+    cycle_result:
+      value: null
+    history_length: 1
+- cycle:
+    events:
+    - Root.A.Go
+    - Root.Target.Gate.Go
+  expect:
+    state:
+    - Root
+    - Target
+    - Good
+    vars:
+      trace: 212113
+    stack:
+    - path:
+      - Root
+      mode: active
+    - path:
+      - Root
+      - Target
+      mode: active
+    - path:
+      - Root
+      - Target
+      - Good
+      mode: active
+    ended: false
+    cycle_result:
+      value: null
+    history_tail:
+    - cycle: 2
+      state: Root.Target.Good
+      vars:
+        trace: 212113
+      events:
+      - Root.A.Go
+      - Root.Target.Gate.Go

--- a/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.fcstm
+++ b/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.fcstm
@@ -1,0 +1,14 @@
+def int x = 0;
+def int spin = 0;
+
+state Root {
+    state A {
+        during { x = x + 1; }
+    }
+    pseudo state P {
+        during { spin = spin + 1; }
+    }
+    [*] -> A;
+    A -> P :: Go effect { x = x + 100; };
+    P -> P;
+}

--- a/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
@@ -1,0 +1,70 @@
+schema_version: 1
+id: pseudo_self_loop_step_limit_raises_dfs_error
+title: Pseudo self loop raises on the step safety limit
+source:
+  fcstm: pseudo_self_loop_step_limit_raises_dfs_error.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631968897
+  assertion_types:
+  - exception
+  - state
+  - vars
+  - stack
+  - history
+categories:
+- runtime
+- pseudo_chain
+- validation
+runners:
+- simulation
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      x: 1
+      spin: 0
+    stack:
+    - path:
+      - Root
+      mode: active
+    - path:
+      - Root
+      - A
+      mode: active
+    ended: false
+    cycle_result:
+      value: null
+    history_length: 1
+- cycle:
+    events:
+    - Root.A.Go
+  expect:
+    raises:
+      type: SimulationRuntimeDfsError
+      match: step safety limit
+      match_kind: substring
+    state:
+    - Root
+    - A
+    vars:
+      x: 1
+      spin: 0
+    stack:
+    - path:
+      - Root
+      mode: active
+    - path:
+      - Root
+      - A
+      mode: active
+    ended: false
+    history_length: 1

--- a/test/fixtures/simulate_semantics/cases/ref_abstract_handler_reports_calling_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/ref_abstract_handler_reports_calling_state.yaml
@@ -41,7 +41,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/fixtures/simulate_semantics/cases/rejected_transition_candidate_defers_anonymous_warning.yaml
+++ b/test/fixtures/simulate_semantics/cases/rejected_transition_candidate_defers_anonymous_warning.yaml
@@ -37,7 +37,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A
@@ -57,7 +57,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Good
@@ -80,11 +80,11 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Bad
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Bad

--- a/test/fixtures/simulate_semantics/cases/root_exit_runs_root_cleanup.yaml
+++ b/test/fixtures/simulate_semantics/cases/root_exit_runs_root_cleanup.yaml
@@ -36,7 +36,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/fixtures/simulate_semantics/cases/transition_into_composite_skips_unstable_initial_candidate.yaml
+++ b/test/fixtures/simulate_semantics/cases/transition_into_composite_skips_unstable_initial_candidate.yaml
@@ -37,7 +37,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A
@@ -58,11 +58,11 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Parent
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - Parent

--- a/test/simulate/test_hot_start_edge_cases.py
+++ b/test/simulate/test_hot_start_edge_cases.py
@@ -9,13 +9,42 @@ import pytest
 
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
-from pyfcstm.simulate import SimulationRuntime
+from pyfcstm.simulate import SimulationRuntime, SimulationRuntimeDfsError
 
 
 def build_state_machine(dsl_code: str):
     """Helper to build state machine from DSL code."""
     ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
     return parse_dsl_node_to_state_machine(ast)
+
+
+def make_deep_initial_chain_dsl(depth: int) -> str:
+    """Build a single-path deep initial-chain state machine."""
+
+    def nested(index: int, indent: int) -> str:
+        space = "    " * indent
+        if index > depth:
+            return space + "state Leaf { during { counter = counter + 1; } }\n"
+        child = "Leaf" if index == depth else f"L{index + 1}"
+        return (
+            space + f"state L{index} {{\n"
+            + space + f"    [*] -> {child};\n"
+            + nested(index + 1, indent + 1)
+            + space + "}\n"
+        )
+
+    return (
+        "def int counter = 0;\n"
+        "state Root {\n"
+        "    [*] -> L1;\n"
+        + nested(1, 1)
+        + "}\n"
+    )
+
+
+def deep_leaf_path(depth: int) -> str:
+    """Build the dot-separated leaf path for a deep initial-chain model."""
+    return "Root." + ".".join(f"L{index}" for index in range(1, depth + 1)) + ".Leaf"
 
 
 @pytest.mark.unittest
@@ -369,3 +398,37 @@ state Root {
         runtime.cycle()
         assert runtime.current_state.path == ('Root', 'A')
         assert runtime.vars['x'] == 30
+
+    def test_hot_start_deep_leaf_rejected_at_constructor(self):
+        """Test that too-deep hot-start stacks fail during construction."""
+        sm = build_state_machine(make_deep_initial_chain_dsl(63))
+
+        with pytest.raises(SimulationRuntimeDfsError, match="structural stack-depth"):
+            SimulationRuntime(
+                sm,
+                initial_state=deep_leaf_path(63),
+                initial_vars={"counter": 0},
+            )
+
+    def test_deep_initial_chain_validation_is_bounded(self):
+        """Test that a single-path initial chain does not validate exponentially."""
+
+        class CountingRuntime(SimulationRuntime):
+            def __init__(self, *args, **kwargs):
+                self.initial_validation_calls = 0
+                super().__init__(*args, **kwargs)
+
+            def _validate_initial_transition(self, *args, **kwargs):
+                self.initial_validation_calls += 1
+                return super()._validate_initial_transition(*args, **kwargs)
+
+        sm = build_state_machine(make_deep_initial_chain_dsl(15))
+        runtime = CountingRuntime(sm)
+
+        runtime.cycle()
+
+        assert runtime.current_state.path == tuple(
+            ["Root"] + [f"L{index}" for index in range(1, 16)] + ["Leaf"]
+        )
+        assert runtime.vars["counter"] == 1
+        assert runtime.initial_validation_calls <= 64

--- a/test/simulate/test_hot_start_edge_cases.py
+++ b/test/simulate/test_hot_start_edge_cases.py
@@ -410,6 +410,70 @@ state Root {
                 initial_vars={"counter": 0},
             )
 
+    def test_hot_start_parent_waits_for_nested_initial_event(self):
+        """Test that nested event-gated initial chains can wait for first cycle."""
+        dsl_code = """
+def int x = 0;
+state Root {
+    state Locked {
+        state Gate {
+            state Ready {
+                during { x = x + 1; }
+            }
+            [*] -> Ready :: Unlock;
+        }
+        [*] -> Gate;
+    }
+    [*] -> Locked;
+}
+"""
+        sm = build_state_machine(dsl_code)
+        runtime = SimulationRuntime(
+            sm,
+            initial_state="Root.Locked",
+            initial_vars={"x": 0},
+        )
+
+        assert runtime.current_state.path == ("Root", "Locked")
+        assert runtime.stack[-1].mode == "init_wait"
+
+        runtime.cycle(["Root.Locked.Gate.Unlock"])
+
+        assert runtime.current_state.path == ("Root", "Locked", "Gate", "Ready")
+        assert runtime.vars["x"] == 1
+        assert [frame.mode for frame in runtime.stack] == [
+            "active",
+            "active",
+            "active",
+            "active",
+        ]
+
+    def test_hot_start_event_wait_does_not_hide_dfs_error(self):
+        """Test that event-gated fallback does not swallow unbounded init errors."""
+        dsl_code = """
+def int spin = 0;
+state Root {
+    state Locked {
+        pseudo state Loop {
+            during { spin = spin + 1; }
+        }
+        state Ready;
+        [*] -> Loop;
+        [*] -> Ready :: Unlock;
+        Loop -> Loop;
+    }
+    [*] -> Locked;
+}
+"""
+        sm = build_state_machine(dsl_code)
+
+        with pytest.raises(SimulationRuntimeDfsError, match="step safety limit"):
+            SimulationRuntime(
+                sm,
+                initial_state="Root.Locked",
+                initial_vars={"spin": 0},
+            )
+
     def test_deep_initial_chain_validation_is_bounded(self):
         """Test that a single-path initial chain does not validate exponentially."""
 


### PR DESCRIPTION
# PR-1：修复 hot start、pseudo 候选、DFS safety 与 stack 稳定化

上游伞 PR：[PR #186](https://github.com/HansBug/pyfcstm/pull/186)  
上游问题集合：[issue #156](https://github.com/HansBug/pyfcstm/issues/156)  
前置基线：[PR #187](https://github.com/HansBug/pyfcstm/pull/187) 已合入，merge commit 为 `94d27a2052d88772a6e1632a4e921c1e28fd10c7`。

本 PR 是上游伞 PR 的 PR-1。目标是修复 `pyfcstm.simulate` 中 hot start、pseudo transition candidate、DFS safety 和 stable stack metadata 相关的六个已确认问题：`PSEUDO-1`、`HOT-1`、`HOT-5`、`STACK-1`、`SAFETY-1`、`SAFETY-2`。

计划阶段已完成三路 reviewer 审阅并确认 C/I=0。本 PR 已进入实现后验证阶段：TDD 回归、runtime 修复、语义 fixture 更新和本地 slow-skip 全量测试已完成，等待 CI 与强对抗 code review 收口。

## 当前分支状态

- base branch：`dev/issue156-simulate-fix-umbrella`。
- head branch：`dev/issue156-pr1-hotstart-pseudo-safety`。
- 当前 head 的 parent 是 PR-0 merge commit `94d27a2052d88772a6e1632a4e921c1e28fd10c7`，即已包含 [PR #187](https://github.com/HansBug/pyfcstm/pull/187) 的 fixture schema / runner 基线。
- 当前 PR 已包含实现 diff，基于 PR-0 merge commit `94d27a2052d88772a6e1632a4e921c1e28fd10c7` 开发；提交前已确认与当前 base 无 conflict。
- 若上游伞 PR 分支在本 PR 实现期间移动，进入 ready 前必须 merge/rebase 最新 `dev/issue156-simulate-fix-umbrella`，并复查 PR-0 fixture schema/helper、runtime exception、stack metadata 契约没有冲突或丢失。

## 范围

### 纳入范围

- 生产代码主落点为 `pyfcstm/simulate/runtime.py`。本 PR 还包含 `templates/python/machine.py.j2` 的 3 行最小镜像变更，仅用于同步 `STACK-1` 的 initial transition 后 composite frame mode 收敛语义，保证现有 generated Python alignment 测试与 runtime metadata 一致；不扩展 generated runtime 的 hot-start / pseudo / DFS safety 主逻辑。
- 测试进入 PR-0 已合入的 canonical fixture 体系和现有 simulate 单测：
  - `test/fixtures/simulate_semantics/schema.md`
  - `test/fixtures/simulate_semantics/cases/*.yaml`
  - `test/fixtures/simulate_semantics/cases/*.fcstm`
  - `test/testings/simulate_semantics.py`
  - `test/simulate/test_semantic_fixtures.py`
  - 必要时补充 `test/simulate/test_hot_start.py` / `test/simulate/test_hot_start_edge_cases.py` 这类窄单测。
- 允许新增 simulate 自有诊断异常或改进现有 `SimulationRuntimeDfsError` 文案，但必须保持 Python 3.7+ 兼容。
- 允许为性能安全边界增加小规模 bounded test，但不能引入长时间、不稳定或依赖机器性能的慢测试。

### 排除范围

- 不处理 expression、persistent 变量类型归一化、event result、terminal query、handler registry、execution context metadata 等后续 PR 负责的问题。
- 不修改 CLI / entry / editor / jsfcstm / solver / render；template 仅允许上述 `templates/python/machine.py.j2` 的 stack mode 最小镜像变更，原因必须在 review 中单独核查。
- 不通过 `Makefile` 修改规避测试。
- 不把 PR 编号、issue 编号、roadmap 阶段等工作流元数据写进代码标识符、fixture id、runtime message、docstring 或 pydoc。
- 不改变 `HOT-2` / `HOT-3` 已确认的设计预期：hot start 到 pseudo leaf 不要求先执行 pseudo `during`；composite initial transition 决策发生在 local `during before` 之前。

## 与上游拆分的一致性

| 条目 | 上游要求 | 本 PR 计划 | 验收方式 | 状态 |
|---|---|---|---|---|
| `PSEUDO-1` | pseudo leaf 多个同事件候选时，应跳过不可稳定候选并继续尝试后续可稳定候选。 | 对 non-stoppable leaf 的普通 transition selection 启用稳定性验证，避免首个不可稳定 candidate 屏蔽后续 candidate。 | 新增 `pseudo_candidate_skips_unstable_branch` semantic fixture。 | ✅ 已实现 |
| `HOT-1` | hot start 到 composite 时，若 initial transition 需要首轮 event，constructor 不应空事件 preflight 拒绝。 | composite hot start constructor 允许停在 `init_wait`；首轮 `cycle(events)` 负责稳定化。 | 新增 `hot_start_composite_waits_for_initial_event` semantic fixture。 | ✅ 已实现 |
| `HOT-5` | hot-start target 是超过结构深度阈值的深层普通 leaf 时，constructor/preflight 阶段一致拒绝并给清晰深度诊断。 | 按伞 PR 当前权威口径收口：hot-start stack 超过 runtime structural depth 上限时，constructor 阶段拒绝，不允许 constructor 接受后首轮 cycle 再报 DFS depth。 | 新增 `test_hot_start_deep_leaf_rejected_at_constructor`。 | ✅ 已实现 |
| `STACK-1` | cold start 经 initial chain 稳定后 ancestor frame mode 应为 `active`。 | initial transition 成功后把 owning composite frame 从 `init_wait` 收敛为 `active`，不只在 `brief_stack` 显示层 masking。 | 新增 `cold_initial_chain_stack_modes_are_active`，并更新既有 stable stack fixture 期望。 | ✅ 已实现 |
| `SAFETY-1` | 合法深层 composite initial chain 不应因嵌套 validation 指数爆炸卡住。 | 以显式 worklist search 替代嵌套 validation 递归，减少重复验证并保留 DFS step/depth safety。 | 新增 `test_deep_initial_chain_validation_is_bounded`。 | ✅ 已实现 |
| `SAFETY-2` | 1000-step safety limit 命中应抛 `SimulationRuntimeDfsError`，并 rollback。 | step limit 分支改为与 depth limit 一致地抛 simulate 自有 DFS 诊断，不再静默当普通 validation failure。 | 新增 `pseudo_self_loop_step_limit_raises_dfs_error` semantic fixture。 | ✅ 已实现 |

## 最小复现索引

这些复现来自上游 issue comment，整理进本 PR body 供后续 TDD 直接执行。最终测试资产必须使用领域行为命名，不使用这些问题编号作为 fixture id。

### `PSEUDO-1`：pseudo candidate 选择未验证后续可稳定性

上游 comment：[PSEUDO-1](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631750074)

最小 DSL：

```fcstm
def int trace = 0;
state Root {
    >> during before { trace = trace + 1000; }
    >> during after { trace = trace + 100000; }
    state A { during { trace = trace + 1; } }
    state Target {
        >> during before { trace = trace + 100; }
        >> during after { trace = trace + 10000; }
        pseudo state Gate { enter { trace = trace + 10; } }
        state Bad {
            enter { trace = trace + 20; }
            state Dead;
            [*] -> Dead : if [false];
        }
        state Good { during { trace = trace + 2; } }
        [*] -> Gate;
        Gate -> Bad :: Go;
        Gate -> Good :: Go;
    }
    [*] -> A;
    A -> Target :: Go;
}
```

最小 Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL_BAD_FIRST = r"""<use the DSL above>"""
DSL_GOOD_FIRST = DSL_BAD_FIRST.replace(
    "Gate -> Bad :: Go;\n        Gate -> Good :: Go;",
    "Gate -> Good :: Go;\n        Gate -> Bad :: Go;",
)

for label, dsl in [("bad_first", DSL_BAD_FIRST), ("good_first", DSL_GOOD_FIRST)]:
    model = parse_dsl_node_to_state_machine(
        parse_with_grammar_entry(dsl, "state_machine_dsl")
    )
    runtime = SimulationRuntime(model)
    runtime.cycle()
    runtime.cycle(["Root.A.Go", "Root.Target.Gate.Go"])
    print(label, runtime.current_state.path, runtime.brief_stack, runtime.vars)
```

复现命令：

```bash
PYTHONPATH=. python /tmp/repro_pseudo_candidate.py
```

当前关键输出：

```text
bad_first ('Root', 'A') ... {'trace': 202002}
good_first ('Root', 'Target', 'Good') ... {'trace': 212113}
```

期望：`bad_first` 也应跳过不可稳定 `Bad` candidate，最终稳定到 `Root.Target.Good`。  
白盒原因：leaf-state 分支调用 `_select_transition(stack, vars_, d_events)` 时，pseudo leaf 不是 stoppable，当前不会验证候选 continuation。

### `HOT-1`：event-gated composite hot start 被 constructor 空事件 preflight 误拒绝

上游 comment：[HOT-1](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631746763)

最小 DSL：

```fcstm
def int x = 0;
state Root {
    state Locked {
        state Ready { during { x = x + 1; } }
        [*] -> Ready :: Unlock;
    }
    [*] -> Locked;
}
```

最小 Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r"""<use the DSL above>"""
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))

cold = SimulationRuntime(model)
cold.cycle(["Root.Locked.Unlock"])
print("cold", cold.brief_stack, cold.vars, cold.cycle_count)

try:
    hot = SimulationRuntime(model, initial_state="Root.Locked", initial_vars={"x": 0})
except Exception as err:
    print("hot_construct_error", type(err).__name__, str(err))
else:
    hot.cycle(["Root.Locked.Unlock"])
    print("hot", hot.brief_stack, hot.vars, hot.cycle_count)
```

复现命令：

```bash
PYTHONPATH=. python /tmp/repro_hot_start_event_gated.py
```

当前关键输出：

```text
cold ... {'x': 1} 1
hot_construct_error ValueError Hot start target 'Root.Locked' cannot reach a stoppable state
```

期望：constructor 接受 `Root.Locked` 的 `init_wait` hot-start stack，首轮 event 完成 initial transition。  
白盒原因：`_validate_hot_start_stack()` 对非-stoppable target 用空事件 `{}` 运行 preflight。

### `HOT-5`：深层 hot-start leaf depth 边界在 constructor / cycle 间不一致

上游 comment：[HOT-5](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632742004)

最小 Python 复现会动态生成 `Root.L1...L63.Leaf`，让 hot-start stack 长度为 65：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime


def make_dsl(depth):
    lines = ["def int ticks = 0;", "state Root {"]
    indent = "  "
    for index in range(1, depth + 1):
        lines.append(indent + f"state L{index} {{")
        indent += "  "
    lines.append(indent + "state Leaf { during { ticks = ticks + 1; } }")
    lines.append(indent + "[*] -> Leaf;")
    for index in range(depth, 0, -1):
        indent = "  " * index
        lines.append(indent + "}")
        lines.append(indent + f"[*] -> L{index};")
    lines.append("}")
    return "\n".join(lines)


def target_path(depth):
    return "Root." + ".".join(f"L{i}" for i in range(1, depth + 1)) + ".Leaf"

model = parse_dsl_node_to_state_machine(
    parse_with_grammar_entry(make_dsl(63), "state_machine_dsl")
)
runtime = SimulationRuntime(model, initial_state=target_path(63), initial_vars={"ticks": 0})
print("constructed", len(runtime.stack), runtime.current_state.path)
runtime.cycle()
print("after", runtime.vars, runtime.history)
```

复现命令：

```bash
PYTHONPATH=. python /tmp/repro_hot_start_deep_leaf.py
```

当前关键输出：

```text
constructed 65 ('Root', 'L1', ..., 'L63', 'Leaf')
cycle EXC SimulationRuntimeDfsError Speculative DFS exceeded the structural stack-depth safety limit (64) ...
```

本 PR 的收口口径：按伞 PR 当前压缩验收表，hot-start stack 超过 structural depth 上限应在 constructor/preflight 阶段一致拒绝并给清晰 depth diagnostic，不允许 constructor 先接受、首轮 cycle 再失败。  
白盒原因：`_validate_hot_start_stack()` 对 stoppable target 直接 return，未统一检查 hot-start stack depth。

### `STACK-1`：cold stable stack 的 ancestor mode 长期保留 `init_wait`

上游 comment：[STACK-1](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633126858)

最小 DSL：

```fcstm
def int x = 0;
state Root {
    state Parent {
        state A { during { x = x + 1; } }
        [*] -> A;
    }
    [*] -> Parent;
}
```

最小 Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r"""<use the DSL above>"""
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))

cold = SimulationRuntime(model)
cold.cycle()
print("cold_after", cold.current_state.path, cold.brief_stack, cold.vars)

hot = SimulationRuntime(model, initial_state="Root.Parent.A", initial_vars={"x": 1})
print("hot_equivalent", hot.current_state.path, hot.brief_stack, hot.vars)
```

复现命令：

```bash
PYTHONPATH=. python /tmp/repro_stack_mode.py
```

当前关键输出：

```text
cold_after ('Root', 'Parent', 'A') [(('Root',), 'init_wait'), (('Root', 'Parent'), 'init_wait'), ...] {'x': 1}
hot_equivalent ('Root', 'Parent', 'A') [(('Root',), 'active'), (('Root', 'Parent'), 'active'), ...] {'x': 1}
```

期望：cold stable stack 的 ancestor frame mode 与等价 hot-start stack 一致，均为 `active`。  
白盒原因：initial transition 成功后，owning composite frame 没有从 `init_wait` 收敛回 `active`。

### `SAFETY-1`：合法深层 initial chain 嵌套 validation 指数爆炸

上游 comment：[SAFETY-1](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631929810)

最小 Python 复现会生成 `Root -> L1 -> ... -> L20 -> Leaf` 的合法单路径 initial chain，并统计 `_validate_initial_transition()` 调用数：

```python
import time
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

class CountingRuntime(SimulationRuntime):
    def __init__(self, *args, **kwargs):
        self.initial_validation_calls = 0
        super().__init__(*args, **kwargs)

    def _validate_initial_transition(self, *args, **kwargs):
        self.initial_validation_calls += 1
        return super()._validate_initial_transition(*args, **kwargs)


def make_deep_dsl(depth):
    def nested(index, indent):
        sp = "    " * indent
        if index > depth:
            return sp + "state Leaf { during { x = x + 1; } }\n"
        child = "Leaf" if index == depth else f"L{index + 1}"
        return sp + f"state L{index} {{\n" + sp + f"    [*] -> {child};\n" + nested(index + 1, indent + 1) + sp + "}\n"
    return "def int x = 0;\nstate Root {\n    [*] -> L1;\n" + nested(1, 1) + "}\n"

model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(make_deep_dsl(15), "state_machine_dsl"))
runtime = CountingRuntime(model)
started = time.perf_counter()
runtime.cycle()
print(runtime.initial_validation_calls, round(time.perf_counter() - started, 3), runtime.current_state.path, runtime.vars)
```

复现命令：

```bash
PYTHONPATH=. python /tmp/repro_deep_initial_chain.py
```

当前关键输出：

```text
depth 14: 65534 validation calls, about 2s
depth 15: 131070 validation calls, about 4s
depth 20: timeout_after_10s
```

期望：合法单路径 deep initial chain 近似线性推进，或在共享 safety budget 内给出清晰诊断；不能指数爆炸。  
白盒原因：`_validate_initial_transition()` 内执行 candidate 后又 `_run_cycle_on_context()`，而 `_enter_state()` 进入 composite child 时会再次 `_attempt_init_transition()`，嵌套 validation 重复验证同一条 initial chain。

### `SAFETY-2`：step safety limit 命中后被当普通 validation rollback

上游 comment：[SAFETY-2](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631968897)

最小 DSL：

```fcstm
def int x = 0;
def int spin = 0;
state Root {
    state A { during { x = x + 1; } }
    pseudo state P { during { spin = spin + 1; } }
    [*] -> A;
    A -> P :: Go effect { x = x + 100; };
    P -> P;
}
```

最小 Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime, SimulationRuntimeDfsError

DSL = r"""<use the DSL above>"""
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))
runtime = SimulationRuntime(model)
runtime.cycle()
print("before", runtime.brief_stack, runtime.vars, runtime.cycle_count, runtime.history)
try:
    runtime.cycle(["Root.A.Go"])
except Exception as exc:
    print("exception", type(exc).__name__, isinstance(exc, SimulationRuntimeDfsError), str(exc))
else:
    print("no_exception")
print("after", runtime.brief_stack, runtime.vars, runtime.cycle_count, runtime.history)
```

复现命令：

```bash
PYTHONPATH=. python /tmp/repro_step_limit.py
```

当前关键输出：

```text
before ... {'x': 1, 'spin': 0} 1 [...]
no_exception
after ... {'x': 2, 'spin': 0} 2 [..., {'events': ['Root.A.Go']}]
```

期望：命中 step safety limit 时抛 `SimulationRuntimeDfsError`，runtime 保持旧稳定边界，vars / stack / history / cycle_count 不新增。  
白盒原因：`steps_taken >= max_steps` 分支当前只 debug log 并 `return False, False`，与普通不可稳定 validation failure 同形。

## 设计约束

- 先写失败测试，再改实现。每个问题至少一个直接回归；能放进 semantic fixture 的优先放进 PR-0 基线体系。
- `PSEUDO-1`、`HOT-1`、`SAFETY-1` 共享同一条 validation/stabilization 主线，修复时必须防止一个问题的 shortcut 破坏另一个问题。
- `HOT-5` 与 `SAFETY-1` 都碰 structural depth 语义，但含义不同：前者是 hot-start input boundary，后者是 initial chain validation 复杂度。不能用简单调大常量糊住问题。
- `STACK-1` 要修 internal frame mode，不只修 `brief_stack` 展示。
- `SAFETY-2` 的异常应从 validation 传播到 public `cycle()`，且 runtime state rollback 到旧 snapshot；不能在抛异常前提交旧 leaf `during`。
- 本 PR 拥有 `SimulationRuntimeDfsError` 的 step/depth safety 诊断契约；PR-2A 的 expression exception wrapping 不应接管这一路径。
- 本 PR 不接管 PR-2A/PR-2B 的 expression 和 variable normalization owner；若实现中发现需要修改相关 helper，应拆出说明，不在本 PR 偷偷扩大范围。
- 若 PR-2A/PR-2B/PR-3 在本 PR merge 前先进入上游，PR-1 必须 merge/rebase 最新上游后复查：`cycle()` 返回值、runtime exception class、fixture schema、persistent vars normalization 不得与本 PR 断言冲突。

## TDD 与实现计划

| 步骤 | 工作内容 | 预期产物 | 验收命令 |
|---|---|---|---|
| TDD-1 | 为六个问题写失败 fixture / 单测。 | 新增领域命名 fixture，不使用 issue/PR 编号；必要时新增 bounded unit test。 | `pytest test/simulate/test_semantic_fixtures.py -q` 与窄单测失败在预期点。 |
| TDD-2 | 修复 `SAFETY-2` step limit 诊断。 | `SimulationRuntimeDfsError` 覆盖 step limit；rollback 断言通过。 | 相关 fixture / 单测。 |
| TDD-3 | 修复 `STACK-1` stable frame mode 收敛。 | cold stable stack 与等价 hot-start stack mode 对齐。 | stack fixture / 单测。 |
| TDD-4 | 修复 `PSEUDO-1` pseudo candidate validation。 | bad-first/good-second 能选中后续可稳定 candidate。 | pseudo fixture。 |
| TDD-5 | 修复 `HOT-1` composite hot start event-gated init。 | constructor 接受 composite `init_wait`，首轮 event 稳定。 | hot-start event fixture。 |
| TDD-6 | 修复 `HOT-5` hot-start depth preflight 与 `SAFETY-1` validation 复杂度。 | deep hot-start stack constructor/preflight 一致拒绝；深层单链不指数爆炸。 | bounded depth tests，避免慢测。 |
| 验证 | 跑精准与全量 slow-skip 测试，并执行 `make rst_auto`。 | 本地通过，CI 全绿，Codecov 无新增未覆盖行。 | 见“本地验收命令”。 |

## 测试资产计划

建议新增或扩展以下测试资产，最终名称可根据实现微调，但必须使用领域行为命名：

| 行为 | 建议 fixture / test 名称 | 覆盖重点 |
|---|---|---|
| pseudo 候选稳定性 | `pseudo_candidate_skips_unstable_branch` | `PSEUDO-1`，bad-first/good-second。 |
| event-gated composite hot start | `hot_start_composite_waits_for_initial_event` | `HOT-1`，constructor init_wait + 首轮 event。 |
| deep hot-start leaf constructor depth boundary | `hot_start_deep_leaf_rejected_at_constructor` | `HOT-5`，stack 长度超过 64 的 hot-start leaf 在 constructor/preflight 阶段清晰拒绝。 |
| cold stack mode 收敛 | `cold_initial_chain_stack_modes_are_active` | `STACK-1`，cold 与 hot-start stack metadata 对齐。 |
| deep initial chain bounded | `deep_initial_chain_stabilizes_without_exponential_validation` | `SAFETY-1`，控制 validation 调用量或 wall time 上界。 |
| pseudo self-loop step limit | `pseudo_self_loop_step_limit_raises_dfs_error` | `SAFETY-2`，异常 + rollback。 |

若 bounded performance test 使用 monkeypatch / subclass 计数 `_validate_initial_transition()`，断言应基于调用量数量级或明确 budget，不依赖绝对机器耗时。

## Mermaid 依赖图

```mermaid
flowchart TD
    U["伞 PR<br/>#156 simulate 修复拆分<br/>🟦 已开启"]:::active
    P0["PR-0<br/>fixture 与诊断契约基线<br/>✅ 已合入"]:::done
    P1["PR-1<br/>hot start / pseudo / DFS safety / stack<br/>🟦 本 PR"]:::active
    S2A["PR-2A<br/>表达式运行时与诊断包装<br/>📝 后续"]:::planned
    S2B["PR-2B<br/>persistent 变量初始化与归一化<br/>📝 后续"]:::planned
    S3["PR-3<br/>event 输入与 cycle 结果对象<br/>📝 后续"]:::planned
    S4["PR-4<br/>terminal query 与 history metadata<br/>📝 后续"]:::planned
    S5["PR-5<br/>execution context 与 ref callsite<br/>📝 后续"]:::planned
    S6["PR-6<br/>handler registry / warning metadata<br/>📝 后续"]:::planned
    S7["PR-7<br/>decorator scanner 与 session copy<br/>📝 后续"]:::planned
    S8["PR-8<br/>全集回归与 issue 收口<br/>📝 后续"]:::planned

    U --> P0
    P0 --> P1
    P0 --> S2A
    P0 --> S2B
    P0 --> S3
    P0 --> S4
    P0 --> S5
    P0 --> S6
    P0 --> S7
    P0 --> S8
    P1 --> S8
    S2A --> S8
    S2B --> S8
    S3 --> S8
    S4 --> S8
    S5 --> S8
    S6 --> S8
    S6 --> S7
    S7 --> S8

    classDef active fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef planned fill:#f3f4f6,stroke:#6b7280,color:#111827;
    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
    classDef blocked fill:#fee2e2,stroke:#dc2626,color:#111827;
```

## 本地验收命令

```bash
pytest test/simulate/test_semantic_fixtures.py -q
pytest test/simulate/test_hot_start.py -q
pytest test/simulate/test_hot_start_edge_cases.py -q
pytest test/simulate/ -q --ignore=test/simulate/test_semantic_fixtures.py
SKIP_SLOW_TESTS=1 make unittest
make rst_auto
```

如果实现新增或修改 public Python API / class / function / module docstring，review 必须按 `CLAUDE.md` 检查 reST pydoc：module 职责清晰；class/function 有 `:param:`、`:type:`、`:return:`、`:rtype:`、必要 `:raises:` 和 `Example::`；如新增 `__init__.py` 导出，应呈现 module roadmap。



## 实现后本地验收记录

- `pytest test/simulate/test_semantic_fixtures.py -q`：203 passed。
- `pytest test/simulate/ -q`：333 passed。
- `pytest test/template/python/test_semantic_fixture_alignment.py -q`：87 passed。
- `pytest test/simulate/test_hot_start.py test/simulate/test_hot_start_edge_cases.py -q`：43 passed。
- `python -m py_compile pyfcstm/simulate/runtime.py test/testings/simulate_semantics.py test/simulate/test_hot_start_edge_cases.py`：通过。
- `make rst_auto`：通过。
- `SKIP_SLOW_TESTS=1 make unittest`：40907 passed, 164 skipped, 63 deselected。

## 实现说明与 review 关注点

- 新增 `_validation_search_reaches_stable()`，用显式 worklist 做 speculative stabilization search，避免合法 initial chain 在嵌套 validation 中指数爆炸，同时保留 1000 step / 64 stack depth safety。
- `_run_cycle_on_context()` 的 step safety limit 现在与 depth limit 一样抛 `SimulationRuntimeDfsError`，让 public `cycle()` 能 rollback 后清晰报告 invalid unbounded pseudo / transition chain。
- hot-start preflight 现在先检查构造出的 stack 是否超过 structural depth 上限；非 stoppable composite 若 initial transition 需要 event，可保留 `init_wait` 等待首轮 `cycle(events)`。
- initial transition 成功后会把 owning composite frame mode 收敛到 `active`。为避免现有 generated Python alignment 测试在 stack metadata 上漂移，`templates/python/machine.py.j2` 同步了同一处 3 行最小镜像逻辑；这是本 PR 唯一 template 变更。
- 新增 fixture / 单测均使用领域行为命名，没有把 PR 编号、issue 编号或 roadmap 阶段写入测试 id / runtime message / docstring。



## 实现 review 修复记录

- codex reviewer 的 C-1 已修复：hot start 到父 composite 时，现在会沿 eventless initial-chain 查找 descendant composite 的 event-gated initial transition，可保留 `init_wait` 等首轮事件稳定。
- claude reviewer 的 I-1 已修复：若空事件 preflight 或 event-gated initial-chain search 触发 DFS step/depth safety，且存在 event-gated fallback 可能掩盖该错误，则继续抛 `SimulationRuntimeDfsError`；不可稳定 pseudo hot-start 的旧 `ValueError` 契约仍保持。
- claude reviewer 的 M-1 已处理：generated Python template 的 `composite_frame in stack` 改为 `any(frame is composite_frame for frame in stack)`，避免 dict equality 误判。
- claude/deepseek reviewer 的 pydoc M 项已处理：`_enter_state()` docstring 补充 initial-transition validation safety 的 `:raises SimulationRuntimeDfsError:`。
- 新增两个 focused tests：`test_hot_start_parent_waits_for_nested_initial_event` 与 `test_hot_start_event_wait_does_not_hide_dfs_error`。

## Review 要求

三路 reviewer 需要检查：

- PR-1 是否严格匹配上游 PR-1 的六个问题，不漏项、不越界。
- PR body 是否足够自包含，能指导后续 TDD 与实现。
- 是否正确基于已合入 PR-0 的 fixture schema / runner，不创建并行 fixture 体系。
- 是否已把上游分支最新内容合进本分支，且无 conflict / 无丢失 PR-0 内容。
- 后续实现是否可能和 PR-2A/PR-2B/PR-3 等共享契约冲突；如有，必须在本 PR 内明确边界。
- pydoc、测试、fixture 命名是否遵守 `CLAUDE.md`，不把工作流元数据写入代码和 fixture id。

## 当前状态

- [x] PR-0 已合入上游分支。
- [x] PR-1 空 PR 已创建。
- [x] 三路 reviewer 完成计划审阅，C/I=0。
- [x] TDD 回归测试与 semantic fixture 已落地。
- [x] 实现修复已完成。
- [x] 本地验收命令通过。
- [ ] CI 全绿。
- [ ] 强对抗 code review C/I=0（二轮 targeted review 待确认）。
- [ ] ready 后直接合并到上游伞 PR 分支，并同步上游 PR body / new comment。


