### PR TITLE
test(template): add C/C poll shared runner framework

### DIFF
--- a/test/fixtures/simulate_semantics/runner_capabilities.yaml
+++ b/test/fixtures/simulate_semantics/runner_capabilities.yaml
@@ -1,0 +1,791 @@
+# Native shared semantic alignment capability matrix.
+# This file is the single test-side fact source for C/C poll shared
+# alignment expected failures while later repair slices fix the generated
+# C-family runtime semantics. Do not encode workflow labels in schema field names;
+# use tracking URLs for issue/PR provenance.
+version: 1
+known_failures:
+  - runner: generated_c_alignment
+    case: abstract_hook_context_hot_start_leaf
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "abstract_hook_context_hot_start_leaf is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: abstract_hook_ref_context_reports_callsite_metadata
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "abstract_hook_ref_context_reports_callsite_metadata is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: aspect_context_reports_active_leaf
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "aspect_context_reports_active_leaf is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_guard_after_event_transition_uses_pre_before_vars
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_after_event_transition_uses_pre_before_vars is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_guard_after_leaf_transition_uses_enter_state
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_after_leaf_transition_uses_enter_state is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_guard_after_named_ref_before_uses_pre_ref_vars
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_after_named_ref_before_uses_pre_ref_vars is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_guard_can_select_terminal_branch_before_plain_before
+    classification: state_or_ended_mismatch
+    observation: state_or_ended
+    support: expected_failure
+    skip_reason: "composite_initial_guard_can_select_terminal_branch_before_plain_before is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_guard_uses_enter_state_before_plain_before
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_uses_enter_state_before_plain_before is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_guard_with_effect_runs_before_plain_before
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_with_effect_runs_before_plain_before is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_handler_log_after_transition_uses_selected_child
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_handler_log_after_transition_uses_selected_child is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_handler_log_keeps_stable_branch_before_exit_branch
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_handler_log_keeps_stable_branch_before_exit_branch is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_handler_log_uses_enter_selected_child
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_handler_log_uses_enter_selected_child is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_nested_entry_order_survives_deep_choice
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_nested_entry_order_survives_deep_choice is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: composite_initial_skips_unstable_candidates_root_entry
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_skips_unstable_candidates_root_entry is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: design_speculative_dfs_safety_limit
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "design_speculative_dfs_safety_limit is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: ended_runtime_ignores_event_inputs
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "ended_runtime_ignores_event_inputs is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: expression_error_preserves_runtime_snapshot
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_error_preserves_runtime_snapshot is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: expression_failure_if_condition_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_if_condition_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: expression_failure_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: expression_failure_transition_effect_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_transition_effect_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: expression_failure_transition_guard_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_transition_guard_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: expression_large_integer_safe_diagnostics
+    classification: parse_render_load
+    observation: parse_render_load
+    support: expected_failure
+    skip_reason: "expression_large_integer_safe_diagnostics is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: expression_type_error_wraps_transition_effect
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "expression_type_error_wraps_transition_effect is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: failed_initial_cycle_skips_abstract_handler_callbacks
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "failed_initial_cycle_skips_abstract_handler_callbacks is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: forced_pseudo_candidate_skips_unstable_branch
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "forced_pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: hot_start_initial_vars_override_skips_int_initializer
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "hot_start_initial_vars_override_skips_int_initializer is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: hot_start_initial_vars_reject_bool_values
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "hot_start_initial_vars_reject_bool_values is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: hot_start_initial_vars_reject_string_values
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "hot_start_initial_vars_reject_string_values is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: hot_start_leaf_defers_during_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "hot_start_leaf_defers_during_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: hot_start_rejects_blocked_composite_initial
+    classification: state_or_ended_mismatch
+    observation: state_or_ended
+    support: expected_failure
+    skip_reason: "hot_start_rejects_blocked_composite_initial is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: hot_start_rejects_overdeep_leaf_stack
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "hot_start_rejects_overdeep_leaf_stack is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: hot_start_rejects_unstable_pseudo_leaf
+    classification: state_or_ended_mismatch
+    observation: state_or_ended
+    support: expected_failure
+    skip_reason: "hot_start_rejects_unstable_pseudo_leaf is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: lifecycle_ref_chain_resolves_long_acyclic_chain
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "lifecycle_ref_chain_resolves_long_acyclic_chain is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: named_ref_context_reports_callsite
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "named_ref_context_reports_callsite is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: persistent_default_int_initializer_rejects_non_integer_float
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "persistent_default_int_initializer_rejects_non_integer_float is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: persistent_operation_writeback_rejects_float_and_rolls_back
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "persistent_operation_writeback_rejects_float_and_rolls_back is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: post_child_exit_continuation_skips_unstable_candidates
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "post_child_exit_continuation_skips_unstable_candidates is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: pseudo_candidate_skips_unstable_branch
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: pseudo_self_loop_step_limit_raises_dfs_error
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "pseudo_self_loop_step_limit_raises_dfs_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: ref_abstract_handler_reports_calling_state
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "ref_abstract_handler_reports_calling_state is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: ref_context_uses_callsite_stage
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "ref_context_uses_callsite_stage is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: root_exit_runs_root_cleanup
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "root_exit_runs_root_cleanup is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: sign_function_aligns_aspect_guard_effect_math
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_aligns_aspect_guard_effect_math is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: sign_function_controls_guard_transition
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_controls_guard_transition is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: sign_function_handles_all_signs
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_handles_all_signs is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: sign_function_preserves_complex_action_precedence
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_preserves_complex_action_precedence is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: sign_function_updates_during_action
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_updates_during_action is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: similar_state_paths_keep_actions_distinct
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "similar_state_paths_keep_actions_distinct is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_alignment
+    case: transition_into_composite_skips_unstable_initial_candidate
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "transition_into_composite_skips_unstable_initial_candidate is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: abstract_hook_context_hot_start_leaf
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "abstract_hook_context_hot_start_leaf is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: abstract_hook_ref_context_reports_callsite_metadata
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "abstract_hook_ref_context_reports_callsite_metadata is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: aspect_context_reports_active_leaf
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "aspect_context_reports_active_leaf is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_guard_after_event_transition_uses_pre_before_vars
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_after_event_transition_uses_pre_before_vars is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_guard_after_leaf_transition_uses_enter_state
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_after_leaf_transition_uses_enter_state is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_guard_after_named_ref_before_uses_pre_ref_vars
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_after_named_ref_before_uses_pre_ref_vars is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_guard_can_select_terminal_branch_before_plain_before
+    classification: state_or_ended_mismatch
+    observation: state_or_ended
+    support: expected_failure
+    skip_reason: "composite_initial_guard_can_select_terminal_branch_before_plain_before is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_guard_uses_enter_state_before_plain_before
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_uses_enter_state_before_plain_before is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_guard_with_effect_runs_before_plain_before
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_guard_with_effect_runs_before_plain_before is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_handler_log_after_transition_uses_selected_child
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_handler_log_after_transition_uses_selected_child is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_handler_log_keeps_stable_branch_before_exit_branch
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_handler_log_keeps_stable_branch_before_exit_branch is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_handler_log_uses_enter_selected_child
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_handler_log_uses_enter_selected_child is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_nested_entry_order_survives_deep_choice
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_nested_entry_order_survives_deep_choice is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: composite_initial_skips_unstable_candidates_root_entry
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "composite_initial_skips_unstable_candidates_root_entry is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: design_speculative_dfs_safety_limit
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "design_speculative_dfs_safety_limit is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: ended_runtime_ignores_event_inputs
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "ended_runtime_ignores_event_inputs is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: expression_error_preserves_runtime_snapshot
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_error_preserves_runtime_snapshot is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: expression_failure_if_condition_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_if_condition_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: expression_failure_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: expression_failure_transition_effect_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_transition_effect_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: expression_failure_transition_guard_raises_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "expression_failure_transition_guard_raises_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: expression_large_integer_safe_diagnostics
+    classification: parse_render_load
+    observation: parse_render_load
+    support: expected_failure
+    skip_reason: "expression_large_integer_safe_diagnostics is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: expression_type_error_wraps_transition_effect
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "expression_type_error_wraps_transition_effect is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: failed_initial_cycle_skips_abstract_handler_callbacks
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "failed_initial_cycle_skips_abstract_handler_callbacks is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: forced_pseudo_candidate_skips_unstable_branch
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "forced_pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: hot_start_initial_vars_override_skips_int_initializer
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "hot_start_initial_vars_override_skips_int_initializer is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: hot_start_initial_vars_reject_bool_values
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "hot_start_initial_vars_reject_bool_values is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: hot_start_initial_vars_reject_string_values
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "hot_start_initial_vars_reject_string_values is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: hot_start_leaf_defers_during_expression_error
+    classification: sigfpe
+    observation: native_process
+    support: expected_failure
+    skip_reason: "hot_start_leaf_defers_during_expression_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: hot_start_rejects_blocked_composite_initial
+    classification: state_or_ended_mismatch
+    observation: state_or_ended
+    support: expected_failure
+    skip_reason: "hot_start_rejects_blocked_composite_initial is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: hot_start_rejects_overdeep_leaf_stack
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "hot_start_rejects_overdeep_leaf_stack is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: hot_start_rejects_unstable_pseudo_leaf
+    classification: state_or_ended_mismatch
+    observation: state_or_ended
+    support: expected_failure
+    skip_reason: "hot_start_rejects_unstable_pseudo_leaf is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: lifecycle_ref_chain_resolves_long_acyclic_chain
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "lifecycle_ref_chain_resolves_long_acyclic_chain is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: named_ref_context_reports_callsite
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "named_ref_context_reports_callsite is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: persistent_default_int_initializer_rejects_non_integer_float
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "persistent_default_int_initializer_rejects_non_integer_float is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: persistent_operation_writeback_rejects_float_and_rolls_back
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "persistent_operation_writeback_rejects_float_and_rolls_back is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: post_child_exit_continuation_skips_unstable_candidates
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "post_child_exit_continuation_skips_unstable_candidates is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: pseudo_candidate_skips_unstable_branch
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: pseudo_self_loop_step_limit_raises_dfs_error
+    classification: exception_type_mismatch
+    observation: raises
+    support: expected_failure
+    skip_reason: "pseudo_self_loop_step_limit_raises_dfs_error is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: ref_abstract_handler_reports_calling_state
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "ref_abstract_handler_reports_calling_state is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: ref_context_uses_callsite_stage
+    classification: handler_mismatch
+    observation: handler_calls
+    support: expected_failure
+    skip_reason: "ref_context_uses_callsite_stage is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: root_exit_runs_root_cleanup
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "root_exit_runs_root_cleanup is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: sign_function_aligns_aspect_guard_effect_math
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_aligns_aspect_guard_effect_math is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: sign_function_controls_guard_transition
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_controls_guard_transition is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: sign_function_handles_all_signs
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_handles_all_signs is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: sign_function_preserves_complex_action_precedence
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_preserves_complex_action_precedence is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: sign_function_updates_during_action
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "sign_function_updates_during_action is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: similar_state_paths_keep_actions_distinct
+    classification: parse_render_load
+    observation: render_build_load
+    support: expected_failure
+    skip_reason: "similar_state_paths_keep_actions_distinct is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"
+  - runner: generated_c_poll_alignment
+    case: transition_into_composite_skips_unstable_initial_candidate
+    classification: vars_mismatch
+    observation: vars
+    support: expected_failure
+    skip_reason: "transition_into_composite_skips_unstable_initial_candidate is a known C/C poll shared alignment gap."
+    tracking: https://github.com/HansBug/pyfcstm/issues/218
+    since: "2026-06-17"

