### PR TITLE
PR-4：修复 terminal query 与 history session metadata

### DIFF
--- a/docs/source/api_doc/simulate/runtime.rst
+++ b/docs/source/api_doc/simulate/runtime.rst
@@ -12,6 +12,12 @@ SimulationRuntimeDfsError
 .. autoclass:: SimulationRuntimeDfsError
 
 
+SimulationRuntimeTerminalStateError
+-----------------------------------------------------
+
+.. autoclass:: SimulationRuntimeTerminalStateError
+
+
 SimulationRuntimeEventError
 -----------------------------------------------------
 

--- a/pyfcstm/simulate/__init__.py
+++ b/pyfcstm/simulate/__init__.py
@@ -67,6 +67,7 @@ from .runtime import (
     SimulationRuntimeDfsError,
     SimulationRuntimeEventError,
     SimulationRuntimeExpressionError,
+    SimulationRuntimeTerminalStateError,
 )
 from .utils import is_state_resolve_event_path
 
@@ -77,6 +78,7 @@ __all__ = [
     "SimulationRuntimeDfsError",
     "SimulationRuntimeEventError",
     "SimulationRuntimeExpressionError",
+    "SimulationRuntimeTerminalStateError",
     "abstract_handler",
     "is_state_resolve_event_path",
 ]

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -274,6 +274,25 @@ class SimulationRuntimeDfsError(RuntimeError):
     pass
 
 
+class SimulationRuntimeTerminalStateError(IndexError):
+    """
+    Raised when an active-state query is unavailable after termination.
+
+    The exception is emitted by active-stack queries such as
+    :attr:`SimulationRuntime.current_state` when the runtime has naturally
+    ended and no active state remains. It subclasses :class:`IndexError` for
+    compatibility with callers that previously caught the generic exception,
+    while giving new callers a simulator-owned terminal-state diagnostic to
+    catch directly.
+
+    Example::
+
+        >>> err = SimulationRuntimeTerminalStateError("runtime has ended")
+        >>> isinstance(err, IndexError)
+        True
+    """
+
+
 class SimulationRuntimeEventError(ValueError):
     """
     Raised when a user-supplied cycle event cannot be resolved.
@@ -2915,8 +2934,7 @@ class SimulationRuntime:
 
             # Add to history and maintain size limit
             self.history.append(history_entry)
-            if self.history_size is not None and len(self.history) > self.history_size:
-                self.history.pop(0)  # Remove oldest entry
+            self._trim_history_to_size()
 
             # Log successful cycle completion with variable changes
             changes = self._format_var_changes(old_vars, self.vars)
@@ -2955,6 +2973,35 @@ class SimulationRuntime:
                 _safe_runtime_repr(self.vars),
             )
 
+    def _trim_history_to_size(self) -> None:
+        """
+        Trim committed history entries to the configured retention size.
+
+        ``None`` keeps all entries. Non-negative integer sizes keep the newest
+        ``history_size`` entries, with ``0`` keeping no entries. Unsupported
+        values intentionally retain the previous one-pop boundary behavior; the
+        public validation contract for invalid ``history_size`` values is owned
+        by a separate simulator issue.
+
+        :return: ``None``.
+        :rtype: None
+        """
+        history_size = self.history_size
+        if history_size is None:
+            return
+
+        if (
+            not isinstance(history_size, int)
+            or isinstance(history_size, bool)
+            or history_size < 0
+        ):
+            if len(self.history) > history_size:
+                self.history.pop(0)
+            return
+
+        while len(self.history) > history_size:
+            self.history.pop(0)
+
     @property
     def current_state(self) -> State:
         """
@@ -2965,9 +3012,16 @@ class SimulationRuntime:
         composite states in ``init_wait`` mode, this is the parent waiting for
         an initial transition.
 
+        Check :attr:`is_ended` before calling this property when a runtime may
+        have terminated. Once the runtime has ended, there is no active state
+        and the query raises :class:`SimulationRuntimeTerminalStateError`.
+
         :return: The current active state.
         :rtype: State
