### PR TITLE
PR-3：persistent variable 初始化与写回归一化对齐

### DIFF
--- a/templates/python/config.yaml
+++ b/templates/python/config.yaml
@@ -10,7 +10,7 @@ stmt_styles:
   python_runtime:
     base_lang: python
     expr_lang: python
-    state_var_target: "scope[{{ name | tojson }}]"
+    state_var_target: "local_scope[{{ name | tojson }}]"
     temp_var_target: "{{ name }}"
     assign: |-
       {{ target }} = self._evaluate_runtime_expr(

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -338,6 +338,67 @@ class {{ machine_class_name(model) }}:
     }
 {% endif %}
 
+    def _normalize_persistent_value(self, name, value, source):
+        if name not in self._VAR_TYPES:
+            raise ValueError(
+                "Variable %r not defined in state machine. Available variables: %s"
+                % (name, list(self._VAR_TYPES.keys()))
+            )
+        declared_type = self._VAR_TYPES[name]
+        if type(value) is bool:
+            raise ValueError("%s must not be bool" % (source,))
+        if type(value) not in (int, float):
+            raise ValueError(
+                "%s must be int or float, got %s" % (source, type(value).__name__)
+            )
+        if type(value) is float and not math.isfinite(value):
+            raise ValueError(
+                "%s for variable %r declared %s must be finite, got %r"
+                % (source, name, declared_type, value)
+            )
+        if declared_type == "int":
+            if type(value) is float:
+                if value != int(value):
+                    raise ValueError(
+                        "Variable %r is int type, cannot assign float %r; "
+                        "non-integer float from %s" % (name, value, source)
+                    )
+                return int(value)
+            return value
+        if declared_type == "float":
+            try:
+                normalized_float = float(value)
+            except OverflowError as err:
+                # OverflowError: ``float(value)`` cannot represent a very
+                # large Python integer as a finite runtime float.
+                raise ValueError(
+                    "%s for variable %r declared float must be finite; "
+                    "integer is outside Python float range" % (source, name)
+                ) from err
+            if not math.isfinite(normalized_float):
+                raise ValueError(
+                    "%s for variable %r declared float must be finite, got %r"
+                    % (source, name, normalized_float)
+                )
+            return normalized_float
+        raise ValueError(
+            "Variable %r has unsupported persistent type %r" % (name, declared_type)
+        )
+
+    def _execute_operation_block(self, operations, vars_, source):
+        local_scope = dict(vars_)
+        operations(local_scope)
+        normalized_updates = {
+            name: self._normalize_persistent_value(
+                name,
+                local_scope[name],
+                source,
+            )
+            for name in self.VARIABLE_NAMES
+        }
+        for name, value in normalized_updates.items():
+            vars_[name] = value
+
     def __init__(self, initial_state=None, initial_vars=None):
         """
         Initialize the generated state machine runtime.
@@ -349,37 +410,42 @@ class {{ machine_class_name(model) }}:
         """
         self._vars = {}
         self.variables = self._vars
-{%- for def_item in define_items %}
-        self._vars[{{ def_item.name | tojson }}] = {{ def_item.init.to_ast_node() | expr_render(style="python_expr") }}
-{% endfor %}
+        if initial_state is not None and initial_vars is None:
+            raise ValueError(
+                "initial_vars must be provided when initial_state is specified"
+            )
         if initial_vars is not None:
-            missing_vars = set(self._VAR_TYPES.keys()) - set(initial_vars.keys())
-            if missing_vars:
-                raise ValueError(
-                    "initial_vars must provide all variables. Missing: %s"
-                    % sorted(missing_vars)
-                )
             extra_vars = set(initial_vars.keys()) - set(self._VAR_TYPES.keys())
             if extra_vars:
+                unknown_name = sorted(extra_vars)[0]
                 raise ValueError(
-                    "initial_vars contains unknown variables: %s" % sorted(extra_vars)
+                    "Variable %r not defined in state machine. Available variables: %s"
+                    % (unknown_name, list(self._VAR_TYPES.keys()))
                 )
-            for name, value in initial_vars.items():
-                if type(value) is bool:
-                    raise ValueError("initial_vars[%r] must not be bool" % (name,))
-                if type(value) not in (int, float):
+            if initial_state is not None:
+                missing_vars = set(self._VAR_TYPES.keys()) - set(initial_vars.keys())
+                if missing_vars:
                     raise ValueError(
-                        "initial_vars[%r] must be int or float, got %s"
-                        % (name, type(value).__name__)
+                        "initial_vars must provide all variables. Missing: %s"
+                        % sorted(missing_vars)
                     )
