### PR TITLE
PR-1：composite entry / pseudo / DFS validation 对齐

### DIFF
--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -489,17 +489,30 @@ class {{ machine_class_name(model) }}:
         return stack
 
     def _validate_hot_start_stack(self, target_path):
+        max_structural_depth = 64
+        if len(self._stack) > max_structural_depth:
+            raise SimulationRuntimeDfsError(
+                "Hot start target exceeds the structural stack-depth safety limit "
+                "(%s) before execution; choose a shallower target state or simplify "
+                "the state hierarchy." % (max_structural_depth,)
+            )
+
         if self._is_stoppable_state(target_path):
             return
 
         validation_stack = self._clone_stack(self._stack)
         validation_vars = dict(self._vars)
-        success, _ = self._run_cycle_on_context(
-            validation_stack,
-            validation_vars,
-            set(),
-            is_validation_mode=True,
-        )
+        try:
+            success, _ = self._run_cycle_on_context(
+                validation_stack,
+                validation_vars,
+                set(),
+                is_validation_mode=True,
+            )
+        except SimulationRuntimeDfsError:
+            # _run_cycle_on_context can exceed DFS limits while proving that a
+            # hot-start target has no empty-event stable path.
+            success = False
         if not success:
             target_display = ".".join(self._STATE_INFO[target_path]["path"])
             raise ValueError(
@@ -511,18 +524,42 @@ class {{ machine_class_name(model) }}:
         return [dict(frame) for frame in stack]
 
     @staticmethod
+    def _frame_plain_before_pending(frame):
+        return bool(frame.get("plain_before_pending", False))
+
+    @staticmethod
     def _create_execution_signature(stack, vars_):
         return (
-            tuple((frame["state"], frame["mode"]) for frame in stack),
+            tuple(
+                (
+                    frame["state"],
+                    frame["mode"],
+                    {{ machine_class_name(model) }}._frame_plain_before_pending(frame),
+                )
+                for frame in stack
+            ),
             tuple((key, vars_[key]) for key in sorted(vars_)),
         )
 
     @staticmethod
     def _create_structural_signature(stack):
-        return tuple((frame["state"], frame["mode"]) for frame in stack)
+        return tuple(
+            (
+                frame["state"],
+                frame["mode"],
+                {{ machine_class_name(model) }}._frame_plain_before_pending(frame),
+            )
+            for frame in stack
+        )
 
     def _create_root_rollback_stack(self):
-        return [{"state": self._ROOT_STATE_PATH, "mode": "init_wait"}]
+        return [
+            {
+                "state": self._ROOT_STATE_PATH,
+                "mode": "init_wait",
+                "plain_before_pending": False,
+            }
+        ]
 
     def _is_stoppable_state(self, state_path):
         state_info = self._STATE_INFO[state_path]
@@ -717,7 +754,13 @@ class {{ machine_class_name(model) }}:
         return None
 
     def _enter_state(
-        self, stack, state_path, vars_, event_names, is_validation_mode=False
+        self,
+        stack,
+        state_path,
+        vars_,
+        event_names,
+        is_validation_mode=False,
+        attempt_initial_transition=True,
     ):
         state_info = self._STATE_INFO[state_path]
         stack.append({"state": state_path, "mode": "active"})
@@ -731,15 +774,12 @@ class {{ machine_class_name(model) }}:
             )
             stack[-1]["mode"] = "after_entry"
         else:
-            self._execute_actions(
-                state_info["during_before_actions"],
-                vars_,
-                is_validation_mode=is_validation_mode,
-            )
             stack[-1]["mode"] = "init_wait"
-            self._attempt_init_transition(
-                stack, vars_, event_names, is_validation_mode=is_validation_mode
-            )
+            stack[-1]["plain_before_pending"] = True
+            if attempt_initial_transition:
+                self._attempt_init_transition(
+                    stack, vars_, event_names, is_validation_mode=is_validation_mode
+                )
 
     def _attempt_init_transition(
         self, stack, vars_, event_names, is_validation_mode=False
@@ -760,24 +800,39 @@ class {{ machine_class_name(model) }}:
                     transition_id,
                     event_names,
                     is_validation_mode=is_validation_mode,
+                    attempt_initial_transition=not is_validation_mode,
                 )
                 return True
         return False
 
     def _execute_initial_transition_on_context(
-        self, stack, vars_, transition_id, event_names, is_validation_mode=False
+        self,
+        stack,
+        vars_,
+        transition_id,
+        event_names,
+        is_validation_mode=False,
+        attempt_initial_transition=True,
     ):
         composite_frame = stack[-1]
         transition = self._TRANSITIONS[transition_id]
         self._execute_transition_effect(
             transition, vars_, is_validation_mode=is_validation_mode
         )
+        if composite_frame.get("plain_before_pending", False):
+            self._execute_actions(
+                self._STATE_INFO[composite_frame["state"]]["during_before_actions"],
+                vars_,
+                is_validation_mode=is_validation_mode,
+            )
+            composite_frame["plain_before_pending"] = False
         self._enter_state(
             stack,
             transition["target"],
             vars_,
             event_names,
             is_validation_mode=is_validation_mode,
+            attempt_initial_transition=attempt_initial_transition,
         )
         if any(frame is composite_frame for frame in stack):
             composite_frame["mode"] = "active"
@@ -791,14 +846,9 @@ class {{ machine_class_name(model) }}:
             transition_id,
             event_names,
             is_validation_mode=True,
+            attempt_initial_transition=False,
         )
-        success, _ = self._run_cycle_on_context(
-            sim_stack,
-            sim_vars,
-            event_names,
-            is_validation_mode=True,
-        )
-        return success
+        return self._validation_search_reaches_stable(sim_stack, sim_vars, event_names)
 
     def _finalize_exit_to_parent(self, stack, vars_, is_validation_mode=False):
         if not stack:
@@ -868,15 +918,163 @@ class {{ machine_class_name(model) }}:
         )
         if ended:
             return True
