### PR TITLE
迁移共享语义 fixture 到 schema v2

### DIFF
--- a/test/fixtures/simulate_semantics/README.md
+++ b/test/fixtures/simulate_semantics/README.md
@@ -1,20 +1,36 @@
 # Simulate semantic fixtures
 
-This corpus turns existing simulator and built-in Python template alignment
-semantics into data files. Each case lives in `cases/<id>.fcstm` plus
+This corpus turns simulator and built-in Python template alignment semantics into
+shared data files. Each case lives in `cases/<id>.fcstm` plus
 `cases/<id>.yaml` and is executed by helpers in
 `test/testings/simulate_semantics.py`.
 
-This corpus is a fixture/test-harness change only. It does not change production
-runtime semantics and does not activate known simulator bug reproductions.
+The shared corpus is a fixture/test-harness contract. It does not change
+production runtime semantics, and it must not activate known simulator bug
+reproductions as expected failures.
+
+## Scope
 
 The shared corpus is intentionally narrow and public-API based. Every YAML case
-defaults to the simulator plus generated Python alignment runners, and the only
-runner-selection field is `exclude_runners` for explicit exceptions. Do not add
-`runners`, top-level boundary markers, CLI command scenarios, model-construction
-diagnostics, runtime options, log/warning assertions, stack snapshots, cycle
-counters, history records, or any other private simulator surface to this
+uses the current shared runner set by default:
+
+- `simulation`
+- `generated_python_alignment`
+
+The only runner-selection field is `exclude_runners` for explicit exceptions.
+Do not add include-style `runners`, top-level boundary markers, CLI command
+scenarios, model-construction diagnostics, runtime options, log/warning
+assertions, stack snapshots, cycle counters, history records, cycle return
+metadata, event accounting, or any other private simulator surface to this
 corpus.
+
+Shared fixtures cover only legal DSL models and legal runtime use: optional legal
+hot-start construction, optional legal abstract-handler registration, and a
+sequence of legal `cycle` calls. Handler fixtures only check whether hooks were
+called, in what order, and with what public context snapshot. Handler
+registration policy, duplicate registration behavior, warning/log/error
+metadata, handler exceptions, and read-only write-attempt diagnostics belong in
+ordinary simulator pytest files.
 
 ## How to run
 
@@ -28,22 +44,64 @@ SKIP_SLOW_TESTS=1 make unittest
 ## Adding a case
 
 1. Add `cases/<id>.fcstm` with the DSL source.
-2. Add `cases/<id>.yaml` using `schema_version: 1` and the schema in
-   `schema.md`.
-3. Keep `id` equal to the YAML/FCSTM basename.
-4. Set `origin.files` to the exact original pytest function(s).
-5. Omit `runners`; the loader applies all current shared runners by default.
-6. Use `exclude_runners` only when a current shared runner cannot consume the
-   case and the exclusion is intentional.
-7. Keep only the public observation surface: `state`, `vars`, `vars_exact`,
-   `vars_keys`, `vars_absent`, `ended`, constructor or hot-start outcomes,
-   per-step cycle state and vars, and `handler_calls`.
+2. Add `cases/<id>.yaml` using the v2 schema in `schema.md`.
+3. Do not write `schema_version`, `id`, or `source`; the loader derives the case
+   id and paired FCSTM file from the YAML basename.
+4. Set `origin.files` to the exact original pytest function(s), issue links, or
+   PR links that supplied the behavior.
+5. Omit `exclude_runners` unless a current shared runner has a documented
+   capability gap for this otherwise shared behavior.
+6. Use only the public observation surface: `state`, `vars`, `vars_exact`,
+   `vars_keys`, `vars_absent`, `ended`, `raises`, and `handler_calls`.
+7. Keep `expect` sparse: omitted fields mean “do not assert this observation,”
+   not a default expected value.
 8. Preserve every original behavior either through the shared public observation
-   surface or through an ordinary pytest outside this corpus.
+   surface or through ordinary pytest outside this corpus.
 9. Run the fixture tests and the ordinary pytest coverage that owns any
    non-shared behavior.
 10. Run `python tools/inventory_simulate_semantics.py --check` to keep the
-    long-term Markdown and runner-selection contract clean.
+    long-term Markdown, pairing, and public-observation contract clean.
+
+Minimal v2 shape:
+
+```yaml
+title: Event sequence reaches active state
+origin:
+  files:
+    - test/simulate/test_runtime.py::test_event_sequence
+categories: [runtime, template_alignment]
+
+initial:
+  state: Root.Gate
+  vars: {counter: 0}
+
+handlers:
+  - action: Root.Gate.Observe
+    behavior: record_call
+
+steps:
+  - cycle_count: 0
+    expect:
+      state: Root.Gate
+      vars: {counter: 0}
+      ended: false
+      handler_calls: []
+
+  - cycle: Root.Gate.Unlock
+    expect:
+      state: Root.Active
+      vars: {counter: 1}
+
+  - cycle_count: 4
+    expect:
+      vars: {counter: 5}
+
+  - cycle: [Root.Active.Tick, Root.Active.Flush]
+    cycle_count: 2
+    expect:
+      state: Root.Done
+      ended: false
+```
 
 ## Maintenance inventory
 
@@ -53,32 +111,33 @@ generated README case table. Long-term documentation in this directory is
 limited to this README and `schema.md`.
 
 Use `python tools/inventory_simulate_semantics.py --check` when changing this
-corpus. The check verifies YAML/FCSTM pairing, the top-level Markdown file
-list, absence of include-style `runners`, and absence of known private
-simulator surfaces in shared YAML.
+corpus. The check verifies YAML/FCSTM pairing, the top-level Markdown file list,
+absence of v1 fields and include-style runner selection, absence of legacy cycle
+and path shapes, and absence of known private simulator surfaces in shared YAML.
 
 ## Public-observation checklist
 
 Use this checklist before deleting or replacing any inline original test:
 
-- `origin.files` points to the original class/function.
+- `origin.files` points to the original class/function, issue, or PR.
 - The `.fcstm` file is semantically equivalent to the original DSL string;
   indentation cleanup is okay, DSL changes are not.
 - The YAML cycle/event sequence matches the original call sequence exactly.
-- Event input strings are not rewritten to a different path form.
+- Event input strings are not rewritten to a different path form unless the test
+  explicitly covers equivalent path spelling.
 - Every helper assertion and every bare assertion either has a public YAML
   equivalent or remains in ordinary pytest coverage.
 - Runtime log assertions, Python warning assertions, stack snapshots, cycle
-  counters, history records, cycle return metadata, and CLI output stay outside
-  this shared corpus.
-- `set(runtime.vars.keys())` and temporary-variable non-leakage use
-  `vars_keys` and/or `vars_absent`.
+  counters, history records, cycle return metadata, event accounting, and CLI
+  output stay outside this shared corpus.
+- `set(runtime.vars.keys())` and temporary-variable non-leakage use `vars_keys`
+  and/or `vars_absent`.
 - Exception tests keep class and message assertions under `raises` and keep
   rollback state/vars assertions when the original checked them.
 - CLI tests stay as ordinary pytest coverage instead of shared fixture YAML.
 - Abstract-handler callbacks use `handlers` plus `handler_calls`; shared cases
-  keep only public hook-call records. Handler error metadata belongs in
-  ordinary simulator pytest coverage.
+  keep only public hook-call records. Handler error metadata belongs in ordinary
+  simulator pytest coverage.
 - Anonymous abstract warning dedupe metadata is a simulator-internal diagnostic
   and belongs in dedicated `test/simulate/` pytest coverage, not shared fixture
   YAML.

--- a/test/fixtures/simulate_semantics/cases/abstract_handler_context_metadata.yaml
+++ b/test/fixtures/simulate_semantics/cases/abstract_handler_context_metadata.yaml
@@ -1,31 +1,19 @@
-schema_version: 1
-id: abstract_handler_context_metadata
 title: Abstract handler context metadata fixture
-source:
-  fcstm: abstract_handler_context_metadata.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
-  assertion_types:
-  - handler_calls
-  - vars
   notes:
   - Minimal fixture proving optional context metadata fields are accepted and asserted.
 categories:
 - runtime
 - abstract
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Active.Touch
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Active
+    state: Root.Active
     vars:
       x: 0
     ended: false
@@ -35,9 +23,7 @@ steps:
       stage: during
       vars:
         x: 0
-      active_leaf:
-      - Root
-      - Active
+      active_leaf: Root.Active
       call_stage: during
       abstract_target: Root.Active.Touch
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/abstract_handler_context_vars_are_read_only.yaml
+++ b/test/fixtures/simulate_semantics/cases/abstract_handler_context_vars_are_read_only.yaml
@@ -1,55 +1,25 @@
-schema_version: 1
-id: abstract_handler_context_vars_are_read_only
 title: Abstract handler context variables are read-only
-source:
-  fcstm: abstract_handler_context_vars_are_read_only.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614012639
-  assertion_types:
-  - ended
-  - handler_calls
-  - state
-  - vars
   notes:
-  - Public handler context read-only observation shared by simulation and generated
-    Python alignment.
+  - Public handler context snapshot observation shared by simulation and generated
+    Python alignment. Read-only write-attempt behavior remains in ordinary simulator
+    tests.
 categories:
 - runtime
 - abstract
-initial:
-  state: null
-  vars: null
 handlers:
-- action: Root.A.Touch
-  behavior: record_var_write_attempt
-  write:
-    name: x
-    value: 999
 - action: Root.A.Touch
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
     ended: false
     handler_calls:
-    - action: Root.A.Touch
-      state: Root.A
-      stage: during
-      vars:
-        x: 0
-      write_attempt:
-        name: x
-        value: 999
-        succeeded: false
-        error_type: TypeError
-        vars:
-          x: 0
     - action: Root.A.Touch
       state: Root.A
       stage: during

--- a/test/fixtures/simulate_semantics/cases/abstract_hook_context_hot_start_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/abstract_hook_context_hot_start_leaf.yaml
@@ -1,17 +1,8 @@
-schema_version: 1
-id: abstract_hook_context_hot_start_leaf
 title: Abstract hook context reports hot-start leaf callsite
-source:
-  fcstm: abstract_hook_context_hot_start_leaf.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/pull/205
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694732793
-  assertion_types:
-  - handler_calls
-  - hot_start
-  - state
-  - vars
   notes:
   - Hot-start leaf ref/aspect context alignment case for generated Python runtime.
 categories:
@@ -32,11 +23,9 @@ handlers:
 - action: Root.ObserveAfter
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       trace: 8
     ended: false
@@ -46,9 +35,7 @@ steps:
       stage: during
       vars:
         trace: 7
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveBefore
       named_ref: null
@@ -57,9 +44,7 @@ steps:
       stage: during
       vars:
         trace: 7
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedDuring
       named_ref: Root.A.ActiveRef
@@ -68,9 +53,7 @@ steps:
       stage: during
       vars:
         trace: 8
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveAfter
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/abstract_hook_ref_context_reports_callsite_metadata.yaml
+++ b/test/fixtures/simulate_semantics/cases/abstract_hook_ref_context_reports_callsite_metadata.yaml
@@ -1,16 +1,8 @@
-schema_version: 1
-id: abstract_hook_ref_context_reports_callsite_metadata
 title: Abstract hook ref context reports callsite metadata
-source:
-  fcstm: abstract_hook_ref_context_reports_callsite_metadata.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/pull/205
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694000657
-  assertion_types:
-  - handler_calls
-  - state
-  - vars
   notes:
   - Canonical ref/aspect context alignment case for generated Python runtime.
 categories:
@@ -18,9 +10,6 @@ categories:
 - template_alignment
 - abstract
 - lifecycle
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Library.SharedEnter
   behavior: record_call
@@ -43,11 +32,9 @@ handlers:
 - action: Root.Gate.C.EnterC
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       trace: 1
       branch: 1
@@ -59,9 +46,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.SharedExit
       named_ref: Root.A.FirstRef
@@ -71,9 +56,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveBefore
       named_ref: null
@@ -83,9 +66,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedEnter
       named_ref: null
@@ -95,19 +76,13 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveAfter
       named_ref: null
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       trace: 12
       branch: 11
@@ -119,9 +94,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.SharedExit
       named_ref: Root.A.FirstRef
@@ -131,9 +104,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveBefore
       named_ref: null
@@ -143,9 +114,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedEnter
       named_ref: null
@@ -155,9 +124,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveAfter
       named_ref: null
@@ -167,9 +134,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: exit
       abstract_target: Root.Library.SharedDuring
       named_ref: null
@@ -179,9 +144,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: enter
       abstract_target: Root.B.EnterB
       named_ref: null
@@ -191,9 +154,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.ObserveBefore
       named_ref: null
@@ -203,9 +164,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.B.DuringB
       named_ref: null
@@ -215,20 +174,13 @@ steps:
       vars:
         trace: 12
         branch: 11
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.ObserveAfter
       named_ref: null
-- cycle:
-    events:
-    - Root.B.ToGate
+- cycle: Root.B.ToGate
   expect:
-    state:
-    - Root
-    - Gate
-    - C
+    state: Root.Gate.C
     vars:
       trace: 1243
       branch: 111
@@ -240,9 +192,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.SharedExit
       named_ref: Root.A.FirstRef
@@ -252,9 +202,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveBefore
       named_ref: null
@@ -264,9 +212,7 @@ steps:
       vars:
         trace: 0
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedEnter
       named_ref: null
@@ -276,9 +222,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.ObserveAfter
       named_ref: null
@@ -288,9 +232,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: exit
       abstract_target: Root.Library.SharedDuring
       named_ref: null
@@ -300,9 +242,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: enter
       abstract_target: Root.B.EnterB
       named_ref: null
@@ -312,9 +252,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.ObserveBefore
       named_ref: null
@@ -324,9 +262,7 @@ steps:
       vars:
         trace: 1
         branch: 1
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.B.DuringB
       named_ref: null
@@ -336,9 +272,7 @@ steps:
       vars:
         trace: 12
         branch: 11
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.ObserveAfter
       named_ref: null
@@ -348,9 +282,7 @@ steps:
       vars:
         trace: 12
         branch: 11
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: exit
       abstract_target: Root.B.ExitB
       named_ref: null
@@ -360,9 +292,7 @@ steps:
       vars:
         trace: 124
         branch: 11
-      active_leaf:
-      - Root
-      - Gate
+      active_leaf: Root.Gate
       call_stage: during
       abstract_target: Root.Gate.ObserveGate
       named_ref: null
@@ -372,10 +302,7 @@ steps:
       vars:
         trace: 124
         branch: 11
-      active_leaf:
-      - Root
-      - Gate
-      - C
+      active_leaf: Root.Gate.C
       call_stage: enter
       abstract_target: Root.Gate.C.EnterC
       named_ref: null
@@ -385,10 +312,7 @@ steps:
       vars:
         trace: 124
         branch: 11
-      active_leaf:
-      - Root
-      - Gate
-      - C
+      active_leaf: Root.Gate.C
       call_stage: during
       abstract_target: Root.ObserveBefore
       named_ref: null
@@ -398,10 +322,7 @@ steps:
       vars:
         trace: 1243
         branch: 111
-      active_leaf:
-      - Root
-      - Gate
-      - C
+      active_leaf: Root.Gate.C
       call_stage: during
       abstract_target: Root.ObserveAfter
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/aspect_context_reports_active_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/aspect_context_reports_active_leaf.yaml
@@ -1,36 +1,23 @@
-schema_version: 1
-id: aspect_context_reports_active_leaf
 title: Aspect abstract handler reports active leaf context
-source:
-  fcstm: aspect_context_reports_active_leaf.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/pull/205
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632446687
-  assertion_types:
-  - handler_calls
-  - state
-  - vars
   notes:
   - CTX-1 regression proving ancestor aspect context uses the current active leaf.
 categories:
 - runtime
 - abstract
 - lifecycle
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Observe
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       branch: 1
     ended: false
@@ -40,19 +27,13 @@ steps:
       stage: during
       vars:
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Observe
       named_ref: null
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       branch: 2
     ended: false
@@ -62,9 +43,7 @@ steps:
       stage: during
       vars:
         branch: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Observe
       named_ref: null
@@ -73,9 +52,7 @@ steps:
       stage: during
       vars:
         branch: 1
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.Observe
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/auto_initialization_on_current_state_access.yaml
+++ b/test/fixtures/simulate_semantics/cases/auto_initialization_on_current_state_access.yaml
@@ -1,92 +1,64 @@
-schema_version: 1
-id: auto_initialization_on_current_state_access
 title: Current state access observes root before first cycle
-source:
-  fcstm: auto_initialization_on_current_state_access.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_auto_initialization_on_current_state_access
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_auto_initialization_on_current_state_access
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - ended
 categories:
 - runtime
 - template_alignment
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- expect_initial:
-    state:
-    - System
+- cycle_count: 0
+  expect:
+    state: System
     vars:
       counter: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Idle
+    state: System.Idle
     vars:
       counter: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Idle
+    state: System.Idle
     vars:
       counter: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Idle
+    state: System.Idle
     vars:
       counter: 3
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Idle
+    state: System.Idle
     vars:
       counter: 4
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Idle
+    state: System.Idle
     vars:
       counter: 5
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Active
+    state: System.Active
     vars:
       counter: 15
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Active
+    state: System.Active
     vars:
       counter: 25
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Active
+    state: System.Active
     vars:
       counter: 35
     ended: false

--- a/test/fixtures/simulate_semantics/cases/cold_initial_chain_stack_modes_are_active.yaml
+++ b/test/fixtures/simulate_semantics/cases/cold_initial_chain_stack_modes_are_active.yaml
@@ -1,30 +1,17 @@
-schema_version: 1
-id: cold_initial_chain_stack_modes_are_active
 title: Cold initial chain stack modes become active after stabilization
-source:
-  fcstm: cold_initial_chain_stack_modes_are_active.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633126858
-  assertion_types:
-  - state
-  - vars
 categories:
 - runtime
 - validation
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Parent
-    - A
+    state: Root.Parent.A
     vars:
       x: 1
     ended: false

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_event_transition_uses_pre_before_vars.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_event_transition_uses_pre_before_vars.yaml
@@ -1,17 +1,9 @@
-schema_version: 1
-id: composite_initial_guard_after_event_transition_uses_pre_before_vars
 title: Composite initial guard ignores plain during-before mutation after event transition
-source:
-  fcstm: composite_initial_guard_after_event_transition_uses_pre_before_vars.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689584606
-  assertion_types:
-  - events
-  - state
-  - vars
   notes:
   - Covers event-driven entry into the affected composite and declaration-order fallback
     behavior.
@@ -19,27 +11,17 @@ categories:
 - runtime
 - event_paths
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       flag: 0
       trace: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - Parent
-    - Fallback
+    state: Root.Parent.Fallback
     vars:
       flag: 1
       trace: 12

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_leaf_transition_uses_enter_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_leaf_transition_uses_enter_state.yaml
@@ -1,41 +1,26 @@
-schema_version: 1
-id: composite_initial_guard_after_leaf_transition_uses_enter_state
 title: Composite initial guard uses enter-state variables after a leaf transition
-source:
-  fcstm: composite_initial_guard_after_leaf_transition_uses_enter_state.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689456018
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers a later transition from an already-stable leaf into the affected composite.
 categories:
 - runtime
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Start
+    state: Root.Start
     vars:
       select: 0
       trace: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Choice
-    - FromEnter
+    state: Root.Choice.FromEnter
     vars:
       select: 2
       trace: 12345

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_named_ref_before_uses_pre_ref_vars.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_after_named_ref_before_uses_pre_ref_vars.yaml
@@ -1,17 +1,9 @@
-schema_version: 1
-id: composite_initial_guard_after_named_ref_before_uses_pre_ref_vars
 title: Composite initial guard is decided before named-ref plain during-before action
-source:
-  fcstm: composite_initial_guard_after_named_ref_before_uses_pre_ref_vars.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689646151
-  assertion_types:
-  - events
-  - state
-  - vars
   notes:
   - Covers the named lifecycle ref variant where the plain during-before action mutates
     the guard variable through a ref.
@@ -19,26 +11,16 @@ categories:
 - runtime
 - lifecycle
 - event_paths
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Start
+    state: Root.Start
     vars:
       x: 1
     ended: false
-- cycle:
-    events:
-    - Root.Start.Go
+- cycle: Root.Start.Go
   expect:
-    state:
-    - Root
-    - Parent
-    - A
+    state: Root.Parent.A
     vars:
       x: 1012
     ended: false

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
@@ -1,18 +1,10 @@
-schema_version: 1
-id: composite_initial_guard_can_select_terminal_branch_before_plain_before
 title: Composite initial guard can choose a terminal branch before plain during-before
   mutation
-source:
-  fcstm: composite_initial_guard_can_select_terminal_branch_before_plain_before.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689585597
-  assertion_types:
-  - ended
-  - state
-  - vars
   notes:
   - Covers the final and is_ended variant where wrong initial selection prevents machine
     termination.
@@ -21,11 +13,8 @@ categories:
 - lifecycle
 - pseudo_chain
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
     state: null
     vars:

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_uses_enter_state_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_uses_enter_state_before_plain_before.yaml
@@ -1,17 +1,10 @@
-schema_version: 1
-id: composite_initial_guard_uses_enter_state_before_plain_before
 title: Composite initial guard uses enter-state variables before plain during-before
-source:
-  fcstm: composite_initial_guard_uses_enter_state_before_plain_before.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689448449
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4691296811
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers root composite entry where the guard variable is written by composite enter
     and then plain during-before.
@@ -19,23 +12,17 @@ categories:
 - runtime
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- expect_initial:
-    state:
-    - Root
+- cycle_count: 0
+  expect:
+    state: Root
     vars:
       select: 0
       trace: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Choice
-    - FromEnter
+    state: Root.Choice.FromEnter
     vars:
       select: 2
       trace: 2345

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_with_effect_runs_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_with_effect_runs_before_plain_before.yaml
@@ -1,17 +1,10 @@
-schema_version: 1
-id: composite_initial_guard_with_effect_runs_before_plain_before
 title: Composite initial transition effect runs after guard selection and before plain
   during-before
-source:
-  fcstm: composite_initial_guard_with_effect_runs_before_plain_before.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4691704320
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers the same root cause with an initial-transition effect so the full selected-transition
     order is pinned.
@@ -19,16 +12,10 @@ categories:
 - runtime
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Parent
-    - A
+    state: Root.Parent.A
     vars:
       route: 3
       trace: 12345

--- a/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_after_transition_uses_selected_child.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_after_transition_uses_selected_child.yaml
@@ -1,18 +1,9 @@
-schema_version: 1
-id: composite_initial_handler_log_after_transition_uses_selected_child
 title: Handler observer follows composite initial child selected before plain during-before
-source:
-  fcstm: composite_initial_handler_log_after_transition_uses_selected_child.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689585273
-  assertion_types:
-  - events
-  - handler_calls
-  - state
-  - vars
   notes:
   - Covers transition-into-composite handler log observation, not just root-entry
     handler observation.
@@ -21,9 +12,6 @@ categories:
 - abstract
 - lifecycle
 - event_paths
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Parent.ObserveParent
   behavior: record_call
@@ -32,24 +20,17 @@ handlers:
 - action: Root.Parent.Child2.EnterChild2
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       phase: 0
       trace: 1
     ended: false
     handler_calls: []
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - Parent
-    - Child1
+    state: Root.Parent.Child1
     vars:
       phase: 1
       trace: 111
@@ -61,9 +42,7 @@ steps:
       vars:
         phase: 1
         trace: 11
-      active_leaf:
-      - Root
-      - Parent
+      active_leaf: Root.Parent
       call_stage: during
       abstract_target: Root.Parent.ObserveParent
       named_ref: null
@@ -73,10 +52,7 @@ steps:
       vars:
         phase: 1
         trace: 11
-      active_leaf:
-      - Root
-      - Parent
-      - Child1
+      active_leaf: Root.Parent.Child1
       call_stage: enter
       abstract_target: Root.Parent.Child1.EnterChild1
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_keeps_stable_branch_before_exit_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_keeps_stable_branch_before_exit_branch.yaml
@@ -1,17 +1,9 @@
-schema_version: 1
-id: composite_initial_handler_log_keeps_stable_branch_before_exit_branch
 title: Composite initial handler log keeps stable branch before exit-capable branch
-source:
-  fcstm: composite_initial_handler_log_keeps_stable_branch_before_exit_branch.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689585273
-  assertion_types:
-  - handler_calls
-  - state
-  - vars
   notes:
   - Covers near-exit handler observation where wrong initial choice would enter an
     exit-capable child.
@@ -20,9 +12,6 @@ categories:
 - abstract
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Gate.ObserveGate
   behavior: record_call
@@ -33,12 +22,9 @@ handlers:
 - action: Root.Gate.Leave.ExitLeave
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Gate
-    - Stay
+    state: Root.Gate.Stay
     vars:
       phase: 1
       trace: 110
@@ -50,9 +36,7 @@ steps:
       vars:
         phase: 1
         trace: 10
-      active_leaf:
-      - Root
-      - Gate
+      active_leaf: Root.Gate
       call_stage: during
       abstract_target: Root.Gate.ObserveGate
       named_ref: null
@@ -62,19 +46,13 @@ steps:
       vars:
         phase: 1
         trace: 10
-      active_leaf:
-      - Root
-      - Gate
-      - Stay
+      active_leaf: Root.Gate.Stay
       call_stage: enter
       abstract_target: Root.Gate.Stay.EnterStay
       named_ref: null
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Gate
-    - Stay
+    state: Root.Gate.Stay
     vars:
       phase: 1
       trace: 210
@@ -86,9 +64,7 @@ steps:
       vars:
         phase: 1
         trace: 10
-      active_leaf:
-      - Root
-      - Gate
+      active_leaf: Root.Gate
       call_stage: during
       abstract_target: Root.Gate.ObserveGate
       named_ref: null
@@ -98,10 +74,7 @@ steps:
       vars:
         phase: 1
         trace: 10
-      active_leaf:
-      - Root
-      - Gate
-      - Stay
+      active_leaf: Root.Gate.Stay
       call_stage: enter
       abstract_target: Root.Gate.Stay.EnterStay
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_uses_enter_selected_child.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_handler_log_uses_enter_selected_child.yaml
@@ -1,38 +1,24 @@
-schema_version: 1
-id: composite_initial_handler_log_uses_enter_selected_child
 title: Composite initial decision selects the child whose handler should observe entry
-source:
-  fcstm: composite_initial_handler_log_uses_enter_selected_child.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689585273
-  assertion_types:
-  - handler_calls
-  - state
-  - vars
   notes:
   - Covers the handler call log variant without testing handler registry mechanics.
 categories:
 - runtime
 - abstract
 - lifecycle
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Choice.FromEnter.ChosenEnter
   behavior: record_call
 - action: Root.Choice.FromBefore.ChosenBefore
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Choice
-    - FromEnter
+    state: Root.Choice.FromEnter
     vars:
       select: 2
       trace: 235
@@ -44,10 +30,7 @@ steps:
       vars:
         select: 2
         trace: 23
-      active_leaf:
-      - Root
-      - Choice
-      - FromEnter
+      active_leaf: Root.Choice.FromEnter
       call_stage: enter
       abstract_target: Root.Choice.FromEnter.ChosenEnter
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/composite_initial_nested_entry_order_survives_deep_choice.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_nested_entry_order_survives_deep_choice.yaml
@@ -1,18 +1,10 @@
-schema_version: 1
-id: composite_initial_nested_entry_order_survives_deep_choice
 title: Deep composite initial guard uses entered state before plain during-before
   mutation
-source:
-  fcstm: composite_initial_nested_entry_order_survives_deep_choice.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4690004949
-  assertion_types:
-  - events
-  - state
-  - vars
   notes:
   - Covers deep nested composite entry rather than only the minimal two-level shape.
 categories:
@@ -20,28 +12,17 @@ categories:
 - lifecycle
 - event_paths
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Idle
+    state: Root.Idle
     vars:
       route: 0
       trace: 1
     ended: false
-- cycle:
-    events:
-    - Root.Idle.Go
+- cycle: Root.Idle.Go
   expect:
-    state:
-    - Root
-    - Outer
-    - Middle
-    - Target
+    state: Root.Outer.Middle.Target
     vars:
       route: 2
       trace: 1234567

--- a/test/fixtures/simulate_semantics/cases/composite_initial_skips_unstable_candidates_root_entry.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_skips_unstable_candidates_root_entry.yaml
@@ -1,29 +1,16 @@
-schema_version: 1
-id: composite_initial_skips_unstable_candidates_root_entry
 title: Composite initial skips unstable candidates from root entry
-source:
-  fcstm: composite_initial_skips_unstable_candidates_root_entry.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614352350
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - template_alignment
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Good
+    state: Root.Good
     vars:
       x: 1
       marker: 1

--- a/test/fixtures/simulate_semantics/cases/design_aspect_actions.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_aspect_actions.yaml
@@ -1,37 +1,22 @@
-schema_version: 1
-id: design_aspect_actions
 title: 4 5 aspect actions
-source:
-  fcstm: design_aspect_actions.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_5_aspect_actions
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_5_aspect_actions
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       trace: 123
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       trace: 123123
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_basic_simple_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_basic_simple_transition.yaml
@@ -1,47 +1,28 @@
-schema_version: 1
-id: design_basic_simple_transition
 title: 4 1 basic simple transition
-source:
-  fcstm: design_basic_simple_transition.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_1_basic_simple_transition
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_1_basic_simple_transition
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 12
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_composite_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_composite_state.yaml
@@ -1,51 +1,28 @@
-schema_version: 1
-id: design_composite_state
 title: 4 2 composite state
-source:
-  fcstm: design_composite_state.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_2_composite_state
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_2_composite_state
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoB
+- cycle: Root.A.GoB
   expect:
-    state:
-    - Root
-    - B
-    - B1
+    state: Root.B.B1
     vars:
       counter: 11
     ended: false
