### PR TITLE
PR-0：对齐 fixture 与复现基线

### DIFF
--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -512,9 +512,11 @@ generated alignment cases in this schema version. `handlers` and
 same fixture handlers are installed in both runtimes and their call records must
 match.
 
-For constructor diagnostics, the alignment runner builds both runtimes and
-requires matching exception class names and messages before applying the
-`initial.expect.raises` matcher.
+For constructor diagnostics, the alignment runner builds both runtimes,
+requires matching exception class names, and then applies the declared
+`initial.expect.raises` matcher to each side. It does not require complete
+exception-message text equality unless a fixture matcher explicitly declares
+that stricter contract.
 
 ## CLI command cases
 

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -1,11 +1,18 @@
 # Simulate semantic fixture schema
 
-This directory stores shared semantic fixtures for Python-side simulator and
-built-in Python runtime alignment tests.  A fixture is a pair of files under
+This directory stores the shared semantic fixture corpus for Python-side
+simulator and built-in Python runtime alignment tests. A fixture is a pair of files under
 `cases/`:
 
 - `<id>.fcstm`: the FCSTM DSL source.
 - `<id>.yaml`: metadata, input sequence, runner selection, and expectations.
+
+The corpus is the long-term single source of truth for executable FCSTM
+semantics on the Python side. Cases that target generated Python alignment must
+also remain executable by the simulator runner, and both runners must consume
+the same YAML schema, FCSTM source, handler setup, cycle inputs, and expectation
+shape. Template-specific tests may add runner adapters, but they must not fork
+the semantic cases into an isolated template-only fixture system.
 
 The schema is intentionally strict. Unknown top-level fields, unknown runner
 names, unknown categories, unknown expectation fields, and unknown nested fields
@@ -63,9 +70,11 @@ Allowed runners:
 present.
 
 `runtime_options` is accepted only for simulation-only cases. `handlers`
-requires the `simulation` runner. When `generated_python_alignment` is also
-present, the same handler behavior is installed into both runtimes so callback
-context and side-effect isolation stay aligned.
+requires the `simulation` runner. Every `generated_python_alignment` case must
+also include `simulation` so the generated runtime is checked against the same
+semantic input that the simulator executes. When `generated_python_alignment`
+is present, the same handler behavior is installed into both runtimes so
+callback context and side-effect isolation stay aligned.
 
 ## Runtime construction diagnostics
 
@@ -109,6 +118,20 @@ Construction-diagnostic cases must use `steps: []`; executable steps are
 rejected so that constructor failures cannot silently skip later assertions.
 `initial.expect` is rejected for `cli_command` cases because CLI diagnostics
 belong under `commands[].expect`.
+
+Generated Python alignment cases check constructor outcomes before any cycle
+steps run. The alignment helper distinguishes three outcomes:
+
+- both runtimes build successfully;
+- both runtimes fail with matching diagnostic type and declared message/cause
+  expectations;
+- exactly one runtime fails, which is reported as a constructor one-sided
+  mismatch.
+
+The one-sided mismatch check is a harness-level parity guard. It does not make
+internal stack shape, exception messages, or exception causes public generated
+runtime obligations unless a fixture declares those fields or a later semantic
+case documents such a contract explicitly.
 
 ## Runtime options
 
@@ -223,6 +246,18 @@ original `action`, `state`, and `stage` record when a handler does not provide
 them. That keeps older handler records compatible while reserving stable schema
 slots for later runtime-context work. Once concrete metadata is collected by a
 handler, the helper preserves the provided values instead of overwriting them.