--- a/test/template/c/test_semantic_fixture_alignment.py
+++ b/test/template/c/test_semantic_fixture_alignment.py
@@ -1,0 +1,31 @@
+import pytest
+
+from test.testings.native_semantic_alignment import (
+    GENERATED_C_ALIGNMENT,
+    run_native_alignment_case,
+    run_native_alignment_case_subprocess,
+)
+from test.testings.simulate_semantics import load_semantic_case
+
+
+@pytest.mark.unittest
+def test_generated_c_alignment_shared_fixture_smoke():
+    case = load_semantic_case("design_basic_simple_transition")
+
+    result = run_native_alignment_case(GENERATED_C_ALIGNMENT, case)
+
+    assert result.status == "passed"
+    assert result.classification is None
+
+
+@pytest.mark.unittest
+def test_generated_c_alignment_subprocess_reports_known_native_failure():
+    result = run_native_alignment_case_subprocess(
+        GENERATED_C_ALIGNMENT, "aspect_context_reports_active_leaf"
+    )
+
+    assert result.status == "expected_failure"
+    assert result.classification == "handler_mismatch"
+    assert result.expected_classification == "handler_mismatch"
+    assert result.support == "expected_failure"
+    assert result.tracking == "https://github.com/HansBug/pyfcstm/issues/218"

--- a/test/template/c_poll/test_semantic_fixture_alignment.py
+++ b/test/template/c_poll/test_semantic_fixture_alignment.py
@@ -1,0 +1,31 @@
+import pytest
+
+from test.testings.native_semantic_alignment import (
+    GENERATED_C_POLL_ALIGNMENT,
+    run_native_alignment_case,
+    run_native_alignment_case_subprocess,
+)
+from test.testings.simulate_semantics import load_semantic_case
+
+
+@pytest.mark.unittest
+def test_generated_c_poll_alignment_shared_fixture_smoke():
+    case = load_semantic_case("design_basic_simple_transition")
+
+    result = run_native_alignment_case(GENERATED_C_POLL_ALIGNMENT, case)
+
+    assert result.status == "passed"
+    assert result.classification is None
+
+
+@pytest.mark.unittest
+def test_generated_c_poll_alignment_subprocess_reports_known_native_failure():
+    result = run_native_alignment_case_subprocess(
+        GENERATED_C_POLL_ALIGNMENT, "aspect_context_reports_active_leaf"
+    )
+
+    assert result.status == "expected_failure"
+    assert result.classification == "handler_mismatch"
+    assert result.expected_classification == "handler_mismatch"
+    assert result.support == "expected_failure"
+    assert result.tracking == "https://github.com/HansBug/pyfcstm/issues/218"

--- a/test/template/test_native_semantic_alignment_framework.py
+++ b/test/template/test_native_semantic_alignment_framework.py
@@ -1,0 +1,205 @@
+import datetime as _dt
+import os
+import signal
+import subprocess
+
+import pytest
+
+from test.testings import native_semantic_alignment as native_alignment
+from test.testings.native_semantic_alignment import (
+    GENERATED_C_ALIGNMENT,
+    GENERATED_C_POLL_ALIGNMENT,
+    NativeAlignmentMatrixError,
+    load_native_capability_matrix,
+    native_capability_by_runner_case,
+)
+from test.testings.simulate_semantics import iter_semantic_cases
+
+
+@pytest.mark.unittest
+def test_native_capability_matrix_covers_known_failures():
+    entries = load_native_capability_matrix()
+    matrix = native_capability_by_runner_case(entries)
+    case_ids = {case.id for case in iter_semantic_cases()}
+
+    assert len(entries) == 98
+    assert {entry.runner for entry in entries} == {
+        GENERATED_C_ALIGNMENT,
+        GENERATED_C_POLL_ALIGNMENT,
+    }
+    for entry in entries:
+        assert entry.case in case_ids
+        assert entry.support == "expected_failure"
+        assert entry.skip_reason
+        assert entry.tracking.startswith("https://github.com/HansBug/pyfcstm/")
+        assert entry.since
+    assert (
+        GENERATED_C_ALIGNMENT,
+        "expression_failure_raises_expression_error",
+    ) in matrix
+    assert (
+        GENERATED_C_POLL_ALIGNMENT,
+        "transition_into_composite_skips_unstable_initial_candidate",
+    ) in matrix
+
+
+@pytest.mark.unittest
+def test_native_capability_matrix_uses_stable_schema_fields():
+    entries = load_native_capability_matrix()
+    assert all(hasattr(entry, "since") for entry in entries)
+    assert not any(hasattr(entry, "since_pr") for entry in entries)
+    assert all(_dt.date.fromisoformat(entry.since) for entry in entries)
+
+
+@pytest.mark.unittest
+def test_native_capability_matrix_rejects_missing_tracking(tmp_path):
+    matrix_file = tmp_path / "runner_capabilities.yaml"
+    matrix_file.write_text(
+        "version: 1\n"
+        "known_failures:\n"
+        "  - runner: generated_c_alignment\n"
+        "    case: design_basic_simple_transition\n"
+        "    classification: state_or_ended_mismatch\n"
+        "    observation: state_or_ended\n"
+        "    support: expected_failure\n"
+        "    skip_reason: known gap\n"
+        "    since: '2026-06-17'\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(NativeAlignmentMatrixError, match="missing fields"):
+        load_native_capability_matrix(str(matrix_file))
+
+
+@pytest.mark.unittest
+def test_native_capability_matrix_file_is_single_fact_source():
+    path = os.path.join(
+        "test", "fixtures", "simulate_semantics", "runner_capabilities.yaml"
+    )
+    assert os.path.isfile(path)
+
+
+@pytest.mark.unittest
+def test_native_subprocess_classifies_sigfpe_expected_failure(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=-signal.SIGFPE,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(native_alignment.subprocess, "run", fake_run)
+
+    result = native_alignment.run_native_alignment_case_subprocess(
+        GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
+    )
+
+    assert result.status == "expected_failure"
+    assert result.classification == "sigfpe"
+    assert result.expected_classification == "sigfpe"
+    assert result.support == "expected_failure"
+    assert result.returncode == -signal.SIGFPE
+
+
+@pytest.mark.unittest
+def test_native_subprocess_rejects_non_sigfpe_signal_for_sigfpe_case(monkeypatch):
+    sigsegv = getattr(signal, "SIGSEGV", 11)
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=-sigsegv,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(native_alignment.subprocess, "run", fake_run)
+
+    result = native_alignment.run_native_alignment_case_subprocess(
+        GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
+    )
+
+    assert result.status == "classification_mismatch"
+    assert result.classification == "native_crash"
+    assert result.expected_classification == "sigfpe"
+    assert result.returncode == -sigsegv
+
+
+@pytest.mark.unittest
+def test_native_subprocess_accepts_windows_arithmetic_crash_for_sigfpe_case(
+    monkeypatch,
+):
+    windows_arithmetic_returncodes = [
+        0xC000008E,
+        0xC0000090,
+        0xC0000094,
+        0xC0000095,
+    ]
+
+    for returncode in windows_arithmetic_returncodes:
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=returncode,
+                stdout="",
+                stderr="",
+            )
+
+        monkeypatch.setattr(native_alignment.subprocess, "run", fake_run)
+
+        result = native_alignment.run_native_alignment_case_subprocess(
+            GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
+        )
+
+        assert result.status == "expected_failure"
+        assert result.classification == "sigfpe"
+        assert result.expected_classification == "sigfpe"
+        assert result.returncode == returncode
+
+
+@pytest.mark.unittest
+def test_native_subprocess_rejects_windows_non_arithmetic_crash_for_sigfpe_case(
+    monkeypatch,
+):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0xC0000005,
+            stdout="",
+            stderr="",
+        )
+
+    monkeypatch.setattr(native_alignment.subprocess, "run", fake_run)
+
+    result = native_alignment.run_native_alignment_case_subprocess(
+        GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
+    )
+
+    assert result.status == "classification_mismatch"
+    assert result.classification == "native_crash"
+    assert result.expected_classification == "sigfpe"
+    assert result.returncode == 0xC0000005
+
+
+@pytest.mark.unittest
+def test_native_subprocess_rejects_worker_failure_for_parse_render_case(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=1,
+            stdout="",
+            stderr="Traceback (most recent call last):\nNameError: harness_bug\n",
+        )
+
+    monkeypatch.setattr(native_alignment.subprocess, "run", fake_run)
+
+    result = native_alignment.run_native_alignment_case_subprocess(
+        GENERATED_C_ALIGNMENT, "expression_type_error_wraps_transition_effect"
+    )
+
+    assert result.status == "classification_mismatch"
+    assert result.classification == "worker_failure"
+    assert result.expected_classification == "parse_render_load"
+    assert result.returncode == 1