-- cycle:
-    events:
-    - Root.B.B1.Next
+- cycle: Root.B.B1.Next
   expect:
-    state:
-    - Root
-    - B
-    - B2
+    state: Root.B.B2
     vars:
       counter: 111
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_composite_stuck_in_init_wait.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_composite_stuck_in_init_wait.yaml
@@ -1,45 +1,31 @@
-schema_version: 1
-id: design_composite_stuck_in_init_wait
 title: 4 27 composite state stuck in init wait without enabled init transition
-source:
-  fcstm: design_composite_stuck_in_init_wait.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_27_composite_state_stuck_in_init_wait_without_enabled_init_transition
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_27_composite_state_stuck_in_init_wait_without_enabled_init_transition
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       phase: 0
       trace: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       phase: 0
       trace: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       phase: 0
       trace: 0

--- a/test/fixtures/simulate_semantics/cases/design_cross_hierarchy_transition_actual_runtime_behavior.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_cross_hierarchy_transition_actual_runtime_behavior.yaml
@@ -1,41 +1,22 @@
-schema_version: 1
-id: design_cross_hierarchy_transition_actual_runtime_behavior
 title: 4 25 cross hierarchy transition actual runtime behavior
-source:
-  fcstm: design_cross_hierarchy_transition_actual_runtime_behavior.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_25_cross_hierarchy_transition_actual_runtime_behavior
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_25_cross_hierarchy_transition_actual_runtime_behavior
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       counter: 110111
     ended: false
-- cycle:
-    events:
-    - Root.System1.Go
+- cycle: Root.System1.Go
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       counter: 220222
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_cross_hierarchy_transition_with_staged_guards.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_cross_hierarchy_transition_with_staged_guards.yaml
@@ -1,110 +1,72 @@
-schema_version: 1
-id: design_cross_hierarchy_transition_with_staged_guards
 title: 4 26 cross hierarchy transition with staged guards
-source:
-  fcstm: design_cross_hierarchy_transition_with_staged_guards.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_26_cross_hierarchy_transition_with_staged_guards
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_26_cross_hierarchy_transition_with_staged_guards
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       phase: 1
       trace: 110111
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       phase: 2
       trace: 220222
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       phase: 3
       trace: 330333
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       phase: 4
       trace: 440444
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       phase: 5
       trace: 550555
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       phase: 6
       trace: 660666
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System1
-    - A
+    state: Root.System1.A
     vars:
       phase: 7
       trace: 770777
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System2
-    - B
+    state: Root.System2.B
     vars:
       phase: 7
       trace: 1881778
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System2
-    - B
+    state: Root.System2.B
     vars:
       phase: 7
       trace: 2992779

--- a/test/fixtures/simulate_semantics/cases/design_evented_pseudo_chain_invalid_then_valid.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_evented_pseudo_chain_invalid_then_valid.yaml
@@ -1,52 +1,31 @@
-schema_version: 1
-id: design_evented_pseudo_chain_invalid_then_valid
 title: 4 19 evented pseudo chain invalid then valid
-source:
-  fcstm: design_evented_pseudo_chain_invalid_then_valid.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_19_evented_pseudo_chain_invalid_then_valid
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_19_evented_pseudo_chain_invalid_then_valid
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoB
+- cycle: Root.A.GoB
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
 - cycle:
-    events:
-    - Root.A.GoB
-    - Root.B.P1.Event
+  - Root.A.GoB
+  - Root.B.P1.Event
   expect:
-    state:
-    - Root
-    - B
-    - B1
+    state: Root.B.B1
     vars:
       counter: 112
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_exit_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_exit_state.yaml
@@ -1,49 +1,32 @@
-schema_version: 1
-id: design_exit_state
 title: 4 10 exit state
-source:
-  fcstm: design_exit_state.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_10_exit_state
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_10_exit_state
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 3
     ended: false
-- cycle: {}
+- cycle: []
   expect:
     state: null
     vars:

--- a/test/fixtures/simulate_semantics/cases/design_exit_to_parent_invalid.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_exit_to_parent_invalid.yaml
@@ -1,41 +1,22 @@
-schema_version: 1
-id: design_exit_to_parent_invalid
 title: 4 17 exit to parent invalid
-source:
-  fcstm: design_exit_to_parent_invalid.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_17_exit_to_parent_invalid
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_17_exit_to_parent_invalid
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.System.A.GoP
+- cycle: Root.System.A.GoP
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 2
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_exit_to_parent_then_event_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_exit_to_parent_then_event_transition.yaml
@@ -1,52 +1,30 @@
-schema_version: 1
-id: design_exit_to_parent_then_event_transition
 title: 4 17 1 exit to parent then event transition
-source:
-  fcstm: design_exit_to_parent_then_event_transition.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_17_1_exit_to_parent_then_event_transition
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_17_1_exit_to_parent_then_event_transition
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.System.A.GoP
+- cycle: Root.System.A.GoP
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 2
     ended: false
 - cycle:
-    events:
-    - Root.System.A.GoP
-    - Root.System.ToB
+  - Root.System.A.GoP
+  - Root.System.ToB
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 112
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_exit_to_parent_then_pseudo_guard.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_exit_to_parent_then_pseudo_guard.yaml
@@ -1,79 +1,47 @@
-schema_version: 1
-id: design_exit_to_parent_then_pseudo_guard
 title: 4 17 2 exit to parent then pseudo then guard
-source:
-  fcstm: design_exit_to_parent_then_pseudo_guard.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_17_2_exit_to_parent_then_pseudo_then_guard
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_17_2_exit_to_parent_then_pseudo_then_guard
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.System.A.GoP
+- cycle: Root.System.A.GoP
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 3
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 4
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 5
     ended: false
-- cycle:
-    events:
-    - Root.System.A.GoP
+- cycle: Root.System.A.GoP
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 1115
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_explicit_exit_to_root_ends_runtime.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_explicit_exit_to_root_ends_runtime.yaml
@@ -1,50 +1,35 @@
-schema_version: 1
-id: design_explicit_exit_to_root_ends_runtime
 title: 4 30 explicit exit to root ends runtime
-source:
-  fcstm: design_explicit_exit_to_root_ends_runtime.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_30_explicit_exit_to_root_ends_runtime
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_30_explicit_exit_to_root_ends_runtime
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       phase: 1
       trace: 10
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       phase: 2
       trace: 20
     ended: false
-- cycle: {}
+- cycle: []
   expect:
     state: null
     vars:
       phase: 2
       trace: 20
     ended: true
-- cycle: {}
+- cycle: []
   expect:
     state: null
     vars:

--- a/test/fixtures/simulate_semantics/cases/design_guard_effect_multilevel_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_guard_effect_multilevel_transition.yaml
@@ -1,57 +1,37 @@
-schema_version: 1
-id: design_guard_effect_multilevel_transition
 title: 4 11 guard effect multilevel transition
-source:
-  fcstm: design_guard_effect_multilevel_transition.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_11_guard_effect_multilevel_transition
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_11_guard_effect_multilevel_transition
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
       flag: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
       flag: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 3
       flag: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - B
-    - B1
+    state: Root.B.B1
     vars:
       counter: 13
       flag: 1

--- a/test/fixtures/simulate_semantics/cases/design_mixed_composite_and_pseudo.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_mixed_composite_and_pseudo.yaml
@@ -1,42 +1,23 @@
-schema_version: 1
-id: design_mixed_composite_and_pseudo
 title: 4 20 mixed composite and pseudo
-source:
-  fcstm: design_mixed_composite_and_pseudo.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_20_mixed_composite_and_pseudo
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_20_mixed_composite_and_pseudo
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoB
+- cycle: Root.A.GoB
   expect:
-    state:
-    - Root
-    - B
-    - C
-    - C1
+    state: Root.B.C.C1
     vars:
       counter: 111
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_multi_layer_aspect_actions.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_multi_layer_aspect_actions.yaml
@@ -1,31 +1,16 @@
-schema_version: 1
-id: design_multi_layer_aspect_actions
 title: 4 22 multi layer aspect actions
-source:
-  fcstm: design_multi_layer_aspect_actions.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_22_multi_layer_aspect_actions
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_22_multi_layer_aspect_actions
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - Module
-    - Active
+    state: Root.System.Module.Active
     vars:
       counter: 111112
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_multi_level_non_stoppable_deep.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_multi_level_non_stoppable_deep.yaml
@@ -1,41 +1,22 @@
-schema_version: 1
-id: design_multi_level_non_stoppable_deep
 title: 4 7 multi level non stoppable
-source:
-  fcstm: design_multi_level_non_stoppable_deep.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_7_multi_level_non_stoppable
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_7_multi_level_non_stoppable
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoB
+- cycle: Root.A.GoB
   expect:
-    state:
-    - Root
-    - B
-    - B1
-    - B1a
+    state: Root.B.B1.B1a
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_multi_level_non_stoppable_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_multi_level_non_stoppable_leaf.yaml
@@ -1,39 +1,22 @@
-schema_version: 1
-id: design_multi_level_non_stoppable_leaf
 title: 4 7 multi level non stoppable
-source:
-  fcstm: design_multi_level_non_stoppable_leaf.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_7_multi_level_non_stoppable
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_7_multi_level_non_stoppable
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoC
+- cycle: Root.A.GoC
   expect:
-    state:
-    - Root
-    - C
+    state: Root.C
     vars:
       counter: 101
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_multiple_leaf_states_share_aspects.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_multiple_leaf_states_share_aspects.yaml
@@ -1,52 +1,28 @@
-schema_version: 1
-id: design_multiple_leaf_states_share_aspects
 title: 4 24 multiple leaf states share aspects
-source:
-  fcstm: design_multiple_leaf_states_share_aspects.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_24_multiple_leaf_states_share_aspects
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_24_multiple_leaf_states_share_aspects
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1112
     ended: false
-- cycle:
-    events:
-    - Root.System.A.GoB
+- cycle: Root.System.A.GoB
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       counter: 2233
     ended: false
-- cycle:
-    events:
-    - Root.System.B.GoC
+- cycle: Root.System.B.GoC
   expect:
-    state:
-    - Root
-    - System
-    - C
+    state: Root.System.C
     vars:
       counter: 3444
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_post_child_exit_without_follow_up.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_post_child_exit_without_follow_up.yaml
@@ -1,44 +1,30 @@
-schema_version: 1
-id: design_post_child_exit_without_follow_up
 title: 4 28 post child exit without follow up transition
-source:
-  fcstm: design_post_child_exit_without_follow_up.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_28_post_child_exit_without_follow_up_transition
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_28_post_child_exit_without_follow_up_transition
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       phase: 0
       trace: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       phase: 0
       trace: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       phase: 0
       trace: 0

--- a/test/fixtures/simulate_semantics/cases/design_pseudo_chain_inside_composite.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_pseudo_chain_inside_composite.yaml
@@ -1,41 +1,23 @@
-schema_version: 1
-id: design_pseudo_chain_inside_composite
 title: 4 18 pseudo chain inside composite
-source:
-  fcstm: design_pseudo_chain_inside_composite.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_18_pseudo_chain_inside_composite
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_18_pseudo_chain_inside_composite
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoB
+- cycle: Root.A.GoB
   expect:
-    state:
-    - Root
-    - B
-    - B1
+    state: Root.B.B1
     vars:
       counter: 1111
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_pseudo_chain_multiple.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_pseudo_chain_multiple.yaml
@@ -1,63 +1,40 @@
-schema_version: 1
-id: design_pseudo_chain_multiple
 title: 4 14 multiple pseudo states chain
-source:
-  fcstm: design_pseudo_chain_multiple.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_14_multiple_pseudo_states_chain
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_14_multiple_pseudo_states_chain
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.Go1
+- cycle: Root.A.Go1
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
 - cycle:
-    events:
-    - Root.A.Go1
-    - Root.P1.Go2
+  - Root.A.Go1
+  - Root.P1.Go2
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 3
     ended: false
 - cycle:
-    events:
-    - Root.A.Go1
-    - Root.P1.Go2
-    - Root.P2.Go3
+  - Root.A.Go1
+  - Root.P1.Go2
+  - Root.P2.Go3
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 1113
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_pseudo_chain_single.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_pseudo_chain_single.yaml
@@ -1,51 +1,31 @@
-schema_version: 1
-id: design_pseudo_chain_single
 title: 4 13 single pseudo state chain
-source:
-  fcstm: design_pseudo_chain_single.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_13_single_pseudo_state_chain
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_13_single_pseudo_state_chain
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoP
+- cycle: Root.A.GoP
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
 - cycle:
-    events:
-    - Root.A.GoP
-    - Root.P.GoB
+  - Root.A.GoP
+  - Root.P.GoB
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 1112
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_pseudo_chain_to_machine_end.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_pseudo_chain_to_machine_end.yaml
@@ -1,36 +1,21 @@
-schema_version: 1
-id: design_pseudo_chain_to_machine_end
 title: 4 16 pseudo chain to machine end
-source:
-  fcstm: design_pseudo_chain_to_machine_end.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_16_pseudo_chain_to_machine_end
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_16_pseudo_chain_to_machine_end
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoP
+- cycle: Root.A.GoP
   expect:
     state: null
     vars:

--- a/test/fixtures/simulate_semantics/cases/design_pseudo_chain_with_guard.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_pseudo_chain_with_guard.yaml
@@ -1,70 +1,47 @@
-schema_version: 1
-id: design_pseudo_chain_with_guard
 title: 4 15 pseudo chain with guard
-source:
-  fcstm: design_pseudo_chain_with_guard.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_15_pseudo_chain_with_guard
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_15_pseudo_chain_with_guard
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 3
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 4
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 5
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 115
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_pseudo_skips_aspect_actions.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_pseudo_skips_aspect_actions.yaml
@@ -1,41 +1,25 @@
-schema_version: 1
-id: design_pseudo_skips_aspect_actions
 title: 4 23 pseudo state skips aspect actions
-source:
-  fcstm: design_pseudo_skips_aspect_actions.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_23_pseudo_state_skips_aspect_actions
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_23_pseudo_state_skips_aspect_actions
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 10101
     ended: false
 - cycle:
-    events:
-    - Root.A.GoP
-    - Root.P.GoB
+  - Root.A.GoP
+  - Root.P.GoB
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 121102
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_pseudo_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_pseudo_state.yaml
@@ -1,26 +1,15 @@
-schema_version: 1
-id: design_pseudo_state
 title: 4 6 pseudo state
-source:
-  fcstm: design_pseudo_state.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_6_pseudo_state
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_6_pseudo_state
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - pseudo_chain
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
     state: null
     vars:

--- a/test/fixtures/simulate_semantics/cases/design_ref_abstract_action_without_side_effects.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_ref_abstract_action_without_side_effects.yaml
@@ -1,47 +1,28 @@
-schema_version: 1
-id: design_ref_abstract_action_without_side_effects
 title: 4 34 ref targets abstract action without side effects
-source:
-  fcstm: design_ref_abstract_action_without_side_effects.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_34_ref_targets_abstract_action_without_side_effects
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_34_ref_targets_abstract_action_without_side_effects
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       trace: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       trace: 11
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       trace: 21
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_ref_named_aspect_action.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_ref_named_aspect_action.yaml
@@ -1,50 +1,28 @@
-schema_version: 1
-id: design_ref_named_aspect_action
 title: 4 35 ref reuses named aspect action
-source:
-  fcstm: design_ref_named_aspect_action.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_35_ref_reuses_named_aspect_action
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_35_ref_reuses_named_aspect_action
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       trace: 201
     ended: false
-- cycle:
-    events:
-    - Root.System.A.Go
+- cycle: Root.System.A.Go
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       trace: 411
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       trace: 621
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_ref_named_enter_action.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_ref_named_enter_action.yaml
@@ -1,49 +1,30 @@
-schema_version: 1
-id: design_ref_named_enter_action
 title: 4 33 ref reuses named enter action
-source:
-  fcstm: design_ref_named_enter_action.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_33_ref_reuses_named_enter_action
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_33_ref_reuses_named_enter_action
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       init_count: 2
       trace: 201
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       init_count: 3
       trace: 311
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       init_count: 3
       trace: 321

--- a/test/fixtures/simulate_semantics/cases/design_self_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_self_transition.yaml
@@ -1,39 +1,22 @@
-schema_version: 1
-id: design_self_transition
 title: 4 9 self transition
-source:
-  fcstm: design_self_transition.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_9_self_transition
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_9_self_transition
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 11
     ended: false
-- cycle:
-    events:
-    - Root.A.Loop
+- cycle: Root.A.Loop
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 122
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_single_layer_aspect_actions.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_single_layer_aspect_actions.yaml
@@ -1,39 +1,22 @@
-schema_version: 1
-id: design_single_layer_aspect_actions
 title: 4 21 single layer aspect actions
-source:
-  fcstm: design_single_layer_aspect_actions.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_21_single_layer_aspect_actions
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_21_single_layer_aspect_actions
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 10101
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 21102
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_speculative_dfs_safety_limit.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_speculative_dfs_safety_limit.yaml
@@ -1,45 +1,27 @@
-schema_version: 1
-id: design_speculative_dfs_safety_limit
 title: 4 32 raises error for non converging speculative dfs
-source:
-  fcstm: design_speculative_dfs_safety_limit.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_32_raises_error_for_non_converging_speculative_dfs
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_32_raises_error_for_non_converging_speculative_dfs
-  assertion_types:
-  - ended
-  - exception
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
     raises:
       type: SimulationRuntimeDfsError
       match: structural stack-depth safety limit
       match_kind: substring
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_speculative_prunes_repeated_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_speculative_prunes_repeated_state.yaml
@@ -1,39 +1,22 @@
-schema_version: 1
-id: design_speculative_prunes_repeated_state
 title: 4 31 prunes repeated speculative execution state
-source:
-  fcstm: design_speculative_prunes_repeated_state.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_31_prunes_repeated_speculative_execution_state
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_31_prunes_repeated_speculative_execution_state
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_transition_priority.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_transition_priority.yaml
@@ -1,53 +1,34 @@
-schema_version: 1
-id: design_transition_priority
 title: 4 8 transition priority
-source:
-  fcstm: design_transition_priority.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_8_transition_priority
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_8_transition_priority
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 3
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - C
+    state: Root.C
     vars:
       counter: 103
     ended: false

--- a/test/fixtures/simulate_semantics/cases/design_validation_cannot_reach_stoppable.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_validation_cannot_reach_stoppable.yaml
@@ -1,41 +1,24 @@
-schema_version: 1
-id: design_validation_cannot_reach_stoppable
 title: 4 3 validation cannot reach stoppable
-source:
-  fcstm: design_validation_cannot_reach_stoppable.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_3_validation_cannot_reach_stoppable
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_3_validation_cannot_reach_stoppable
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
       ready: 0
     ended: false
-- cycle:
-    events:
-    - Root.A.GoB
+- cycle: Root.A.GoB
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
       ready: 0

--- a/test/fixtures/simulate_semantics/cases/design_validation_failure_multilevel_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_validation_failure_multilevel_transition.yaml
@@ -1,57 +1,38 @@
-schema_version: 1
-id: design_validation_failure_multilevel_transition
 title: 4 12 validation failure multilevel transition
-source:
-  fcstm: design_validation_failure_multilevel_transition.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_12_validation_failure_multilevel_transition
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_12_validation_failure_multilevel_transition
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
       flag: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
       flag: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 3
       flag: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 4
       flag: 0

--- a/test/fixtures/simulate_semantics/cases/design_validation_init_transition_requires_event.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_validation_init_transition_requires_event.yaml
@@ -1,52 +1,31 @@
-schema_version: 1
-id: design_validation_init_transition_requires_event
 title: 4 4 validation init transition requires event
-source:
-  fcstm: design_validation_init_transition_requires_event.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_4_validation_init_transition_requires_event
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_4_validation_init_transition_requires_event
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - design_example
 - runtime
 - template_alignment
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.GoB
+- cycle: Root.A.GoB
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false
 - cycle:
-    events:
-    - Root.A.GoB
-    - Root.B.Start
+  - Root.A.GoB
+  - Root.B.Start
   expect:
-    state:
-    - Root
-    - B
-    - B1
+    state: Root.B.B1
     vars:
       counter: 12
     ended: false

--- a/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.yaml
+++ b/test/fixtures/simulate_semantics/cases/ended_runtime_ignores_event_inputs.yaml
@@ -1,46 +1,29 @@
-schema_version: 1
-id: ended_runtime_ignores_event_inputs
 title: ended runtime ignores event inputs
-source:
-  fcstm: ended_runtime_ignores_event_inputs.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614008879
-  assertion_types:
-  - ended
-  - state
-  - vars
   notes:
   - Covers ended cycle no-op behavior before event parsing.
 categories:
 - event_paths
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
     ended: false
-- cycle:
-    events:
-    - Root.A.End
+- cycle: Root.A.End
   expect:
     state: null
     vars:
       x: 0
     ended: true
-- cycle:
-    events:
-    - Missing
+- cycle: Missing
   expect:
     state: null
     vars:

--- a/test/fixtures/simulate_semantics/cases/event_duplicate_inputs_preserve_public_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_duplicate_inputs_preserve_public_state.yaml
@@ -1,43 +1,28 @@
-schema_version: 1
-id: event_duplicate_inputs_preserve_public_state
 title: Duplicate event inputs preserve public state
-source:
-  fcstm: event_duplicate_inputs_preserve_public_state.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633873538
-  assertion_types:
-  - events
-  - state
-  - vars
   notes:
-  - Covers duplicate event inputs while shared assertions stay limited to public state and variables.
+  - Covers duplicate event inputs while shared assertions stay limited to public state
+    and variables.
 categories:
 - runtime
 - event_paths
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
 - cycle:
-    events:
-    - Root.A.Tick
-    - Root.A.Noise
-    - Root.A.Tick
+  - Root.A.Tick
+  - Root.A.Noise
+  - Root.A.Tick
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 2
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_input_bare_string_path.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_input_bare_string_path.yaml
@@ -1,41 +1,26 @@
-schema_version: 1
-id: event_input_bare_string_path
 title: bare string event input is a single event path
-source:
-  fcstm: event_input_bare_string_path.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614133609
-  assertion_types:
-  - ended
-  - state
-  - vars
   notes:
   - Covers a bare string passed directly to cycle(events=...).
 categories:
 - event_paths
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
     ended: false
 - cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       x: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_input_model_event_object.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_input_model_event_object.yaml
@@ -1,43 +1,26 @@
-schema_version: 1
-id: event_input_model_event_object
-title: model Event object input is accepted
-source:
-  fcstm: event_input_model_event_object.fcstm
+title: event path input reaches the same transition as the prior model-event case
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614288612
-  assertion_types:
-  - ended
-  - state
-  - vars
   notes:
-  - Covers model Event objects resolved from fixture event descriptors.
+  - Legacy model Event descriptor coverage is now represented by a legal string event path in shared schema v2; object-input API coverage stays in ordinary simulator tests.
 categories:
 - event_paths
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
     ended: false
-- cycle:
-    events:
-    - event: Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       x: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_path_absolute.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_path_absolute.yaml
@@ -1,42 +1,23 @@
-schema_version: 1
-id: event_path_absolute
 title: 4 202 flexible path absolute
-source:
-  fcstm: event_path_absolute.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_202_flexible_path_absolute
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_202_flexible_path_absolute
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - event_paths
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - /global_reset
+- cycle: /global_reset
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_path_basic_relative.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_path_basic_relative.yaml
@@ -1,40 +1,23 @@
-schema_version: 1
-id: event_path_basic_relative
 title: 4 200 flexible path basic relative
-source:
-  fcstm: event_path_basic_relative.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_200_flexible_path_basic_relative
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_200_flexible_path_basic_relative
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - event_paths
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - go
+- cycle: go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_absolute.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_absolute.yaml
@@ -1,42 +1,23 @@
-schema_version: 1
-id: event_path_mixed_formats_absolute
 title: 4 203 flexible path mixed formats
-source:
-  fcstm: event_path_mixed_formats_absolute.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - event_paths
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - /global_event
+- cycle: /global_event
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_full.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_full.yaml
@@ -1,42 +1,23 @@
-schema_version: 1
-id: event_path_mixed_formats_full
 title: 4 203 flexible path mixed formats
-source:
-  fcstm: event_path_mixed_formats_full.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - event_paths
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - Root.System.A.local_a
+- cycle: Root.System.A.local_a
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_parent_relative.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_parent_relative.yaml
@@ -1,42 +1,23 @@
-schema_version: 1
-id: event_path_mixed_formats_parent_relative
 title: 4 203 flexible path mixed formats
-source:
-  fcstm: event_path_mixed_formats_parent_relative.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - event_paths
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - .system_event
+- cycle: .system_event
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_relative.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_path_mixed_formats_relative.yaml
@@ -1,42 +1,23 @@
-schema_version: 1
-id: event_path_mixed_formats_relative
 title: 4 203 flexible path mixed formats
-source:
-  fcstm: event_path_mixed_formats_relative.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_203_flexible_path_mixed_formats
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - event_paths
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - local_a
+- cycle: local_a
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       counter: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_path_parent_relative.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_path_parent_relative.yaml
@@ -1,53 +1,29 @@
-schema_version: 1
-id: event_path_parent_relative
 title: 4 201 flexible path parent relative
-source:
-  fcstm: event_path_parent_relative.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_201_flexible_path_parent_relative
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_201_flexible_path_parent_relative
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - event_paths
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - Active
+    state: Root.System.Active
     vars:
       counter: 1
     ended: false
-- cycle:
-    events:
-    - active_event
+- cycle: active_event
   expect:
-    state:
-    - Root
-    - System
-    - Idle
+    state: Root.System.Idle
     vars:
       counter: 11
     ended: false
-- cycle:
-    events:
-    - .system_event
+- cycle: .system_event
   expect:
-    state:
-    - Root
-    - System
-    - Active
+    state: Root.System.Active
     vars:
       counter: 12
     ended: false

--- a/test/fixtures/simulate_semantics/cases/event_transition_updates_public_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/event_transition_updates_public_state.yaml
@@ -1,39 +1,23 @@
-schema_version: 1
-id: event_transition_updates_public_state
 title: Event transition updates public state
-source:
-  fcstm: event_transition_updates_public_state.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
-  assertion_types:
-  - events
-  - state
-  - vars
   notes:
-  - Minimal fixture proving that an event transition updates public state through the shared observation contract.
+  - Minimal fixture proving that an event transition updates public state through
+    the shared observation contract.
 categories:
 - runtime
 - event_paths
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Idle
+    state: Root.Idle
     vars:
       counter: 0
     ended: false
-- cycle:
-    events:
-    - Root.Idle.Start
+- cycle: Root.Idle.Start
   expect:
-    state:
-    - Root
-    - Active
+    state: Root.Active
     vars:
       counter: 5
     ended: false

--- a/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.yaml
@@ -1,24 +1,14 @@
-schema_version: 1
-id: expression_error_preserves_runtime_snapshot
 title: Expression errors preserve runtime snapshot assertions
-source:
-  fcstm: expression_error_preserves_runtime_snapshot.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
-  assertion_types:
-  - raises
-  - vars
   notes:
   - Minimal fixture proving exception assertions can be combined with rollback snapshot
     assertions.
 categories:
 - runtime
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
     raises:
       type: SimulationRuntimeExpressionError

--- a/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.yaml
@@ -1,22 +1,13 @@
-schema_version: 1
-id: expression_failure_if_condition_raises_expression_error
 title: if block condition expression failure raises expression error
-source:
-  fcstm: expression_failure_if_condition_raises_expression_error.fcstm
 origin:
   files:
   - test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.fcstm
-  assertion_types:
-  - exception
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
     raises:
       type: SimulationRuntimeExpressionError

--- a/test/fixtures/simulate_semantics/cases/expression_failure_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_raises_expression_error.yaml
@@ -1,22 +1,13 @@
-schema_version: 1
-id: expression_failure_raises_expression_error
 title: 4 200 dsl expression failure raises expression error
-source:
-  fcstm: expression_failure_raises_expression_error.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_200_dsl_expression_failure_raises_expression_error
-  assertion_types:
-  - exception
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
     raises:
       type: SimulationRuntimeExpressionError

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.yaml
@@ -1,32 +1,19 @@
-schema_version: 1
-id: expression_failure_transition_effect_raises_expression_error
 title: transition effect expression failure raises expression error
-source:
-  fcstm: expression_failure_transition_effect_raises_expression_error.fcstm
 origin:
   files:
   - test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.fcstm
-  assertion_types:
-  - exception
-  - state
-  - vars
 categories:
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
       sink: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
     raises:
       type: SimulationRuntimeExpressionError
@@ -35,9 +22,7 @@ steps:
       cause_type: ZeroDivisionError
       cause_match: division by zero
       cause_match_kind: substring
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 1
       sink: 0

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.yaml
@@ -1,32 +1,19 @@
-schema_version: 1
-id: expression_failure_transition_guard_raises_expression_error
 title: transition guard expression failure raises expression error
-source:
-  fcstm: expression_failure_transition_guard_raises_expression_error.fcstm
 origin:
   files:
   - test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.fcstm
-  assertion_types:
-  - exception
-  - state
-  - vars
 categories:
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 0
       divisor: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
     raises:
       type: SimulationRuntimeExpressionError
@@ -35,9 +22,7 @@ steps:
       cause_type: ZeroDivisionError
       cause_match: division by zero
       cause_match_kind: substring
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       counter: 0
       divisor: 0

--- a/test/fixtures/simulate_semantics/cases/expression_large_integer_safe_diagnostics.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_large_integer_safe_diagnostics.yaml
@@ -1,29 +1,17 @@
-schema_version: 1
-id: expression_large_integer_safe_diagnostics
 title: Large integer expression does not fail during runtime diagnostics
