### PR TITLE
固化模板格式化与构建验收门

### DIFF
--- a/test/template/c/test_runtime.py
+++ b/test/template/c/test_runtime.py
@@ -1,4 +1,5 @@
 import os.path
+import re
 import shutil
 import subprocess
 import textwrap
@@ -6,6 +7,55 @@ import textwrap
 import pytest
 
 from ._utils import render_c_artifacts, render_c_runtime
+
+
+_CLANG_FORMAT_STYLE = "{BasedOnStyle: LLVM, IndentWidth: 4, ContinuationIndentWidth: 4}"
+
+
+def _format_c_text(text, filename):
+    clang_format = shutil.which("clang-format")
+    if clang_format is None:
+        pytest.skip("clang-format is required for C formatter convergence tests.")
+
+    return subprocess.run(
+        [
+            clang_format,
+            "-style=" + _CLANG_FORMAT_STYLE,
+            "--assume-filename=" + filename,
+        ],
+        input=text,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def _representative_gate_dsl():
+    return """
+    def int counter = 0;
+    def int ready = 0;
+    def float gain = 1.5;
+    state Control {
+        enter abstract Boot;
+        state Idle {
+            during { counter = counter + 1; }
+        }
+        state Active {
+            enter abstract ActiveEnter;
+            during before { gain = gain + 0.5; }
+            state Work {
+                enter { counter = counter + 2; }
+                during { counter = counter + 3; }
+            }
+            [*] -> Work : if [ready == 1];
+        }
+        state Done;
+        [*] -> Idle;
+        Idle -> Active :: Start effect { ready = 1; counter = counter + 10; };
+        Active -> Done : if [counter >= 20] effect { counter = counter + 1; };
+    }
+    """
 
 
 def _workflow_metadata_labels():
@@ -521,48 +571,257 @@ class TestCBuiltinTemplate:
             assert '不适合修改状态机持久变量' in readme_zh
             assert 'RootMachine_vars(&machine)' in readme_zh
 
-    def test_generated_machine_source_is_c99_and_build_files_work(self):
-        dsl_code = """
-        def int counter = 0;
-        state Root {
-            state Idle {
-                during { counter = counter + 1; }
-            }
-            [*] -> Idle;
-        }
-        """
+    def test_generated_readme_code_blocks_are_formatter_friendly(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            with open(artifacts["readme_file"], "r", encoding="utf-8") as f:
+                readme = f.read()
+            with open(artifacts["readme_zh_file"], "r", encoding="utf-8") as f:
+                readme_zh = f.read()
 
-        with render_c_artifacts(dsl_code) as artifacts:
-            with open(artifacts['machine_h_file'], 'r', encoding='utf-8') as f:
+            for content in [readme, readme_zh]:
+                blocks = re.findall(r"```(?:c|cpp|bash)\n(.*?)```", content, flags=re.S)
+                assert blocks
+                for block in blocks:
+                    assert "\t" not in block
+
+            assert "clang-format" in readme
+            assert "clang-format" in readme_zh
+
+    def test_generated_machine_clang_format_converges_under_four_space_style(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            for key in ["machine_h_file", "machine_c_file"]:
+                path = artifacts[key]
+                with open(path, "r", encoding="utf-8") as f:
+                    original = f.read()
+
+                formatted_once = _format_c_text(original, os.path.basename(path))
+                formatted_twice = _format_c_text(formatted_once, os.path.basename(path))
+
+                assert formatted_once == formatted_twice
+                assert "\t" not in formatted_once
+
+    def test_generated_machine_source_is_c99_and_build_files_work(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            with open(artifacts["machine_h_file"], "r", encoding="utf-8") as f:
                 header = f.read()
-            with open(artifacts['machine_c_file'], 'r', encoding='utf-8') as f:
+            with open(artifacts["machine_c_file"], "r", encoding="utf-8") as f:
                 source = f.read()
 
-            assert '#include <stddef.h>' in header
-            assert '#include <math.h>' in source
-            assert 'windows.h' not in source
-            assert 'pthread.h' not in source
-            assert 'fork(' not in source
+            assert "#include <stddef.h>" in header
+            assert "#include <math.h>" in source
+            assert "windows.h" not in source
+            assert "pthread.h" not in source
+            assert "fork(" not in source
 
-            assert os.path.isfile(artifacts['shared_lib'])
-            assert os.path.isfile(artifacts['build_files']['cmakelists'])
+            assert os.path.isfile(artifacts["shared_lib"])
+            assert os.path.isfile(artifacts["build_files"]["cmakelists"])
 
-            make_executable = shutil.which('make')
-            if make_executable is not None and os.name != 'nt':
+            make_executable = shutil.which("make")
+            if make_executable is not None and os.name != "nt":
                 subprocess.run(
                     [make_executable],
-                    cwd=artifacts['output_dir'],
+                    cwd=artifacts["output_dir"],
                     check=True,
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
                 )
-                assert os.path.isfile(os.path.join(artifacts['output_dir'], 'libmachine.a'))
-                assert os.path.isfile(artifacts['build_files']['makefile'])
+                assert os.path.isfile(
+                    os.path.join(artifacts["output_dir"], "libmachine.a")
+                )
+                assert os.path.isfile(artifacts["build_files"]["makefile"])
 
-            if artifacts['cmake'] is not None:
-                built_entries = set(os.listdir(artifacts['build_dir']))
-                assert 'CMakeCache.txt' in built_entries
+            if artifacts["cmake"] is not None:
+                built_entries = set(os.listdir(artifacts["build_dir"]))
+                assert "CMakeCache.txt" in built_entries
+
+    def test_generated_machine_c99_gate_runs_representative_model(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            run = _compile_and_run_c_harness(
+                artifacts,
+                "representative_c99_gate",
+                textwrap.dedent(
+                    r"""
+                    #include "machine.h"
+                    #include <string.h>
+
+                    typedef struct HookLog {
+                        int boot_calls;
+                        int active_calls;
+                    } HookLog;
+
+                    static void boot_hook(
+                        ControlMachine *machine,
+                        const ControlMachineExecutionContext *ctx,
+                        void *user_data
+                    )
+                    {
+                        HookLog *log = (HookLog *)user_data;
+                        (void)machine;
+                        if (strcmp(ctx->action_name, "Control.Boot") == 0) {
+                            log->boot_calls += 1;
+                        }
+                    }
+
+                    static void active_hook(
+                        ControlMachine *machine,
+                        const ControlMachineExecutionContext *ctx,
+                        void *user_data
+                    )
+                    {
+                        HookLog *log = (HookLog *)user_data;
+                        (void)machine;
+                        if (
+                            strcmp(ctx->action_name, "Control.Active.ActiveEnter") == 0 &&
+                            strcmp(ctx->state_path, "Control.Active") == 0
+                        ) {
+                            log->active_calls += 1;
+                        }
+                    }
+
+                    int main(void)
+                    {
+                        ControlMachine machine;
+                        ControlMachineHooks hooks = CONTROLMACHINE_HOOKS_INIT;
+                        HookLog log = {0, 0};
+                        static const ControlMachineEventId start_events[] = {
+                            CONTROL_MACHINE_EVENT_CONTROL_IDLE_START
+                        };
+
+                        if (!ControlMachine_init(&machine)) {
+                            return 10;
+                        }
+                        hooks.on_Control_Boot = boot_hook;
+                        hooks.on_Control_Active_ActiveEnter = active_hook;
+                        ControlMachine_set_hooks(&machine, &hooks, &log);
+
+                        if (!ControlMachine_cycle(&machine, NULL, 0u)) {
+                            return 11;
+                        }
+                        if (strcmp(ControlMachine_current_state_path(&machine), "Control.Idle") != 0) {
+                            return 12;
+                        }
+                        if (ControlMachine_vars(&machine)->counter != (ControlMachineInt)1) {
+                            return 13;
+                        }
+                        if (log.boot_calls != 1 || log.active_calls != 0) {
+                            return 14;
+                        }
+
+                        if (!ControlMachine_cycle(&machine, start_events, 1u)) {
+                            return 15;
+                        }
+                        if (strcmp(ControlMachine_current_state_path(&machine), "Control.Active.Work") != 0) {
+                            return 16;
+                        }
+                        if (
+                            ControlMachine_vars(&machine)->ready != (ControlMachineInt)1 ||
+                            ControlMachine_vars(&machine)->counter != (ControlMachineInt)16 ||
+                            ControlMachine_vars(&machine)->gain != 2.0
+                        ) {
+                            return 17;
+                        }
+                        if (log.boot_calls != 1 || log.active_calls != 1) {
+                            return 18;
+                        }
+
+                        return 0;
+                    }
+                    """
+                ),
+            )
+            assert run.returncode == 0, run.stderr
+
+    def test_generated_machine_cpp98_gate_runs_representative_model(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            run = _compile_and_run_cpp_harness(
+                artifacts,
+                "representative_cpp98_gate",
+                textwrap.dedent(
+                    r"""
+                    #include "machine.h"
+                    #include <cstring>
+
+                    struct HookLog {
+                        int boot_calls;
+                        int active_calls;
+                    };
+
+                    static void boot_hook(
+                        ControlMachine *machine,
+                        const ControlMachineExecutionContext *ctx,
+                        void *user_data
+                    )
+                    {
+                        HookLog *log = static_cast<HookLog *>(user_data);
+                        (void)machine;
+                        if (std::strcmp(ctx->action_name, "Control.Boot") == 0) {
+                            log->boot_calls += 1;
+                        }
+                    }
+
+                    static void active_hook(
+                        ControlMachine *machine,
+                        const ControlMachineExecutionContext *ctx,
+                        void *user_data
+                    )
+                    {
+                        HookLog *log = static_cast<HookLog *>(user_data);
+                        (void)machine;
+                        if (
+                            std::strcmp(ctx->action_name, "Control.Active.ActiveEnter") == 0 &&
+                            std::strcmp(ctx->state_path, "Control.Active") == 0
+                        ) {
+                            log->active_calls += 1;
+                        }
+                    }
+
+                    int main()
+                    {
+                        ControlMachine machine;
+                        ControlMachineHooks hooks = CONTROLMACHINE_HOOKS_INIT;
+                        HookLog log = {0, 0};
+                        static const ControlMachineEventId start_events[] = {
+                            CONTROL_MACHINE_EVENT_CONTROL_IDLE_START
+                        };
+
+                        if (!ControlMachine_init(&machine)) {
+                            return 30;
+                        }
+                        hooks.on_Control_Boot = boot_hook;
+                        hooks.on_Control_Active_ActiveEnter = active_hook;
+                        ControlMachine_set_hooks(&machine, &hooks, &log);
+
+                        if (!ControlMachine_cycle(&machine, 0, 0u)) {
+                            return 31;
+                        }
+                        if (std::strcmp(ControlMachine_current_state_path(&machine), "Control.Idle") != 0) {
+                            return 32;
+                        }
+                        if (!ControlMachine_cycle(&machine, start_events, 1u)) {
+                            return 33;
+                        }
+                        if (std::strcmp(ControlMachine_current_state_path(&machine), "Control.Active.Work") != 0) {
+                            return 34;
+                        }
+                        if (
+                            ControlMachine_vars(&machine)->ready != (ControlMachineInt)1 ||
+                            ControlMachine_vars(&machine)->counter != (ControlMachineInt)16 ||
+                            ControlMachine_vars(&machine)->gain != 2.0
+                        ) {
+                            return 35;
+                        }
+                        if (log.boot_calls != 1 || log.active_calls != 1) {
+                            return 36;
+                        }
+
+                        return 0;
+                    }
+                    """
+                ),
+            )
+            assert run.returncode == 0, run.stderr
+
 
     def test_generated_machine_rolls_back_transition_effects_on_validation_failure(self):
         dsl_code = """

--- a/test/template/c_poll/test_runtime.py
+++ b/test/template/c_poll/test_runtime.py
@@ -11,6 +11,33 @@ from ._utils import render_c_artifacts, render_c_runtime
 _CLANG_FORMAT_STYLE = '{BasedOnStyle: LLVM, IndentWidth: 4, ContinuationIndentWidth: 4}'
 
 
+def _representative_gate_dsl():
+    return """
+    def int counter = 0;
+    def int ready = 0;
+    def float gain = 1.5;
+    state Control {
+        enter abstract Boot;
+        state Idle {
+            during { counter = counter + 1; }
+        }
+        state Active {
+            enter abstract ActiveEnter;
+            during before { gain = gain + 0.5; }
+            state Work {
+                enter { counter = counter + 2; }
+                during { counter = counter + 3; }
+            }
+            [*] -> Work : if [ready == 1];
+        }
+        state Done;
+        [*] -> Idle;
+        Idle -> Active :: Start effect { ready = 1; counter = counter + 10; };
+        Active -> Done : if [counter >= 20] effect { counter = counter + 1; };
+    }
+    """
+
+
 def _format_c_text(text, filename):
     clang_format = shutil.which('clang-format')
     if clang_format is None:
@@ -79,37 +106,26 @@ def _assert_generated_c_banner(source, *, template_name, root_name, extra_terms=
 @pytest.mark.unittest
 class TestCPollBuiltinTemplate:
     def test_generated_machine_source_banners_document_file_contract(self):
-        dsl_code = """
-        def int counter = 0;
-        state Root {
-            state A {
-                during { counter = counter + 1; }
-            }
-            state B;
-            [*] -> A;
-            A -> B :: Go;
-        }
-        """
-
-        with render_c_artifacts(dsl_code) as artifacts:
-            with open(artifacts['machine_h_file'], 'r', encoding='utf-8') as f:
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            with open(artifacts["machine_h_file"], "r", encoding="utf-8") as f:
                 header = f.read()
-            with open(artifacts['machine_c_file'], 'r', encoding='utf-8') as f:
+            with open(artifacts["machine_c_file"], "r", encoding="utf-8") as f:
                 source = f.read()
 
             _assert_generated_c_banner(
                 header,
-                template_name='c_poll',
-                root_name='Root',
-                extra_terms=['public integration header', 'event-check polling'],
+                template_name="c_poll",
+                root_name="Control",
+                extra_terms=["public integration header", "event-check polling"],
             )
             _assert_generated_c_banner(
                 source,
-                template_name='c_poll',
-                root_name='Root',
-                extra_terms=['implementation', 'event-check polling'],
+                template_name="c_poll",
+                root_name="Control",
+                extra_terms=["implementation", "event-check polling"],
             )
-            assert source.index('/*') < source.index('#include "machine.h"')
+            assert source.index("/*") < source.index('#include "machine.h"')
+
 
     def test_generated_machine_runs_cycle_and_event_transition(self):
         dsl_code = """
@@ -344,242 +360,236 @@ class TestCPollBuiltinTemplate:
             assert '返回 `0`' in readme_zh
 
     def test_generated_machine_clang_format_converges_under_four_space_style(self):
-        dsl_code = """
-        def int counter = 0;
-        def int ready = 0;
-        state Root {
-            enter abstract RootInit;
-            state A {
-                during { counter = counter + 1; }
-            }
-            state B {
-                enter abstract BEnter;
-                state B1 {
-                    during { counter = counter + 10; }
-                }
-                [*] -> B1 : if [ready == 1];
-            }
-            [*] -> A;
-            A -> B :: Go effect { counter = counter + 100; };
-        }
-        """
-
-        with render_c_artifacts(dsl_code) as artifacts:
-            for key in ['machine_h_file', 'machine_c_file']:
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            for key in ["machine_h_file", "machine_c_file"]:
                 path = artifacts[key]
-                with open(path, 'r', encoding='utf-8') as f:
+                with open(path, "r", encoding="utf-8") as f:
                     original = f.read()
 
                 formatted_once = _format_c_text(original, os.path.basename(path))
                 formatted_twice = _format_c_text(formatted_once, os.path.basename(path))
 
                 assert formatted_once == formatted_twice
-                assert '\t' not in formatted_once
+                assert "\t" not in formatted_once
+
 
     def test_generated_readme_code_blocks_are_formatter_friendly(self):
-        dsl_code = """
-        def int counter = 0;
-        state Root {
-            state A {
-                during { counter = counter + 1; }
-            }
-            state B;
-            [*] -> A;
-            A -> B :: Go;
-        }
-        """
-
-        with render_c_artifacts(dsl_code) as artifacts:
-            with open(artifacts['readme_file'], 'r', encoding='utf-8') as f:
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            with open(artifacts["readme_file"], "r", encoding="utf-8") as f:
                 readme = f.read()
-            with open(artifacts['readme_zh_file'], 'r', encoding='utf-8') as f:
+            with open(artifacts["readme_zh_file"], "r", encoding="utf-8") as f:
                 readme_zh = f.read()
 
             for content in [readme, readme_zh]:
-                blocks = re.findall(r'```(?:c|cpp|bash)\n(.*?)```', content, flags=re.S)
+                blocks = re.findall(r"```(?:c|cpp|bash)\n(.*?)```", content, flags=re.S)
                 assert blocks
                 for block in blocks:
-                    assert '\t' not in block
+                    assert "\t" not in block
 
-            assert 'clang-format' in readme
-            assert 'clang-format' in readme_zh
+            assert "clang-format" in readme
+            assert "clang-format" in readme_zh
+
 
     def test_generated_machine_c_event_checks_install_and_drive_cycle(self):
-        dsl_code = """
-        def int counter = 0;
-        state Root {
-            state A {
-                during { counter = counter + 1; }
-            }
-            state B {
-                during { counter = counter + 10; }
-            }
-            [*] -> A;
-            A -> B :: Go;
-        }
-        """
-
-        with render_c_artifacts(dsl_code) as artifacts:
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
             run = _compile_and_run_c_harness(
                 artifacts,
-                'event_check_mount_test',
+                "event_check_mount_test",
                 textwrap.dedent(
-                    r'''
+                    r"""
                     #include "machine.h"
                     #include <string.h>
 
                     typedef struct EventLog {
-                        int allow_go;
-                        int seen;
+                        int allow_start;
+                        int seen_start;
                     } EventLog;
 
-                    static int check_go(
-                        RootMachine *machine,
-                        const RootMachineEventContext *ctx,
+                    typedef struct HookLog {
+                        int boot_calls;
+                        int active_calls;
+                    } HookLog;
+
+                    static int check_start(
+                        ControlMachine *machine,
+                        const ControlMachineEventContext *ctx,
                         void *user_data
                     )
                     {
                         EventLog *log = (EventLog *)user_data;
                         (void)machine;
                         if (
-                            strcmp(ctx->event_path, "Root.A.Go") == 0 &&
-                            strcmp(ctx->current_state_path, "Root.A") == 0
+                            strcmp(ctx->event_path, "Control.Idle.Start") == 0 &&
+                            strcmp(ctx->current_state_path, "Control.Idle") == 0
                         ) {
-                            log->seen += 1;
+                            log->seen_start += 1;
                         }
-                        return log->allow_go;
+                        return log->allow_start;
+                    }
+
+                    static void boot_hook(
+                        ControlMachine *machine,
+                        const ControlMachineExecutionContext *ctx,
+                        void *user_data
+                    )
+                    {
+                        HookLog *log = (HookLog *)user_data;
+                        (void)machine;
+                        if (strcmp(ctx->action_name, "Control.Boot") == 0) {
+                            log->boot_calls += 1;
+                        }
+                    }
+
+                    static void active_hook(
+                        ControlMachine *machine,
+                        const ControlMachineExecutionContext *ctx,
+                        void *user_data
+                    )
+                    {
+                        HookLog *log = (HookLog *)user_data;
+                        (void)machine;
+                        if (strcmp(ctx->action_name, "Control.Active.ActiveEnter") == 0) {
+                            log->active_calls += 1;
+                        }
                     }
 
                     int main(void)
                     {
-                        RootMachine machine;
-                        RootMachineEventChecks event_checks = ROOTMACHINE_EVENT_CHECKS_INIT;
+                        ControlMachine machine;
+                        ControlMachineHooks hooks = CONTROLMACHINE_HOOKS_INIT;
+                        ControlMachineEventChecks event_checks = CONTROLMACHINE_EVENT_CHECKS_INIT;
                         EventLog log = {0};
+                        HookLog hooks_log = {0};
 
-                        if (!RootMachine_init(&machine)) {
+                        if (!ControlMachine_init(&machine)) {
                             return 10;
                         }
-                        if (RootMachine_cycle(&machine)) {
+                        if (ControlMachine_cycle(&machine)) {
                             return 11;
                         }
 
-                        event_checks.check_Root_A_Go = check_go;
-                        RootMachine_set_event_checks(&machine, &event_checks, &log);
+                        hooks.on_Control_Boot = boot_hook;
+                        hooks.on_Control_Active_ActiveEnter = active_hook;
+                        ControlMachine_set_hooks(&machine, &hooks, &hooks_log);
+                        event_checks.check_Control_Idle_Start = check_start;
+                        ControlMachine_set_event_checks(&machine, &event_checks, &log);
 
-                        if (!RootMachine_cycle(&machine)) {
+                        if (!ControlMachine_cycle(&machine)) {
                             return 12;
                         }
-                        if (strcmp(RootMachine_current_state_path(&machine), "Root.A") != 0) {
+                        if (strcmp(ControlMachine_current_state_path(&machine), "Control.Idle") != 0) {
                             return 13;
                         }
-                        if (RootMachine_vars(&machine)->counter != 1) {
+                        if (ControlMachine_vars(&machine)->counter != 1) {
                             return 14;
                         }
-
-                        log.allow_go = 1;
-                        if (!RootMachine_cycle(&machine)) {
+                        if (hooks_log.boot_calls != 1 || hooks_log.active_calls != 0) {
                             return 15;
                         }
-                        if (strcmp(RootMachine_current_state_path(&machine), "Root.B") != 0) {
+
+                        log.allow_start = 1;
+                        if (!ControlMachine_cycle(&machine)) {
                             return 16;
                         }
-                        if (RootMachine_vars(&machine)->counter != 11) {
+                        if (strcmp(ControlMachine_current_state_path(&machine), "Control.Active.Work") != 0) {
                             return 17;
                         }
-                        if (log.seen != 1) {
+                        if (
+                            ControlMachine_vars(&machine)->ready != (ControlMachineInt)1 ||
+                            ControlMachine_vars(&machine)->counter != (ControlMachineInt)16 ||
+                            ControlMachine_vars(&machine)->gain != 2.0
+                        ) {
                             return 18;
+                        }
+                        if (log.seen_start != 1) {
+                            return 19;
+                        }
+                        if (hooks_log.boot_calls != 1 || hooks_log.active_calls != 1) {
+                            return 20;
                         }
 
                         return 0;
                     }
-                    '''
+                    """
                 ),
             )
             assert run.returncode == 0, run.stderr
 
-    def test_generated_machine_cpp98_event_checks_install_and_drive_cycle(self):
-        dsl_code = """
-        def int counter = 0;
-        state Root {
-            state A {
-                during { counter = counter + 1; }
-            }
-            state B {
-                during { counter = counter + 10; }
-            }
-            [*] -> A;
-            A -> B :: Go;
-        }
-        """
 
-        with render_c_artifacts(dsl_code) as artifacts:
+    def test_generated_machine_cpp98_event_checks_install_and_drive_cycle(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
             run = _compile_and_run_cpp_harness(
                 artifacts,
-                'cpp98_event_check_mount',
+                "cpp98_event_check_mount",
                 textwrap.dedent(
-                    r'''
+                    r"""
                     #include "machine.h"
                     #include <cstring>
 
                     struct EventLog {
-                        int allow_go;
-                        int seen;
+                        int allow_start;
+                        int seen_start;
                     };
 
-                    static int check_go(
-                        RootMachine *machine,
-                        const RootMachineEventContext *ctx,
+                    static int check_start(
+                        ControlMachine *machine,
+                        const ControlMachineEventContext *ctx,
                         void *user_data
                     )
                     {
                         EventLog *log = static_cast<EventLog *>(user_data);
                         (void)machine;
                         if (
-                            std::strcmp(ctx->event_path, "Root.A.Go") == 0 &&
-                            std::strcmp(ctx->current_state_path, "Root.A") == 0
+                            std::strcmp(ctx->event_path, "Control.Idle.Start") == 0 &&
+                            std::strcmp(ctx->current_state_path, "Control.Idle") == 0
                         ) {
-                            log->seen += 1;
+                            log->seen_start += 1;
                         }
-                        return log->allow_go;
+                        return log->allow_start;
                     }
 
                     int main()
                     {
-                        RootMachine machine;
-                        RootMachineEventChecks event_checks = ROOTMACHINE_EVENT_CHECKS_INIT;
+                        ControlMachine machine;
+                        ControlMachineEventChecks event_checks = CONTROLMACHINE_EVENT_CHECKS_INIT;
                         EventLog log = {0, 0};
 
-                        if (!RootMachine_init(&machine)) {
+                        if (!ControlMachine_init(&machine)) {
                             return 20;
                         }
-                        event_checks.check_Root_A_Go = check_go;
-                        RootMachine_set_event_checks(&machine, &event_checks, &log);
+                        event_checks.check_Control_Idle_Start = check_start;
+                        ControlMachine_set_event_checks(&machine, &event_checks, &log);
 
-                        if (!RootMachine_cycle(&machine)) {
+                        if (!ControlMachine_cycle(&machine)) {
                             return 21;
                         }
-                        if (std::strcmp(RootMachine_current_state_path(&machine), "Root.A") != 0) {
+                        if (std::strcmp(ControlMachine_current_state_path(&machine), "Control.Idle") != 0) {
                             return 22;
                         }
-                        log.allow_go = 1;
-                        if (!RootMachine_cycle(&machine)) {
+                        log.allow_start = 1;
+                        if (!ControlMachine_cycle(&machine)) {
                             return 23;
                         }
-                        if (std::strcmp(RootMachine_current_state_path(&machine), "Root.B") != 0) {
+                        if (std::strcmp(ControlMachine_current_state_path(&machine), "Control.Active.Work") != 0) {
                             return 24;
                         }
-                        if (RootMachine_vars(&machine)->counter != 11) {
+                        if (
+                            ControlMachine_vars(&machine)->ready != (ControlMachineInt)1 ||
+                            ControlMachine_vars(&machine)->counter != (ControlMachineInt)16 ||
+                            ControlMachine_vars(&machine)->gain != 2.0
+                        ) {
                             return 25;
                         }
-                        if (log.seen != 1) {
+                        if (log.seen_start != 1) {
                             return 26;
                         }
                         return 0;
                     }
-                    '''
+                    """
                 ),
             )
             assert run.returncode == 0, run.stderr
+
 
     def test_generated_machine_cpp98_supports_cxx_keyword_safe_identifiers(self):
         dsl_code = """

--- a/test/template/python/test_runtime.py
+++ b/test/template/python/test_runtime.py
@@ -1,6 +1,7 @@
 import ast
 import importlib.util
 import os.path
+import re
 import subprocess
 import sys
 import textwrap
@@ -60,6 +61,45 @@ def _render_python_artifacts(dsl_code, module_name='generated_python'):
 def _render_python_module(dsl_code, module_name='generated_python'):
     with _render_python_artifacts(dsl_code, module_name=module_name) as artifacts:
         yield artifacts['module']
+
+
+def _representative_gate_dsl():
+    return """
+    def int counter = 0;
+    def int ready = 0;
+    def float gain = 1.5;
+    state Control {
+        enter abstract Boot;
+        state Idle {
+            during { counter = counter + 1; }
+        }
+        state Active {
+            enter abstract ActiveEnter;
+            during before { gain = gain + 0.5; }
+            state Work {
+                enter { counter = counter + 2; }
+                during { counter = counter + 3; }
+            }
+            [*] -> Work : if [ready == 1];
+        }
+        state Done;
+        [*] -> Idle;
+        Idle -> Active :: Start effect { ready = 1; counter = counter + 10; };
+        Active -> Done : if [counter >= 20] effect { counter = counter + 1; };
+    }
+    """
+
+
+def _python_code_blocks(markdown):
+    return re.findall(r"```python\n(.*?)```", markdown, flags=re.S)
+
+
+def _assert_python_readme_code_blocks_are_formatter_friendly(markdown):
+    blocks = _python_code_blocks(markdown)
+    assert blocks
+    for block in blocks:
+        assert "\t" not in block
+        assert "\r" not in block
 
 
 @pytest.mark.unittest
@@ -466,8 +506,23 @@ class TestPythonBuiltinTemplate:
             assert 'abstract hook' in readme_zh
             assert '修改状态机持久变量' in readme_zh
 
+    def test_generated_readme_python_code_blocks_are_formatter_friendly(self):
+        with _render_python_artifacts(_representative_gate_dsl()) as artifacts:
+            with open(artifacts["readme_file"], "r", encoding="utf-8") as f:
+                readme = f.read()
+            with open(artifacts["readme_zh_file"], "r", encoding="utf-8") as f:
+                readme_zh = f.read()
+
+            _assert_python_readme_code_blocks_are_formatter_friendly(readme)
+            _assert_python_readme_code_blocks_are_formatter_friendly(readme_zh)
+            assert "CustomMachine" in readme
+            assert "CustomMachine" in readme_zh
+            assert "machine.cycle" in readme
+            assert "machine.cycle" in readme_zh
+
     def test_generated_machine_source_stays_platform_neutral_and_python37_compatible(self):
         dsl_codes = [
+            _representative_gate_dsl(),
             """
             def int counter = 0;
             state Root {


### PR DESCRIPTION
## 背景

本 PR 是模板系统治理升级伞 PR 的 PR-4，对应：

- 上游 issue：[issue #209](https://github.com/HansBug/pyfcstm/issues/209)
- 上游伞 PR：[PR #210](https://github.com/HansBug/pyfcstm/pull/210)
- 已完成前置：
  - PR-0：[PR #211](https://github.com/HansBug/pyfcstm/pull/211)
  - PR-1：[PR #212](https://github.com/HansBug/pyfcstm/pull/212)
  - PR-2：[PR #213](https://github.com/HansBug/pyfcstm/pull/213)
  - PR-3：[PR #214](https://github.com/HansBug/pyfcstm/pull/214)

PR-4 的目标是把现有内置模板的 formatter / build / representative generated-output gate 固化成可重复执行、可审阅、可验收的测试与维护记录。这里的 gate 是务实质量门槛：保证生成代码整体专业、清爽、可集成，避免明显 formatter/build 漂移；不是追求绝对风格一致，也不得为了极端 formatter-only edge case 牺牲语义、性能、兼容性或自包含 runtime 边界。

本 PR 不新增 Java / JS / Rust / Ruby / Go 模板，但必须让当前规则能自然扩展到未来这些模板；未来模板接入时也应继承同样的“务实质量门槛”而不是绝对风格目标。

## 当前问题

| 问题类别 | 当前风险 | PR-4 处理方向 | 验收方式 |
| --- | --- | --- | --- |
| Python generated source gate 不够明确 | 现有 ruff 检查覆盖多例，但 PR-4 需要把最低代表性覆盖和验收口径写清楚 | 确认并必要时增强 Python 生成物 ruff gate，覆盖嵌套复合状态、abstract hook、persistent vars、guard/effect | `ruff check` + `ruff format --check` 针对生成后的 `machine.py` |
| C formatter gate 不完整 | C 模板当前已有 C99/C++98 编译路径，但缺少与 `c_poll` 对齐的 clang-format convergence gate / README code block 检查 | 为 `c` 生成物补齐 4-space clang-format convergence 和 README code block formatter-friendly 检查 | 生成后 `machine.h` / `machine.c` 经 `clang-format` 两次收敛；README code blocks 无明显制表符/工具提示缺失 |
| C poll gate 需要复核 | `c_poll` 已有 clang-format、README code block、C99/C++98 harness 检查，需要确认代表性 DSL 与上游最低覆盖要求一致 | 必要时增强 `c_poll` 代表性 DSL 或测试说明，避免只覆盖简单两态 | 对 event-check polling generated runtime 跑 formatter + C99/C++98 harness |
| 可运行 README 示例验证口径不清 | generated README 里既有可运行片段，也有说明性片段；不应把所有 prose snippet 都强行编译 | 明确可运行代码块抽取或等价验证；说明性片段 best-effort 且不阻塞 formatter gate | 测试只对可机械验证的代码块做硬断言，对说明性片段保持宽松 |
| CI 与本地 gate 分工 | PR-4 本身就是 formatter/build gate 固化，不能只靠 `[skip-slow]` CI 规避 C/C poll 编译路径 | 本地先用 slow-skip 快速迭代；ready 前必须至少跑定向 C/C poll formatter/build tests；实现提交不使用 `[skip-slow]`，让 CI 真实覆盖慢速模板测试 | PR comment/body 记录本地命令；GitHub checks 全绿 |
| merge conflict 风险 | PR-4 依赖 PR-1/2/3 内容，ready 前如果上游伞分支推进必须重新同步 | ready 前 merge/rebase 最新上游并处理冲突，重新跑测试和 reviewer | `mergeStateStatus=CLEAN`；三路 reviewer 复查 conflict 处理 |

## 执行范围

### 必查 / 可能修改文件

| 文件 | 预计工作 |
| --- | --- |
| `test/template/python/test_runtime.py` | 检查现有 `test_generated_machine_source_stays_platform_neutral_and_python37_compatible` 是否满足 PR-4；必要时补充代表性 DSL 覆盖 abstract hook + nested composite + persistent vars + guard/effect |
| `test/template/c/test_runtime.py` | 补齐或增强 `c` 模板 clang-format convergence、README code block formatter-friendly、C99/C++98 representative harness gate |
| `test/template/c_poll/test_runtime.py` | 复核并必要时增强已有 c_poll formatter/build gate，使其覆盖 event-check polling、nested composite、abstract hook、persistent vars、guard/effect |
| `templates/*/README*.md` | 仅当 gate 命令/维护说明与新增测试明显不一致时，做最小文档修正；不得重写大段 README |
| `templates/*/README*.md.j2` | 仅当 generated README 可运行示例无法按自身说明编译/运行时做最小修复；不得新增 wording-specific 测试 |

### 非目标

- 不修改 Makefile。
- 不新增 README wording-specific 单元测试；只验证可执行/可格式化/可构建的客观契约。
- 不改变 FCSTM DSL、simulator 行为、generated runtime public API 或执行语义。
- 不新增 Java / JS / Rust / Ruby / Go 模板。
- 不把 formatter gate 做成绝对风格目标；发现极端 formatter-only edge case 时，优先记录窄范围例外，不为了风格牺牲 semantics、performance、compatibility。
- 不修改 renderer raw source context、template packaging 机制、setup.py 或 release workflow。

## 最低代表性 DSL 覆盖要求

PR-4 的 generated-output gate 至少要覆盖一个复杂度不低的合法 DSL，包含：

- root state + nested composite state + composite initial transition；
- persistent `int` / `float` vars；
- concrete lifecycle action；
- abstract hook；
- normal event transition；
- guard transition；
- transition effect；
- generated README / generated source 能围绕同一模型解释 event、vars、hooks 和 cycle flow。

可以复用现有 fixture 或测试内 DSL；如果复用较简单 DSL，则必须另有一个测试覆盖上述复杂模型，避免 gate 只证明 trivial output 可格式化/可编译。判断“较简单”的参考信号：模型不含 nested composite、不含 abstract hook、不含 guard transition、不含 transition effect 中任意两项以上。

## TDD 与实现步骤

1. 基于最新 `dev/template-governance-umbrella` 创建本分支并确认 PR-0/1/2/3 已合入。
2. 计划审查：三路 reviewer 对 PR body 与上游 issue/伞 PR 的一致性、可执行性、可验收性进行审阅，并自行评论到本 PR；C/I=0 后进入实现。
3. TDD：先检查现有测试是否已经覆盖 PR-4 最低代表性 DSL；如不足，先新增/增强测试并确认会暴露当前缺口。
4. Python gate：生成代表性 `machine.py` 后运行 `ruff check` 与 `ruff format --check`；测试允许在本地未安装 ruff 时 skip，但 CI / reviewer 环境若有 ruff 必须真实执行。
5. C gate：生成代表性 `machine.h` / `machine.c` 后运行 4-space `clang-format` convergence 检查；通过 cmake 编译并运行 C99 harness；通过 C++98 harness 编译/运行 public header integration。
6. C poll gate：同 C gate，并额外覆盖 event-check polling registration / event checks drive cycle 的代表性路径。
7. README 示例验证：对 generated README 中标记为 `c` / `cpp` / `bash` / `python` 且可机械判断的可运行代码块做 formatter-friendly 或等价 harness 验证；说明性片段可 best-effort，不应成为脆弱 wording gate。
8. 更新必要模板/README 文档，保持最小改动；不改 Makefile。
9. 运行 `make tpl`；如 tracked `pyfcstm/template/index.json` 变化需核对，zip archives 保持 gitignored。
10. 运行 `make rst_auto`；若无 tracked RST diff，在 PR comment/body 记录。
11. 本地验证：迭代时可用 `SKIP_SLOW_TESTS=1 make unittest`；ready 前必须至少跑定向 PR-4 tests（含 C/C poll cmake/clang-format 路径），并在实现提交后让 CI 不使用 `[skip-slow]`，确保慢速模板测试也在 GitHub Actions 中真实执行。
12. 推送后 watch CI 到终态。
13. 三路实现 reviewer 复审：codex reviewer、claude reviewer、deepseek reviewer。Reviewer 必须独立生成至少一个复杂 DSL 输出，并白盒验证 formatter/build/readme gate 是否确实覆盖 PR-4 目标；如发现真实问题，必须贴 DSL、命令、期望/实际结果。
14. ready 前同步最新 `dev/template-governance-umbrella`；如有 conflict，自行处理后重新跑相称测试、watch CI、三路 reviewer 复审。

## 验收标准

| 验收项 | 通过标准 |
| --- | --- |
| Python ruff gate | 代表性 `machine.py` 通过 `ruff check` 与 `ruff format --check`；生成代码不需要用户手改即可 lint-clean / formatter-stable，并保持 Python 3.7+ syntax compatibility |
| C clang-format gate | 代表性 `machine.h` / `machine.c` 在 4-space clang-format style 下两次格式化收敛，无明显制表符/粗糙输出 |
| C C99 build gate | 代表性 C generated runtime 通过 cmake C99 harness 编译并运行 |
| C C++98 integration gate | 代表性 public header / generated runtime 通过 C++98 harness 编译并运行 |
| C poll event-check gate | c_poll 代表性 generated runtime 覆盖 event-check registration / event-driven cycle，并通过 C99/C++98 harness |
| README executable guidance | generated README 的可运行示例或等价 harness 验证通过；说明性片段不被误当作必须编译的完整程序 |
| 复杂 DSL 覆盖 | 至少一个 gate 模型覆盖 nested composite、abstract hook、persistent vars、guard/effect、event transition |
| formatter philosophy | 测试和文档体现 formatter/linter 是务实质量门槛，不是绝对风格目标；未来模板也应继承该口径 |
| scope clean | 不修改 Makefile、不改变 runtime semantics、不新增未来语言模板、不扩展 packaging/setup 机制 |
| packaging sync | `make tpl` 成功；packaged built-in templates 可生成被 gate 检查的输出 |
| docs generation | `make rst_auto` 成功；若无 tracked RST diff，记录为无变化 |
| upstream sync | ready 前 merge/rebase 最新伞分支；`mergeStateStatus=CLEAN`；冲突处理经 reviewer 复查 |
| review gate | 三路 reviewer 自行评论，C/I 级问题归零；M 级不阻塞但尽量处理 |
| CI gate | GitHub checks 全部通过；本 PR 实现提交不得用 `[skip-slow]` 避开 C/C poll slow template tests；若 Codecov 因 template test helper 产生比例变化，在 PR comment 中记录原因并评估，不把 template-test-only helper 当作无条件阻塞项 |

## Reviewer 必查清单

- PR-4 是否只做 formatter/build/test gate 固化，没有混入 PR-5 结构检查或 runtime 语义修改。
- 是否真的检查 generated output，而不是只检查 `.j2` 模板源码或 README 文本。
- 代表性 DSL 是否达到 nested composite + abstract hook + vars + guard/effect + event transition 的最低复杂度。
- Python ruff、C/C poll clang-format、C99/C++98 cmake harness 是否能独立复现。
- README 代码块验证是否避免 wording-specific 脆弱断言，且不会把说明性片段误判为必须编译程序。
- formatter/linter 口径是否保持务实质量门槛；不得为了极端 formatter-only edge case 牺牲语义、性能、兼容性。
- 上游 PR-0/1/2/3 内容是否已同步进来；若有 conflict，处理后是否重新跑测试和 review。
- 实现提交和最终 head commit 是否避免 `ci skip`、`test skip`、`[skip-slow]`、`[python skip]`、`[js skip]` 等 CI trigger 子串，确保慢速模板 gate 真正在 CI 运行。

## 当前状态

- 当前 PR 已完成 PR-4 gate 实现并推送到 head commit `7122d4a5`：`test(templates): strengthen generated formatter build gates`。
- 实现范围只改动模板测试 gate：
  - `test/template/python/test_runtime.py`
  - `test/template/c/test_runtime.py`
  - `test/template/c_poll/test_runtime.py`
- 已新增/增强代表性 DSL gate，覆盖 nested composite、composite initial transition、persistent `int` / `float` vars、abstract hook、event transition、guard transition、transition effect。
- Python 侧新增 generated README python code block formatter-friendly 检查，并将代表性 DSL 纳入 generated `machine.py` 的 ruff / Python 3.7+ compatibility gate。
- C 侧补齐 generated README code block formatter-friendly、4-space clang-format convergence、C99 harness、C++98 public-header integration harness。
- C poll 侧复用同一代表性 DSL，覆盖 clang-format/readme gate，并增强 event-check polling registration + event-driven cycle 的 C99/C++98 harness。
- 最终实现提交未包含 `ci skip`、`test skip`、`[skip-slow]`、`[python skip]`、`[js skip]` 等 head commit trigger，CI 应真实运行慢速模板测试。
- 已完成本地验证：
  - `pytest test/template/python/test_runtime.py test/template/c/test_runtime.py test/template/c_poll/test_runtime.py -q`：43 passed。
  - `make rst_auto`：成功；无 tracked RST diff。
  - `SKIP_SLOW_TESTS=1 make unittest`：41078 passed, 170 skipped, 63 deselected, 1231 warnings。
- GitHub CI 正在运行；CI 全绿后进入/完成三路实现 reviewer 收口。
- 三路计划 reviewer 已完成并自行评论：codex reviewer C=0/I=0/M=1，claude reviewer C=0/I=0/M=4，deepseek reviewer C=0/I=0/M=3；M 级反馈已吸收。

