### PR TITLE
PR-8：pyfcstm.simulate 全集回归与 issue 收口

### DIFF
--- a/test/simulate/test_runtime_contract_integration.py
+++ b/test/simulate/test_runtime_contract_integration.py
@@ -1,0 +1,422 @@
+"""
+Integration tests for simulator runtime contract combinations.
+
+These tests exercise interactions between simulator contracts that are already
+covered individually elsewhere. They intentionally use only ``pyfcstm.simulate``
+public runtime behavior.
+"""
+
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import Event, parse_dsl_node_to_state_machine
+from pyfcstm.simulate import (
+    CycleResult,
+    ReadOnlyExecutionContext,
+    SimulationRuntime,
+    SimulationRuntimeDfsError,
+    SimulationRuntimeEventError,
+    SimulationRuntimeTerminalStateError,
+    abstract_handler,
+)
+
+
+def _build_runtime(dsl_code, **kwargs):
+    """
+    Build a simulation runtime from FCSTM source.
+
+    :param dsl_code: FCSTM DSL source code.
+    :type dsl_code: str
+    :param kwargs: Keyword arguments forwarded to
+        :class:`pyfcstm.simulate.SimulationRuntime`.
+    :type kwargs: typing.Any
+    :return: Runtime constructed from the parsed state-machine model.
+    :rtype: pyfcstm.simulate.SimulationRuntime
+
+    Example::
+
+        >>> runtime = _build_runtime("state Root { state A; [*] -> A; }")
+        >>> runtime.is_ended
+        False
+    """
+    ast = parse_with_grammar_entry(dsl_code, "state_machine_dsl")
+    return SimulationRuntime(parse_dsl_node_to_state_machine(ast), **kwargs)
+
+
+@pytest.mark.unittest
+def test_event_accounting_and_handler_context_remain_consistent_together():
+    """Combine event accounting with abstract-handler context metadata."""
+    runtime = _build_runtime(
+        """
+def int ticks = 0;
+def float reading = 0.0;
+state Root {
+    >> during before abstract Audit;
+
+    state Idle {
+        enter abstract Init;
+        during { ticks = ticks + 1; reading = reading + 1.0; }
+        during abstract Monitor;
+    }
+    state Done { during { ticks = ticks + 100; } }
+
+    [*] -> Idle;
+    Idle -> Done :: Go;
+}
+"""
+    )
+
+    calls = []
+
+    def record(ctx: ReadOnlyExecutionContext):
+        calls.append(
+            {
+                "target": ctx.abstract_target,
+                "action": ctx.action_name,
+                "stage": ctx.action_stage,
+                "call_stage": ctx.call_stage,
+                "state": ctx.get_full_state_path(),
+                "active_leaf": ctx.active_leaf,
+                "vars": dict(ctx.vars),
+            }
+        )
+
+    runtime.register_abstract_handler("Root.Audit", record)
+    runtime.register_abstract_handler("Root.Idle.Init", record)
+    runtime.register_abstract_handler("Root.Idle.Monitor", record)
+
+    first = runtime.cycle()
+    assert first == CycleResult(
+        input_events=(), consumed_events=(), unconsumed_events=()
+    )
+    assert runtime.current_state.path == ("Root", "Idle")
+    assert runtime.vars == {"ticks": 1, "reading": 1.0}
+    assert type(runtime.vars["reading"]) is float
+    assert calls == [
+        {
+            "target": "Root.Idle.Init",
+            "action": "Root.Idle.Init",
+            "stage": "enter",
+            "call_stage": "enter",
+            "state": "Root.Idle",
+            "active_leaf": ("Root", "Idle"),
+            "vars": {"ticks": 0, "reading": 0.0},
+        },
+        {
+            "target": "Root.Audit",
+            "action": "Root.Audit",
+            "stage": "during",
+            "call_stage": "during",
+            "state": "Root.Idle",
+            "active_leaf": ("Root", "Idle"),
+            "vars": {"ticks": 0, "reading": 0.0},
+        },
+        {
+            "target": "Root.Idle.Monitor",
+            "action": "Root.Idle.Monitor",
+            "stage": "during",
+            "call_stage": "during",
+            "state": "Root.Idle",
+            "active_leaf": ("Root", "Idle"),
+            "vars": {"ticks": 1, "reading": 1.0},
+        },
+    ]
+
+    second = runtime.cycle(["Root.Idle.Go", "Root.Idle.Go"])
+    assert second == CycleResult(
+        input_events=("Root.Idle.Go", "Root.Idle.Go"),
+        consumed_events=("Root.Idle.Go",),
+        unconsumed_events=("Root.Idle.Go",),
+    )
+    assert runtime.current_state.path == ("Root", "Done")
+    assert runtime.vars == {"ticks": 101, "reading": 1.0}
+    assert runtime.history[-1]["events"] == ["Root.Idle.Go", "Root.Idle.Go"]
+
+
+@pytest.mark.unittest
+def test_failed_handler_cycle_rolls_back_warning_errors_and_event_result():
+    """A raising handler rolls warning metadata back without consuming events."""
+    runtime = _build_runtime(
+        """
+def int x = 0;
+state Root {
+    state A {
+        enter abstract /* anonymous */;
+        enter abstract Fail;
+        during { x = x + 1; }
+    }
+    state B { during { x = x + 10; } }
+
+    [*] -> A;
+    A -> B :: Go;
+}
+""",
+        abstract_error_mode="raise",
+    )
+
+    def fail(_ctx: ReadOnlyExecutionContext):
+        raise RuntimeError("boom")
+
+    runtime.register_abstract_handler("Root.A.Fail", fail)
+
+    with pytest.warns(UserWarning, match="has no name"):
+        with pytest.raises(RuntimeError, match="boom"):
+            runtime.cycle(["Root.A.Go"])
+
+    assert runtime.is_error_state is True
+    assert runtime.error_info[0] == "Root.A.Fail"
+    assert runtime.vars == {"x": 0}
+    assert runtime.abstract_handler_errors == []
+    assert len(runtime._warned_anonymous_abstracts) == 0
+    assert runtime.cycle(["Root.A.Go"]) == CycleResult()
+    assert runtime.vars == {"x": 0}
+
+    removed = runtime.clear_abstract_handler_session()
+    assert removed == 1
+    assert runtime.abstract_handler_errors == []
+    assert len(runtime._warned_anonymous_abstracts) == 0
+
+
+@pytest.mark.unittest
+def test_decorator_registry_copy_and_duplicate_cleanup_share_callable_identity():
+    """Object scanner, duplicate cleanup, and session copy use one identity rule."""
+    dsl_code = """
+def int visits = 0;
+state Root {
+    state A {
+        enter abstract Start;
+        during abstract Tick;
+        during { visits = visits + 1; }
+    }
+    [*] -> A;
+}
+"""
+    source = _build_runtime(dsl_code, abstract_error_mode="log", history_size=3)
+    target = _build_runtime(dsl_code)
+
+    class Handlers:
+        def __init__(self):
+            self.calls = []
+
+        @abstract_handler("Root.A.Start")
+        @abstract_handler("Root.A.Tick")
+        def shared(self, ctx: ReadOnlyExecutionContext):
+            self.calls.append((ctx.action_name, ctx.call_stage, ctx.active_leaf))
+
+        @staticmethod
+        @abstract_handler("Root.A.Tick")
+        def static_tick(ctx: ReadOnlyExecutionContext):
+            Handlers.static_calls.append(ctx.action_name)
+
+    Handlers.static_calls = []
+    handlers = Handlers()
+    assert source.register_handlers_from_object(handlers) == 3
+    with pytest.raises(ValueError, match="already registered"):
+        source.register_handlers_from_object(handlers)
+
+    with pytest.warns(UserWarning, match="Duplicate abstract handler"):
+        source.register_abstract_handler(
+            "Root.A.Tick", handlers.shared, allow_duplicates=True
+        )
+    assert len(source.get_abstract_handlers("Root.A.Tick")) == 3
+    assert (
+        source.unregister_abstract_handler(
+            "Root.A.Tick", handlers.shared, removal_mode="one"
+        )
+        == 1
+    )
+    assert len(source.get_abstract_handlers("Root.A.Tick")) == 2
+
+    source.copy_session_configuration_to(target)
+    assert target.history_size == 3
+    assert target.abstract_error_mode == "log"
+    assert len(target.get_abstract_handlers("Root.A.Start")) == 1
+    assert len(target.get_abstract_handlers("Root.A.Tick")) == 2
+
+    target.cycle()
+    assert handlers.calls == [
+        ("Root.A.Start", "enter", ("Root", "A")),
+        ("Root.A.Tick", "during", ("Root", "A")),
+    ]
+    assert Handlers.static_calls == ["Root.A.Tick"]
+    assert target.vars == {"visits": 1}
+
+
+@pytest.mark.unittest
+def test_persistent_normalization_rejects_nonfinite_values_across_entry_paths():
+    """Persistent vars share finite numeric validation across all entry paths."""
+    initializer_runtime = _build_runtime(
+        """
+def float level = 1.0 / 0.0;
+def int counter = 0;
+state Root { state A; [*] -> A; }
+""",
+        initial_vars={"level": 5, "counter": 2.0},
+    )
+    assert initializer_runtime.vars == {"level": 5.0, "counter": 2}
+    assert type(initializer_runtime.vars["level"]) is float
+    assert type(initializer_runtime.vars["counter"]) is int
+
+    with pytest.raises(ValueError, match="level.*initializer"):
+        _build_runtime(
+            """
+def float level = 1.0 / 0.0;
+def int counter = 0;
+state Root { state A; [*] -> A; }
+"""
+        )
+
+    with pytest.raises(ValueError, match="counter.*finite"):
+        _build_runtime(
+            """
+def int counter = 0;
+state Root { state A; [*] -> A; }
+""",
+            initial_state="Root.A",
+            initial_vars={"counter": float("nan")},
+        )
+
+    with pytest.raises((ValueError, ArithmeticError), match="evaluation failed"):
+        _build_runtime(
+            """
+def float level = 0.0;
+state Root {
+    state A { during { level = 1.0 / 0.0; } }
+    [*] -> A;
+}
+"""
+        ).cycle()
+
+    with pytest.raises(ValueError, match="level.*finite"):
+        _build_runtime(
+            """
+def float level = 0.0;
+state Root {
+    state A { during { level = 1.0e309; } }
+    [*] -> A;
+}
+"""
+        ).cycle()
+
+
+@pytest.mark.unittest
+def test_hot_start_transient_and_composite_boundaries_keep_declared_order():
+    """Hot start handles pseudo leaves and composite initial guards in order."""
+    transient_runtime = _build_runtime(
+        """
+def int x = 0;
+state Root {
+    pseudo state Gate { during { x = x + 100; } }
+    state Ready {
+        enter { x = x + 10; }
+        during { x = x + 1; }
+    }
+    [*] -> Gate;
+    Gate -> Ready;
+}
+""",
+        initial_state="Root.Gate",
+        initial_vars={"x": 0},
+    )
+
+    transient_runtime.cycle()
+    assert transient_runtime.current_state.path == ("Root", "Ready")
+    assert transient_runtime.vars == {"x": 11}
+
+    composite_runtime = _build_runtime(
+        """
+def int x = 0;
+state Root {
+    state Parent {
+        during before { x = x + 10; }
+        state A { enter { x = x + 100; } }
+        state B { enter { x = x + 1000; } }
+        [*] -> B : if [x >= 10];
+        [*] -> A;
+    }
+    [*] -> Parent;
+}
+""",
+        initial_state="Root.Parent",
+        initial_vars={"x": 0},
+    )
+
+    composite_runtime.cycle()
+    assert composite_runtime.current_state.path == ("Root", "Parent", "A")
+    assert composite_runtime.vars == {"x": 100}
+
+
+@pytest.mark.unittest
+def test_invalid_event_and_state_inputs_do_not_modify_runtime_state():
+    """Unsupported event and state references are rejected before mutation."""
+    runtime = _build_runtime(
+        """
+def int x = 0;
+state Root {
+    state A { during { x = x + 1; } }
+    state B { during { x = x + 10; } }
+    [*] -> A;
+    A -> B :: Go;
+}
+"""
+    )
+    runtime.cycle()
+    assert runtime.current_state.path == ("Root", "A")
+    assert runtime.vars == {"x": 1}
+
+    class EventLike:
+        path_name = "Root.A.Go"
+
+    with pytest.raises(SimulationRuntimeEventError, match="Unsupported event input"):
+        runtime.cycle([EventLike()])
+    assert runtime.current_state.path == ("Root", "A")
+    assert runtime.vars == {"x": 1}
+
+    with pytest.raises(SimulationRuntimeEventError, match="not owned"):
+        runtime.cycle(Event(name="Go", state_path=("Root", "A")))
+    assert runtime.current_state.path == ("Root", "A")
+    assert runtime.vars == {"x": 1}
+
+
+@pytest.mark.unittest
+def test_diagnostics_for_safety_expression_and_terminal_queries_remain_specific():
+    """Safety, expression, and terminal diagnostics use simulator exceptions."""
+    with pytest.raises(SimulationRuntimeDfsError, match="step safety limit"):
+        _build_runtime(
+            """
+def int x = 0;
+state Root {
+    pseudo state Loop { during { x = x + 1; } }
+    [*] -> Loop;
+    Loop -> Loop;
+}
+"""
+        ).cycle()
+
+    expression_runtime = _build_runtime(
+        """
+def int x = 0;
+state Root {
+    state A { during { x = 1.5 << 1; } }
+    [*] -> A;
+}
+"""
+    )
+    with pytest.raises((ValueError, ArithmeticError), match="evaluation failed"):
+        expression_runtime.cycle()
+    assert expression_runtime.vars == {"x": 0}
+
+    terminal_runtime = _build_runtime(
+        """
+state Root {
+    state A;
+    [*] -> A;
+    A -> [*];
+}
+"""
+    )
+    terminal_runtime.cycle()
+    terminal_runtime.cycle()
+    assert terminal_runtime.is_ended is True
+    with pytest.raises(SimulationRuntimeTerminalStateError, match="is_ended"):
+        terminal_runtime.current_state