-source:
-  fcstm: expression_large_integer_safe_diagnostics.fcstm
 origin:
   files:
   - test/simulate/test_runtime_expression_diagnostics.py::test_large_integer_cycle_does_not_depend_on_disabled_debug_logging
   - test/simulate/test_runtime_expression_diagnostics.py::test_large_integer_cycle_uses_safe_debug_logging
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633784802
-  assertion_types:
-  - state
-  - vars
 categories:
 - runtime
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars_keys:
     - x
     ended: false

--- a/test/fixtures/simulate_semantics/cases/expression_logical_and_short_circuits_in_guard.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_logical_and_short_circuits_in_guard.yaml
@@ -1,36 +1,22 @@
-schema_version: 1
-id: expression_logical_and_short_circuits_in_guard
 title: Logical and short circuits in transition guards
-source:
-  fcstm: expression_logical_and_short_circuits_in_guard.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632515679
-  assertion_types:
-  - state
-  - vars
 categories:
 - runtime
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
       y: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
       y: 2

--- a/test/fixtures/simulate_semantics/cases/expression_logical_and_short_circuits_in_if.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_logical_and_short_circuits_in_if.yaml
@@ -1,28 +1,16 @@
-schema_version: 1
-id: expression_logical_and_short_circuits_in_if
 title: Logical and short circuits in if block conditions
-source:
-  fcstm: expression_logical_and_short_circuits_in_if.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632515679
-  assertion_types:
-  - state
-  - vars
 categories:
 - runtime
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
       y: 1

--- a/test/fixtures/simulate_semantics/cases/expression_logical_or_short_circuits_in_guard.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_logical_or_short_circuits_in_guard.yaml
@@ -1,36 +1,22 @@
-schema_version: 1
-id: expression_logical_or_short_circuits_in_guard
 title: Logical or short circuits in transition guards
-source:
-  fcstm: expression_logical_or_short_circuits_in_guard.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632515679
-  assertion_types:
-  - state
-  - vars
 categories:
 - runtime
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
       y: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       x: 0
       y: 1

--- a/test/fixtures/simulate_semantics/cases/expression_logical_or_short_circuits_in_if.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_logical_or_short_circuits_in_if.yaml
@@ -1,28 +1,16 @@
-schema_version: 1
-id: expression_logical_or_short_circuits_in_if
 title: Logical or short circuits in if block conditions
-source:
-  fcstm: expression_logical_or_short_circuits_in_if.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4632515679
-  assertion_types:
-  - state
-  - vars
 categories:
 - runtime
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
       y: 101

--- a/test/fixtures/simulate_semantics/cases/expression_type_error_wraps_transition_effect.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_type_error_wraps_transition_effect.yaml
@@ -1,35 +1,20 @@
-schema_version: 1
-id: expression_type_error_wraps_transition_effect
 title: Type errors in transition effects are wrapped and rolled back
-source:
-  fcstm: expression_type_error_wraps_transition_effect.fcstm
 origin:
   files:
   - test/simulate/test_runtime_expression_diagnostics.py::test_transition_effect_type_error_is_wrapped_and_rolls_back
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631787793
-  assertion_types:
-  - raises
-  - state
-  - vars
 categories:
 - runtime
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
       y: 1.5
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
     raises:
       type: SimulationRuntimeExpressionError
@@ -38,9 +23,7 @@ steps:
       cause_type: TypeError
       cause_match: unsupported operand type
       cause_match_kind: substring
-    state:
-    - Root
-    - A
+    state: Root.A
     vars_exact:
       x: 1
       y: 1.5

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
@@ -1,15 +1,7 @@
-schema_version: 1
-id: failed_initial_cycle_preserves_root_entry_lifecycle
 title: Failed initial cycle preserves root entry lifecycle on later success
-source:
-  fcstm: failed_initial_cycle_preserves_root_entry_lifecycle.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134
-  assertion_types:
-  - ended
-  - state
-  - vars
   notes:
   - Tracks failed-initial-cycle rollback of root entry lifecycle state.
 categories:
@@ -17,25 +9,16 @@ categories:
 - template_alignment
 - validation
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle:
-    events: []
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       x: 0
     ended: false
-- cycle:
-    events:
-    - Root.Start
+- cycle: Root.Start
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: failed_initial_cycle_skips_abstract_handler_callbacks
 title: Failed initial cycle skips abstract handler callbacks
-source:
-  fcstm: failed_initial_cycle_skips_abstract_handler_callbacks.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614005134
-  assertion_types:
-  - ended
-  - handler_calls
-  - state
-  - vars
   notes:
   - Tracks speculative initial-cycle isolation for abstract handlers.
 categories:
@@ -18,18 +9,13 @@ categories:
 - template_alignment
 - validation
 - abstract
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.RootInit
   behavior: record_call
 steps:
-- cycle:
-    events: []
+- cycle: []
   expect:
-    state:
-    - Root
+    state: Root
     vars:
       x: 0
     ended: false

--- a/test/fixtures/simulate_semantics/cases/forced_pseudo_candidate_skips_unstable_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/forced_pseudo_candidate_skips_unstable_branch.yaml
@@ -1,16 +1,9 @@
-schema_version: 1
-id: forced_pseudo_candidate_skips_unstable_branch
 title: Forced pseudo candidate selection skips an unstable branch
-source:
-  fcstm: forced_pseudo_candidate_skips_unstable_branch.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694430886
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers forced-transition expansion on a pseudo source where the first candidate
     is unstable and a later candidate is valid.
@@ -19,16 +12,10 @@ categories:
 - pseudo_chain
 - validation
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Target
-    - Good
+    state: Root.Target.Good
     vars:
       trace: 3
     ended: false

--- a/test/fixtures/simulate_semantics/cases/hot_start_accepts_structural_depth_limit_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_accepts_structural_depth_limit_leaf.yaml
@@ -1,18 +1,10 @@
-schema_version: 1
-id: hot_start_accepts_structural_depth_limit_leaf
 title: Hot-start accepts a leaf stack exactly at the structural depth limit
-source:
-  fcstm: hot_start_accepts_structural_depth_limit_leaf.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694747151
-  assertion_types:
-  - initial
-  - state
-  - vars
   notes:
   - The path contains exactly 64 frames from Root through S62 and Leaf.
   - This guards against changing the structural depth check from greater-than to greater-than-or-equal.
@@ -26,142 +18,15 @@ initial:
   vars:
     x: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - S1
-    - S2
-    - S3
-    - S4
-    - S5
-    - S6
-    - S7
-    - S8
-    - S9
-    - S10
-    - S11
-    - S12
-    - S13
-    - S14
-    - S15
-    - S16
-    - S17
-    - S18
-    - S19
-    - S20
-    - S21
-    - S22
-    - S23
-    - S24
-    - S25
-    - S26
-    - S27
-    - S28
-    - S29
-    - S30
-    - S31
-    - S32
-    - S33
-    - S34
-    - S35
-    - S36
-    - S37
-    - S38
-    - S39
-    - S40
-    - S41
-    - S42
-    - S43
-    - S44
-    - S45
-    - S46
-    - S47
-    - S48
-    - S49
-    - S50
-    - S51
-    - S52
-    - S53
-    - S54
-    - S55
-    - S56
-    - S57
-    - S58
-    - S59
-    - S60
-    - S61
-    - S62
-    - Leaf
+- cycle_count: 0
+  expect:
+    state: Root.S1.S2.S3.S4.S5.S6.S7.S8.S9.S10.S11.S12.S13.S14.S15.S16.S17.S18.S19.S20.S21.S22.S23.S24.S25.S26.S27.S28.S29.S30.S31.S32.S33.S34.S35.S36.S37.S38.S39.S40.S41.S42.S43.S44.S45.S46.S47.S48.S49.S50.S51.S52.S53.S54.S55.S56.S57.S58.S59.S60.S61.S62.Leaf
     vars:
       x: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - S1
-    - S2
-    - S3
-    - S4
-    - S5
-    - S6
-    - S7
-    - S8
-    - S9
-    - S10
-    - S11
-    - S12
-    - S13
-    - S14
-    - S15
-    - S16
-    - S17
-    - S18
-    - S19
-    - S20
-    - S21
-    - S22
-    - S23
-    - S24
-    - S25
-    - S26
-    - S27
-    - S28
-    - S29
-    - S30
-    - S31
-    - S32
-    - S33
-    - S34
-    - S35
-    - S36
-    - S37
-    - S38
-    - S39
-    - S40
-    - S41
-    - S42
-    - S43
-    - S44
-    - S45
-    - S46
-    - S47
-    - S48
-    - S49
-    - S50
-    - S51
-    - S52
-    - S53
-    - S54
-    - S55
-    - S56
-    - S57
-    - S58
-    - S59
-    - S60
-    - S61
-    - S62
-    - Leaf
+    state: Root.S1.S2.S3.S4.S5.S6.S7.S8.S9.S10.S11.S12.S13.S14.S15.S16.S17.S18.S19.S20.S21.S22.S23.S24.S25.S26.S27.S28.S29.S30.S31.S32.S33.S34.S35.S36.S37.S38.S39.S40.S41.S42.S43.S44.S45.S46.S47.S48.S49.S50.S51.S52.S53.S54.S55.S56.S57.S58.S59.S60.S61.S62.Leaf
     vars:
       x: 1
     ended: false

--- a/test/fixtures/simulate_semantics/cases/hot_start_composite_evented_initial_skips_entry_boundary_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_composite_evented_initial_skips_entry_boundary_before.yaml
@@ -1,20 +1,11 @@
-schema_version: 1
-id: hot_start_composite_evented_initial_skips_entry_boundary_before
 title: Hot-started composite evented initial transition skips entry boundary before
   actions
-source:
-  fcstm: hot_start_composite_evented_initial_skips_entry_boundary_before.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/pull/198#issuecomment-4692891140
   - https://github.com/HansBug/pyfcstm/pull/198#issuecomment-4692979672
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - handler_calls
   notes:
   - Locks the hot-start contract that a composite target simulates an already-entered
     boundary.
@@ -38,32 +29,24 @@ handlers:
 - action: Root.Gate.Armed.EnterArmed
   behavior: record_call
 steps:
-- expect_initial:
-    state:
-    - Root
-    - Gate
+- cycle_count: 0
+  expect:
+    state: Root.Gate
     vars:
       gate: 0
       trace: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Gate
+    state: Root.Gate
     vars:
       gate: 0
       trace: 0
     ended: false
     handler_calls: []
-- cycle:
-    events:
-    - Root.Gate.Unlock
+- cycle: Root.Gate.Unlock
   expect:
-    state:
-    - Root
-    - Gate
-    - Armed
+    state: Root.Gate.Armed
     vars:
       gate: 0
       trace: 13
@@ -75,10 +58,7 @@ steps:
       vars:
         gate: 0
         trace: 1
-      active_leaf:
-      - Root
-      - Gate
-      - Armed
+      active_leaf: Root.Gate.Armed
       call_stage: enter
       abstract_target: Root.Gate.Armed.EnterArmed
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/hot_start_composite_state_with_init.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_composite_state_with_init.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: hot_start_composite_state_with_init
 title: Hot start from composite state with init transition
-source:
-  fcstm: hot_start_composite_state_with_init.fcstm
 origin:
   files:
   - test/simulate/test_hot_start.py::TestHotStartCompositeState::test_hot_start_from_composite_state_with_init
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - ended
 categories:
 - runtime
 - hot_start
@@ -20,37 +11,27 @@ initial:
   vars:
     counter: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - System
+- cycle_count: 0
+  expect:
+    state: Root.System
     vars:
       counter: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - Idle
+    state: Root.System.Idle
     vars:
       counter: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - Idle
+    state: Root.System.Idle
     vars:
       counter: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - Idle
+    state: Root.System.Idle
     vars:
       counter: 3
     ended: false

--- a/test/fixtures/simulate_semantics/cases/hot_start_composite_waits_for_initial_event.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_composite_waits_for_initial_event.yaml
@@ -1,17 +1,9 @@
-schema_version: 1
-id: hot_start_composite_waits_for_initial_event
 title: Hot start composite waits for an initial transition event
-source:
-  fcstm: hot_start_composite_waits_for_initial_event.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631746763
-  assertion_types:
-  - initial
-  - state
-  - vars
 categories:
 - runtime
 - template_alignment
@@ -22,21 +14,15 @@ initial:
   vars:
     x: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - Locked
+- cycle_count: 0
+  expect:
+    state: Root.Locked
     vars:
       x: 0
     ended: false
-- cycle:
-    events:
-    - Root.Locked.Unlock
+- cycle: Root.Locked.Unlock
   expect:
-    state:
-    - Root
-    - Locked
-    - Ready
+    state: Root.Locked.Ready
     vars:
       x: 1
     ended: false

--- a/test/fixtures/simulate_semantics/cases/hot_start_deep_evented_initial_waits_for_event.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_deep_evented_initial_waits_for_event.yaml
@@ -1,9 +1,5 @@
-schema_version: 1
-id: hot_start_deep_evented_initial_waits_for_event
 title: Hot-started deep composite waits after eventless initial chain reaches an event
   gate
-source:
-  fcstm: hot_start_deep_evented_initial_waits_for_event.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
@@ -11,10 +7,6 @@ origin:
   docs:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694439541
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694781586
-  assertion_types:
-  - initial
-  - state
-  - vars
   notes:
   - Covers a hot-start composite whose eventless initial chain reaches a nested evented
     initial boundary.
@@ -32,33 +24,23 @@ initial:
     trace: 0
     branch: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - Gate
+- cycle_count: 0
+  expect:
+    state: Root.Gate
     vars:
       trace: 0
       branch: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Gate
+    state: Root.Gate
     vars:
       trace: 0
       branch: 0
     ended: false
-- cycle:
-    events:
-    - Root.Gate.Prep.Wait.Unlock
+- cycle: Root.Gate.Prep.Wait.Unlock
   expect:
-    state:
-    - Root
-    - Gate
-    - Prep
-    - Wait
-    - Armed
+    state: Root.Gate.Prep.Wait.Armed
     vars:
       trace: 21345
       branch: 0

--- a/test/fixtures/simulate_semantics/cases/hot_start_evented_initial_matches_cold_suffix.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_evented_initial_matches_cold_suffix.yaml
@@ -1,19 +1,11 @@
-schema_version: 1
-id: hot_start_evented_initial_matches_cold_suffix
 title: Hot-started evented initial boundary follows the same suffix as an equivalent
   cold-start boundary
-source:
-  fcstm: hot_start_evented_initial_matches_cold_suffix.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694447739
-  assertion_types:
-  - initial
-  - state
-  - vars
   notes:
   - The hot-start suffix starts from the same already-entered Gate boundary that a
     cold Boot-to-Gate transition would reach.
@@ -31,43 +23,30 @@ initial:
     trace: 0
     seed: 1
 steps:
-- expect_initial:
-    state:
-    - Root
-    - Gate
+- cycle_count: 0
+  expect:
+    state: Root.Gate
     vars:
       trace: 0
       seed: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Gate
+    state: Root.Gate
     vars:
       trace: 0
       seed: 1
     ended: false
-- cycle:
-    events:
-    - Root.Gate.Unlock
+- cycle: Root.Gate.Unlock
   expect:
-    state:
-    - Root
-    - Gate
-    - Armed
+    state: Root.Gate.Armed
     vars:
       trace: 111
       seed: 1
     ended: false
-- cycle:
-    events:
-    - Root.Gate.Armed.Finish
+- cycle: Root.Gate.Armed.Finish
   expect:
-    state:
-    - Root
-    - Gate
-    - Idle
+    state: Root.Gate.Idle
     vars:
       trace: 11111
       seed: 1

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: hot_start_initial_vars_override_skips_int_initializer
 title: Hot start initial vars override skips failing int initializer
-source:
-  fcstm: hot_start_initial_vars_override_skips_int_initializer.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694623177
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - constructor_exception
   notes:
   - Covers the canonical int failing-initializer override case.
 categories:
@@ -23,19 +14,16 @@ initial:
     bad: 7
     ticks: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - Safe
+- cycle_count: 0
+  expect:
+    state: Root.Safe
     vars:
       bad: 7
       ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Safe
+    state: Root.Safe
     vars:
       bad: 7
       ticks: 1

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.yaml
@@ -1,14 +1,8 @@
-schema_version: 1
-id: hot_start_initial_vars_reject_bool_values
 title: Hot start rejects bool initial variable values at construction
-source:
-  fcstm: hot_start_initial_vars_reject_bool_values.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
-  assertion_types:
-  - constructor_exception
   notes:
   - Guards against Python bool being accepted as an int subclass.
 categories:

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.yaml
@@ -1,14 +1,8 @@
-schema_version: 1
-id: hot_start_initial_vars_reject_string_values
 title: Hot start rejects string initial variable values at construction
-source:
-  fcstm: hot_start_initial_vars_reject_string_values.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
-  assertion_types:
-  - constructor_exception
   notes:
   - Covers non-DSL numeric objects before the first cycle.
 categories:

--- a/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.yaml
@@ -1,13 +1,7 @@
-schema_version: 1
-id: hot_start_leaf_defers_during_expression_error
 title: Hot start leaf defers during expression errors until the first cycle
-source:
-  fcstm: hot_start_leaf_defers_during_expression_error.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/pull/153#issuecomment-4627323375
-  assertion_types:
-  - exception
   notes:
   - A non-pseudo leaf target is already stoppable, so construction must not run its
     first-cycle during action.
@@ -21,7 +15,7 @@ initial:
   vars:
     x: 0
 steps:
-- cycle: {}
+- cycle: []
   expect:
     raises:
       type: SimulationRuntimeExpressionError

--- a/test/fixtures/simulate_semantics/cases/hot_start_leaf_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_leaf_state.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: hot_start_leaf_state
 title: Hot start from leaf state string path
-source:
-  fcstm: hot_start_leaf_state.fcstm
 origin:
   files:
   - test/simulate/test_hot_start.py::TestHotStartLeafState::test_hot_start_from_leaf_state_string_path
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - ended
 categories:
 - runtime
 - hot_start
@@ -20,34 +11,27 @@ initial:
   vars:
     counter: 0
 steps:
-- expect_initial:
-    state:
-    - System
-    - Active
+- cycle_count: 0
+  expect:
+    state: System.Active
     vars:
       counter: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Active
+    state: System.Active
     vars:
       counter: 10
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Active
+    state: System.Active
     vars:
       counter: 20
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - System
-    - Active
+    state: System.Active
     vars:
       counter: 30
     ended: false

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.yaml
@@ -1,14 +1,8 @@
-schema_version: 1
-id: hot_start_rejects_blocked_composite_initial
 title: Hot start rejects a composite target whose initial transition is blocked
-source:
-  fcstm: hot_start_rejects_blocked_composite_initial.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
-  assertion_types:
-  - constructor_exception
   notes:
   - The target composite remains in init_wait because its guarded initial transition
     is false.

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_overdeep_leaf_stack.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_overdeep_leaf_stack.yaml
@@ -1,17 +1,10 @@
-schema_version: 1
-id: hot_start_rejects_overdeep_leaf_stack
 title: Hot-start rejects a leaf stack beyond the structural depth limit
-source:
-  fcstm: hot_start_rejects_overdeep_leaf_stack.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694747151
-  assertion_types:
-  - initial
-  - exception
   notes:
   - The path contains 65 frames from Root through S63 and Leaf.
   - Both runtimes must reject the constructor before any cycle can execute.

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.yaml
@@ -1,14 +1,8 @@
-schema_version: 1
-id: hot_start_rejects_unstable_pseudo_leaf
 title: Hot start rejects a pseudo leaf that cannot stabilize
-source:
-  fcstm: hot_start_rejects_unstable_pseudo_leaf.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   - test/template/python/test_semantic_fixture_alignment.py::test_generated_python_alignment_semantic_fixture
-  assertion_types:
-  - constructor_exception
   notes:
   - The pseudo state's during action may run only in an isolated preflight clone.
 categories:

--- a/test/fixtures/simulate_semantics/cases/hot_start_skips_enter_actions.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_skips_enter_actions.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: hot_start_skips_enter_actions
 title: Hot start skips enter actions
-source:
-  fcstm: hot_start_skips_enter_actions.fcstm
 origin:
   files:
   - test/simulate/test_hot_start.py::TestHotStartWithLifecycleActions::test_hot_start_skips_enter_actions
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - ended
 categories:
 - runtime
 - hot_start
@@ -21,37 +12,30 @@ initial:
     enter_count: 0
     during_count: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - A
+- cycle_count: 0
+  expect:
+    state: Root.A
     vars:
       enter_count: 0
       during_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       enter_count: 0
       during_count: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       enter_count: 0
       during_count: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       enter_count: 0
       during_count: 3

--- a/test/fixtures/simulate_semantics/cases/hot_start_with_aspect_actions.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_with_aspect_actions.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: hot_start_with_aspect_actions
 title: Hot start executes aspect actions during cycles
-source:
-  fcstm: hot_start_with_aspect_actions.fcstm
 origin:
   files:
   - test/simulate/test_hot_start.py::TestHotStartWithLifecycleActions::test_hot_start_with_aspect_actions
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - ended
 categories:
 - runtime
 - hot_start
@@ -22,62 +13,49 @@ initial:
     during_count: 0
     after_count: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - A
+- cycle_count: 0
+  expect:
+    state: Root.A
     vars:
       before_count: 0
       during_count: 0
       after_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       before_count: 1
       during_count: 1
       after_count: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       before_count: 2
       during_count: 2
       after_count: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       before_count: 3
       during_count: 3
       after_count: 3
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       before_count: 4
       during_count: 13
       after_count: 4
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       before_count: 5
       during_count: 23

--- a/test/fixtures/simulate_semantics/cases/hot_start_with_composite_during_before_after.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_with_composite_during_before_after.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: hot_start_with_composite_during_before_after
 title: Hot start nested leaf skips composite enter then follows child transition semantics
-source:
-  fcstm: hot_start_with_composite_during_before_after.fcstm
 origin:
   files:
   - test/simulate/test_hot_start.py::TestHotStartWithLifecycleActions::test_hot_start_with_composite_during_before_after
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - ended
 categories:
 - runtime
 - hot_start
@@ -22,68 +13,49 @@ initial:
     during_count: 0
     exit_count: 0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - System
-    - A
+- cycle_count: 0
+  expect:
+    state: Root.System.A
     vars:
       enter_count: 0
       during_count: 0
       exit_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       enter_count: 0
       during_count: 1
       exit_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       enter_count: 0
       during_count: 2
       exit_count: 0
     ended: false
-- cycle:
-    events:
-    - Root.System.A.Go
+- cycle: Root.System.A.Go
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       enter_count: 0
       during_count: 12
       exit_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       enter_count: 0
       during_count: 22
       exit_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - B
+    state: Root.System.B
     vars:
       enter_count: 0
       during_count: 32

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_else_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_else_branch.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_else_branch
 title: if blocks during else branch
-source:
-  fcstm: if_blocks_during_else_branch.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 100
       y: 0

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_else_if_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_else_if_branch.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_else_if_branch
 title: if blocks during else if branch
-source:
-  fcstm: if_blocks_during_else_if_branch.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 10
       y: 0

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_false_then_continues.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_false_then_continues.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_false_then_continues
 title: if blocks during false then continues
-source:
-  fcstm: if_blocks_during_false_then_continues.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
       y: 0

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_nested_outer_else.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_nested_outer_else.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_nested_outer_else
 title: if blocks during nested outer else
-source:
-  fcstm: if_blocks_during_nested_outer_else.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1000
       y: 0

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_nested_true_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_nested_true_branch.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_nested_true_branch
 title: if blocks during nested true branch
-source:
-  fcstm: if_blocks_during_nested_true_branch.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 10
       y: 0

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_sequential_updates.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_sequential_updates.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_sequential_updates
 title: if blocks during sequential updates
-source:
-  fcstm: if_blocks_during_sequential_updates.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 2
       y: 12

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_temp_reassigned.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_temp_reassigned.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_temp_reassigned
 title: if blocks during temp reassigned
-source:
-  fcstm: if_blocks_during_temp_reassigned.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 11
       y: 0

--- a/test/fixtures/simulate_semantics/cases/if_blocks_during_then_without_else.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_during_then_without_else.yaml
@@ -1,31 +1,18 @@
-schema_version: 1
-id: if_blocks_during_then_without_else
 title: if blocks during then without else
-source:
-  fcstm: if_blocks_during_then_without_else.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_during_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
   notes:
   - Migrated from one parameter row of the parametrized if-block runtime test.
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 10
       y: 0

--- a/test/fixtures/simulate_semantics/cases/if_blocks_exit_effect_enter_actions.yaml
+++ b/test/fixtures/simulate_semantics/cases/if_blocks_exit_effect_enter_actions.yaml
@@ -1,40 +1,23 @@
-schema_version: 1
-id: if_blocks_exit_effect_enter_actions
 title: If blocks in exit effect and enter actions
-source:
-  fcstm: if_blocks_exit_effect_enter_actions.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestIfBlockRuntime::test_if_blocks_in_exit_effect_and_enter_actions
   - test/template/python/test_runtime_alignment.py::TestIfBlockRuntime::test_if_blocks_in_exit_effect_and_enter_actions
-  assertion_types:
-  - state
-  - vars
-  - ended
 categories:
 - runtime
 - template_alignment
 - if_blocks
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
       flag: 0
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       x: 111
       flag: 0

--- a/test/fixtures/simulate_semantics/cases/lifecycle_ref_chain_resolves_long_acyclic_chain.yaml
+++ b/test/fixtures/simulate_semantics/cases/lifecycle_ref_chain_resolves_long_acyclic_chain.yaml
@@ -1,16 +1,8 @@
-schema_version: 1
-id: lifecycle_ref_chain_resolves_long_acyclic_chain
 title: Lifecycle ref chain resolves long acyclic chain
-source:
-  fcstm: lifecycle_ref_chain_resolves_long_acyclic_chain.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/pull/205
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694663908
-  assertion_types:
-  - handler_calls
-  - state
-  - vars
   notes:
   - Canonical long lifecycle ref-chain alignment case for generated Python runtime.
 categories:
@@ -18,18 +10,13 @@ categories:
 - template_alignment
 - abstract
 - lifecycle
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Library.Final
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Active
+    state: Root.Active
     vars:
       trace: 11
     ended: false
@@ -39,9 +26,7 @@ steps:
       stage: enter
       vars:
         trace: 1
-      active_leaf:
-      - Root
-      - Active
+      active_leaf: Root.Active
       call_stage: enter
       abstract_target: Root.Library.Final
       named_ref: Root.Active.ChainStart

--- a/test/fixtures/simulate_semantics/cases/named_ref_context_reports_callsite.yaml
+++ b/test/fixtures/simulate_semantics/cases/named_ref_context_reports_callsite.yaml
@@ -1,35 +1,22 @@
-schema_version: 1
-id: named_ref_context_reports_callsite
 title: Named ref context reports the concrete callsite
-source:
-  fcstm: named_ref_context_reports_callsite.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4634004004
-  assertion_types:
-  - handler_calls
-  - state
-  - vars
   notes:
   - REFMIX-1 regression proving two named refs to one abstract target remain distinguishable.
 categories:
 - runtime
 - abstract
 - lifecycle
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Library.Shared
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 0
     ended: false
@@ -39,9 +26,7 @@ steps:
       stage: enter
       vars:
         x: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.Shared
       named_ref: Root.A.FirstRef
@@ -50,9 +35,7 @@ steps:
       stage: enter
       vars:
         x: 0
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.Shared
       named_ref: Root.A.SecondRef

--- a/test/fixtures/simulate_semantics/cases/persistent_default_float_initializer_converts_int.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_float_initializer_converts_int.yaml
@@ -1,36 +1,23 @@
-schema_version: 1
-id: persistent_default_float_initializer_converts_int
 title: Persistent default float initializer converts integer value
-source:
-  fcstm: persistent_default_float_initializer_converts_int.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145
-  assertion_types:
-  - initial
-  - state
-  - vars
   notes:
   - Completeness guard for declared float normalization on default initializers.
 categories:
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- expect_initial:
-    state:
-    - Root
+- cycle_count: 0
+  expect:
+    state: Root
     vars:
       ratio: 2.0
       marker: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       ratio: 2.0
       marker: 1

--- a/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_normalizes_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_normalizes_integer_float.yaml
@@ -1,37 +1,23 @@
-schema_version: 1
-id: persistent_default_int_initializer_normalizes_integer_float
 title: Persistent default int initializer normalizes integer-valued float
-source:
-  fcstm: persistent_default_int_initializer_normalizes_integer_float.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - exception
   notes:
   - Covers declared int default initializer normalization before the first cycle.
 categories:
 - runtime
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- expect_initial:
-    state:
-    - Root
+- cycle_count: 0
+  expect:
+    state: Root
     vars:
       bits: 3
       marker: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       bits: 3
       marker: 1

--- a/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.yaml
@@ -1,13 +1,7 @@
-schema_version: 1
-id: persistent_default_int_initializer_rejects_non_integer_float
 title: Persistent default int initializer rejects non-integer float
-source:
-  fcstm: persistent_default_int_initializer_rejects_non_integer_float.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694530145
-  assertion_types:
-  - constructor_exception
   notes:
   - Guards the constructor-side persistent int boundary for default initializers.
 categories:

--- a/test/fixtures/simulate_semantics/cases/persistent_effect_writeback_normalizes_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_effect_writeback_normalizes_integer_float.yaml
@@ -1,15 +1,7 @@
-schema_version: 1
-id: persistent_effect_writeback_normalizes_integer_float
 title: Persistent transition effect writeback normalizes integer-valued float
-source:
-  fcstm: persistent_effect_writeback_normalizes_integer_float.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694002673
-  assertion_types:
-  - state
-  - vars
-  - exception
   notes:
   - Covers transition-effect writeback through the same persistent boundary as lifecycle
     actions.
@@ -17,26 +9,17 @@ categories:
 - runtime
 - template_alignment
 - temporary_vars
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       bits: 0
       marker: 0
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       bits: 3
       marker: 1