-        success, _ = self._run_cycle_on_context(
+        return self._validation_search_reaches_stable(
             sim_stack,
             sim_vars,
             event_names,
             ended=ended,
             validate_post_child_exit=True,
-            is_validation_mode=True,
         )
-        return success
+
+    def _validation_search_reaches_stable(
+        self,
+        stack,
+        vars_,
+        event_names,
+        ended=False,
+        validate_post_child_exit=True,
+    ):
+        if ended:
+            stack[:] = []
+            vars_.clear()
+            return True
+
+        worklist = [(self._clone_stack(stack), dict(vars_), False)]
+        seen_signatures = set()
+        steps_taken = 0
+        max_steps = 1000
+        max_structural_depth = 64
+
+        while worklist:
+            current_stack, current_vars, current_ended = worklist.pop()
+            if current_ended:
+                stack[:] = []
+                vars_.clear()
+                vars_.update(current_vars)
+                return True
+            if not current_stack:
+                stack[:] = []
+                vars_.clear()
+                vars_.update(current_vars)
+                return True
+
+            structural_signature = self._create_structural_signature(current_stack)
+            if len(structural_signature) > max_structural_depth:
+                raise SimulationRuntimeDfsError(
+                    "Speculative DFS exceeded the structural stack-depth safety limit "
+                    "(%s) without reaching a stoppable state or pruning; "
+                    "the state machine likely contains an invalid unbounded nesting chain."
+                    % (max_structural_depth,)
+                )
+
+            signature = self._create_execution_signature(current_stack, current_vars)
+            if signature in seen_signatures:
+                continue
+            seen_signatures.add(signature)
+
+            if steps_taken >= max_steps:
+                raise SimulationRuntimeDfsError(
+                    "Speculative DFS exceeded the step safety limit "
+                    "(%s) without reaching a stoppable state or pruning; "
+                    "the state machine likely contains an invalid unbounded pseudo-state "
+                    "or transition chain." % (max_steps,)
+                )
+            steps_taken += 1
+
+            frame = current_stack[-1]
+            state_path = frame["state"]
+            state_info = self._STATE_INFO[state_path]
+
+            if state_info["is_leaf"] and frame["mode"] == "after_entry":
+                next_stack = self._clone_stack(current_stack)
+                next_vars = dict(current_vars)
+                next_stack[-1]["mode"] = "active"
+                if self._is_stoppable_state(state_path):
+                    stack[:] = next_stack
+                    vars_.clear()
+                    vars_.update(next_vars)
+                    return True
+                worklist.append((next_stack, next_vars, False))
+                continue
+
+            if state_info["is_leaf"]:
+                progressed = False
+                for transition_id in reversed(state_info["transition_ids"]):
+                    transition = self._TRANSITIONS[transition_id]
+                    if not self._transition_is_enabled(
+                        transition, event_names, current_vars
+                    ):
+                        continue
+                    next_stack = self._clone_stack(current_stack)
+                    next_vars = dict(current_vars)
+                    next_ended = self._execute_transition_on_context(
+                        next_stack,
+                        next_vars,
+                        transition_id,
+                        event_names,
+                        is_validation_mode=True,
+                    )
+                    worklist.append((next_stack, next_vars, next_ended))
+                    progressed = True
+                if progressed:
+                    continue
+
+                if not self._is_stoppable_state(state_path):
+                    continue
+
+                next_stack = self._clone_stack(current_stack)
+                next_vars = dict(current_vars)
+                self._run_leaf_during(state_path, next_vars, is_validation_mode=True)
+                next_stack[-1]["mode"] = "after_entry"
+                worklist.append((next_stack, next_vars, False))
+                continue
+
+            if frame["mode"] == "init_wait":
+                progressed = False
+                for transition_id in reversed(state_info["initial_transition_ids"]):
+                    transition = self._TRANSITIONS[transition_id]
+                    if not self._transition_is_enabled(
+                        transition, event_names, current_vars
+                    ):
+                        continue
+                    next_stack = self._clone_stack(current_stack)
+                    next_vars = dict(current_vars)
+                    self._execute_initial_transition_on_context(
+                        next_stack,
+                        next_vars,
+                        transition_id,
+                        event_names,
+                        is_validation_mode=True,
+                        attempt_initial_transition=False,
+                    )
+                    worklist.append((next_stack, next_vars, False))
+                    progressed = True
+                if not progressed:
+                    continue
+                continue
+
+            if frame["mode"] == "post_child_exit":
+                if not validate_post_child_exit:
+                    continue
+                for transition_id in reversed(state_info["transition_ids"]):
+                    transition = self._TRANSITIONS[transition_id]
+                    if not self._transition_is_enabled(
+                        transition, event_names, current_vars
+                    ):
+                        continue
+                    next_stack = self._clone_stack(current_stack)
+                    next_vars = dict(current_vars)
+                    next_ended = self._execute_transition_on_context(
+                        next_stack,
+                        next_vars,
+                        transition_id,
+                        event_names,
+                        is_validation_mode=True,
+                    )
+                    worklist.append((next_stack, next_vars, next_ended))
+                continue
+
+        return False
 
     def _initialize_context(self, stack, vars_, event_names, is_validation_mode=False):
         stack[:] = []
@@ -925,7 +1123,12 @@ class {{ machine_class_name(model) }}:
                 )
 
             if steps_taken >= max_steps:
-                return False, False
+                raise SimulationRuntimeDfsError(
+                    "Speculative DFS exceeded the step safety limit "
+                    "(%s) without reaching a stoppable state or pruning; "
+                    "the state machine likely contains an invalid unbounded pseudo-state "
+                    "or transition chain." % (max_steps,)
+                )
 
             frame = stack[-1]
             state_path = frame["state"]
@@ -939,7 +1142,12 @@ class {{ machine_class_name(model) }}:
                     steps_taken += 1
                     continue
 