--- a/test/testings/native_semantic_alignment.py
+++ b/test/testings/native_semantic_alignment.py
@@ -1,0 +1,1006 @@
+"""
+Native generated-runtime alignment helpers for semantic fixtures.
+
+This module adapts the schema v2 shared semantic fixture corpus to the built-in
+C and C poll templates. It owns the test-side runner names, capability-matrix
+validation, native public-observation adapter, and subprocess report helpers
+used by the C-family template alignment tests.
+
+The module contains:
+
+* :class:`NativeCapabilityEntry` - One known native alignment capability row.
+* :class:`NativeAlignmentResult` - Serializable outcome of one native case run.
+* :class:`NativeAlignmentReport` - Aggregate report for one native runner.
+* :func:`load_native_capability_matrix` - Load and validate the matrix YAML.
+* :func:`run_native_alignment_case` - Execute one case in-process.
+* :func:`run_native_alignment_case_subprocess` - Execute one case safely in a
+  child process so native crashes do not terminate pytest.
+
+Example::
+
+    >>> from test.testings.simulate_semantics import load_semantic_case
+    >>> case = load_semantic_case("design_basic_simple_transition")
+    >>> result = run_native_alignment_case("generated_c_alignment", case)
+    >>> result.case_id
+    'design_basic_simple_transition'
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import yaml
+
+from pyfcstm.simulate import (
+    SimulationRuntimeActionReferenceError,
+    SimulationRuntimeDfsError,
+    SimulationRuntimeEventError,
+    SimulationRuntimeExpressionError,
+    SimulationRuntimeTerminalStateError,
+)
+from test.testings import simulate_semantics
+from test.testings.simulate_semantics import (
+    SemanticCase,
+    iter_semantic_cases,
+    load_semantic_case,
+)
+
+GENERATED_C_ALIGNMENT = "generated_c_alignment"
+GENERATED_C_POLL_ALIGNMENT = "generated_c_poll_alignment"
+NATIVE_ALIGNMENT_RUNNERS = (GENERATED_C_ALIGNMENT, GENERATED_C_POLL_ALIGNMENT)
+CAPABILITY_MATRIX_PATH = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        "fixtures",
+        "simulate_semantics",
+        "runner_capabilities.yaml",
+    )
+)
+_REQUIRED_CAPABILITY_FIELDS = {
+    "runner",
+    "case",
+    "classification",
+    "observation",
+    "support",
+    "skip_reason",
+    "tracking",
+    "since",
+}
+_ALLOWED_CLASSIFICATIONS = {
+    "event_resolution",
+    "exception_type_mismatch",
+    "handler_mismatch",
+    "native_crash",
+    "native_timeout",
+    "parse_render_load",
+    "sigfpe",
+    "state_or_ended_mismatch",
+    "vars_mismatch",
+}
+# Worker failures are intentionally not allowed in the capability matrix:
+# harness/worker bugs must surface as unexpected or mismatched results.
+_WORKER_FAILURE_CLASSIFICATION = "worker_failure"
+# Windows reports native arithmetic traps as positive NTSTATUS values instead
+# of POSIX-style negative signals; these codes are equivalent to SIGFPE for
+# alignment classification, while non-arithmetic NTSTATUS values remain native
+# crashes.
+_WINDOWS_ARITHMETIC_EXCEPTION_NAMES = {
+    0xC000008D: "STATUS_FLOAT_DENORMAL_OPERAND",
+    0xC000008E: "STATUS_FLOAT_DIVIDE_BY_ZERO",
+    0xC000008F: "STATUS_FLOAT_INEXACT_RESULT",
+    0xC0000090: "STATUS_FLOAT_INVALID_OPERATION",
+    0xC0000091: "STATUS_FLOAT_OVERFLOW",
+    0xC0000092: "STATUS_FLOAT_STACK_CHECK",
+    0xC0000093: "STATUS_FLOAT_UNDERFLOW",
+    0xC0000094: "STATUS_INTEGER_DIVIDE_BY_ZERO",
+    0xC0000095: "STATUS_INTEGER_OVERFLOW",
+}
+_WINDOWS_NATIVE_EXCEPTION_NAMES = {
+    0xC0000005: "STATUS_ACCESS_VIOLATION",
+    0xC000001D: "STATUS_ILLEGAL_INSTRUCTION",
+    0xC000008C: "STATUS_ARRAY_BOUNDS_EXCEEDED",
+    0xC0000096: "STATUS_PRIVILEGED_INSTRUCTION",
+    **_WINDOWS_ARITHMETIC_EXCEPTION_NAMES,
+}
+_PARSE_RENDER_LOAD_EXCEPTIONS = (OSError, subprocess.CalledProcessError, AttributeError)
+_NATIVE_RUNTIME_EXCEPTIONS = (
+    RuntimeError,
+    ValueError,
+    TypeError,
+    KeyError,
+    AssertionError,
+)
+_SIMULATION_RUNTIME_EXCEPTIONS = (
+    SimulationRuntimeActionReferenceError,
+    SimulationRuntimeDfsError,
+    SimulationRuntimeEventError,
+    SimulationRuntimeExpressionError,
+    SimulationRuntimeTerminalStateError,
+    RuntimeError,
+    ValueError,
+    ArithmeticError,
+    TypeError,
+    KeyError,
+)
+
+
+class NativeAlignmentMatrixError(ValueError):
+    """
+    Raised when the native alignment capability matrix is malformed.
+
+    :param args: Positional message arguments accepted by :class:`ValueError`.
+    :type args: object
+
+    Example::
+
+        >>> err = NativeAlignmentMatrixError("bad native matrix")
+        >>> "matrix" in str(err)
+        True
+    """
+
+
+@dataclass(frozen=True)
+class NativeCapabilityEntry:
+    """
+    Known native alignment capability or expected-failure entry.
+
+    :param runner: Native alignment runner name.
+    :type runner: str
+    :param case: Shared semantic fixture case id.
+    :type case: str
+    :param classification: Stable failure classification for the case.
+    :type classification: str
+    :param observation: Public observation family affected by the entry.
+    :type observation: str
+    :param support: Support status, currently ``"expected_failure"`` for
+        native semantic alignment staging entries.
+    :type support: str
+    :param skip_reason: Human-readable reason for not treating the case as a
+        passing gate yet.
+    :type skip_reason: str
+    :param tracking: URL that tracks the native alignment gap.
+    :type tracking: str
+    :param since: Stable date, version, or commit for when the entry became
+        applicable. This is deliberately not named after a PR or roadmap item.
+    :type since: str
+
+    Example::
+
+        >>> entry = NativeCapabilityEntry(
+        ...     runner="generated_c_alignment",
+        ...     case="demo",
+        ...     classification="state_or_ended_mismatch",
+        ...     observation="state_or_ended",
+        ...     support="expected_failure",
+        ...     skip_reason="known gap",
+        ...     tracking="https://github.com/HansBug/pyfcstm/",
+        ...     since="2026-06-17",
+        ... )
+        >>> entry.runner
+        'generated_c_alignment'
+    """
+
+    runner: str
+    case: str
+    classification: str
+    observation: str
+    support: str
+    skip_reason: str
+    tracking: str
+    since: str
+
+
+@dataclass(frozen=True)
+class NativeAlignmentResult:
+    """
+    Serializable result for one native semantic alignment case.
+
+    :param runner: Native alignment runner name.
+    :type runner: str
+    :param case_id: Shared semantic fixture case id.
+    :type case_id: str
+    :param status: Outcome status, such as ``"passed"`` or ``"failed"``.
+    :type status: str
+    :param classification: Optional failure classification.
+    :type classification: str, optional
+    :param expected_classification: Optional known-failure classification from
+        the capability matrix.
+    :type expected_classification: str, optional
+    :param support: Optional capability support state for the case.
+    :type support: str, optional
+    :param tracking: Optional URL that tracks the known native gap.
+    :type tracking: str, optional
+    :param message: Short diagnostic message.
+    :type message: str
+    :param returncode: Subprocess return code when a child process was used.
+    :type returncode: int, optional
+
+    Example::
+
+        >>> result = NativeAlignmentResult("generated_c_alignment", "demo", "passed", None, "ok")
+        >>> result.status
+        'passed'
+    """
+
+    runner: str
+    case_id: str
+    status: str
+    classification: Optional[str]
+    message: str
+    returncode: Optional[int] = None
+    expected_classification: Optional[str] = None
+    support: Optional[str] = None
+    tracking: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Convert the result to a JSON-serializable dictionary.
+
+        :return: Result fields as a dictionary.
+        :rtype: dict
+
+        Example::
+
+            >>> NativeAlignmentResult("r", "c", "passed", None, "ok").to_dict()["status"]
+            'passed'
+        """
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class NativeAlignmentReport:
+    """
+    Aggregate native alignment report for one runner.
+
+    :param runner: Native alignment runner name.
+    :type runner: str
+    :param results: Individual case results.
+    :type results: typing.Sequence[NativeAlignmentResult]
+
+    Example::
+
+        >>> report = NativeAlignmentReport("generated_c_alignment", [])
+        >>> report.summary()["total"]
+        0
+    """
+
+    runner: str
+    results: Sequence[NativeAlignmentResult]
+
+    def summary(self) -> Dict[str, int]:
+        """
+        Count results by status.
+
+        :return: Summary dictionary with total and per-status counts.
+        :rtype: dict
+
+        Example::
+
+            >>> report = NativeAlignmentReport("r", [NativeAlignmentResult("r", "c", "passed", None, "ok")])
+            >>> report.summary()["passed"]
+            1
+        """
+        counts = {"total": len(self.results)}
+        for result in self.results:
+            counts[result.status] = counts.get(result.status, 0) + 1
+        return counts
+
+    def to_dict(self) -> Dict[str, Any]:
+        """
+        Convert the report to a JSON-serializable dictionary.
+
+        :return: Report fields and summary as a dictionary.
+        :rtype: dict
+
+        Example::
+
+            >>> NativeAlignmentReport("r", []).to_dict()["runner"]
+            'r'
+        """
+        return {
+            "runner": self.runner,
+            "summary": self.summary(),
+            "results": [result.to_dict() for result in self.results],
+        }
+
+
+def _matrix_error(message: str) -> NativeAlignmentMatrixError:
+    return NativeAlignmentMatrixError("native capability matrix: %s" % message)
+
+
+def _validate_runner_name(runner: str) -> None:
+    if runner not in NATIVE_ALIGNMENT_RUNNERS:
+        raise ValueError("unknown native alignment runner: %r" % runner)
+
+
+def load_native_capability_matrix(
+    path: str = CAPABILITY_MATRIX_PATH,
+) -> Tuple[NativeCapabilityEntry, ...]:
+    """
+    Load and validate the native runner capability matrix.
+
+    :param path: Path to the capability YAML file, defaults to the shared
+        fixture matrix path.
+    :type path: str, optional
+    :return: Validated capability entries.
+    :rtype: tuple[test.testings.native_semantic_alignment.NativeCapabilityEntry, ...]
+    :raises NativeAlignmentMatrixError: If the YAML schema is invalid.
+
+    Example::
+
+        >>> entries = load_native_capability_matrix()
+        >>> bool(entries)
+        True
+    """
+    with open(path, "r", encoding="utf-8") as file:
+        data = yaml.safe_load(file)
+    if not isinstance(data, dict):
+        raise _matrix_error("root must be a mapping")
+    if data.get("version") != 1:
+        raise _matrix_error("version must be 1")
+    raw_entries = data.get("known_failures")
+    if not isinstance(raw_entries, list):
+        raise _matrix_error("known_failures must be a list")
+
+    case_ids = {case.id for case in iter_semantic_cases()}
+    seen = set()
+    entries = []
+    for index, item in enumerate(raw_entries):
+        if not isinstance(item, dict):
+            raise _matrix_error("known_failures[%d] must be a mapping" % index)
+        missing = _REQUIRED_CAPABILITY_FIELDS - set(item.keys())
+        if missing:
+            raise _matrix_error(
+                "known_failures[%d] missing fields: %r" % (index, sorted(missing))
+            )
+        unknown = set(item.keys()) - _REQUIRED_CAPABILITY_FIELDS
+        if unknown:
+            raise _matrix_error(
+                "known_failures[%d] has unknown fields: %r" % (index, sorted(unknown))
+            )
+        entry = NativeCapabilityEntry(**item)
+        _validate_runner_name(entry.runner)
+        if entry.case not in case_ids:
+            raise _matrix_error(
+                "known_failures[%d] references unknown case %r" % (index, entry.case)
+            )
+        if entry.classification not in _ALLOWED_CLASSIFICATIONS:
+            raise _matrix_error(
+                "known_failures[%d] has unknown classification %r"
+                % (index, entry.classification)
+            )
+        if entry.support != "expected_failure":
+            raise _matrix_error(
+                "known_failures[%d].support must be 'expected_failure'" % index
+            )
+        if not entry.skip_reason:
+            raise _matrix_error("known_failures[%d].skip_reason is required" % index)
+        if not entry.tracking.startswith("https://github.com/HansBug/pyfcstm/"):
+            raise _matrix_error(
+                "known_failures[%d].tracking must be a pyfcstm URL" % index
+            )
+        if not entry.since:
+            raise _matrix_error("known_failures[%d].since is required" % index)
+        key = (entry.runner, entry.case)
+        if key in seen:
+            raise _matrix_error("duplicate entry for runner/case: %r" % (key,))
+        seen.add(key)
+        entries.append(entry)
+    return tuple(entries)
+
+
+def native_capability_by_runner_case(
+    entries: Optional[Iterable[NativeCapabilityEntry]] = None,
+) -> Dict[Tuple[str, str], NativeCapabilityEntry]:
+    """
+    Index capability entries by ``(runner, case_id)``.
+
+    :param entries: Optional entries to index, defaults to loading the matrix.
+    :type entries: typing.Iterable[NativeCapabilityEntry], optional
+    :return: Mapping from runner/case pairs to entries.
+    :rtype: dict
+
+    Example::
+
+        >>> matrix = native_capability_by_runner_case()
+        >>> ("generated_c_alignment", "expression_failure_raises_expression_error") in matrix
+        True
+    """
+    source = tuple(entries) if entries is not None else load_native_capability_matrix()
+    return {(entry.runner, entry.case): entry for entry in source}
+
+
+def _native_utils_for_runner(runner: str):
+    _validate_runner_name(runner)
+    if runner == GENERATED_C_ALIGNMENT:
+        from test.template.c import _utils as native_utils
+    else:
+        from test.template.c_poll import _utils as native_utils
+    return native_utils
+
+
+class _StateProxy:
+    def __init__(self, path: Optional[Tuple[str, ...]]):
+        self.path = path
+
+
+def _normalize_events_for_native(events: Any) -> Any:
+    if isinstance(events, str):
+        return [events]
+    return events
+
+
+def _native_handler_call_record(runtime: Any, ctx: Any) -> Dict[str, Any]:
+    return {
+        "action": ctx.action_name,
+        "state": ctx.get_full_state_path(),
+        "stage": ctx.action_stage,
+        "vars": {name: ctx.get_var(name) for name in runtime._var_names},
+    }
+
+
+def _install_native_fixture_handlers(
+    runtime: Any, case: SemanticCase
+) -> List[Mapping[str, Any]]:
+    calls = []
+    if not case.data.get("handlers"):
+        return calls
+    hook_map = runtime.get_abstract_hook_map()
+    callback_map = {}
+    for handler_data in case.data.get("handlers") or []:
+        hook_name = hook_map[handler_data["action"]]
+
+        def fixture_handler(
+            ctx, machine=runtime, item=handler_data, handler_calls=calls
+        ):
+            if item["behavior"] == "record_call":
+                handler_calls.append(_native_handler_call_record(machine, ctx))
+            else:
+                raise ValueError("handlers behavior is invalid: %r" % item["behavior"])
+
+        callback_map[hook_name] = fixture_handler
+    runtime.install_hooks(callback_map)
+    return calls
+
+
+class _GeneratedNativeAlignmentRuntime:
+    def __init__(self, simulation_runtime: Any, native_runtime: Any, dsl_code: str):
+        self._simulation_runtime = simulation_runtime
+        self._native_runtime = native_runtime
+        self._dsl_code = dsl_code
+
+    @property
+    def vars(self) -> Mapping[str, Any]:
+        return self._native_runtime.vars
+
+    @property
+    def is_ended(self) -> bool:
+        return self._native_runtime.is_ended
+
+    @property
+    def current_state(self) -> Optional[_StateProxy]:
+        path = self._native_runtime.current_state_path
+        if path is None:
+            return None
+        return _StateProxy(path)
+
+    def _assert_aligned(self, when: str) -> None:
+        sim_ended = self._simulation_runtime.is_ended
+        native_ended = self._native_runtime.is_ended
+        assert sim_ended == native_ended, (
+            "%s: is_ended mismatch for DSL:\n%s\nsimulation=%r, native=%r"
+            % (when, self._dsl_code, sim_ended, native_ended)
+        )
+        sim_vars = dict(self._simulation_runtime.vars)
+        native_vars = dict(self._native_runtime.vars)
+        assert sim_vars == native_vars, (
+            "%s: vars mismatch for DSL:\n%s\nsimulation=%r\nnative=%r"
+            % (when, self._dsl_code, sim_vars, native_vars)
+        )
+        if sim_ended:
+            assert self._native_runtime.current_state_path is None, (
+                "%s: native current_state_path should be None after end for DSL:\n%s\npath=%r"
+                % (when, self._dsl_code, self._native_runtime.current_state_path)
+            )
+        else:
+            sim_path = self._simulation_runtime.current_state.path
+            native_path = self._native_runtime.current_state_path
+            assert sim_path == native_path, (
+                "%s: current state mismatch for DSL:\n%s\nsimulation=%r\nnative=%r"
+                % (when, self._dsl_code, sim_path, native_path)
+            )
+
+    def cycle(self, events: Any = None) -> Any:
+        sim_exc = None
+        native_exc = None
+        native_events = _normalize_events_for_native(events)
+        try:
+            sim_result = self._simulation_runtime.cycle(events)
+        except _SIMULATION_RUNTIME_EXCEPTIONS as err:
+            # SimulationRuntime semantic exceptions are compared by class name;
+            # unexpected exception classes still propagate and expose harness
+            # bugs instead of being converted into alignment mismatches.
+            sim_exc = err
+        try:
+            self._native_runtime.cycle(native_events)
+        except _NATIVE_RUNTIME_EXCEPTIONS as err:
+            # Native adapters expose generated diagnostics as Python exceptions.
+            native_exc = err
+        if sim_exc is not None or native_exc is not None:
+            assert sim_exc is not None and native_exc is not None, (
+                "cycle(events=%r) exception mismatch for DSL:\n%s\nsimulation=%r, native=%r"
+                % (events, self._dsl_code, sim_exc, native_exc)
+            )
+            assert type(sim_exc).__name__ == type(native_exc).__name__, (
+                "cycle(events=%r) exception type mismatch for DSL:\n%s\nsimulation=%s: %s\nnative=%s: %s"
+                % (
+                    events,
+                    self._dsl_code,
+                    type(sim_exc).__name__,
+                    sim_exc,
+                    type(native_exc).__name__,
+                    native_exc,
+                )
+            )
+            assert str(sim_exc) == str(native_exc), (
+                "cycle(events=%r) exception message mismatch for DSL:\n%s\nsimulation=%s: %s\nnative=%s: %s"
+                % (
+                    events,
+                    self._dsl_code,
+                    type(sim_exc).__name__,
+                    sim_exc,
+                    type(native_exc).__name__,
+                    native_exc,
+                )
+            )
+            raise sim_exc
+        self._assert_aligned("after cycle(events=%r)" % (events,))
+        return sim_result
+
+
+def _build_native_runtime(runner: str, case: SemanticCase) -> Any:
+    native_utils = _native_utils_for_runner(runner)
+    return native_utils.build_c_runtime(
+        case.dsl_code, **simulate_semantics._initial_kwargs(case)
+    )
+
+
+def _capture_native_construction(runner: str, case: SemanticCase):
+    try:
+        return _build_native_runtime(runner, case), None
+    except _PARSE_RENDER_LOAD_EXCEPTIONS as err:
+        # OSError covers shared-library load failures; CalledProcessError covers
+        # cmake/build failures; AttributeError covers missing exported symbols.
+        return None, err
+    except _NATIVE_RUNTIME_EXCEPTIONS as err:
+        # RuntimeError/ValueError/TypeError/KeyError/AssertionError cover native
+        # wrapper construction and hot-start diagnostics. Unexpected exceptions
+        # propagate to expose harness bugs.
+        return None, err
+
+
+def _classify_exception(error: BaseException) -> str:
+    message = "%s: %s" % (type(error).__name__, error)
+    lowered = message.lower()
+    if isinstance(error, _PARSE_RENDER_LOAD_EXCEPTIONS):
+        return "parse_render_load"
+    if (
+        "cmake" in lowered
+        or "shared library" in lowered
+        or "shared-library" in lowered
+        or "exported symbol" in lowered
+        or "integer string conversion" in lowered
+        or "4300 digits" in lowered
+    ):
+        return "parse_render_load"
+    if "handler call" in lowered or "handler_calls" in lowered:
+        return "handler_mismatch"
+    if "var" in lowered:
+        return "vars_mismatch"
+    if "exception" in lowered or "raises" in lowered or "dfs" in lowered:
+        return "exception_type_mismatch"
+    if (
+        "unknown event path" in lowered
+        or "cannot resolve event path" in lowered
+        or "event resolution" in lowered
+    ):
+        return "event_resolution"
+    if "state" in lowered or "ended" in lowered:
+        return "state_or_ended_mismatch"
+    return "state_or_ended_mismatch"
+
+
+def _apply_capability_entry(result: NativeAlignmentResult) -> NativeAlignmentResult:
+    if result.status not in {"passed", "failed"}:
+        return result
+
+    entry = native_capability_by_runner_case().get((result.runner, result.case_id))
+    if entry is None:
+        if result.status == "failed":
+            return NativeAlignmentResult(
+                result.runner,
+                result.case_id,
+                "unexpected_failure",
+                result.classification,
+                result.message,
+                result.returncode,
+            )
+        return result
+
+    if result.status == "passed":
+        return NativeAlignmentResult(
+            result.runner,
+            result.case_id,
+            "unexpected_pass",
+            result.classification,
+            "known native alignment gap passed; update the capability matrix",
+            result.returncode,
+            expected_classification=entry.classification,
+            support=entry.support,
+            tracking=entry.tracking,
+        )
+
+    if result.classification == entry.classification:
+        return NativeAlignmentResult(
+            result.runner,
+            result.case_id,
+            "expected_failure",
+            result.classification,
+            result.message,
+            result.returncode,
+            expected_classification=entry.classification,
+            support=entry.support,
+            tracking=entry.tracking,
+        )
+
+    return NativeAlignmentResult(
+        result.runner,
+        result.case_id,
+        "classification_mismatch",
+        result.classification,
+        (
+            "%s; expected known-failure classification %s"
+            % (result.message, entry.classification)
+        ),
+        result.returncode,
+        expected_classification=entry.classification,
+        support=entry.support,
+        tracking=entry.tracking,
+    )
+
+
+def _raw_native_alignment_case(
+    runner: str, case: SemanticCase
+) -> NativeAlignmentResult:
+    _validate_runner_name(runner)
+    simulation_runtime, simulation_err = simulate_semantics._capture_construction(
+        lambda: simulate_semantics._build_simulation_runtime(case)
+    )
+    native_runtime, native_err = _capture_native_construction(runner, case)
+    initial_expect = simulate_semantics._initial_constructor_expect(case)
+    try:
+        simulate_semantics._assert_aligned_constructor_outcome(
+            case,
+            initial_expect,
+            simulation_runtime,
+            simulation_err,
+            native_runtime,
+            native_err,
+        )
+        if initial_expect is not None:
+            return NativeAlignmentResult(runner, case.id, "passed", None, "passed")
+        simulation_handler_calls = simulate_semantics._register_fixture_handlers(
+            simulation_runtime, case
+        )
+        native_handler_calls = _install_native_fixture_handlers(native_runtime, case)
+        runtime = _GeneratedNativeAlignmentRuntime(
+            simulation_runtime, native_runtime, case.dsl_code
+        )
+        runtime._assert_aligned("initial build")
+        for index, step in enumerate(case.data.get("steps") or []):
+            simulate_semantics._run_step(
+                runtime,
+                step,
+                case,
+                index,
+                handler_calls=simulation_handler_calls,
+            )
+            simulation_calls = simulate_semantics._normalize_handler_call_records(
+                simulation_handler_calls
+            )
+            native_calls = simulate_semantics._normalize_handler_call_records(
+                native_handler_calls
+            )
+            assert simulation_calls == native_calls, (
+                "%s steps[%d] handler call mismatch: simulation=%r, native=%r"
+                % (case.id, index, simulation_calls, native_calls)
+            )
+    except AssertionError as err:
+        return NativeAlignmentResult(
+            runner, case.id, "failed", _classify_exception(err), str(err)
+        )
+    except _PARSE_RENDER_LOAD_EXCEPTIONS as err:
+        return NativeAlignmentResult(
+            runner,
+            case.id,
+            "failed",
+            "parse_render_load",
+            "%s: %s" % (type(err).__name__, err),
+        )
+    except _NATIVE_RUNTIME_EXCEPTIONS as err:
+        return NativeAlignmentResult(
+            runner,
+            case.id,
+            "failed",
+            _classify_exception(err),
+            "%s: %s" % (type(err).__name__, err),
+        )
+    finally:
+        if native_runtime is not None:
+            native_runtime.close()
+    return NativeAlignmentResult(runner, case.id, "passed", None, "passed")
+
+
+def run_native_alignment_case(runner: str, case: SemanticCase) -> NativeAlignmentResult:
+    """
+    Execute one semantic fixture against a native generated runtime.
+
+    :param runner: Native runner name, either ``generated_c_alignment`` or
+        ``generated_c_poll_alignment``.
+    :type runner: str
+    :param case: Semantic fixture to execute.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :return: Serializable native alignment result.
+    :rtype: test.testings.native_semantic_alignment.NativeAlignmentResult
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> run_native_alignment_case("generated_c_alignment", case).status
+        'passed'
+    """
+    return _apply_capability_entry(_raw_native_alignment_case(runner, case))
+
+
+def _signal_name(returncode: int) -> str:
+    signal_number = -returncode
+    try:
+        return signal.Signals(signal_number).name
+    except ValueError:
+        return "signal_%d" % signal_number
+
+
+def _windows_exception_code(returncode: int) -> Optional[int]:
+    unsigned_code = returncode & 0xFFFFFFFF
+    if unsigned_code in _WINDOWS_NATIVE_EXCEPTION_NAMES:
+        return unsigned_code
+    return None
+
+
+def _classify_worker_returncode(returncode: int) -> Tuple[str, str]:
+    windows_code = _windows_exception_code(returncode)
+    if windows_code is not None:
+        name = _WINDOWS_NATIVE_EXCEPTION_NAMES[windows_code]
+        if windows_code in _WINDOWS_ARITHMETIC_EXCEPTION_NAMES:
+            return "sigfpe", "native alignment worker terminated by %s" % name
+        return "native_crash", "native alignment worker terminated by %s" % name
+
+    if returncode < 0:
+        classification = "sigfpe" if returncode == -signal.SIGFPE else "native_crash"
+        return (
+            classification,
+            "native alignment worker terminated by %s" % _signal_name(returncode),
+        )
+
+    return (
+        _WORKER_FAILURE_CLASSIFICATION,
+        "native alignment worker exited with status %s" % returncode,
+    )
+
+
+def _worker_failure_message(completed: subprocess.CompletedProcess) -> str:
+    output = (completed.stderr or completed.stdout).strip()
+    prefix = _classify_worker_returncode(completed.returncode)[1]
+    if output:
+        return "%s: %s" % (prefix, output)
+    return prefix
+
+
+def run_native_alignment_case_subprocess(
+    runner: str, case_id: str, timeout: int = 240
+) -> NativeAlignmentResult:
+    """
+    Execute one native alignment case in a child Python process.
+
+    Subprocess execution protects pytest from native process crashes such as
+    ``SIGFPE`` while preserving a JSON result for ordinary mismatches.
+
+    :param runner: Native runner name.
+    :type runner: str
+    :param case_id: Semantic fixture id.
+    :type case_id: str
+    :param timeout: Child-process timeout in seconds, defaults to ``240``.
+    :type timeout: int, optional
+    :return: Serializable native alignment result.
+    :rtype: test.testings.native_semantic_alignment.NativeAlignmentResult
+
+    Example::
+
+        >>> result = run_native_alignment_case_subprocess("generated_c_alignment", "design_basic_simple_transition")
+        >>> result.case_id
+        'design_basic_simple_transition'
+    """
+    _validate_runner_name(runner)
+    cmd = [
+        sys.executable,
+        "-m",
+        "test.testings.native_semantic_alignment",
+        "--worker",
+        "--runner",
+        runner,
+        "--case-id",
+        case_id,
+    ]
+    try:
+        completed = subprocess.run(
+            cmd,
+            cwd=os.path.abspath(
+                os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+            ),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as err:
+        return _apply_capability_entry(
+            NativeAlignmentResult(
+                runner,
+                case_id,
+                "failed",
+                "native_timeout",
+                "native alignment worker timed out after %s seconds" % err.timeout,
+                None,
+            )
+        )
+    crash_classification, crash_message = _classify_worker_returncode(
+        completed.returncode
+    )
+    if crash_classification != _WORKER_FAILURE_CLASSIFICATION:
+        return _apply_capability_entry(
+            NativeAlignmentResult(
+                runner,
+                case_id,
+                "failed",
+                crash_classification,
+                crash_message,
+                completed.returncode,
+            )
+        )
+    if completed.returncode != 0:
+        return _apply_capability_entry(
+            NativeAlignmentResult(
+                runner,
+                case_id,
+                "failed",
+                _WORKER_FAILURE_CLASSIFICATION,
+                _worker_failure_message(completed),
+                completed.returncode,
+            )
+        )
+    lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    if not lines:
+        return _apply_capability_entry(
+            NativeAlignmentResult(
+                runner,
+                case_id,
+                "failed",
+                _WORKER_FAILURE_CLASSIFICATION,
+                "native alignment worker produced no JSON output",
+                completed.returncode,
+            )
+        )
+    try:
+        data = json.loads(lines[-1])
+    except json.JSONDecodeError as err:
+        # json.loads raises JSONDecodeError when the worker exits successfully
+        # but does not emit the expected final JSON result line.
+        return _apply_capability_entry(
+            NativeAlignmentResult(
+                runner,
+                case_id,
+                "failed",
+                _WORKER_FAILURE_CLASSIFICATION,
+                "native alignment worker produced invalid JSON output: %s" % err,
+                completed.returncode,
+            )
+        )
+    return _apply_capability_entry(NativeAlignmentResult(**data))
+
+
+def run_native_alignment_report(
+    runner: str, case_ids: Optional[Sequence[str]] = None, subprocess_mode: bool = True
+) -> NativeAlignmentReport:
+    """
+    Run a native alignment report for selected semantic fixtures.
+
+    :param runner: Native runner name.
+    :type runner: str
+    :param case_ids: Optional explicit case ids, defaults to all shared cases.
+    :type case_ids: typing.Sequence[str], optional
+    :param subprocess_mode: Whether to isolate each case in a subprocess,
+        defaults to ``True``.
+    :type subprocess_mode: bool, optional
+    :return: Native alignment report.
+    :rtype: test.testings.native_semantic_alignment.NativeAlignmentReport
+
+    Example::
+
+        >>> report = run_native_alignment_report("generated_c_alignment", ["design_basic_simple_transition"])
+        >>> report.runner
+        'generated_c_alignment'
+    """
+    _validate_runner_name(runner)
+    selected_ids = list(case_ids or [case.id for case in iter_semantic_cases()])
+    results = []
+    for case_id in selected_ids:
+        if subprocess_mode:
+            results.append(run_native_alignment_case_subprocess(runner, case_id))
+        else:
+            results.append(
+                run_native_alignment_case(runner, load_semantic_case(case_id))
+            )
+    return NativeAlignmentReport(runner, results)
+
+
+def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run native shared semantic alignment."
+    )
+    parser.add_argument("--runner", choices=NATIVE_ALIGNMENT_RUNNERS, required=True)
+    parser.add_argument("--case-id", action="append", dest="case_ids")
+    parser.add_argument("--worker", action="store_true")
+    parser.add_argument("--in-process", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """
+    Command-line entry point for native semantic alignment reports.
+
+    :param argv: Optional command-line arguments without the executable name.
+    :type argv: typing.Sequence[str], optional
+    :return: Process exit status.
+    :rtype: int
+
+    Example::
+
+        >>> main(["--runner", "generated_c_alignment", "--case-id", "design_basic_simple_transition"])
+        0
+    """
+    args = _parse_args(argv)
+    if args.worker:
+        if not args.case_ids or len(args.case_ids) != 1:
+            raise SystemExit("--worker requires exactly one --case-id")
+        result = _raw_native_alignment_case(
+            args.runner, load_semantic_case(args.case_ids[0])
+        )
+        print(json.dumps(result.to_dict(), sort_keys=True))
+        return 0
+    report = run_native_alignment_report(
+        args.runner,
+        case_ids=args.case_ids,
+        subprocess_mode=not args.in_process,
+    )
+    print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/native_semantic_alignment_report.py
+++ b/tools/native_semantic_alignment_report.py
@@ -1,0 +1,29 @@
+"""
+Run native C-family semantic alignment reports.
+
+This command is a thin wrapper around
+:mod:`test.testings.native_semantic_alignment`. It gives maintainers a stable
+entry point for generating the formal C / C poll shared fixture report for
+native generated-runtime parity work.
+
+Example::
+
+    $ python tools/native_semantic_alignment_report.py --runner generated_c_alignment --case-id design_basic_simple_transition
+"""
+
+import importlib
+import os
+import sys
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _load_main():
+    return importlib.import_module("test.testings.native_semantic_alignment").main
+
+
+if __name__ == "__main__":
+    raise SystemExit(_load_main()())


### PR DESCRIPTION
Base umbrella PR: https://github.com/HansBug/pyfcstm/pull/233  
Refs https://github.com/HansBug/pyfcstm/issues/218

## PR-0 范围

本 PR 是 issue #218 / umbrella PR #233 的 PR-0：**native shared runner 框架**。目标是先建立 C / C poll 接入 schema v2 shared semantic fixture corpus 的正式 runner / adapter / capability / skip / report 基座，不在本 PR 内修复 C-family 语义差异本身。

## 前置事实

| 前置项 | 当前状态 | PR-0 消费方式 |
|---|---|---|
| [issue #217](https://github.com/HansBug/pyfcstm/issues/217) | ✅ 已关闭 | shared fixture 已收束为跨实现公开观察面语料；非共享测试不回流本 PR。 |
| [PR #219](https://github.com/HansBug/pyfcstm/pull/219) | ✅ 已合入 [`a4c2f2e`](https://github.com/HansBug/pyfcstm/commit/a4c2f2ed3576576ad16550f925d2295e83df7540) | 第一阶段 shared corpus 收束已进入 `main`。 |
| [issue #227](https://github.com/HansBug/pyfcstm/issues/227) | ✅ 已关闭 | schema v2 规则已定稿，本 PR 只消费 v2。 |
| [PR #231](https://github.com/HansBug/pyfcstm/pull/231) | ✅ 已合入 [`6ec3489`](https://github.com/HansBug/pyfcstm/commit/6ec3489f5ad50b8e181fa72877ef4ae0d411eaeb) | 143 个 shared semantic fixture 已迁移到 schema v2。 |
| [umbrella PR #233](https://github.com/HansBug/pyfcstm/pull/233) | ✅ body ready，base branch | 本 PR 以 `dev/issue-218-c-cpoll-shared-alignment` 为 base，并向该伞 PR 分支合入。 |

本 PR 必须完成：

| 工作项 | 本 PR 验收目标 | 当前证据 |
|---|---|---|
| C / C poll shared fixture runner | 增加 `generated_c_alignment` 与 `generated_c_poll_alignment` 集中 runner 入口，能消费 `test/fixtures/simulate_semantics/cases/` 中 143 个 schema v2 case。 | ✅ `tools/native_semantic_alignment_report.py --runner ...` 对两个 runner 均覆盖 143 case。 |
| native adapter 契约 | C / C poll runner 只暴露公开观察面：`current_state_path`、`vars`、`is_ended`、构造 / hot start、`cycle(events)`、hook call records。不得读取 C/C poll 内部 enum、frame、stack、history、cycle counter 或私有状态 ID 来证明对齐。 | ✅ 新增 `test/testings/native_semantic_alignment.py` 通过 generated runtime adapter 与 simulator 对照。 |
| capability / skip 单一事实源 | 所有 native alignment skip / xfail / unsupported 必须集中记录 runner、observation、support、skip_reason、tracking、since；不得散落在 pytest 条件里。`since` 表达能力事实首次适用的稳定版本 / 日期 / commit，不得把 PR-0、阶段名或 issue 编号写入 schema 字段名、API、测试 id 或 runtime message；具体追踪请放在 `tracking` URL。 | ✅ `test/fixtures/simulate_semantics/runner_capabilities.yaml` 是单一 test-side fact source；framework tests 校验字段、tracking 和 `since`。 |
| 正式分类报告 | PR-0 必须生成正式 C/C poll shared runner 分类报告，并用该报告回填本 PR / umbrella PR #233 / issue #218 的失败分类表。临时摸底结果不能长期替代正式 runner 输出。 | ✅ 本 PR body 已回填正式 runner 结果；umbrella PR / issue 在本 PR 合入后再同步最终进度。 |
| 旧门禁保留 | `test/template/c/test_runtime_alignment.py` 与 `test/template/c_poll/test_runtime_alignment.py` 在 shared runner 等价覆盖前继续运行并通过。 | ✅ `pytest test/template/c test/template/c_poll -v`：174 passed。 |
| slow/native gate | 本 PR ready 前禁止以 `SKIP_SLOW_TESTS=1` 或 `[skip-slow]` 作为最终验收依据；必须真实生成、编译、加载并执行 C/C poll native gate。 | ✅ 本地已运行无 slow-skip `make unittest`：41306 passed, 63 deselected。 |

## 非目标

| 非目标 | 说明 |
|---|---|
| 修复 C-family 语义 bug | `sigfpe`、parse/render/load、exception type、composite/pseudo/init、hook context 等语义修复归 PR-1/2/3。PR-0 只建立可重复暴露和分类这些问题的 runner 基座。 |
| shared fixture 语义重定义 | 本 PR 只消费 schema v2 shared fixture，不重新定义 DSL、cycle、expect、handler 规则。 |
| simulator-only debug surface | `CycleResult.value`、event accounting、`_stack`、history、cycle counter、private state id 不能进入 shared fixture 对齐面。 |
| CLI / REPL / jsfcstm / model_build | 本 PR 不把这些范围重新纳入 shared fixture alignment。 |

## 正式 runner 结果

当前基线来自 umbrella PR #233：`origin/dev/issue-218-c-cpoll-shared-alignment`。正式 runner 已落地，旧的 48-case 临时摸底账本被以下结果取代：两个 native runner 均为 **143 total / 94 passed / 49 expected_failure**，且没有 `unexpected_failure`、`classification_mismatch`、`unexpected_pass`。

正式命令：

```bash
./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_alignment
./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment
```

| Runner | Passed | Expected failure | Unexpected failure | Classification mismatch | Unexpected pass | 总计 |
|---|---:|---:|---:|---:|---:|---:|
| `generated_c_alignment` | 94 | 49 | 0 | 0 | 0 | 143 |
| `generated_c_poll_alignment` | 94 | 49 | 0 | 0 | 0 | 143 |

两个 runner 的分类分布一致：

| 分类 | 数量 | 后续归属 | PR-0 责任 |
|---|---:|---|---|
| `vars_mismatch` | 19 | PR-2 / PR-3 | 正式 runner 中保持具名 expected failure，不修。 |
| `handler_mismatch` | 8 | PR-3 | 正式 runner 中保持 handler 调用 / 上下文 mismatch 分类，不修。 |
| `parse_render_load` | 8 | PR-1 | 分类为生成/编译/加载链路失败；包含正式 runner 新确认的 `expression_large_integer_safe_diagnostics`。 |
| `sigfpe` | 7 | PR-1 | 不得 core dump 到 pytest 进程；通过 subprocess 隔离分类为 native crash / SIGFPE。 |
| `exception_type_mismatch` | 4 | PR-1 | 分类为异常类型 / 消息口径 mismatch。 |
| `state_or_ended_mismatch` | 3 | PR-2 / PR-3 | 分类为公开状态 / ended 观察面 mismatch。 |

<details>
<summary>49 个正式 expected-failure case（两个 runner 均一致）</summary>

#### `vars_mismatch`（19）

- `composite_initial_guard_after_event_transition_uses_pre_before_vars`
- `composite_initial_guard_after_leaf_transition_uses_enter_state`
- `composite_initial_guard_after_named_ref_before_uses_pre_ref_vars`
- `composite_initial_guard_uses_enter_state_before_plain_before`
- `composite_initial_guard_with_effect_runs_before_plain_before`
- `composite_initial_handler_log_after_transition_uses_selected_child`
- `composite_initial_handler_log_keeps_stable_branch_before_exit_branch`
- `composite_initial_handler_log_uses_enter_selected_child`
- `composite_initial_nested_entry_order_survives_deep_choice`
- `composite_initial_skips_unstable_candidates_root_entry`
- `forced_pseudo_candidate_skips_unstable_branch`
- `hot_start_initial_vars_reject_bool_values`
- `hot_start_initial_vars_reject_string_values`
- `persistent_default_int_initializer_rejects_non_integer_float`
- `persistent_operation_writeback_rejects_float_and_rolls_back`
- `post_child_exit_continuation_skips_unstable_candidates`
- `pseudo_candidate_skips_unstable_branch`
- `root_exit_runs_root_cleanup`
- `transition_into_composite_skips_unstable_initial_candidate`

#### `handler_mismatch`（8）

- `abstract_hook_context_hot_start_leaf`
- `abstract_hook_ref_context_reports_callsite_metadata`
- `aspect_context_reports_active_leaf`
- `failed_initial_cycle_skips_abstract_handler_callbacks`
- `lifecycle_ref_chain_resolves_long_acyclic_chain`
- `named_ref_context_reports_callsite`
- `ref_abstract_handler_reports_calling_state`
- `ref_context_uses_callsite_stage`

#### `parse_render_load`（8）

- `expression_large_integer_safe_diagnostics`
- `expression_type_error_wraps_transition_effect`
- `sign_function_aligns_aspect_guard_effect_math`
- `sign_function_controls_guard_transition`
- `sign_function_handles_all_signs`
- `sign_function_preserves_complex_action_precedence`
- `sign_function_updates_during_action`
- `similar_state_paths_keep_actions_distinct`

#### `sigfpe` native crash（7）

- `expression_error_preserves_runtime_snapshot`
- `expression_failure_if_condition_raises_expression_error`
- `expression_failure_raises_expression_error`
- `expression_failure_transition_effect_raises_expression_error`
- `expression_failure_transition_guard_raises_expression_error`
- `hot_start_initial_vars_override_skips_int_initializer`
- `hot_start_leaf_defers_during_expression_error`

#### `exception_type_mismatch`（4）

- `design_speculative_dfs_safety_limit`
- `ended_runtime_ignores_event_inputs`
- `hot_start_rejects_overdeep_leaf_stack`
- `pseudo_self_loop_step_limit_raises_dfs_error`

#### `state_or_ended_mismatch`（3）

- `composite_initial_guard_can_select_terminal_branch_before_plain_before`
- `hot_start_rejects_blocked_composite_initial`
- `hot_start_rejects_unstable_pseudo_leaf`

</details>

## TDD / 实现内容

1. ✅ 新增 `test/testings/native_semantic_alignment.py`：集中实现 native runner 名称、capability matrix 校验、generated runtime adapter、subprocess crash isolation、单 case/report 入口。
2. ✅ 新增 `test/fixtures/simulate_semantics/runner_capabilities.yaml`：两个 runner 共 98 条 expected-failure 记录，作为 native alignment skip / expected-failure 单一事实源。
3. ✅ 新增 `tools/native_semantic_alignment_report.py`：维护者可直接生成正式 C / C poll shared fixture report。
4. ✅ 新增 framework tests：校验 matrix 覆盖、稳定 schema 字段、tracking 必填、single fact source。
5. ✅ 新增 C / C poll smoke tests：验证 shared fixture 正常通过路径与 known native SIGFPE failure 的 subprocess 分类路径。
   - ✅ 补充白盒回归：`sigfpe` expected failure 只接受真实 POSIX `SIGFPE` / Windows arithmetic NTSTATUS；其他 native signal / non-arithmetic NTSTATUS 必须变成 `classification_mismatch`；worker/harness 正数非 0 退出必须分类为 `worker_failure`，不能伪装成 `parse_render_load`。
6. ✅ 保留旧 C/C poll runtime tests，不在 PR-0 中修复 49 个已知语义 gap。

## Slow-skip 禁用边界

本 PR 涉及 C/C poll native runner / template alignment 基座，**ready / merge 前禁止以 `SKIP_SLOW_TESTS=1` 或 commit message `[skip-slow]` 作为最终验收依据**。即便 prompt、review comment 或自动化提示提到 slow skip，也不能覆盖该禁用边界。

硬性要求：

1. 本 PR head commit message 不得包含 `[skip-slow]`、`ci skip`、`test skip`、`[python skip]`、`[js skip]` 等 CI 跳过触发 token。
2. ready 前必须至少有一次不带 `SKIP_SLOW_TESTS=1` 的本地 native gate 或 GitHub Actions native gate 证据。
3. `SKIP_SLOW_TESTS=1 make unittest` 只能作为迭代期补充信息，不能作为 ready 证据。
4. Reviewer 必须把 slow-skip 使用情况纳入 C/I/M；若本 PR 用 slow skip 作为最终 ready 证据，应给 C 级阻塞。

## 验收命令与本地证据

全部命令均显式使用 venv，且最终验收没有设置 `SKIP_SLOW_TESTS=1`：

```bash
PATH="$PWD/venv/bin:$PATH" ./venv/bin/ruff check \
  test/testings/native_semantic_alignment.py \
  tools/native_semantic_alignment_report.py \
  test/template/test_native_semantic_alignment_framework.py \
  test/template/c/test_semantic_fixture_alignment.py \
  test/template/c_poll/test_semantic_fixture_alignment.py
PATH="$PWD/venv/bin:$PATH" ./venv/bin/ruff format --check \
  test/testings/native_semantic_alignment.py \
  tools/native_semantic_alignment_report.py \
  test/template/test_native_semantic_alignment_framework.py \
  test/template/c/test_semantic_fixture_alignment.py \
  test/template/c_poll/test_semantic_fixture_alignment.py
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python -m pytest \
  test/template/test_native_semantic_alignment_framework.py \
  test/template/c/test_semantic_fixture_alignment.py \
  test/template/c_poll/test_semantic_fixture_alignment.py -q
./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_alignment
./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python -m pytest test/template/c test/template/c_poll -v
PATH="$PWD/venv/bin:$PATH" make rst_auto
PATH="$PWD/venv/bin:$PATH" make unittest
```

本地结果：

> CI note: first push exposed a macOS Python 3.14 portability issue where the smoke test bound a real native arithmetic-crash case to the Linux `SIGFPE` signal. The implementation now uses a cross-platform stable handler-mismatch case for subprocess known-failure smoke coverage, and keeps SIGFPE crash isolation covered by a synthetic subprocess-return test.

| Gate | 结果 |
|---|---|
| ruff check / format check | ✅ passed |
| focused native framework tests | ✅ 13 passed |
| formal `generated_c_alignment` report | ✅ 143 total / 94 passed / 49 expected_failure |
| formal `generated_c_poll_alignment` report | ✅ 143 total / 94 passed / 49 expected_failure |
| `pytest test/template/c test/template/c_poll -v` | ✅ 174 passed |
| `make rst_auto` | ✅ passed |
| full no-slow-skip `make unittest` | ✅ 41306 passed, 63 deselected, 2863 warnings |

## Review gate

开空 PR 后已完成 3 路 plan review：codex reviewer、claude reviewer、deepseek reviewer。实现 push 后还需要进行同样 3 路强对抗 code review，并纳入 CI / Codecov comment。

Implementation review 必须重点检查：

- 正式 runner 是否真的覆盖 143 个 schema v2 shared fixture；
- capability matrix 是否为唯一 expected-failure fact source；
- subprocess isolation 是否能稳定捕获 native crash 而不杀 pytest；
- 49 个 expected failure 是否没有被误报为 pass、unexpected failure 或 classification mismatch；
- 是否误把 simulator-only debug surface 回流 shared fixture；
- no-slow-skip native/full gate 证据是否充分；
- 新增 pydoc/docstring 是否符合 CLAUDE.md。

## Final ready summary

- ✅ Latest head: `32a873d77fd5b8cb29aa2666ddca0f44b804bc0c`.
- ✅ GitHub Actions: 33 / 33 checks passed.
- ✅ Local full gate without slow skip: `41306 passed, 63 deselected, 2863 warnings`.
- ✅ Final three-way adversarial review: codex / claude / deepseek all C=0 / I=0.
- ✅ Windows native crash classification delta: arithmetic NTSTATUS values map to `sigfpe`; known non-arithmetic NTSTATUS values remain `native_crash`; worker positive exits remain `worker_failure` and cannot be accepted as `parse_render_load`.
- ⏸️ Do not merge until explicit user instruction.

## 当前状态

- [x] Empty PR opened from umbrella branch.
- [x] Plan review C/I=0.
- [x] TDD + implementation.
- [x] `make rst_auto`.
- [x] Full local native gate without slow skip.
- [x] Full local `make unittest` without slow skip.
- [x] Push implementation.
- [x] Watch CI all passed.
- [x] Strong adversarial implementation review C/I=0.
- [x] Ready to merge into umbrella PR branch; do not merge without user instruction.