--- a/test/fixtures/simulate_semantics/cases/persistent_initial_vars_override_skips_initializer.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_initial_vars_override_skips_initializer.yaml
@@ -1,16 +1,7 @@
-schema_version: 1
-id: persistent_initial_vars_override_skips_initializer
 title: Persistent initial_vars override skips failing default initializer
-source:
-  fcstm: persistent_initial_vars_override_skips_initializer.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4633663497
-  assertion_types:
-  - initial
-  - state
-  - vars
-  - ended
   notes:
   - Ensures provided initial_vars values take priority over their default initializer.
 categories:
@@ -22,10 +13,9 @@ initial:
   vars:
     recovered: 5.0
 steps:
-- expect_initial:
-    state:
-    - Root
-    - A
+- cycle_count: 0
+  expect:
+    state: Root.A
     vars:
       recovered: 5.0
     ended: false

--- a/test/fixtures/simulate_semantics/cases/persistent_int_writeback_normalizes_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_int_writeback_normalizes_integer_float.yaml
@@ -1,16 +1,8 @@
-schema_version: 1
-id: persistent_int_writeback_normalizes_integer_float
 title: Persistent int writeback normalizes integer-valued float
-source:
-  fcstm: persistent_int_writeback_normalizes_integer_float.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694002673
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694852936
-  assertion_types:
-  - state
-  - vars
-  - exception
   notes:
   - Covers operation-block temporary propagation into a declared int variable.
 categories:
@@ -18,26 +10,17 @@ categories:
 - template_alignment
 - temporary_vars
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       bits: 3
       marker: 1
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       bits: 3
       marker: 1

--- a/test/fixtures/simulate_semantics/cases/persistent_operation_writeback_rejects_float_and_rolls_back.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_operation_writeback_rejects_float_and_rolls_back.yaml
@@ -1,15 +1,7 @@
-schema_version: 1
-id: persistent_operation_writeback_rejects_float_and_rolls_back
 title: Persistent writeback rejects non-integer float and rolls back
-source:
-  fcstm: persistent_operation_writeback_rejects_float_and_rolls_back.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631935935
-  assertion_types:
-  - exception
-  - state
-  - vars
   notes:
   - Covers operation block temporary variables crossing the persistent int boundary.
 categories:
@@ -17,18 +9,14 @@ categories:
 - temporary_vars
 - lifecycle
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
     raises:
       type: ValueError
       match: count.*int.*non-integer float
       match_kind: regex
-    state:
-    - Root
+    state: Root
     vars:
       count: 0
       marker: 0

--- a/test/fixtures/simulate_semantics/cases/post_child_exit_continuation_skips_unstable_candidates.yaml
+++ b/test/fixtures/simulate_semantics/cases/post_child_exit_continuation_skips_unstable_candidates.yaml
@@ -1,42 +1,24 @@
-schema_version: 1
-id: post_child_exit_continuation_skips_unstable_candidates
 title: Post child exit continuation skips unstable candidates
-source:
-  fcstm: post_child_exit_continuation_skips_unstable_candidates.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614271348
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - template_alignment
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - System
-    - A
+    state: Root.System.A
     vars:
       trace: 1
     ended: false
 - cycle:
-    events:
-    - Root.System.A.Exit
-    - Root.System.Switch
+  - Root.System.A.Exit
+  - Root.System.Switch
   expect:
-    state:
-    - Root
-    - Good
-    - B
+    state: Root.Good.B
     vars:
       trace: 12365
     ended: false

--- a/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.yaml
+++ b/test/fixtures/simulate_semantics/cases/pseudo_candidate_skips_unstable_branch.yaml
@@ -1,42 +1,26 @@
-schema_version: 1
-id: pseudo_candidate_skips_unstable_branch
 title: Pseudo candidate selection skips an unstable branch
-source:
-  fcstm: pseudo_candidate_skips_unstable_branch.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631750074
-  assertion_types:
-  - state
-  - vars
 categories:
 - runtime
 - pseudo_chain
 - validation
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       trace: 101001
     ended: false
 - cycle:
-    events:
-    - Root.A.Go
-    - Root.Target.Gate.Go
+  - Root.A.Go
+  - Root.Target.Gate.Go
   expect:
-    state:
-    - Root
-    - Target
-    - Good
+    state: Root.Target.Good
     vars:
       trace: 212113
     ended: false

--- a/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
@@ -1,45 +1,28 @@
-schema_version: 1
-id: pseudo_self_loop_step_limit_raises_dfs_error
 title: Pseudo self loop raises on the step safety limit
-source:
-  fcstm: pseudo_self_loop_step_limit_raises_dfs_error.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631968897
-  assertion_types:
-  - exception
-  - state
-  - vars
 categories:
 - runtime
 - pseudo_chain
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
       spin: 0
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
     raises:
       type: SimulationRuntimeDfsError
       match: step safety limit
       match_kind: substring
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
       spin: 0

--- a/test/fixtures/simulate_semantics/cases/ref_abstract_handler_reports_calling_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/ref_abstract_handler_reports_calling_state.yaml
@@ -1,17 +1,8 @@
-schema_version: 1
-id: ref_abstract_handler_reports_calling_state
 title: Ref abstract handler reports the calling state
-source:
-  fcstm: ref_abstract_handler_reports_calling_state.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/pull/205
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614012639
-  assertion_types:
-  - ended
-  - handler_calls
-  - state
-  - vars_exact
   notes:
   - Public callback contract for referenced abstract actions across shared runners.
 categories:
@@ -19,18 +10,13 @@ categories:
 - template_alignment
 - abstract
 - lifecycle
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Library.Shared
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars_exact: {}
     ended: false
     handler_calls:
@@ -38,9 +24,7 @@ steps:
       state: Root.A
       stage: enter
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.Shared
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/ref_context_uses_callsite_stage.yaml
+++ b/test/fixtures/simulate_semantics/cases/ref_context_uses_callsite_stage.yaml
@@ -1,26 +1,15 @@
-schema_version: 1
-id: ref_context_uses_callsite_stage
 title: Ref abstract handler reports callsite lifecycle stage
-source:
-  fcstm: ref_context_uses_callsite_stage.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631761534
-  assertion_types:
-  - handler_calls
-  - state
-  - vars_exact
   notes:
   - REF-1 regression proving cross-stage refs report the callsite stage.
 categories:
 - runtime
 - abstract
 - lifecycle
-initial:
-  state: null
-  vars: null
 handlers:
 - action: Root.Library.SharedEnter
   behavior: record_call
@@ -29,11 +18,9 @@ handlers:
 - action: Root.Library.SharedExit
   behavior: record_call
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars_exact: {}
     ended: false
     handler_calls:
@@ -41,9 +28,7 @@ steps:
       state: Root.A
       stage: enter
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.SharedExit
       named_ref: null
@@ -51,9 +36,7 @@ steps:
       state: Root.A
       stage: during
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedExit
       named_ref: null
@@ -61,19 +44,13 @@ steps:
       state: Root.A
       stage: during
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedEnter
       named_ref: null
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars_exact: {}
     ended: false
     handler_calls:
@@ -81,9 +58,7 @@ steps:
       state: Root.A
       stage: enter
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: enter
       abstract_target: Root.Library.SharedExit
       named_ref: null
@@ -91,9 +66,7 @@ steps:
       state: Root.A
       stage: during
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedExit
       named_ref: null
@@ -101,9 +74,7 @@ steps:
       state: Root.A
       stage: during
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: during
       abstract_target: Root.Library.SharedEnter
       named_ref: null
@@ -111,9 +82,7 @@ steps:
       state: Root.A
       stage: exit
       vars: {}
-      active_leaf:
-      - Root
-      - A
+      active_leaf: Root.A
       call_stage: exit
       abstract_target: Root.Library.SharedDuring
       named_ref: null
@@ -121,9 +90,7 @@ steps:
       state: Root.B
       stage: during
       vars: {}
-      active_leaf:
-      - Root
-      - B
+      active_leaf: Root.B
       call_stage: during
       abstract_target: Root.Library.SharedExit
       named_ref: null

--- a/test/fixtures/simulate_semantics/cases/root_exit_runs_root_cleanup.yaml
+++ b/test/fixtures/simulate_semantics/cases/root_exit_runs_root_cleanup.yaml
@@ -1,35 +1,20 @@
-schema_version: 1
-id: root_exit_runs_root_cleanup
 title: Root exit runs root cleanup actions
-source:
-  fcstm: root_exit_runs_root_cleanup.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614013960
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - template_alignment
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       trace: 1234
     ended: false
-- cycle:
-    events:
-    - Root.A.Stop
+- cycle: Root.A.Stop
   expect:
     state: null
     vars:

--- a/test/fixtures/simulate_semantics/cases/scenario_ac_charger_session_control_normal.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_ac_charger_session_control_normal.yaml
@@ -1,78 +1,51 @@
-schema_version: 1
-id: scenario_ac_charger_session_control_normal
 title: 4 103 ac charger session control
-source:
-  fcstm: scenario_ac_charger_session_control_normal.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Idle
+    state: Root.Idle
     vars:
       soc: 70
       sessions: 0
     ended: false
-- cycle:
-    events:
-    - Root.Idle.PlugIn
+- cycle: Root.Idle.PlugIn
   expect:
-    state:
-    - Root
-    - Charging
+    state: Root.Charging
     vars:
       soc: 80
       sessions: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Charging
+    state: Root.Charging
     vars:
       soc: 90
       sessions: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Charging
+    state: Root.Charging
     vars:
       soc: 100
       sessions: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Complete
+    state: Root.Complete
     vars:
       soc: 100
       sessions: 0
     ended: false
-- cycle:
-    events:
-    - Root.Complete.Unplug
+- cycle: Root.Complete.Unplug
   expect:
-    state:
-    - Root
-    - Idle
+    state: Root.Idle
     vars:
       soc: 100
       sessions: 1

--- a/test/fixtures/simulate_semantics/cases/scenario_ac_charger_session_control_unplug.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_ac_charger_session_control_unplug.yaml
@@ -1,71 +1,44 @@
-schema_version: 1
-id: scenario_ac_charger_session_control_unplug
 title: 4 103 ac charger session control
-source:
-  fcstm: scenario_ac_charger_session_control_unplug.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_103_ac_charger_session_control
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Idle
+    state: Root.Idle
     vars:
       soc: 70
       sessions: 0
     ended: false
-- cycle:
-    events:
-    - Root.Idle.PlugIn
+- cycle: Root.Idle.PlugIn
   expect:
-    state:
-    - Root
-    - Charging
+    state: Root.Charging
     vars:
       soc: 80
       sessions: 0
     ended: false
-- cycle:
-    events:
-    - Root.Charging.Unplug
+- cycle: Root.Charging.Unplug
   expect:
-    state:
-    - Root
-    - Idle
+    state: Root.Idle
     vars:
       soc: 80
       sessions: 1
     ended: false
-- cycle:
-    events:
-    - Root.Idle.PlugIn
+- cycle: Root.Idle.PlugIn
   expect:
-    state:
-    - Root
-    - Charging
+    state: Root.Charging
     vars:
       soc: 90
       sessions: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Charging
+    state: Root.Charging
     vars:
       soc: 100
       sessions: 1

--- a/test/fixtures/simulate_semantics/cases/scenario_ats_mains_generator_transfer_outage.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_ats_mains_generator_transfer_outage.yaml
@@ -1,47 +1,30 @@
-schema_version: 1
-id: scenario_ats_mains_generator_transfer_outage
 title: 4 104 ats mains generator transfer
-source:
-  fcstm: scenario_ats_mains_generator_transfer_outage.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_104_ats_mains_generator_transfer
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_104_ats_mains_generator_transfer
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - OnMains
+    state: Root.OnMains
     vars:
       warmup: 0
       transfer_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - OnMains
+    state: Root.OnMains
     vars:
       warmup: 0
       transfer_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - OnMains
+    state: Root.OnMains
     vars:
       warmup: 0
       transfer_count: 0

--- a/test/fixtures/simulate_semantics/cases/scenario_ats_mains_generator_transfer_restore.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_ats_mains_generator_transfer_restore.yaml
@@ -1,69 +1,44 @@
-schema_version: 1
-id: scenario_ats_mains_generator_transfer_restore
 title: 4 104 ats mains generator transfer
-source:
-  fcstm: scenario_ats_mains_generator_transfer_restore.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_104_ats_mains_generator_transfer
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_104_ats_mains_generator_transfer
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - OnMains
+    state: Root.OnMains
     vars:
       warmup: 0
       transfer_count: 0
     ended: false
-- cycle:
-    events:
-    - Root.OnMains.GridFail
+- cycle: Root.OnMains.GridFail
   expect:
-    state:
-    - Root
-    - StartingGen
+    state: Root.StartingGen
     vars:
       warmup: 1
       transfer_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - StartingGen
+    state: Root.StartingGen
     vars:
       warmup: 2
       transfer_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - OnGenerator
+    state: Root.OnGenerator
     vars:
       warmup: 2
       transfer_count: 1
     ended: false
-- cycle:
-    events:
-    - Root.OnGenerator.GridRestore
+- cycle: Root.OnGenerator.GridRestore
   expect:
-    state:
-    - Root
-    - OnMains
+    state: Root.OnMains
     vars:
       warmup: 0
       transfer_count: 2

--- a/test/fixtures/simulate_semantics/cases/scenario_cold_storage_defrost_cycle_defrost.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_cold_storage_defrost_cycle_defrost.yaml
@@ -1,86 +1,58 @@
-schema_version: 1
-id: scenario_cold_storage_defrost_cycle_defrost
 title: 4 105 cold storage defrost cycle
-source:
-  fcstm: scenario_cold_storage_defrost_cycle_defrost.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_105_cold_storage_defrost_cycle
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_105_cold_storage_defrost_cycle
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Cooling
+    state: Root.Cooling
     vars:
       frost: 2
       drip_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Cooling
+    state: Root.Cooling
     vars:
       frost: 4
       drip_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Cooling
+    state: Root.Cooling
     vars:
       frost: 6
       drip_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - DefrostCycle
-    - Defrost
+    state: Root.DefrostCycle.Defrost
     vars:
       frost: 1
       drip_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - DefrostCycle
-    - Defrost
+    state: Root.DefrostCycle.Defrost
     vars:
       frost: -4
       drip_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - DefrostCycle
-    - Drip
+    state: Root.DefrostCycle.Drip
     vars:
       frost: 0
       drip_ticks: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Cooling
+    state: Root.Cooling
     vars:
       frost: 2
       drip_ticks: 0

--- a/test/fixtures/simulate_semantics/cases/scenario_cold_storage_defrost_cycle_normal.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_cold_storage_defrost_cycle_normal.yaml
@@ -1,47 +1,30 @@
-schema_version: 1
-id: scenario_cold_storage_defrost_cycle_normal
 title: 4 105 cold storage defrost cycle
-source:
-  fcstm: scenario_cold_storage_defrost_cycle_normal.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_105_cold_storage_defrost_cycle
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_105_cold_storage_defrost_cycle
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Cooling
+    state: Root.Cooling
     vars:
       frost: 2
       drip_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Cooling
+    state: Root.Cooling
     vars:
       frost: 4
       drip_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Cooling
+    state: Root.Cooling
     vars:
       frost: 6
       drip_ticks: 0

--- a/test/fixtures/simulate_semantics/cases/scenario_elevator_door_control_blocked.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_elevator_door_control_blocked.yaml
@@ -1,93 +1,64 @@
-schema_version: 1
-id: scenario_elevator_door_control_blocked
 title: 4 100 elevator door control
-source:
-  fcstm: scenario_elevator_door_control_blocked.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_100_elevator_door_control
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_100_elevator_door_control
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Closed
+    state: Root.Closed
     vars:
       door_pos: 0
       hold: 0
       reopen_count: 0
     ended: false
-- cycle:
-    events:
-    - Root.Closed.HallCall
+- cycle: Root.Closed.HallCall
   expect:
-    state:
-    - Root
-    - Opening
+    state: Root.Opening
     vars:
       door_pos: 50
       hold: 0
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Opening
+    state: Root.Opening
     vars:
       door_pos: 100
       hold: 0
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Opened
+    state: Root.Opened
     vars:
       door_pos: 100
       hold: 1
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Opened
+    state: Root.Opened
     vars:
       door_pos: 100
       hold: 2
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Closing
+    state: Root.Closing
     vars:
       door_pos: 50
       hold: 2
       reopen_count: 0
     ended: false
-- cycle:
-    events:
-    - Root.Closing.BeamBlocked
+- cycle: Root.Closing.BeamBlocked
   expect:
-    state:
-    - Root
-    - Opened
+    state: Root.Opened
     vars:
       door_pos: 100
       hold: 1

--- a/test/fixtures/simulate_semantics/cases/scenario_elevator_door_control_normal.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_elevator_door_control_normal.yaml
@@ -1,101 +1,72 @@
-schema_version: 1
-id: scenario_elevator_door_control_normal
 title: 4 100 elevator door control
-source:
-  fcstm: scenario_elevator_door_control_normal.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_100_elevator_door_control
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_100_elevator_door_control
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Closed
+    state: Root.Closed
     vars:
       door_pos: 0
       hold: 0
       reopen_count: 0
     ended: false
-- cycle:
-    events:
-    - Root.Closed.HallCall
+- cycle: Root.Closed.HallCall
   expect:
-    state:
-    - Root
-    - Opening
+    state: Root.Opening
     vars:
       door_pos: 50
       hold: 0
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Opening
+    state: Root.Opening
     vars:
       door_pos: 100
       hold: 0
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Opened
+    state: Root.Opened
     vars:
       door_pos: 100
       hold: 1
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Opened
+    state: Root.Opened
     vars:
       door_pos: 100
       hold: 2
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Closing
+    state: Root.Closing
     vars:
       door_pos: 50
       hold: 2
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Closing
+    state: Root.Closing
     vars:
       door_pos: 0
       hold: 2
       reopen_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Closed
+    state: Root.Closed
     vars:
       door_pos: 0
       hold: 0

--- a/test/fixtures/simulate_semantics/cases/scenario_storage_water_heater_control_cooldown.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_storage_water_heater_control_cooldown.yaml
@@ -1,83 +1,58 @@
-schema_version: 1
-id: scenario_storage_water_heater_control_cooldown
 title: 4 101 storage water heater control
-source:
-  fcstm: scenario_storage_water_heater_control_cooldown.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_101_storage_water_heater_control
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_101_storage_water_heater_control
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 54
       draw_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 53
       draw_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 52
       draw_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 51
       draw_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 50
       draw_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Heating
+    state: Root.Heating
     vars:
       water_temp: 54
       draw_count: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Heating
+    state: Root.Heating
     vars:
       water_temp: 58
       draw_count: 0

--- a/test/fixtures/simulate_semantics/cases/scenario_storage_water_heater_control_draw.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_storage_water_heater_control_draw.yaml
@@ -1,85 +1,58 @@
-schema_version: 1
-id: scenario_storage_water_heater_control_draw
 title: 4 101 storage water heater control
-source:
-  fcstm: scenario_storage_water_heater_control_draw.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_101_storage_water_heater_control
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_101_storage_water_heater_control
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 54
       draw_count: 0
     ended: false
-- cycle:
-    events:
-    - Root.Standby.HotWaterDraw
+- cycle: Root.Standby.HotWaterDraw
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 45
       draw_count: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Heating
+    state: Root.Heating
     vars:
       water_temp: 49
       draw_count: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Heating
+    state: Root.Heating
     vars:
       water_temp: 53
       draw_count: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Heating
+    state: Root.Heating
     vars:
       water_temp: 57
       draw_count: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Heating
+    state: Root.Heating
     vars:
       water_temp: 61
       draw_count: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Standby
+    state: Root.Standby
     vars:
       water_temp: 60
       draw_count: 1

--- a/test/fixtures/simulate_semantics/cases/scenario_traffic_signal_with_pedestrian_request_normal.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_traffic_signal_with_pedestrian_request_normal.yaml
@@ -1,62 +1,43 @@
-schema_version: 1
-id: scenario_traffic_signal_with_pedestrian_request_normal
 title: 4 102 traffic signal with pedestrian request
-source:
-  fcstm: scenario_traffic_signal_with_pedestrian_request_normal.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_102_traffic_signal_with_pedestrian_request
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_102_traffic_signal_with_pedestrian_request
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 1
       request_latched: 0
       yellow_ticks: 0
       walk_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 2
       request_latched: 0
       yellow_ticks: 0
       walk_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 3
       request_latched: 0
       yellow_ticks: 0
       walk_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 4
       request_latched: 0

--- a/test/fixtures/simulate_semantics/cases/scenario_traffic_signal_with_pedestrian_request_pedestrian.yaml
+++ b/test/fixtures/simulate_semantics/cases/scenario_traffic_signal_with_pedestrian_request_pedestrian.yaml
@@ -1,100 +1,70 @@
-schema_version: 1
-id: scenario_traffic_signal_with_pedestrian_request_pedestrian
 title: 4 102 traffic signal with pedestrian request
-source:
-  fcstm: scenario_traffic_signal_with_pedestrian_request_pedestrian.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestSimulationDesignExamples::test_4_102_traffic_signal_with_pedestrian_request
   - test/template/python/test_runtime_alignment.py::TestSimulationDesignExamples::test_4_102_traffic_signal_with_pedestrian_request
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - scenario_example
 - template_alignment
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 1
       request_latched: 0
       yellow_ticks: 0
       walk_ticks: 0
     ended: false
-- cycle:
-    events:
-    - Root.MainGreen.PedRequest
+- cycle: Root.MainGreen.PedRequest
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 2
       request_latched: 1
       yellow_ticks: 0
       walk_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 3
       request_latched: 1
       yellow_ticks: 0
       walk_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - PedestrianPhase
-    - MainYellow
+    state: Root.PedestrianPhase.MainYellow
     vars:
       green_ticks: 3
       request_latched: 0
       yellow_ticks: 1
       walk_ticks: 0
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - PedestrianPhase
-    - PedWalk
+    state: Root.PedestrianPhase.PedWalk
     vars:
       green_ticks: 3
       request_latched: 0
       yellow_ticks: 1
       walk_ticks: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - PedestrianPhase
-    - PedWalk
+    state: Root.PedestrianPhase.PedWalk
     vars:
       green_ticks: 3
       request_latched: 0
       yellow_ticks: 1
       walk_ticks: 2
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - MainGreen
+    state: Root.MainGreen
     vars:
       green_ticks: 1
       request_latched: 0

--- a/test/fixtures/simulate_semantics/cases/sign_function_aligns_aspect_guard_effect_math.yaml
+++ b/test/fixtures/simulate_semantics/cases/sign_function_aligns_aspect_guard_effect_math.yaml
@@ -1,15 +1,8 @@
-schema_version: 1
-id: sign_function_aligns_aspect_guard_effect_math
 title: Sign function aligns aspect guard and effect math
-source:
-  fcstm: sign_function_aligns_aspect_guard_effect_math.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694810781
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4695001326
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers sign in aspect actions, during actions, transition guards, transition effects,
     and target enter actions.
@@ -19,37 +12,28 @@ categories:
 - runtime
 - template_alignment
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Alpha
+    state: Root.Alpha
     vars:
       x: -1
       bias: 1
       gate: -1
       trace: -100
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Alpha
+    state: Root.Alpha
     vars:
       x: 2
       bias: 1
       gate: 12
       trace: -100
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Beta
+    state: Root.Beta
     vars:
       x: 2
       bias: 1

--- a/test/fixtures/simulate_semantics/cases/sign_function_controls_guard_transition.yaml
+++ b/test/fixtures/simulate_semantics/cases/sign_function_controls_guard_transition.yaml
@@ -1,38 +1,24 @@
-schema_version: 1
-id: sign_function_controls_guard_transition
 title: Sign function controls a guard transition
-source:
-  fcstm: sign_function_controls_guard_transition.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694810781
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4695001326
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers the C8 sign guard duplicate with target enter action after the transition.
 categories:
 - runtime
 - template_alignment
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       marker: 1
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       marker: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/sign_function_handles_all_signs.yaml
+++ b/test/fixtures/simulate_semantics/cases/sign_function_handles_all_signs.yaml
@@ -1,30 +1,18 @@
-schema_version: 1
-id: sign_function_handles_all_signs
 title: Sign function handles negative zero and positive values
-source:
-  fcstm: sign_function_handles_all_signs.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694810781
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4695001326
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers the sign function's three-value semantics in one lifecycle action block.
 categories:
 - runtime
 - template_alignment
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       negative_sign: -1
       zero_sign: 0

--- a/test/fixtures/simulate_semantics/cases/sign_function_preserves_complex_action_precedence.yaml
+++ b/test/fixtures/simulate_semantics/cases/sign_function_preserves_complex_action_precedence.yaml
@@ -1,15 +1,8 @@
-schema_version: 1
-id: sign_function_preserves_complex_action_precedence
 title: Sign function preserves complex action precedence
-source:
-  fcstm: sign_function_preserves_complex_action_precedence.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694810781
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4695001326
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers complex sign expressions in enter, during, exit, guard, and effect blocks.
   - This case also guards generated Python formatter convergence for long sign expressions.
@@ -17,37 +10,28 @@ categories:
 - runtime
 - template_alignment
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Work
+    state: Root.Work
     vars:
       x: 0
       y: 2
       score: 98
       marker: 7
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Work
+    state: Root.Work
     vars:
       x: 3
       y: 2
       score: 200
       marker: 7
     ended: false
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Done
+    state: Root.Done
     vars:
       x: 3
       y: 2

--- a/test/fixtures/simulate_semantics/cases/sign_function_updates_during_action.yaml
+++ b/test/fixtures/simulate_semantics/cases/sign_function_updates_during_action.yaml
@@ -1,15 +1,8 @@
-schema_version: 1
-id: sign_function_updates_during_action
 title: Sign function updates a during action value
-source:
-  fcstm: sign_function_updates_during_action.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694810781
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4695001326
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers the canonical generated Python sign expression mismatch in a lifecycle
     action.
@@ -17,15 +10,10 @@ categories:
 - runtime
 - template_alignment
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       marker: -1
       x: -3

--- a/test/fixtures/simulate_semantics/cases/similar_state_paths_keep_actions_distinct.yaml
+++ b/test/fixtures/simulate_semantics/cases/similar_state_paths_keep_actions_distinct.yaml
@@ -1,14 +1,7 @@
-schema_version: 1
-id: similar_state_paths_keep_actions_distinct
 title: Similar state paths keep generated actions distinct
-source:
-  fcstm: similar_state_paths_keep_actions_distinct.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/199#issuecomment-4694962840
-  assertion_types:
-  - state
-  - vars
   notes:
   - Covers distinct state paths that previously collapsed to the same generated method
     slug.
@@ -16,16 +9,10 @@ categories:
 - runtime
 - template_alignment
 - lifecycle
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
-    - B
+    state: Root.A.B
     vars:
       trace: 11
     ended: false

--- a/test/fixtures/simulate_semantics/cases/stable_leaf_cycle_updates_public_state.yaml
+++ b/test/fixtures/simulate_semantics/cases/stable_leaf_cycle_updates_public_state.yaml
@@ -1,27 +1,16 @@
-schema_version: 1
-id: stable_leaf_cycle_updates_public_state
 title: Stable leaf cycle updates public state
-source:
-  fcstm: stable_leaf_cycle_updates_public_state.fcstm
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
-  assertion_types:
-  - state
-  - vars
   notes:
-  - Minimal fixture proving that a stable leaf cycle updates public state through the shared observation contract.
+  - Minimal fixture proving that a stable leaf cycle updates public state through
+    the shared observation contract.
 categories:
 - runtime
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - Counting
+    state: Root.Counting
     vars:
       counter: 1
     ended: false

--- a/test/fixtures/simulate_semantics/cases/temporary_variables_are_block_local.yaml
+++ b/test/fixtures/simulate_semantics/cases/temporary_variables_are_block_local.yaml
@@ -1,31 +1,16 @@
-schema_version: 1
-id: temporary_variables_are_block_local
 title: temporary variables are block local
-source:
-  fcstm: temporary_variables_are_block_local.fcstm
 origin:
   files:
   - test/simulate/test_runtime.py::TestTemporaryVariables::test_temporary_variables_are_block_local
   - test/template/python/test_runtime_alignment.py::TestTemporaryVariables::test_temporary_variables_are_block_local
-  assertion_types:
-  - ended
-  - state
-  - vars
-  - vars_absent
-  - vars_keys
 categories:
 - runtime
 - template_alignment
 - temporary_vars
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
       y: 0
@@ -35,13 +20,9 @@ steps:
     - y
     vars_absent:
     - tmp
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - B
+    state: Root.B
     vars:
       x: 11
       y: 12

--- a/test/fixtures/simulate_semantics/cases/transition_into_composite_skips_unstable_initial_candidate.yaml
+++ b/test/fixtures/simulate_semantics/cases/transition_into_composite_skips_unstable_initial_candidate.yaml
@@ -1,41 +1,23 @@
-schema_version: 1
-id: transition_into_composite_skips_unstable_initial_candidate
 title: Transition into composite skips unstable initial candidate
-source:
-  fcstm: transition_into_composite_skips_unstable_initial_candidate.fcstm
 origin:
   files:
   - https://github.com/HansBug/pyfcstm/issues/143#issuecomment-4614352350
-  assertion_types:
-  - ended
-  - state
-  - vars
 categories:
 - runtime
 - template_alignment
 - lifecycle
 - validation
-initial:
-  state: null
-  vars: null
 steps:
-- cycle: {}
+- cycle: []
   expect:
-    state:
-    - Root
-    - A
+    state: Root.A
     vars:
       x: 1
       marker: 0
     ended: false
-- cycle:
-    events:
-    - Root.A.Go
+- cycle: Root.A.Go
   expect:
-    state:
-    - Root
-    - Parent
-    - Good
+    state: Root.Parent.Good
     vars:
       x: 101
       marker: 1

