### PR TITLE
PR-7：修复 decorator scanner 与 session copy 契约

### DIFF
--- a/pyfcstm/simulate/decorators.py
+++ b/pyfcstm/simulate/decorators.py
@@ -2,12 +2,18 @@
 Decorators for abstract handler registration.
 
 This module provides decorators that allow users to define abstract handlers
-as methods in a class, making it easy to organize complex handler logic.
+as methods in a class, making it easy to organize complex handler logic. A
+single callable may be marked for multiple abstract actions, and handlers may
+be declared as instance methods, static methods, or class methods.
 
 The module contains the following main components:
 
-* :func:`abstract_handler` - Decorator to mark a method as an abstract handler.
-* :func:`register_handlers_from_object` - Register all decorated methods from an object.
+* :func:`abstract_handler` - Decorator to mark a callable as an abstract handler.
+* :func:`get_handler_metadata` - Return the first abstract action path for compatibility.
+* :func:`is_abstract_handler` - Check whether a callable has handler metadata.
+
+The runtime method :meth:`pyfcstm.simulate.runtime.SimulationRuntime.register_handlers_from_object`
+consumes this metadata and registers bound handlers on a runtime instance.
 
 Example::
 
@@ -30,10 +36,128 @@ Example::
     >>> runtime.register_handlers_from_object(handlers)
 """
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Tuple
 
 # Attribute name used to store handler metadata on decorated methods
 _HANDLER_METADATA_ATTR = '__abstract_handler_metadata__'
+
+
+def _metadata_targets(func: object) -> Tuple[object, ...]:
+    """
+    Return objects that should carry abstract-handler metadata.
+
+    ``staticmethod`` and ``classmethod`` wrap an underlying function. Metadata
+    is mirrored to both the descriptor and the underlying function when the
+    descriptor accepts custom attributes. ``property`` metadata is stored on
+    the getter so the scanner can reject it as an unsupported handler descriptor
+    without executing user code.
+
+    :param func: Callable or descriptor to annotate.
+    :type func: object
+    :return: Objects that should receive metadata.
+    :rtype: Tuple[object, ...]
+
+    Example::
+
+        >>> class Handlers:
+        ...     @staticmethod
+        ...     def handle(ctx):
+        ...         pass
+        >>> targets = _metadata_targets(Handlers.__dict__['handle'])
+        >>> len(targets) >= 1
+        True
+    """
+    targets = [func]
+    wrapped = getattr(func, "__func__", None)
+    if wrapped is not None:
+        targets.append(wrapped)
+
+    getter = getattr(func, "fget", None)
+    if getter is not None:
+        targets.append(getter)
+
+    return tuple(targets)
+
+
+def _get_handler_metadata_paths(func: object) -> Tuple[str, ...]:
+    """
+    Return all abstract action paths attached to a callable.
+
+    Metadata may be stored either as a single string or as a tuple of strings.
+    The tuple form allows one callable to handle multiple abstract actions,
+    while the string form keeps direct metadata inspection simple for single
+    action handlers.
+
+    :param func: Callable or descriptor to inspect.
+    :type func: object
+    :return: Abstract action paths attached to ``func``.
+    :rtype: Tuple[str, ...]
+
+    Example::
+
+        >>> @abstract_handler('System.Active.Init')
+        ... def my_handler(ctx):
+        ...     pass
+        >>> _get_handler_metadata_paths(my_handler)
+        ('System.Active.Init',)
+    """
+    value = getattr(func, _HANDLER_METADATA_ATTR, None)
+    if value is None:
+        wrapped = getattr(func, "__func__", None)
+        if wrapped is not None:
+            value = getattr(wrapped, _HANDLER_METADATA_ATTR, None)
+
+    if value is None:
+        getter = getattr(func, "fget", None)
+        if getter is not None:
+            value = getattr(getter, _HANDLER_METADATA_ATTR, None)
+
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    return tuple(value)
+
+
+def _set_handler_metadata_paths(func: object, paths: Tuple[str, ...]) -> None:
+    """
+    Store abstract action paths on a callable and supported descriptors.
+
+    :param func: Callable or descriptor to annotate.
+    :type func: object
+    :param paths: Abstract action paths to store.
+    :type paths: Tuple[str, ...]
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> def handler(ctx):
+        ...     pass
+        >>> _set_handler_metadata_paths(handler, ('System.Active.Init',))
+        >>> get_handler_metadata(handler)
+        'System.Active.Init'
+    """
+    value = paths[0] if len(paths) == 1 else paths
+    targets = _metadata_targets(func)
+    stored = False
+    for target in targets:
+        try:
+            setattr(target, _HANDLER_METADATA_ATTR, value)
+        except AttributeError:
+            # AttributeError: built-in descriptor wrappers such as
+            # ``staticmethod``, ``classmethod``, or ``property`` may reject
+            # custom attributes on some supported Python versions; their
+            # underlying callable target is also attempted in this loop.
+            if len(targets) == 1:
+                raise
+        else:
+            stored = True
+
+    if not stored:
+        raise AttributeError(
+            "abstract handler metadata could not be attached to %r" % (func,)
+        )
 
 
 def abstract_handler(action_path: str) -> Callable[[Callable], Callable]:
@@ -42,7 +166,9 @@ def abstract_handler(action_path: str) -> Callable[[Callable], Callable]:
 
     This decorator attaches metadata to the method, which can later be used by
     :meth:`SimulationRuntime.register_handlers_from_object` to automatically
-    register all handlers from a class instance.
+    register all handlers from a class instance. Applying the decorator more
+    than once to the same callable registers that callable for every decorated
+    action path in source order.
 
     :param action_path: The full path to the abstract action (e.g., 'System.Active.Init')
     :type action_path: str
@@ -70,8 +196,8 @@ def abstract_handler(action_path: str) -> Callable[[Callable], Callable]:
         raise ValueError('action_path cannot be empty')
 
     def decorator(func: Callable) -> Callable:
-        # Attach metadata to the function
-        setattr(func, _HANDLER_METADATA_ATTR, action_path)
+        paths = _get_handler_metadata_paths(func)
+        _set_handler_metadata_paths(func, (action_path,) + paths)
         return func
 
     return decorator
@@ -83,7 +209,7 @@ def get_handler_metadata(func: Callable) -> Optional[str]:
 
     :param func: The function to check
     :type func: Callable
-    :return: The action path if the function is decorated, None otherwise
+    :return: The first action path if the function is decorated, ``None`` otherwise.
     :rtype: Optional[str]
 
     Example::
@@ -94,7 +220,8 @@ def get_handler_metadata(func: Callable) -> Optional[str]:
         >>> get_handler_metadata(my_handler)
         'System.Active.Init'
     """