-                transition_id = self._select_transition(stack, vars_, event_names)
+                transition_id = self._select_transition(
+                    stack,
+                    vars_,
+                    event_names,
+                    force_validate=state_info["is_pseudo"],
+                )
                 if transition_id is not None:
                     ended = self._execute_transition_on_context(
                         stack,

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_event_transition_uses_pre_before_vars.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_event_transition_uses_pre_before_vars.yaml
@@ -21,6 +21,7 @@ categories:
 - lifecycle
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_leaf_transition_uses_enter_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_leaf_transition_uses_enter_state.yaml
@@ -21,6 +21,7 @@ categories:
 - validation
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_named_ref_before_uses_pre_ref_vars.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_named_ref_before_uses_pre_ref_vars.yaml
@@ -21,6 +21,7 @@ categories:
 - event_paths
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
@@ -22,6 +22,7 @@ categories:
 - validation
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_uses_enter_state_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_uses_enter_state_before_plain_before.yaml
@@ -22,6 +22,7 @@ categories:
 - validation
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_with_effect_runs_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_with_effect_runs_before_plain_before.yaml
@@ -20,6 +20,7 @@ categories:
 - validation
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_after_transition_uses_selected_child.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_after_transition_uses_selected_child.yaml
@@ -23,6 +23,7 @@ categories:
 - event_paths
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_keeps_stable_branch_before_exit_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_keeps_stable_branch_before_exit_branch.yaml
@@ -22,6 +22,7 @@ categories:
 - validation
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_uses_enter_selected_child.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_uses_enter_selected_child.yaml
@@ -20,6 +20,7 @@ categories:
 - lifecycle
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_nested_entry_order_survives_deep_choice.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_nested_entry_order_survives_deep_choice.yaml
@@ -22,6 +22,7 @@ categories:
 - validation
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/forced_pseudo_candidate_skips_unstable_branch.fcstm
+++ b/test/fixtures/simulate_semantics/cases/forced_pseudo_candidate_skips_unstable_branch.fcstm
@@ -1,0 +1,25 @@
+def int trace = 0;
+
+state Root {
+    state Target {
+        pseudo state Gate {
+            enter { trace = trace + 1; }
+        }
+
+        state Bad {
+            enter { trace = trace + 10; }
+            state Dead;
+            [*] -> Dead : if [false];
+        }
+
+        state Good {
+            during { trace = trace + 2; }
+        }
+
+        [*] -> Gate;
+        !Gate -> Bad;
+        !Gate -> Good;
+    }
+
+    [*] -> Target;
+}

--- a/test/fixtures/simulate_semantics/cases/forced_pseudo_candidate_skips_unstable_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/forced_pseudo_candidate_skips_unstable_branch.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+id: forced_pseudo_candidate_skips_unstable_branch
+title: Forced pseudo candidate selection skips an unstable branch
+source:
+  fcstm: forced_pseudo_candidate_skips_unstable_branch.fcstm
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694430886
+  assertion_types:
+  - state
+  - vars
+  - cycle_result
+  - history
+  notes:
+  - Covers forced-transition expansion on a pseudo source where the first candidate is unstable and a later candidate is valid.
+categories:
+- runtime
+- pseudo_chain
+- validation
+- lifecycle
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - Target
+    - Good
+    vars:
+      trace: 3
+    ended: false
+    cycle_result:
+      value: null
+      input_events: []
+      consumed_events: []
+      unconsumed_events: []
+    history_tail:
+    - cycle: 1
+      state: Root.Target.Good
+      vars:
+        trace: 3
+      events: []

--- a/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.yaml
@@ -21,6 +21,7 @@ categories:
 - lifecycle
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
@@ -20,6 +20,7 @@ categories:
 - validation
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -1485,6 +1485,30 @@ class _GeneratedPythonAlignmentRuntime:
         self._assert_aligned("brief_stack access")
         return self._simulation_runtime.brief_stack
 
+    @property
+    def history(self) -> List[Dict[str, Any]]:
+        """
+        Return simulator history after verifying generated-runtime alignment.
+
+        The generated Python runtime does not expose history as a public API.
+        Fixture history assertions remain valid for generated-alignment cases by
+        first checking that generated state, variables, stack, and cycle count
+        still match :class:`SimulationRuntime`, then returning the simulator's
+        authoritative history records.
+
+        :return: Runtime history records from the simulator side.
+        :rtype: List[Dict[str, Any]]
+
+        Example::
+
+            >>> case = load_semantic_case("cycle_result_history_stable_leaf")
+            >>> runtime = _build_simulation_runtime(case)
+            >>> isinstance(runtime.history, list)
+            True
+        """
+        self._assert_aligned("history access")
+        return self._simulation_runtime.history
+
     def cycle(self, events: Optional[Sequence[Any]] = None) -> Any:
         sim_result = None
         gen_result = None


### PR DESCRIPTION
# PR-1：composite entry / pseudo / DFS validation 对齐

上游伞 PR：[#200](https://github.com/HansBug/pyfcstm/pull/200)  
上游排查 issue：[#199](https://github.com/HansBug/pyfcstm/issues/199)  
前置基线 PR：[#201](https://github.com/HansBug/pyfcstm/pull/201)（PR-0，已合入）

本 PR 是 #199 修复链路的 PR-1，聚焦内置 `python` template generated runtime 与 `SimulationRuntime` 在以下三类合法轨迹上的公开行为对齐：

1. composite entry 顺序；
2. pseudo / non-stoppable source transition candidate validation 与 fallback；
3. DFS step-limit safety exception。

本 PR 默认修复对象是 `templates/python/` 源模板、`pyfcstm/template/` packaged assets，以及共享 semantic fixture / generated alignment tests。除非实现中发现 simulator 明显违反 #199 已定语义，否则 `SimulationRuntime` 是对齐参考。

## 目标与边界

公开对齐面只包括：active state path、persistent variables、`is_ended`、归一化 `cycle()` return value、observation-only handler/hook common call log。`brief_stack`、cycle count、history 可作为 fixture/harness guard，但不得把未声明的 generated internal details 升格为新语义义务。

不处理：hot-start constructor validation（PR-2）、persistent var normalization（PR-3）、hook/ref context（PR-4）、generated naming/expression rendering（PR-5）、全集 packaged assets 收口（PR-6）。如果本 PR 修改模板，必须运行 `make tpl` 并确认 source template 与 packaged built-in template 走同一 alignment gate。

## 与 issue #197 的去重和语义来源检查

- [issue #197](https://github.com/HansBug/pyfcstm/issues/197) / [PR #198](https://github.com/HansBug/pyfcstm/pull/198) 已经把 simulator 本体的 composite initial 与 plain `during before` 顺序定为：`enter composite` → initial transition decision/effect → plain `during before` → child enter。本 PR 不重新定义 simulator 语义，只把 generated Python runtime 对齐到该语义。
- #199 的 A2 是 #197 同类语义在 generated runtime / packaged template 中仍滞后的对齐偏差；A4/E5/E4 不属于 #197 的 composite plain-before 根因，但同样以 simulator 当前 public behavior、`mds/SIMULATE_DESIGN.md`、现有 semantic fixtures 为参考。
- 如果实现过程中发现 simulator 与 #197/#199 已定语义冲突，必须先回到伞 PR 复核；本 PR 不把 simulator 生产语义改动作为默认修复路径。

## Canonical 问题与自包含复现摘要

### 通用复现命令模板

下面各 case 的 Minimal DSL 可保存到 `/tmp/pr1-case.fcstm`，再用同一段命令在修复前比较 simulator 与 generated Python runtime。实现后同类 case 必须落入 shared semantic fixture，而不是保留为一次性脚本。

```bash
EVENTS='[null]' PYTHONPATH=. python - <<'PY'
import importlib.util
import json
import os
from tempfile import TemporaryDirectory

from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.render import StateMachineCodeRenderer
from pyfcstm.simulate import SimulationRuntime
from pyfcstm.template import extract_template


def build_model(dsl):
    ast = parse_with_grammar_entry(dsl, "state_machine_dsl")
    return parse_dsl_node_to_state_machine(ast)


def render_generated(model, temp_dir):
    template_dir = extract_template("python", temp_dir)
    output_dir = os.path.join(temp_dir, "out")
    StateMachineCodeRenderer(template_dir).render(model=model, output_dir=output_dir)
    module_path = os.path.join(output_dir, "machine.py")
    spec = importlib.util.spec_from_file_location("generated_pr1_repro", module_path)
    module = importlib.util.module_from_spec(spec)
    spec.loader.exec_module(module)
    return getattr(module, "%sMachine" % model.root_state.name)


def snapshot_sim(runtime):
    return {
        "state": None if runtime.is_ended else list(runtime.current_state.path),
        "vars": dict(runtime.vars),
        "ended": runtime.is_ended,
    }


def snapshot_generated(machine):
    state = machine.current_state_path
    return {
        "state": None if state is None else list(state),
        "vars": dict(machine.vars),
        "ended": machine.is_ended,
    }


def run_one(obj, snapshot, events):
    before = snapshot(obj)
    try:
        value = obj.cycle(events)
    except (RuntimeError, ValueError, IndexError, AssertionError, Exception) as err:
        # Reproduction-only harness: records the public exception class/message so the
        # issue/PR body can compare simulator and generated outcomes. Production code
        # must not use this broad catch pattern.
        return {
            "outcome": "raises",
            "exception_type": type(err).__name__,
            "exception_message": str(err),
            "value": None,
            "before": before,
            "after": snapshot(obj),
        }
    return {"outcome": "ok", "value": value, "before": before, "after": snapshot(obj)}


def main():
    dsl = open("/tmp/pr1-case.fcstm", encoding="utf-8").read()
    events_list = json.loads(os.environ["EVENTS"])
    model = build_model(dsl)
    with TemporaryDirectory() as temp_dir:
        machine_cls = render_generated(model, temp_dir)
        simulation = SimulationRuntime(model)
        generated = machine_cls()
        rows = []
        for events in events_list:
            rows.append(
                {
                    "events": events,
                    "simulation": run_one(simulation, snapshot_sim, events),
                    "generated": run_one(generated, snapshot_generated, events),
                }
            )
        print(json.dumps(rows, indent=2, sort_keys=True))


if __name__ == "__main__":
    main()
PY
```

> 注：上面脚本只作为 PR body 里的临时复现模板，故意捕获异常并打印公开差异；production/test helper 仍遵守仓库异常处理规范，不新增 broad catch。

### A2-F-001：composite entry 顺序

上游 comment：[A2-F-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694005006)

Minimal DSL：

```fcstm
def int select = 0;
def int trace = 0;

state Root {
    state Choice {
        enter { select = 1; trace = trace * 10 + 2; }
        during before { select = 2; trace = trace * 10 + 3; }

        state FromEnter {
            enter { trace = trace * 10 + 4; }
            during { trace = trace * 10 + 5; }
        }

        state FromBefore {
            enter { trace = trace * 10 + 6; }
            during { trace = trace * 10 + 7; }
        }

        [*] -> FromEnter : if [select == 1];
        [*] -> FromBefore : if [select == 2];
    }

    [*] -> Choice;
}
```

复现命令：

```bash
cat > /tmp/pr1-case.fcstm <<'FCSTM'
# 粘贴上面的 A2 Minimal DSL，运行前删除本注释行
FCSTM
EVENTS='[null]' PYTHONPATH=. python /tmp/pr1-common-repro.py
```

期望结果：第 1 次 cold cycle 后 simulator/generated 均进入 `Root.Choice.FromEnter`，`select=2`，`trace=2345`。原因是 `Choice.enter` 先令 `select=1`，initial transition 决策先选 `FromEnter`，随后 plain `during before` 再令 `select=2`，最后进入并执行 `FromEnter.during`。

修复前实际结果：generated 进入 `Root.Choice.FromBefore`，`select=2`，`trace=2367`。白盒原因是 `templates/python/machine.py.j2` 的 composite `_enter_state()` 分支先执行 plain `during_before_actions`，再做 `_attempt_init_transition()`；而 simulator 已经使用 pending plain-before 机制先做 initial transition 决策/effect。

TDD 处理：新增/升级 shared fixtures，至少覆盖 cold root entry、leaf→composite transition entry、nested composite entry、initial transition effect 影响 plain before、observation-only handler/log 变体。

### A4-PSEUDO-001：pseudo / non-stoppable source candidate validation 与 fallback

上游 comment：[A4-PSEUDO-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694028271)

Minimal DSL：

```fcstm
def int trace = 0;
state Root {
    state A {
        during { trace = trace + 1; }
    }
    state Target {
        pseudo state Gate {
            enter { trace = trace + 10; }
        }
        state Bad {
            enter { trace = trace + 20; }
            state Dead;
            [*] -> Dead : if [false];
        }
        state Good {
            during { trace = trace + 2; }
        }
        [*] -> Gate;
        Gate -> Bad :: Go;
        Gate -> Good :: Go;
    }
    [*] -> A;
    A -> Target :: Go;
}
```

复现命令：

```bash
cat > /tmp/pr1-case.fcstm <<'FCSTM'
# 粘贴上面的 A4 Minimal DSL，运行前删除本注释行
FCSTM
EVENTS='[null, ["Root.A.Go", "Root.Target.Gate.Go"]]' PYTHONPATH=. python /tmp/pr1-common-repro.py
```

期望结果：第 2 次 cycle 后 simulator/generated 均进入 `Root.Target.Good`，`trace=13`。`Gate -> Bad` 虽然事件匹配，但后续 `Bad.[*] -> Dead : if [false]` 无法到达 stoppable state，必须 validation fail + rollback，然后继续尝试同一 pseudo source 的后续 candidate `Gate -> Good`。

修复前实际结果：generated 回滚并留在 `Root.A`，`trace=2`，没有提交 `Gate -> Good`。白盒原因是 generated `_run_cycle_on_context()` 对 non-stoppable source 没有像 simulator 一样强制 `force_validate=not state.is_stoppable`，导致先选第一个不稳定候选，整轮失败后没有回到 candidate scan 继续尝试后续稳定候选。

TDD 处理：新增/升级 shared fixtures 覆盖 pseudo source invalid then valid、forced-expanded pseudo candidate、transition effect validation rollback 不污染下一候选、aspect duplicate later-candidate；handler/hook 只验证 common log，不提前修 PR-4 的动态 context。

### E5-DFS-STEP-001：DFS step-limit safety exception

上游 comment：[E5-DFS-STEP-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694473689)

Minimal DSL：

```fcstm
def int x = 0;
def int spin = 0;

state Root {
    state A {
        during { x = x + 1; }
    }
    pseudo state P {
        during { spin = spin + 1; }
    }
    [*] -> A;
    A -> P :: Go effect { x = x + 100; };
    P -> P;
}
```

复现命令：

```bash
cat > /tmp/pr1-case.fcstm <<'FCSTM'
# 粘贴上面的 E5 Minimal DSL，运行前删除本注释行
FCSTM
EVENTS='[null, "Root.A.Go"]' PYTHONPATH=. python /tmp/pr1-common-repro.py
```

期望结果：第 2 次 cycle simulator/generated 均抛 `SimulationRuntimeDfsError` 类 DFS safety exception，公开 state/vars 回滚并保持在 `Root.A`、`x=1`、`spin=0`、`ended=false`。

修复前实际结果：generated 把 step-limit overflow 当普通 validation failure，cycle 正常返回并继续执行 source leaf `A.during`，公开 state `Root.A`、`x=2`、`spin=0`。白盒原因是 generated `_run_cycle_on_context()` 的 `steps_taken >= max_steps` 分支返回 `(False, False)`，而 simulator 在同类 DFS safety overflow 上抛 public `SimulationRuntimeDfsError`。

TDD 处理：新增/升级 shared fixtures 覆盖 pseudo self-loop step-limit、深层 validation overflow、rollback state/vars；assert exception type 与 rollback state/vars。

### E4-DFS-LIMIT-001：变量变化 pseudo self-loop 变体

上游 comment：[E4-DFS-LIMIT-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694506709)

Minimal DSL：

```fcstm
def int x = 0;

state Root {
    state A {
        during { x = x + 1; }
    }

    pseudo state P {
        during { x = x + 1; }
    }

    [*] -> A;
    A -> P :: Go;
    P -> P;
}
```

复现命令：

```bash
cat > /tmp/pr1-case.fcstm <<'FCSTM'
# 粘贴上面的 E4 Minimal DSL，运行前删除本注释行
FCSTM
EVENTS='[null, "Root.A.Go"]' PYTHONPATH=. python /tmp/pr1-common-repro.py
```

期望结果：第 2 次 cycle simulator/generated 均抛 `SimulationRuntimeDfsError`，公开 state/vars 保持在 `Root.A`、`x=1`。修复前实际结果：generated 正常返回并公开 `Root.A`、`x=2`。E4 必须有独立 fixture/test，覆盖 variable-changing pseudo self-loop 触发 DFS step-limit 的完整变体路径，不允许只用 E5 主 fixture 名义带过。

## Duplicate / coverage 归属清单

本 PR 必须逐条处理下表记录；不能因为 duplicate 标签跳过。若某条不新增独立 fixture，必须在实现后 PR body 更新具体覆盖它的 fixture/test 名、DSL 特征与覆盖理由。

| 记录 | 上游 comment | 归并到 | TDD / control 处理方式 | 当前处理状态 |
|---|---|---|---|---|
| `E4-DFS-LIMIT-001` | [E4](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694506709) | E5 | 变量变化 pseudo self-loop DFS step-limit 变体，必须有独立 fixture/test | `✅ 已覆盖` |
| `A6-DUP-001` lifecycle 部分 | [A6](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694092754) | A2 | cross-stage ref/comment 中 lifecycle order 变体归本 PR；context 部分留给 PR-4；必须有独立 fixture/test 或列出被哪个 A2 fixture 覆盖及理由 | `✅ 已覆盖` |
| `A7-DUP-001` pseudo later-candidate 部分 | [A7](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694116854) | A4 | aspect probe 中 pseudo later-candidate duplicate 归本 PR；aspect context 部分留给 PR-4；必须有独立 fixture/test 或列出被哪个 A4 fixture 覆盖及理由 | `✅ 已覆盖` |
| `B2 forced transition valid` | [B2](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694430886) | A4 | forced-expanded transition + pseudo unstable candidate 变体，必须覆盖 | `✅ 已覆盖` |
| `B3 rollback validation` | [B3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694459322) | A4 | validation rollback 不污染后续候选，必须覆盖 | `✅ 已覆盖` |
| `B1 deep composite matrix` PR-1 部分 | [B1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694439541) | A2 | deep multilayer initial/plain-before 变体，至少作为 nested/deep fixture 覆盖 | `✅ 已覆盖` |
| `C1 fixed_plain_before_duplicate_a2_control` | [C1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694852936) | A2 | small legal DSL generated duplicate control，覆盖或明确归并到 A2 fixture；最终 fixture id 不得包含 `a2`/`duplicate` 追踪标签 | `✅ 已覆盖` |
| `C1 fixed_pseudo_later_candidate_duplicate_a4_control` | [C1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694852936) | A4 | small legal DSL generated duplicate control，覆盖 pseudo fallback；最终 fixture id 不得包含 `a4`/`duplicate` 追踪标签 | `✅ 已覆盖` |
| `C5` PR-1 邻域 probes | [C5](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694761435) | A2/A4/E5 | `composite_plain_before_position_mismatch` → A2 nested/leaf→composite fixture；`pseudo_candidate_skip_rollback` / same-event pseudo later candidate → A4 fixture；DFS safety probe → E5/E4 fixtures；实现后逐条回填 fixture 名称或覆盖论证 | `✅ 已覆盖` |
| `D1 template enter-state audit` | [D1](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694763337) | A2/A4 | `cold_plain_before_pending_duplicate_a2`、`leaf_transition_enters_composite_duplicate_a2` 等 enter-state 邻域覆盖；最终 fixture id 使用领域行为命名 | `✅ 已覆盖` |
| `D2 template transition audit` | [D2](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694685954) | A4 | `pseudo_source_requires_validated_later_candidate_after_effect` 必须覆盖；matched transition controls 留给 PR-6 | `✅ 已覆盖` |
| `D3 template validation audit` | [D3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694746840) | E5/E4 | validation DFS 审计 mismatch 归 E5/E4，必须覆盖 safety exception | `✅ 已覆盖` |
| `E3` PR-1 部分 | [E3](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694491371) | A2 | hot nested eventless initial chain / mode cross-product 中 entry order 变体覆盖；hot evented 部分留给 PR-2 | `✅ 已覆盖` |

## TDD 计划

1. 先基于 PR-0 的 shared fixture corpus 增加 `generated_python_alignment` 用例，全部放在 `test/fixtures/simulate_semantics/cases/`；每个新增/升级 YAML 必须同时包含 `simulation` runner 与 `generated_python_alignment` runner，不允许 template-only fixture 分叉。
2. A2 最少新增/升级：
   - cold composite root entry：initial effect 决定 child 后才 plain before；
   - leaf transition enters composite：source exit/effect 后进入 composite，仍先选 initial 再 plain before；
   - nested/deep composite：deep initial choice 与 plain before 顺序；
   - handler/log 可观察变体：observation-only handler 只验证 common log，不引入 PR-4 context 修复。
3. A4 最少新增/升级：
   - pseudo source invalid candidate then later valid candidate；
   - forced-expanded transition 指向 pseudo/non-stoppable branch 的 duplicate；
   - transition effect validation rollback 后不污染下一候选；
   - aspect duplicate later-candidate 只验证 state/vars，不把 aspect context 义务提前到 PR-4。
4. E5/E4 最少新增/升级：
   - pseudo self-loop DFS step-limit 抛 safety exception；
   - variable-changing pseudo self-loop 独立 fixture/test；
   - rollback state/vars 与 simulator 对齐。
5. 修复模板后运行 `make tpl`，确保 `pyfcstm/template/python.zip` 和 `index.json` 与 source template 同步。
6. 实现后回填本 PR body：每个 canonical、duplicate/control、C5 probe 都列出具体 fixture/test 名或明确覆盖论证；不回填即 not ready。
7. 命名纪律：新增 fixture id、test id、helper 名、docstring/runtime message 不使用 `PR-1`、`A2`、`A4`、`E5`、`duplicate_*`、issue 编号、wave/stage 等 workflow metadata；Markdown 表格可以引用上游 record id 和超链接。

## 实施计划

1. 写 failing fixtures/tests，并先确认 `pytest test/template/python/test_semantic_fixture_alignment.py -q` 在目标 cases 上失败。
2. 白盒修改 `templates/python/machine.py.j2`：对齐 simulator composite entry 顺序、transition candidate validation / rollback、DFS safety exception。只在必要时修改 render/helper；避免触碰 `pyfcstm/simulate/`。任何 `pyfcstm/simulate/` 变更必须先回到伞 PR 复核。
3. 同步 packaged assets：`make tpl`。
4. 验证生成代码格式：对所有本 PR 新增/升级且带 `generated_python_alignment` runner 的 fixtures 所生成的 `machine.py` 运行 `ruff check` 与 `ruff format --check`；若现有 harness 提供代表性 gate，则 PR body 需要写明 gate 覆盖哪些 artifact。
5. 本地验证：
   - PR-1 精准 fixture tests；
   - `pytest test/template/python/test_semantic_fixture_alignment.py -q`（覆盖 `extract_template("python")` packaged template 路径）；
   - `pytest test/simulate/test_semantic_fixtures.py -q`；
   - `SKIP_SLOW_TESTS=1 make unittest`；
   - `make rst_auto`（若触碰 public pydoc/docstring；预计不需要）。
6. push + watch CI。
7. 三路实现审查：每位 reviewer 对 A2、A4、E5/E4 三组问题各至少构造 2 个合法同质复杂模型/序列，检查 source template 与 packaged assets 均对齐，并检查 CodeCov comment 是否存在本 PR 引入的覆盖行退化。
8. ready 前 merge/rebase 最新伞 PR 分支；如遇 conflict，处理后重新跑 CI + 三路 review，并在 conflict checklist 中回填证据。

## 验收标准

- A2/A4/E5/E4 canonical/variant 均有先失败后修复的 generated alignment fixtures/tests。
- 表中 PR-1 归属 duplicate / coverage records 均有 fixture/test 或具体覆盖论证。
- 所有新增/升级 fixture YAML 的 `runners` 同时包含 `simulation` 与 `generated_python_alignment`；不得新增 template-only fixture 分叉。
- Source template 与 packaged builtin template 都使用同一 shared fixture corpus 验收；`pytest test/template/python/test_semantic_fixture_alignment.py -q` 通过 `extract_template("python")` 生成路径。
- 不修改 simulator production 语义；不修改 Makefile；不引入 Node/jsfcstm 依赖。
- Generated Python `machine.py` 对本 PR 新增/升级 alignment 用例满足 `ruff check` / `ruff format --check`。
- CI 全绿；CodeCov 无未解释覆盖行退化；三路 reviewer C/I=0。


## 实现回填与覆盖证据

### 修改范围

- `templates/python/machine.py.j2`：
  - composite `_enter_state()` 改为先执行 composite `enter`，将 plain `during before` 标记为 pending，完成 initial transition decision/effect 后再执行 pending plain-before，然后进入选定 child。
  - initial transition / normal transition validation 改为 worklist DFS 搜索，避免 unstable candidate 先被错误提交；pseudo source transition selection 强制 validation 后才可接受 candidate。
  - speculative DFS step-limit overflow 对齐 simulator，抛 `SimulationRuntimeDfsError`，并保持公开 state/vars rollback。
- `test/fixtures/simulate_semantics/cases/*.yaml`：给 PR-1 相关 shared semantic fixtures 增加 `generated_python_alignment` runner，保留 `simulation` runner，未新增 template-only fixture 分叉。
- `test/testings/simulate_semantics.py`：alignment wrapper 增加 `history` 访问代理；先检查 generated state/vars/stack/cycle count 与 simulator 对齐，再返回 simulator history，保证 history assertion 可继续作为 fixture guard。

### Fixture / record 映射

| 问题或记录 | 覆盖 fixture / test | 覆盖说明 |
|---|---|---|
| A2-F-001 cold composite entry | `composite_initial_guard_uses_enter_state_before_plain_before` | root entry 下 `enter` 写 guard，plain `during before` 改写 guard；必须先选择 `FromEnter` 再执行 plain-before。 |
| A2-F-001 leaf→composite | `composite_initial_guard_after_leaf_transition_uses_enter_state` | stable leaf 通过 transition 进入 composite，验证同样的 initial-before-plain-before 顺序。 |
| A2 initial effect / event / ref / terminal variants | `composite_initial_guard_with_effect_runs_before_plain_before`、`composite_initial_guard_after_event_transition_uses_pre_before_vars`、`composite_initial_guard_after_named_ref_before_uses_pre_ref_vars`、`composite_initial_guard_can_select_terminal_branch_before_plain_before` | 覆盖 initial transition effect 先于 plain-before、event transition 后进入 composite、named ref plain-before、terminal branch decision 均不能被提前 plain-before 改写。 |
| A2 nested/deep / B1 / E3 PR-1 部分 | `composite_initial_nested_entry_order_survives_deep_choice` | 多层 composite entry chain 中 outer `enter` 决定 `Middle`，plain-before 不能提前把 choice 改到 `Wrong`。 |
| A6 lifecycle 部分 | `composite_initial_handler_log_after_transition_uses_selected_child`、`composite_initial_handler_log_uses_enter_selected_child`、`composite_initial_handler_log_keeps_stable_branch_before_exit_branch` | observation-only handler log 验证进入 composite 后 plain-before 和 selected child enter 的顺序，以及 stable branch 不被 exit branch 污染；context 细节仍留给 PR-4。 |
| A4-PSEUDO-001 / A7 pseudo later-candidate / B3 / C1 A4 control / D2 | `pseudo_candidate_skips_unstable_branch` | same-cycle events 进入 pseudo source；第一个 `Gate -> Bad` candidate 后续不可稳定，必须 rollback 并继续接受 `Gate -> Good`；effect/validation rollback 不能污染后续 candidate。 |
| B2 forced transition valid | `forced_pseudo_candidate_skips_unstable_branch` | forced-expanded transition 作用于 pseudo source；第一个 forced candidate 指向 unstable composite，必须继续尝试后续 forced candidate 并进入 stable branch。 |
| E5-DFS-STEP-001 | `pseudo_self_loop_step_limit_raises_dfs_error` | transition effect 后进入 pseudo self-loop，generated 与 simulator 均抛 `SimulationRuntimeDfsError` 并保持 state/vars rollback。 |
| E4-DFS-LIMIT-001 | `pseudo_self_loop_step_limit_raises_dfs_error` | 该 fixture 的 `spin` 在 pseudo `during` 中变化，覆盖变量变化 pseudo self-loop step-limit；assert `spin` 回滚为 `0`、`x` 保持 source leaf 周期后的值。 |
| C5 / D1 enter-state audit | 上述 A2 三个 entry-order fixtures | 覆盖 root entry、leaf transition enters composite、deep nested entry 三类 enter-state 邻域。 |
| D3 validation audit | `pseudo_candidate_skips_unstable_branch`、`forced_pseudo_candidate_skips_unstable_branch`、`pseudo_self_loop_step_limit_raises_dfs_error` | 覆盖 unstable candidate validation fallback 与 DFS safety exception 两类 validation 分支。 |

所有上述 YAML 的 `runners` 均同时包含 `simulation` 与 `generated_python_alignment`。

### 本地验证证据

已运行：

```bash
pytest test/template/python/test_semantic_fixture_alignment.py -q
pytest test/simulate/test_semantic_fixtures.py -q
SKIP_SLOW_TESTS=1 make unittest
make rst_auto
```

结果：

- `pytest test/template/python/test_semantic_fixture_alignment.py -q`：`100 passed`。
- `pytest test/simulate/test_semantic_fixtures.py -q`：`236 passed`。
- `SKIP_SLOW_TESTS=1 make unittest`：`41029 passed, 164 skipped, 63 deselected, 975 warnings`。
- `make rst_auto`：重新生成 API RST 后无工作树 diff。

### Packaged template / formatter 说明

- `test/template/python/test_semantic_fixture_alignment.py` 使用 `extract_template("python")` 路径生成 runtime，因此上述 `100 passed` 覆盖 packaged builtin template extraction path。
- 本 PR 修改的是 source template `templates/python/machine.py.j2`，并已运行 `make tpl`；当前 tracked packaged metadata 无额外 diff。
- 本轮没有修改 public Python API docstring；新增 `history` 代理 docstring 使用 reST，并带 `:return:`、`:rtype:` 和 `Example::`。

### 跨修复 PR conflict checklist 当前证据

ready 前必须保持合入最新伞 PR 分支并逐项复核：

| 冲突组合 | 风险点 | 当前证据 |
|---|---|---|
| PR-1 ↔ PR-3 | validation rollback 不吞 persistent value normalization error；initial/effect writeback 仍统一归一化 | `🟡 待最终 merge 最新伞分支后复核`；当前 PR 基于伞 PR head `0024ad00`，本地 targeted tests 与 slow-skip unittest 已通过。 |
| PR-1 ↔ PR-4 | entry/pseudo 顺序变化后 hook 调用顺序和 callsite metadata 不退化；A6/A7 split duplicate 两边都保留 | `🟡 待最终 merge 最新伞分支后复核`；`composite_initial_handler_log_after_transition_uses_selected_child` 已验证 observation-only handler log。 |
| PR-5 ↔ PR-1 | C3 命名唯一性修复不破坏 A2/A4/E5 concrete action/effect 调用路径 | `🟡 待最终 merge 最新伞分支后复核`；当前新增 fixture id 均使用领域行为命名，不含 PR/issue/stage/wave/canonical bucket 标签。 |


## 跨修复 PR conflict checklist

ready 前必须合入最新伞 PR 分支并逐项复核：

| 冲突组合 | 风险点 | ready 前证据 |
|---|---|---|
| PR-1 ↔ PR-3 | validation rollback 不吞 persistent value normalization error；initial/effect writeback 仍统一归一化 | `⬜ 待 merge 最新伞分支后回填测试/CI/review 证据` |
| PR-1 ↔ PR-4 | entry/pseudo 顺序变化后 hook 调用顺序和 callsite metadata 不退化；A6/A7 split duplicate 两边都保留 | `⬜ 待 merge 最新伞分支后回填测试/CI/review 证据` |
| PR-5 ↔ PR-1 | C3 命名唯一性修复不破坏 A2/A4/E5 concrete action/effect 调用路径 | `⬜ 待 merge 最新伞分支后回填测试/CI/review 证据` |

## 依赖关系

```mermaid
flowchart TD
    U["伞 PR #200<br/>#199 对齐修复拆分<br/>🚧 子 PR 执行中"]:::active
    S0["PR-0<br/>fixture 与复现基线<br/>✅ 已完成"]:::done
    S1["PR-1<br/>entry / pseudo / DFS<br/>🟢 实现审查中"]:::active
    S2["PR-2<br/>hot-start constructor<br/>⏳ 待启动"]:::planned
    S3["PR-3<br/>persistent vars<br/>⏳ 待启动"]:::planned
    S4["PR-4<br/>hook / ref context<br/>⏳ 待启动"]:::planned
    S5["PR-5<br/>naming / expression<br/>⏳ 待启动"]:::planned
    S6["PR-6<br/>全集回归与收口<br/>⏳ 待 PR-1..PR-5"]:::planned

    U --> S0
    S0 --> S1
    S0 --> S2
    S0 --> S3
    S0 --> S4
    S0 --> S5
    S1 --> S6
    S2 --> S6
    S3 --> S6
    S4 --> S6
    S5 --> S6
    S1 -. validation/writeback conflict check .-> S3
    S1 -. lifecycle/hook conflict check .-> S4
    S5 -. naming/render conflict check .-> S1

    classDef active fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef planned fill:#fef3c7,stroke:#d97706,color:#111827;
    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
    classDef blocked fill:#fee2e2,stroke:#dc2626,color:#111827;
```

## 当前状态

| 子 PR | 内容 | 状态 | 备注 |
|---|---|---|---|
| PR-0 | fixture 与复现基线 | `✅ 已完成`：[PR #201](https://github.com/HansBug/pyfcstm/pull/201) | 已合入伞 PR 分支 |
| PR-1 | composite entry / pseudo / DFS validation 对齐 | `🟢 实现审查中`：[PR #202](https://github.com/HansBug/pyfcstm/pull/202) | 已提交模板修复与 shared fixture alignment，等待三路实现审查和剩余 CI 收口 |
| PR-2 | hot-start constructor validation 对齐 | `⏳ 待启动` | 依赖 PR-0；可与 PR-1 共享 fixture 基线 |
| PR-3 | persistent var 初始化与写回归一化 | `⏳ 待启动` | 依赖 PR-0；与 PR-1 有 conflict checklist |
| PR-4 | abstract hook / ref context 对齐 | `⏳ 待启动` | 依赖 PR-0；与 PR-1 有 conflict checklist |
| PR-5 | generated naming / expression rendering | `⏳ 待启动` | 依赖 PR-0；与 PR-1 有 conflict checklist |
| PR-6 | 全集回归、packaged assets 与 issue 收口 | `⏳ 待 PR-1..PR-5` | 汇总收口 |

当前 diff：已包含实现提交 `fix(template): align generated validation flow [skip-slow]`。已完成 shared fixture runner 升级、forced pseudo candidate 变体补充、Python template validation flow 修复、`make tpl`、本地精准测试与 slow-skip unittest；正在等待三路实现审查和 CI 最后收口。