--- a/test/fixtures/simulate_semantics/schema.md
+++ b/test/fixtures/simulate_semantics/schema.md
@@ -1,4 +1,4 @@
-# Simulate semantic fixture schema
+# Simulate semantic fixture schema v2
 
 This directory stores the shared semantic fixture corpus for simulator and
 built-in Python runtime alignment tests. A fixture is a pair of files under
@@ -7,10 +7,11 @@ built-in Python runtime alignment tests. A fixture is a pair of files under
 - `<id>.fcstm`: the FCSTM DSL source.
 - `<id>.yaml`: metadata, construction inputs, cycle inputs, and expectations.
 
-The schema is intentionally strict. Unknown top-level fields, unknown
-categories, unknown expectation fields, and unknown nested fields inside
-`cycle`, `raises`, handlers, and handler calls fail fast with a diagnostic
-containing the case id and YAML path.
+The loader derives the case id and paired FCSTM path from the YAML basename. The
+schema is intentionally strict. Unknown top-level fields, unknown categories,
+unknown expectation fields, and unknown nested fields inside construction input,
+cycle input, exceptions, handlers, and handler-call records fail fast with a
+diagnostic containing the case id and YAML path.
 
 ## Contract
 
@@ -21,8 +22,8 @@ the current shared runner set automatically:
 - `generated_python_alignment`
 
 The only runner-selection field is `exclude_runners`, and it is an exception
-list. Do not add an include-style `runners` field. Future template runners
-should join the default shared set, then opt out case-by-case only when a
+list. Do not add an include-style `runners` field. Future shared template
+runners should join the default shared set, then opt out case-by-case only when a
 concrete capability gap is documented.
 
 The shared corpus may assert only public observations:
@@ -34,34 +35,36 @@ The shared corpus may assert only public observations:
 - cycle inputs and post-cycle state/vars through `steps`
 - abstract hook call behavior through `handlers` plus `handler_calls`
 
-Cycle return values and event accounting are simulator-only debug / introspection
-metadata. They belong in ordinary `test/simulate/` pytest coverage and must not
-appear in shared fixture YAML or generated-template alignment expectations.
+Cycle return values and event accounting are simulator-only debug /
+introspection metadata. They belong in ordinary `test/simulate/` pytest coverage
+and must not appear in shared fixture YAML or generated-template alignment
+expectations. Event accounting includes `CycleResult.input_events`,
+`consumed_events`, `unconsumed_events`, or any similar event-ledger field.
 
 These surfaces are not part of the shared fixture contract and must stay in
 ordinary pytest coverage instead of shared YAML: CLI/REPL command transcripts,
 model-construction diagnostics, simulator runtime options, stack snapshots,
 cycle counters, history records, logs, warnings, abstract handler error lists,
 error-state metadata, anonymous-warning dedupe metadata, cycle return metadata,
-and top-level expected-failure markers.
+event accounting, and top-level expected-failure markers.
 
-## Top-Level Fields
+## Top-level fields
 
 | Field | Required | Description |
 |---|---:|---|
-| `schema_version` | yes | Fixed integer value `1`. |
-| `id` | yes | Stable snake-case id. Must match the YAML basename. |
 | `title` | yes | Human-readable title. |
-| `source.fcstm` | yes | FCSTM file name in the same directory. |
 | `origin.files` | yes | Original pytest functions or issue/PR links that supplied the behavior. |
 | `origin.docs` | no | Optional design-document references. |
-| `origin.assertion_types` | no | Review hint: assertion families carried by the fixture. |
 | `origin.notes` | no | Optional equivalence or provenance notes. |
 | `categories` | yes | Non-empty list from the allowed category set. |
 | `exclude_runners` | no | Non-empty list of current shared runners to exclude. Omit for all shared runners. |
-| `initial` | no | Runtime construction state and variables. |
-| `steps` | yes | Runtime observations. Use `[]` only when `initial.expect.raises` asserts constructor failure. |
+| `initial` | no | Optional runtime construction state and variables. Omit for normal cold start. |
 | `handlers` | no | Abstract-handler fixtures for public hook-call records. |
+| `steps` | yes | Runtime checkpoints. Use `[]` only when `initial.expect.raises` asserts constructor failure. |
+
+Rejected v1 or non-shared top-level fields include `schema_version`, `id`,
+`source`, `runners`, `runtime_options`, `model_build`, `commands`, and
+`expected_failure`.
 
 Allowed categories:
 
@@ -91,9 +94,14 @@ initial:
 
 Allowed fields:
 
-- `initial.state`: state path string or `null`
+- `initial.state`: dot-separated state path string or `null`
 - `initial.vars`: full variable snapshot mapping or `null`
 - `initial.expect.raises`: constructor exception expectation
+
+Omitting `initial` is the preferred cold-start spelling. `initial.state: null`
+is also legal and means no hot-start target is provided. `cycle: null` is still
+rejected; `null` is only meaningful for explicit state sentinels such as
+`initial.state` and `expect.state`.
 
 When `initial.expect` is present, `initial.state` and `initial.vars` keys must
 both be explicit. Constructor-failure fixtures must use `steps: []`.
@@ -119,58 +127,75 @@ Handlers install public abstract-hook observations:
 handlers:
   - action: Root.RootInit
     behavior: record_call
-  - action: Root.A.Touch
-    behavior: record_var_write_attempt
-    write:
-      name: x
-      value: 999
 ```
 
-Allowed handler behaviors:
+Allowed handler behavior:
 
-- `record_call`: appends one hook call record.
-- `record_var_write_attempt`: attempts `ctx.vars[name] = value` and records the
-  public read-only context result.
+- `record_call`: appends one public hook-call record.
 
-`raise_error` and handler exception metadata are not shared fixture behavior.
-They belong in ordinary simulator diagnostic tests.
+`record_var_write_attempt`, `raise_error`, handler exception metadata, duplicate
+registration behavior, override policy, warning/log/error metadata, and
+thread-safety concerns are not shared fixture behavior. They belong in ordinary
+simulator diagnostic tests.
 
-## Steps
+## Steps and cycle input
 
-A runtime step is either an initial assertion or a cycle call:
+Each step contains either `cycle`, `cycle_count`, or both, plus an `expect`
+mapping. `cycle` input is passed to `runtime.cycle(...)` repeatedly according to
+`cycle_count`.
 
 ```yaml
 steps:
-  - expect_initial:
-      state: [Root, A]
+  - cycle_count: 0
+    expect:
+      state: Root.A
       vars:
         counter: 0
       ended: false
-  - cycle:
-      events: [Root.A.Go]
+
+  - cycle: Root.A.Go
     expect:
-      state: [Root, B]
+      state: Root.B
       vars:
         counter: 10
-      ended: false
+
+  - cycle: [Root.B.Tick, Root.B.Flush]
+    cycle_count: 2
+    expect:
+      state: Root.Done
 ```
 
-`cycle` may be `{}`, `null`, a bare event-path string, or a mapping with only
-the `events` field. `events` may be `null` or a list. Each list item may be an
-event-path string or an event-object descriptor with exactly one `event` key:
+Allowed cycle shapes:
 
-```yaml
-cycle:
-  events:
-    - Root.A.Go
-    - {event: Root.A.Other}
-```
+| Shape | Python call | Meaning |
+|---|---|---|
+| `cycle: []` | `runtime.cycle([])` | One cycle with no input events. |
+| `cycle: Root.A.Go` | `runtime.cycle("Root.A.Go")` | One cycle with one event path. |
+| `cycle: [Root.A.Go, Root.B.Next]` | `runtime.cycle(["Root.A.Go", "Root.B.Next"])` | One cycle with multiple event paths. |
+| `cycle_count: 3` | `runtime.cycle([])` three times | Repeat empty-event cycles. |
+| `cycle: Root.A.Go` + `cycle_count: 3` | `runtime.cycle("Root.A.Go")` three times | Repeat the same event input. |
+| `cycle_count: 0` | no cycle call | Checkpoint immediately after construction or previous step. |
+
+`cycle_count` defaults to `1` when `cycle` is present. If `cycle_count` is
+present and `cycle` is omitted, `cycle` defaults to `[]`. A step that omits both
+`cycle` and `cycle_count` is invalid, because humans can easily misread a
+missing cycle as “do nothing.” Use `cycle_count: 0` for a no-cycle checkpoint.
+
+`cycle_count` must be a non-negative integer. Booleans, floats, strings, and
+negative values are rejected. `cycle_count: 0` is legal only when `cycle` is
+omitted or `cycle: []`; non-empty cycle input with `cycle_count: 0` is rejected.
+`cycle: []` with `cycle_count: N` where `N > 0` is legal but usually less clear
+than just writing `cycle_count: N`.
+
+Rejected v1 cycle shapes include `cycle: {}`, `cycle: null`,
+`cycle: {events: [...]}`, and event-object descriptors such as
+`cycle: [{event: Root.A.Go}]`.
 
 ## Expectations
 
 | Field | Meaning |
 |---|---|
-| `state` | Expected current state path as a list of segments, or `null` for ended runtime. |
+| `state` | Expected current state path as a dot-separated string, or `null` for ended runtime. |
 | `vars` | Partial variable-value assertion. |
 | `vars_exact` | Exact full `dict(runtime.vars)` assertion. |
 | `vars_keys` | Exact variable key-set assertion. |
@@ -179,20 +204,23 @@ cycle:
 | `raises` | Expected exception class name and optional message/cause match. |
 | `handler_calls` | Exact accumulated fixture-handler call records. |
 
-`vars` and `vars_exact` may both be present only when the partial `vars` mapping
-is consistent with `vars_exact`. `vars_keys` and `vars_absent` must not overlap.
+Expectations are sparse. Missing fields mean “do not assert this observation,”
+not a default value.
 
-Every `expect` or `expect_initial` mapping must assert at least one public
-observation field.
+Rules:
 
-## Simulator-only cycle return metadata
-
-`cycle_result` is intentionally not a shared fixture field.
-`pyfcstm.simulate.SimulationRuntime.cycle()` may return simulator debug metadata,
-including event-accounting details, but generated runtimes are not required to
-mirror that return object. Keep those assertions in ordinary simulator pytest
-files such as `test/simulate/test_event_inputs.py` and
-`test/simulate/test_runtime_contract_integration.py`.
+- Every `expect` mapping must assert at least one public observation field.
+- `vars` and `vars_exact` are mutually exclusive.
+- `vars_exact` is mutually exclusive with `vars_keys` and `vars_absent`, because
+  a full snapshot already fixes the variable key set.
+- `vars_keys` and `vars_absent` must not overlap.
+- `state: null` means the runtime is ended. `state: null` with `ended: false`,
+  or non-null `state` with `ended: true`, is a schema error.
+- `expect` must not contain `cycle_count`; repeat count is an input-side field,
+  not a runtime observation.
+- `return`, `cycle_result`, event accounting, stack, history, logs, warnings,
+  error-state metadata, anonymous-warning counters, and generated-template
+  private state IDs remain rejected.
 
 ## Exceptions
 
@@ -202,7 +230,7 @@ expect:
     type: SimulationRuntimeDfsError
     match: structural stack-depth safety limit
     match_kind: substring
-  state: [Root, A]
+  state: Root.A
   vars:
     counter: 1
   ended: false
@@ -217,10 +245,17 @@ Allowed exception type names:
 - `ValueError`
 
 `match_kind` and `cause_match_kind` may be `substring` or `regex`; default is
-`substring`. Exception steps may still assert rollback state, vars, and ended
-status through public fields.
+`substring`. `cause_match_kind` requires `cause_match`.
 
-## Handler Calls
+`expect.raises` is legal only when the effective step `cycle_count` is `1`.
+Constructor failures must use `initial.expect.raises` with `steps: []`. Repeated
+cycle failures must be split into multiple single-cycle steps so the failing
+cycle is explicit.
+
+Exception steps may still assert rollback state, variables, ended status, and
+handler-call records through public fields.
+
+## Handler calls
 
 ```yaml
 expect:
@@ -230,7 +265,17 @@ expect:
       stage: enter
       vars:
         x: 0