-    return getattr(func, _HANDLER_METADATA_ATTR, None)
+    paths = _get_handler_metadata_paths(func)
+    return paths[0] if paths else None
 
 
 def is_abstract_handler(func: Callable) -> bool:
@@ -114,4 +241,4 @@ def is_abstract_handler(func: Callable) -> bool:
         >>> is_abstract_handler(my_handler)
         True
     """
-    return hasattr(func, _HANDLER_METADATA_ATTR)
+    return bool(_get_handler_metadata_paths(func))

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -3517,6 +3517,13 @@ class SimulationRuntime:
         :rtype: None
         :raises ValueError: If the target runtime does not contain every named
             abstract action path registered in this runtime.
+
+        Example::
+
+            >>> replacement = SimulationRuntime(state_machine)
+            >>> runtime.copy_session_configuration_to(replacement)
+            >>> replacement.history_size == runtime.history_size
+            True
         """
         for action_path in self._abstract_handlers:
             try:
@@ -3821,6 +3828,10 @@ class SimulationRuntime:
                     continue
                 seen_names.add(name)
                 if name.startswith("__") and name.endswith("__"):
+                    # True dunder methods are language protocol hooks, not
+                    # handler declarations. Name-mangled private methods such
+                    # as ``__hidden`` appear as ``_ClassName__hidden`` and are
+                    # still eligible when explicitly decorated.
                     continue
                 if _get_handler_metadata_paths(raw_member):
                     members.append((name, raw_member))

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -96,6 +96,7 @@ Abstract handler registration::
 
 import copy
 import math
+import types
 import warnings
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -3514,7 +3515,21 @@ class SimulationRuntime:
         :type runtime: SimulationRuntime
         :return: ``None``.
         :rtype: None
+        :raises ValueError: If the target runtime does not contain every named
+            abstract action path registered in this runtime.
         """
+        for action_path in self._abstract_handlers:
+            try:
+                runtime._validate_abstract_action_path(action_path)
+            except ValueError as err:
+                # ValueError: target runtime path validation rejects a handler
+                # path that was valid for the source runtime but is not a named
+                # abstract action in the target model.
+                raise ValueError(
+                    "Cannot copy abstract handler session to target runtime: "
+                    "target runtime has no named abstract action %r" % action_path
+                ) from err
+
         runtime.history_size = self.history_size
         runtime._abstract_error_mode = self._abstract_error_mode
         runtime._abstract_handlers = {
@@ -3746,6 +3761,143 @@ class SimulationRuntime:
             and len(self._abstract_handlers[action_path]) > 0
         )
 
+    @staticmethod
+    def _is_supported_handler_member(member: object) -> bool:
+        """
+        Check whether a raw class member can be registered as a handler.
+
+        The object scanner supports plain functions, :class:`staticmethod`, and
+        :class:`classmethod`. Other descriptors with abstract-handler metadata
+        are rejected instead of being silently ignored, because the runtime
+        cannot safely bind them without executing user code.
+
+        :param member: Raw member from a class ``__dict__``.
+        :type member: object
+        :return: ``True`` if the member can be bound as a handler.
+        :rtype: bool
+
+        Example::
+
+            >>> def handler(ctx):
+            ...     pass
+            >>> SimulationRuntime._is_supported_handler_member(handler)
+            True
+        """
+        return isinstance(member, (types.FunctionType, staticmethod, classmethod))
+
+    @staticmethod
+    def _object_handler_members(obj: object) -> List[Tuple[str, object]]:
+        """
+        Return raw decorated handler members from an object.
+
+        Scanning raw class dictionaries avoids executing unrelated descriptors.
+        The most-derived class wins for overridden member names; inherited
+        decorated members with different names remain visible. Within each
+        class dictionary, Python's definition order is preserved.
+
+        :param obj: Object instance containing decorated handler members.
+        :type obj: object
+        :return: ``(name, raw_member)`` pairs for decorated members.
+        :rtype: List[Tuple[str, object]]
+
+        Example::
+
+            >>> class Handlers:
+            ...     @abstract_handler('System.Active.Init')
+            ...     def init(self, ctx):
+            ...         pass
+            >>> len(SimulationRuntime._object_handler_members(Handlers()))
+            1
+        """
+        from .decorators import _get_handler_metadata_paths
+
+        members: List[Tuple[str, object]] = []
+        seen_names = set()
+        for cls in obj.__class__.__mro__:
+            if cls is object:
+                continue
+            for name, raw_member in cls.__dict__.items():
+                if name in seen_names:
+                    continue
+                seen_names.add(name)
+                if name.startswith("__") and name.endswith("__"):
+                    continue
+                if _get_handler_metadata_paths(raw_member):
+                    members.append((name, raw_member))
+        return members
+
+    def _collect_object_handler_registrations(
+        self, obj: object
+    ) -> List[Tuple[str, Callable[[ReadOnlyExecutionContext], None], str]]:
+        """
+        Collect and validate decorated handlers from an object without mutation.
+
+        This collection step supports :meth:`register_handlers_from_object`.
+        It validates every action path and bindable member before the registry
+        is modified, preventing failed scans from leaving partial handler
+        registrations behind.
+
+        :param obj: Object instance containing decorated handler members.
+        :type obj: object
+        :return: ``(action_path, bound_handler, member_name)`` registrations.
+        :rtype: List[Tuple[str, Callable[[ReadOnlyExecutionContext], None], str]]
+        :raises ValueError: If a decorated member cannot be bound safely or any
+            action path is invalid for this runtime.
+
+        Example::
+
+            >>> registrations = runtime._collect_object_handler_registrations(handlers)
+            >>> all(len(item) == 3 for item in registrations)
+            True
+        """
+        from .decorators import _get_handler_metadata_paths
+
+        registrations: List[
+            Tuple[str, Callable[[ReadOnlyExecutionContext], None], str]
+        ] = []
+        for name, raw_member in self._object_handler_members(obj):
+            action_paths = _get_handler_metadata_paths(raw_member)
+            if not self._is_supported_handler_member(raw_member):
+                raise ValueError(
+                    "Abstract handler member %s.%s uses unsupported descriptor "
+                    "type %s"
+                    % (obj.__class__.__name__, name, type(raw_member).__name__)
+                )
+
+            bound_handler = getattr(obj, name)
+            if not callable(bound_handler):
+                raise ValueError(
+                    "Abstract handler member %s.%s did not bind to a callable"
+                    % (obj.__class__.__name__, name)
+                )
+
+            for action_path in action_paths:
+                registrations.append(
+                    (
+                        self._validate_abstract_action_path(action_path),
+                        bound_handler,
+                        name,
+                    )
+                )
+
+        seen_keys = set()
+        existing_keys = {
+            (action_path, self._handler_identity(handler))
+            for action_path, handlers in self._abstract_handlers.items()
+            for handler in handlers
+        }
+        for action_path, handler, name in registrations:
+            key = (action_path, self._handler_identity(handler))
+            if key in existing_keys or key in seen_keys:
+                raise ValueError(
+                    "Abstract handler member %s.%s is already registered for "
+                    "named abstract action %r"
+                    % (obj.__class__.__name__, name, action_path)
+                )
+            seen_keys.add(key)
+
+        return registrations
+
     def register_handlers_from_object(self, obj: object) -> int:
         """
         Register all decorated methods from an object as abstract handlers.