### PR DESCRIPTION
# PR-8：`pyfcstm.simulate` 全集回归与 issue 收口

关联伞 PR：[PR #186](https://github.com/HansBug/pyfcstm/pull/186)。关联 issue：[issue #156](https://github.com/HansBug/pyfcstm/issues/156)。

本 PR 是 #156 修复拆分的最终收口 PR。目标不是引入新的局部契约，而是在全部前序子 PR 已合入伞 PR 分支后，对 `pyfcstm.simulate` 本体进行全集回归、跨契约组合验收、测试语义防漂移检查和 issue / 伞 PR 状态收口。

## 边界

- 生产代码边界：只允许触碰 `pyfcstm/simulate/`，且仅当全集回归发现真实 C/I 问题时才修改生产代码。
- 测试边界：新增或调整测试应进入 `test/simulate/` 或 `test/fixtures/simulate_semantics/` 现有体系；不得新建割裂的测试框架。
- 不处理：template / generated runtime / CLI / entry / editor / jsfcstm / solver / render。
- 不修改 `Makefile`。
- 不把 PR 编号、issue 编号、roadmap 阶段等工作流元数据写入代码标识符、fixture id、runtime message、docstring 或 pydoc；Markdown 中引用 PR/issue 必须使用显式链接。

## 前序子 PR 状态

| 子 PR | 主要修复面 | 当前状态 | 本 PR 收口验收点 |
|---|---|---|---|
| PR-0 / [PR #187](https://github.com/HansBug/pyfcstm/pull/187) | semantic fixture 与诊断契约基线 | ✅ 已完成 | fixture runner/schema 能承载最终新增组合回归，不产生测试语义漂移。 |
| PR-1 / [PR #190](https://github.com/HansBug/pyfcstm/pull/190) | hot start / pseudo / DFS safety / stack 稳定化 | ✅ 已完成 | hot-start、pseudo、DFS safety、stable stack 语义在全集测试中保持稳定。 |
| PR-2A / [PR #189](https://github.com/HansBug/pyfcstm/pull/189) | 表达式运行时与诊断包装 | ✅ 已完成 | expression error wrapping、短路、超大整数诊断未被后续合并破坏。 |
| PR-2B / [PR #192](https://github.com/HansBug/pyfcstm/pull/192) | persistent 变量初始化与归一化 | ✅ 已完成 | initializer / `initial_vars` / 写回路径共享 normalization；NaN 禁止不漂移。 |
| PR-3 / [PR #188](https://github.com/HansBug/pyfcstm/pull/188) | event 输入校验与 `cycle()` 结果对象 | ✅ 已完成 | event input、foreign / synthetic event 拒绝、consumed / unconsumed accounting 保持一致。 |
| PR-4 / [PR #194](https://github.com/HansBug/pyfcstm/pull/194) | terminal query 与 history session metadata | ✅ 已完成 | terminal query 自有异常、history shrink / zero / widen 行为保持稳定。 |
| PR-5 / [PR #193](https://github.com/HansBug/pyfcstm/pull/193) | execution context metadata 与 ref callsite | ✅ 已完成 | context 能同时表达 active leaf、callsite stage、abstract target、named ref。 |
| PR-6 / [PR #191](https://github.com/HansBug/pyfcstm/pull/191) | handler registry / clear / duplicate / warning metadata | ✅ 已完成 | registry path validate、duplicate policy、clear API、warning rollback 语义保持协同。 |
| PR-7 / [PR #195](https://github.com/HansBug/pyfcstm/pull/195) | decorator scanner 与 session copy 契约 | ✅ 已完成 | object scanner、decorator metadata、private handler、session copy validation 不被最终合并破坏。 |

## Mermaid 依赖图

```mermaid
flowchart TD
    U["伞 PR #186<br/>simulate 修复拆分<br/>🟦 已开启"]:::active
    S0["PR-0 / #187<br/>fixture 与诊断基线<br/>✅ 已完成"]:::done
    S1["PR-1 / #190<br/>hot start / pseudo / DFS<br/>✅ 已完成"]:::done
    S2A["PR-2A / #189<br/>表达式诊断<br/>✅ 已完成"]:::done
    S2B["PR-2B / #192<br/>变量归一化<br/>✅ 已完成"]:::done
    S3["PR-3 / #188<br/>event 与 cycle result<br/>✅ 已完成"]:::done
    S4["PR-4 / #194<br/>terminal / history<br/>✅ 已完成"]:::done
    S5["PR-5 / #193<br/>context / ref callsite<br/>✅ 已完成"]:::done
    S6["PR-6 / #191<br/>handler registry<br/>✅ 已完成"]:::done
    S7["PR-7 / #195<br/>decorator scanner / copy<br/>✅ 已完成"]:::done
    S8["PR-8<br/>全集回归与 issue 收口<br/>🟨 本 PR"]:::active

    U --> S0
    S0 --> S1
    S0 --> S2A
    S0 --> S2B
    S0 --> S3
    S0 --> S4
    S0 --> S5
    S0 --> S6
    S0 --> S7
    S1 --> S8
    S2A --> S8
    S2B --> S8
    S3 --> S8
    S4 --> S8
    S5 --> S8
    S6 --> S8
    S7 --> S8

    classDef active fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
```

## 自包含问题验收清单

本 PR 需要从 issue #156 的当前索引逐条确认：

| 分类 | 条目 | 期望收口状态 | 验收要求 |
|---|---|---|---|
| 确凿逻辑问题 | `PSEUDO-1`、`HOT-1`、`EXPR-2`、`TYPE-1`、`TYPE-2`、`SAFETY-1`、`SAFETY-2` | 🔍 已验证 | 对应 fixture / 单测仍在全集 `test/simulate` 中执行；若新增组合用例，必须复用 PR-0 fixture 体系。 |
| 确凿契约问题 | `HOT-5`、`AH-2`、`AH-4`、`AH-5`、`AH-6`、`AH-7`、`AH-8`、`DECOR-1`、`DECOR-2`、`DECOR-3`、`COPY-1`、`WARN-1`、`WARN-2`、`CTX-1`、`EV-1`、`EV-3`、`QUERY-1`、`STACK-1`、`HIST-3`、`REF-1`、`REFMIX-1`、`EXPR-1`、`DIAG-1`、`TYPE-3`、`TYPE-4`、`INIT-1`、`SAFETY-3` | 🔍 已验证 | 对应测试不丢线；跨契约组合至少覆盖 handler metadata / event result / rollback / context / persistent var 中容易互相影响的路径。 |
| 非修复项 | `HOT-2`、`HOT-3`、`AH-1`、`AH-3`、`HIST-1`、`CTX-2`、`EV-2`、`STATE-1`、`VARS-1`、`HIST-2`、`SESSIONAPI-1`、`HOT-4`、`EXPR-3` | 非修复状态不变 | 不把已判定为设计预期、未定义行为、转模型校验或非关注范围的问题误改成 runtime bug；最终收口检查必须显式覆盖全量非修复项，而不是只用 catch-all 文案。 |

## TDD / 实现计划

1. 先跑基线：`pytest test/simulate -q`，确认当前伞分支在 PR-8 开工点全绿。
2. 增加最终收口测试，优先选择不引入新生产逻辑的组合回归：
   - semantic fixture 索引完整性 / issue156 关键语义覆盖映射检查；
   - cross-contract runtime test：event consumption、handler warning rollback、context metadata、registry clear / duplicate、persistent var normalization 等组合路径不互相打架；
   - 全量非修复项状态检查，确保设计预期 / 未定义行为 / 转模型校验 / 非关注范围不会被最终收口误改；
   - 如果 reviewer 发现真实 C/I 级缺口，再按最小变更修复 `pyfcstm/simulate/`。
3. 对抗验证必须贯穿计划审查、实现审查以及处理 merge conflict 后的复审；不能只做文本一致性检查。每一次 review 中，每个 reviewer 都必须围绕 issue #156 自包含问题验收清单里的每一个问题条目，独立构造并真实运行至少 2 个白盒强对抗测试（DSL 模型或 Python 调用场景均可）。这些测试必须是同类但不同形态、或比原 issue comment 更复杂的场景；不能三路 reviewer 互相复用，也不能只覆盖一个代表性问题就结束。每个问题条目的 comment 记录必须包含复现代码、复现命令、期望结果、实际结果、C/I/M 结论，以及为什么这 2 个测试能证明该条目没有复发或非修复状态没有被误改。
4. 跑精准测试：`pytest test/simulate -q`。
5. 跑全量 slow-skip：`SKIP_SLOW_TESTS=1 make unittest`。
6. 提交前跑 `make rst_auto`，并复核 pydoc / `__init__.py` 是否仍符合 `CLAUDE.md` 的 reST 和 module roadmap 要求。
7. merge 前必须合入最新伞 PR 分支，确认无 merge conflict；reviewer 需额外检查合并没有丢失前序 PR 内容。

## 验收标准

- GitHub CI 全绿。
- 三路 reviewer 均给出 PR comment，且 C/I=0。
- 三路 reviewer 的计划审查、最终实现审查、以及 merge conflict 后复审 comment 都必须按问题条目逐项给出强对抗证据：每名 reviewer 对 issue #156 自包含问题验收清单里的每一个问题条目至少 2 个独立白盒强对抗测试；comment 中必须给出可复现代码 / 命令、期望结果、实际结果、是否通过、C/I/M 结论，以及为什么能证明该条目没有复发或非修复状态没有被误改。
- Codecov comment 不显示 `pyfcstm/simulate/` 或本 PR 触碰行的实质覆盖回退；如有覆盖提示，必须解释或补测。
- `test/simulate` 与 semantic fixture 的语义不漂移：迁移 / 汇总测试不得只检查文件名或工作流标签，必须检查真实 runtime 行为或 fixture expected semantics。
- Issue #156 body 中无 `| 🐞 待修复 |` / `| ❓ 待确认 |` 问题行；最终同步 comment 明确 PR-8 的全集验证结果。
- 本 PR 不在代码、fixture id、runtime message、docstring 或 pydoc 中引入工作流 metadata。


## Reviewer 强对抗要求

计划阶段 reviewer 不能只确认文字存在；实现阶段 reviewer 也不能只抽样一个代表性场景。最低要求如下，属于硬性 merge gate：

| Reviewer | 必须逐项覆盖的问题范围 | 每个问题条目的最低对抗测试量 | 输出要求 |
|---|---|---|---|
| codex reviewer | issue #156 自包含问题验收清单里的全部问题条目，重点从 hot start / pseudo / DFS safety / event input / cycle result 方向补强。 | 每个问题条目至少 2 个独立白盒强对抗测试；同一 reviewer 不能用一个测试跨多个条目草率抵数，除非 comment 明确解释同一场景如何分别击中各条目的不同断言。 | PR comment 中按问题条目列出 DSL / Python 片段、命令、期望、实际、C/I/M 结论和防复发解释。 |
| claude reviewer | issue #156 自包含问题验收清单里的全部问题条目，重点从 handler registry / warning rollback / decorator scanner / session copy 方向补强。 | 每个问题条目至少 2 个独立白盒强对抗测试；必须独立设计，不能复用 codex reviewer 的测试作为自己的证据。 | PR comment 中按问题条目列出 DSL / Python 片段、命令、期望、实际、C/I/M 结论和防复发解释。 |
| deepseek reviewer | issue #156 自包含问题验收清单里的全部问题条目，重点从 persistent var normalization / expression diagnostics / context metadata / ref callsite / terminal history 方向补强。 | 每个问题条目至少 2 个独立白盒强对抗测试；必须独立设计，不能复用其他 reviewer 的测试作为自己的证据。 | PR comment 中按问题条目列出 DSL / Python 片段、命令、期望、实际、C/I/M 结论和防复发解释。 |

非修复项同样要测：每个 reviewer 需要为每个非修复条目构造至少 2 个白盒边界验证，证明 runtime 没有把设计预期、未定义行为、模型校验职责或非关注范围误当成 simulate bug 去改。

如果单条 PR comment 放不下完整证据，reviewer 必须拆成多条连续 PR comment；不得用“见本地日志”“代表性抽样”“其余同理”等摘要替代逐项证据。

如果任一 review 阶段没有做到“每个 reviewer × 每个问题条目 × 至少 2 个白盒强对抗测试”，该轮 review 视为不满足门禁；如果 reviewer 发现 C/I 级真实复发或新同类问题，本 PR 必须先修复并补回归，再重新触发 CI 与三路 review。