-        :raises IndexError: If the runtime has ended and the stack is empty.
+        :raises SimulationRuntimeTerminalStateError: If the runtime has ended
+            and the active stack is empty.
+        :raises RuntimeError: If the active stack is unexpectedly empty before
+            the runtime has ended.
 
         Example::
 
@@ -2999,16 +3053,21 @@ class SimulationRuntime:
         .. note::
            Before the first :meth:`cycle` call, this returns the root state.
            After the runtime has ended, accessing this property will raise
-           an IndexError.
+           :class:`SimulationRuntimeTerminalStateError`.
         """
         if not self.stack:
             if self._ended:
-                raise IndexError("Cannot access current_state: runtime has ended.")
-            else:
-                raise IndexError(
-                    "Cannot access current_state: runtime has not been initialized. "
-                    "This should not happen - the stack should be initialized in __init__."
+                raise SimulationRuntimeTerminalStateError(
+                    "Cannot access current_state: runtime has ended and the "
+                    "active stack is empty. Check is_ended before querying "
+                    "current_state, or use terminal-safe queries such as "
+                    "brief_stack or history."
                 )
+            raise RuntimeError(
+                "Cannot access current_state: runtime active stack is empty "
+                "before termination. This indicates an internal runtime "
+                "invariant failure."
+            )
         return self.stack[-1].state
 
     @property

--- a/test/fixtures/simulate_semantics/cases/expression_type_error_wraps_transition_effect.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_type_error_wraps_transition_effect.yaml
@@ -55,7 +55,7 @@ steps:
     stack:
     - path:
       - Root
-      mode: init_wait
+      mode: active
     - path:
       - Root
       - A

--- a/test/simulate/test_history_retention.py
+++ b/test/simulate/test_history_retention.py
@@ -1,0 +1,118 @@
+"""
+Unit tests for simulation history retention updates.
+"""
+
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.simulate import SimulationRuntime
+
+
+_HISTORY_DSL = """
+def int ticks = 0;
+state System {
+    state Idle {
+        during { ticks = ticks + 1; }
+    }
+    state Active {
+        during { ticks = ticks + 10; }
+    }
+    [*] -> Idle;
+    Idle -> Active :: Start;
+    Active -> Idle :: Stop;
+}
+"""
+
+
+def _build_runtime(**kwargs):
+    ast = parse_with_grammar_entry(_HISTORY_DSL, "state_machine_dsl")
+    return SimulationRuntime(parse_dsl_node_to_state_machine(ast), **kwargs)
+
+
+def _advance_to_cycle(runtime, cycle_count):
+    if runtime.cycle_count == 0 and cycle_count > 0:
+        runtime.cycle()
+
+    while runtime.cycle_count < cycle_count:
+        if runtime.current_state.name == "Idle":
+            runtime.cycle("System.Idle.Start")
+        else:
+            runtime.cycle("System.Active.Stop")
+
+
+def _history_cycles(runtime):
+    return [entry["cycle"] for entry in runtime.history]
+
+
+@pytest.mark.unittest
+def test_shrinking_unlimited_history_converges_on_next_successful_cycle():
+    runtime = _build_runtime()
+
+    _advance_to_cycle(runtime, 30)
+    assert len(runtime.history) == 30
+    assert _history_cycles(runtime) == list(range(1, 31))
+
+    runtime.history_size = 5
+    _advance_to_cycle(runtime, 31)
+
+    assert len(runtime.history) == 5
+    assert _history_cycles(runtime) == [27, 28, 29, 30, 31]
+
+    _advance_to_cycle(runtime, 70)
+
+    assert len(runtime.history) == 5
+    assert _history_cycles(runtime) == [66, 67, 68, 69, 70]
+
+
+@pytest.mark.unittest
+def test_constructor_history_size_retains_latest_entries():
+    runtime = _build_runtime(history_size=5)
+
+    _advance_to_cycle(runtime, 70)
+
+    assert len(runtime.history) == 5
+    assert _history_cycles(runtime) == [66, 67, 68, 69, 70]
+
+
+@pytest.mark.unittest
+def test_shrinking_integer_history_size_converges_on_next_successful_cycle():
+    runtime = _build_runtime(history_size=20)
+
+    _advance_to_cycle(runtime, 30)
+    assert len(runtime.history) == 20
+    assert _history_cycles(runtime) == list(range(11, 31))
+
+    runtime.history_size = 3
+    _advance_to_cycle(runtime, 31)
+
+    assert len(runtime.history) == 3
+    assert _history_cycles(runtime) == [29, 30, 31]
+
+
+@pytest.mark.unittest
+def test_zero_history_size_keeps_history_empty_after_successful_cycles():
+    runtime = _build_runtime()
+
+    _advance_to_cycle(runtime, 3)
+    assert len(runtime.history) == 3
+
+    runtime.history_size = 0
+    _advance_to_cycle(runtime, 4)
+    assert runtime.history == []
+
+    _advance_to_cycle(runtime, 5)
+    assert runtime.history == []
+
+
+@pytest.mark.unittest
+def test_widening_history_size_does_not_restore_discarded_entries():
+    runtime = _build_runtime(history_size=5)
+
+    _advance_to_cycle(runtime, 10)
+    assert _history_cycles(runtime) == [6, 7, 8, 9, 10]
+
+    runtime.history_size = 50
+    _advance_to_cycle(runtime, 11)
+
+    assert _history_cycles(runtime) == [6, 7, 8, 9, 10, 11]

--- a/test/simulate/test_terminal_query.py
+++ b/test/simulate/test_terminal_query.py
@@ -1,0 +1,96 @@
+"""
+Unit tests for terminal runtime query contracts.
+"""
+
+import re
+
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.simulate import SimulationRuntime, SimulationRuntimeTerminalStateError
+
+
+def _build_runtime(dsl_code, **kwargs):
+    ast = parse_with_grammar_entry(dsl_code, "state_machine_dsl")
+    return SimulationRuntime(parse_dsl_node_to_state_machine(ast), **kwargs)
+
+
+@pytest.mark.unittest
+def test_current_state_raises_terminal_state_error_after_runtime_ends():
+    runtime = _build_runtime(
+        """
+state Root {
+    state A;
+    [*] -> A;
+    A -> [*];
+}
+"""
+    )
+
+    runtime.cycle()
+    runtime.cycle()
+
+    assert runtime.is_ended is True
+    assert runtime.brief_stack == []
+    assert runtime.vars == {}
+    assert len(runtime.history) == 2
+    assert runtime.cycle_count == 2
+    assert runtime.is_error_state is False
+    assert runtime.error_info is None
+    assert runtime.abstract_handler_errors == []
+
+    with pytest.raises(
+        SimulationRuntimeTerminalStateError,
+        match=r"current_state.*ended.*is_ended",
+    ):
+        runtime.current_state
+
+
+@pytest.mark.unittest
+def test_terminal_state_error_remains_index_error_compatible():
+    runtime = _build_runtime(
+        """
+state Root {
+    state A;
+    [*] -> A;
+    A -> [*];
+}
+"""
+    )
+
+    runtime.cycle()
+    runtime.cycle()
+
+    with pytest.raises(IndexError) as exc_info:
+        runtime.current_state
+
+    assert isinstance(exc_info.value, SimulationRuntimeTerminalStateError)
+
+
+@pytest.mark.unittest
+def test_error_state_keeps_current_state_available():
+    runtime = _build_runtime(
+        """
+state Root {
+    state A {
+        enter abstract Boom;
+    }
+    [*] -> A;
+}
+""",
+        abstract_error_mode="raise",
+    )
+
+    def boom(_ctx):
+        raise RuntimeError("boom")
+
+    runtime.register_abstract_handler("Root.A.Boom", boom)
+
+    with pytest.raises(RuntimeError, match=re.escape("boom")):
+        runtime.cycle()
+
+    assert runtime.is_error_state is True
+    assert runtime.is_ended is False
+    assert runtime.current_state.path == ("Root",)
+    assert runtime.brief_stack == [(("Root",), "init_wait")]


### PR DESCRIPTION
# PR-4：修复 terminal query 与 history session metadata

关联上游伞 PR：[PR #186](https://github.com/HansBug/pyfcstm/pull/186)  
关联 issue：[issue #156](https://github.com/HansBug/pyfcstm/issues/156)  
本 PR 覆盖 PR-4 范围：`QUERY-1`、`HIST-3`。

## 目标与边界

本 PR 只处理 `pyfcstm.simulate` 本体的两个 public runtime contract：

| ID | 目标 | 上游来源 |
|---|---|---|
| `QUERY-1` | `SimulationRuntime.current_state` 在 runtime 已自然 ended 后不再只暴露 generic `IndexError`，改为 `pyfcstm.simulate` 自有 terminal-state 诊断异常，并在 pydoc 中明确 `is_ended` 前置条件。 | [issue #156 comment](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633445368) |
| `HIST-3` | 运行中把 `runtime.history_size` 从 `None` 或较大整数收紧为较小整数后，下一次成功 `cycle()` 必须把 `runtime.history` 一次性裁剪到新上限，保留最新 N 条。 | [issue #156 comment](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633030702) |

不处理：`HIST-1` 非 int / 负数 `history_size` 的正式诊断契约、`HIST-2` 外部直接篡改 `runtime.history` live list、PR-3 的 `cycle()` result 对象、PR-5 的 execution context metadata、PR-6/PR-7 handler registry / decorator 问题、template / generated runtime / CLI / entry / editor / jsfcstm / solver / render。

## 与上游状态的一致性

- base 分支必须是 `dev/issue156-simulate-fix-umbrella`。
- 当前 base 已包含 PR-0、PR-1、PR-2A：
  - PR-0 fixture / runner 事实源：[PR #187](https://github.com/HansBug/pyfcstm/pull/187)
  - PR-1 hot start / pseudo / DFS safety / stack 稳定化事实源：[PR #190](https://github.com/HansBug/pyfcstm/pull/190)
  - PR-2A 表达式诊断事实源：[PR #189](https://github.com/HansBug/pyfcstm/pull/189)
- PR-5 已另开 [PR #193](https://github.com/HansBug/pyfcstm/pull/193)，本 PR 不应接管 CTX / REF / REFMIX 语义。
- PR-3 已另开 [PR #188](https://github.com/HansBug/pyfcstm/pull/188)，本 PR 不应接管 `cycle()` result 或 event accounting 语义。
- 若本 PR 与已开启兄弟 PR 发生 conflict，先 merge / rebase 最新伞 PR 分支，再证明两个 PR 的 fixture schema、异常类、pydoc 与 public metadata 契约没有互相覆盖。尤其注意 `pyfcstm/simulate/__init__.py` 的 `__all__` 导出和 module docstring，不能在 rebase / conflict 处理中删掉兄弟 PR 的 public export。

## 复现 1：QUERY-1

### 最小 DSL

```fcstm
state Root {
    state A;
    [*] -> A;
    A -> [*];
}
```

### 最小复现代码

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r'''
state Root {
    state A;
    [*] -> A;
    A -> [*];
}
'''
model = parse_dsl_node_to_state_machine(
    parse_with_grammar_entry(DSL, 'state_machine_dsl')
)
runtime = SimulationRuntime(model)

runtime.cycle()  # 进入 Root.A
runtime.cycle()  # A -> [*]，runtime ended

print('is_ended =', runtime.is_ended)
print('brief_stack =', runtime.brief_stack)
try:
    print(runtime.current_state)
except Exception as err:
    print(type(err).__name__, str(err))
```

### 当前实际结果

```text
is_ended = True
brief_stack = []
IndexError Cannot access current_state: runtime has ended.
```

### 期望结果

- `runtime.current_state` 在 `runtime.is_ended is True` 后抛出 `pyfcstm.simulate` 自有的 terminal-state 异常：`SimulationRuntimeTerminalStateError`。
- `SimulationRuntimeTerminalStateError` 明确继承 `IndexError`，用于保留已有 `except IndexError` 调用方的兼容性；同时它是具名 simulate 异常，新增调用方可以精确捕获，不再依赖 message 字符串区分 runtime terminal contract 与普通列表越界。
- 异常 message 应说明：runtime 已结束、active stack 为空、调用方应先检查 `runtime.is_ended` 或使用 `brief_stack` / `history` 等 terminal-safe query。
- 未 ended 但 stack 为空的 internal-invariant 防御分支继续抛 `RuntimeError`，message 明确这是 runtime internal invariant failure，而不是 terminal state；该分支不新增 public exception 类型。
- `current_state` 保持返回类型 `State`，不采用 ended 后返回 `None` 的方案。理由是返回 `None` 会把 public contract 改成 `Optional[State]`，迫使所有调用方新增 None 分支；具名异常能在保留 `current_state -> State` 语义的同时给 terminal path 更清晰的诊断。

### 白盒原因

`SimulationRuntime.current_state` 目前直接在空 stack 上抛 `IndexError`：

```python
if not self.stack:
    if self._ended:
        raise IndexError("Cannot access current_state: runtime has ended.")
```

`cycle()` 在自然 ended 时会清空 stack 并设置 `_ended=True`，所以 production ended 路径稳定命中该 generic exception。调用方若想区分 runtime terminal contract 与自己代码的 list 越界，只能解析 message 字符串。

### 测试计划

- 新增 `test/simulate/test_terminal_query.py`，以单元测试覆盖 naturally ended 后访问 `current_state` 抛 `SimulationRuntimeTerminalStateError`。
- 覆盖 `SimulationRuntimeTerminalStateError` 是 `IndexError` 的 subclass，保证 legacy `except IndexError` 仍能捕获。
- 覆盖异常 message 包含 `current_state`、`ended`、`is_ended`。
- 覆盖 raise-mode handler error 这种 `is_error_state=True` 但 stack 仍存在的路径，确保 `current_state` 可继续返回当前 frame，不把 error-state 误当 ended。
- 明确不修改同族 terminal-safe query：`brief_stack`、`vars`、`history`、`cycle_count`、`is_error_state`、`error_info`、`abstract_handler_errors` 继续保持现有安全空值 / 末次提交快照行为。
- 补 pydoc：`SimulationRuntime.current_state` 的 `:raises:` 应写明 `SimulationRuntimeTerminalStateError` 和 internal-invariant `RuntimeError` 两个触发条件，并同步更新当前 docstring note 中 “raise an IndexError” 的旧说法。
- 新增 public exception 后，`pyfcstm/simulate/__init__.py` 需要导出，并保持 module roadmap / import surface 清晰。

## 复现 2：HIST-3

### 最小 DSL

```fcstm
def int ticks = 0;
state System {
    state Idle {
        during { ticks = ticks + 1; }
    }
    state Active {
        during { ticks = ticks + 10; }
    }
    [*] -> Idle;
    Idle -> Active :: Start;
    Active -> Idle :: Stop;
}
```

### 最小复现代码

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = r'''
def int ticks = 0;
state System {
    state Idle {
        during { ticks = ticks + 1; }
    }
    state Active {
        during { ticks = ticks + 10; }
    }
    [*] -> Idle;
    Idle -> Active :: Start;
    Active -> Idle :: Stop;
}
'''
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, 'state_machine_dsl'))
runtime = SimulationRuntime(model)

runtime.cycle()
for _ in range(29):
    if runtime.current_state.name == 'Idle':
        runtime.cycle('System.Idle.Start')
    else:
        runtime.cycle('System.Active.Stop')

print(len(runtime.history), runtime.history[0]['cycle'], runtime.history[-1]['cycle'])
runtime.history_size = 5
runtime.cycle('System.Idle.Start' if runtime.current_state.name == 'Idle' else 'System.Active.Stop')
print(len(runtime.history), [entry['cycle'] for entry in runtime.history])
```

### 当前实际结果

```text
30 1 30
30 [2, 3, 4, ..., 31]
```

`history_size` 已经是 `5`，但每次成功 `cycle()` 只 `pop(0)` 一条，因此历史长度会长期停在旧 backlog 长度，永远不收敛到新上限。

### 期望结果

```text
30 1 30
5 [27, 28, 29, 30, 31]
```

运行中收紧 `history_size` 后，下一次成功 cycle 应保留最新 N 条，使 `len(runtime.history) <= runtime.history_size`。继续运行时应滚动保持最新 N 条。

### 白盒原因

成功 cycle 末尾目前是 append 后单次 pop：

```python
self.history.append(history_entry)
if self.history_size is not None and len(self.history) > self.history_size:
    self.history.pop(0)
```

当旧长度远大于新上限时，append + 单次 pop 只保持旧长度，不会裁剪到新上限。

### 测试计划

- 新增 `test/simulate/test_history_retention.py`，以单元测试直接覆盖 history retention config 的运行期行为。
- 覆盖 unlimited history 跑到 30 条，再设置 `history_size = 5`，下一次成功 cycle 后断言长度为 5，cycles 为最新 `[27, 28, 29, 30, 31]`。
- 覆盖继续运行到 70 cycles 后仍滚动保持长度为 5，cycles 为最新 `[66, 67, 68, 69, 70]`。
- 覆盖 constructor 直接 `history_size=5` 的现有行为不变。
- 覆盖从较大整数收紧到较小整数，同样一次 cycle 裁剪到位。
- 覆盖 `history_size=0`：本 PR 明确把它定义为合法 int 边界，下一次成功 cycle 后清空 history，之后继续成功 cycle 仍保持空 history。
- 覆盖放宽 `history_size` 不重建已丢弃 entry，例如 `5 -> 50` 后只允许未来 history 继续增长，不会回填旧 entry。
- 不新增负数 / 非 int `history_size` 的正式诊断；这部分仍归 `HIST-1`。实现 helper 时必须避免切片或循环写法偶然把负数定义成新语义。

## 修复设计

### `QUERY-1`

1. 在 `pyfcstm/simulate/runtime.py` 新增自有异常类 `SimulationRuntimeTerminalStateError(IndexError)`，用于 ended runtime 上 active-state query 不可用的 public 诊断。
2. 该异常继承 `IndexError` 是有意的兼容策略：旧调用方继续能用 `except IndexError` 捕获；新调用方可改捕获 `SimulationRuntimeTerminalStateError`，避免依赖 message 字符串。
3. `current_state` 在 `self._ended and not self.stack` 时抛该异常，message 指导用户检查 `is_ended`。
4. `not self._ended and not self.stack` 的防御分支改为 `RuntimeError`，message 明确 internal invariant failure；不导出新的 internal-only 异常类。
5. 更新 `pyfcstm/simulate/__init__.py` 导出表，确保 public import 可用：`from pyfcstm.simulate import SimulationRuntimeTerminalStateError`。若与 PR-3 / PR-5 同时修改 `__init__.py`，后合并者必须保留所有新增导出。
6. 更新 pydoc，遵守 `CLAUDE.md`：class / function docstring 有清晰说明、`:raises:`、必要例子；不要把 PR 编号或 issue 编号写进 docstring / runtime message。

### `HIST-3`

1. 抽出 `_trim_history_to_size()` 私有 helper，集中处理 “`history_size is None` 不裁剪，否则保留最新 N 条”。
2. 成功 cycle append history entry 后调用 helper，一次性裁剪到位，而不是只 pop 一次。
3. `history_size == 0` 明确定义为合法边界：保留最新 0 条，即清空 history。
4. `history_size > 0` 时保留最新 N 条；`history_size` 从小值放宽到大值时不回填已丢弃 entry。
5. 负数 / 非 int `history_size` 不在本 PR 正式修复范围内。helper 实现需要保持它们不获得新的稳定语义：非 int 仍沿用现有比较路径触发原生错误；负数仍不作为合法 retention 值处理，避免借由 `history[-size:]` 之类写法定义出新行为。后续应由 `HIST-1` 统一收口。
6. 不改变 history entry schema、cycle_count 递增、vars snapshot、event list、rollback 语义。

## 测试组织方式

本 PR 使用两个独立单元测试文件，而不是新增 semantic fixture：

| 测试文件 | 覆盖内容 | 不使用 semantic fixture 的原因 |
|---|---|---|
| `test/simulate/test_terminal_query.py` | `current_state` ended 异常、legacy `IndexError` 兼容、error-state 反例、pydoc 相关 public import。 | 需要在 runtime ended 后直接访问 property 并断言异常类；这属于 public API query 行为，不是单个 cycle 的 DSL trace。 |
| `test/simulate/test_history_retention.py` | 运行期收紧 / 放宽 `history_size`、`history_size=0`、长尾滚动稳定性、constructor 初始上限不变。 | 需要在 cycles 之间直接修改 `runtime.history_size` 并断言完整 history list；PR-0 fixture runner 当前不是 session config mutation DSL。 |

仍需补跑 `test/simulate/test_semantic_fixtures.py`，证明 PR-0 fixture corpus 没有被破坏。

## 验收标准

### 计划阶段验收

| 检查 | 通过标准 |
|---|---|
| 三路计划 review | codex / claude / deepseek 均直接评论，C/I 清零。 |
| 范围一致性 | PR body 与 issue #156 的 `QUERY-1` / `HIST-3`、伞 PR #186 的 PR-4 行一致。 |
| 依赖一致性 | base 为 `dev/issue156-simulate-fix-umbrella`，且已包含 PR-0/#187、PR-1/#190、PR-2A/#189。 |

### 实现阶段验收

| 分类 | 命令 / 检查 | 通过标准 |
|---|---|---|
| TDD 红灯 | `pytest test/simulate/test_terminal_query.py -q`、`pytest test/simulate/test_history_retention.py -q` | 新增测试在实现前能复现旧问题。 |
| PR-4 精准回归 | `pytest test/simulate/test_terminal_query.py test/simulate/test_history_retention.py test/simulate/test_semantic_fixtures.py -q` | 全部通过。 |
| simulate 局部回归 | `pytest test/simulate/ -q` | 全部通过。 |
| 全量快速回归 | `SKIP_SLOW_TESTS=1 make unittest` | 全部通过，不跑慢速 C/C++ template tests。 |
| 文档生成 | `make rst_auto` | 通过；若新增 public exception 导致 RST 更新，必须同 commit 提交。 |
| CI | PR checks | 全部通过；commit message 使用 `[skip-slow]`，避免慢速矩阵拖延。 |
| review | codex / claude / deepseek 三路强对抗 review | C/I 必须清零；M 不阻塞但尽量修。 |

## 预期变更文件

| 路径 | 目的 |
|---|---|
| `pyfcstm/simulate/runtime.py` | 新增 terminal-state 异常、修改 `current_state`、新增 / 调用 history 裁剪 helper。 |
| `pyfcstm/simulate/__init__.py` | 导出新增 public exception；保持 `__all__` / module roadmap 清晰。 |
| `test/simulate/test_terminal_query.py` | QUERY-1 单元测试。 |
| `test/simulate/test_history_retention.py` | HIST-3 单元测试。 |
| `docs/source/api/...` 或自动生成 RST | `make rst_auto` 可能产生的 intentional 更新。 |

不预期修改 grammar、model、render、template、CLI、jsfcstm、Makefile。

## Mermaid 依赖图

```mermaid
flowchart TD
    U["伞 PR<br/>#156 simulate 修复拆分<br/>🟦 已开启"]:::active
    S0["PR-0<br/>共用 fixture 与诊断契约基线<br/>✅ 已完成（#187）"]:::done
    S1["PR-1<br/>hot start / pseudo / DFS safety<br/>✅ 已完成（#190）"]:::done
    S2A["PR-2A<br/>表达式运行时与诊断包装<br/>✅ 已完成（#189）"]:::done
    S4["PR-4<br/>terminal query 与 history metadata<br/>🟦 本 PR"]:::active
    S5["PR-5<br/>execution context 与 ref callsite<br/>🟦 已开启（#193）"]:::active
    S8["PR-8<br/>全集回归与 issue 收口同步<br/>📝 规划中"]:::planned

    U --> S0
    S0 --> S1
    S0 --> S2A
    S0 --> S4
    S0 --> S5
    S1 --> S8
    S2A --> S8
    S4 --> S8
    S5 --> S8

    classDef active fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef planned fill:#f3f4f6,stroke:#6b7280,color:#111827;
    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
    classDef blocked fill:#fee2e2,stroke:#dc2626,color:#111827;
```

## Review 要求

计划阶段 reviewer 需要重点检查：

- PR body 是否与 issue #156 的 `QUERY-1` / `HIST-3` 和伞 PR #186 的 PR-4 拆分一致。
- `current_state` 选择自有 terminal-state 异常是否符合伞 PR 验收，不应改为返回 `None`。
- `SimulationRuntimeTerminalStateError(IndexError)` 的兼容策略是否清楚：具名 simulate 异常 + legacy `except IndexError` 可捕获。
- `history_size` 的运行中收紧语义是否只覆盖合法 `None`、`0`、正整数，以及不越界处理 `HIST-1` 的非 int / 负数正式诊断。
- 是否与 PR-3 的 cycle result、PR-5 的 context metadata、PR-6/PR-7 handler registry 没有契约冲突。
- pydoc 是否符合 `CLAUDE.md`：public class / function 文档清晰，`:param:` / `:type:` / `:return:` / `:rtype:` / `:raises:` / `Example::` 按需齐全。
- 测试 / fixture / runtime message / docstring 里不得写 PR 编号、issue 编号、roadmap 阶段等工作流元数据。

## 计划 review 处理记录

| 来源 | 原问题 | 处理 |
|---|---|---|
| deepseek I-1 / I-2 | internal-invariant 分支异常未定，docstring `:raises:` 不完整。 | 明确 ended 分支抛 `SimulationRuntimeTerminalStateError`，internal-invariant 分支抛 `RuntimeError`；pydoc 要同时列出两类 `:raises:`。 |
| deepseek I-3 / claude I-2 | 新异常基类未定。 | 明确 `SimulationRuntimeTerminalStateError(IndexError)`，不新增公共基类。 |
| claude I-1 | 新异常替换 `IndexError` 的兼容策略未声明。 | 明确新异常继承 `IndexError`，保留 legacy `except IndexError` 兼容，同时提供具名 simulate 异常。 |
| claude I-3 / codex M-1 | helper 对负数 / 非 int 可能无意定义新语义。 | 明确非 int / 负数正式诊断留给 `HIST-1`；helper 不使用会给负数稳定语义的切片写法。 |
| claude I-4 | `history_size == 0` 决策自相矛盾。 | 明确 `0` 是合法边界，语义为清空 history，并纳入测试。 |
| claude I-5 / deepseek M-4 | 测试组织方式未定。 | 明确新增两个独立单元测试文件，不新增 semantic fixture，并解释原因。 |
| claude M-1 / M-2 / M-3 / M-4 / M-5 | 同族 query untouched、长尾 history、error-state 反例、pydoc note、放宽 history_size 未说明。 | 全部纳入测试计划、修复设计或 pydoc 要求。 |