+      active_leaf: Root.A
+      call_stage: enter
+      abstract_target: Root.RootInit
+      named_ref: null
 ```
+
+`handler_calls` is the exact accumulated sequence from runtime construction,
+handler installation, and all executed steps up to the current checkpoint. A
+step with `handler_calls: []` asserts that no fixture handler has been called so
+far. Omitting `handler_calls` means the fixture does not assert handler calls at
+that checkpoint.
 
 Required handler-call fields:
 
@@ -245,16 +290,13 @@ Optional handler-call fields:
 - `call_stage`
 - `abstract_target`
 - `named_ref`
-- `write_attempt`
 
-When a handler call includes `write_attempt`, the record asserts the attempted
-variable name, attempted value, success flag, optional exception type, and the
-handler-visible variable snapshot after the attempt.
+Unknown handler-call fields, including `write_attempt`, are rejected.
 
 For generated Python alignment cases, the helper installs the same fixture
 handlers into both runtimes and asserts that their public call records match.
 
-## Generated Python Alignment Runner
+## Generated Python alignment runner
 
 `generated_python_alignment` builds a `SimulationRuntime` and a generated Python
 runtime from the same fixture DSL. The generated runtime is rendered from the
@@ -264,8 +306,8 @@ alignment runner checks construction outcomes and, after every step:
 - `is_ended`
 - variables
 - current state path
-- expected exception class names and messages
+- expected exception class names, messages, and causes
 - public handler call records
 
-It must not depend on private stack shape, cycle counters, history records, or
-other simulator internals.
+It must not depend on private stack shape, cycle counters, history records,
+cycle returns, event accounting, or other simulator internals.

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -848,7 +848,15 @@ def test_shared_fixture_accepts_initial_constructor_observation(tmp_path):
 
 @pytest.mark.unittest
 @pytest.mark.parametrize(
-    "field_name", ["input_events", "consumed_events", "unconsumed_events"]
+    "field_name",
+    [
+        "input_events",
+        "consumed_events",
+        "unconsumed_events",
+        "event_accounting",
+        "event_ledger",
+        "event_log",
+    ],
 )
 def test_shared_fixture_contract_rejects_event_accounting_fields(tmp_path, field_name):
     data = _shared_case_data()
@@ -881,6 +889,9 @@ def test_shared_fixture_corpus_uses_public_observation_fields():
         "input_events",
         "consumed_events",
         "unconsumed_events",
+        "event_accounting",
+        "event_ledger",
+        "event_log",
         "history",
         "history_tail",
         "history_length",

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -115,7 +115,7 @@ def test_semantic_fixture_assertion_families_are_executable():
     covered = set()
     for case in cases:
         for step in case.data.get("steps") or []:
-            expect = step.get("expect_initial") or step.get("expect") or {}
+            expect = step.get("expect") or {}
             if "ended" in expect:
                 covered.add("ended")
             if "state" in expect:
@@ -125,9 +125,9 @@ def test_semantic_fixture_assertion_families_are_executable():
                 for field in ("vars", "vars_exact", "vars_keys", "vars_absent")
             ):
                 covered.add("vars")
-            if step.get("cycle") not in (None, {}) and "events" in step.get(
-                "cycle", {}
-            ):
+            cycle_count = step.get("cycle_count", 1)
+            cycle_input = step.get("cycle", [])
+            if cycle_count > 0 and cycle_input:
                 covered.add("events")
             if "raises" in expect:
                 covered.add("exception")
@@ -154,7 +154,7 @@ def test_generated_alignment_constructor_outcome_helper_covers_three_modes():
     from test.testings.simulate_semantics import SemanticCase
 
     case = SemanticCase(
-        data={"id": "constructor_outcome_helper"},
+        data={"title": "constructor outcome helper"},
         yaml_path="/tmp/constructor_outcome_helper.yaml",
         fcstm_path="/tmp/constructor_outcome_helper.fcstm",
         dsl_code="state Root { state A; [*] -> A; }",
@@ -217,7 +217,6 @@ def test_initial_vars_override_fixture_runs_generated_alignment_contract():
     assert case.runners == ("simulation", "generated_python_alignment")
     assert case.data["initial"]["state"] == "Root.A"
     assert case.data["initial"]["vars"] == {"recovered": 5.0}
-    assert "initial" in case.data["origin"]["assertion_types"]
     assert "hot_start" in case.data["categories"]
     assert "template_alignment" in case.data["categories"]
 
@@ -290,27 +289,23 @@ def test_simulation_semantic_fixture(case):
 
 
 def _write_fixture(tmp_path, data, fcstm="state Root { state A; [*] -> A; }"):
-    yaml_path = tmp_path / ("%s.yaml" % data.get("id", "bad"))
-    fcstm_name = data.get("source", {}).get("fcstm", "bad.fcstm")
-    (tmp_path / fcstm_name).write_text(fcstm, encoding="utf-8")
+    yaml_path = tmp_path / "bad.yaml"
+    fcstm_path = tmp_path / "bad.fcstm"
+    fcstm_path.write_text(fcstm, encoding="utf-8")
     yaml_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
     return str(yaml_path)
 
 
 def _valid_case_data():
     return {
-        "schema_version": 1,
-        "id": "bad",
         "title": "Bad fixture used by schema tests",
-        "source": {"fcstm": "bad.fcstm"},
         "origin": {"files": ["test/example.py::test_example"]},
         "categories": ["runtime"],
-        "initial": {"state": None, "vars": None},
         "steps": [
             {
-                "cycle": {},
+                "cycle": [],
                 "expect": {
-                    "state": ["Root", "A"],
+                    "state": "Root.A",
                     "ended": False,
                 },
             },
@@ -332,16 +327,31 @@ def _shared_case_data():
     ["mutate", "message"],
     [
         (lambda data: data.update({"unexpected": True}), "unknown top-level fields"),
+        (lambda data: data.update({"schema_version": 2}), "unknown top-level fields"),
+        (lambda data: data.update({"id": "bad"}), "unknown top-level fields"),
+        (
+            lambda data: data.update({"source": {"fcstm": "bad.fcstm"}}),
+            "unknown top-level fields",
+        ),
         (lambda data: data.update({"boundary": "shared"}), "unknown top-level fields"),
-        (lambda data: data.update({"runners": ["simulation"]}), "unknown top-level fields"),
+        (
+            lambda data: data.update({"runners": ["simulation"]}),
+            "unknown top-level fields",
+        ),
         (lambda data: data.update({"commands": []}), "unknown top-level fields"),
         (
-            lambda data: data.update({"runtime_options": {"abstract_error_mode": "log"}}),
+            lambda data: data.update(
+                {"runtime_options": {"abstract_error_mode": "log"}}
+            ),
             "unknown top-level fields",
         ),
         (
             lambda data: data.update(
-                {"model_build": {"expect": {"raises": {"type": "ModelValidationError"}}}}
+                {
+                    "model_build": {
+                        "expect": {"raises": {"type": "ModelValidationError"}}
+                    }
+                }
             ),
             "unknown top-level fields",
         ),
@@ -349,9 +359,14 @@ def _shared_case_data():
             lambda data: data.update({"expected_failure": {"reason": "known bug"}}),
             "unknown top-level fields",
         ),
-        (lambda data: data["source"].pop("fcstm"), "source.fcstm is required"),
-        (lambda data: data["source"].update({"extra": "x"}), "source has unknown fields"),
-        (lambda data: data["origin"].update({"extra": "x"}), "origin has unknown fields"),
+        (
+            lambda data: data["origin"].update({"extra": "x"}),
+            "origin has unknown fields",
+        ),
+        (
+            lambda data: data["origin"].update({"assertion_types": ["state"]}),
+            "origin has unknown fields",
+        ),
         (lambda data: data.update({"categories": ["unknown"]}), "unknown categories"),
         (
             lambda data: data.update({"exclude_runners": ["unknown"]}),
@@ -385,7 +400,10 @@ def _shared_case_data():
             ),
             "exclude_runners cannot remove all default runners",
         ),
-        (lambda data: data.update({"handlers": "Root.Init"}), "handlers must be a list"),
+        (
+            lambda data: data.update({"handlers": "Root.Init"}),
+            "handlers must be a list",
+        ),
         (
             lambda data: data.update({"handlers": [{"action": "Root.Init"}]}),
             "handlers\\[0\\].behavior is required",
@@ -421,73 +439,70 @@ def _shared_case_data():
                     ]
                 }
             ),
-            "handlers\\[0\\].write must be a mapping",
+            "handlers\\[0\\].behavior is invalid",
         ),
         (
             lambda data: data.update(
                 {
                     "handlers": [
-                        {
-                            "action": "Root.Init",
-                            "behavior": "record_var_write_attempt",
-                            "write": {"name": "x", "value": 1, "extra": True},
-                        }
+                        {"action": "Root.Init", "behavior": "record_call", "write": {}}
                     ]
                 }
             ),
-            "handlers\\[0\\].write has unknown fields",
+            "handlers\\[0\\] has unknown fields",
         ),
         (
-            lambda data: data.update(
-                {
-                    "handlers": [
-                        {
-                            "action": "Root.Init",
-                            "behavior": "record_var_write_attempt",
-                            "write": {"value": 1},
-                        }
-                    ]
-                }
-            ),
-            "handlers\\[0\\].write.name is required",
-        ),
-        (
-            lambda data: data["initial"].update({"unexpected": True}),
+            lambda data: data.update({"initial": {"unexpected": True}}),
             "initial has unknown fields",
         ),
         (
-            lambda data: data["initial"].update(
-                {"state": "Root.A", "vars": {}, "expect": {"return": None}}
+            lambda data: data.update({"initial": {"state": ["Root", "A"]}}),
+            "initial.state must be a dot-separated state path string or null",
+        ),
+        (
+            lambda data: data.update(
+                {"initial": {"state": "Root.A", "vars": {}, "expect": {"return": None}}}
             ),
             "initial.expect has unknown fields",
         ),
         (
-            lambda data: (
-                data["initial"].pop("state")
-                or data["initial"].update(
-                    {"vars": {}, "expect": {"raises": {"type": "ValueError"}}}
-                )
+            lambda data: data.update(
+                {"initial": {"vars": {}, "expect": {"raises": {"type": "ValueError"}}}}
             ),
             "initial.expect requires initial.state",
         ),
         (
-            lambda data: (
-                data["initial"].pop("vars")
-                or data["initial"].update(
-                    {"state": "Root.A", "expect": {"raises": {"type": "ValueError"}}}
-                )
+            lambda data: data.update(
+                {
+                    "initial": {
+                        "state": "Root.A",
+                        "expect": {"raises": {"type": "ValueError"}},
+                    }
+                }
             ),
             "initial.expect requires initial.vars",
         ),
         (
-            lambda data: data["initial"].update(
-                {"state": "Root.A", "vars": {}, "expect": {"raises": {"type": "UnknownError"}}}
+            lambda data: data.update(
+                {
+                    "initial": {
+                        "state": "Root.A",
+                        "vars": {},
+                        "expect": {"raises": {"type": "UnknownError"}},
+                    }
+                }
             ),
             "initial.expect.raises.type is unknown",
         ),
         (
-            lambda data: data["initial"].update(
-                {"state": "Root.A", "vars": {}, "expect": {"raises": {"type": "ValueError"}}}
+            lambda data: data.update(
+                {
+                    "initial": {
+                        "state": "Root.A",
+                        "vars": {},
+                        "expect": {"raises": {"type": "ValueError"}},
+                    }
+                }
             ),
             "initial.expect.raises cases require empty steps",
         ),
@@ -499,31 +514,65 @@ def _shared_case_data():
         ),
         (
             lambda data: data["steps"][0].pop("cycle"),
-            "steps\\[0\\] must contain cycle or expect_initial",
+            "steps\\[0\\] must contain cycle or cycle_count",
         ),
         (
             lambda data: data["steps"][0].pop("expect"),
             "steps\\[0\\].expect is required",
         ),
         (
+            lambda data: data["steps"][0].update(
+                {"expect_initial": {"state": "Root.A"}}
+            ),
+            "steps\\[0\\] has unknown fields",
+        ),
+        (
             lambda data: data["steps"][0]["expect"].update({"unknown_expect": True}),
             "unknown fields",
         ),
         (
-            lambda data: data["steps"][0].update({"expect_initial": {"return": None}}),
-            "unknown fields",
+            lambda data: data["steps"][0]["expect"].update(
+                {"vars": {"x": 1}, "vars_exact": {"x": 1}}
+            ),
+            "vars and vars_exact conflict",
         ),
         (
             lambda data: data["steps"][0]["expect"].update(
-                {"vars": {"x": 1}, "vars_exact": {"x": 2}}
+                {"vars_exact": {"x": 1}, "vars_keys": ["x"]}
             ),
-            "vars and vars_exact conflict",
+            "vars_exact and vars_keys conflict",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"vars_exact": {"x": 1}, "vars_absent": ["tmp"]}
+            ),
+            "vars_exact and vars_absent conflict",
         ),
         (
             lambda data: data["steps"][0]["expect"].update(
                 {"vars_keys": ["tmp"], "vars_absent": ["tmp"]}
             ),
             "vars_keys and vars_absent overlap",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"state": ["Root", "A"]}),
+            "state must be a dot-separated state path string or null",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"state": None, "ended": False}
+            ),
+            "state and ended conflict",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update(
+                {"state": "Root.A", "ended": True}
+            ),
+            "state and ended conflict",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"ended": "false"}),
+            "ended must be a boolean",
         ),
         (
             lambda data: data["steps"][0]["expect"].update(
@@ -560,52 +609,70 @@ def _shared_case_data():
             "raises.cause_match_kind requires cause_match",
         ),
         (
-            lambda data: _set_expected_raises(data, {"type": "ValueError", "matc": "typo"}),
+            lambda data: _set_expected_raises(
+                data, {"type": "ValueError", "matc": "typo"}
+            ),
             "raises has unknown fields",
         ),
         (
-            lambda data: data["steps"][0]["expect"].update({"state": "Root.A"}),
-            "state must be a list",
+            lambda data: data["steps"][0].update({"cycle": {}}),
+            "cycle: {} is not valid v2",
         ),
         (
-            lambda data: data.update({"initial": {"state": ["Root", "A"]}}),
-            "initial.state must be a string",
+            lambda data: data["steps"][0].update({"cycle": None}),
+            "cycle: null is not valid v2",
         ),
         (
-            lambda data: data["steps"][0]["cycle"].update({"eventz": []}),
-            "cycle has unknown fields",
+            lambda data: data["steps"][0].update({"cycle": {"events": ["Root.A.Go"]}}),
+            "cycle.events is not valid v2",
+        ),
+        (
+            lambda data: data["steps"][0].update({"cycle": [{"event": "Root.A.Go"}]}),
+            r"cycle\[0\] must be a string event path",
         ),
         (
             lambda data: data["steps"][0].update({"cycle": 12}),
-            "cycle must be a mapping, string, or null",
+            "cycle must be a string event path or a list of string event paths",
         ),
         (
-            lambda data: data["steps"][0].update({"cycle": []}),
-            "cycle must be a mapping, string, or null",
+            lambda data: data["steps"][0].update({"cycle": [7]}),
+            r"cycle\[0\] must be a string event path",
         ),
         (
-            lambda data: data["steps"][0]["cycle"].update({"events": "Root.A.Go"}),
-            "cycle.events must be a list or null",
+            lambda data: data["steps"][0].update({"cycle_count": True}),
+            "cycle_count must be a non-negative integer",
         ),
         (
-            lambda data: data["steps"][0]["cycle"].update({"events": [7]}),
-            r"cycle.events\[0\] must be a string or event descriptor",
+            lambda data: data["steps"][0].update({"cycle_count": 1.5}),
+            "cycle_count must be a non-negative integer",
         ),
         (
-            lambda data: data["steps"][0]["cycle"].update(
-                {"events": [{"event": "Root.A.Go", "extra": True}]}
+            lambda data: data["steps"][0].update({"cycle_count": "1"}),
+            "cycle_count must be a non-negative integer",
+        ),
+        (
+            lambda data: data["steps"][0].update({"cycle_count": -1}),
+            "cycle_count must be a non-negative integer",
+        ),
+        (
+            lambda data: data["steps"][0].update(
+                {"cycle": "Root.A.Go", "cycle_count": 0}
             ),
-            r"cycle.events\[0\] event descriptor must contain only event",
+            "cycle_count: 0 cannot have non-empty cycle",
         ),
         (
-            lambda data: data["steps"][0]["cycle"].update(
-                {"events": [{"unknown": "Root.A.Go"}]}
+            lambda data: (
+                data["steps"][0].update({"cycle_count": 0})
+                or _set_expected_raises(data, {"type": "ValueError"})
             ),
-            r"cycle.events\[0\] event descriptor must contain only event",
+            "expect.raises requires effective cycle_count == 1",
         ),
         (
-            lambda data: data["steps"][0]["cycle"].update({"events": [{"event": 12}]}),
-            r"cycle.events\[0\].event must be a string",
+            lambda data: (
+                data["steps"][0].update({"cycle_count": 2})
+                or _set_expected_raises(data, {"type": "ValueError"})
+            ),
+            "expect.raises requires effective cycle_count == 1",
         ),
         (
             lambda data: data["steps"][0]["expect"].update(
@@ -628,16 +695,12 @@ def _shared_case_data():
                             "state": "Root",
                             "stage": "enter",
                             "vars": {},
-                            "write_attempt": {
-                                "name": "x",
-                                "value": 1,
-                                "succeeded": "no",
-                            },
+                            "write_attempt": {"name": "x"},
                         }
                     ]
                 }
             ),
-            "write_attempt.succeeded must be a boolean",
+            "handler_calls\\[0\\] has unknown fields",
         ),
         (
             lambda data: data["steps"][0]["expect"].update(
@@ -648,12 +711,16 @@ def _shared_case_data():
                             "state": "Root",
                             "stage": "enter",
                             "vars": {},
-                            "active_leaf": "Root",
+                            "active_leaf": ["Root"],
                         }
                     ]
                 }
             ),
-            "handler_calls\\[0\\].active_leaf must be a list",
+            "active_leaf must be a dot-separated state path string or null",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"handler_calls": []}),
+            "handler_calls requires top-level handlers",
         ),
         (
             lambda data: data["steps"][0]["expect"].update({"history": []}),
@@ -710,7 +777,9 @@ def _shared_case_data():
             "has unknown fields",
         ),
         (
-            lambda data: data["steps"][0]["expect"].update({"output_contains": "Commands"}),
+            lambda data: data["steps"][0]["expect"].update(
+                {"output_contains": "Commands"}
+            ),
             "has unknown fields",
         ),
         (
@@ -731,34 +800,18 @@ def test_semantic_fixture_schema_rejects_invalid_yaml(tmp_path, mutate, message)
 @pytest.mark.unittest
 def test_shared_fixture_accepts_public_observations(tmp_path):
     data = _shared_case_data()
-    data["handlers"] = [
-        {
-            "action": "Root.Init",
-            "behavior": "record_var_write_attempt",
-            "write": {"name": "x", "value": 1},
-        },
-        {"action": "Root.Init", "behavior": "record_call"},
-    ]
+    data["handlers"] = [{"action": "Root.Init", "behavior": "record_call"}]
     data["steps"][0]["expect"]["handler_calls"] = [
         {
             "action": "Root.Init",
             "state": "Root",
             "stage": "enter",
             "vars": {},
-            "write_attempt": {
-                "name": "x",
-                "value": 1,
-                "succeeded": False,
-                "error_type": "TypeError",
-                "vars": {},
-            },
-        },
-        {
-            "action": "Root.Init",
-            "state": "Root",
-            "stage": "enter",
-            "vars": {},
-        },
+            "active_leaf": "Root",
+            "call_stage": "enter",
+            "abstract_target": "Root.Init",
+            "named_ref": None,
+        }
     ]
     yaml_path = _write_fixture(tmp_path, data)
 
@@ -785,6 +838,9 @@ def test_shared_fixture_accepts_initial_constructor_observation(tmp_path):
 def test_shared_fixture_corpus_uses_public_observation_fields():
     disallowed_top_level_fields = {
         "boundary",
+        "id",
+        "schema_version",
+        "source",
         "runners",
         "model_build",
         "commands",
@@ -796,6 +852,10 @@ def test_shared_fixture_corpus_uses_public_observation_fields():
         "brief_stack",
         "cycle_count",
         "return",
+        "cycle_result",
+        "input_events",
+        "consumed_events",
+        "unconsumed_events",
         "history",
         "history_tail",
         "history_length",
@@ -810,13 +870,16 @@ def test_shared_fixture_corpus_uses_public_observation_fields():
     }
     cases = list(iter_semantic_cases())
     top_level_hits = {
-        field for case in cases for field in case.data if field in disallowed_top_level_fields
+        field
+        for case in cases
+        for field in case.data
+        if field in disallowed_top_level_fields
     }
     observation_hits = {
         field
         for case in cases
         for step in case.data.get("steps") or []
-        for expect in (step.get("expect_initial"), step.get("expect"))
+        for expect in (step.get("expect"),)
         if isinstance(expect, dict)
         for field in expect
         if field in disallowed_observation_fields
@@ -844,8 +907,13 @@ def test_shared_fixture_corpus_satisfies_current_contract():
 
     assert cases
     assert all("boundary" not in case.data for case in cases)
+    assert all("id" not in case.data for case in cases)
+    assert all("schema_version" not in case.data for case in cases)
+    assert all("source" not in case.data for case in cases)
     assert all("runners" not in case.data for case in cases)
-    assert all(case.runners == ("simulation", "generated_python_alignment") for case in cases)
+    assert all(
+        case.runners == ("simulation", "generated_python_alignment") for case in cases
+    )
     assert all("exclude_runners" not in case.data for case in cases)
 
 

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -747,6 +747,18 @@ def _shared_case_data():
             "has unknown fields",
         ),
         (
+            lambda data: data["steps"][0]["expect"].update({"input_events": []}),
+            "has unknown fields",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"consumed_events": []}),
+            "has unknown fields",
+        ),
+        (
+            lambda data: data["steps"][0]["expect"].update({"unconsumed_events": []}),
+            "has unknown fields",
+        ),
+        (
             lambda data: data["steps"][0]["expect"].update({"warnings": {"count": 0}}),
             "has unknown fields",
         ),
@@ -835,6 +847,19 @@ def test_shared_fixture_accepts_initial_constructor_observation(tmp_path):
 
 
 @pytest.mark.unittest
+@pytest.mark.parametrize(
+    "field_name", ["input_events", "consumed_events", "unconsumed_events"]
+)
+def test_shared_fixture_contract_rejects_event_accounting_fields(tmp_path, field_name):
+    data = _shared_case_data()
+    data["steps"][0]["expect"][field_name] = []
+    yaml_path = _write_fixture(tmp_path, data)
+
+    with pytest.raises(SemanticCaseError, match="has unknown fields"):
+        validate_shared_fixture_contract(data, yaml_path)
+
+
+@pytest.mark.unittest
 def test_shared_fixture_corpus_uses_public_observation_fields():
     disallowed_top_level_fields = {
         "boundary",
@@ -866,6 +891,8 @@ def test_shared_fixture_corpus_uses_public_observation_fields():
         "error_info",
         "anonymous_warning_count",
         "output_contains",
+        "output_not_contains",
+        "error_contains",
         "should_exit",
     }
     cases = list(iter_semantic_cases())

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -52,10 +52,7 @@ FIXTURE_ROOT = os.path.abspath(
 )
 CASE_DIR = os.path.join(FIXTURE_ROOT, "cases")
 _ALLOWED_TOP_LEVEL_FIELDS = {
-    "schema_version",
-    "id",
     "title",
-    "source",
     "origin",
     "categories",
     "exclude_runners",
@@ -63,8 +60,7 @@ _ALLOWED_TOP_LEVEL_FIELDS = {
     "steps",
     "handlers",
 }
-_ALLOWED_SOURCE_FIELDS = {"fcstm"}
-_ALLOWED_ORIGIN_FIELDS = {"files", "docs", "assertion_types", "notes"}
+_ALLOWED_ORIGIN_FIELDS = {"files", "docs", "notes"}
 _ALLOWED_CATEGORIES = {
     "runtime",
     "template_alignment",
@@ -91,17 +87,8 @@ _ALLOWED_EXPECT_FIELDS = {
     "raises",
     "handler_calls",
 }
-_ALLOWED_INITIAL_EXPECT_FIELDS = {
-    "state",
-    "vars",
-    "vars_exact",
-    "vars_keys",
-    "vars_absent",
-    "ended",
-}
 _ALLOWED_INITIAL_FIELDS = {"state", "vars", "expect"}
 _ALLOWED_INITIAL_CONSTRUCTOR_EXPECT_FIELDS = {"raises"}
-_ALLOWED_CYCLE_FIELDS = {"events"}
 _ALLOWED_RAISES_FIELDS = {
     "type",
     "match",
@@ -110,18 +97,15 @@ _ALLOWED_RAISES_FIELDS = {
     "cause_match",
     "cause_match_kind",
 }
-_ALLOWED_HANDLER_FIELDS = {"action", "behavior", "write"}
-_ALLOWED_HANDLER_BEHAVIORS = {"record_call", "record_var_write_attempt"}
-_ALLOWED_HANDLER_WRITE_FIELDS = {"name", "value"}
+_ALLOWED_HANDLER_FIELDS = {"action", "behavior"}
+_ALLOWED_HANDLER_BEHAVIORS = {"record_call"}
 _REQUIRED_HANDLER_CALL_FIELDS = {"action", "state", "stage", "vars"}
 _ALLOWED_HANDLER_CALL_FIELDS = _REQUIRED_HANDLER_CALL_FIELDS | {
     "active_leaf",
     "call_stage",
     "abstract_target",
     "named_ref",
-    "write_attempt",
 }
-_ALLOWED_WRITE_ATTEMPT_FIELDS = {"name", "value", "succeeded", "error_type", "vars"}
 _PUBLIC_EXPECT_FIELDS = {
     "state",
     "vars",
@@ -205,7 +189,7 @@ class SemanticCase:
 
     @property
     def id(self) -> str:
-        return str(self.data["id"])
+        return os.path.splitext(os.path.basename(self.yaml_path))[0]
 
     @property
     def runners(self) -> Sequence[str]:
@@ -224,7 +208,9 @@ def _validate_runner_list(
     allowed_runners: Iterable[str],
 ) -> Tuple[str, ...]:
     if not isinstance(value, list) or not value:
-        raise _case_error(case_id, yaml_path, "%s must be a non-empty list" % field_path)
+        raise _case_error(
+            case_id, yaml_path, "%s must be a non-empty list" % field_path
+        )
     if not all(isinstance(item, str) for item in value):
         raise _case_error(
             case_id, yaml_path, "%s must be a list of strings" % field_path
@@ -277,18 +263,31 @@ def _effective_runners_from_data(
     return effective
 
 
-def _as_tuple_path(
-    value: Any, case: SemanticCase, field_path: str
+def _path_segments_from_dot_string(
+    value: Any, case_id: str, yaml_path: str, field_path: str
 ) -> Optional[Tuple[str, ...]]:
     if value is None:
         return None
-    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+    if not isinstance(value, str) or not value:
         raise _case_error(
-            case.id,
-            case.yaml_path,
-            "%s must be a list of path segments or null" % field_path,
+            case_id,
+            yaml_path,
+            "%s must be a dot-separated state path string or null" % field_path,
         )
-    return tuple(value)
+    parts = value.split(".")
+    if any(not part for part in parts):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s must be a dot-separated state path string or null" % field_path,
+        )
+    return tuple(parts)
+
+
+def _as_tuple_path(
+    value: Any, case: SemanticCase, field_path: str
+) -> Optional[Tuple[str, ...]]:
+    return _path_segments_from_dot_string(value, case.id, case.yaml_path, field_path)
 
 
 def _vars_dict(runtime: Any) -> Dict[str, Any]:
@@ -309,9 +308,7 @@ def _handler_call_comparable_record(actual: Mapping[str, Any]) -> Dict[str, Any]
     state = actual.get("state")
     # Handlers may provide optional metadata directly. When a record omits an
     # optional field, derive the stable public value from required call data.
-    result.setdefault(
-        "active_leaf", state.split(".") if isinstance(state, str) else None
-    )
+    result.setdefault("active_leaf", state if isinstance(state, str) else None)
     result.setdefault("call_stage", actual.get("stage"))
     result.setdefault("abstract_target", actual.get("action"))
     result.setdefault("named_ref", None)
@@ -524,63 +521,142 @@ def _event_input_from_fixture_item(
 ) -> Any:
     if isinstance(item, str):
         return item
-    if isinstance(item, dict):
-        if set(item.keys()) != {"event"}:
-            raise _case_error(
-                case.id,
-                case.yaml_path,
-                "%s event descriptor must contain only event" % field_path,
-            )
-        path_name = item["event"]
-        if not isinstance(path_name, str):
-            raise _case_error(
-                case.id,
-                case.yaml_path,
-                "%s.event must be a string" % field_path,
-            )
-        state_machine = getattr(runtime, "state_machine", None)
-        if state_machine is None:
-            raise _case_error(
-                case.id,
-                case.yaml_path,
-                "%s.event requires a simulation runtime with state_machine"
-                % field_path,
-            )
-        return state_machine.resolve_event(path_name)
-    return item
+    raise _case_error(
+        case.id,
+        case.yaml_path,
+        "%s must be a string event path" % field_path,
+    )
 
 
 def _step_events(
     cycle_data: Any, runtime: Any, case: SemanticCase, field_path: str
 ) -> Any:
-    if cycle_data in (None, {}):
-        return None
     if isinstance(cycle_data, str):
         return cycle_data
-    if not isinstance(cycle_data, dict):
+    if isinstance(cycle_data, list):
+        return [
+            _event_input_from_fixture_item(
+                item,
+                runtime,
+                case,
+                "%s.cycle[%d]" % (field_path, index),
+            )
+            for index, item in enumerate(cycle_data)
+        ]
+    raise _case_error(
+        case.id,
+        case.yaml_path,
+        "%s.cycle must be a string event path or a list of string event paths"
+        % field_path,
+    )
+
+
+def _effective_cycle_count(
+    step: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> int:
+    if "cycle_count" in step:
+        cycle_count = step["cycle_count"]
+        if not isinstance(cycle_count, int) or isinstance(cycle_count, bool):
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.cycle_count must be a non-negative integer" % field_path,
+            )
+        if cycle_count < 0:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.cycle_count must be a non-negative integer" % field_path,
+            )
+        return cycle_count
+    return 1
+
+
+def _cycle_input_for_step(
+    step: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> Any:
+    if "cycle" not in step:
+        return []
+    cycle_data = step["cycle"]
+    if isinstance(cycle_data, str):
+        return cycle_data
+    if isinstance(cycle_data, list):
+        return cycle_data
+    if isinstance(cycle_data, dict):
+        if not cycle_data:
+            raise _case_error(
+                case_id, yaml_path, "%s.cycle: {} is not valid v2" % field_path
+            )
+        if "events" in cycle_data:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.cycle.events is not valid v2; use cycle: <event> or cycle: [<event>]"
+                % field_path,
+            )
         raise _case_error(
-            case.id,
-            case.yaml_path,
-            "%s.cycle must be a mapping, string, null, or omitted" % field_path,
+            case_id,
+            yaml_path,
+            "%s.cycle must be a string event path or a list of string event paths"
+            % field_path,
         )
-    events = cycle_data.get("events")
-    if events is None:
-        return None
-    if not isinstance(events, list):
+    if cycle_data is None:
         raise _case_error(
-            case.id,
-            case.yaml_path,
-            "%s.cycle.events must be a list or null" % field_path,
+            case_id, yaml_path, "%s.cycle: null is not valid v2" % field_path
         )
-    return [
-        _event_input_from_fixture_item(
-            item,
-            runtime,
-            case,
-            "%s.cycle.events[%d]" % (field_path, index),
+    raise _case_error(
+        case_id,
+        yaml_path,
+        "%s.cycle must be a string event path or a list of string event paths"
+        % field_path,
+    )
+
+
+def _validate_cycle_input_items(
+    cycle_input: Any, case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if isinstance(cycle_input, str):
+        return
+    if not isinstance(cycle_input, list):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.cycle must be a string event path or a list of string event paths"
+            % field_path,
         )
-        for index, item in enumerate(events)
-    ]
+    for index, item in enumerate(cycle_input):
+        if not isinstance(item, str):
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s.cycle[%d] must be a string event path" % (field_path, index),
+            )
+
+
+def _cycle_input_is_non_empty(cycle_input: Any) -> bool:
+    if isinstance(cycle_input, str):
+        return True
+    return bool(cycle_input)
+
+
+def _validate_step_cycle_shape(
+    step: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
+) -> None:
+    if "cycle" not in step and "cycle_count" not in step:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s must contain cycle or cycle_count" % field_path,
+        )
+    cycle_count = _effective_cycle_count(step, case_id, yaml_path, field_path)
+    cycle_input = _cycle_input_for_step(step, case_id, yaml_path, field_path)
+    _validate_cycle_input_items(cycle_input, case_id, yaml_path, field_path)
+    if cycle_count == 0 and _cycle_input_is_non_empty(cycle_input):
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s.cycle_count: 0 cannot have non-empty cycle" % field_path,
+        )
 
 
 def _run_step(
@@ -591,19 +667,10 @@ def _run_step(
     handler_calls: Optional[Sequence[Mapping[str, Any]]] = None,
 ) -> None:
     field_path = "steps[%d]" % index
-    if "expect_initial" in step:
-        expect = step["expect_initial"]
-        _assert_runtime_expectation(
-            runtime,
-            expect,
-            case,
-            field_path + ".expect_initial",
-            handler_calls=handler_calls,
-        )
-        return
-
     expect = step.get("expect") or {}
-    events = _step_events(step.get("cycle", {}), runtime, case, field_path)
+    cycle_count = _effective_cycle_count(step, case.id, case.yaml_path, field_path)
+    cycle_input = _cycle_input_for_step(step, case.id, case.yaml_path, field_path)
+    events = _step_events(cycle_input, runtime, case, field_path)
     if "raises" in expect:
         try:
             runtime.cycle(events)
@@ -613,11 +680,11 @@ def _run_step(
             _assert_exception(err, expect, case, field_path + ".expect.raises")
         else:
             raise AssertionError(
-                "%s %s expected exception %r"
-                % (case.id, field_path, expect["raises"])
+                "%s %s expected exception %r" % (case.id, field_path, expect["raises"])
             )
     else:
-        runtime.cycle(events)
+        for _ in range(cycle_count):
+            runtime.cycle(events)
     _assert_runtime_expectation(
         runtime,
         expect,
@@ -796,7 +863,6 @@ def _assert_aligned_constructor_outcome(
     _assert_exception(generated_err, expect, case, "initial.expect.raises")
 
 
-
 def _initial_kwargs(case: SemanticCase) -> Dict[str, Any]:
     initial = case.data.get("initial") or {}
     kwargs = {}
@@ -821,28 +887,7 @@ def _handler_call_record(ctx: Any) -> Dict[str, Any]:
     for name in ("active_leaf", "call_stage", "abstract_target", "named_ref"):
         if hasattr(ctx, name):
             value = getattr(ctx, name)
-            record[name] = list(value) if isinstance(value, tuple) else value
-    return record
-
-
-def _handler_var_write_record(ctx: Any, name: str, value: Any) -> Dict[str, Any]:
-    write_record = {
-        "name": name,
-        "value": value,
-        "succeeded": False,
-        "vars": dict(ctx.vars),
-    }
-    try:
-        ctx.vars[name] = value
-    except TypeError as err:
-        # MappingProxyType and other immutable mappings reject item assignment
-        # with TypeError; other exceptions should surface as test bugs.
-        write_record["error_type"] = type(err).__name__
-    else:
-        write_record["succeeded"] = True
-        write_record["vars"] = dict(ctx.vars)
-    record = _handler_call_record(ctx)
-    record["write_attempt"] = write_record
+            record[name] = ".".join(value) if isinstance(value, tuple) else value
     return record
 
 
@@ -852,11 +897,6 @@ def _run_fixture_handler(
     behavior = handler_data["behavior"]
     if behavior == "record_call":
         calls.append(_handler_call_record(ctx))
-    elif behavior == "record_var_write_attempt":
-        write_data = handler_data["write"]
-        calls.append(
-            _handler_var_write_record(ctx, write_data["name"], write_data["value"])
-        )
     else:
         raise ValueError("handlers behavior is invalid: %r" % behavior)
 
@@ -889,13 +929,12 @@ class _GeneratedPythonAlignmentRuntime:
     @property
     def state_machine(self):
         """
-        Return the simulator model used for fixture event-object descriptors.
+        Return the simulator model used for generated-runtime alignment.
 
-        Generated Python alignment cases still resolve YAML ``{event: ...}``
-        descriptors through the authoritative :class:`SimulationRuntime`
-        model, then pass the resulting model event to both runtimes. The
-        generated runtime accepts event-like objects by path today, while the
-        simulator verifies that the object belongs to the same model.
+        Schema v2 fixtures pass only string event paths or lists of string event
+        paths to :meth:`cycle`. The state machine remains available here for
+        alignment diagnostics and for callers that need to inspect the
+        authoritative simulator model while comparing generated behavior.
 
         :return: State machine model owned by the simulation runtime.
         :rtype: pyfcstm.model.StateMachine
@@ -968,8 +1007,6 @@ class _GeneratedPythonAlignmentRuntime:
         return self._simulation_runtime.current_state
 
     def cycle(self, events: Optional[Sequence[Any]] = None) -> Any:
-        sim_result = None
-        gen_result = None
         sim_exc = None
         gen_exc = None
         try:
@@ -979,7 +1016,7 @@ class _GeneratedPythonAlignmentRuntime:
             # alignment compares its class name with the generated runtime.
             sim_exc = err
         try:
-            gen_result = self._generated_runtime.cycle(events)
+            self._generated_runtime.cycle(events)
         except Exception as err:
             # Generated runtime has its own local exception classes, so class-name
             # comparison is the stable cross-runtime contract.
@@ -1202,13 +1239,23 @@ def _validate_vars_contract(
     expect: Mapping[str, Any], case_id: str, yaml_path: str, field_path: str
 ) -> None:
     if "vars" in expect and "vars_exact" in expect:
-        for name, value in dict(expect["vars"]).items():
-            if name in expect["vars_exact"] and expect["vars_exact"][name] != value:
-                raise _case_error(
-                    case_id,
-                    yaml_path,
-                    "%s vars and vars_exact conflict for %s" % (field_path, name),
-                )
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s vars and vars_exact conflict" % field_path,
+        )
+    if "vars_exact" in expect and "vars_keys" in expect:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s vars_exact and vars_keys conflict" % field_path,
+        )
+    if "vars_exact" in expect and "vars_absent" in expect:
+        raise _case_error(
+            case_id,
+            yaml_path,
+            "%s vars_exact and vars_absent conflict" % field_path,
+        )
     if "vars_keys" in expect and "vars_absent" in expect:
         overlap = set(expect["vars_keys"]) & set(expect["vars_absent"])
         if overlap:
@@ -1320,15 +1367,8 @@ def _validate_handler_calls(
             yaml_path,
             "%s.handler_calls[%d].vars" % (field_path, index),
         )
-        if "write_attempt" in item:
-            _validate_write_attempt(
-                item["write_attempt"],
-                case_id,
-                yaml_path,
-                "%s.handler_calls[%d].write_attempt" % (field_path, index),
-            )
         if "active_leaf" in item:
-            _validate_path_segments(
+            _validate_dot_state_path(
                 item["active_leaf"],
                 case_id,
                 yaml_path,
@@ -1348,46 +1388,10 @@ def _validate_handler_calls(
                 )
 
 
-def _validate_write_attempt(
+def _validate_dot_state_path(
     value: Any, case_id: str, yaml_path: str, field_path: str
 ) -> None:
-    if not isinstance(value, dict):
-        raise _case_error(case_id, yaml_path, "%s must be a mapping" % field_path)
-    unknown = set(value.keys()) - _ALLOWED_WRITE_ATTEMPT_FIELDS
-    if unknown:
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "%s has unknown fields: %r" % (field_path, sorted(unknown)),
-        )
-    for field_name in ("name", "error_type"):
-        if field_name in value and not isinstance(value[field_name], str):
-            raise _case_error(
-                case_id, yaml_path, "%s.%s must be a string" % (field_path, field_name)
-            )
-    if "name" not in value:
-        raise _case_error(case_id, yaml_path, "%s.name is required" % field_path)
-    if "value" not in value:
-        raise _case_error(case_id, yaml_path, "%s.value is required" % field_path)
-    if "succeeded" not in value or not isinstance(value["succeeded"], bool):
-        raise _case_error(
-            case_id, yaml_path, "%s.succeeded must be a boolean" % field_path
-        )
-    if "vars" in value:
-        _validate_vars_mapping(value["vars"], case_id, yaml_path, field_path + ".vars")
-
-
-def _validate_path_segments(
-    value: Any, case_id: str, yaml_path: str, field_path: str
-) -> None:
-    if value is None:
-        return
-    if not isinstance(value, list) or not all(
-        isinstance(segment, str) for segment in value
-    ):
-        raise _case_error(
-            case_id, yaml_path, "%s must be a list of strings or null" % field_path
-        )
+    _path_segments_from_dot_string(value, case_id, yaml_path, field_path)
 
 
 def _validate_vars_mapping(
@@ -1425,7 +1429,7 @@ def _validate_expect(
             "%s has unknown fields: %r" % (field_path, sorted(unknown)),
         )
     if "state" in expect:
-        _validate_path_segments(
+        _validate_dot_state_path(
             expect["state"], case_id, yaml_path, field_path + ".state"
         )
     for vars_field in ("vars", "vars_exact"):
@@ -1438,23 +1442,24 @@ def _validate_expect(
             _validate_string_list(
                 expect[list_field], case_id, yaml_path, field_path + "." + list_field
             )
+    if "ended" in expect and not isinstance(expect["ended"], bool):
+        raise _case_error(case_id, yaml_path, "%s.ended must be a boolean" % field_path)
+    if "state" in expect and "ended" in expect:
+        if expect["state"] is None and expect["ended"] is False:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s state and ended conflict" % field_path,
+            )
+        if expect["state"] is not None and expect["ended"] is True:
+            raise _case_error(
+                case_id,
+                yaml_path,
+                "%s state and ended conflict" % field_path,
+            )
     _validate_vars_contract(expect, case_id, yaml_path, field_path)
     _validate_raises(expect, case_id, yaml_path, field_path)
     _validate_handler_calls(expect, case_id, yaml_path, field_path)
-
-
-def _validate_source(source: Any, case_id: str, yaml_path: str) -> None:
-    if not isinstance(source, dict):
-        raise _case_error(case_id, yaml_path, "source must be a mapping")
-    unknown_source = set(source.keys()) - _ALLOWED_SOURCE_FIELDS
-    if unknown_source:
-        raise _case_error(
-            case_id, yaml_path, "source has unknown fields: %r" % sorted(unknown_source)
-        )
-    if not source.get("fcstm"):
-        raise _case_error(case_id, yaml_path, "source.fcstm is required")
-    if not isinstance(source["fcstm"], str):
-        raise _case_error(case_id, yaml_path, "source.fcstm must be a string")
 
 
 def _validate_origin(origin: Any, case_id: str, yaml_path: str) -> None:
@@ -1474,7 +1479,7 @@ def _validate_origin(origin: Any, case_id: str, yaml_path: str) -> None:
         raise _case_error(
             case_id, yaml_path, "origin.files must be a non-empty list of strings"
         )
-    for field_name in ("docs", "assertion_types", "notes"):
+    for field_name in ("docs", "notes"):
         if field_name in origin:
             _validate_string_list(
                 origin[field_name], case_id, yaml_path, "origin." + field_name
@@ -1495,8 +1500,10 @@ def _validate_initial(
             yaml_path,
             "initial has unknown fields: %r" % sorted(unknown_initial),
         )
-    if initial.get("state") is not None and not isinstance(initial.get("state"), str):
-        raise _case_error(case_id, yaml_path, "initial.state must be a string or null")
+    if initial.get("state") is not None:
+        _validate_dot_state_path(
+            initial.get("state"), case_id, yaml_path, "initial.state"
+        )
     if initial.get("vars") is not None:
         _validate_vars_mapping(initial.get("vars"), case_id, yaml_path, "initial.vars")
     if "expect" not in initial:
@@ -1526,71 +1533,6 @@ def _validate_initial(
     )
     if "raises" not in expect:
         raise _case_error(case_id, yaml_path, "initial.expect.raises is required")
-
-
-def _validate_cycle_event_item(
-    item: Any, case_id: str, yaml_path: str, field_path: str
-) -> None:
-    if isinstance(item, str):
-        return
-    if not isinstance(item, dict):
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "%s must be a string or event descriptor" % field_path,
-        )
-    if set(item.keys()) != {"event"}:
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "%s event descriptor must contain only event" % field_path,
-        )
-    if not isinstance(item["event"], str):
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "%s.event must be a string" % field_path,
-        )
-
-
-def _validate_cycle_data(
-    cycle_data: Any, case_id: str, yaml_path: str, field_path: str
-) -> None:
-    if cycle_data in (None, {}):
-        return
-    if isinstance(cycle_data, str):
-        return
-    if not isinstance(cycle_data, dict):
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "%s.cycle must be a mapping, string, or null" % field_path,
-        )
-    unknown_cycle = set(cycle_data.keys()) - _ALLOWED_CYCLE_FIELDS
-    if unknown_cycle:
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "%s.cycle has unknown fields: %r" % (field_path, sorted(unknown_cycle)),
-        )
-    if "events" not in cycle_data:
-        return
-    events = cycle_data["events"]
-    if events is None:
-        return
-    if not isinstance(events, list):
-        raise _case_error(
-            case_id,
-            yaml_path,
-            "%s.cycle.events must be a list or null" % field_path,
-        )
-    for event_index, item in enumerate(events):
-        _validate_cycle_event_item(
-            item,
-            case_id,
-            yaml_path,
-            "%s.cycle.events[%d]" % (field_path, event_index),
-        )
 
 
 def _validate_handlers(
@@ -1639,41 +1581,6 @@ def _validate_handlers(
                 yaml_path,
                 "handlers[%d].behavior is invalid: %r" % (index, item["behavior"]),
             )
-        if item["behavior"] != "record_var_write_attempt" and "write" in item:
-            raise _case_error(
-                case_id,
-                yaml_path,
-                "handlers[%d].write is only allowed for record_var_write_attempt"
-                % index,
-            )
-        if item["behavior"] == "record_var_write_attempt":
-            write_data = item.get("write")
-            if not isinstance(write_data, dict):
-                raise _case_error(
-                    case_id, yaml_path, "handlers[%d].write must be a mapping" % index
-                )
-            unknown_write = set(write_data.keys()) - _ALLOWED_HANDLER_WRITE_FIELDS
-            if unknown_write:
-                raise _case_error(
-                    case_id,
-                    yaml_path,
-                    "handlers[%d].write has unknown fields: %r"
-                    % (index, sorted(unknown_write)),
-                )
-            if "name" not in write_data:
-                raise _case_error(
-                    case_id, yaml_path, "handlers[%d].write.name is required" % index
-                )
-            if not isinstance(write_data["name"], str):
-                raise _case_error(
-                    case_id,
-                    yaml_path,
-                    "handlers[%d].write.name must be a string" % index,
-                )
-            if "value" not in write_data:
-                raise _case_error(
-                    case_id, yaml_path, "handlers[%d].write.value is required" % index
-                )
 
 
 def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) -> None:
@@ -1697,12 +1604,14 @@ def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) ->
 
         >>> validate_shared_fixture_contract(
         ...     {
-        ...         "id": "shared_case",
+        ...         "title": "shared case",
+        ...         "origin": {"files": ["test/example.py::test_example"]},
+        ...         "categories": ["runtime"],
         ...         "steps": [
         ...             {
-        ...                 "cycle": {},
+        ...                 "cycle": [],
         ...                 "expect": {
-        ...                     "state": ["Root", "A"],
+        ...                     "state": "Root.A",
         ...                     "ended": False,
         ...                 },
         ...             }
@@ -1712,8 +1621,10 @@ def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) ->
         ... )
         >>> validate_shared_fixture_contract(
         ...     {
-        ...         "id": "bad_case",
-        ...         "steps": [{"expect": {"bogus": None}}],
+        ...         "title": "bad case",
+        ...         "origin": {"files": ["test/example.py::test_example"]},
+        ...         "categories": ["runtime"],
+        ...         "steps": [{"cycle": [], "expect": {"bogus": None}}],
         ...     },
         ...     "/tmp/bad_case.yaml",
         ... )
@@ -1721,7 +1632,7 @@ def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) ->
         ...
         test.testings.simulate_semantics.SemanticCaseError: bad_case (/tmp/bad_case.yaml): steps[0].expect has unknown fields: ['bogus']
     """
-    case_id = str(data.get("id", "<unknown>")) if isinstance(data, dict) else "<unknown>"
+    case_id = os.path.splitext(os.path.basename(yaml_path))[0]
     if not isinstance(data, dict):
         raise _case_error(case_id, yaml_path, "fixture data must be a mapping")
     unknown_top_level = set(data.keys()) - _ALLOWED_TOP_LEVEL_FIELDS
@@ -1781,29 +1692,19 @@ def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) ->
                 raise _case_error(
                     case_id,
                     yaml_path,
-                    "handlers[%d].behavior is invalid: %r"
-                    % (handler_index, behavior),
-                )
-            if behavior != "record_var_write_attempt" and "write" in handler:
-                raise _case_error(
-                    case_id,
-                    yaml_path,
-                    "handlers[%d].write is only allowed for record_var_write_attempt"
-                    % handler_index,
+                    "handlers[%d].behavior is invalid: %r" % (handler_index, behavior),
                 )
     steps = data.get("steps")
     if not isinstance(steps, list):
         raise _case_error(case_id, yaml_path, "shared fixture requires steps")
     if not steps and not has_initial_expect:
-        raise _case_error(
-            case_id, yaml_path, "shared fixture requires non-empty steps"
-        )
+        raise _case_error(case_id, yaml_path, "shared fixture requires non-empty steps")
     for step_index, step in enumerate(steps):
         if not isinstance(step, dict):
             raise _case_error(
                 case_id, yaml_path, "steps[%d] must be a mapping" % step_index
             )
-        for expect_name in ("expect_initial", "expect"):
+        for expect_name in ("expect",):
             expect = step.get(expect_name)
             if not isinstance(expect, dict):
                 continue
@@ -1823,21 +1724,14 @@ def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) ->
 
 
 def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
-    case_id = str(data.get("id", "<unknown>"))
+    case_id = os.path.splitext(os.path.basename(yaml_path))[0]
     unknown = set(data.keys()) - _ALLOWED_TOP_LEVEL_FIELDS
     if unknown:
         raise _case_error(
             case_id, yaml_path, "unknown top-level fields: %r" % sorted(unknown)
         )
-    if data.get("schema_version") != 1:
-        raise _case_error(case_id, yaml_path, "schema_version must be 1")
-    if not data.get("id"):
-        raise _case_error(case_id, yaml_path, "id is required")
     if not data.get("title") or not isinstance(data.get("title"), str):
         raise _case_error(case_id, yaml_path, "title is required")
-    if os.path.splitext(os.path.basename(yaml_path))[0] != case_id:
-        raise _case_error(case_id, yaml_path, "id must match YAML file name")
-    _validate_source(data.get("source"), case_id, yaml_path)
     _validate_origin(data.get("origin"), case_id, yaml_path)
     categories = data.get("categories")
     if not isinstance(categories, list) or not categories:
@@ -1872,52 +1766,36 @@ def _validate_case_data(data: Mapping[str, Any], yaml_path: str) -> None:
                     case_id, yaml_path, "steps[%d] must be a mapping" % index
                 )
             field_path = "steps[%d]" % index
-            if "expect_initial" in step:
-                unknown_step = set(step.keys()) - {"expect_initial"}
-                if unknown_step:
-                    raise _case_error(
-                        case_id,
-                        yaml_path,
-                        "%s has unknown fields: %r"
-                        % (
-                            field_path,
-                            sorted(unknown_step),
-                        ),
-                    )
-                _validate_expect(
-                    step["expect_initial"],
+            unknown_step = set(step.keys()) - {"cycle", "cycle_count", "expect"}
+            if unknown_step:
+                raise _case_error(
                     case_id,
                     yaml_path,
-                    field_path + ".expect_initial",
-                    runners,
-                    allowed_fields=_ALLOWED_INITIAL_EXPECT_FIELDS,
+                    "%s has unknown fields: %r"
+                    % (
+                        field_path,
+                        sorted(unknown_step),
+                    ),
                 )
-            else:
-                unknown_step = set(step.keys()) - {"cycle", "expect"}
-                if unknown_step:
+            if "expect" not in step:
+                raise _case_error(
+                    case_id, yaml_path, "%s.expect is required" % field_path
+                )
+            _validate_step_cycle_shape(step, case_id, yaml_path, field_path)
+            _validate_expect(
+                step["expect"], case_id, yaml_path, field_path + ".expect", runners
+            )
+            if "raises" in step["expect"]:
+                cycle_count = _effective_cycle_count(
+                    step, case_id, yaml_path, field_path
+                )
+                if cycle_count != 1:
                     raise _case_error(
                         case_id,
                         yaml_path,
-                        "%s has unknown fields: %r"
-                        % (
-                            field_path,
-                            sorted(unknown_step),
-                        ),
+                        "%s.expect.raises requires effective cycle_count == 1"
+                        % field_path,
                     )
-                if "cycle" not in step:
-                    raise _case_error(
-                        case_id,
-                        yaml_path,
-                        "%s must contain cycle or expect_initial" % field_path,
-                    )
-                if "expect" not in step:
-                    raise _case_error(
-                        case_id, yaml_path, "%s.expect is required" % field_path
-                    )
-                _validate_cycle_data(step.get("cycle"), case_id, yaml_path, field_path)
-                _validate_expect(
-                    step["expect"], case_id, yaml_path, field_path + ".expect", runners
-                )
     validate_shared_fixture_contract(data, yaml_path)
 
 
@@ -1955,10 +1833,11 @@ def load_semantic_case(path_or_id: str) -> SemanticCase:
     if not isinstance(data, dict):
         raise SemanticCaseError("%s: fixture YAML must be a mapping" % yaml_path)
     _validate_case_data(data, yaml_path)
-    fcstm_path = os.path.join(os.path.dirname(yaml_path), data["source"]["fcstm"])
+    case_id = os.path.splitext(os.path.basename(yaml_path))[0]
+    fcstm_path = os.path.join(os.path.dirname(yaml_path), case_id + ".fcstm")
     if not os.path.isfile(fcstm_path):
         raise _case_error(
-            str(data["id"]), yaml_path, "source.fcstm does not exist: %s" % fcstm_path
+            case_id, yaml_path, "paired FCSTM source does not exist: %s" % fcstm_path
         )
     with open(fcstm_path, "r", encoding="utf-8") as file:
         dsl_code = file.read()

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -1590,7 +1590,9 @@ def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) ->
     The fixture corpus has a single current schema: every case is shared by
     default, uses exclude-only runner selection, and may only assert public
     observations that are stable across the simulator and generated Python
-    alignment runtime.
+    alignment runtime. This guard enforces the shared public-observation
+    surface; :func:`load_semantic_case` applies the full fixture schema before
+    constructing a :class:`SemanticCase`.
 
     :param data: Parsed fixture YAML mapping.
     :type data: typing.Mapping[str, typing.Any]
@@ -1708,6 +1710,14 @@ def validate_shared_fixture_contract(data: Mapping[str, Any], yaml_path: str) ->
             expect = step.get(expect_name)
             if not isinstance(expect, dict):
                 continue
+            field_path = "steps[%d].%s" % (step_index, expect_name)
+            unknown_expect = set(expect.keys()) - _PUBLIC_EXPECT_FIELDS
+            if unknown_expect:
+                raise _case_error(
+                    case_id,
+                    yaml_path,
+                    "%s has unknown fields: %r" % (field_path, sorted(unknown_expect)),
+                )
             public_expect = _PUBLIC_EXPECT_FIELDS & set(expect.keys())
             if not public_expect:
                 raise _case_error(

--- a/tools/inventory_simulate_semantics.py
+++ b/tools/inventory_simulate_semantics.py
@@ -45,6 +45,9 @@ DISALLOWED_EXPECTATION_FIELDS = (
     "input_events",
     "consumed_events",
     "unconsumed_events",
+    "event_accounting",
+    "event_ledger",
+    "event_log",
     "history",
     "history_tail",
     "history_length",
@@ -210,6 +213,17 @@ def _expectation_field_counts(records: Sequence[SemanticCaseRecord]) -> Dict[str
         for field_name in set(_expectation_fields(record)):
             counter[field_name] += 1
     return {field_name: counter[field_name] for field_name in sorted(counter)}
+
+
+def _unknown_expectation_field_case_ids(
+    records: Sequence[SemanticCaseRecord],
+) -> Dict[str, List[str]]:
+    known_fields = set(PUBLIC_EXPECTATION_FIELDS) | set(DISALLOWED_EXPECTATION_FIELDS)
+    result = {}
+    for record in records:
+        for field_name in set(_expectation_fields(record)) - known_fields:
+            result.setdefault(field_name, []).append(record.case_id)
+    return {field_name: result[field_name] for field_name in sorted(result)}
 
 
 def _step_count(records: Sequence[SemanticCaseRecord]) -> int:
@@ -381,6 +395,7 @@ def _render_report(
         ]
         for field_name in DISALLOWED_EXPECTATION_FIELDS
     }
+    unknown_expectation_cases = _unknown_expectation_field_case_ids(records)
     legacy_cycle_cases = _legacy_cycle_shape_case_ids(records)
     legacy_path_cases = _legacy_path_shape_case_ids(records)
     public_expectation_counts = {
@@ -401,6 +416,9 @@ def _render_report(
     )
     disallowed_expectation_hits = sorted(
         set().union(*(set(items) for items in disallowed_expectation_cases.values()))
+    )
+    unknown_expectation_hits = sorted(
+        set().union(*(set(items) for items in unknown_expectation_cases.values()))
     )
     legacy_cycle_hits = sorted(
         set().union(*(set(items) for items in legacy_cycle_cases.values()))
@@ -499,8 +517,13 @@ def _render_report(
                 ),
                 (
                     "契约外观察字段",
-                    _case_ids(disallowed_expectation_hits),
-                    "通过：未出现 stack、cycle_count、history*、cycle_result、return、event accounting、logs、warnings 或错误诊断字段。",
+                    _case_ids(
+                        sorted(
+                            set(disallowed_expectation_hits)
+                            | set(unknown_expectation_hits)
+                        )
+                    ),
+                    "通过：只出现 state、vars、vars_exact、vars_keys、vars_absent、ended、raises 和 handler_calls 公开观察字段；未出现 event accounting 或其他私有观察字段。",
                 ),
                 (
                     "长期 Markdown 文件",
@@ -602,6 +625,17 @@ def _render_report(
                 (field_name, str(len(disallowed_expectation_cases[field_name])))
                 for field_name in DISALLOWED_EXPECTATION_FIELDS
             ),
+        ),
+        "",
+        "## Unknown Expectation Field Counts",
+        "",
+        _format_markdown_table(
+            ("Expectation field", "Case files"),
+            tuple(
+                (field_name, str(len(case_ids)))
+                for field_name, case_ids in sorted(unknown_expectation_cases.items())
+            )
+            or (("-", "0"),),
         ),
         "",
         "## Handler Behavior Distribution",
@@ -738,6 +772,13 @@ def _field_contract_errors(records: Sequence[SemanticCaseRecord]) -> List[str]:
                 "shared fixture 观察字段 %s 不属于公开观察面，命中：%s"
                 % (field_name, _case_ids(case_ids))
             )
+
+    unknown_expectation_cases = _unknown_expectation_field_case_ids(records)
+    for field_name, case_ids in sorted(unknown_expectation_cases.items()):
+        errors.append(
+            "shared fixture 观察字段 %s 未在 schema v2 公开观察面中声明，命中：%s"
+            % (field_name, _case_ids(case_ids))
+        )
     return errors
 
 

--- a/tools/inventory_simulate_semantics.py
+++ b/tools/inventory_simulate_semantics.py
@@ -25,12 +25,17 @@ DEFAULT_SHARED_RUNNERS = ("simulation", "generated_python_alignment")
 ALLOWED_MARKDOWN_FILES = ("README.md", "schema.md")
 DISALLOWED_TOP_LEVEL_FIELDS = (
     "boundary",
+    "id",
+    "schema_version",
+    "source",
     "runners",
     "runtime_options",
     "model_build",
     "commands",
     "expected_failure",
 )
+DISALLOWED_ORIGIN_FIELDS = ("assertion_types",)
+DISALLOWED_STEP_FIELDS = ("expect_initial",)
 DISALLOWED_EXPECTATION_FIELDS = (
     "stack",
     "brief_stack",
@@ -50,6 +55,18 @@ DISALLOWED_EXPECTATION_FIELDS = (
     "output_not_contains",
     "error_contains",
     "should_exit",
+)
+LEGACY_CYCLE_SHAPES = (
+    "cycle_null",
+    "cycle_mapping",
+    "cycle_empty_mapping",
+    "cycle_events_mapping",
+    "cycle_event_descriptor",
+)
+LEGACY_PATH_SHAPES = (
+    "initial_state_list",
+    "expect_state_list",
+    "handler_active_leaf_list",
 )
 PUBLIC_EXPECTATION_FIELDS = (
     "state",
@@ -134,10 +151,9 @@ def _expectation_fields(record: SemanticCaseRecord) -> List[str]:
     for step in record.data.get("steps") or []:
         if not isinstance(step, Mapping):
             continue
-        for expect_name in ("expect_initial", "expect"):
-            expect = step.get(expect_name)
-            if isinstance(expect, Mapping):
-                result.extend(str(key) for key in expect.keys())
+        expect = step.get("expect")
+        if isinstance(expect, Mapping):
+            result.extend(str(key) for key in expect.keys())
     initial = record.data.get("initial")
     if isinstance(initial, Mapping):
         expect = initial.get("expect")
@@ -150,8 +166,36 @@ def _field_case_ids(
     records: Sequence[SemanticCaseRecord], fields: Sequence[str]
 ) -> Dict[str, List[str]]:
     return {
+        field_name: [record.case_id for record in records if field_name in record.data]
+        for field_name in fields
+    }
+
+
+def _origin_field_case_ids(
+    records: Sequence[SemanticCaseRecord], fields: Sequence[str]
+) -> Dict[str, List[str]]:
+    return {
         field_name: [
-            record.case_id for record in records if field_name in record.data
+            record.case_id
+            for record in records
+            if isinstance(record.data.get("origin"), Mapping)
+            and field_name in record.data["origin"]
+        ]
+        for field_name in fields
+    }
+
+
+def _step_field_case_ids(
+    records: Sequence[SemanticCaseRecord], fields: Sequence[str]
+) -> Dict[str, List[str]]:
+    return {
+        field_name: [
+            record.case_id
+            for record in records
+            if any(
+                isinstance(step, Mapping) and field_name in step
+                for step in record.data.get("steps") or []
+            )
         ]
         for field_name in fields
     }
@@ -163,6 +207,117 @@ def _expectation_field_counts(records: Sequence[SemanticCaseRecord]) -> Dict[str
         for field_name in set(_expectation_fields(record)):
             counter[field_name] += 1
     return {field_name: counter[field_name] for field_name in sorted(counter)}
+
+
+def _step_count(records: Sequence[SemanticCaseRecord]) -> int:
+    return sum(
+        len(record.data.get("steps") or [])
+        for record in records
+        if isinstance(record.data.get("steps") or [], list)
+    )
+
+
+def _cycle_shape_counts(records: Sequence[SemanticCaseRecord]) -> Counter:
+    result = Counter()
+    for record in records:
+        for step in record.data.get("steps") or []:
+            if not isinstance(step, Mapping):
+                continue
+            if "cycle_count" in step:
+                result["steps with cycle_count"] += 1
+            if "cycle" not in step:
+                result["steps without cycle"] += 1
+                continue
+            cycle = step["cycle"]
+            if cycle is None:
+                result["cycle_null"] += 1
+            elif isinstance(cycle, str):
+                result["cycle_string"] += 1
+            elif isinstance(cycle, list):
+                if not cycle:
+                    result["cycle_empty_list"] += 1
+                else:
+                    result["cycle_list"] += 1
+                if any(isinstance(item, Mapping) for item in cycle):
+                    result["cycle_event_descriptor"] += 1
+            elif isinstance(cycle, Mapping):
+                result["cycle_mapping"] += 1
+                if not cycle:
+                    result["cycle_empty_mapping"] += 1
+                if "events" in cycle:
+                    result["cycle_events_mapping"] += 1
+                    events = cycle.get("events")
+                    if isinstance(events, list) and any(
+                        isinstance(item, Mapping) for item in events
+                    ):
+                        result["cycle_event_descriptor"] += 1
+            else:
+                result["cycle_other"] += 1
+    return result
+
+
+def _legacy_cycle_shape_case_ids(
+    records: Sequence[SemanticCaseRecord],
+) -> Dict[str, List[str]]:
+    result = {field_name: [] for field_name in LEGACY_CYCLE_SHAPES}
+    for record in records:
+        found = {field_name: False for field_name in LEGACY_CYCLE_SHAPES}
+        for step in record.data.get("steps") or []:
+            if not isinstance(step, Mapping) or "cycle" not in step:
+                continue
+            cycle = step["cycle"]
+            if cycle is None:
+                found["cycle_null"] = True
+            elif isinstance(cycle, Mapping):
+                found["cycle_mapping"] = True
+                if not cycle:
+                    found["cycle_empty_mapping"] = True
+                if "events" in cycle:
+                    found["cycle_events_mapping"] = True
+                    events = cycle.get("events")
+                    if isinstance(events, list) and any(
+                        isinstance(item, Mapping) for item in events
+                    ):
+                        found["cycle_event_descriptor"] = True
+            elif isinstance(cycle, list) and any(
+                isinstance(item, Mapping) for item in cycle
+            ):
+                found["cycle_event_descriptor"] = True
+        for field_name, present in found.items():
+            if present:
+                result[field_name].append(record.case_id)
+    return result
+
+
+def _legacy_path_shape_case_ids(
+    records: Sequence[SemanticCaseRecord],
+) -> Dict[str, List[str]]:
+    result = {field_name: [] for field_name in LEGACY_PATH_SHAPES}
+    for record in records:
+        initial = record.data.get("initial")
+        if isinstance(initial, Mapping) and isinstance(initial.get("state"), list):
+            result["initial_state_list"].append(record.case_id)
+        expect_state_hit = False
+        handler_active_leaf_hit = False
+        for step in record.data.get("steps") or []:
+            if not isinstance(step, Mapping):
+                continue
+            expect = step.get("expect")
+            if not isinstance(expect, Mapping):
+                continue
+            if isinstance(expect.get("state"), list):
+                expect_state_hit = True
+            calls = expect.get("handler_calls")
+            if isinstance(calls, list) and any(
+                isinstance(item, Mapping) and isinstance(item.get("active_leaf"), list)
+                for item in calls
+            ):
+                handler_active_leaf_hit = True
+        if expect_state_hit:
+            result["expect_state_list"].append(record.case_id)
+        if handler_active_leaf_hit:
+            result["handler_active_leaf_list"].append(record.case_id)
+    return result
 
 
 def _handler_behavior_distribution(records: Sequence[SemanticCaseRecord]) -> Counter:
@@ -182,7 +337,9 @@ def _handler_behavior_distribution(records: Sequence[SemanticCaseRecord]) -> Cou
     return result
 
 
-def _format_markdown_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> str:
+def _format_markdown_table(
+    headers: Sequence[str], rows: Sequence[Sequence[str]]
+) -> str:
     lines = [
         "| %s |" % " | ".join(headers),
         "|%s|" % "|".join("---" for _ in headers),
@@ -210,6 +367,8 @@ def _render_report(
         runner_combo_counter[", ".join(record.runners)] += 1
 
     disallowed_top_level_cases = _field_case_ids(records, DISALLOWED_TOP_LEVEL_FIELDS)
+    disallowed_origin_cases = _origin_field_case_ids(records, DISALLOWED_ORIGIN_FIELDS)
+    disallowed_step_cases = _step_field_case_ids(records, DISALLOWED_STEP_FIELDS)
     expectation_field_counts = _expectation_field_counts(records)
     disallowed_expectation_cases = {
         field_name: [
@@ -219,17 +378,32 @@ def _render_report(
         ]
         for field_name in DISALLOWED_EXPECTATION_FIELDS
     }
+    legacy_cycle_cases = _legacy_cycle_shape_case_ids(records)
+    legacy_path_cases = _legacy_path_shape_case_ids(records)
     public_expectation_counts = {
         field_name: expectation_field_counts.get(field_name, 0)
         for field_name in PUBLIC_EXPECTATION_FIELDS
     }
+    cycle_shape_counts = _cycle_shape_counts(records)
     handler_distribution = _handler_behavior_distribution(records)
 
     disallowed_top_level_hits = sorted(
         set().union(*(set(items) for items in disallowed_top_level_cases.values()))
     )
+    disallowed_origin_hits = sorted(
+        set().union(*(set(items) for items in disallowed_origin_cases.values()))
+    )
+    disallowed_step_hits = sorted(
+        set().union(*(set(items) for items in disallowed_step_cases.values()))
+    )
     disallowed_expectation_hits = sorted(
         set().union(*(set(items) for items in disallowed_expectation_cases.values()))
+    )
+    legacy_cycle_hits = sorted(
+        set().union(*(set(items) for items in legacy_cycle_cases.values()))
+    )
+    legacy_path_hits = sorted(
+        set().union(*(set(items) for items in legacy_path_cases.values()))
     )
     markdown_files = _fixture_markdown_files(root)
     markdown_file_names = [path.name for path in markdown_files]
@@ -248,6 +422,7 @@ def _render_report(
             (
                 ("YAML cases", str(len(records))),
                 ("FCSTM files", str(fcstm_count)),
+                ("Runtime steps", str(_step_count(records))),
                 (
                     "Runner counts",
                     ", ".join(
@@ -288,14 +463,36 @@ def _render_report(
                     "runners 字段=%s；exclude_runners 字段=%s"
                     % (
                         len(disallowed_top_level_cases["runners"]),
-                        sum(1 for record in records if "exclude_runners" in record.data),
+                        sum(
+                            1 for record in records if "exclude_runners" in record.data
+                        ),
                     ),
                     "通过：当前 corpus 只使用默认 runner 集合加排除例外。",
                 ),
                 (
                     "契约外 top-level 字段",
                     _case_ids(disallowed_top_level_hits),
-                    "通过：未出现 boundary、runners、runtime_options、model_build、commands 或 expected_failure。",
+                    "通过：未出现 v1 id/schema/source、runners、runtime_options、model_build、commands 或 expected_failure。",
+                ),
+                (
+                    "契约外 origin 字段",
+                    _case_ids(disallowed_origin_hits),
+                    "通过：未出现 origin.assertion_types 等旧维护提示字段。",
+                ),
+                (
+                    "契约外 step 字段",
+                    _case_ids(disallowed_step_hits),
+                    "通过：未出现 expect_initial 等 v1 step 字段。",
+                ),
+                (
+                    "旧 cycle 形态",
+                    _case_ids(legacy_cycle_hits),
+                    "通过：未出现 cycle: {}、cycle.events、cycle: null 或 event descriptor。",
+                ),
+                (
+                    "旧 path 形态",
+                    _case_ids(legacy_path_hits),
+                    "通过：state / active_leaf 均使用 dot-string 或 null。",
                 ),
                 (
                     "契约外观察字段",
@@ -309,6 +506,28 @@ def _render_report(
                     if tuple(markdown_file_names) == ALLOWED_MARKDOWN_FILES
                     else "失败：顶层 Markdown 文件清单不符合长期维护口径。",
                 ),
+            ),
+        ),
+        "",
+        "## Cycle Shape Counts",
+        "",
+        _format_markdown_table(
+            ("Cycle shape", "Steps"),
+            tuple(
+                (name, str(cycle_shape_counts.get(name, 0)))
+                for name in (
+                    "cycle_empty_list",
+                    "cycle_string",
+                    "cycle_list",
+                    "steps with cycle_count",
+                    "steps without cycle",
+                    "cycle_null",
+                    "cycle_mapping",
+                    "cycle_empty_mapping",
+                    "cycle_events_mapping",
+                    "cycle_event_descriptor",
+                    "cycle_other",
+                )
             ),
         ),
         "",
@@ -332,6 +551,46 @@ def _render_report(
             ),
         ),
         "",
+        "## Disallowed Origin Field Counts",
+        "",
+        _format_markdown_table(
+            ("Disallowed field", "Case files"),
+            tuple(
+                (field_name, str(len(disallowed_origin_cases[field_name])))
+                for field_name in DISALLOWED_ORIGIN_FIELDS
+            ),
+        ),
+        "",
+        "## Disallowed Step Field Counts",
+        "",
+        _format_markdown_table(
+            ("Disallowed field", "Case files"),
+            tuple(
+                (field_name, str(len(disallowed_step_cases[field_name])))
+                for field_name in DISALLOWED_STEP_FIELDS
+            ),
+        ),
+        "",
+        "## Legacy Cycle Shape Counts",
+        "",
+        _format_markdown_table(
+            ("Legacy shape", "Case files"),
+            tuple(
+                (field_name, str(len(legacy_cycle_cases[field_name])))
+                for field_name in LEGACY_CYCLE_SHAPES
+            ),
+        ),
+        "",
+        "## Legacy Path Shape Counts",
+        "",
+        _format_markdown_table(
+            ("Legacy shape", "Case files"),
+            tuple(
+                (field_name, str(len(legacy_path_cases[field_name])))
+                for field_name in LEGACY_PATH_SHAPES
+            ),
+        ),
+        "",
         "## Disallowed Expectation Field Counts",
         "",
         _format_markdown_table(
@@ -347,7 +606,8 @@ def _render_report(
         _format_markdown_table(
             ("Metric", "Count"),
             tuple(
-                (name, str(count)) for name, count in sorted(handler_distribution.items())
+                (name, str(count))
+                for name, count in sorted(handler_distribution.items())
             )
             or (("-", "0"),),
         ),
@@ -378,17 +638,6 @@ def _paired_file_errors(root: Path, records: Sequence[SemanticCaseRecord]) -> Li
         errors.append("YAML fixture 缺少配对 FCSTM：%s.yaml" % case_id)
     for case_id in sorted(fcstm_ids - yaml_ids):
         errors.append("FCSTM fixture 缺少配对 YAML：%s.fcstm" % case_id)
-    for record in records:
-        source = record.data.get("source")
-        if not isinstance(source, Mapping):
-            errors.append("%s 缺少 source mapping" % record.case_id)
-            continue
-        source_fcstm = source.get("fcstm")
-        if source_fcstm != record.fcstm_path.name:
-            errors.append(
-                "%s 的 source.fcstm=%r，应为 %r"
-                % (record.case_id, source_fcstm, record.fcstm_path.name)
-            )
     return errors
 
 
@@ -422,7 +671,9 @@ def _runner_field_errors(root: Path) -> List[str]:
     pattern = re.compile(r"^[ \t]*runners:", re.MULTILINE)
     for yaml_path in sorted((root / CASE_DIR_RELATIVE_PATH).glob("*.yaml")):
         if pattern.search(_read_text(yaml_path)):
-            errors.append("shared fixture 禁止 include-style runners 字段：%s" % yaml_path)
+            errors.append(
+                "shared fixture 禁止 include-style runners 字段：%s" % yaml_path
+            )
     return errors
 
 
@@ -434,6 +685,42 @@ def _field_contract_errors(records: Sequence[SemanticCaseRecord]) -> List[str]:
         if case_ids:
             errors.append(
                 "shared fixture 顶层字段 %s 不属于长期契约，命中：%s"
+                % (field_name, _case_ids(case_ids))
+            )
+
+    disallowed_origin_cases = _origin_field_case_ids(records, DISALLOWED_ORIGIN_FIELDS)
+    for field_name in DISALLOWED_ORIGIN_FIELDS:
+        case_ids = disallowed_origin_cases[field_name]
+        if case_ids:
+            errors.append(
+                "shared fixture origin 字段 %s 是 v1 维护字段，命中：%s"
+                % (field_name, _case_ids(case_ids))
+            )
+
+    disallowed_step_cases = _step_field_case_ids(records, DISALLOWED_STEP_FIELDS)
+    for field_name in DISALLOWED_STEP_FIELDS:
+        case_ids = disallowed_step_cases[field_name]
+        if case_ids:
+            errors.append(
+                "shared fixture step 字段 %s 是 v1 字段，命中：%s"
+                % (field_name, _case_ids(case_ids))
+            )
+
+    legacy_cycle_cases = _legacy_cycle_shape_case_ids(records)
+    for field_name in LEGACY_CYCLE_SHAPES:
+        case_ids = legacy_cycle_cases[field_name]
+        if case_ids:
+            errors.append(
+                "shared fixture cycle 旧形态 %s 不属于 schema v2，命中：%s"
+                % (field_name, _case_ids(case_ids))
+            )
+
+    legacy_path_cases = _legacy_path_shape_case_ids(records)
+    for field_name in LEGACY_PATH_SHAPES:
+        case_ids = legacy_path_cases[field_name]
+        if case_ids:
+            errors.append(
+                "shared fixture state path 旧形态 %s 不属于 schema v2，命中：%s"
                 % (field_name, _case_ids(case_ids))
             )
 

--- a/tools/inventory_simulate_semantics.py
+++ b/tools/inventory_simulate_semantics.py
@@ -42,6 +42,9 @@ DISALLOWED_EXPECTATION_FIELDS = (
     "cycle_count",
     "cycle_result",
     "return",
+    "input_events",
+    "consumed_events",
+    "unconsumed_events",
     "history",
     "history_tail",
     "history_length",
@@ -497,7 +500,7 @@ def _render_report(
                 (
                     "契约外观察字段",
                     _case_ids(disallowed_expectation_hits),
-                    "通过：未出现 stack、cycle_count、history*、cycle_result、return、logs、warnings 或错误诊断字段。",
+                    "通过：未出现 stack、cycle_count、history*、cycle_result、return、event accounting、logs、warnings 或错误诊断字段。",
                 ),
                 (
                     "长期 Markdown 文件",


### PR DESCRIPTION
## 背景

本 PR 对应 [issue #227](https://github.com/HansBug/pyfcstm/issues/227)，目标是把 `test/fixtures/simulate_semantics/` 的 shared semantic fixture 一次性迁移到 schema v2。

[issue #217](https://github.com/HansBug/pyfcstm/issues/217) 和 [PR #219](https://github.com/HansBug/pyfcstm/pull/219) 已经把 `test/fixtures/simulate_semantics/` 收束为跨实现共享语义语料：默认覆盖 simulator 与当前 shared template runner，禁止 CLI/REPL、model-build 诊断、simulator-only 诊断、栈快照、cycle counter、history、cycle return / event accounting 等内部或调试观察面回流。

本 PR 规划并实现 shared fixture schema v2：目标不是扩大语义面，而是降低 YAML 噪音，让 fixture 更接近“配对 DSL + 合法执行步骤 + 稀疏公开观察断言”的高语义密度格式。本 PR 不改变 simulator 或模板运行语义，只改变测试语料格式、loader 归一化、schema 文档和维护检查。

## 当前基线

以下统计基于 `main` 上 [PR #219](https://github.com/HansBug/pyfcstm/pull/219) 合入后的 merge commit [`a4c2f2e`](https://github.com/HansBug/pyfcstm/commit/a4c2f2ed3576576ad16550f925d2295e83df7540)。实现开始前会重新跑一次 inventory；实现完成后会把最终迁移统计同步回本 PR body / comment。

| 项目 | 当前值 | 说明 |
|---|---:|---|
| YAML case | 143 | 每个 case 都有配对 `.fcstm`。 |
| YAML 总行数 | 约 7488 | 平均约 52 行 / case。 |
| `schema_version` | 143 / 143 | v2 应删除该噪音字段；loader 直接按当前 v2 schema 解释。 |
| `id == basename` | 143 / 143 | v2 应从 YAML basename 推导 case id。 |
| `source.fcstm == <id>.fcstm` | 143 / 143 | v2 应从 YAML basename 推导配对 FCSTM。 |
| `runners` | 0 | 已完成 include-style runner 删除。 |
| `exclude_runners` | 0 | 机制保留；当前没有例外。 |
| 空 cycle | 248 个 step | 当前写作 `cycle: {}`；v2 改为显式 `cycle: []` 或 `cycle_count`。 |
| `cycle.events` mapping | 87 个 step | v2 改为 `cycle: EventName` 或 `cycle: [A, B]`。 |
| bare string cycle | 1 个 step | v2 保留并文档化为合法 `runtime.cycle("Event")` 输入。 |
| `expect_initial` | 16 个 step | v2 用 `cycle_count: 0` 表示构造后、无 cycle 的 checkpoint。 |
| `return` / `cycle_result` | 0 | 已从 shared fixture 移除；v2 继续拒绝回流。 |
| `handler_calls` | 21 个 expectation | v2 继续作为 shared public hook-call 观察面，但只测试调用时机和上下文快照。 |


## 实现后统计

以下统计来自本分支实现后执行 `python tools/inventory_simulate_semantics.py --check` 和 inventory report 的结果。

| 项目 | 实现后值 | 说明 |
|---|---:|---|
| YAML case | 143 | 全部仍有配对 `.fcstm`，未丢失 case。 |
| FCSTM files | 143 | YAML/FCSTM basename 配对完整。 |
| Runtime steps | 352 | 其中 `cycle_count: 0` checkpoint 16 个。 |
| shared runner 组合 | 143 | 全部仍为 `simulation, generated_python_alignment`。 |
| `schema_version` / `id` / `source` | 0 | v1 顶层字段已从 corpus 中移除，并作为 negative tests 保留。 |
| `runners` / `exclude_runners` | 0 / 0 | 当前 corpus 无 runner 例外；仍保留 exclude-only 机制。 |
| `cycle: []` | 250 steps | 空事件 cycle 已改为 v2 显式 list。 |
| bare string cycle | 76 steps | 单事件 cycle 已从旧 `cycle.events` mapping 迁移为直观 string。 |
| list cycle | 10 steps | 多事件 cycle 已迁移为 `List[str]`。 |
| 旧 cycle mapping / `cycle.events` / event descriptor / `cycle: null` | 0 | inventory check 会拒绝这些旧形态回流。 |
| `expect_initial` | 0 | 已迁移为 `cycle_count: 0` + 同步 `expect`。 |
| state list / handler `active_leaf` list | 0 | state path 统一为 dot-string 或 `null`。 |
| `handler_calls` | 14 case files | shared handler 只保留 `record_call` public call snapshots。 |
| 契约外 observation fields | 0 | cycle return/event accounting/stack/history/log/warning/error metadata 未回流。 |

## 已确认原则

| 原则 | 结论 |
|---|---|
| v2-only | 不做 v1/v2 双读兼容；迁移完成后旧字段、旧 loader 分支、旧示例和旧测试入口都应删除或改成 negative test。 |
| 单 PR 完成 | 本 PR 直接完成 schema、loader、corpus、docs、inventory 和测试迁移；不开伞 PR / sub PR。PR body 需要自包含写清楚迁移规则、TDD、统计和验收结果。 |
| exclude-only runner | shared fixture 默认覆盖当前 shared runner 集合；例外只能通过 `exclude_runners` 表达，不能恢复 `runners` include 白名单。 |
| 合法输入范围 | DSL、hot start、handler registration、cycle event 输入都必须是合法用法；schema v2 不承担非法 Python API 边界 fuzz。 |
| 稀疏断言 | `expect` 缺省字段表示“不关注该观察项、不执行 assert”，绝不是默认期望值。 |
| handler 范围 | 允许 abstract handler 和合法注册，但 shared fixture 只测试“是否在该调用时调用、调用顺序、调用时上下文快照是否正确”；handler 注册机制、异常模式、warning/log/error metadata 等不进入 shared schema。 |
| 不回流调试面 | stack、history、cycle counter、cycle return、event accounting、logs、warnings、error_state、anonymous-warning dedupe 等保持 simulator-only 普通 pytest。这里的 event accounting 指 `CycleResult.input_events` / `consumed_events` / `unconsumed_events` 或任何类似事件账目统计。 |

## 非目标

| 非目标 | 原因 |
|---|---|
| 不改变 simulator 或 template 执行语义 | schema v2 只改变测试语料写法和 loader 归一化。 |
| 不扩大 template 能力面 | 全模板对齐能力缺口继续在 [issue #218](https://github.com/HansBug/pyfcstm/issues/218) 跟踪。 |
| 不把 simulator-only 测试重新 fixture 化 | 非 shared 诊断应继续用普通 pytest，不能借 v2 回流。 |
| 不测试 handler 机制本身 | 重复注册、override、warning、handler 抛错、read-only write attempt 等属于 simulator API / diagnostic tests。 |
| 不保留 v1 兼容层 | 这是内部测试语料格式迁移，尚未形成对外稳定用户契约。 |

## v2 顶层形态

v2 YAML 默认从文件名推导 `id` 和配对 `.fcstm`，不再手写 `schema_version`、`id`、`source.fcstm` 或 include-style `runners`。

```yaml
title: Hot start event sequence reaches active state
origin:
  files:
    - test/simulate/test_runtime.py::test_hot_start_event_sequence