-                if self._VAR_TYPES[name] == "int" and type(value) is float:
-                    if value != int(value):
-                        raise ValueError(
-                            "Variable %r is int type, cannot assign float %r"
-                            % (name, value)
-                        )
-                    value = int(value)
-                self._vars[name] = value
+{%- for def_item in define_items %}
+        if initial_vars is not None and {{ def_item.name | tojson }} in initial_vars:
+            self._vars[{{ def_item.name | tojson }}] = self._normalize_persistent_value(
+                {{ def_item.name | tojson }},
+                initial_vars[{{ def_item.name | tojson }}],
+                "initial_vars[%r]" % ({{ def_item.name | tojson }},),
+            )
+        else:
+            self._vars[{{ def_item.name | tojson }}] = self._normalize_persistent_value(
+                {{ def_item.name | tojson }},
+                self._evaluate_runtime_expr(
+                    lambda: {{ def_item.init.to_ast_node() | expr_render(style="python_expr") }},
+                    "variable {{ def_item.name }} initializer",
+                ),
+                "variable {{ def_item.name }} initializer",
+            )
+{% endfor %}
 
         self._ended = False
         self._entered_root = initial_state is not None
@@ -387,10 +453,6 @@ class {{ machine_class_name(model) }}:
         if initial_state is None:
             self._stack = [{"state": self._ROOT_STATE_PATH, "mode": "init_wait"}]
         else:
-            if initial_vars is None:
-                raise ValueError(
-                    "initial_vars must be provided when initial_state is specified"
-                )
             self._stack = self._build_hot_start_stack(
                 self._normalize_state_path(initial_state)
             )
@@ -780,11 +842,13 @@ class {{ machine_class_name(model) }}:
     def _evaluate_runtime_expr(self, fn, usage):
         try:
             return fn()
-        except (ValueError, ArithmeticError) as err:
+        except (ValueError, ArithmeticError, TypeError) as err:
             # ValueError: math domain errors or invalid numeric operations
             # raised while evaluating a user's DSL expression.
             # ArithmeticError: division by zero, overflow, or other numeric
             # runtime failure while evaluating a user's DSL expression.
+            # TypeError: Python numeric, bitwise, and shift operators reject
+            # runtime operand combinations such as ``float << int``.
             raise SimulationRuntimeExpressionError(
                 "%s evaluation failed: %s" % (usage, err)
             ) from err
@@ -1410,7 +1474,11 @@ class {{ machine_class_name(model) }}:
         """
 {% if resolved.item.operations %}
         scope = vars_ if vars_ is not None else self._vars
-{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 {% else %}
         pass
 {% endif %}
@@ -1463,7 +1531,11 @@ class {{ machine_class_name(model) }}:
         """
 {% if resolved.item.operations %}
         scope = vars_ if vars_ is not None else self._vars