@@ -3794,39 +3946,28 @@ class SimulationRuntime:
            Only methods decorated with :func:`~pyfcstm.simulate.decorators.abstract_handler`
            will be registered. Other methods are ignored.
         """
-        from .decorators import get_handler_metadata
+        registrations = self._collect_object_handler_registrations(obj)
 
-        registered_count = 0
-
-        # Iterate through all attributes of the object
-        for name in dir(obj):
-            # Skip private/magic methods
-            if name.startswith("_"):
-                continue
-
-            try:
-                attr = getattr(obj, name)
-            except AttributeError:
-                continue
-
-            # Check if it's a callable method
-            if not callable(attr):
-                continue
-
-            # Check if it has handler metadata
-            action_path = get_handler_metadata(attr)
-            if action_path is None:
-                continue
-
-            # Register the bound method
-            self.register_abstract_handler(action_path, attr)
-            registered_count += 1
-            self.logger.debug(
-                f"Registered method {name} from {obj.__class__.__name__} "
-                f"for action {action_path}"
-            )
+        registry_snapshot = {
+            action_path: list(handlers)
+            for action_path, handlers in self._abstract_handlers.items()
+        }
+        try:
+            for action_path, handler, name in registrations:
+                self.register_abstract_handler(action_path, handler)
+                self.logger.debug(
+                    f"Registered method {name} from {obj.__class__.__name__} "
+                    f"for action {action_path}"
+                )
+        except ValueError:
+            # ValueError: register_abstract_handler may still reject a
+            # registration if registry contents change after collection or
+            # validation policy tightens; restore the pre-scan registry to keep
+            # object registration atomic.
+            self._abstract_handlers = registry_snapshot
+            raise
 
         self.logger.info(
-            f"Registered {registered_count} handler(s) from {obj.__class__.__name__}"
+            f"Registered {len(registrations)} handler(s) from {obj.__class__.__name__}"
         )
-        return registered_count
+        return len(registrations)

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -3508,7 +3508,9 @@ class SimulationRuntime:
         Command-line ``init`` and ``clear`` rebuild a runtime while preserving
         the user's session-level configuration. This helper copies only that
         configuration: history retention, abstract-handler error mode, and
-        registered abstract handlers. Execution history, warning records, and
+        registered abstract handlers. The target handler registry is replaced
+        with this runtime's registry so rebuilt sessions do not retain stale
+        target-only handlers. Execution history, warning records, and
         error-state diagnostics are intentionally not copied.
 
         :param runtime: Target runtime that should receive session settings.
@@ -3800,12 +3802,17 @@ class SimulationRuntime:
         Scanning raw class dictionaries avoids executing unrelated descriptors.
         The most-derived class wins for overridden member names; inherited
         decorated members with different names remain visible. Within each
-        class dictionary, Python's definition order is preserved.
+        class dictionary, Python's definition order is preserved. Unsupported
+        descriptor metadata, including metadata mirrored to a ``property``
+        getter, is detected from the raw class dictionary without invoking
+        descriptor code.
 
         :param obj: Object instance containing decorated handler members.
         :type obj: object
         :return: ``(name, raw_member)`` pairs for decorated members.
         :rtype: List[Tuple[str, object]]
+        :raises ValueError: If a language-level dunder protocol method is
+            explicitly decorated as an abstract handler.
 
         Example::
 
@@ -3827,13 +3834,22 @@ class SimulationRuntime:
                 if name in seen_names:
                     continue
                 seen_names.add(name)
+                action_paths = _get_handler_metadata_paths(raw_member)
                 if name.startswith("__") and name.endswith("__"):
                     # True dunder methods are language protocol hooks, not
                     # handler declarations. Name-mangled private methods such
                     # as ``__hidden`` appear as ``_ClassName__hidden`` and are
-                    # still eligible when explicitly decorated.
+                    # still eligible when explicitly decorated. If a true
+                    # dunder method is explicitly decorated, report that
+                    # mismatch instead of silently dropping user intent.
+                    if action_paths:
+                        raise ValueError(
+                            "Abstract handler member %s.%s uses a reserved "
+                            "dunder protocol name"
+                            % (obj.__class__.__name__, name)
+                        )
                     continue
-                if _get_handler_metadata_paths(raw_member):
+                if action_paths:
                     members.append((name, raw_member))
         return members
 
@@ -3920,10 +3936,14 @@ class SimulationRuntime:
         This provides a convenient way to organize multiple related handlers
         in a single class, maintaining state and shared logic between handlers.
 
-        :param obj: Object instance containing decorated handler methods
+        :param obj: Object instance containing decorated handler methods.
         :type obj: object
-        :return: Number of handlers registered
+        :return: Number of handlers registered.
         :rtype: int
+        :raises ValueError: If any decorated member uses an unsupported
+            descriptor shape, reserved dunder protocol name, duplicate handler
+            registration, or action path that is not a named abstract action in
+            this runtime's model.
 
         Example::
 

--- a/test/simulate/test_abstract_handlers.py
+++ b/test/simulate/test_abstract_handlers.py
@@ -1316,3 +1316,75 @@ class TestAbstractHandlerUtilities:
                 'Root.A.SecondRef',
             ),
         ]
+
+    def test_copy_session_configuration_rejects_incompatible_handler_paths(self):
+        """Test handler registry copy rejects incompatible targets atomically."""
+        source_dsl = '''
+        state Root {
+            state A {
+                enter abstract Init;
+            }
+
+            [*] -> A;
+        }
+        '''
+        target_dsl = '''
+        state Root {
+            state A;
+
+            [*] -> A;
+        }
+        '''
+        source_ast = parse_with_grammar_entry(source_dsl, 'state_machine_dsl')
+        target_ast = parse_with_grammar_entry(target_dsl, 'state_machine_dsl')
+        source_sm = parse_dsl_node_to_state_machine(source_ast)
+        target_sm = parse_dsl_node_to_state_machine(target_ast)
+        source = SimulationRuntime(
+            source_sm, history_size=7, abstract_error_mode='log'
+        )
+        target = SimulationRuntime(
+            target_sm, history_size=3, abstract_error_mode='raise'
+        )
+
+        def handler(ctx: ReadOnlyExecutionContext):
+            pass
+
+        source.register_abstract_handler('Root.A.Init', handler)
+
+        with pytest.raises(ValueError, match='target runtime'):
+            source.copy_session_configuration_to(target)
+
+        assert target.history_size == 3
+        assert target.abstract_error_mode == 'raise'
+        assert target.get_abstract_handlers('Root.A.Init') == []
+
+    def test_copy_session_configuration_preserves_compatible_handlers(self):
+        """Test compatible session configuration copy remains supported."""
+        dsl_code = '''
+        state Root {
+            state A {
+                enter abstract Init;
+            }
+
+            [*] -> A;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        source = SimulationRuntime(sm, history_size=7, abstract_error_mode='log')
+        target = SimulationRuntime(sm, history_size=3, abstract_error_mode='raise')
+
+        calls = []
+
+        def handler(ctx: ReadOnlyExecutionContext):
+            calls.append(ctx.action_name)
+
+        source.register_abstract_handler('Root.A.Init', handler)
+        source.copy_session_configuration_to(target)
+
+        assert target.history_size == 7
+        assert target.abstract_error_mode == 'log'
+        assert target.get_abstract_handlers('Root.A.Init') == [handler]
+
+        target.cycle()
+        assert calls == ['Root.A.Init']

--- a/test/simulate/test_handler_decorator.py
+++ b/test/simulate/test_handler_decorator.py
@@ -398,3 +398,321 @@ class TestAbstractHandlerDecorator:
         # Pre should see counter before increment, post after
         assert handlers.pre_calls == [0, 1, 2]
         assert handlers.post_calls == [1, 2, 3]
+
+    def test_object_scanner_preserves_declaration_order(self):
+        """Test decorated object handlers follow class declaration order."""
+        dsl_code = '''
+        state System {
+            state Active {
+                enter abstract Init;
+            }
+
+            [*] -> Active;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class OrderedHandlers:
+            def __init__(self):
+                self.calls = []
+
+            @abstract_handler('System.Active.Init')
+            def z_declared_first(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append('z_declared_first')
+
+            @abstract_handler('System.Active.Init')
+            def a_declared_second(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append('a_declared_second')
+
+        handlers = OrderedHandlers()
+        count = runtime.register_handlers_from_object(handlers)
+
+        assert count == 2
+        assert [
+            handler.__name__
+            for handler in runtime.get_abstract_handlers('System.Active.Init')
+        ] == ['z_declared_first', 'a_declared_second']
+
+        runtime.cycle()
+        assert handlers.calls == ['z_declared_first', 'a_declared_second']
+
+    def test_object_scanner_skips_non_handler_descriptors_atomically(self):
+        """Test object scanning does not execute unrelated descriptors."""
+        dsl_code = '''
+        state System {
+            state Active {
+                enter abstract Init;
+            }
+
+            [*] -> Active;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class DescriptorBombHandlers:
+            def __init__(self):
+                self.calls = []
+
+            @abstract_handler('System.Active.Init')
+            def handle(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append('handle')
+
+            @property
+            def public_config(self):
+                raise RuntimeError('public_config getter should not run')
+
+        handlers = DescriptorBombHandlers()
+        count = runtime.register_handlers_from_object(handlers)
+
+        assert count == 1
+        assert [
+            handler.__name__
+            for handler in runtime.get_abstract_handlers('System.Active.Init')
+        ] == ['handle']
+
+        runtime.cycle()
+        assert handlers.calls == ['handle']
+
+    def test_object_scanner_rejects_decorated_unsupported_descriptor(self):
+        """Test decorated unsupported descriptors fail without partial registration."""
+        dsl_code = '''
+        state Root {
+            state A {
+                enter abstract Supported;
+                enter abstract Unsupported;
+            }
+
+            [*] -> A;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class DescriptorHandlers:
+            @abstract_handler('Root.A.Supported')
+            def supported(self, ctx: ReadOnlyExecutionContext):
+                pass
+
+            @property
+            @abstract_handler('Root.A.Unsupported')
+            def unsupported(self):
+                raise RuntimeError('decorated property getter should not run')
+
+        with pytest.raises(ValueError, match='unsupported descriptor'):
+            runtime.register_handlers_from_object(DescriptorHandlers())
+
+        assert runtime.get_abstract_handlers('Root.A.Supported') == []
+        assert runtime.get_abstract_handlers('Root.A.Unsupported') == []
+
+    def test_object_scanner_rolls_back_failed_bulk_registration(self):
+        """Test invalid decorated paths do not partially modify registry."""
+        dsl_code = '''
+        state System {
+            state Active {
+                enter abstract Init;
+            }
+
+            [*] -> Active;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class InvalidHandlers:
+            @abstract_handler('System.Active.Init')
+            def valid(self, ctx: ReadOnlyExecutionContext):
+                pass
+
+            @abstract_handler('System.Active.Missing')
+            def invalid(self, ctx: ReadOnlyExecutionContext):
+                pass
+
+        with pytest.raises(ValueError, match='named abstract action'):
+            runtime.register_handlers_from_object(InvalidHandlers())
+
+        assert runtime.get_abstract_handlers('System.Active.Init') == []
+        assert runtime.get_abstract_handlers('System.Active.Missing') == []
+
+    def test_multiple_abstract_handler_decorators_register_all_paths(self):
+        """Test stacked abstract-handler decorators keep every action path."""
+        dsl_code = '''
+        def int ticks = 0;
+
+        state System {
+            state Active {
+                enter abstract InitA;
+                during abstract MonitorB;
+                during { ticks = ticks + 1; }
+            }
+
+            [*] -> Active;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class Handlers:
+            def __init__(self):
+                self.calls = []
+
+            @abstract_handler('System.Active.InitA')
+            @abstract_handler('System.Active.MonitorB')
+            def shared(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append(ctx.action_name)
+
+        handlers = Handlers()
+        count = runtime.register_handlers_from_object(handlers)
+
+        assert count == 2
+        assert len(runtime.get_abstract_handlers('System.Active.InitA')) == 1
+        assert len(runtime.get_abstract_handlers('System.Active.MonitorB')) == 1
+
+        runtime.cycle()
+        assert handlers.calls == ['System.Active.InitA', 'System.Active.MonitorB']
+
+    def test_descriptor_decorator_orders_register_static_and_class_methods(self):
+        """Test staticmethod and classmethod decorator orders are supported."""
+        dsl_code = '''
+        state Root {
+            state A {
+                enter abstract StaticOuter;
+                during abstract StaticInner;
+                during abstract ClassOuter;
+                during abstract ClassInner;
+            }
+
+            [*] -> A;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class Handlers:
+            calls = []
+
+            @abstract_handler('Root.A.StaticOuter')
+            @staticmethod
+            def static_outer(ctx: ReadOnlyExecutionContext):
+                Handlers.calls.append(('static_outer', ctx.action_name))
+
+            @staticmethod
+            @abstract_handler('Root.A.StaticInner')
+            def static_inner(ctx: ReadOnlyExecutionContext):
+                Handlers.calls.append(('static_inner', ctx.action_name))
+
+            @abstract_handler('Root.A.ClassOuter')
+            @classmethod
+            def class_outer(cls, ctx: ReadOnlyExecutionContext):
+                cls.calls.append(('class_outer', ctx.action_name, cls.__name__))
+
+            @classmethod
+            @abstract_handler('Root.A.ClassInner')
+            def class_inner(cls, ctx: ReadOnlyExecutionContext):
+                cls.calls.append(('class_inner', ctx.action_name, cls.__name__))
+
+        count = runtime.register_handlers_from_object(Handlers())
+
+        assert count == 4
+        runtime.cycle()
+        assert Handlers.calls == [
+            ('static_outer', 'Root.A.StaticOuter'),
+            ('static_inner', 'Root.A.StaticInner'),
+            ('class_outer', 'Root.A.ClassOuter', 'Handlers'),
+            ('class_inner', 'Root.A.ClassInner', 'Handlers'),
+        ]
+
+    def test_decorated_private_methods_are_registered(self):
+        """Test decorated private methods are not silently skipped."""
+        dsl_code = '''
+        state Root {
+            state A {
+                enter abstract Hidden;
+            }
+
+            [*] -> A;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class PrivateHandlers:
+            def __init__(self):
+                self.calls = []
+
+            @abstract_handler('Root.A.Hidden')
+            def _hidden(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append(ctx.action_name)
+
+            @property
+            def _ignored_property(self):
+                raise RuntimeError('private property should not run')
+
+        handlers = PrivateHandlers()
+        count = runtime.register_handlers_from_object(handlers)
+
+        assert count == 1
+        runtime.cycle()
+        assert handlers.calls == ['Root.A.Hidden']
+
+    def test_object_scanner_inherited_handlers_use_override_order(self):
+        """Test inherited decorated handlers use stable override rules."""
+        dsl_code = '''
+        state Root {
+            state A {
+                enter abstract Parent;
+                enter abstract Child;
+                enter abstract Shared;
+            }
+
+            [*] -> A;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class ParentHandlers:
+            def __init__(self):
+                self.calls = []
+
+            @abstract_handler('Root.A.Parent')
+            def parent(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append(('parent', ctx.action_name))
+
+            @abstract_handler('Root.A.Shared')
+            def shared(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append(('parent_shared', ctx.action_name))
+
+        class ChildHandlers(ParentHandlers):
+            @abstract_handler('Root.A.Child')
+            def child(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append(('child', ctx.action_name))
+
+            @abstract_handler('Root.A.Shared')
+            def shared(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append(('child_shared', ctx.action_name))
+
+        handlers = ChildHandlers()
+        count = runtime.register_handlers_from_object(handlers)
+
+        assert count == 3
+        assert [
+            handler.__name__
+            for handler in runtime.get_abstract_handlers('Root.A.Shared')
+        ] == ['shared']
+
+        runtime.cycle()
+        assert handlers.calls == [
+            ('parent', 'Root.A.Parent'),
+            ('child', 'Root.A.Child'),
+            ('child_shared', 'Root.A.Shared'),
+        ]

--- a/test/simulate/test_handler_decorator.py
+++ b/test/simulate/test_handler_decorator.py
@@ -663,8 +663,8 @@ class TestAbstractHandlerDecorator:
         runtime.cycle()
         assert handlers.calls == ['Root.A.Hidden']
 
-    def test_decorated_dunder_methods_are_ignored_as_protocol_hooks(self):
-        """Test decorated true dunder methods remain outside object scanning."""
+    def test_decorated_dunder_methods_raise_clear_error(self):
+        """Test decorated true dunder methods report unsupported handler names."""
         dsl_code = '''
         state Root {
             state A {
@@ -687,9 +687,9 @@ class TestAbstractHandlerDecorator:
                 self.calls.append(ctx.action_name)
 
         handlers = CallableHandlers()
-        count = runtime.register_handlers_from_object(handlers)
+        with pytest.raises(ValueError, match='reserved dunder protocol name'):
+            runtime.register_handlers_from_object(handlers)
 
-        assert count == 0
         runtime.cycle()
         assert handlers.calls == []
 

--- a/test/simulate/test_handler_decorator.py
+++ b/test/simulate/test_handler_decorator.py
@@ -663,6 +663,36 @@ class TestAbstractHandlerDecorator:
         runtime.cycle()
         assert handlers.calls == ['Root.A.Hidden']
 
+    def test_decorated_dunder_methods_are_ignored_as_protocol_hooks(self):
+        """Test decorated true dunder methods remain outside object scanning."""
+        dsl_code = '''
+        state Root {
+            state A {
+                enter abstract Call;
+            }
+
+            [*] -> A;
+        }
+        '''
+        ast = parse_with_grammar_entry(dsl_code, 'state_machine_dsl')
+        sm = parse_dsl_node_to_state_machine(ast)
+        runtime = SimulationRuntime(sm)
+
+        class CallableHandlers:
+            def __init__(self):
+                self.calls = []
+
+            @abstract_handler('Root.A.Call')
+            def __call__(self, ctx: ReadOnlyExecutionContext):
+                self.calls.append(ctx.action_name)
+
+        handlers = CallableHandlers()
+        count = runtime.register_handlers_from_object(handlers)
+
+        assert count == 0
+        runtime.cycle()
+        assert handlers.calls == []
+
     def test_object_scanner_inherited_handlers_use_override_order(self):
         """Test inherited decorated handlers use stable override rules."""
         dsl_code = '''


### PR DESCRIPTION
# PR-7：修复 decorator / object scanner 与 session copy 契约

关联：伞 PR [#186](https://github.com/HansBug/pyfcstm/pull/186)，issue [#156](https://github.com/HansBug/pyfcstm/issues/156)。本 PR 是 #156 的 PR-7 子 PR，负责 `pyfcstm.simulate` 本体中的 decorator-based abstract handler scanner 与 session configuration copy 契约。

## 状态

🧪 实现已推送，等待 CI 与三路强对抗实现 review。当前提交已完成 TDD、`make rst_auto`、simulate 精准测试和本地快线回归；review 后若仍有 C/I 级问题将继续修复迭代。

## 范围边界

- 只改 `pyfcstm/simulate/` 及其 API doc / RST 生成结果。
- 测试只落在 `test/simulate/`，必要时复用 `test/fixtures/simulate_semantics/` 和 `test/testings/simulate_semantics.py`，不得新建割裂测试框架。
- 不改 template / generated runtime / CLI / entry / jsfcstm / editor / render / solver / Makefile。
- 不把 PR 编号、issue 编号、roadmap 阶段等 workflow metadata 写入代码标识符、fixture id、runtime message、docstring 或 pydoc。
- 实现前、ready 前都必须 merge 最新伞分支 `origin/dev/issue156-simulate-fix-umbrella`；如有 conflict 主线自行处理，reviewer 必须检查处理是否正确。

## 子问题分工与验收表

| ID | 上游 comment | 问题简述 | 期望结果 | 主要测试落点 | 状态 |
|---|---|---|---|---|---|
| `AH-4` | [AH-4](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632691038) | `register_handlers_from_object()` 用 `dir()` + `getattr()` 扫描对象，执行 public property / descriptor；descriptor 抛错后已注册 handler 半提交；同一 action 多 method 顺序被字母序打乱。 | scanner 不 eager 执行无关 descriptor；按 class declaration order 注册 decorated handlers；扫描或注册失败时不污染 registry。 | `test/simulate/test_handler_decorator.py`：descriptor safety、declaration order、atomic failure。 | 🧪 已实现待 review |
| `DECOR-1` | [DECOR-1](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632841666) | 同一 callable 叠加多个 `@abstract_handler(...)` 时 metadata 被后一次覆盖，路径静默丢失。 | 支持同一 callable 对应多个 abstract action path；或明确拒绝。按 maintainer 批示，本 PR 选择支持多 path，且 path 顺序稳定。 | `test/simulate/test_handler_decorator.py`：multi-path decorator registration。 | 🧪 已实现待 review |
| `DECOR-2` | [DECOR-2](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633179055) | `@abstract_handler` 标注在 `staticmethod` / `classmethod` descriptor 外层时装饰成功但 object scanner 注册 0 个 handler。 | 支持 descriptor 外层和内层两种装饰顺序；如果未来新增无法支持的 descriptor，应明确拒绝而不是静默漏注册。 | `test/simulate/test_handler_decorator.py`：staticmethod / classmethod decorator order matrix。 | 🧪 已实现待 review |
| `DECOR-3` | [DECOR-3](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633581345) | decorated `_private` / `__private` method 被 scanner 因 name startswith `_` 跳过，装饰成功但静默漏注册。 | decorated private methods 应被注册；未装饰 private/magic 成员仍应忽略且不执行。 | `test/simulate/test_handler_decorator.py`：private decorated method registration。 | 🧪 已实现待 review |
| `COPY-1` | [COPY-1](https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633210519) | `copy_session_configuration_to()` 跨不同 model / session 复制 handler registry 时，source path 在 target 中可能变成 dead bucket。 | copy 前校验 target runtime 是否存在每个 named abstract action path；不兼容时抛可读 `ValueError` 且 target 不半更新；兼容 model 正常复制 history_size、error mode 和 handlers。 | `test/simulate/test_abstract_handlers.py`：copy session compatibility / atomic rejection。 | 🧪 已实现待 review |

## Mermaid 依赖图

```mermaid
flowchart TD
    U["伞 PR #186<br/>simulate 修复拆分<br/>🟦 已开启"]:::active
    S6["PR-6 #191<br/>handler registry / warning metadata<br/>✅ 已完成"]:::done
    S7["PR-7 本 PR<br/>decorator scanner 与 session copy<br/>🧪 已实现待 review"]:::active
    S8["PR-8<br/>全集回归与 issue 收口同步<br/>📝 后续"]:::planned

    U --> S6
    S6 --> S7
    S7 --> S8

    classDef active fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef planned fill:#fef3c7,stroke:#d97706,color:#111827;
    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
```

## 最小复现与期望 / 实际

### `AH-4`：object scanner 执行 descriptor、失败半提交、顺序漂移

DSL：

```fcstm
state System {
    state Active {
        enter abstract Init;
    }
    [*] -> Active;
}
```

Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime, ReadOnlyExecutionContext, abstract_handler

DSL = """
state System {
    state Active {
        enter abstract Init;
    }
    [*] -> Active;
}
"""


def build():
    return parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))


class OrderedHandlers:
    def __init__(self):
        self.calls = []

    @abstract_handler("System.Active.Init")
    def z_declared_first(self, ctx: ReadOnlyExecutionContext):
        self.calls.append("z_declared_first")

    @abstract_handler("System.Active.Init")
    def a_declared_second(self, ctx: ReadOnlyExecutionContext):
        self.calls.append("a_declared_second")


runtime = SimulationRuntime(build())
ordered = OrderedHandlers()
runtime.register_handlers_from_object(ordered)
runtime.cycle()
print(ordered.calls)


class PropertyBombHandlers:
    def __init__(self):
        self.calls = []

    @abstract_handler("System.Active.Init")
    def handle(self, ctx: ReadOnlyExecutionContext):
        self.calls.append("handle")

    @property
    def public_config(self):
        raise RuntimeError("public_config getter should not run during handler scan")


runtime = SimulationRuntime(build())
bomb = PropertyBombHandlers()
try:
    runtime.register_handlers_from_object(bomb)
except RuntimeError as exc:
    print(type(exc).__name__, str(exc))
print([handler.__name__ for handler in runtime.get_abstract_handlers("System.Active.Init")])
runtime.cycle()
print(bomb.calls)
```

当前实际：顺序为 `['a_declared_second', 'z_declared_first']`；property getter 被执行并抛 `RuntimeError`；异常后 registry 仍残留 `handle`，后续 cycle 调用它。  
期望：顺序按 class declaration order；非 handler property 不被执行；若扫描 / 注册失败，registry 不半提交。

白盒原因：当前 scanner 使用 `dir(obj)` 得到字母序名字，再对每个 public name 做 `getattr(obj, name)`；这会执行 descriptor，也无法保持声明顺序；注册是边扫边写，异常没有 rollback。

### `DECOR-1`：多重 `@abstract_handler` 路径丢失

DSL：

```fcstm
def int ticks = 0;
state System {
    state Active {
        enter abstract InitA;
        during abstract MonitorB;
        during { ticks = ticks + 1; }
    }
    [*] -> Active;
}
```

Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime, abstract_handler

DSL = """
def int ticks = 0;
state System {
    state Active {
        enter abstract InitA;
        during abstract MonitorB;
        during { ticks = ticks + 1; }
    }
    [*] -> Active;
}
"""

model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))

class Handlers:
    def __init__(self):
        self.calls = []

    @abstract_handler("System.Active.InitA")
    @abstract_handler("System.Active.MonitorB")
    def shared(self, ctx):
        self.calls.append(ctx.action_name)

runtime = SimulationRuntime(model)
handlers = Handlers()
print(runtime.register_handlers_from_object(handlers))
runtime.cycle()
print(handlers.calls)
```

当前实际：只注册一个 path，另一个 abstract action 静默无 handler。  
期望：注册两个 path；第一轮 cycle 中 `InitA` 与 `MonitorB` 都可调用同一 callable。

白盒原因：decorator metadata 当前是单个 string，第二次 decorator 覆盖第一次 metadata。

### `DECOR-2`：descriptor 外层装饰静默漏注册

DSL：

```fcstm
state Root {
    state A {
        enter abstract H;
    }
    [*] -> A;
}
```

Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime, abstract_handler

DSL = """
state Root {
    state A {
        enter abstract H;
    }
    [*] -> A;
}
"""
PATH = "Root.A.H"
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))

class StaticOuter:
    calls = []

    @abstract_handler(PATH)
    @staticmethod
    def h(ctx):
        StaticOuter.calls.append(ctx.action_name)

class ClassOuter:
    calls = []

    @abstract_handler(PATH)
    @classmethod
    def h(cls, ctx):
        cls.calls.append((cls.__name__, ctx.action_name))

for cls in (StaticOuter, ClassOuter):
    runtime = SimulationRuntime(model)
    count = runtime.register_handlers_from_object(cls())
    runtime.cycle()
    print(cls.__name__, count, cls.calls)
```

当前实际：descriptor 外层装饰可创建 metadata，但 scanner 注册 0 个 handler。  
期望：staticmethod / classmethod 外层和内层装饰顺序均可注册并执行；至少不能静默漏注册。

白盒原因：metadata 挂在 raw descriptor 或 underlying function 上时，当前 scanner 只看 `getattr()` 之后的 callable，无法统一识别 descriptor metadata。

### `DECOR-3`：decorated private method 静默漏注册

DSL 同 `DECOR-2`。

Python 复现：

```python
class PrivateHandlers:
    def __init__(self):
        self.calls = []

    @abstract_handler("Root.A.H")
    def _hidden(self, ctx):
        self.calls.append(ctx.action_name)

runtime = SimulationRuntime(model)
handlers = PrivateHandlers()
print(runtime.register_handlers_from_object(handlers))
runtime.cycle()
print(handlers.calls)
```

当前实际：注册数为 0，handler 不执行。  
期望：decorated private method 被注册；未装饰 private/magic 成员继续忽略且不触发 descriptor。

白盒原因：scanner 在检查 decorator metadata 前先跳过所有 `name.startswith("_")` 的成员，导致 decorated private method 静默丢失。

### `COPY-1`：跨 model copy 产生 target dead bucket

DSL：

```fcstm
state Root {
    state A {
        enter abstract Init;
    }
    [*] -> A;
}
```

目标模型移除 `enter abstract Init;`。

Python 复现：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

WITH_HANDLER = """
state Root {
    state A { enter abstract Init; }
    [*] -> A;
}
"""
WITHOUT_HANDLER = """
state Root {
    state A;
    [*] -> A;
}
"""


def build(code):
    return parse_dsl_node_to_state_machine(parse_with_grammar_entry(code, "state_machine_dsl"))


def handler(ctx):
    pass

source = SimulationRuntime(build(WITH_HANDLER))
target = SimulationRuntime(build(WITHOUT_HANDLER))
source.register_abstract_handler("Root.A.Init", handler)
source.copy_session_configuration_to(target)
print(target.get_abstract_handlers("Root.A.Init"))
target.cycle()
```

当前实际：copy 成功，target registry 里出现 `Root.A.Init` dead bucket，但 target model 永远不会 dispatch。  
期望：copy 前校验 target compatibility；缺失 path 时抛可读 `ValueError`，且不修改 target 的 history_size、error mode、handler registry。

白盒原因：`copy_session_configuration_to()` 直接复制 `_abstract_handlers` dict，没有用 PR-6 的 path validation 在目标 runtime 上重新校验。

## 修复设计

1. `@abstract_handler` metadata 改成可表达多个 path 的内部结构，同时保留兼容读取单 path 的 helper。新增或调整 helper 时不要让 public docstring 暴露临时迁移概念。
2. decorator 支持 plain function、staticmethod、classmethod：metadata 同步到 descriptor 与 `__func__`，scanner 可从 raw class member 读取 metadata。
3. `register_handlers_from_object()` 改为 class MRO / `__dict__` 原始 member 扫描：
   - 不对非 decorated member 调用 `getattr()`；
   - decorated private method 不跳过；
   - magic / undecorated private / ordinary property 不执行；
   - 按 class declaration order 收集；
   - 先完整收集 + validate，再统一注册，确保失败原子性。
4. object scanner 使用 PR-6 的 `register_abstract_handler()` validation 和 duplicate policy；如果同一 callable 多 path 注册到不同 action，这是允许行为。
5. `copy_session_configuration_to()` 先对 target runtime 校验所有 source handler path；成功后再一次性写入 target 的 history_size、abstract_error_mode、handler registry。失败时 target 不变。
6. 所有新增异常使用可读 `ValueError`，说明 action path / target runtime 不兼容原因；不使用 broad catch。


## Planning review 已纳入的实现约束

来自规划 review 的 I 级意见已转为本 PR 的实现验收约束：

1. **Object scanner 必须两阶段提交。** 收集阶段只读取 raw class member metadata、解析 bound callable、预校验全部 action path，不得边扫描边写 registry。全部校验通过后才能调用 `register_abstract_handler()` 写入；任一 path / descriptor / duplicate 失败时，原 registry 必须保持不变。
2. **MRO override 去重必须明确。** 扫描 class MRO 时，同名成员以 most-derived class 为准，父类同名 decorated member 不应在子类 override 后重复注册；不同名称的 inherited decorated members 仍应按稳定顺序注册。
3. **Descriptor 支持边界必须清晰。** plain function、`staticmethod`、`classmethod` 需要支持；带 abstract-handler metadata 但无法安全绑定成 callable 的 descriptor 必须抛可读 `ValueError`，不能静默漏注册；无 metadata 的普通 property / descriptor 必须跳过且不得触发 getter。
4. **Decorator metadata helper 必须兼容。** `get_handler_metadata()` 继续返回 `Optional[str]` 以兼容旧调用方；新增内部 helper 可返回 tuple/list 多 path，但 public 单 path helper 不应破坏。

## TDD 与实现步骤

1. 先跑一次基线：`pytest test/simulate/test_handler_decorator.py test/simulate/test_abstract_handlers.py -q`。
2. 先写失败测试：`AH-4`、`DECOR-1`、`DECOR-2`、`DECOR-3` 放在 `test/simulate/test_handler_decorator.py`；`COPY-1` 放在 `test/simulate/test_abstract_handlers.py`。
3. 确认失败测试在当前 head 上复现真实问题，记录精准命令。
4. 实现 decorator metadata 多 path 与 descriptor 支持。
5. 实现 object scanner 的 raw class member collection、declaration order、MRO override 去重与 atomic registration。
6. 实现 copy session configuration target validation 与 atomic update。
7. 执行 `make rst_auto`，检查 API doc diff 只来自真实 pydoc 变更。
8. 精准测试:
   - `pytest test/simulate/test_handler_decorator.py -q`
   - `pytest test/simulate/test_abstract_handlers.py -q`
   - `pytest test/simulate/test_semantic_fixtures.py -q`
9. 全量本地快线：`SKIP_SLOW_TESTS=1 make unittest`。
10. push 后等待 CI 全绿，再做三路强对抗实现 review。

## 实现摘要与本地验证

实现提交：[70f6b7fc](https://github.com/HansBug/pyfcstm/commit/70f6b7fc9cba5b991381f17a5c50afe951f49d24)。

主要实现点：

- `@abstract_handler` 支持同一 callable 挂多个 action path；单 path 直读 metadata 仍保持 string 兼容，`get_handler_metadata()` 仍返回 `Optional[str]`。
- object scanner 改为 raw class `__dict__` + MRO 扫描，按 declaration order 注册，most-derived override 去重；未装饰 descriptor 不执行，decorated unsupported descriptor 抛可读 `ValueError`。
- `register_handlers_from_object()` 先 collect / validate / duplicate 预检，再写入；写入阶段如遇 `ValueError` 会恢复 registry snapshot。
- `copy_session_configuration_to()` 在写入 target 前验证所有 handler path 均为 target runtime 的 named abstract action。

本地验证：

```bash
pytest test/simulate/test_handler_decorator.py test/simulate/test_abstract_handlers.py -q
pytest test/simulate/test_handler_decorator.py test/simulate/test_abstract_handlers.py test/simulate/test_semantic_fixtures.py -q
ruff check pyfcstm/simulate test/simulate test/testings/simulate_semantics.py
pytest test/simulate -q
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
```

结果：`pytest test/simulate -q` 为 `403 passed`；`SKIP_SLOW_TESTS=1 make unittest` 为 `40981 passed, 164 skipped, 63 deselected`。

## Reviewer 必查项

- PR body 是否逐条覆盖上游 issue / 伞 PR 中 PR-7 的 `AH-4`、`DECOR-1`、`DECOR-2`、`DECOR-3`、`COPY-1`，无遗漏、无混入 PR-3 / PR-6 范围。
- `DECOR-1` 选择“支持多 path”是否与 maintainer 批示“支持或明确拒绝”一致，且不会与 PR-6 duplicate policy 冲突。
- object scanner 是否避免执行非 handler descriptor，并保持失败原子性。
- copy session validation 是否保持 target runtime 失败不半更新。
- pydoc / RST 是否符合 CLAUDE.md：module doc 清晰；函数 / 类 doc 有 params / return / raises / Examples::；`__init__.py` 若变更需保持 roadmap 表格形态。
- 无 workflow metadata 进入代码标识符、fixture id、runtime message、docstring 或 pydoc。
- ready 前必须合入最新上游伞分支并检查 conflict 处理正确。