categories: [runtime, template_alignment, hot_start]

initial:
  state: Root.Gate
  vars: {counter: 0}

handlers:
  - action: Root.Gate.Observe
    behavior: record_call

steps:
  - cycle_count: 0
    expect:
      state: Root.Gate
      vars: {counter: 0}
      ended: false
      handler_calls: []

  - cycle: Root.Gate.Unlock
    expect:
      state: Root.Active
      vars: {counter: 1}

  - cycle_count: 4
    expect:
      vars: {counter: 5}

  - cycle: [Root.Active.Tick, Root.Active.Flush]
    cycle_count: 2
    expect:
      state: Root.Done
      ended: false
```

### v2 顶层字段

| 字段 | 必填 | 说明 |
|---|---:|---|
| `title` | 是 | 人类可读标题。 |
| `origin.files` | 是 | 行为来源的原 pytest 函数、issue 或 PR 链接。 |
| `origin.docs` | 否 | 可选设计文档引用。 |
| `origin.notes` | 否 | 可选等价性或来源说明。 |
| `categories` | 是 | 非空分类列表，取值来自允许集合。 |
| `exclude_runners` | 否 | 当前 shared runner 的例外排除列表。省略表示覆盖所有 shared runner。 |
| `initial` | 否 | 可选 runtime 构造状态和变量；省略表示 cold start。 |
| `handlers` | 否 | abstract hook 调用记录器。shared v2 只使用 `record_call`。 |
| `steps` | 是 | runtime checkpoint 列表。只有 `initial.expect.raises` 断言构造失败时才允许 `[]`。 |

拒绝的 v1 / 非 shared 顶层字段包括 `schema_version`、`id`、`source`、`runners`、`runtime_options`、`model_build`、`commands` 和 `expected_failure`。

## runtime 构造

`initial` 提供可选构造输入：

```yaml
initial:
  state: Root.A
  vars: {counter: 0}