-{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 {% else %}
         pass
 {% endif %}
@@ -1516,7 +1588,11 @@ class {{ machine_class_name(model) }}:
         """
 {% if resolved.item.operations %}
         scope = vars_ if vars_ is not None else self._vars
-{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 {% else %}
         pass
 {% endif %}
@@ -1571,7 +1647,11 @@ class {{ machine_class_name(model) }}:
         """
 {% if resolved.item.operations %}
         scope = vars_ if vars_ is not None else self._vars
-{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 {% else %}
         pass
 {% endif %}
@@ -1626,7 +1706,11 @@ class {{ machine_class_name(model) }}:
         """
 {% if resolved.item.operations %}
         scope = vars_ if vars_ is not None else self._vars
-{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 {% else %}
         pass
 {% endif %}
@@ -1681,7 +1765,11 @@ class {{ machine_class_name(model) }}:
         """
 {% if resolved.item.operations %}
         scope = vars_ if vars_ is not None else self._vars
-{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 {% else %}
         pass
 {% endif %}
@@ -1736,7 +1824,11 @@ class {{ machine_class_name(model) }}:
         """
 {% if resolved.item.operations %}
         scope = vars_ if vars_ is not None else self._vars
-{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ resolved.item.operations | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 {% else %}
         pass
 {% endif %}
@@ -1772,7 +1864,11 @@ class {{ machine_class_name(model) }}:
 {{ (transition.to_ast_node() | string) | indent(12, true) }}
         """
         scope = vars_ if vars_ is not None else self._vars
-{{ transition.effects | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ transition.effects | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 
 {% endif %}
 {% endfor %}
@@ -1805,7 +1901,11 @@ class {{ machine_class_name(model) }}:
 {{ (transition.to_ast_node() | string) | indent(12, true) }}
         """
         scope = vars_ if vars_ is not None else self._vars
-{{ transition.effects | stmts_render(style='python_runtime', indent='    ', level=2) }}
+
+        def operations(local_scope):
+{{ transition.effects | stmts_render(style='python_runtime', indent='    ', level=3) }}
+
+        self._execute_operation_block(operations, scope, "operation block writeback")
 
 {% endif %}
 {% endfor %}

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.fcstm
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.fcstm
@@ -1,0 +1,10 @@
+def int bad = 1 / 0;
+def int ticks = 0;
+
+state Root {
+    state Safe {
+        during { ticks = ticks + 1; }
+    }
+
+    [*] -> Safe;
+}

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.yaml
@@ -1,0 +1,47 @@
+schema_version: 1
+id: hot_start_initial_vars_override_skips_int_initializer
+title: Hot start initial vars override skips failing int initializer
+source:
+  fcstm: hot_start_initial_vars_override_skips_int_initializer.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694623177
+  assertion_types:
+  - initial
+  - state
+  - vars
+  - constructor_exception
+  notes:
+  - Covers the canonical int failing-initializer override case.
+categories:
+- runtime
+- template_alignment
+- hot_start
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: Root.Safe
+  vars:
+    bad: 7
+    ticks: 0
+steps:
+- expect_initial:
+    state:
+    - Root
+    - Safe
+    vars:
+      bad: 7
+      ticks: 0
+    ended: false
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - Safe
+    vars:
+      bad: 7
+      ticks: 1
+    ended: false
+    cycle_result:
+      value: null

--- a/test/fixtures/simulate_semantics/cases/persistent_default_float_initializer_converts_int.fcstm
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_float_initializer_converts_int.fcstm
@@ -1,0 +1,10 @@
+def float ratio = 2;
+def int marker = 0;
+
+state Root {
+    state A {
+        during { marker = (ratio == 2.0) ? 1 : 0; }
+    }
+
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/persistent_default_float_initializer_converts_int.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_float_initializer_converts_int.yaml
@@ -1,0 +1,42 @@
+schema_version: 1
+id: persistent_default_float_initializer_converts_int
+title: Persistent default float initializer converts integer value
+source:
+  fcstm: persistent_default_float_initializer_converts_int.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145
+  assertion_types:
+  - initial
+  - state
+  - vars
+  notes:
+  - Completeness guard for declared float normalization on default initializers.
+categories:
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- expect_initial:
+    state:
+    - Root
+    vars:
+      ratio: 2.0
+      marker: 0
+    ended: false
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      ratio: 2.0
+      marker: 1
+    ended: false
+    cycle_result:
+      value: null

--- a/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_normalizes_integer_float.fcstm
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_normalizes_integer_float.fcstm
@@ -1,0 +1,10 @@
+def int bits = 6 / 2;
+def int marker = 0;
+
+state Root {
+    state A {
+        during { marker = bits & 1; }
+    }
+
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_normalizes_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_normalizes_integer_float.yaml
@@ -1,0 +1,43 @@
+schema_version: 1
+id: persistent_default_int_initializer_normalizes_integer_float
+title: Persistent default int initializer normalizes integer-valued float
+source:
+  fcstm: persistent_default_int_initializer_normalizes_integer_float.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145
+  assertion_types:
+  - initial
+  - state
+  - vars
+  - exception
+  notes:
+  - Covers declared int default initializer normalization before the first cycle.
+categories:
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- expect_initial:
+    state:
+    - Root
+    vars:
+      bits: 3
+      marker: 0
+    ended: false
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      bits: 3
+      marker: 1
+    ended: false
+    cycle_result:
+      value: null

--- a/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.fcstm
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.fcstm
@@ -1,0 +1,6 @@
+def int count = 1.5;
+
+state Root {
+    state A;
+    [*] -> A;
+}

--- a/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.yaml
@@ -1,0 +1,27 @@
+schema_version: 1
+id: persistent_default_int_initializer_rejects_non_integer_float
+title: Persistent default int initializer rejects non-integer float
+source:
+  fcstm: persistent_default_int_initializer_rejects_non_integer_float.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145
+  assertion_types:
+  - constructor_exception
+  notes:
+  - Guards the constructor-side persistent int boundary for default initializers.
+categories:
+- runtime
+- template_alignment
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+  expect:
+    raises:
+      type: ValueError
+      match: "Variable 'count' is int type, cannot assign float 1.5"
+      match_kind: substring
+steps: []

--- a/test/fixtures/simulate_semantics/cases/persistent_effect_writeback_normalizes_integer_float.fcstm
+++ b/test/fixtures/simulate_semantics/cases/persistent_effect_writeback_normalizes_integer_float.fcstm
@@ -1,0 +1,15 @@
+def int bits = 0;
+def int marker = 0;
+
+state Root {
+    state A;
+    state B {
+        during { marker = bits & 1; }
+    }
+
+    [*] -> A;
+    A -> B :: Go effect {
+        tmp = 6 / 2;
+        bits = tmp;
+    };
+}

--- a/test/fixtures/simulate_semantics/cases/persistent_effect_writeback_normalizes_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_effect_writeback_normalizes_integer_float.yaml
@@ -1,0 +1,49 @@
+schema_version: 1
+id: persistent_effect_writeback_normalizes_integer_float
+title: Persistent transition effect writeback normalizes integer-valued float
+source:
+  fcstm: persistent_effect_writeback_normalizes_integer_float.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694002673
+  assertion_types:
+  - state
+  - vars
+  - exception
+  notes:
+  - Covers transition-effect writeback through the same persistent boundary as lifecycle actions.
+categories:
+- runtime
+- template_alignment
+- temporary_vars
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      bits: 0
+      marker: 0
+    ended: false
+    cycle_result:
+      value: null
+- cycle:
+    events:
+    - Root.A.Go
+  expect:
+    state:
+    - Root
+    - B
+    vars:
+      bits: 3
+      marker: 1
+    ended: false
+    cycle_result:
+      value: null

--- a/test/fixtures/simulate_semantics/cases/persistent_initial_vars_override_skips_initializer.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_initial_vars_override_skips_initializer.yaml
@@ -17,8 +17,10 @@ origin:
 categories:
 - runtime
 - hot_start
+- template_alignment
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: Root.A
   vars:

--- a/test/fixtures/simulate_semantics/cases/persistent_int_writeback_normalizes_integer_float.fcstm
+++ b/test/fixtures/simulate_semantics/cases/persistent_int_writeback_normalizes_integer_float.fcstm
@@ -1,0 +1,20 @@
+def int bits = 0;
+def int marker = 0;
+
+state Root {
+    state A {
+        during {
+            tmp = 6 / 2;
+            bits = tmp;
+            marker = marker + 1;
+        }
+    }
+    state B {
+        during {
+            marker = bits & 1;
+        }
+    }
+
+    [*] -> A;
+    A -> B :: Go;
+}

--- a/test/fixtures/simulate_semantics/cases/persistent_int_writeback_normalizes_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_int_writeback_normalizes_integer_float.yaml
@@ -1,0 +1,51 @@
+schema_version: 1
+id: persistent_int_writeback_normalizes_integer_float
+title: Persistent int writeback normalizes integer-valued float
+source:
+  fcstm: persistent_int_writeback_normalizes_integer_float.fcstm
+origin:
+  files:
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694002673
+  - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694852936
+  assertion_types:
+  - state
+  - vars
+  - exception
+  notes:
+  - Covers operation-block temporary propagation into a declared int variable.
+categories:
+- runtime
+- template_alignment
+- temporary_vars
+- lifecycle
+runners:
+- simulation
+- generated_python_alignment
+initial:
+  state: null
+  vars: null
+steps:
+- cycle: {}
+  expect:
+    state:
+    - Root
+    - A
+    vars:
+      bits: 3
+      marker: 1
+    ended: false
+    cycle_result:
+      value: null
+- cycle:
+    events:
+    - Root.A.Go
+  expect:
+    state:
+    - Root
+    - B
+    vars:
+      bits: 3
+      marker: 1
+    ended: false
+    cycle_result:
+      value: null

--- a/test/fixtures/simulate_semantics/cases/persistent_operation_writeback_rejects_float_and_rolls_back.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_operation_writeback_rejects_float_and_rolls_back.yaml
@@ -18,8 +18,10 @@ categories:
 - runtime
 - temporary_vars
 - lifecycle
+- template_alignment
 runners:
 - simulation
+- generated_python_alignment
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -111,8 +111,9 @@ Allowed fields:
 - `initial.vars`: full variable snapshot mapping or `null`.
 - `initial.expect.raises`: required constructor exception expectation.
 
-When `initial.expect` is present, `initial.state` and `initial.vars` must both
-be explicit non-null values. Use `initial.vars: {}` for zero-variable machines.
+When `initial.expect` is present, `initial.state` and `initial.vars` keys must
+both be explicit. Use `null` / `null` to assert cold-start constructor
+diagnostics and `initial.vars: {}` for zero-variable hot-start diagnostics.
 
 Construction-diagnostic cases must use `steps: []`; executable steps are
 rejected so that constructor failures cannot silently skip later assertions.

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -178,14 +178,15 @@ def test_generated_alignment_constructor_outcome_helper_covers_three_modes():
 
 
 @pytest.mark.unittest
-def test_initial_vars_override_fixture_remains_simulation_only_seed():
+def test_initial_vars_override_fixture_runs_generated_alignment_contract():
     case = load_semantic_case("persistent_initial_vars_override_skips_initializer")
 
-    assert case.runners == ("simulation",)
+    assert case.runners == ("simulation", "generated_python_alignment")
     assert case.data["initial"]["state"] == "Root.A"
     assert case.data["initial"]["vars"] == {"recovered": 5.0}
     assert "initial" in case.data["origin"]["assertion_types"]
     assert "hot_start" in case.data["categories"]
+    assert "template_alignment" in case.data["categories"]
 
 
 @pytest.mark.unittest
@@ -497,22 +498,26 @@ def _set_model_build_expectation(data, raises):
             "initial.expect has unknown fields",
         ),
         (
-            lambda data: data["initial"].update(
-                {
-                    "state": None,
-                    "vars": {},
-                    "expect": {"raises": {"type": "ValueError"}},
-                }
+            lambda data: (
+                data["initial"].pop("state")
+                or data["initial"].update(
+                    {
+                        "vars": {},
+                        "expect": {"raises": {"type": "ValueError"}},
+                    }
+                )
             ),
             "initial.expect requires initial.state",
         ),
         (
-            lambda data: data["initial"].update(
-                {
-                    "state": "Root.A",
-                    "vars": None,
-                    "expect": {"raises": {"type": "ValueError"}},
-                }
+            lambda data: (
+                data["initial"].pop("vars")
+                or data["initial"].update(
+                    {
+                        "state": "Root.A",
+                        "expect": {"raises": {"type": "ValueError"}},
+                    }
+                )
             ),
             "initial.expect requires initial.vars",
         ),
@@ -520,7 +525,7 @@ def _set_model_build_expectation(data, raises):
             lambda data: data["initial"].update(
                 {"expect": {"raises": {"type": "UnknownError"}}}
             ),
-            "initial.expect requires initial.state",
+            "initial.expect.raises.type is unknown",
         ),
         (
             lambda data: data["initial"].update(

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -2657,13 +2657,13 @@ def _validate_initial(
         _validate_vars_mapping(initial.get("vars"), case_id, yaml_path, "initial.vars")
     if "expect" not in initial:
         return
-    if initial.get("state") is None:
+    if "state" not in initial:
         raise _case_error(
             case_id,
             yaml_path,
             "initial.expect requires initial.state",
         )
-    if initial.get("vars") is None:
+    if "vars" not in initial:
         raise _case_error(
             case_id,
             yaml_path,


### PR DESCRIPTION
# PR-3：persistent variable 初始化与写回归一化对齐

上游伞 PR：[#200](https://github.com/HansBug/pyfcstm/pull/200)  
上游排查 issue：[#199](https://github.com/HansBug/pyfcstm/issues/199)  
已合入前置：[#201](https://github.com/HansBug/pyfcstm/pull/201)、[#202](https://github.com/HansBug/pyfcstm/pull/202)、[#203](https://github.com/HansBug/pyfcstm/pull/203)

本 PR 是 #199 修复链路的 PR-3，聚焦内置 `python` template generated runtime 与 `SimulationRuntime` 在 **persistent variable 初始化与写回归一化** 上的公开行为对齐。

默认修复对象是 `templates/python/` 源模板、`pyfcstm/template/` packaged assets、必要的 statement/template helper，以及 PR-0 建立的共享 semantic fixture / generated Python alignment tests。除非实现中证明 simulator 明显违反 #199 已定语义，否则 `SimulationRuntime` 是对齐参考。

## 目标与边界

公开对齐面包括：

- declared persistent `int` / `float` 的 default initializer normalization；
- hot-start `initial_vars` 覆盖 default initializer 的求值顺序；
- operation / effect / lifecycle block 写回 declared persistent vars 时的 normalization；
- 因上述差异导致的 active state path、persistent vars、`is_ended`、constructor/cycle one-sided exception、handler/hook common log 偏差。

本 PR 不处理：entry / pseudo / DFS validation（PR-1 已处理）、hot-start evented initial / structural depth（PR-2 已处理）、hook/ref context（PR-4）、generated naming / `sign()` expression rendering（PR-5）、全集收口（PR-6）。


## 与 issue #197 的去重和语义来源检查

- [issue #197](https://github.com/HansBug/pyfcstm/issues/197) 的 canonical `F-001`、重复变体和后续 triage 已收口为 simulator 侧 composite initial / plain `during before` 执行顺序语义；对应 generated template alignment 修复已由 [PR #202](https://github.com/HansBug/pyfcstm/pull/202) 覆盖。本 PR 不重新定义该语义，也不把 #197 的 simulator-side 历史问题重复包装成新的 template alignment 问题。
- 本 PR 的 A9 / E1 / E10 均属于 #199 中 generated Python runtime 与 `SimulationRuntime` 在 persistent variable 边界上的对齐偏差：同一合法 DSL、同一合法 constructor / `cycle()` 输入下，generated runtime 的 public vars 或 constructor/cycle outcome 偏离 simulator。
- 语义参考顺序为：#199 已定调的合法对齐范围、`SimulationRuntime._normalize_persistent_value()` 的 public docstring/实现、既有 semantic fixtures，以及 #156 中已确认的 initializer / type-boundary 行为。除非实现阶段发现 simulator 明显违反这些已定语义，否则本 PR 按 generated template 追平 simulator 处理。
- 实现和 review 阶段仍需检查 #197/#199 已合入修复没有被本 PR 的 constructor / operation writeback 改动破坏，尤其是 PR-1 的 composite entry / pseudo / DFS validation 和 PR-2 的 hot-start evented-initial wait / structural-depth precheck。


## 与共享 fixture 系统的关系

- 所有主错误与 duplicate/control 必须进入 PR-0 建立的 `test/fixtures/simulate_semantics/` + `test/testings/simulate_semantics.py` 共享语义语料，而不是写一次性测试脚本。
- 新增或升级的 fixture 必须能被 `simulation` 与 `generated_python_alignment` 双 runner 消费，长期作为仿真器和 `python` template 的共同语义合同。
- 已存在但当前只跑 `simulation` 的相关 fixture，若表达本 PR 的 alignment 合同，必须升级为 `generated_python_alignment`，不能另建重复语义。
- fixture id、测试名、docstring 和 runtime message 必须按领域行为命名，不得写入 PR 编号、issue 编号、worker 编号、wave/stage 等工作流元数据。

## Canonical 问题与自包含复现摘要

### A9-001：operation/effect/lifecycle 写回 declared int 时未归一化

上游 comment：[A9-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694002673)

Minimal DSL：

```fcstm
def int bits = 0;
def int marker = 0;
state Root {
    state A {
        during {
            tmp = 6 / 2;
            bits = tmp;
            marker = marker + 1;
        }
    }
    state B {
        during {
            marker = bits & 1;
        }
    }
    [*] -> A;
    A -> B :: Go;
}
```

复现方式：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = """
def int bits = 0;
def int marker = 0;
state Root {
    state A { during { tmp = 6 / 2; bits = tmp; marker = marker + 1; } }
    state B { during { marker = bits & 1; } }
    [*] -> A;
    A -> B :: Go;
}
"""
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))
runtime = SimulationRuntime(model)
runtime.cycle(None)
assert runtime.vars == {"bits": 3, "marker": 1}
runtime.cycle("Root.A.Go")
assert tuple(runtime.current_state.path) == ("Root", "B")
assert runtime.vars == {"bits": 3, "marker": 1}
```

期望结果：generated runtime 与 simulator 一样，`bits` 作为 declared `int` 在 persistent vars 中保持 `int(3)`；第二轮 `bits & 1` 正常执行并转入 `Root.B`。

修复前实际结果：generated runtime 第一轮公开 `bits=3.0`；第二轮执行 `bits & 1` 时单侧抛 `TypeError: unsupported operand type(s) for &: 'float' and 'int'`，state 仍留在 `Root.A`。

白盒原因：simulator `_execute_operation_block()` 先用 block-local scope 执行 statements，block 结束后对每个 declared var 调用 `_normalize_persistent_value(..., "operation block writeback")` 再写回；generated template 当前直接渲染 `scope["bits"] = self._evaluate_runtime_expr(...)`，没有 block-end persistent normalization。

TDD 要求：至少覆盖 lifecycle `during` 写回、transition effect 写回、initial transition effect 写回、named/ref lifecycle block 写回或其等价覆盖论证；同时保留 non-integer float 写回应抛可读 `ValueError` 并 rollback 的 negative control。

### E1-INIT-001：default initializer 对 declared int 未归一化

上游 comment：[E1-INIT-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145)

Minimal DSL：

```fcstm
def int bits = 6 / 2;
def int marker = 0;

state Root {
    state A {
        during { marker = bits & 1; }
    }
    [*] -> A;
}
```

复现方式：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = """
def int bits = 6 / 2;
def int marker = 0;
state Root { state A { during { marker = bits & 1; } } [*] -> A; }
"""
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))
runtime = SimulationRuntime(model)
assert runtime.vars == {"bits": 3, "marker": 0}
runtime.cycle(None)
assert tuple(runtime.current_state.path) == ("Root", "A")
assert runtime.vars == {"bits": 3, "marker": 1}
```

期望结果：generated runtime constructor 与 simulator 一样，对 `def int bits = 6 / 2` 得到的 `3.0` 做 declared-int normalization，公开 `bits=3`，后续 bitwise expression 正常运行。

修复前实际结果：generated runtime constructor 公开 `bits=3.0`，首轮 `cycle(None)` 执行 `bits & 1` 时单侧抛 `TypeError`，停在 `Root`。

白盒原因：simulator constructor 对 initializer 或 override 统一调用 `_normalize_persistent_value()`；generated constructor 当前无条件 `self._vars["bits"] = 6 / 2`，只在 `initial_vars` override 分支做部分 int 检查。

TDD 要求：升级/新增 shared fixture 覆盖 integer-valued float default initializer、non-integer float default initializer error、float variable accepts int and normalizes to `float`、finite boundary diagnostics。

### E10-INIT-OVERRIDE-001：hot-start initial_vars 覆盖变量时仍先求值失败 initializer

上游 comment：[E10-INIT-OVERRIDE-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694623177)  
重复佐证：[D9-INIT-OVERRIDE-001](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694683787)

Minimal DSL：

```fcstm
def int bad = 1 / 0;
def int ticks = 0;

state Root {
    state Safe {
        during { ticks = ticks + 1; }
    }
    [*] -> Safe;
}
```

复现方式：

```python
from pyfcstm.dsl import parse_with_grammar_entry
from pyfcstm.model import parse_dsl_node_to_state_machine
from pyfcstm.simulate import SimulationRuntime

DSL = """
def int bad = 1 / 0;
def int ticks = 0;
state Root { state Safe { during { ticks = ticks + 1; } } [*] -> Safe; }
"""
model = parse_dsl_node_to_state_machine(parse_with_grammar_entry(DSL, "state_machine_dsl"))
runtime = SimulationRuntime(
    model,
    initial_state="Root.Safe",
    initial_vars={"bad": 7, "ticks": 0},
)
assert tuple(runtime.current_state.path) == ("Root", "Safe")
assert runtime.vars == {"bad": 7, "ticks": 0}
runtime.cycle(None)
assert runtime.vars == {"bad": 7, "ticks": 1}
```

期望结果：hot-start 提供完整 `initial_vars` 时，每个 provided variable 跳过其 default initializer；generated runtime 构造成功并进入 `Root.Safe`。

修复前实际结果：generated runtime 在应用 `initial_vars` 前先求值 `bad = 1 / 0`，构造期单侧抛 `ZeroDivisionError`。

白盒原因：simulator constructor 逐变量先判断 `initial_vars[name]`，只有未覆盖变量才求值 initializer；generated constructor 当前先求值所有 default initializer，再遍历 `initial_vars` 覆盖。

TDD 要求：必须具名覆盖 int 与 float 两类被覆盖 failing initializer：新增或升级 `hot_start_initial_vars_override_skips_int_initializer`（或同等纯领域命名 fixture）覆盖 E10 canonical `def int bad = 1 / 0` + `initial_vars={"bad": 7, "ticks": 0}`；升级既有 `persistent_initial_vars_override_skips_initializer` 或新增等价 fixture 覆盖 `def float recovered = 1.0 / 0.0` + `initial_vars={"recovered": 5.0}` 的 D9 duplicate。两者都必须使用 `runners: [simulation, generated_python_alignment]`。同时覆盖未覆盖变量仍按声明顺序求值并保留错误诊断。

## Duplicate / duplicate-coverage 归属清单

| 记录 | 上游 comment | 归并原因 | 本 PR 处理方式 |
|---|---|---|---|
| `C1` legal DSL generator small | [C1 result](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694852936) | `fixed_int_writeback_duplicate_a9_control` 归 A9 | 进入 operation writeback shared fixture 或明确由 A9 canonical fixture 覆盖 |
| `C5` fixture neighborhood | [C5 result](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694761435) | `int_division_nested_duplicate` 归 A9；`default_initializer_int_normalization_nested` 归 E1；`hot_start_initial_vars_override_nested` 归 E10 | 每个 mismatch probe 至少一个 fixture/test 覆盖或在 PR body 中列出对应 canonical fixture 名称与 DSL 特征 |
| `D9` alignment harness audit | [D9 result](https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694683787) | `D9-INIT-OVERRIDE-001` 是 E10 duplicate，同时暴露已有 simulation-only fixture 未进 generated alignment 的覆盖缺口 | 升级 `persistent_initial_vars_override_skips_initializer` 到 `generated_python_alignment` 以覆盖 float failing-initializer override；同时新增/升级 E10 canonical int failing-initializer override fixture，PR body 记录 D9 duplicate 与 E10 canonical 分别由哪个 fixture 覆盖 |
| `persistent_operation_writeback_rejects_float_and_rolls_back` 既有 fixture | [issue #156 INIT/TYPE context](https://github.com/HansBug/pyfcstm/issues/156) | 已表达 simulator 的 non-integer float writeback negative contract，但当前仅 simulation runner | 升级或新增等价双 runner fixture，确保 generated 对 non-integer declared `int` 写回抛可读 `ValueError` 且 rollback |

## 子 PR 状态表

| 项目 | 状态 | 验收标准 |
|---|---|---|
| 计划审查 | `🟡 待三路 review` | codex / claude / deepseek reviewer 均自行 comment，C/I=0 |
| TDD fixture | `✅ 已实现` | A9、E1、E10 与上表 duplicate/control 已进入共享 fixture，并由 simulation / generated Python alignment 双 runner 执行 |
| 模板修复 | `✅ 已实现` | source template 已实现 constructor 与 operation/effect/lifecycle 写回归一化；`make tpl` 已同步 packaged built-in template assets |
| 本地验证 | `✅ 已通过` | 精准 pytest、generated alignment、代表 generated `machine.py` ruff gate、`make rst_auto`、`SKIP_SLOW_TESTS=1 make unittest` 已通过 |
| CI / review | `🟡 进行中` | 已 push 实现，等待 CI；即将执行三路强对抗实现 review，ready 前继续确认 merge conflict gate |

## Mermaid 依赖图

```mermaid
flowchart TD
    U["伞 PR #200<br/>#199 对齐修复拆分<br/>🚧 子 PR 执行中"]:::active
    B["PR-0<br/>对齐 fixture 与复现基线<br/>✅ 已完成"]:::done
    P1["PR-1<br/>entry / pseudo / DFS validation<br/>✅ 已完成"]:::done
    P2["PR-2<br/>hot-start constructor validation<br/>✅ 已完成"]:::done
    P3["PR-3<br/>persistent var normalization<br/>🟡 当前 PR"]:::active
    P4["PR-4<br/>hook / ref context parity<br/>⏳ 后续"]:::planned
    P5["PR-5<br/>naming / expression rendering<br/>⏳ 后续"]:::planned
    P6["PR-6<br/>全集回归与收口<br/>⏳ 后续"]:::planned

    U --> B
    B --> P1
    B --> P2
    B --> P3
    B --> P4
    B --> P5
    P2 -. constructor 冲突复核 .-> P3
    P3 -. expression/writeback 冲突复核 .-> P5
    P1 --> P6
    P2 --> P6
    P3 --> P6
    P4 --> P6
    P5 --> P6

    classDef active fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef planned fill:#fef3c7,stroke:#d97706,color:#111827;
    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
    classDef blocked fill:#fee2e2,stroke:#dc2626,color:#111827;
```

## 实施计划

1. TDD：先新增/升级共享 semantic fixtures：
   - default initializer integer-valued float → declared `int` 归一；
   - default initializer non-integer float → constructor `ValueError`；
   - hot-start initial_vars override skips failing initializer：一个 int failing-initializer fixture 覆盖 E10 canonical，一个 float failing-initializer fixture 覆盖 D9 duplicate / 既有 `persistent_initial_vars_override_skips_initializer`；
   - operation / transition effect / lifecycle action declared `int` writeback 归一；
   - non-integer float writeback rejects and rollback；
   - float variable receives int and persists as float（normalization 完备性补充，用于防止只修 int 边界而遗漏 declared `float` 对称入口）。
2. 确认 simulation runner 通过，generated alignment 在修复前能暴露 A9/E1/E10 对齐偏差。
3. 修改 `templates/python/machine.py.j2` 与必要 statement/template style：
   - generated runtime 增加 `_normalize_persistent_value(name, value, source)`，语义与 simulator 对齐：reject bool、只接受 int/float、finite float、declared `int` integer-valued float 转 int、declared `float` 转 float 且 finite；
   - constructor 按 simulator 顺序逐变量处理：若 `initial_vars` 提供该变量，则跳过 default initializer；否则才求值 initializer；随后统一 normalization；
   - operation/effect/lifecycle block 先使用 local working scope，block 成功结束后统一 normalization + writeback，避免中途把 temporary / invalid persistent value 泄漏到 `self._vars`；
   - validation/preflight 分支仍在临时 vars 上运行，异常不污染真实 runtime state。
4. 运行 `make tpl` 同步 `pyfcstm/template/` packaged assets。
5. 运行精准测试、generated alignment、representative generated `machine.py` 的 `ruff check` / `ruff format --check`、`SKIP_SLOW_TESTS=1 make unittest`。如修改 public Python API/docstring，则运行 `make rst_auto` 并提交对应 RST；若只改 template/fixture，可记录未触发 public API RST 更新。
6. push 后 watch CI。
7. 三路 reviewer 强对抗实现审查：每个 reviewer 对 A9、E1、E10 各至少构造 2 个同质但非完全相同的复杂合法模型/序列；duplicate/control 必须抽样或全量实测；reviewer 必须自行 PR comment 并按 C/I/M 分级。
8. ready 前 merge/rebase 最新伞 PR 分支，若有 conflict 则处理后重新跑 CI + 三路 review，确认没有丢失 PR-1 与 PR-2 已合入修复，尤其是 constructor hot-start evented-initial wait、structural depth precheck、entry/pseudo/DFS validation。

## 本地验收命令

已执行：

```bash
pytest test/simulate/test_semantic_fixtures.py -q
make tpl
pytest test/template/python/test_semantic_fixture_alignment.py -q
# representative generated machine.py examples rendered from:
# - persistent_int_writeback_normalizes_integer_float
# - persistent_effect_writeback_normalizes_integer_float
# - persistent_default_int_initializer_normalizes_integer_float
# - persistent_default_int_initializer_rejects_non_integer_float
# - hot_start_initial_vars_override_skips_int_initializer
# - persistent_initial_vars_override_skips_initializer
ruff check /tmp/pyfcstm-pr3-ruff-VQ5Wp1/*/machine.py
ruff format --check /tmp/pyfcstm-pr3-ruff-VQ5Wp1/*/machine.py
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
```

如果本 PR 修改 public Python API 或 docstring，再执行：

```bash
make rst_auto
```

## Reviewer 硬性检查点

- PR body 是否与伞 PR #200 和 issue #199 完全一致，尤其是 A9/E1/E10 与 C1/C5/D9 duplicate/control 是否无遗漏。
- 新 fixtures 是否用领域行为命名，且能被 simulation runner 和 generated Python alignment runner 共同消费。
- 新 fixture/测试是否只引用 `pyfcstm/` 与 `test/`，不调用 Node.js、jsfcstm、`editors/jsfcstm/test/` 或外部网络。
- 是否误把 PR 编号、issue 编号、worker/wave/stage 写入代码标识符、fixture id、docstring、runtime message。
- Constructor 顺序是否严格对齐 simulator：provided `initial_vars` 必须跳过对应 initializer；未覆盖变量仍求值 initializer。
- Persistent normalization 是否覆盖 default initializer、initial_vars、operation/effect/lifecycle writeback 三个入口；declared `float` 接受 int 并持久化为 float；declared `int` 接受 integer-valued float 并转 int；bool、非 numeric、non-finite、non-integer float 均给出可读错误。
- Operation/effect/lifecycle writeback 是否具备 block-local temporary 语义：block 成功后统一写回 declared vars，异常时不污染真实 state；validation/preflight 不吞异常、不污染真实 state。
- 是否未修改 `Makefile`；source template 与 packaged assets 是否通过 `make tpl` 同步，generated `machine.py` 是否 `ruff check` / `ruff format --check` 稳定。
- ready 前是否已合入最新伞 PR 分支并处理冲突，且冲突处理没有丢失 PR-1 / PR-2 的 entry、pseudo、DFS、hot-start evented-initial、structural-depth 修复。