+
+For generated-runtime alignment, the common call-log terminology maps onto the
+fixture fields as follows:
+
+- action name: `action`;
+- state path: `state`;
+- lifecycle action stage: `stage`;
+- variables snapshot: `vars`.
+
+The optional `active_leaf`, `call_stage`, `abstract_target`, and `named_ref`
+fields provide additional white-box context assertions without changing the
+required common log shape.
 
 ## Runtime steps
 

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -16,8 +16,51 @@ from test.testings.simulate_semantics import (
 def test_all_semantic_fixtures_load():
     cases = iter_semantic_cases()
 
-    assert len(cases) >= 84
+    assert len(cases) >= 136
     assert {case.id for case in cases}
+
+
+@pytest.mark.unittest
+def test_generated_alignment_fixture_baseline_counts():
+    """
+    Guard generated-alignment fixture coverage baselines.
+
+    The checks are intentionally lower-bound and identity based: they prevent
+    silently dropping the semantic harness inputs while allowing later template
+    repairs to add more fixtures.
+    """
+    cases = iter_semantic_cases()
+    generated_cases = [
+        case for case in cases if "generated_python_alignment" in case.runners
+    ]
+    expected_failure_cases = [case for case in cases if "expected_failure" in case.data]
+    generated_handler_cases = [
+        case for case in generated_cases if case.data.get("handlers")
+    ]
+
+    assert len(cases) >= 136
+    assert len(generated_cases) >= 86
+    assert expected_failure_cases == []
+    assert {case.id for case in generated_handler_cases} >= {
+        "failed_initial_cycle_skips_abstract_handler_callbacks",
+        "ref_abstract_handler_reports_calling_state",
+    }
+
+
+@pytest.mark.unittest
+def test_generated_alignment_cases_share_the_simulation_fixture_corpus():
+    """
+    Guard simulator and generated-runtime alignment against fixture drift.
+
+    Generated Python alignment is a runner adapter over the shared semantic
+    corpus, not a separate fixture system. Every generated-alignment case must
+    also be executable by the simulator runner so both sides consume the same
+    DSL, handlers, cycle inputs, and expectation shape.
+    """
+    generated_cases = iter_semantic_cases(runners=["generated_python_alignment"])
+
+    assert generated_cases
+    assert all("simulation" in case.runners for case in generated_cases)
 
 
 @pytest.mark.unittest
@@ -29,6 +72,8 @@ def test_semantic_fixture_assertion_families_are_executable():
             continue
         for step in case.data.get("steps") or []:
             expect = step.get("expect_initial") or step.get("expect") or {}
+            if "ended" in expect:
+                covered.add("ended")
             if "stack" in expect:
                 covered.add("stack")
             if "state" in expect:
@@ -56,6 +101,7 @@ def test_semantic_fixture_assertion_families_are_executable():
 
     assert {
         "stack",
+        "ended",
         "current_state",
         "vars",
         "history",
@@ -64,6 +110,83 @@ def test_semantic_fixture_assertion_families_are_executable():
         "exception",
         "context",
     }.issubset(covered)
+
+
+@pytest.mark.unittest
+def test_generated_alignment_constructor_outcome_helper_covers_three_modes():
+    from test.testings import simulate_semantics
+    from test.testings.simulate_semantics import SemanticCase
+
+    case = SemanticCase(
+        data={
+            "id": "constructor_outcome_helper",
+            "runners": ["simulation", "generated_python_alignment"],
+        },
+        yaml_path="/tmp/constructor_outcome_helper.yaml",
+        fcstm_path="/tmp/constructor_outcome_helper.fcstm",
+        dsl_code="state Root { state A; [*] -> A; }",
+    )
+    expect = {
+        "raises": {
+            "type": "ValueError",
+            "match": "boom",
+            "match_kind": "substring",
+        }
+    }
+
+    simulate_semantics._assert_aligned_constructor_outcome(
+        case, None, object(), None, object(), None
+    )
+    simulate_semantics._assert_aligned_constructor_outcome(
+        case, expect, None, ValueError("boom"), None, ValueError("boom")
+    )
+    simulation_runtime, simulation_err = simulate_semantics._capture_construction(
+        lambda: (_ for _ in ()).throw(
+            simulate_semantics.SimulationRuntimeDfsError("dfs")
+        )
+    )
+    assert simulation_runtime is None
+    assert isinstance(simulation_err, simulate_semantics.SimulationRuntimeDfsError)
+    with pytest.raises(AssertionError, match="constructor one-sided mismatch"):
+        simulate_semantics._assert_aligned_constructor_outcome(
+            case, None, object(), None, None, ValueError("boom")
+        )
+    with pytest.raises(AssertionError, match="constructor failed unexpectedly"):
+        simulate_semantics._assert_aligned_constructor_outcome(
+            case, None, None, ValueError("boom"), None, ValueError("boom")
+        )
+    with pytest.raises(AssertionError, match="expected constructor failure"):
+        simulate_semantics._assert_aligned_constructor_outcome(
+            case, expect, object(), None, object(), None
+        )
+
+
+@pytest.mark.unittest
+def test_initial_vars_override_fixture_remains_simulation_only_seed():
+    case = load_semantic_case("persistent_initial_vars_override_skips_initializer")
+
+    assert case.runners == ("simulation",)
+    assert case.data["initial"]["state"] == "Root.A"
+    assert case.data["initial"]["vars"] == {"recovered": 5.0}
+    assert "initial" in case.data["origin"]["assertion_types"]
+    assert "hot_start" in case.data["categories"]
+
+
+@pytest.mark.unittest
+def test_generated_alignment_handler_metadata_mapping_is_available():
+    case = load_semantic_case("ref_abstract_handler_reports_calling_state")
+    call = case.data["steps"][0]["expect"]["handler_calls"][0]
+
+    assert "generated_python_alignment" in case.runners
+    assert case.data["handlers"] == [
+        {"action": "Root.Library.Shared", "behavior": "record_call"}
+    ]
+    assert {
+        "action": "Root.Library.Shared",
+        "state": "Root.A",
+        "stage": "enter",
+        "vars": {},
+    }.items() <= call.items()
 
 
 @pytest.mark.unittest
@@ -273,7 +396,7 @@ def _set_model_build_expectation(data, raises):
         ),
         (
             lambda data: (
-                data.update({"runners": ["generated_python_alignment"]})
+                data.update({"runners": ["cli_command"]})
                 or data.update(
                     {"handlers": [{"action": "Root.Init", "behavior": "record_call"}]}
                 )
@@ -302,6 +425,10 @@ def _set_model_build_expectation(data, raises):
             "expected_failure is reserved",
         ),
         (lambda data: data.update({"runners": ["unknown"]}), "unknown runners"),
+        (
+            lambda data: data.update({"runners": ["generated_python_alignment"]}),
+            "generated_python_alignment requires the simulation runner",
+        ),
         (
             lambda data: _set_model_build_expectation(data, {"type": "UnknownError"}),
             "model_build.expect.raises.type is unknown",

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -140,6 +140,14 @@ def test_generated_alignment_constructor_outcome_helper_covers_three_modes():
     simulate_semantics._assert_aligned_constructor_outcome(
         case, expect, None, ValueError("boom"), None, ValueError("boom")
     )
+    simulate_semantics._assert_aligned_constructor_outcome(
+        case,
+        expect,
+        None,
+        ValueError("simulation boom details"),
+        None,
+        ValueError("generated boom details"),
+    )
     simulation_runtime, simulation_err = simulate_semantics._capture_construction(
         lambda: (_ for _ in ()).throw(
             simulate_semantics.SimulationRuntimeDfsError("dfs")

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -194,6 +194,13 @@ _EXCEPTION_TYPES = {
     "ValueError": ValueError,
 }
 _CONSTRUCTOR_EXCEPTION_TYPES = tuple(_EXCEPTION_TYPES.values())
+_ALIGNMENT_CONSTRUCTOR_EXCEPTION_TYPES = (
+    ValueError,
+    ArithmeticError,
+    SimulationRuntimeDfsError,
+    TypeError,
+    KeyError,
+)
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
@@ -1153,10 +1160,12 @@ def _initial_constructor_expect_data(initial: Any) -> bool:
 def _capture_construction(build_runtime):
     try:
         return build_runtime(), None
-    except _CONSTRUCTOR_EXCEPTION_TYPES as err:
-        # Each class in _CONSTRUCTOR_EXCEPTION_TYPES is an allowed semantic
-        # diagnostic in fixture ``raises`` matchers. Unexpected exceptions
-        # propagate and fail the test as implementation bugs.
+    except _ALIGNMENT_CONSTRUCTOR_EXCEPTION_TYPES as err:
+        # ValueError/ArithmeticError/SimulationRuntimeDfsError cover simulator
+        # and generated constructor diagnostics; TypeError covers invalid
+        # runtime constructor references; KeyError covers generated hook-map
+        # lookup misses while installing fixture handlers. Unexpected classes
+        # still propagate and surface harness bugs.
         return None, err
 
 
@@ -1172,19 +1181,83 @@ def _assert_constructor_failure(build_runtime, expect, case: SemanticCase) -> No
     _assert_exception(err, expect, case, "initial.expect.raises")
 
 
-def _assert_aligned_constructor_failure(case: SemanticCase) -> None:
-    expect = _initial_constructor_expect(case)
-    _, simulation_err = _capture_construction(lambda: _build_simulation_runtime(case))
-    _, generated_err = _capture_construction(lambda: _build_generated_runtime(case))
+def _exception_display(error: BaseException) -> str:
+    return "%s: %s" % (type(error).__name__, error)
 
-    assert simulation_err is not None, (
-        "%s initial.expect.raises expected SimulationRuntime construction failure %r"
-        % (case.id, expect["raises"])
-    )
-    assert generated_err is not None, (
-        "%s initial.expect.raises expected generated Python construction failure %r"
-        % (case.id, expect["raises"])
-    )
+
+def _assert_aligned_constructor_outcome(
+    case: SemanticCase,
+    expect: Optional[Mapping[str, Any]],
+    simulation_runtime: Any,
+    simulation_err: Optional[BaseException],
+    generated_runtime: Any,
+    generated_err: Optional[BaseException],
+) -> None:
+    """
+    Assert generated-runtime constructor parity for a semantic fixture.
+
+    Constructor alignment has three observable outcomes: both runtimes build
+    successfully, both runtimes fail with matching diagnostics, or exactly one
+    side fails. The last outcome is a first-class alignment mismatch because
+    hot-start and handler-installation bugs can happen before a cycle executes.
+
+    :param case: Semantic fixture being constructed.
+    :type case: SemanticCase
+    :param expect: Optional ``initial.expect`` mapping.
+    :type expect: typing.Mapping[str, typing.Any], optional
+    :param simulation_runtime: Constructed simulator runtime, if available.
+    :type simulation_runtime: typing.Any
+    :param simulation_err: Simulator construction error, if construction
+        failed.
+    :type simulation_err: BaseException, optional
+    :param generated_runtime: Constructed generated runtime, if available.
+    :type generated_runtime: typing.Any
+    :param generated_err: Generated-runtime construction error, if
+        construction failed.
+    :type generated_err: BaseException, optional
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If constructor outcomes diverge or do not satisfy
+        the fixture expectation.
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> _assert_aligned_constructor_outcome(case, None, object(), None, object(), None)
+    """
+    if (simulation_err is None) != (generated_err is None):
+        if simulation_err is None:
+            simulation_text = "built successfully"
+            generated_text = _exception_display(generated_err)
+        else:
+            simulation_text = _exception_display(simulation_err)
+            generated_text = "built successfully"
+        raise AssertionError(
+            "%s constructor one-sided mismatch: simulation=%s, generated=%s"
+            % (case.id, simulation_text, generated_text)
+        )
+
+    if simulation_err is None and generated_err is None:
+        if expect is not None:
+            raise AssertionError(
+                "%s initial.expect.raises expected constructor failure %r"
+                % (case.id, expect["raises"])
+            )
+        assert simulation_runtime is not None, "%s simulation runtime missing" % case.id
+        assert generated_runtime is not None, "%s generated runtime missing" % case.id
+        return
+
+    assert simulation_err is not None
+    assert generated_err is not None
+    if expect is None:
+        raise AssertionError(
+            "%s constructor failed unexpectedly: simulation=%s, generated=%s"
+            % (
+                case.id,
+                _exception_display(simulation_err),
+                _exception_display(generated_err),
+            )
+        )
     assert type(simulation_err).__name__ == type(generated_err).__name__, (
         "%s constructor exception type mismatch: simulation=%s generated=%s"
         % (
@@ -1199,6 +1272,24 @@ def _assert_aligned_constructor_failure(case: SemanticCase) -> None:
     )
     _assert_exception(simulation_err, expect, case, "initial.expect.raises")
     _assert_exception(generated_err, expect, case, "initial.expect.raises")
+
+
+def _assert_aligned_constructor_failure(case: SemanticCase) -> None:
+    expect = _initial_constructor_expect(case)
+    simulation_runtime, simulation_err = _capture_construction(
+        lambda: _build_simulation_runtime(case)
+    )
+    generated_runtime, generated_err = _capture_construction(
+        lambda: _build_generated_runtime(case)
+    )
+    _assert_aligned_constructor_outcome(
+        case,
+        expect,
+        simulation_runtime,
+        simulation_err,
+        generated_runtime,
+        generated_err,
+    )
 
 
 def _initial_kwargs(case: SemanticCase) -> Dict[str, Any]:
@@ -1623,15 +1714,25 @@ def run_generated_python_alignment_case(case: SemanticCase, caplog: Any = None) 
         >>> case = load_semantic_case("design_basic_simple_transition")
         >>> run_generated_python_alignment_case(case)
     """
-    if _initial_constructor_expect(case) is not None:
-        _assert_aligned_constructor_failure(case)
-        return
-    simulation_runtime = _build_simulation_runtime(case)
-    simulation_handler_calls = _register_fixture_handlers(simulation_runtime, case)
     generated_handler_calls = []
-    generated_runtime = _build_generated_runtime(
-        case, handler_calls=generated_handler_calls
+    simulation_runtime, simulation_err = _capture_construction(
+        lambda: _build_simulation_runtime(case)
     )
+    generated_runtime, generated_err = _capture_construction(
+        lambda: _build_generated_runtime(case, handler_calls=generated_handler_calls)
+    )
+    initial_expect = _initial_constructor_expect(case)
+    _assert_aligned_constructor_outcome(
+        case,
+        initial_expect,
+        simulation_runtime,
+        simulation_err,
+        generated_runtime,
+        generated_err,
+    )
+    if initial_expect is not None:
+        return
+    simulation_handler_calls = _register_fixture_handlers(simulation_runtime, case)
     runtime = _GeneratedPythonAlignmentRuntime(
         simulation_runtime, generated_runtime, case.dsl_code
     )
@@ -2833,6 +2934,12 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
     if "cli_command" in runners and len(runners) != 1:
         raise _case_error(
             case_id, yaml_path, "cli_command cannot be mixed with other runners"
+        )
+    if "generated_python_alignment" in runners and "simulation" not in runners:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "generated_python_alignment requires the simulation runner",
         )
     _validate_initial(data.get("initial"), case_id, yaml_path, runners)
     _validate_runtime_options(data.get("runtime_options"), case_id, yaml_path, runners)

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -193,7 +193,6 @@ _EXCEPTION_TYPES = {
     "SimulationRuntimeExpressionError": SimulationRuntimeExpressionError,
     "ValueError": ValueError,
 }
-_CONSTRUCTOR_EXCEPTION_TYPES = tuple(_EXCEPTION_TYPES.values())
 _ALIGNMENT_CONSTRUCTOR_EXCEPTION_TYPES = (
     ValueError,
     ArithmeticError,
@@ -1266,30 +1265,9 @@ def _assert_aligned_constructor_outcome(
             type(generated_err).__name__,
         )
     )
-    assert str(simulation_err) == str(generated_err), (
-        "%s constructor exception message mismatch: simulation=%s generated=%s"
-        % (case.id, simulation_err, generated_err)
-    )
     _assert_exception(simulation_err, expect, case, "initial.expect.raises")
     _assert_exception(generated_err, expect, case, "initial.expect.raises")
 
-
-def _assert_aligned_constructor_failure(case: SemanticCase) -> None:
-    expect = _initial_constructor_expect(case)
-    simulation_runtime, simulation_err = _capture_construction(
-        lambda: _build_simulation_runtime(case)
-    )
-    generated_runtime, generated_err = _capture_construction(
-        lambda: _build_generated_runtime(case)
-    )
-    _assert_aligned_constructor_outcome(
-        case,
-        expect,
-        simulation_runtime,
-        simulation_err,
-        generated_runtime,
-        generated_err,
-    )
 
 
 def _initial_kwargs(case: SemanticCase) -> Dict[str, Any]:


### PR DESCRIPTION
# PR-0：对齐 fixture 与复现基线

上游伞 PR：[#200](https://github.com/HansBug/pyfcstm/pull/200)  
上游排查 issue：[#199](https://github.com/HansBug/pyfcstm/issues/199)

本 PR 是 #199 修复链路的第一个子 PR，只负责把后续 generated Python alignment 修复所需的 fixture / helper / schema / 验收基线补齐到可执行状态。**本 PR 不修复任何 production runtime/template 行为**；如果发现 template 行为偏差，只把它作为后续 PR 的可复现输入和 fixture 能力需求来约束。

## 目标与边界

目标：确认并补齐现有 `test/fixtures/simulate_semantics/`、`test/testings/simulate_semantics.py`、`test/template/python/test_semantic_fixture_alignment.py` 能承载 #199 后续所有子 PR 的 TDD：

**共享 fixture 纪律：** `test/fixtures/simulate_semantics/` 是 simulation runner 与 generated Python template alignment runner 长期共用的单一语义基线。任何带 `generated_python_alignment` 的 fixture 都必须同时带 `simulation` runner，并通过同一份 YAML、FCSTM、handler 配置、cycle 输入和 expectation schema 驱动两侧；后续 template 修复只能扩展 runner adapter / helper，不能另起 template-only fixture 系统导致两侧语义基线分裂。

- constructor parity：双方成功、双方抛同类异常、一侧抛一侧不抛的 one-sided mismatch 都必须能被 harness 明确表达和诊断；
- hot-start initial state / initial vars；
- active state path、persistent vars、`is_ended`、stack mode、cycle count；
- `cycle()` return value / normalized `CycleResult`；
- observation-only abstract handler / generated hook common call log；PR-0 需明确现有 fixture 字段与 #199 common log 术语的映射；
- generated hook subclass 挂载；
- packaged builtin template extraction path；更广泛的 source template + packaged assets 同 gate alignment 留给后续模板修复 PR 和 PR-6；
- shared fixture corpus gate：PR-0 需用元测试锁定 generated alignment case 同时接入 simulation runner，确保后续 simulator 与 template alignment 能长期复用同一语义输入；
- duplicate / duplicate-coverage / coverage control 留档进入 TDD 或控制清单的记录方式。

不处理：

- 不修改 `pyfcstm/simulate/` 生产语义；
- 不修改 `templates/python/` 行为；
- 不修改 `pyfcstm/template/` packaged assets，除非 PR-0 实际触碰 template packaging 工具链且必须同步；
- 不引入 jsfcstm / Node 依赖；
- 不用 PR 编号、issue 编号、stage/wave/roadmap 等 workflow metadata 命名测试、fixture id、helper、docstring 或 runtime message。

## 上游问题覆盖清单

PR-0 不负责修复下列 bug，但 fixture 基线必须能够表达它们，且后续子 PR 必须把分配给自己的主错误和所有 duplicate 留档一并纳入 TDD/控制清单。

| 记录 | 上游分类 | 后续责任 PR | PR-0 验收关注点 | 上游链接 |
|---|---|---|---|---|
| `A2-F-001` | `🐞 确凿对齐偏差` | PR-1 | fixture 能表达 composite entry 顺序、initial transition effect、plain `during before`、handler log 与 state/vars/stack 对齐 | [A2-F-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694005006) |
| `A3-HOT-COMP-EVENTED-INIT-001` | `🐞 确凿对齐偏差` | PR-2 | fixture 能表达 hot-start composite `init_wait`、evented initial transition、constructor 成功/失败 parity | [A3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694047896) |
| `A4-PSEUDO-001` | `🐞 确凿对齐偏差` | PR-1 | fixture 能表达 pseudo/non-stoppable source candidate validation、rollback、继续搜索后续候选 | [A4](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694028271) |
| `A9-001` | `🐞 确凿对齐偏差` | PR-3 | fixture 能表达 persistent `int` writeback / normalization 后的 vars 对齐 | [A9](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694002673) |
| `A10-HOOK-CTX-001` | `🐞 确凿对齐偏差` | PR-4 | fixture 能表达 observation-only handler/hook common context 字段、顺序、快照 | [A10](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694000657) |
| `C3-STATE-SLUG-001` | `🐞 确凿对齐偏差` | PR-5 | fixture 能跑 generated alignment 并在 state/action 命名碰撞时暴露调用路径偏差 | [C3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694962840) |
| `D4-HOT-DEPTH-001` | `🐞 确凿对齐偏差` | PR-2 | fixture 能表达 hot-start constructor one-sided structural-depth exception parity | [D4](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694747151) |
| `D7-SIGN-UFUNC-001` | `🐞 确凿对齐偏差` | PR-5 | fixture 能表达合法 expression 函数在 generated alignment cycle 中的 exception/return/state/vars 偏差 | [D7](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694810781) |
| `E1-INIT-001` | `🐞 确凿对齐偏差` | PR-3 | fixture 能表达 default initializer 后的 vars 类型/值对齐 | [E1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145) |
| `E5-DFS-STEP-001` | `🐞 确凿对齐偏差` | PR-1 | fixture 能表达 DFS safety exception parity，且不能被普通 rollback 结果误判为通过 | [E5](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694473689) |
| `E10-INIT-OVERRIDE-001` | `🐞 确凿对齐偏差` | PR-3 | fixture 能表达 hot-start `initial_vars` 覆盖默认 initializer 的 constructor parity | [E10](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694623177) |
| `E6-HOOK-REFCHAIN-001` | `🐞 确凿对齐偏差` | PR-4 | fixture 能表达长 ref chain 后 abstract hook 仍被调用且 common context 对齐 | [E6](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694663908) |

### duplicate / coverage 留档处理要求

PR-0 需保证后续子 PR 能按统一方式记录这些留档，不要求在 PR-0 修复或新增所有具体 regression fixture；但如果 PR-0 发现现有 schema/helper 无法表达某类 duplicate，就必须补能力和 meta-test。

| 留档 | 后续归属 | PR-0 处理方式 | 上游链接 |
|---|---|---|---|
| `E4-DFS-LIMIT-001` | PR-1 | 验证 constructor/cycle exception parity 与 DFS safety 类型可表达 | [E4](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694506709) |
| `A6-DUP-001` | PR-1、PR-4 | 验证同一上游 comment 可在子 PR body 覆盖清单中拆成 lifecycle 与 context 两个处理项 | [A6](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694092754) |
| `A7-DUP-001` | PR-1、PR-4 | 验证 pseudo later-candidate 与 aspect context 都能用 fixture/assertion 表达 | [A7](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694116854) |
| `B1`/`B2`/`B3`/`D1`/`D2`/`D3` | PR-1/PR-2/PR-4/PR-6 | 验证 deep composite、forced+pseudo、rollback validation、template audit controls 可映射到 fixture/test 或 PR body 覆盖论证 | [B1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694439541), [B2](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694430886), [B3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694459322), [D1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694763337), [D2](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694685954), [D3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694746840) |
| `B5`/`B10`/`D6`/`E2`/`E9` | PR-4/PR-6 | 验证 handler/hook log、common context、长序列控制可表达 | [B5](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694453880), [B10](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694405966), [D6](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694732793), [E2](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694789236), [E9](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694484773) |
| `B6`/`D4` | PR-2 | 验证 hot/cold equivalence 与 structural-depth constructor parity 可表达 | [B6](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694447739), [D4](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694747151) |
| `C1`/`C2`/`C5`/`C8`/`D9`/`D10`/`E3`/`E7` | PR-0、PR-3、PR-5、PR-6 | 验证 fuzz/control/no-new-independent-finding 记录能在 PR body 覆盖清单里保留判定、排除理由或控制 fixture；`D9-INIT-OVERRIDE-001` 与 `E10-INIT-OVERRIDE-001` 同属 hot-start `initial_vars` 覆盖默认 initializer 主题，是 PR-0 重点 harness 覆盖缺口输入；具体输入 fixture 为 `persistent_initial_vars_override_skips_initializer` | [C1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694852936), [C2](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694781586), [C5](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694761435), [C8](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4695001326), [D9](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694683787), [D10](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694746888), [E3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694491371), [E7](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694509160) |

### 后续子 PR 覆盖清单模板

PR-0 需要把下表格式固化为后续子 PR 可照抄的覆盖清单。每个子 PR 必须列出分配给自己的 canonical、duplicate、duplicate-coverage、coverage control 和明确排除项；同一个上游 comment 如果拆给多个责任 PR（例如 `A6-DUP-001`、`A7-DUP-001`），必须拆成多行分别说明。

| record id | 上游 comment URL | 分类 | 归并到 canonical | 后续责任 PR | TDD / control 处理方式 | fixture/test 名 | 排除或覆盖理由 |
|---|---|---|---|---|---|---|---|
| `<record>` | `<url>` | `🐞 finding` / `🔁 duplicate` / `✅ control` / `🚫 excluded` | `<canonical 或 N/A>` | `<PR-x>` | `新增 failing fixture` / `已有 fixture 覆盖` / `control rerun` / `明确排除` | `<fixture_or_test>` | `<覆盖论证或排除理由>` |

硬性规则：

- canonical 主错误必须完整转成先失败再修复的 fixture/test，并在子 PR body 自包含写明 Minimal DSL、复现代码/命令、期望/实际、白盒原因和语义来源。
- duplicate / duplicate-coverage 不能因为“重复”标签跳过；有具体 mismatch、复现代码、同质变体或 probe 的记录必须有 fixture/test，或给出已被哪个 canonical fixture 覆盖的具体理由。
- C1/C2/C5/C8/D9/D10/E3/E7 这类 fuzz/control/no-new-independent-finding 记录必须保留判定、排除理由或 control fixture；不能只写“无新发现”。

## 实施计划

1. **盘点现有 fixture 能力**：核对 schema、runner、assertion family、generated alignment runner、packaged template extraction hook、handler/hook fixture adapter，并记录当前基线数量（当前审查口径为 136 个 semantic YAML cases、86 个 generated alignment cases、0 个活跃 `expected_failure`）。
2. **写 PR-0 TDD/meta-tests**：先写失败或不足暴露测试，重点覆盖：
   - generated alignment constructor parity 必须明确覆盖三种情况：双方构造成功、双方构造抛同类异常、一侧抛一侧不抛的 one-sided mismatch。PR-0 需要决定并实现最小 schema/helper 表达方式，例如扩展 constructor alignment helper 统一诊断 one-sided mismatch；不把双方都抛时的完整 message/cause parity 升格为 #199 finding 要求，除非后续子 PR body 给出公开语义来源。
   - D9 具体输入 `persistent_initial_vars_override_skips_initializer` 必须在 PR-0 中有明确处理：若当前 generated runtime 已能通过，则把它升级为 `generated_python_alignment` runner；若当前 generated runtime 仍因 E10 生产行为失败，则补 meta-test/注释说明该 fixture 是 PR-3 的 TDD 入口，并确保 PR-3 可直接升级 runner 后先失败再修复。
   - generated alignment 使用 packaged builtin template：PR-0 至少保证 `extract_template("python", ...)` 路径被 gate 覆盖；复杂 fixture 的 source template + packaged assets 同 gate 全量回归留给模板修复子 PR 和 PR-6。
   - handler/hook common call log 可在 simulation 与 generated runtime 之间比较。PR-0 需要明确现有字段映射：#199 `action_name` ↔ fixture `action`，`state_path` ↔ `state`，`action_stage` ↔ `stage`，`vars_snapshot` ↔ `vars`；可选 metadata 使用 `active_leaf`、`call_stage`、`abstract_target`、`named_ref`。如果现有 2 个 generated-handler fixture 不足以证明 generated hook subclass、多 handler 顺序、aspect context 可承载 PR-4 TDD，则补最小 meta-test 或最小 fixture。
   - fixture assertion family 至少覆盖 state、vars、ended、stack、history、events、cycle_result、exception、context；`write_attempt`、`abstract_handler_errors`、`error_state`、`error_info` 属于 simulation-only 或 optional assertion 面，除非后续子 PR body 明确需要，不作为 generated alignment 必需面。
   - fixture body 不允许 `expected_failure` 活跃用例；后续 duplicate 覆盖清单需要能追踪到 origin/comment/test 名称。
3. **最小实现**：只补 `test/` helper/schema/meta-tests；若无需改代码则保留空实现并用审计测试证明能力已存在。PR-0 只落实 harness/schema/记录能力；PR-3 才负责 E10/D9 对应 template 行为修复和目标 fixture runner 升级后的通过。
4. **测试漂移防护**：后续 #199 TDD 的必需断言面以 #199 public trajectory 为准：active state path、persistent vars、`is_ended`、normalized cycle value、observation-only handler/hook common log。stack mode、cycle count、history、exception message/cause、generated internal `_stack` 等 helper-extra surfaces 只能作为 harness guard 或诊断；除非子 PR body 给出明确公开语义来源，不得把这些额外面单独变成 template 修复要求。新增 generated alignment fixture 不得把 event-accounting parity 当作 generated runtime 义务。
5. **命名纪律**：新增 fixture id、helper 名、test 名都按领域行为命名，不出现 `PR-0`、issue id、wave/stage 等 workflow metadata。
6. **验证**：
   - `pytest test/simulate/test_semantic_fixtures.py -q`
   - `pytest test/template/python/test_semantic_fixture_alignment.py -q`
   - `SKIP_SLOW_TESTS=1 make unittest`
   - 如果修改 Python public API/docstring：先运行 `make rst_auto`，并检查 pydoc 是否符合 CLAUDE.md：module doc 清晰，class/function 有 params/returns/raises/examples。
   - 本 PR 不预计修改 `pyfcstm/llm/fcstm_grammar_guide.md`；若实际修改该文件，必须额外运行 `make sha256` 并提交 checksum。
7. **push + watch CI**：CI 必须通过；CodeCov comment 若指出覆盖行退化，需要评估并修复或解释。
8. **实现审查**：三路 reviewer 独立强对抗白盒 review；必须检查 PR-0 是否足以承载后续 #199 主错误和 duplicate 留档 TDD，且没有测试语义漂移。

## 验收标准

- PR body 与伞 PR #200 的 PR-0 分工一致，没有遗漏 #199 中对 fixture baseline 的执行要求。
- PR-0 不修改 production runtime/template 行为。
- 现有或新增测试能证明 fixture schema/helper 支持后续 12 个 canonical buckets 的必要观察面，并明确哪些是 #199 public trajectory 必需面、哪些只是 helper-extra guard。
- `D9-INIT-OVERRIDE-001` / `persistent_initial_vars_override_skips_initializer` 这类 historical/harness 覆盖缺口有明确处理：要么直接升级 generated alignment runner，要么保留为 PR-3 TDD 入口并用 meta-test 证明 harness/schema 已能承载。
- duplicate / duplicate-coverage 留档不会因“重复”标签被跳过；后续子 PR body 有统一覆盖清单格式可照抄，且 A6/A7 这类同一 comment 多归属记录会拆行处理。
- Python 单元测试仍只依赖 repo-level `test/` 与 production `pyfcstm/`，不调用 Node/jsfcstm。
- 若改 docstring/pydoc，符合 CLAUDE.md reST 风格，且运行 `make rst_auto`。若不触碰 public Python API/docstring，可在 PR body 明确说明 `make rst_auto` 不产生变更；若触碰 LLM grammar guide，额外运行 `make sha256`。
- CI、精准 pytest、slow-skip unittest、CodeCov 无未解释覆盖行退化、三路 reviewer 均 C/I=0 后才可标记 ready；本 PR 不由主线自行 merge，等待用户指示。

## 依赖关系

```mermaid
flowchart TD
    S0["PR-0<br/>fixture 与复现基线<br/>⏳ 待启动"]
    S1["PR-1<br/>entry / pseudo / DFS<br/>⏳ 待 PR-0"]
    S2["PR-2<br/>hot-start constructor<br/>⏳ 待 PR-0"]
    S3["PR-3<br/>persistent vars normalization<br/>⏳ 待 PR-0"]
    S4["PR-4<br/>hook / ref context<br/>⏳ 待 PR-0"]
    S5["PR-5<br/>命名与表达式渲染<br/>⏳ 待 PR-0"]
    S6["PR-6<br/>全集回归与收口<br/>⏳ 待 PR-1..5"]

    S0 --> S1
    S0 --> S2
    S0 --> S3
    S0 --> S4
    S0 --> S5
    S1 --> S6
    S2 --> S6
    S3 --> S6
    S4 --> S6
    S5 --> S6

    classDef active fill:#fff3bf,stroke:#d6a100,color:#111;
    classDef planned fill:#e7f5ff,stroke:#1c7ed6,color:#111;
    classDef done fill:#d3f9d8,stroke:#2b8a3e,color:#111;
    classDef blocked fill:#ffe3e3,stroke:#c92a2a,color:#111;
    class S0 active;
    class S1,S2,S3,S4,S5,S6 planned;
```

## 当前状态

- 本 PR：`🧭 计划审查中`
- 本 PR 当前 diff：empty planning commits only（当前无 file diff，后续实现提交会补测试/helper 变更）。
- 下一步：三路 reviewer 审查 PR body 与 #200/#199 一致性、可执行性、可验收性。C/I 级问题必须先修 PR body 后复审。