```

允许字段：

- `initial.state`：state path string 或 `null`。
- `initial.vars`：完整变量快照 mapping 或 `null`。
- `initial.expect.raises`：构造期异常断言。

省略 `initial` 表示 cold start。`initial.state: null` 是显式 cold-start 写法，等价于不提供 hot-start target；新 v2 fixture 在没有构造输入时应优先省略 `initial`。当 `initial.expect` 存在时，`initial.state` 和 `initial.vars` 必须都显式写出，并且 fixture 必须使用 `steps: []`，因为 runtime 构造阶段预期失败。

```yaml
initial:
  state: Root.A
  vars: {counter: "0"}
  expect:
    raises:
      type: ValueError
      match: "initial_vars['counter'] must be int or float"
      match_kind: substring
steps: []
```

## step 语法

v2 step 是“执行 0 到 N 次同一 cycle 输入，然后做一次稀疏公开观察断言”的 checkpoint。

| 字段 | 必填 | 说明 |
|---|---:|---|
| `cycle` | 条件必填 | 单次 cycle 输入，可以是 string event path 或 string event path list。 |
| `cycle_count` | 条件必填 | 非负整数重复次数。 |
| `expect` | 是 | 非空稀疏公开观察断言 mapping。 |

### `cycle` 输入形态

`cycle` 支持两种直观、贴近 Python API 的形态：

```yaml
cycle: Root.A.Go
```

等价于：

```python
runtime.cycle("Root.A.Go")
```

```yaml
cycle: [Root.A.Go, Root.B.Next]
```

等价于：

```python
runtime.cycle(["Root.A.Go", "Root.B.Next"])
```

空事件 cycle 必须显式写作：

```yaml
cycle: []
```

等价于：

```python
runtime.cycle([])
```

v2 拒绝以下旧形态或非 shared API 形态：

```yaml
cycle: {}
cycle: null
cycle:
  events: [Root.A.Go]
cycle:
  - {event: Root.A.Go}
```

`cycle: null` 被拒绝只针对 cycle 输入；`initial.state: null` 和 `expect.state: null` 仍保留各自的构造 / ended-runtime 语义，不能据此推断 `cycle: null` 等价于空事件 cycle。

如果仍需覆盖 `Event` object、tuple、`None` 等 Python API 边界输入，应迁入普通 simulator pytest；shared fixture 只表达合法 DSL / hot start / handler / event path 序列的公共行为。

### `cycle_count` 语义

| 写法 | 合法性 | 含义 |
|---|---:|---|
| `cycle: []` | ✅ | 执行 1 次 `runtime.cycle([])` 后断言。 |
| `cycle: Tick` | ✅ | 执行 1 次 `runtime.cycle("Tick")` 后断言。 |
| `cycle: [A, B]` | ✅ | 执行 1 次 `runtime.cycle(["A", "B"])` 后断言。 |
| `cycle_count: 5` | ✅ | 缺省 `cycle` 为 `[]`，执行 5 次空事件 cycle 后断言。 |
| `cycle: []` + `cycle_count: 5` | ✅ | 与单独 `cycle_count: 5` 等价；合法但不推荐，迁移时优先省略 `cycle`。 |
| `cycle: Tick` + `cycle_count: 5` | ✅ | 执行 5 次 `runtime.cycle("Tick")` 后断言。 |
| `cycle: [A, B]` + `cycle_count: 5` | ✅ | 执行 5 次同一个事件列表后断言。 |
| `cycle_count: 0` | ✅ | 不执行任何 cycle，直接对当前 runtime 做 checkpoint；用于替代旧 `expect_initial`。 |
| `cycle: []` + `cycle_count: 0` | ✅ | 与单独 `cycle_count: 0` 等价；合法但不推荐，迁移时优先省略 `cycle`。 |
| `cycle` 和 `cycle_count` 都缺省 | ❌ | schema error，避免人类误解到底是否执行 cycle。 |
| `cycle_count: 0` 同时带非空 `cycle` | ❌ | schema error，避免事件被静默忽略。 |

补充规则：

- 如果 `cycle` 存在且 `cycle_count` 缺省，`cycle_count` 等价于 `1`。
- 如果 `cycle_count` 存在且 `cycle` 缺省，`cycle` 等价于 `[]`。
- `cycle_count` 必须是非负整数；bool、float、string、负数都应 fail fast。
- `expect.raises` 只在 effective `cycle_count == 1` 时合法。effective count 为 0 或大于 1 时都必须 schema error。
- 如果需要“先成功 N 次、再失败一次”，应写成多个 step，避免 `cycle_count > 1` 下异常发生在哪一次产生歧义。
- `cycle_count: 0` 不能和 `expect.raises` 组合；构造失败应使用 `initial.expect.raises`。

## `expect` 语法

`expect` 是稀疏断言对象：**只断言显式写出的字段**。缺省字段表示“不关注该观察项，不执行 assert”，不是默认期待值。

示例：

```yaml
expect:
  vars: {counter: 3}
```

只断言 `counter == 3`，不关心当前 state、`ended`、其他变量或 handler calls。

允许的 shared expectation 字段：

| 字段 | 含义 |
|---|---|
| `state` | 期望当前 state path，使用 dot string；`null` 表示 ended runtime。 |
| `vars` | 变量值 partial assertion。 |
| `vars_exact` | 完整 `dict(runtime.vars)` 断言。 |
| `vars_keys` | 精确变量 key-set 断言。 |
| `vars_absent` | 必须不存在的变量。 |
| `ended` | 期望 `runtime.is_ended`。 |
| `raises` | 单次 cycle call 的期望异常类名和可选 message / cause 匹配。 |
| `handler_calls` | 从 runtime 构造 / handler 安装到当前 step 结束为止的累计 fixture-handler 调用序列；每条 record 只比较显式声明字段。 |

规则：

- `expect` 必须是非空 mapping。
- `state` 应使用 `Root.A` dot-string path；loader 可以内部归一化。当前 FCSTM 语法中 state name 是 identifier，不能包含 dot，因此该写法无歧义。`state: null` 表示 ended runtime。
- `vars` 是 partial；省略变量不做断言。
- `vars_exact` 是完整快照断言。
- `vars` 和 `vars_exact` 互斥；稀疏检查用 `vars`，完整快照检查用 `vars_exact`。
- `vars_keys` 和 `vars_absent` 不得 overlap。
- `vars_exact` 与 `vars_keys` 和 `vars_absent` 互斥，因为完整快照已经固定变量 key set。
- `state: null` 表示 runtime 已 ended。`state: null` 搭配 `ended: false`，或非空 `state` 搭配 `ended: true`，都是 schema error，而不是互相矛盾的 runtime assertion。
- `expect` 不得包含 `cycle_count`；step repeat count 是输入侧字段，不是 runtime 观察契约。
- `return`、`cycle_result`、event accounting（`input_events` / `consumed_events` / `unconsumed_events` 或类似事件账目统计）、stack、history、logs、warnings、error-state metadata、anonymous-warning counters 和 generated-template private state IDs 均继续拒绝。

### 异常断言

`raises` 允许字段：`type`、`match`、`match_kind`、`cause_type`、`cause_match` 和 `cause_match_kind`。`match_kind` 和 `cause_match_kind` 默认值为 `substring`，且只允许 `substring` 或 `regex`。不支持的 exception 字段或 matcher kind 必须 fail fast。

## handler 设计

Shared v2 允许 abstract handler，但只把它作为公开 hook-call 观察面：测试 handler 是否在正确生命周期位置被调用、调用顺序是否正确、调用时上下文快照是否正确。handler 注册 API、重复注册、override、warning、handler 抛错、read-only write attempt、thread safety 等不属于 shared fixture 目标。

### 顶层 `handlers`

v2 shared corpus 只允许 `record_call`：

```yaml
handlers:
  - action: Root.A.EnterHook
    behavior: record_call
  - action: Root.B.DuringHook
    behavior: record_call
```

`record_call` 会在 simulator 和 generated Python runtime 上安装等价 handler/hook，并把调用时的 public context 快照追加到记录列表。

`record_var_write_attempt`、`raise_error`、handler exception metadata、warning/log/error metadata 都应迁入普通 simulator pytest 或保留在现有普通 pytest 中。正向 `handler_calls` 记录应默认写出 `action`、`state`、`stage`、`vars` 四个核心字段；如果某个 case 故意只断言其中一部分，需要在 `origin.notes` 里说明为什么不会弱化调用时机或上下文快照验证。

### `expect.handler_calls`

`handler_calls` 的含义是从 runtime 构造、handler 安装到当前 step 结束为止的**累计调用序列**：

- 列表长度必须精确匹配。
- 顺序必须精确匹配。
- 每个 record 只比较 YAML 显式声明的字段。
- `handler_calls: []` 用来证明截至该 checkpoint 没有任何 fixture handler 被调用。
- 顶层 `expect` 未写 `handler_calls` 时，完全不检查 handler 记录。

建议正向调用记录至少保留 `action`、`state`、`stage`、`vars` 四个核心字段，以确保调用时机和上下文快照不被弱化；可选字段按需要补充。

允许的 handler call 字段：

| 字段 | 含义 |
|---|---|
| `action` | handler 观察到的 abstract action path。 |
| `state` | handler 观察到的 calling state path。 |
| `stage` | 生命周期阶段，例如 `enter`、`during`、`exit` 或 `effect`。 |
| `vars` | handler 可见变量快照。 |
| `active_leaf` | context 暴露的可选 active leaf path。 |
| `call_stage` | context 暴露的可选 call stage。 |
| `abstract_target` | context 暴露的可选 abstract target path。 |
| `named_ref` | 可选 named reference callsite path，或 `null`。 |

示例：

```yaml
handlers:
  - action: Root.A.EnterHook
    behavior: record_call
  - action: Root.B.EnterHook
    behavior: record_call

steps:
  - cycle_count: 0
    expect:
      handler_calls: []

  - cycle: []
    expect:
      state: Root.A
      vars: {x: 1}
      handler_calls:
        - action: Root.A.EnterHook
          state: Root.A
          stage: enter
          vars: {x: 1}

  - cycle: Root.A.Go
    expect:
      state: Root.B
      vars: {x: 11}
      handler_calls:
        - action: Root.A.EnterHook
          state: Root.A
          stage: enter
          vars: {x: 1}
        - action: Root.B.EnterHook
          state: Root.B
          stage: enter
          vars: {x: 11}
```

## 单 PR 执行计划

本 PR 不开伞 PR；直接一个 PR 完成。PR body 必须自包含说明全部迁移规则、TDD 策略、负向测试、迁移统计和验收命令。

| 阶段 | 内容 | 验收目标 |
|---|---|---|
| V2-1：TDD 与文档原型 | 先更新 schema tests / negative tests，明确 v2-only 字段、cycle/cycle_count、稀疏 expect、handler 范围。 | 旧写法回流会失败；新写法示例能加载。 |
| V2-2：loader 归一化 | 实现 v2-only loader：从 basename 推导 id/source；归一化 dot-string state；归一化 `cycle` + `cycle_count`；删除 v1 分支。 | loader 内部仍向 runner 提供稳定数据结构；错误信息包含 case id 和 YAML path。 |
| V2-3：批量迁移 corpus | 机械迁移全部 YAML：删除 `schema_version` / `id` / `source`；`cycle: {}` -> `cycle: []`；`cycle.events` -> str/list；`expect_initial` -> `cycle_count: 0` 且把 `expect_initial.state` / `vars` / `ended` 等子字段提升到同一步的 `expect`；state list -> dot string。 | DSL、cycle 输入序列、公开 state/vars/ended/raises/handler calls 语义等价。 |
| V2-4：文档、inventory 与验收 | 更新 README/schema/inventory；报告迁移前后行数和字段统计；确认 no v1 residue。 | fixture tests、generated Python alignment、inventory check 和 unittest fast path 通过。 |

```mermaid
flowchart TD
    I227["issue #227<br/>schema v2 规则定稿<br/>✅ ready"]:::done
    TDD["V2-1<br/>TDD + negative tests<br/>✅ done"]:::done
    LOADER["V2-2<br/>v2-only loader 归一化<br/>✅ done"]:::done
    CORPUS["V2-3<br/>批量迁移 shared corpus<br/>✅ done"]:::done
    DOCS["V2-4<br/>文档 inventory 验收<br/>✅ done"]:::done
    I218["issue #218<br/>后续全模板对齐消费更干净语料<br/>🔵 下游收益"]:::downstream
    READY["PR ready<br/>CI + multi-agent review 清零 C/I<br/>🟨 待最终审查"]:::todo

    I227 --> TDD --> LOADER --> CORPUS --> DOCS --> READY
    DOCS -. 提供 v2 shared corpus .-> I218

    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
    classDef todo fill:#fef3c7,stroke:#d97706,color:#111827;
    classDef downstream fill:#dbeafe,stroke:#2563eb,color:#111827;
    class I227,TDD,LOADER,CORPUS,DOCS done;
    class READY todo;
    class I218 downstream;
```

## TDD / negative test 清单

实现 PR 至少需要覆盖这些负向或边界用例：

| 类别 | 必测内容 |
|---|---|
| v1 residue | `schema_version`、`id`、`source`、`runners`、`expect_initial`、`cycle.events`、`return`、`cycle_result`、stack/history/log/warning/error metadata 回流必须失败。 |
| cycle shape | `cycle: {}`、`cycle: null`、`cycle: {events: [...]}`、event-object descriptor、非 string/list 输入必须失败。 |
| cycle_count | 缺省 `cycle` 且缺省 `cycle_count` 失败；负数、float、string、bool 失败；`cycle_count: 0` + 非空 `cycle` 失败；`expect.raises` 在 effective `cycle_count != 1` 时失败。 |
| sparse expect | 缺省 `state` / `vars` / `ended` 不触发任何默认 assert；只有显式字段被比较；`vars` 与 `vars_exact` 共存失败；`vars_exact` 与 `vars_keys` / `vars_absent` 共存失败；`vars_keys` 与 `vars_absent` overlap 失败；`expect.cycle_count` 失败；`state` / `ended` 矛盾组合失败。 |
| state path | dot-string path 正常；歧义或非法 path 字段有可读错误。 |
| handler scope | shared handler 只允许 `record_call`；`record_var_write_attempt`、`raise_error`、`write_attempt` 回流失败；未知 handler-call 字段失败；`handler_calls: []` 和累计 exact sequence 行为可验证；核心字段缺失必须有 `origin.notes` 解释或被 lint 拒绝。 |
| exception assertions | `raises` 只允许 `type`、`match`、`match_kind`、`cause_type`、`cause_match`、`cause_match_kind`；未知字段和非法 `match_kind` / `cause_match_kind` 失败；constructor failure 必须走 `initial.expect.raises` + `steps: []`。 |
| no shared debug surface | cycle return / event accounting（`input_events` / `consumed_events` / `unconsumed_events` 等）/ cycle counter / history / stack 等仍被拒绝。 |

## 验收标准

| 验收项 | 标准 |
|---|---|
| 语义等价 | 迁移前后 shared fixture 的 DSL、hot start 输入、cycle event 序列、公开 state、vars、ended、raises、handler call 观察语义等价。 |
| 更少冗余 | YAML 行数和重复默认字段显著下降；PR body / comment 给出迁移前后统计。 |
| 严格 schema | 未知字段、旧字段、非共享字段继续 fail fast，错误信息包含 case id 和 YAML path。 |
| v2-only | loader、README、schema、tests、shared YAML 都只描述/接受 v2 当前格式；v1 回流有 negative tests。 |
| exclude-only | 继续默认覆盖当前 shared runner；只有例外使用 `exclude_runners`。 |
| handler 口径正确 | shared fixture 只验证调用时机、顺序和上下文快照；handler 机制和诊断边界不回流。 |
| 文档自洽 | `README.md` 和 `schema.md` 示例、字段表、添加 case 流程都只描述 v2 当前事实。 |
| 测试通过 | 至少通过 `python -m pytest test/simulate/test_semantic_fixtures.py -q`、`python -m pytest test/template/python/test_semantic_fixture_alignment.py -q`、`python tools/inventory_simulate_semantics.py --check`、`SKIP_SLOW_TESTS=1 make unittest`。提交前运行 `make rst_auto` 并确认无意外 pydoc/RST 漂移。 |
| CI 与 review | push 后 watch CI 直至全绿；三路 implementation reviewer 强对抗测试后 C/I=0。 |

## 开工前检查

实现开始前先确认：

1. `main` 已包含 [PR #219](https://github.com/HansBug/pyfcstm/pull/219) 的最终收束结果。
2. 本 PR body 已完整继承 issue #227 最新 body 中 `cycle` / `cycle_count` / sparse `expect` / handler 口径，不得退回“缺省 cycle 等于空 cycle”的旧设计。
3. 本 PR 不混入行为变更、新增 template rendering feature、新增 simulator diagnostic API 或变更公开 Python API 签名；如果开发中发现 schema v2 会同时引入 runtime/template 行为变更，应停下来拆 scope，而不是混入本 PR。

## 当前状态

- ✅ 空 PR 已创建，计划审查两轮已完成，三路 reviewer 对 PR body 计划 C/I=0。
- ✅ 已完成 V2-1 TDD / negative tests：旧 v1 residue、旧 cycle shapes、`cycle_count` 边界、稀疏 `expect`、handler scope、debug surface 回流均有 schema failure 覆盖。
- ✅ 已完成 V2-2 loader 归一化：case id 和 paired FCSTM 从 basename 推导；state path 使用 dot-string；`cycle` 支持 `str` / `List[str]`；`cycle_count` 支持 0 checkpoint 与重复执行；constructor failure 继续使用 `initial.expect.raises`。
- ✅ 已完成 V2-3 corpus 迁移：143 个 YAML case 已删除 `schema_version` / `id` / `source`，迁移 `cycle: {}`、`cycle.events`、`expect_initial`、state list 和旧 handler write-attempt shared 字段。
- ✅ 已完成 V2-4 README/schema/inventory 更新：文档只描述 v2 当前事实，inventory check 报告 no v1 residue / no legacy cycle/path shape。
- ✅ 已确认当前分支包含最新 `origin/main`（`git merge-base --is-ancestor origin/main HEAD` 返回 0），当前无 merge conflict。
- ✅ 已执行本地验证：
  - `python -m pytest test/simulate/test_semantic_fixtures.py -q` → 252 passed。
  - `python -m pytest test/template/python/test_semantic_fixture_alignment.py -q` → 144 passed。
  - `python tools/inventory_simulate_semantics.py --check` → passed。
  - 临时 corpus 注入 `expect.consumed_events` 的 inventory negative check → correctly rejected。
  - `python -m ruff check test/testings/simulate_semantics.py test/simulate/test_semantic_fixtures.py tools/inventory_simulate_semantics.py` → passed。
  - `python -m ruff format --check test/testings/simulate_semantics.py test/simulate/test_semantic_fixtures.py tools/inventory_simulate_semantics.py` → passed。
  - `SKIP_SLOW_TESTS=1 make unittest` → 41120 passed, 170 skipped, 63 deselected。
  - `make rst_auto` → 已运行，无意外 docs diff。
- ✅ 已修复 implementation reviewer I1：`validate_shared_fixture_contract()` 和 `tools/inventory_simulate_semantics.py --check` 均会拒绝 `input_events` / `consumed_events` / `unconsumed_events` 等 event accounting 字段回流。
- 🟨 已 push 最新实现提交 [`acdb5504`](https://github.com/HansBug/pyfcstm/commit/acdb55049aeeebeda78ae86e2f8bdbdd977394a3)；当前正在 watch CI，并启动三路 implementation reviewer 复审。C/I=0 且 CI 全绿后进入 ready-to-merge 状态。本 PR 暂不 merge，ready 后等待用户下一步指示。

