### PR TITLE
添加模板结构与防漂移检查

### DIFF
--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -1,0 +1,429 @@
+"""Regression checks for built-in template structure and generated contracts."""
+
+import ast
+import json
+import re
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pathspec
+import pytest
+import yaml
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.render import StateMachineCodeRenderer
+from pyfcstm.template import extract_template, get_template_info, list_templates
+from tools.package_templates import package_templates
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TEMPLATES_DIR = _REPO_ROOT / "templates"
+_PACKAGED_TEMPLATE_DIR = _REPO_ROOT / "pyfcstm" / "template"
+_CURRENT_TEMPLATE_NAMES = ("c", "c_poll", "python")
+_TEMPLATE_LANGUAGE_VOCABULARY = {"c", "python", "java", "js", "rust", "ruby", "go"}
+_CONFIG_TOP_LEVEL_KEYS = {
+    "expr_styles",
+    "stmt_styles",
+    "globals",
+    "filters",
+    "tests",
+    "ignores",
+}
+_MAINTAINER_ONLY_FILES = {"README.md", "README_zh.md", "template.json"}
+_REQUIRED_TEMPLATE_FILES = {
+    "c": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+    },
+    "c_poll": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+    },
+    "python": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.py.j2",
+    },
+}
+_RUNTIME_TEMPLATES = {
+    "c": ("machine.h.j2", "machine.c.j2"),
+    "c_poll": ("machine.h.j2", "machine.c.j2"),
+    "python": ("machine.py.j2",),
+}
+_ALLOWED_PYTHON_RUNTIME_IMPORTS = {"dataclasses", "math", "types", "typing"}
+_ALLOWED_C_RUNTIME_INCLUDES = {
+    "machine.h",
+    "math.h",
+    "stddef.h",
+    "stdarg.h",
+    "stdio.h",
+    "stdlib.h",
+    "string.h",
+}
+_BANNED_RUNTIME_DEPENDENCIES = (
+    "pyfcstm",
+    "jinja2",
+    "yaml",
+    "pathspec",
+)
+_BANNED_SOURCE_WORDING = (
+    "original source",
+    "raw source",
+    "raw dsl source",
+    "original dsl source",
+)
+
+
+@pytest.fixture(scope="session")
+def representative_model():
+    dsl_code = """
+    def int counter = 0;
+    def int ready = 0;
+    def float gain = 1.5;
+    state Control {
+        enter abstract Boot;
+        state Idle {
+            during { counter = counter + 1; }
+        }
+        state Active {
+            enter abstract ActiveEnter;
+            during before { gain = gain + 0.5; }
+            state Work {
+                enter { counter = counter + 2; }
+                during { counter = counter + 3; }
+            }
+            [*] -> Work : if [ready == 1];
+        }
+        state Done;
+        [*] -> Idle;
+        Idle -> Active :: Start effect { ready = 1; counter = counter + 10; };
+        Active -> Done : if [counter >= 20] effect { counter = counter + 1; };
+    }
+    """
+    ast_node = parse_with_grammar_entry(
+        re.sub(r"^ {4}", "", dsl_code, flags=re.M).strip(),
+        entry_name="state_machine_dsl",
+    )
+    return parse_dsl_node_to_state_machine(ast_node)
+
+
+@pytest.fixture(scope="session")
+def rendered_templates(representative_model):
+    with TemporaryDirectory() as td:
+        output_root = Path(td)
+        rendered = {}
+        for name in _CURRENT_TEMPLATE_NAMES:
+            output_dir = output_root / name
+            StateMachineCodeRenderer(str(_TEMPLATES_DIR / name)).render(
+                model=representative_model,
+                output_dir=str(output_dir),
+            )
+            rendered[name] = output_dir
+        yield rendered
+
+
+def _repository_template_names():
+    return tuple(
+        item.name
+        for item in sorted(_TEMPLATES_DIR.iterdir())
+        if item.is_dir() and not item.name.startswith(".")
+    )
+
+
+def _read_json(path):
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _read_text(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _load_template_metadata(name):
+    return _read_json(_TEMPLATES_DIR / name / "template.json")
+
+
+def _load_config(name):
+    with (_TEMPLATES_DIR / name / "config.yaml").open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _ignore_spec(config):
+    return pathspec.GitIgnoreSpec.from_lines(config.get("ignores", []))
+
+
+def _first_c_comment_block(source):
+    start = source.find("/*")
+    end = source.find("*/", start)
+    assert start >= 0
+    assert end > start
+    return source[start : end + 2]
+
+
+def _normalize_generated_comment(text):
+    text = re.sub(r"/\*|\*/", " ", text)
+    text = re.sub(r"(?m)^\s*\* ?", "", text)
+    return " ".join(text.lower().split())
+
+
+def _assert_banner_terms(text, *, template_name, root_name):
+    normalized = _normalize_generated_comment(text)
+    assert "generated" in normalized
+    assert template_name in normalized
+    assert root_name.lower() in normalized
+    assert "do not edit" in normalized
+    assert "regenerate" in normalized
+    assert "self-contained" in normalized
+    assert "third-party runtime" in normalized
+
+
+def _assert_source_context_terms(text):
+    normalized = " ".join(text.lower().split())
+    assert (
+        "canonical model export" in normalized
+        or "normalized model export" in normalized
+    )
+    for banned in _BANNED_SOURCE_WORDING:
+        assert banned not in normalized
+
+
+def _assert_python_runtime_imports_are_self_contained(source):
+    tree = ast.parse(source)
+    imported_modules = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.update(alias.name.split(".", 1)[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            assert node.level == 0
+            imported_modules.add((node.module or "").split(".", 1)[0])
+    assert imported_modules <= _ALLOWED_PYTHON_RUNTIME_IMPORTS
+    assert not (imported_modules & set(_BANNED_RUNTIME_DEPENDENCIES))
+
+
+def _assert_c_runtime_includes_are_self_contained(source):
+    include_targets = re.findall(r'^\s*#include\s+[<"]([^>"]+)[>"]', source, flags=re.M)
+    assert include_targets
+    assert set(include_targets) <= _ALLOWED_C_RUNTIME_INCLUDES
+    assert not (set(include_targets) & set(_BANNED_RUNTIME_DEPENDENCIES))
+
+
+@pytest.mark.unittest
+def test_repository_templates_expose_required_file_contract():
+    template_names = _repository_template_names()
+    assert set(_CURRENT_TEMPLATE_NAMES) <= set(template_names)
+
+    for name in template_names:
+        metadata = _load_template_metadata(name)
+        assert metadata["name"] == name
+        assert metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
+        if name not in _REQUIRED_TEMPLATE_FILES:
+            pytest.fail(
+                "Add a required-file contract for built-in template {name!r}.".format(
+                    name=name,
+                )
+            )
+
+        files = {
+            item.name for item in (_TEMPLATES_DIR / name).iterdir() if item.is_file()
+        }
+        assert _REQUIRED_TEMPLATE_FILES[name] <= files
+
+
+@pytest.mark.unittest
+def test_template_metadata_matches_packaged_index_contract():
+    index = _read_json(_PACKAGED_TEMPLATE_DIR / "index.json")
+    index_items = {item["name"]: item for item in index["templates"]}
+    repository_names = set(_repository_template_names())
+
+    assert set(list_templates()) == repository_names
+    assert set(index_items) == repository_names
+
+    for name in repository_names:
+        repo_metadata = _load_template_metadata(name)
+        indexed_metadata = index_items[name]
+        api_metadata = get_template_info(name)
+
+        assert api_metadata == indexed_metadata
+        assert indexed_metadata["name"] == name
+        assert indexed_metadata["archive"] == "{name}.zip".format(name=name)
+        assert indexed_metadata["root_dir"] == name
+        for key in ["title", "description", "language", "experimental"]:
+            assert indexed_metadata[key] == repo_metadata[key]
+        assert indexed_metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
+
+
+@pytest.mark.unittest
+def test_template_configs_keep_renderer_contract_and_ignores():
+    for name in _repository_template_names():
+        config = _load_config(name)
+        unknown_keys = set(config) - _CONFIG_TOP_LEVEL_KEYS
+        assert not unknown_keys
+
+        spec = _ignore_spec(config)
+        for maintainer_file in _MAINTAINER_ONLY_FILES:
+            assert spec.match_file(maintainer_file)
+        assert not spec.match_file("README.md.j2")
+        assert not spec.match_file("README_zh.md.j2")
+        for runtime_template in _RUNTIME_TEMPLATES[name]:
+            assert not spec.match_file(runtime_template)
+
+
+@pytest.mark.unittest
+def test_template_readmes_keep_maintainer_and_generated_guidance_separate(
+    rendered_templates,
+):
+    root_readme = _read_text(_TEMPLATES_DIR / "README.md")
+    root_readme_zh = _read_text(_TEMPLATES_DIR / "README_zh.md")
+    for expected in ["python", "c", "c_poll", "java", "js", "rust", "ruby", "go"]:
+        assert expected in root_readme
+        assert expected in root_readme_zh
+
+    for name in _repository_template_names():
+        template_dir = _TEMPLATES_DIR / name
+        maintainer_readme = _read_text(template_dir / "README.md").lower()
+        maintainer_readme_zh = _read_text(template_dir / "README_zh.md").lower()
+        assert "maintainer" in maintainer_readme
+        assert "template" in maintainer_readme
+        assert "not copied" in maintainer_readme or "ignored" in maintainer_readme
+        assert "template" in maintainer_readme_zh or "模板" in maintainer_readme_zh
+
+        generated_readme = _read_text(rendered_templates[name] / "README.md")
+        generated_readme_zh = _read_text(rendered_templates[name] / "README_zh.md")
+        for generated_text in [generated_readme, generated_readme_zh]:
+            lowered = generated_text.lower()
+            assert "template maintainer handbook" not in lowered
+            assert "generated files" in lowered or "生成文件" in generated_text
+            assert "model text" in lowered or "模型文本" in generated_text
+            assert "cycle" in lowered or "周期" in generated_text
+
+
+@pytest.mark.unittest
+def test_generated_sources_preserve_banner_source_context_and_dependency_boundary(
+    rendered_templates,
+):
+    python_source = _read_text(rendered_templates["python"] / "machine.py")
+    python_docstring = ast.get_docstring(ast.parse(python_source))
+    assert python_docstring is not None
+    _assert_banner_terms(python_docstring, template_name="python", root_name="Control")
+    _assert_source_context_terms(python_docstring)
+    _assert_source_context_terms(_read_text(rendered_templates["python"] / "README.md"))
+    _assert_source_context_terms(
+        _read_text(rendered_templates["python"] / "README_zh.md")
+    )
+    _assert_python_runtime_imports_are_self_contained(python_source)
+
+    for name in ["c", "c_poll"]:
+        header_source = _read_text(rendered_templates[name] / "machine.h")
+        runtime_source = _read_text(rendered_templates[name] / "machine.c")
+        _assert_banner_terms(
+            _first_c_comment_block(header_source),
+            template_name=name,
+            root_name="Control",
+        )
+        _assert_banner_terms(
+            _first_c_comment_block(runtime_source),
+            template_name=name,
+            root_name="Control",
+        )
+        for generated_text in [
+            header_source,
+            runtime_source,
+            _read_text(rendered_templates[name] / "README.md"),
+            _read_text(rendered_templates[name] / "README_zh.md"),
+        ]:
+            _assert_source_context_terms(generated_text)
+        _assert_c_runtime_includes_are_self_contained(header_source)
+        _assert_c_runtime_includes_are_self_contained(runtime_source)
+
+
+@pytest.mark.unittest
+def test_generated_source_templates_keep_source_metadata_wording():
+    for name in _repository_template_names():
+        for rel_path in ["README.md.j2", "README_zh.md.j2"] + list(
+            _RUNTIME_TEMPLATES[name]
+        ):
+            source = _read_text(_TEMPLATES_DIR / name / rel_path)
+            lowered = " ".join(source.lower().split())
+            for banned in _BANNED_SOURCE_WORDING:
+                assert banned not in lowered
+
+
+@pytest.mark.unittest
+def test_packaging_output_preserves_metadata_and_archive_roots():
+    with TemporaryDirectory() as td:
+        output_dir = Path(td)
+        stale_zip = output_dir / "stale.zip"
+        stale_zip.write_bytes(b"stale")
+
+        package_templates(str(_TEMPLATES_DIR), str(output_dir), verbose=False)
+
+        assert not stale_zip.exists()
+        index = _read_json(output_dir / "index.json")
+        assert [item["name"] for item in index["templates"]] == list(
+            _repository_template_names()
+        )
+
+        for item in index["templates"]:
+            name = item["name"]
+            repo_metadata = _load_template_metadata(name)
+            assert item["archive"] == "{name}.zip".format(name=name)
+            assert item["root_dir"] == name
+            for key in ["title", "description", "language", "experimental"]:
+                assert item[key] == repo_metadata[key]
+
+            archive_path = output_dir / item["archive"]
+            assert archive_path.is_file()
+            with zipfile.ZipFile(str(archive_path), "r") as zf:
+                names = zf.namelist()
+            assert names
+            assert all(path.startswith(name + "/") for path in names)
+            archived_rel_paths = {path[len(name) + 1 :] for path in names}
+            assert _REQUIRED_TEMPLATE_FILES[name] <= archived_rel_paths
+            assert not any("__pycache__" in path for path in names)
+
+
+@pytest.mark.unittest
+def test_distribution_metadata_keeps_template_assets_declared():
+    setup_text = _read_text(_REPO_ROOT / "setup.py")
+    manifest_text = _read_text(_REPO_ROOT / "MANIFEST.in")
+
+    assert "from tools.package_templates import package_templates" in setup_text
+    assert "package_templates(" in setup_text
+    assert "package_data" in setup_text
+    assert "*.zip" in setup_text
+    assert "*.json" in setup_text
+    assert "recursive-include pyfcstm/template *.zip *.json" in manifest_text
+
+
+@pytest.mark.unittest
+def test_extracted_builtin_templates_preserve_source_structure_contract():
+    with TemporaryDirectory() as td:
+        for name in _repository_template_names():
+            extracted_dir = Path(extract_template(name, td))
+            assert extracted_dir.name == get_template_info(name)["root_dir"]
+            files = {item.name for item in extracted_dir.iterdir() if item.is_file()}
+            assert _REQUIRED_TEMPLATE_FILES[name] <= files
+
+            config = yaml.safe_load(_read_text(extracted_dir / "config.yaml"))
+            assert not (set(config) - _CONFIG_TOP_LEVEL_KEYS)
+            spec = _ignore_spec(config)
+            for maintainer_file in _MAINTAINER_ONLY_FILES:
+                assert spec.match_file(maintainer_file)

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -403,9 +403,11 @@ def test_generated_source_templates_keep_source_metadata_wording():
             _RUNTIME_TEMPLATES[name]
         ):
             source = _read_text(_TEMPLATES_DIR / name / rel_path)
-            lowered = " ".join(source.lower().split())
+            normalized = " ".join(source.lower().split())
+            compact = "".join(source.lower().split())
             for banned in _BANNED_SOURCE_WORDING:
-                assert banned not in lowered
+                assert banned not in normalized
+                assert "".join(banned.split()) not in compact
 
 
 @pytest.mark.unittest

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -89,6 +89,12 @@ _BANNED_SOURCE_WORDING = (
     "raw source",
     "raw dsl source",
     "original dsl source",
+    "原始 dsl",
+    "原始 dsl 源码",
+    "原始 source",
+    "原始源码",
+    "原始源代码",
+    "raw 源码",
 )
 
 
@@ -129,15 +135,27 @@ def representative_model():
 def rendered_templates(representative_model):
     with TemporaryDirectory() as td:
         output_root = Path(td)
-        rendered = {}
-        for name in _CURRENT_TEMPLATE_NAMES:
-            output_dir = output_root / name
-            StateMachineCodeRenderer(str(_TEMPLATES_DIR / name)).render(
-                model=representative_model,
-                output_dir=str(output_dir),
-            )
-            rendered[name] = output_dir
-        yield rendered
+        yield _render_template_directories(
+            {name: _TEMPLATES_DIR / name for name in _CURRENT_TEMPLATE_NAMES},
+            representative_model,
+            output_root,
+        )
+
+
+@pytest.fixture(scope="session")
+def extracted_rendered_templates(representative_model):
+    with TemporaryDirectory() as extraction_td, TemporaryDirectory() as render_td:
+        extraction_root = Path(extraction_td)
+        output_root = Path(render_td)
+        template_dirs = {
+            name: Path(extract_template(name, str(extraction_root / name)))
+            for name in _CURRENT_TEMPLATE_NAMES
+        }
+        yield _render_template_directories(
+            template_dirs,
+            representative_model,
+            output_root,
+        )
 
 
 def _repository_template_names():
@@ -170,10 +188,23 @@ def _ignore_spec(config):
     return pathspec.GitIgnoreSpec.from_lines(config.get("ignores", []))
 
 
+def _render_template_directories(template_dirs, model, output_root):
+    rendered = {}
+    for name, template_dir in template_dirs.items():
+        output_dir = output_root / name
+        StateMachineCodeRenderer(str(template_dir)).render(
+            model=model,
+            output_dir=str(output_dir),
+        )
+        rendered[name] = output_dir
+    return rendered
+
+
 def _first_c_comment_block(source):
     start = source.find("/*")
     end = source.find("*/", start)
     assert start >= 0
+    assert source[:start].strip() == ""
     assert end > start
     return source[start : end + 2]
 
@@ -223,6 +254,42 @@ def _assert_c_runtime_includes_are_self_contained(source):
     assert include_targets
     assert set(include_targets) <= _ALLOWED_C_RUNTIME_INCLUDES
     assert not (set(include_targets) & set(_BANNED_RUNTIME_DEPENDENCIES))
+
+
+def _assert_rendered_template_contracts(rendered_templates):
+    python_source = _read_text(rendered_templates["python"] / "machine.py")
+    python_docstring = ast.get_docstring(ast.parse(python_source))
+    assert python_docstring is not None
+    _assert_banner_terms(python_docstring, template_name="python", root_name="Control")
+    _assert_source_context_terms(python_docstring)
+    _assert_source_context_terms(_read_text(rendered_templates["python"] / "README.md"))
+    _assert_source_context_terms(
+        _read_text(rendered_templates["python"] / "README_zh.md")
+    )
+    _assert_python_runtime_imports_are_self_contained(python_source)
+
+    for name in ["c", "c_poll"]:
+        header_source = _read_text(rendered_templates[name] / "machine.h")
+        runtime_source = _read_text(rendered_templates[name] / "machine.c")
+        _assert_banner_terms(
+            _first_c_comment_block(header_source),
+            template_name=name,
+            root_name="Control",
+        )
+        _assert_banner_terms(
+            _first_c_comment_block(runtime_source),
+            template_name=name,
+            root_name="Control",
+        )
+        for generated_text in [
+            header_source,
+            runtime_source,
+            _read_text(rendered_templates[name] / "README.md"),
+            _read_text(rendered_templates[name] / "README_zh.md"),
+        ]:
+            _assert_source_context_terms(generated_text)
+        _assert_c_runtime_includes_are_self_contained(header_source)
+        _assert_c_runtime_includes_are_self_contained(runtime_source)
 
 
 @pytest.mark.unittest
@@ -318,40 +385,10 @@ def test_template_readmes_keep_maintainer_and_generated_guidance_separate(
 @pytest.mark.unittest
 def test_generated_sources_preserve_banner_source_context_and_dependency_boundary(
     rendered_templates,
+    extracted_rendered_templates,
 ):
-    python_source = _read_text(rendered_templates["python"] / "machine.py")
-    python_docstring = ast.get_docstring(ast.parse(python_source))
-    assert python_docstring is not None
-    _assert_banner_terms(python_docstring, template_name="python", root_name="Control")
-    _assert_source_context_terms(python_docstring)
-    _assert_source_context_terms(_read_text(rendered_templates["python"] / "README.md"))
-    _assert_source_context_terms(
-        _read_text(rendered_templates["python"] / "README_zh.md")
-    )
-    _assert_python_runtime_imports_are_self_contained(python_source)
-
-    for name in ["c", "c_poll"]:
-        header_source = _read_text(rendered_templates[name] / "machine.h")
-        runtime_source = _read_text(rendered_templates[name] / "machine.c")
-        _assert_banner_terms(
-            _first_c_comment_block(header_source),
-            template_name=name,
-            root_name="Control",
-        )
-        _assert_banner_terms(
-            _first_c_comment_block(runtime_source),
-            template_name=name,
-            root_name="Control",
-        )
-        for generated_text in [
-            header_source,
-            runtime_source,
-            _read_text(rendered_templates[name] / "README.md"),
-            _read_text(rendered_templates[name] / "README_zh.md"),
-        ]:
-            _assert_source_context_terms(generated_text)
-        _assert_c_runtime_includes_are_self_contained(header_source)
-        _assert_c_runtime_includes_are_self_contained(runtime_source)
+    _assert_rendered_template_contracts(rendered_templates)
+    _assert_rendered_template_contracts(extracted_rendered_templates)
 
 
 @pytest.mark.unittest

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -94,7 +94,10 @@ _BANNED_SOURCE_WORDING = (
     "原始 source",
     "原始源码",
     "原始源代码",
+    "原始输入源码",
+    "原始输入源代码",
     "raw 源码",
+    "raw 源代码",
 )
 
 
@@ -228,12 +231,14 @@ def _assert_banner_terms(text, *, template_name, root_name):
 
 def _assert_source_context_terms(text):
     normalized = " ".join(text.lower().split())
+    compact = "".join(text.lower().split())
     assert (
         "canonical model export" in normalized
         or "normalized model export" in normalized
     )
     for banned in _BANNED_SOURCE_WORDING:
         assert banned not in normalized
+        assert "".join(banned.split()) not in compact
 
 
 def _assert_python_runtime_imports_are_self_contained(source):


### PR DESCRIPTION
## 背景

本 PR 是模板系统治理升级伞 PR 的 PR-5，对应：

- 上游 issue：[issue #209](https://github.com/HansBug/pyfcstm/issues/209)
- 上游伞 PR：[PR #210](https://github.com/HansBug/pyfcstm/pull/210)
- 已完成前置：
  - PR-0：[PR #211](https://github.com/HansBug/pyfcstm/pull/211)
  - PR-1：[PR #212](https://github.com/HansBug/pyfcstm/pull/212)
  - PR-2：[PR #213](https://github.com/HansBug/pyfcstm/pull/213)
  - PR-3：[PR #214](https://github.com/HansBug/pyfcstm/pull/214)
  - PR-4：[PR #215](https://github.com/HansBug/pyfcstm/pull/215)

PR-5 的目标是给内置模板系统补上稳定、可重复执行的结构检查与防漂移 gate。它要把 PR-0/1/2/3/4 已经形成的制度转成可机械检查的契约，防止后续模板维护或新增模板时出现 required files 缺失、metadata/config 漂移、README 分层混乱、generated source banner 退化、runtime dependency 越界、packaged template 与 repository template 不一致等问题。

本 PR 不新增未来语言模板，也不修改 Makefile。若新增 pytest 测试，测试对象必须是生产模板源码、packaged built-in assets、或通过生产 renderer 生成出的模板契约；不得把 test tree 自身的维护元数据当成被测对象。

## 当前问题

| 问题类别 | 当前风险 | PR-5 处理方向 | 验收方式 |
| --- | --- | --- | --- |
| required files 漂移 | 新模板或现有模板可能漏掉 `config.yaml`、`template.json`、维护 README、generated README 模板或 runtime source 模板 | 对每个 repository-source built-in template 做 required files 检查；按模板名区分 `python` / `c` / `c_poll` 所需 runtime source 模板；future vocabulary 对应模板不存在时视为通过 | pytest 明确列出当前模板与对应 required files；缺失时给出可读断言 |
| metadata 漂移 | `template.json` 与 packaged `pyfcstm/template/index.json` 可能不一致，或出现未来语言 vocabulary 外的值 | 检查 repository metadata、packaged metadata、`list_templates()` / `get_template_info()` 一致；允许当前 `python` / `c`，预留未来 `java/js/rust/ruby/go` vocabulary | pytest 比对模板名、language、archive/root_dir 关键字段 |
| config key 漂移 | `config.yaml` 新增未知顶层 key 或忘记 ignore 维护文档，可能导致维护 README 泄露到 generated output | 检查已知顶层 key 集合；检查 `README.md`、`README_zh.md`、`template.json` 被 ignores 排除；检查 generated README `.j2` 不被 ignore | pytest 解析 YAML 并断言 known keys / ignores contract |
| README 分层漂移 | 模板级维护 README 与 generated README 容易混写职责 | 检查 root README、template README、generated README 模板同时存在；模板级 README 应描述 maintenance/template；generated README 模板应产生 runtime user guidance | pytest 做结构性存在与关键 role 词检查，避免 wording-specific 过强断言 |
| generated banner 漂移 | PR-3 已补源码 banner，但后续修改可能破坏首注释块/docstring | 通过生产 renderer 生成当前模板输出，机械检查 `machine.py` / `machine.h` / `machine.c` 首部 generated/do-not-edit/self-contained/root/template 信息 | pytest 生成代表性模型并检查 generated source banner，不只检查 `.j2` 源码 |
| source context / metadata 漂移 | PR-2 已统一 canonical model export 口径，但后续 README、`DSL_SOURCE`、`_dsl_source()` 或注释可能重新把 canonical export 误称为 original/raw source | 对模板源和实际 generated output 同时做 source wording 检查；确认 `DSL_SOURCE`、`_dsl_source()`、generated README/source comments 均明确 canonical / normalized model export，且不出现 raw/original source 误标 | pytest 生成代表性模型后检查 README、`machine.py`、`machine.h`、`machine.c` 的 source metadata wording；同时检查模板源中相关位置 |
| runtime dependency 越界 | generated runtime 必须自包含，不能依赖 `pyfcstm` 或第三方 runtime package | 对生成后的 Python/C/C poll runtime source 做 dependency/import/include 扫描；允许目标语言标准库/核心头文件 | pytest 扫描 generated source，禁止 `pyfcstm`、Jinja/YAML/pathspec 等 generation-time dependency 泄露 |
| packaging/loading 漂移 | `templates/`、`tools.package_templates`、`setup.py`、`MANIFEST.in`、`pyfcstm/template/*.zip`、`index.json`、`extract_template()` 之间可能不一致 | 覆盖完整链路：从 repository-source `templates/` required files contract 起步；调用 `tools.package_templates.package_templates()` 到临时目录，核对 metadata 强制字段、zip root、archive 内容；核对 tracked packaged `index.json` 与 repository metadata；用静态等价信号核对 `setup.py` packaging hook、`MANIFEST.in` 和 `package_data` 仍包含 template assets；最后用 `extract_template()` 验证 runtime extraction/fallback contract | pytest 同时验证 source templates、temp packaging output、tracked packaged metadata、zip archive roots、setup/manifest/package_data contract、`extract_template()` 解包结果 |
| 未来模板扩展漂移 | 后续 Java/JS/Rust/Ruby/Go 模板需要共用规则，不能被当前模板硬编码误伤 | 预留 language vocabulary 和 required-file rule 扩展点；当前不要求这些模板存在 | pytest 允许 vocabulary，但只对已存在模板执行 required checks |

## 执行范围

### 必查 / 可能修改文件

| 文件 | 预计工作 |
| --- | --- |
| `test/template/test_template.py` 或新增 `test/template/test_template_structure.py` | 增加模板结构、防漂移、packaging/generated contract 测试；测试名按客观行为命名，不出现 PR 编号/阶段等 workflow label |
| `tools/package_templates.py`、`setup.py`、`MANIFEST.in` | 原则上只读核对；仅当检查发现现有 packaging contract 已与实际机制不一致时，才做最小修正 |
| `templates/*/README*.md` | 仅当结构检查发现现有维护 README 缺少必要角色说明时做最小修正 |
| `templates/*/README*.md.j2` | 仅当 generated README 模板与分层契约明显冲突时做最小修正 |
| `templates/*/template.json` / `config.yaml` | 仅当 metadata/config 与现行契约不一致时做最小修正 |

### 非目标

- 不修改 Makefile。
- 不新增 Java / JS / Rust / Ruby / Go 模板。
- 不改变 FCSTM DSL、simulator 行为、renderer public API 或 generated runtime public API。
- 不把 README 文案做成脆弱 wording-specific 测试；只检查分层职责、关键契约和机械可验证结构。
- 不编译 C/C poll runtime；编译/formatter gate 已由 PR-4 覆盖。本 PR 聚焦结构与防漂移。
- 不修改 template packaging 设计；只通过现有生产机制验证一致性。
- 不把 test-tree 元数据作为被测对象；测试应面向 `templates/`、`pyfcstm/template/`、生产 renderer 输出。

## 机械检查口径补充

- `config.yaml` 当前允许的顶层 key 集合为：`expr_styles`、`stmt_styles`、`globals`、`filters`、`tests`、`ignores`。当前模板可以只使用其中子集；出现其他顶层 key 必须先更新 renderer contract 与本检查口径。
- `template.json` / packaged index 关键字段至少包括：`name`、`title`、`description`、`language`、`experimental`、`archive`、`root_dir`。其中 `archive` / `root_dir` 由 packaging 强制写入，repository `template.json` 不需要手写。
- language vocabulary：当前存在 `python` / `c`；预留但不强制存在 `java`、`js`、`rust`、`ruby`、`go`。新增语言模板时应先扩展 required-file rule，而不是把当前模板名硬编码到业务逻辑。
- source context wording：由 `model.to_ast_node()` 或 generated runtime helper 导出的文本必须称为 `canonical model export` / `normalized model export` 或等价表述；除非未来 renderer 显式传入用户原始输入文本，否则 generated README、`DSL_SOURCE`、`_dsl_source()`、docstring、comments 不得称其为 `original source`、`raw source` 或等价表述。
- packaging/loading 链路必须覆盖四层：repository-source `templates/`、临时 `package_templates()` 输出、tracked packaged `pyfcstm/template/index.json` / zip assets、runtime API `extract_template()`。只检查 `extract_template()` 不足以证明 packaging 机制未漂移。

## TDD 与实现步骤

1. 基于最新 `dev/template-governance-umbrella` 创建本分支并确认 PR-0/1/2/3/4 已合入。
2. 计划审查：三路 reviewer 对本 PR body 与 [issue #209](https://github.com/HansBug/pyfcstm/issues/209)、[PR #210](https://github.com/HansBug/pyfcstm/pull/210) 的一致性、可执行性、可验收性进行审阅并自行评论到本 PR；C/I=0 后进入实现。
3. TDD：先新增结构检查测试，覆盖 required files / metadata / config ignores / generated banner / source context metadata / dependency scan / full packaging-loading chain；确认测试对象是生产模板源码、tracked packaged assets、临时 packaging output 或生产 renderer 生成物。
4. 若测试发现现有模板文档或 metadata 有真实漂移，做最小修复；不得扩大到重写模板制度文档。
5. 用代表性合法 DSL 通过生产 renderer 生成 `python`、`c`、`c_poll` 输出，检查 generated source banner 与 dependency boundary。
6. 覆盖完整 packaging/loading 链路：从 repository-source `templates/` contract 起步；调用 `package_templates()` 到临时目录并核对 zip root / archive files / generated `index.json`；核对 tracked `pyfcstm/template/index.json` 与 repository `template.json` 关键字段一致；用静态等价信号核对 `setup.py` 仍 import/call `tools.package_templates.package_templates` 且 `package_data` 覆盖 zip/json assets；核对 `MANIFEST.in` 仍包含 `recursive-include pyfcstm/template *.zip *.json`；通过 `extract_template()` 解包 packaged assets，核对 packaged built-in template 文件结构与 repository-source contract 一致。
7. 运行 `make tpl`；若 tracked packaged metadata 变化，核对原因；zip archives 保持 gitignored。
8. 运行 `make rst_auto`；如无 tracked RST diff，在 PR comment/body 记录。
9. 本地验证：迭代时可用 `SKIP_SLOW_TESTS=1 make unittest`；本 PR 不新增 C 编译 gate，但仍需至少跑新增/相关 template tests。
10. 推送后 watch CI 到终态。
11. 三路实现 reviewer 复审：codex reviewer、claude reviewer、deepseek reviewer。Reviewer 必须独立构造至少一个结构漂移/依赖越界/metadata 漂移的负例或白盒检查脚本，验证新增 gate 能抓住同类问题；如发现真实问题，必须贴复现方式、期望结果、实际结果。
12. ready 前同步最新 `dev/template-governance-umbrella`；如有 conflict，自行处理后重新跑相称测试、watch CI、三路 reviewer 复审。

## 验收标准

| 验收项 | 通过标准 |
| --- | --- |
| required files | 当前 `python` / `c` / `c_poll` repository-source templates 都具备模板级 README、中英 generated README 模板、`config.yaml`、`template.json`、对应 runtime source `.j2`；future vocabulary 中尚不存在的模板目录视为通过 |
| metadata consistency | `template.json`、packaged `index.json`、`list_templates()`、`get_template_info()` 对 name/language/archive/root_dir 等关键字段一致；future language vocabulary 被允许但不强制存在 |
| config contract | `config.yaml` 只使用已知顶层 key；维护 README 和 `template.json` 在 ignores 中；generated README `.j2` 和 runtime source `.j2` 不被维护 ignores 误排除 |
| README layering | root README / template README / generated README 模板职责分层可机械核对；不得把维护手册直接生成到用户输出，也不得让 generated README 依赖用户理解 pyfcstm template 内部机制 |
| generated banner | 实际 generated `machine.py` 首部 docstring、`machine.h` / `machine.c` 首部注释块仍包含 generated、template/root、do-not-edit/regenerate、自包含依赖边界信息 |
| source metadata wording | generated README、`DSL_SOURCE`、`_dsl_source()`、docstrings/comments 中的 embedded model text 均标注为 canonical / normalized model export；未在没有 raw renderer context 的情况下称为 original/raw source |
| runtime dependency boundary | generated runtime source 不导入/包含 `pyfcstm`、Jinja2、YAML、pathspec 或第三方 runtime dependency；Python 只允许标准库，C/C poll 只允许标准 C 头文件和本地 `machine.h` |
| packaging/loading chain | repository-source `templates/`、临时 `package_templates()` 输出、tracked packaged `index.json` / zip archive root、`setup.py` packaging hook 静态等价信号、`MANIFEST.in` / `package_data` asset inclusion、`extract_template()` 解包结果共同满足同一 required-file/config/metadata contract |
| scope clean | 不修改 Makefile、不改变 runtime semantics、不新增未来语言模板、不引入编译 gate 重复 PR-4 |
| docs generation | `make rst_auto` 成功；若无 tracked RST diff，记录为无变化 |
| upstream sync | ready 前 merge/rebase 最新伞分支；`mergeStateStatus=CLEAN`；冲突处理经 reviewer 复查 |
| review gate | 三路 reviewer 自行评论，C/I 级问题归零；M 级不阻塞但尽量处理 |
| CI gate | GitHub checks 全部通过；最终 head commit 可按需要保留 `[skip-slow]` 以节省 C/C poll 编译时间，但若 PR 修改触及 C/C poll runtime compile path 则不得跳过慢速模板测试 |

## Reviewer 必查清单

- PR-5 是否只做结构/防漂移 gate，没有混入 PR-4 formatter/build gate、runtime 语义变更或未来模板新增。
- 测试对象是否是生产模板源码、packaged built-in assets、或生产 renderer 输出；不得检查 test-tree 自身元数据来伪造覆盖。
- `templates/`、临时 `package_templates()` 输出、tracked `pyfcstm/template/index.json` / zip assets、`setup.py` / `MANIFEST.in` / `package_data`、`extract_template()` 是否都被覆盖到。
- generated source banner 和 source metadata wording 检查是否针对实际生成输出，而不是只 grep `.j2` 源码。
- dependency scan 是否避免误判标准库，同时能抓住 `pyfcstm` / third-party runtime 依赖泄露。
- README layering 检查是否足够稳定，避免 wording-specific 脆弱断言。
- future `java/js/rust/ruby/go` vocabulary 是否预留，但本 PR 未新增这些模板；`config.yaml` known key 集合是否在 PR body 中自包含。
- 上游 PR-0/1/2/3/4 内容是否已同步进来；若有 conflict，处理后是否重新跑测试和 review。

## 当前状态

- 当前 PR 是 empty planning PR，尚未实现 PR-5 gate 改动。
- 第一轮 codex planning review 指出的 I 级缺口已补齐；三路复审均 C/I=0。
- 已吸收 M 级清晰度建议：future vocabulary 空目录视为通过、`setup.py` / `MANIFEST.in` 采用静态等价信号、`machine.c` 使用注释块表述、`c` / `c_poll` required files 按模板名区分。
- 当前计划审查 C/I=0，可进入 TDD + 实现。


