### PR TITLE
fix(template): align C native hard blockers

### DIFF
--- a/docs/source/api_doc/render/c_runtime.rst
+++ b/docs/source/api_doc/render/c_runtime.rst
@@ -22,5 +22,3 @@ render\_c\_condition\_body
 -----------------------------------------------------
 
 .. autofunction:: render_c_condition_body
-
-

--- a/docs/source/api_doc/render/c_runtime.rst
+++ b/docs/source/api_doc/render/c_runtime.rst
@@ -1,0 +1,26 @@
+pyfcstm.render.c\_runtime
+========================================================
+
+.. currentmodule:: pyfcstm.render.c_runtime
+
+.. automodule:: pyfcstm.render.c_runtime
+
+
+OperationalNode
+-----------------------------------------------------
+
+.. autodata:: OperationalNode
+
+
+render\_c\_action\_body
+-----------------------------------------------------
+
+.. autofunction:: render_c_action_body
+
+
+render\_c\_condition\_body
+-----------------------------------------------------
+
+.. autofunction:: render_c_condition_body
+
+

--- a/docs/source/api_doc/render/index.rst
+++ b/docs/source/api_doc/render/index.rst
@@ -9,6 +9,7 @@ pyfcstm.render
 .. toctree::
     :maxdepth: 3
 
+    c_runtime
     env
     expr
     func

--- a/docs/source/api_doc/utils/jinja2.rst
+++ b/docs/source/api_doc/utils/jinja2.rst
@@ -6,6 +6,12 @@ pyfcstm.utils.jinja2
 .. automodule:: pyfcstm.utils.jinja2
 
 
+to\_c\_path\_identifier
+-----------------------------------------------------
+
+.. autofunction:: to_c_path_identifier
+
+
 add\_builtins\_to\_env
 -----------------------------------------------------
 

--- a/pyfcstm/render/c_runtime.py
+++ b/pyfcstm/render/c_runtime.py
@@ -627,66 +627,60 @@ def _render_statement_sequence(
             continue
 
         if isinstance(statement, dsl_nodes.OperationIf):
-            for index, branch in enumerate(statement.branches):
-                if index == 0:
-                    condition = branch.condition
-                    assert condition is not None
-                    branch_known = {**state_types, **current_types}
-                    _emit_expr_checks(
-                        lines,
-                        condition,
-                        branch_known,
-                        state_types.keys(),
-                        names,
-                        "if-block condition",
-                        indent,
-                        level,
-                    )
-                    _line(
-                        lines,
-                        indent,
-                        level,
-                        "if (%s) {"
-                        % _render_expr(
-                            condition, branch_known, state_types.keys()
-                        ).text,
-                    )
-                elif branch.condition is None:
-                    _line(lines, indent, level, "} else {")
-                else:
-                    branch_known = {**state_types, **current_types}
-                    _emit_expr_checks(
-                        lines,
-                        branch.condition,
-                        branch_known,
-                        state_types.keys(),
-                        names,
-                        "if-block condition",
-                        indent,
-                        level,
-                    )
-                    _line(
-                        lines,
-                        indent,
-                        level,
-                        "} else if (%s) {"
-                        % _render_expr(
-                            branch.condition, branch_known, state_types.keys()
-                        ).text,
-                    )
+
+            def emit_branch_body(
+                branch: dsl_nodes.OperationIfBranch, body_level: int
+            ) -> None:
+                """Emit one branch body with simulator-compatible local scope."""
                 body, _ = _render_statement_sequence(
                     tuple(branch.statements),
                     state_types,
                     dict(current_types),
                     names,
                     indent,
-                    level + 1,
+                    body_level,
                 )
                 if body:
                     lines.extend(body)
                 else:
-                    _line(lines, indent, level + 1, "/* no-op */")
-            _line(lines, indent, level, "}")
+                    _line(lines, indent, body_level, "/* no-op */")
+
+            def emit_branch_chain(index: int, chain_level: int) -> None:
+                """Nest later branch checks so earlier matched branches stay lazy."""
+                branch = statement.branches[index]
+                if branch.condition is None:
+                    emit_branch_body(branch, chain_level)
+                    return
+
+                branch_known = {**state_types, **current_types}
+                _emit_expr_checks(
+                    lines,
+                    branch.condition,
+                    branch_known,
+                    state_types.keys(),
+                    names,
+                    "if-block condition",
+                    indent,
+                    chain_level,
+                )
+                _line(
+                    lines,
+                    indent,
+                    chain_level,
+                    "if (%s) {"
+                    % _render_expr(
+                        branch.condition, branch_known, state_types.keys()
+                    ).text,
+                )
+                emit_branch_body(branch, chain_level + 1)
+                if index + 1 < len(statement.branches):
+                    _line(lines, indent, chain_level, "} else {")
+                    emit_branch_chain(index + 1, chain_level + 1)
+                    _line(lines, indent, chain_level, "}")
+                else:
+                    _line(lines, indent, chain_level, "}")
+
+            emit_branch_chain(0, level)
             continue
 
         raise TypeError("Unsupported C operation statement: %r" % (type(statement),))

--- a/pyfcstm/render/c_runtime.py
+++ b/pyfcstm/render/c_runtime.py
@@ -1,0 +1,796 @@
+"""
+C runtime code-generation helpers for built-in native templates.
+
+This module contains small, deterministic emitters used by the built-in
+``c`` and ``c_poll`` templates. The helpers render lifecycle action,
+transition-effect, and guard bodies with explicit runtime diagnostics around
+DSL expression failures that would otherwise surface as native crashes or C
+compile errors.
+
+The module contains:
+
+* :func:`render_c_action_body` - Render operation statements as a fallible C body.
+* :func:`render_c_condition_body` - Render a fallible C guard/condition body.
+
+The generated code remains C99-only and uses only helpers already emitted by
+``machine.c``; it does not add third-party runtime dependencies.
+
+Example::
+
+    >>> from pyfcstm.dsl.node import Integer, OperationAssignment
+    >>> code = render_c_action_body(
+    ...     [OperationAssignment("x", Integer("1"))],
+    ...     {"x": "int"},
+    ...     "DemoMachine",
+    ...     "DEMO_MACHINE",
+    ... )
+    >>> "scope->x = 1;" in code
+    True
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple, Union
+
+from ..dsl import node as dsl_nodes
+from ..model import IfBlock, Operation, OperationStatement
+from ..utils import to_c_identifier
+
+
+@dataclass(frozen=True)
+class _ExprRenderResult:
+    """
+    Rendered C expression plus coarse DSL type metadata.
+
+    :param text: C expression text.
+    :type text: str
+    :param value_type: Coarse DSL value type, such as ``"int"`` or ``"float"``.
+    :type value_type: str, optional
+
+    Example::
+
+        >>> result = _ExprRenderResult("scope->x", "int")
+        >>> result.text
+        'scope->x'
+    """
+
+    text: str
+    value_type: Optional[str]
+
+
+@dataclass(frozen=True)
+class _CNames:
+    """
+    Generated C naming context.
+
+    :param machine_class_name: Generated machine class prefix.
+    :type machine_class_name: str
+    :param machine_macro_name: Generated macro prefix.
+    :type machine_macro_name: str
+
+    Example::
+
+        >>> names = _CNames("RootMachine", "ROOT_MACHINE")
+        >>> names.failure
+        'ROOT_MACHINE_FAILURE'
+    """
+
+    machine_class_name: str
+    machine_macro_name: str
+
+    @property
+    def success(self) -> str:
+        """
+        Return the generated success macro.
+
+        :return: Success macro name.
+        :rtype: str
+
+        Example::
+
+            >>> _CNames("Demo", "DEMO").success
+            'DEMO_SUCCESS'
+        """
+        return "%s_SUCCESS" % self.machine_macro_name
+
+    @property
+    def failure(self) -> str:
+        """
+        Return the generated failure macro.
+
+        :return: Failure macro name.
+        :rtype: str
+
+        Example::
+
+            >>> _CNames("Demo", "DEMO").failure
+            'DEMO_FAILURE'
+        """
+        return "%s_FAILURE" % self.machine_macro_name
+
+    @property
+    def set_error(self) -> str:
+        """
+        Return the generated internal error setter name.
+
+        :return: Error-setter function name.
+        :rtype: str
+
+        Example::
+
+            >>> _CNames("Demo", "DEMO").set_error
+            '_Demo_set_error'
+        """
+        return "_%s_set_error" % self.machine_class_name
+
+
+OperationalNode = Union[OperationStatement, dsl_nodes.OperationalStatement]
+
+
+_MATH_FUNC_NAMES = {
+    "sin",
+    "cos",
+    "tan",
+    "asin",
+    "acos",
+    "atan",
+    "sinh",
+    "cosh",
+    "tanh",
+    "asinh",
+    "acosh",
+    "atanh",
+    "sqrt",
+    "cbrt",
+    "exp",
+    "log",
+    "log10",
+    "log2",
+    "log1p",
+    "ceil",
+    "floor",
+    "round",
+    "trunc",
+}
+
+
+_INT_OPERATORS = {"<<", ">>", "&", "^", "|"}
+
+
+def _quote_c_string(value: str) -> str:
+    """
+    Quote a string for generated C source.
+
+    :param value: Text to quote.
+    :type value: str
+    :return: C string literal text.
+    :rtype: str
+
+    Example::
+
+        >>> _quote_c_string("a'b")
+        '"a\'b"'
+    """
+    return json.dumps(value)
+
+
+def _line(lines: List[str], indent: str, level: int, text: str) -> None:
+    lines.append("%s%s" % (indent * level, text))
+
+
+def _normalise_var_types(var_types: Mapping[str, Any]) -> Dict[str, str]:
+    """
+    Convert model define metadata to a name/type mapping.
+
+    :param var_types: Mapping of variable names to type strings or define objects.
+    :type var_types: typing.Mapping[str, typing.Any]
+    :return: Normalized variable type map.
+    :rtype: dict
+
+    Example::
+
+        >>> _normalise_var_types({"x": "int"})
+        {'x': 'int'}
+    """
+    result = {}
+    for name, value in var_types.items():
+        if isinstance(value, str):
+            result[name] = value
+        elif hasattr(value, "type"):
+            result[name] = str(value.type)
+        else:
+            result[name] = str(value)
+    return result
+
+
+def _coerce_expr(expr: Any) -> dsl_nodes.Expr:
+    if isinstance(expr, dsl_nodes.Expr):
+        return expr
+    if hasattr(expr, "to_ast_node"):
+        return expr.to_ast_node()
+    raise TypeError("Unsupported C expression node: %r" % (type(expr),))
+
+
+def _coerce_statement(statement: OperationalNode) -> dsl_nodes.OperationalStatement:
+    if isinstance(statement, dsl_nodes.OperationalStatement):
+        return statement
+    if isinstance(statement, (Operation, IfBlock)):
+        return statement.to_ast_node()
+    if hasattr(statement, "to_ast_node"):
+        node = statement.to_ast_node()
+        if isinstance(node, dsl_nodes.OperationalStatement):
+            return node
+    raise TypeError("Unsupported C operation statement: %r" % (type(statement),))
+
+
+def _merge_types(type_a: Optional[str], type_b: Optional[str]) -> Optional[str]:
+    known = {type_a, type_b} - {None}
+    if not known:
+        return None
+    if "float" in known:
+        return "float"
+    if known == {"int"}:
+        return "int"
+    return next(iter(known))
+
+
+def _infer_expr_type(
+    expr: dsl_nodes.Expr, known_types: Mapping[str, str]
+) -> Optional[str]:
+    if isinstance(expr, (dsl_nodes.Integer, dsl_nodes.HexInt, dsl_nodes.Boolean)):
+        return "int"
+    if isinstance(expr, (dsl_nodes.Float, dsl_nodes.Constant)):
+        return "float"
+    if isinstance(expr, dsl_nodes.Name):
+        return known_types.get(expr.name)
+    if isinstance(expr, dsl_nodes.Paren):
+        return _infer_expr_type(expr.expr, known_types)
+    if isinstance(expr, dsl_nodes.UnaryOp):
+        return _infer_expr_type(expr.expr, known_types)
+    if isinstance(expr, dsl_nodes.UFunc):
+        if expr.func in {"floor", "ceil", "round", "trunc", "int", "sign"}:
+            return "int"
+        if expr.func == "abs":
+            return _infer_expr_type(expr.expr, known_types)
+        return "float"
+    if isinstance(expr, dsl_nodes.BinaryOp):
+        if expr.op in _INT_OPERATORS:
+            return "int"
+        if expr.op in {
+            "&&",
+            "||",
+            "=>",
+            "xor",
+            "iff",
+            "==",
+            "!=",
+            "<",
+            "<=",
+            ">",
+            ">=",
+        }:
+            return "int"
+        if expr.op == "/":
+            return "float"
+        return _merge_types(
+            _infer_expr_type(expr.expr1, known_types),
+            _infer_expr_type(expr.expr2, known_types),
+        )
+    if isinstance(expr, dsl_nodes.ConditionalOp):
+        return _merge_types(
+            _infer_expr_type(expr.value_true, known_types),
+            _infer_expr_type(expr.value_false, known_types),
+        )
+    return None
+
+
+def _render_expr(
+    expr: dsl_nodes.Expr,
+    known_types: Mapping[str, str],
+    state_names: Optional[Iterable[str]] = None,
+) -> _ExprRenderResult:
+    expr = _coerce_expr(expr)
+    state_name_set = set(state_names if state_names is not None else known_types.keys())
+    if isinstance(expr, dsl_nodes.Integer):
+        return _ExprRenderResult(repr(expr.value), "int")
+    if isinstance(expr, dsl_nodes.HexInt):
+        return _ExprRenderResult(hex(expr.value), "int")
+    if isinstance(expr, dsl_nodes.Float):
+        return _ExprRenderResult(repr(expr.value), "float")
+    if isinstance(expr, dsl_nodes.Boolean):
+        return _ExprRenderResult("1" if expr.value else "0", "int")
+    if isinstance(expr, dsl_nodes.Constant):
+        return _ExprRenderResult(repr(expr.value), "float")
+    if isinstance(expr, dsl_nodes.Name):
+        if expr.name in known_types:
+            text = (
+                "scope->%s" % to_c_identifier(expr.name)
+                if expr.name in state_name_set
+                else to_c_identifier(expr.name)
+            )
+            return _ExprRenderResult(text, known_types.get(expr.name))
+        return _ExprRenderResult(to_c_identifier(expr.name), None)
+    if isinstance(expr, dsl_nodes.Paren):
+        inner = _render_expr(expr.expr, known_types, state_name_set)
+        return _ExprRenderResult("(%s)" % inner.text, inner.value_type)
+    if isinstance(expr, dsl_nodes.UnaryOp):
+        inner = _render_expr(expr.expr, known_types, state_name_set)
+        op = "!" if expr.op == "not" else expr.op
+        return _ExprRenderResult(
+            "(%s%s)" % (op, inner.text), _infer_expr_type(expr, known_types)
+        )
+    if isinstance(expr, dsl_nodes.UFunc):
+        inner = _render_expr(expr.expr, known_types, state_name_set)
+        if expr.func == "sign":
+            text = "(((%s) > 0) - ((%s) < 0))" % (inner.text, inner.text)
+        elif expr.func == "abs":
+            text = (
+                "fabs(%s)" % inner.text
+                if inner.value_type == "float"
+                else "llabs(%s)" % inner.text
+            )
+        elif expr.func == "cbrt":
+            text = "cbrt(%s)" % inner.text
+        elif expr.func in _MATH_FUNC_NAMES:
+            text = "%s(%s)" % (expr.func, inner.text)
+        else:
+            text = "%s(%s)" % (expr.func, inner.text)
+        return _ExprRenderResult(text, _infer_expr_type(expr, known_types))
+    if isinstance(expr, dsl_nodes.BinaryOp):
+        left = _render_expr(expr.expr1, known_types, state_name_set)
+        right = _render_expr(expr.expr2, known_types, state_name_set)
+        if expr.op in _INT_OPERATORS and (
+            left.value_type == "float" or right.value_type == "float"
+        ):
+            text = "0"
+        elif expr.op == "**":
+            text = "pow(%s, %s)" % (left.text, right.text)
+        elif expr.op == "%" and (
+            left.value_type == "float" or right.value_type == "float"
+        ):
+            text = "fmod(%s, %s)" % (left.text, right.text)
+        elif expr.op == "/":
+            text = "(((double)(%s)) / (%s))" % (left.text, right.text)
+        elif expr.op == "=>":
+            text = "((!(%s)) || (%s))" % (left.text, right.text)
+        elif expr.op == "xor":
+            text = "((%s) != (%s))" % (left.text, right.text)
+        elif expr.op == "iff":
+            text = "((%s) == (%s))" % (left.text, right.text)
+        else:
+            text = "((%s) %s (%s))" % (left.text, expr.op, right.text)
+        return _ExprRenderResult(text, _infer_expr_type(expr, known_types))
+    if isinstance(expr, dsl_nodes.ConditionalOp):
+        cond = _render_expr(expr.cond, known_types, state_name_set)
+        value_true = _render_expr(expr.value_true, known_types, state_name_set)
+        value_false = _render_expr(expr.value_false, known_types, state_name_set)
+        text = "((%s) ? (%s) : (%s))" % (cond.text, value_true.text, value_false.text)
+        return _ExprRenderResult(text, _infer_expr_type(expr, known_types))
+    raise TypeError("Unsupported C expression node: %r" % (type(expr),))
+
+
+def _python_type_name(value_type: Optional[str]) -> str:
+    if value_type == "float":
+        return "float"
+    return "int"
+
+
+def _zero_division_message(
+    operator_text: str, value_type: Optional[str], right_text: str
+) -> str:
+    if operator_text == "%":
+        if value_type == "float":
+            return "float modulo"
+        return "integer modulo by zero"
+    if value_type == "float" or "." in right_text:
+        return "float division by zero"
+    return "division by zero"
+
+
+def _emit_error(
+    lines: List[str], names: _CNames, indent: str, level: int, message: str
+) -> None:
+    _line(
+        lines,
+        indent,
+        level,
+        "%s(machine, %s);" % (names.set_error, _quote_c_string(message)),
+    )
+    _line(lines, indent, level, "return %s;" % names.failure)
+
+
+def _emit_expr_checks(
+    lines: List[str],
+    expr: dsl_nodes.Expr,
+    known_types: Mapping[str, str],
+    state_names: Iterable[str],
+    names: _CNames,
+    usage: str,
+    indent: str,
+    level: int,
+) -> bool:
+    expr = _coerce_expr(expr)
+    state_name_set = set(state_names)
+    if isinstance(expr, dsl_nodes.Paren):
+        return _emit_expr_checks(
+            lines, expr.expr, known_types, state_name_set, names, usage, indent, level
+        )
+    if isinstance(expr, dsl_nodes.UnaryOp):
+        return _emit_expr_checks(
+            lines, expr.expr, known_types, state_name_set, names, usage, indent, level
+        )
+    if isinstance(expr, dsl_nodes.UFunc):
+        return _emit_expr_checks(
+            lines, expr.expr, known_types, state_name_set, names, usage, indent, level
+        )
+    if isinstance(expr, dsl_nodes.ConditionalOp):
+        cond = _render_expr(expr.cond, known_types, state_name_set).text
+        safe = _emit_expr_checks(
+            lines, expr.cond, known_types, state_name_set, names, usage, indent, level
+        )
+        _line(lines, indent, level, "if (%s) {" % cond)
+        safe = (
+            _emit_expr_checks(
+                lines,
+                expr.value_true,
+                known_types,
+                state_name_set,
+                names,
+                usage,
+                indent,
+                level + 1,
+            )
+            and safe
+        )
+        _line(lines, indent, level, "} else {")
+        safe = (
+            _emit_expr_checks(
+                lines,
+                expr.value_false,
+                known_types,
+                state_name_set,
+                names,
+                usage,
+                indent,
+                level + 1,
+            )
+            and safe
+        )
+        _line(lines, indent, level, "}")
+        return safe
+    if isinstance(expr, dsl_nodes.BinaryOp):
+        left = _render_expr(expr.expr1, known_types, state_name_set)
+        right = _render_expr(expr.expr2, known_types, state_name_set)
+        if expr.op == "&&":
+            safe = _emit_expr_checks(
+                lines,
+                expr.expr1,
+                known_types,
+                state_name_set,
+                names,
+                usage,
+                indent,
+                level,
+            )
+            _line(lines, indent, level, "if (%s) {" % left.text)
+            safe = (
+                _emit_expr_checks(
+                    lines,
+                    expr.expr2,
+                    known_types,
+                    state_name_set,
+                    names,
+                    usage,
+                    indent,
+                    level + 1,
+                )
+                and safe
+            )
+            _line(lines, indent, level, "}")
+            return safe
+        if expr.op == "||":
+            safe = _emit_expr_checks(
+                lines,
+                expr.expr1,
+                known_types,
+                state_name_set,
+                names,
+                usage,
+                indent,
+                level,
+            )
+            _line(lines, indent, level, "if (!(%s)) {" % left.text)
+            safe = (
+                _emit_expr_checks(
+                    lines,
+                    expr.expr2,
+                    known_types,
+                    state_name_set,
+                    names,
+                    usage,
+                    indent,
+                    level + 1,
+                )
+                and safe
+            )
+            _line(lines, indent, level, "}")
+            return safe
+
+        safe = _emit_expr_checks(
+            lines, expr.expr1, known_types, state_name_set, names, usage, indent, level
+        )
+        safe = (
+            _emit_expr_checks(
+                lines,
+                expr.expr2,
+                known_types,
+                state_name_set,
+                names,
+                usage,
+                indent,
+                level,
+            )
+            and safe
+        )
+        if expr.op in {"/", "%"}:
+            _line(lines, indent, level, "if ((%s) == 0) {" % right.text)
+            _emit_error(
+                lines,
+                names,
+                indent,
+                level + 1,
+                "%s evaluation failed: %s"
+                % (
+                    usage,
+                    _zero_division_message(
+                        expr.op,
+                        _merge_types(left.value_type, right.value_type),
+                        right.text,
+                    ),
+                ),
+            )
+            _line(lines, indent, level, "}")
+        if expr.op in _INT_OPERATORS:
+            invalid = left.value_type == "float" or right.value_type == "float"
+            if invalid:
+                message = (
+                    "%s evaluation failed: unsupported operand type(s) for %s: '%s' and '%s'"
+                    % (
+                        usage,
+                        expr.op,
+                        _python_type_name(left.value_type),
+                        _python_type_name(right.value_type),
+                    )
+                )
+                _emit_error(lines, names, indent, level, message)
+                return False
+        return safe
+    return True
+
+
+def _state_target(name: str, state_vars: Mapping[str, str]) -> str:
+    if name in state_vars:
+        return "scope->%s" % to_c_identifier(name)
+    return to_c_identifier(name)
+
+
+def _c_type(value_type: Optional[str]) -> str:
+    if value_type == "int":
+        return "PYFCSTM_GENERATED_INT64"
+    return "double"
+
+
+def _render_statement_sequence(
+    statements: Sequence[dsl_nodes.OperationalStatement],
+    state_types: Mapping[str, str],
+    visible_types: Mapping[str, str],
+    names: _CNames,
+    indent: str,
+    level: int,
+) -> Tuple[List[str], Dict[str, str]]:
+    lines: List[str] = []
+    current_types = dict(visible_types)
+    for statement in statements:
+        known_types = {**state_types, **current_types}
+        if isinstance(statement, dsl_nodes.OperationAssignment):
+            target = _state_target(statement.name, state_types)
+            expr = _render_expr(statement.expr, known_types, state_types.keys())
+            checks: List[str] = []
+            safe = _emit_expr_checks(
+                checks,
+                statement.expr,
+                known_types,
+                state_types.keys(),
+                names,
+                "operation assignment to '%s'" % statement.name,
+                indent,
+                level,
+            )
+            lines.extend(checks)
+            if not safe:
+                continue
+            if statement.name not in state_types:
+                inferred_type = _infer_expr_type(statement.expr, known_types)
+                if statement.name not in current_types:
+                    _line(
+                        lines,
+                        indent,
+                        level,
+                        "%s %s;"
+                        % (_c_type(inferred_type), to_c_identifier(statement.name)),
+                    )
+                if inferred_type is not None:
+                    current_types[statement.name] = inferred_type
+            _line(lines, indent, level, "%s = %s;" % (target, expr.text))
+            continue
+
+        if isinstance(statement, dsl_nodes.OperationIf):
+            for index, branch in enumerate(statement.branches):
+                if index == 0:
+                    condition = branch.condition
+                    assert condition is not None
+                    branch_known = {**state_types, **current_types}
+                    _emit_expr_checks(
+                        lines,
+                        condition,
+                        branch_known,
+                        state_types.keys(),
+                        names,
+                        "if-block condition",
+                        indent,
+                        level,
+                    )
+                    _line(
+                        lines,
+                        indent,
+                        level,
+                        "if (%s) {"
+                        % _render_expr(
+                            condition, branch_known, state_types.keys()
+                        ).text,
+                    )
+                elif branch.condition is None:
+                    _line(lines, indent, level, "} else {")
+                else:
+                    branch_known = {**state_types, **current_types}
+                    _emit_expr_checks(
+                        lines,
+                        branch.condition,
+                        branch_known,
+                        state_types.keys(),
+                        names,
+                        "if-block condition",
+                        indent,
+                        level,
+                    )
+                    _line(
+                        lines,
+                        indent,
+                        level,
+                        "} else if (%s) {"
+                        % _render_expr(
+                            branch.condition, branch_known, state_types.keys()
+                        ).text,
+                    )
+                body, _ = _render_statement_sequence(
+                    tuple(branch.statements),
+                    state_types,
+                    dict(current_types),
+                    names,
+                    indent,
+                    level + 1,
+                )
+                if body:
+                    lines.extend(body)
+                else:
+                    _line(lines, indent, level + 1, "/* no-op */")
+            _line(lines, indent, level, "}")
+            continue
+
+        raise TypeError("Unsupported C operation statement: %r" % (type(statement),))
+    return lines, current_types
+
+
+def render_c_action_body(
+    statements: Iterable[OperationalNode],
+    var_types: Mapping[str, Any],
+    machine_class_name: str,
+    machine_macro_name: str,
+    indent: str = "    ",
+) -> str:
+    """
+    Render a fallible generated C body for operation statements.
+
+    :param statements: Operation statements from an action or transition effect.
+    :type statements: typing.Iterable[typing.Union[pyfcstm.model.OperationStatement, pyfcstm.dsl.node.OperationalStatement]]
+    :param var_types: Persistent variable type mapping or model defines mapping.
+    :type var_types: typing.Mapping[str, typing.Any]
+    :param machine_class_name: Generated machine class name, such as
+        ``"RootMachine"``.
+    :type machine_class_name: str
+    :param machine_macro_name: Generated macro prefix, such as
+        ``"ROOT_MACHINE"``.
+    :type machine_macro_name: str
+    :param indent: Indentation unit used for generated C code, defaults to four
+        spaces.
+    :type indent: str, optional
+    :return: C statements ending in a generated success or failure return.
+    :rtype: str
+
+    Example::
+
+        >>> from pyfcstm.dsl.node import Integer, OperationAssignment
+        >>> body = render_c_action_body(
+        ...     [OperationAssignment("x", Integer("1"))], {"x": "int"}, "M", "M"
+        ... )
+        >>> body.strip().endswith("return M_SUCCESS;")
+        True
+    """
+    state_types = _normalise_var_types(var_types)
+    nodes = tuple(_coerce_statement(statement) for statement in statements)
+    names = _CNames(machine_class_name, machine_macro_name)
+    lines = [
+        "%s(void)machine;" % indent,
+        "%s(void)scope;" % indent,
+    ]
+    body, _ = _render_statement_sequence(nodes, state_types, {}, names, indent, 1)
+    lines.extend(body)
+    lines.append("%sreturn %s;" % (indent, names.success))
+    return "\n".join(lines)
+
+
+def render_c_condition_body(
+    expr: Any,
+    var_types: Mapping[str, Any],
+    machine_class_name: str,
+    machine_macro_name: str,
+    usage: str,
+    result_name: str = "result",
+    indent: str = "    ",
+) -> str:
+    """
+    Render a fallible generated C body for a boolean condition.
+
+    :param expr: Guard or condition expression.
+    :type expr: typing.Any
+    :param var_types: Persistent variable type mapping or model defines mapping.
+    :type var_types: typing.Mapping[str, typing.Any]
+    :param machine_class_name: Generated machine class name.
+    :type machine_class_name: str
+    :param machine_macro_name: Generated macro prefix.
+    :type machine_macro_name: str
+    :param usage: Diagnostic usage prefix, for example
+        ``"transition guard"``.
+    :type usage: str
+    :param result_name: Pointer variable receiving the truth value, defaults to
+        ``"result"``.
+    :type result_name: str, optional
+    :param indent: Indentation unit used for generated C code, defaults to four
+        spaces.
+    :type indent: str, optional
+    :return: C condition body ending in generated success or failure return.
+    :rtype: str
+
+    Example::
+
+        >>> from pyfcstm.dsl.node import Integer
+        >>> body = render_c_condition_body(Integer("1"), {}, "M", "M", "guard")
+        >>> "*result = !!(1);" in body
+        True
+    """
+    state_types = _normalise_var_types(var_types)
+    expr_node = _coerce_expr(expr)
+    names = _CNames(machine_class_name, machine_macro_name)
+    lines = [
+        "%s(void)machine;" % indent,
+        "%s(void)scope;" % indent,
+    ]
+    _emit_expr_checks(
+        lines, expr_node, state_types, state_types.keys(), names, usage, indent, 1
+    )
+    rendered = _render_expr(expr_node, state_types, state_types.keys())
+    lines.append("%s*%s = !!(%s);" % (indent, result_name, rendered.text))
+    lines.append("%sreturn %s;" % (indent, names.success))
+    return "\n".join(lines)

--- a/pyfcstm/render/c_runtime.py
+++ b/pyfcstm/render/c_runtime.py
@@ -171,7 +171,7 @@ def _quote_c_string(value: str) -> str:
     Example::
 
         >>> _quote_c_string("a'b")
-        '"a\'b"'
+        '"a\\'b"'
     """
     return json.dumps(value)
 

--- a/pyfcstm/render/render.py
+++ b/pyfcstm/render/render.py
@@ -61,6 +61,7 @@ from .statement import (
     _KNOWN_STMT_STYLES, _normalize_stmt_style,
 )
 from .func import process_item_to_object
+from .c_runtime import render_c_action_body, render_c_condition_body
 from ..dsl import node as dsl_nodes
 from ..model import StateMachine
 from ..utils import auto_decode
@@ -229,6 +230,8 @@ class StateMachineCodeRenderer:
         self.env.filters['stmt_render'] = _fn_stmt_render
         self.env.globals['stmts_render'] = _fn_stmts_render
         self.env.filters['stmts_render'] = _fn_stmts_render
+        self.env.globals['render_c_action_body'] = render_c_action_body
+        self.env.globals['render_c_condition_body'] = render_c_condition_body
 
         globals_ = config_info.pop('globals', None) or {}
         for name, value in globals_.items():

--- a/pyfcstm/utils/__init__.py
+++ b/pyfcstm/utils/__init__.py
@@ -14,6 +14,7 @@ The package exposes the following main components:
 * :func:`format_multiline_comment` - Normalize multiline comments from parsers
 * :func:`add_builtins_to_env` - Register Python built-ins in a Jinja2 environment
 * :func:`add_settings_for_env` - Apply common filters and globals to Jinja2
+* :func:`to_c_path_identifier` - Build collision-resistant C path identifiers
 * :class:`IJsonOp` - Interface for JSON/YAML serialization
 * :func:`sequence_safe` - Build a safe underscore-separated identifier
 * :func:`normalize` - Normalize text to identifier-friendly form
@@ -51,7 +52,7 @@ from .binary import is_binary_file
 from .decode import auto_decode
 from .doc import format_multiline_comment
 from .fixed import Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64
-from .jinja2 import add_builtins_to_env, add_settings_for_env
+from .jinja2 import add_builtins_to_env, add_settings_for_env, to_c_path_identifier
 from .json import IJsonOp
 from .logging import get_logger
 from .parse import parse_value, parse_key_value_pairs

--- a/pyfcstm/utils/jinja2.py
+++ b/pyfcstm/utils/jinja2.py
@@ -36,6 +36,34 @@ import jinja2
 from .text import normalize, to_identifier, to_c_identifier
 
 
+def to_c_path_identifier(segments) -> str:
+    """
+    Convert a path sequence into a collision-resistant C identifier.
+
+    Each path segment is normalized independently and prefixed with its
+    normalized length. Encoding segment boundaries this way avoids collisions
+    such as ``Root.A.B`` and ``Root.A_B`` while keeping the output acceptable
+    for C/C++ identifiers.
+
+    :param segments: Iterable path segments to encode.
+    :type segments: typing.Iterable[str]
+    :return: C/C++-safe path identifier.
+    :rtype: str
+
+    Example::
+
+        >>> to_c_path_identifier(["Root", "A", "B"])
+        'p4_Root_p1_A_p1_B'
+        >>> to_c_path_identifier(["Root", "A_B"])
+        'p4_Root_p3_A_B'
+    """
+    parts = []
+    for segment in segments:
+        item = to_c_identifier(str(segment))
+        parts.append("p%d_%s" % (len(item), item))
+    return "_".join(parts) or "p0_empty"
+
+
 def add_builtins_to_env(env: jinja2.Environment) -> jinja2.Environment:
     """
     Mount Python built-in functions to a Jinja2 environment.
@@ -162,6 +190,7 @@ def add_settings_for_env(env: jinja2.Environment) -> jinja2.Environment:
     env.filters['normalize'] = normalize
     env.filters['to_identifier'] = to_identifier
     env.filters['to_c_identifier'] = to_c_identifier
+    env.filters['to_c_path_identifier'] = to_c_path_identifier
     env.globals['indent'] = textwrap.indent
     for key, value in os.environ.items():
         if key not in env.globals:

--- a/templates/c/config.yaml
+++ b/templates/c/config.yaml
@@ -39,7 +39,7 @@ globals:
     type: template
     params:
       - state
-    template: "{{ state.path | join('_') | to_c_identifier }}"
+    template: "{{ state.path | to_c_path_identifier }}"
   state_enum_name:
     type: template
     params:

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -1818,12 +1818,12 @@ int {{ machine_class_name(model) }}_hot_start(
 
     path_count = 0u;
     while (current_state_id >= 0) {
-        path_ids[path_count++] = current_state_id;
-        current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
-        if (path_count > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
+        if (path_count >= {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
             _{{ machine_class_name(model) }}_set_error(machine, "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.", {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
             return {{ machine_macro_name(model) }}_FAILURE;
         }
+        path_ids[path_count++] = current_state_id;
+        current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
     }
 
     machine->stack_size = 0u;

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -71,8 +71,8 @@
  * helper functions. Public users only interact with `machine.h`; everything in
  * this file is generated implementation detail.
  */
-typedef int (*_{{ machine_class_name(model) }}GuardFn)(const {{ machine_class_name(model) }}Vars *scope);
-typedef void (*_{{ machine_class_name(model) }}ActionFn)({{ machine_class_name(model) }}Vars *scope);
+typedef int (*_{{ machine_class_name(model) }}GuardFn)({{ machine_class_name(model) }} *machine, const {{ machine_class_name(model) }}Vars *scope, int *result);
+typedef int (*_{{ machine_class_name(model) }}ActionFn)({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope);
 
 /* Internal execution-stack frame modes used by the generated runtime loop. */
 enum {
@@ -306,12 +306,14 @@ static PYFCSTM_GENERATED_UNUSED void _{{ machine_class_name(model) }}_invoke_abs
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'enter', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'enter', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -325,12 +327,14 @@ static void {{ action_method_name(state, 'enter', id_) }}({{ machine_class_name(
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'during', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'during', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -344,12 +348,14 @@ static void {{ action_method_name(state, 'during', id_) }}({{ machine_class_name
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'exit', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'exit', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -363,12 +369,14 @@ static void {{ action_method_name(state, 'exit', id_) }}({{ machine_class_name(m
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'during_before', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'during_before', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -382,12 +390,14 @@ static void {{ action_method_name(state, 'during_before', id_) }}({{ machine_cla
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'during_after', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'during_after', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -401,12 +411,14 @@ static void {{ action_method_name(state, 'during_after', id_) }}({{ machine_clas
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'aspect_before', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'aspect_before', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -420,12 +432,14 @@ static void {{ action_method_name(state, 'aspect_before', id_) }}({{ machine_cla
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'aspect_after', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'aspect_after', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -433,32 +447,32 @@ static void {{ action_method_name(state, 'aspect_after', id_) }}({{ machine_clas
 {% endfor -%}
 {% for transition in state.init_transitions -%}
 {% if transition.guard is not none -%}
-static int {{ init_guard_method_name(state, loop.index) }}(const {{ machine_class_name(model) }}Vars *scope)
+static int {{ init_guard_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, const {{ machine_class_name(model) }}Vars *scope, int *result)
 {
-    return !!({{ transition.guard.to_ast_node() | expr_render(style='c_scope_expr') }});
+{{ render_c_condition_body(transition.guard.to_ast_node(), model.defines, machine_class_name(model), machine_macro_name(model), "transition guard") }}
 }
 
 {% endif -%}
 {% if transition.effects -%}
-static void {{ init_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ init_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
-{{ (transition.effects | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(transition.effects, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
 {% endif -%}
 {% endfor -%}
 {% for transition in state.transitions_from -%}
 {% if transition.guard is not none -%}
-static int {{ transition_guard_method_name(state, loop.index) }}(const {{ machine_class_name(model) }}Vars *scope)
+static int {{ transition_guard_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, const {{ machine_class_name(model) }}Vars *scope, int *result)
 {
-    return !!({{ transition.guard.to_ast_node() | expr_render(style='c_scope_expr') }});
+{{ render_c_condition_body(transition.guard.to_ast_node(), model.defines, machine_class_name(model), machine_macro_name(model), "transition guard") }}
 }
 
 {% endif -%}
 {% if transition.effects -%}
-static void {{ transition_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ transition_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
-{{ (transition.effects | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(transition.effects, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
 {% endif -%}
@@ -466,7 +480,7 @@ static void {{ transition_effect_method_name(state, loop.index) }}({{ machine_cl
 {% endfor -%}
 
 {% for state in model.walk_states() %}
-static void {{ action_stage_runner_name(state, 'enter') }}(
+static int {{ action_stage_runner_name(state, 'enter') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -494,19 +508,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'enter', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'enter', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'during') }}(
+static int {{ action_stage_runner_name(state, 'during') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -534,19 +552,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'during', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'during', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'exit') }}(
+static int {{ action_stage_runner_name(state, 'exit') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -574,19 +596,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'exit', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'exit', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'during_before') }}(
+static int {{ action_stage_runner_name(state, 'during_before') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -614,19 +640,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'during_before', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'during_before', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'during_after') }}(
+static int {{ action_stage_runner_name(state, 'during_after') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -654,19 +684,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'during_after', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'during_after', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'aspect_before') }}(
+static int {{ action_stage_runner_name(state, 'aspect_before') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -694,19 +728,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'aspect_before', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'aspect_before', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'aspect_after') }}(
+static int {{ action_stage_runner_name(state, 'aspect_after') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -734,21 +772,25 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'aspect_after', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'aspect_after', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
 {% endfor %}
 
-static void _{{ machine_class_name(model) }}_run_enter_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_enter_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -757,15 +799,15 @@ static void _{{ machine_class_name(model) }}_run_enter_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'enter') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'enter') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_during_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_during_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -774,15 +816,15 @@ static void _{{ machine_class_name(model) }}_run_during_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'during') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'during') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_exit_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_exit_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -791,15 +833,15 @@ static void _{{ machine_class_name(model) }}_run_exit_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'exit') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'exit') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_during_before_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -808,15 +850,15 @@ static void _{{ machine_class_name(model) }}_run_during_before_actions_for_state
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'during_before') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'during_before') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -825,15 +867,15 @@ static void _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'during_after') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'during_after') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -842,15 +884,15 @@ static void _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'aspect_before') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'aspect_before') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -859,12 +901,12 @@ static void _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'aspect_after') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'aspect_after') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
 {% for state in model.walk_states() -%}
@@ -880,14 +922,11 @@ static int {{ select_transition_state_name(state) }}(
     (void)validate_stoppable;
 {% if state.transitions_from | list -%}
 {% for transition in state.transitions_from -%}
-{% set condition -%}
+{% set event_condition -%}
 {% if transition.event is not none -%}
 _{{ machine_class_name(model) }}_event_set_has(event_set, {{ all_events.items.index(transition.event.path_name) }})
 {% else -%}
 1
-{% endif -%}
-{% if transition.guard is not none -%}
-&& {{ transition_guard_method_name(state, loop.index) }}(&context->vars)
 {% endif -%}
 {%- endset %}
 {% set branch_body -%}
@@ -912,8 +951,18 @@ if (validate_stoppable) {
 return {{ normal_transition_id(state, loop.index) }};
 {% endif -%}
 {%- endset %}
-    if ({{ condition | trim | replace('\n', ' ') }}) {
+    if ({{ event_condition | trim | replace('\n', ' ') }}) {
+{% if transition.guard is not none %}
+        int guard_result = 0;
+        if ({{ transition_guard_method_name(state, loop.index) }}(machine, &context->vars, &guard_result) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return -1;
+        }
+        if (guard_result) {
+{{ branch_body.strip('\n') | indent(12, true) }}
+        }
+{% else %}
 {{ branch_body.strip('\n') | indent(8, true) }}
+{% endif %}
     }
 {% endfor -%}
 {% else %}
@@ -936,29 +985,41 @@ static int {{ attempt_init_state_name(state) }}(
     (void)is_validation_mode;
 {% if state.init_transitions | list -%}
 {% for transition in state.init_transitions -%}
-{% set condition -%}
+{% set event_condition -%}
 {% if transition.event is not none -%}
 _{{ machine_class_name(model) }}_event_set_has(event_set, {{ all_events.items.index(transition.event.path_name) }})
 {% else -%}
 1
 {% endif -%}
-{% if transition.guard is not none -%}
-&& {{ init_guard_method_name(state, loop.index) }}(&context->vars)
-{% endif -%}
 {%- endset %}
-    if ({{ condition | trim | replace('\n', ' ') }}) {
+{% set init_body -%}
 {% if transition.effects %}
-        {{ init_effect_method_name(state, loop.index) }}(&context->vars);
+if ({{ init_effect_method_name(state, loop.index) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return 0;
+}
 {% endif %}
-        if (_{{ machine_class_name(model) }}_enter_state(
-                machine,
-                context,
-                {{ state_enum(state.substates[transition.to_state]) }},
-                event_set,
-                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+if (_{{ machine_class_name(model) }}_enter_state(
+        machine,
+        context,
+        {{ state_enum(state.substates[transition.to_state]) }},
+        event_set,
+        is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return 0;
+}
+return 1;
+{%- endset %}
+    if ({{ event_condition | trim | replace('\n', ' ') }}) {
+{% if transition.guard is not none %}
+        int guard_result = 0;
+        if ({{ init_guard_method_name(state, loop.index) }}(machine, &context->vars, &guard_result) != {{ machine_macro_name(model) }}_SUCCESS) {
             return 0;
         }
-        return 1;
+        if (guard_result) {
+{{ init_body.strip('\n') | indent(12, true) }}
+        }
+{% else %}
+{{ init_body.strip('\n') | indent(8, true) }}
+{% endif %}
     }
 {% endfor -%}
 {% else %}
@@ -1260,7 +1321,7 @@ static void _{{ machine_class_name(model) }}_invoke_abstract_action(
     machine->_active_vars = saved_active_vars;
 }
 
-static void _{{ machine_class_name(model) }}_run_leaf_during(
+static int _{{ machine_class_name(model) }}_run_leaf_during(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1283,38 +1344,47 @@ static void _{{ machine_class_name(model) }}_run_leaf_during(
 
     if (!state_info->is_pseudo) {
         for (i = path_count; i > 0u; --i) {
-            _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
-                machine,
-                path_ids[i - 1u],
-                context,
-                is_validation_mode);
+            if (_{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
+                    machine,
+                    path_ids[i - 1u],
+                    context,
+                    is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return {{ machine_macro_name(model) }}_FAILURE;
+            }
         }
     }
 
-    _{{ machine_class_name(model) }}_run_during_actions_for_state(
-        machine,
-        state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_during_actions_for_state(
+            machine,
+            state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
 
     if (!state_info->is_pseudo) {
         for (i = 0u; i < path_count; ++i) {
-            _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
-                machine,
-                path_ids[i],
-                context,
-                is_validation_mode);
+            if (_{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
+                    machine,
+                    path_ids[i],
+                    context,
+                    is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return {{ machine_macro_name(model) }}_FAILURE;
+            }
         }
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_execute_transition_effect(
+static int _{{ machine_class_name(model) }}_execute_transition_effect(
+    {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}TransitionInfo *transition,
     _{{ machine_class_name(model) }}RuntimeContext *context)
 {
     if (transition->effect_fn != NULL) {
-        transition->effect_fn(&context->vars);
+        return transition->effect_fn(machine, &context->vars);
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
 static int _{{ machine_class_name(model) }}_is_stoppable_state(int state_id)
@@ -1380,23 +1450,29 @@ static int _{{ machine_class_name(model) }}_enter_state(
         return {{ machine_macro_name(model) }}_FAILURE;
     }
 
-    _{{ machine_class_name(model) }}_run_enter_actions_for_state(
-        machine,
-        state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_enter_actions_for_state(
+            machine,
+            state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
 
     if (state_info->is_leaf) {
-        _{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode);
+        if (_{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
         context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_AFTER_ENTRY;
         return {{ machine_macro_name(model) }}_SUCCESS;
     }
 
-    _{{ machine_class_name(model) }}_run_during_before_actions_for_state(
-        machine,
-        state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+            machine,
+            state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
     init_result = _{{ machine_class_name(model) }}_attempt_init_transition(machine, context, event_set, is_validation_mode);
     if (init_result != {{ machine_macro_name(model) }}_SUCCESS && machine != NULL && machine->last_error[0] != '\0') {
@@ -1446,11 +1522,13 @@ static int _{{ machine_class_name(model) }}_finalize_exit_to_parent(
         return 1;
     }
 
-    _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
-        machine,
-        parent_state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_during_after_actions_for_state(
+            machine,
+            parent_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_POST_CHILD_EXIT;
     return 0;
 }
@@ -1468,12 +1546,16 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
     transition = &_{{ machine_class_name(model) }}_transitions[transition_id];
     current_state_id = context->stack[context->stack_size - 1u].state_id;
 
-    _{{ machine_class_name(model) }}_run_exit_actions_for_state(
-        machine,
-        current_state_id,
-        context,
-        is_validation_mode);
-    _{{ machine_class_name(model) }}_execute_transition_effect(transition, context);
+    if (_{{ machine_class_name(model) }}_run_exit_actions_for_state(
+            machine,
+            current_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     --context->stack_size;
 
     if (transition->to_exit) {
@@ -1527,7 +1609,11 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
             return {{ machine_macro_name(model) }}_FAILURE;
         }
         if (steps_taken >= {{ machine_macro_name(model) }}_MAX_DFS_STEPS) {
-            return 0;
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Speculative DFS exceeded the step safety limit (%d) without reaching a stoppable state or pruning; the state machine likely contains an invalid unbounded pseudo-state or transition chain.",
+                {{ machine_macro_name(model) }}_MAX_DFS_STEPS);
+            return {{ machine_macro_name(model) }}_FAILURE;
         }
 
         frame = &context->stack[context->stack_size - 1u];
@@ -1566,7 +1652,13 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
                 continue;
             }
 
-            _{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode);
+            if (!_{{ machine_class_name(model) }}_is_stoppable_state(state_id)) {
+                return 0;
+            }
+
+            if (_{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return {{ machine_macro_name(model) }}_FAILURE;
+            }
             frame->mode = {{ machine_macro_name(model) }}_FRAME_MODE_AFTER_ENTRY;
             ++steps_taken;
             continue;
@@ -1660,9 +1752,14 @@ static int _{{ machine_class_name(model) }}_initialize_context(
     return context->stack_size == 0u;
 }
 
+{{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create_uninitialized(void)
+{
+    return ({{ machine_class_name(model) }} *)calloc(1u, sizeof({{ machine_class_name(model) }}));
+}
+
 {{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create(void)
 {
-    {{ machine_class_name(model) }} *machine = ({{ machine_class_name(model) }} *)calloc(1u, sizeof({{ machine_class_name(model) }}));
+    {{ machine_class_name(model) }} *machine = {{ machine_class_name(model) }}_create_uninitialized();
     if (machine == NULL) {
         return NULL;
     }
@@ -1712,7 +1809,6 @@ int {{ machine_class_name(model) }}_hot_start(
     saved_hooks = machine->hooks;
     saved_hook_user_data = machine->hook_user_data;
     memset(machine, 0, sizeof(*machine));
-    _{{ machine_class_name(model) }}_reset_vars(&machine->vars);
     machine->vars = *initial_vars;
     current_state_id = initial_state_id;
     if (!_{{ machine_class_name(model) }}_state_id_is_valid(current_state_id)) {
@@ -1725,7 +1821,7 @@ int {{ machine_class_name(model) }}_hot_start(
         path_ids[path_count++] = current_state_id;
         current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
         if (path_count > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
-            _{{ machine_class_name(model) }}_set_error(machine, "Hot-start path is too deep.");
+            _{{ machine_class_name(model) }}_set_error(machine, "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.", {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
             return {{ machine_macro_name(model) }}_FAILURE;
         }
     }

--- a/templates/c/machine.h.j2
+++ b/templates/c/machine.h.j2
@@ -198,6 +198,8 @@ struct {{ machine_class_name(model) }} {
 extern "C" {
 #endif
 
+/* Allocate a zeroed machine instance without evaluating DSL defaults. */
+{{ machine_macro_name(model) }}_API {{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create_uninitialized(void);
 /* Allocate a machine instance and initialize it to cold-start state. */
 {{ machine_macro_name(model) }}_API {{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create(void);
 /* Free an instance previously returned by `..._create()`. */

--- a/templates/c_poll/config.yaml
+++ b/templates/c_poll/config.yaml
@@ -39,7 +39,7 @@ globals:
     type: template
     params:
       - state
-    template: "{{ state.path | join('_') | to_c_identifier }}"
+    template: "{{ state.path | to_c_path_identifier }}"
   state_enum_name:
     type: template
     params:

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -71,8 +71,8 @@
  * helper functions. Public users only interact with `machine.h`; everything in
  * this file is generated implementation detail.
  */
-typedef int (*_{{ machine_class_name(model) }}GuardFn)(const {{ machine_class_name(model) }}Vars *scope);
-typedef void (*_{{ machine_class_name(model) }}ActionFn)({{ machine_class_name(model) }}Vars *scope);
+typedef int (*_{{ machine_class_name(model) }}GuardFn)({{ machine_class_name(model) }} *machine, const {{ machine_class_name(model) }}Vars *scope, int *result);
+typedef int (*_{{ machine_class_name(model) }}ActionFn)({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope);
 
 /* Internal execution-stack frame modes used by the generated runtime loop. */
 enum {
@@ -403,12 +403,14 @@ static PYFCSTM_GENERATED_UNUSED void _{{ machine_class_name(model) }}_invoke_abs
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'enter', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'enter', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -422,12 +424,14 @@ static void {{ action_method_name(state, 'enter', id_) }}({{ machine_class_name(
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'during', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'during', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -441,12 +445,14 @@ static void {{ action_method_name(state, 'during', id_) }}({{ machine_class_name
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'exit', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'exit', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -460,12 +466,14 @@ static void {{ action_method_name(state, 'exit', id_) }}({{ machine_class_name(m
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'during_before', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'during_before', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -479,12 +487,14 @@ static void {{ action_method_name(state, 'during_before', id_) }}({{ machine_cla
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'during_after', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'during_after', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -498,12 +508,14 @@ static void {{ action_method_name(state, 'during_after', id_) }}({{ machine_clas
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'aspect_before', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'aspect_before', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -517,12 +529,14 @@ static void {{ action_method_name(state, 'aspect_before', id_) }}({{ machine_cla
 {% endif -%}
 {% endfor -%}
 {% if not resolved.item.is_abstract -%}
-static void {{ action_method_name(state, 'aspect_after', id_) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ action_method_name(state, 'aspect_after', id_) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
 {% if resolved.item.operations -%}
-{{ (resolved.item.operations | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(resolved.item.operations, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 {% else -%}
+    (void)machine;
     (void)scope;
+    return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 }
 
@@ -530,32 +544,32 @@ static void {{ action_method_name(state, 'aspect_after', id_) }}({{ machine_clas
 {% endfor -%}
 {% for transition in state.init_transitions -%}
 {% if transition.guard is not none -%}
-static int {{ init_guard_method_name(state, loop.index) }}(const {{ machine_class_name(model) }}Vars *scope)
+static int {{ init_guard_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, const {{ machine_class_name(model) }}Vars *scope, int *result)
 {
-    return !!({{ transition.guard.to_ast_node() | expr_render(style='c_scope_expr') }});
+{{ render_c_condition_body(transition.guard.to_ast_node(), model.defines, machine_class_name(model), machine_macro_name(model), "transition guard") }}
 }
 
 {% endif -%}
 {% if transition.effects -%}
-static void {{ init_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ init_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
-{{ (transition.effects | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(transition.effects, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
 {% endif -%}
 {% endfor -%}
 {% for transition in state.transitions_from -%}
 {% if transition.guard is not none -%}
-static int {{ transition_guard_method_name(state, loop.index) }}(const {{ machine_class_name(model) }}Vars *scope)
+static int {{ transition_guard_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, const {{ machine_class_name(model) }}Vars *scope, int *result)
 {
-    return !!({{ transition.guard.to_ast_node() | expr_render(style='c_scope_expr') }});
+{{ render_c_condition_body(transition.guard.to_ast_node(), model.defines, machine_class_name(model), machine_macro_name(model), "transition guard") }}
 }
 
 {% endif -%}
 {% if transition.effects -%}
-static void {{ transition_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }}Vars *scope)
+static int {{ transition_effect_method_name(state, loop.index) }}({{ machine_class_name(model) }} *machine, {{ machine_class_name(model) }}Vars *scope)
 {
-{{ (transition.effects | stmts_render(style='c_runtime', indent='    ', level=1)).strip('\n') }}
+{{ render_c_action_body(transition.effects, model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
 {% endif -%}
@@ -563,7 +577,7 @@ static void {{ transition_effect_method_name(state, loop.index) }}({{ machine_cl
 {% endfor -%}
 
 {% for state in model.walk_states() %}
-static void {{ action_stage_runner_name(state, 'enter') }}(
+static int {{ action_stage_runner_name(state, 'enter') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -591,19 +605,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'enter', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'enter', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'during') }}(
+static int {{ action_stage_runner_name(state, 'during') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -631,19 +649,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'during', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'during', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'exit') }}(
+static int {{ action_stage_runner_name(state, 'exit') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -671,19 +693,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'exit', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'exit', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'during_before') }}(
+static int {{ action_stage_runner_name(state, 'during_before') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -711,19 +737,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'during_before', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'during_before', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'during_after') }}(
+static int {{ action_stage_runner_name(state, 'during_after') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -751,19 +781,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'during_after', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'during_after', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'aspect_before') }}(
+static int {{ action_stage_runner_name(state, 'aspect_before') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -791,19 +825,23 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'aspect_before', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'aspect_before', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void {{ action_stage_runner_name(state, 'aspect_after') }}(
+static int {{ action_stage_runner_name(state, 'aspect_after') }}(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int is_validation_mode)
@@ -831,21 +869,25 @@ _{{ machine_class_name(model) }}_invoke_abstract_action(
     {{ cstr(resolved.item.func_name) }},
     {{ cstr(resolved.item.stage) }});
 {% else -%}
-{{ action_method_name(state, 'aspect_after', id_) }}(&context->vars);
+if ({{ action_method_name(state, 'aspect_after', id_) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return {{ machine_macro_name(model) }}_FAILURE;
+}
 {% endif -%}
 {% endfor -%}
 {% else -%}
 (void)machine;
 (void)context;
 (void)is_validation_mode;
+return {{ machine_macro_name(model) }}_SUCCESS;
 {% endif -%}
 {%- endset %}
 {{ (runner_body.strip('\n')) | indent(4, true) }}
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
 {% endfor %}
 
-static void _{{ machine_class_name(model) }}_run_enter_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_enter_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -854,15 +896,15 @@ static void _{{ machine_class_name(model) }}_run_enter_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'enter') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'enter') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_during_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_during_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -871,15 +913,15 @@ static void _{{ machine_class_name(model) }}_run_during_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'during') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'during') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_exit_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_exit_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -888,15 +930,15 @@ static void _{{ machine_class_name(model) }}_run_exit_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'exit') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'exit') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_during_before_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -905,15 +947,15 @@ static void _{{ machine_class_name(model) }}_run_during_before_actions_for_state
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'during_before') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'during_before') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -922,15 +964,15 @@ static void _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'during_after') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'during_after') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -939,15 +981,15 @@ static void _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'aspect_before') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'aspect_before') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
+static int _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -956,12 +998,12 @@ static void _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
     switch (state_id) {
 {% for state in model.walk_states() %}
         case {{ state_enum(state) }}:
-            {{ action_stage_runner_name(state, 'aspect_after') }}(machine, context, is_validation_mode);
-            break;
+            return {{ action_stage_runner_name(state, 'aspect_after') }}(machine, context, is_validation_mode);
 {% endfor %}
         default:
             break;
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
 {% for state in model.walk_states() -%}
@@ -977,14 +1019,11 @@ static int {{ select_transition_state_name(state) }}(
     (void)validate_stoppable;
 {% if state.transitions_from | list -%}
 {% for transition in state.transitions_from -%}
-{% set condition -%}
+{% set event_condition -%}
 {% if transition.event is not none -%}
-                _{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ all_events.items.index(transition.event.path_name) }})
+_{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ all_events.items.index(transition.event.path_name) }})
 {% else -%}
 1
-{% endif -%}
-{% if transition.guard is not none -%}
-&& {{ transition_guard_method_name(state, loop.index) }}(&context->vars)
 {% endif -%}
 {%- endset %}
 {% set branch_body -%}
@@ -1009,8 +1048,18 @@ if (validate_stoppable) {
 return {{ normal_transition_id(state, loop.index) }};
 {% endif -%}
 {%- endset %}
-    if ({{ condition | trim | replace('\n', ' ') }}) {
+    if ({{ event_condition | trim | replace('\n', ' ') }}) {
+{% if transition.guard is not none %}
+        int guard_result = 0;
+        if ({{ transition_guard_method_name(state, loop.index) }}(machine, &context->vars, &guard_result) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return -1;
+        }
+        if (guard_result) {
+{{ branch_body.strip('\n') | indent(12, true) }}
+        }
+{% else %}
 {{ branch_body.strip('\n') | indent(8, true) }}
+{% endif %}
     }
 {% endfor -%}
 {% else %}
@@ -1033,29 +1082,41 @@ static int {{ attempt_init_state_name(state) }}(
     (void)is_validation_mode;
 {% if state.init_transitions | list -%}
 {% for transition in state.init_transitions -%}
-{% set condition -%}
+{% set event_condition -%}
 {% if transition.event is not none -%}
-                _{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ all_events.items.index(transition.event.path_name) }})
+_{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ all_events.items.index(transition.event.path_name) }})
 {% else -%}
 1
 {% endif -%}
-{% if transition.guard is not none -%}
-&& {{ init_guard_method_name(state, loop.index) }}(&context->vars)
-{% endif -%}
 {%- endset %}
-    if ({{ condition | trim | replace('\n', ' ') }}) {
+{% set init_body -%}
 {% if transition.effects %}
-        {{ init_effect_method_name(state, loop.index) }}(&context->vars);
+if ({{ init_effect_method_name(state, loop.index) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return 0;
+}
 {% endif %}
-        if (_{{ machine_class_name(model) }}_enter_state(
-                machine,
-                context,
-                {{ state_enum(state.substates[transition.to_state]) }},
-                event_set,
-                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+if (_{{ machine_class_name(model) }}_enter_state(
+        machine,
+        context,
+        {{ state_enum(state.substates[transition.to_state]) }},
+        event_set,
+        is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+    return 0;
+}
+return 1;
+{%- endset %}
+    if ({{ event_condition | trim | replace('\n', ' ') }}) {
+{% if transition.guard is not none %}
+        int guard_result = 0;
+        if ({{ init_guard_method_name(state, loop.index) }}(machine, &context->vars, &guard_result) != {{ machine_macro_name(model) }}_SUCCESS) {
             return 0;
         }
-        return 1;
+        if (guard_result) {
+{{ init_body.strip('\n') | indent(12, true) }}
+        }
+{% else %}
+{{ init_body.strip('\n') | indent(8, true) }}
+{% endif %}
     }
 {% endfor -%}
 {% else %}
@@ -1314,7 +1375,7 @@ static void _{{ machine_class_name(model) }}_invoke_abstract_action(
     machine->_active_vars = saved_active_vars;
 }
 
-static void _{{ machine_class_name(model) }}_run_leaf_during(
+static int _{{ machine_class_name(model) }}_run_leaf_during(
     {{ machine_class_name(model) }} *machine,
     int state_id,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1337,38 +1398,47 @@ static void _{{ machine_class_name(model) }}_run_leaf_during(
 
     if (!state_info->is_pseudo) {
         for (i = path_count; i > 0u; --i) {
-            _{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
-                machine,
-                path_ids[i - 1u],
-                context,
-                is_validation_mode);
+            if (_{{ machine_class_name(model) }}_run_aspect_before_actions_for_state(
+                    machine,
+                    path_ids[i - 1u],
+                    context,
+                    is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return {{ machine_macro_name(model) }}_FAILURE;
+            }
         }
     }
 
-    _{{ machine_class_name(model) }}_run_during_actions_for_state(
-        machine,
-        state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_during_actions_for_state(
+            machine,
+            state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
 
     if (!state_info->is_pseudo) {
         for (i = 0u; i < path_count; ++i) {
-            _{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
-                machine,
-                path_ids[i],
-                context,
-                is_validation_mode);
+            if (_{{ machine_class_name(model) }}_run_aspect_after_actions_for_state(
+                    machine,
+                    path_ids[i],
+                    context,
+                    is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return {{ machine_macro_name(model) }}_FAILURE;
+            }
         }
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
-static void _{{ machine_class_name(model) }}_execute_transition_effect(
+static int _{{ machine_class_name(model) }}_execute_transition_effect(
+    {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}TransitionInfo *transition,
     _{{ machine_class_name(model) }}RuntimeContext *context)
 {
     if (transition->effect_fn != NULL) {
-        transition->effect_fn(&context->vars);
+        return transition->effect_fn(machine, &context->vars);
     }
+    return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
 static int _{{ machine_class_name(model) }}_is_stoppable_state(int state_id)
@@ -1434,23 +1504,29 @@ static int _{{ machine_class_name(model) }}_enter_state(
         return {{ machine_macro_name(model) }}_FAILURE;
     }
 
-    _{{ machine_class_name(model) }}_run_enter_actions_for_state(
-        machine,
-        state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_enter_actions_for_state(
+            machine,
+            state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
 
     if (state_info->is_leaf) {
-        _{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode);
+        if (_{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
         context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_AFTER_ENTRY;
         return {{ machine_macro_name(model) }}_SUCCESS;
     }
 
-    _{{ machine_class_name(model) }}_run_during_before_actions_for_state(
-        machine,
-        state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+            machine,
+            state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
     init_result = _{{ machine_class_name(model) }}_attempt_init_transition(machine, context, event_set, is_validation_mode);
     if (init_result != {{ machine_macro_name(model) }}_SUCCESS && machine != NULL && machine->last_error[0] != '\0') {
@@ -1500,11 +1576,13 @@ static int _{{ machine_class_name(model) }}_finalize_exit_to_parent(
         return 1;
     }
 
-    _{{ machine_class_name(model) }}_run_during_after_actions_for_state(
-        machine,
-        parent_state_id,
-        context,
-        is_validation_mode);
+    if (_{{ machine_class_name(model) }}_run_during_after_actions_for_state(
+            machine,
+            parent_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_POST_CHILD_EXIT;
     return 0;
 }
@@ -1522,12 +1600,16 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
     transition = &_{{ machine_class_name(model) }}_transitions[transition_id];
     current_state_id = context->stack[context->stack_size - 1u].state_id;
 
-    _{{ machine_class_name(model) }}_run_exit_actions_for_state(
-        machine,
-        current_state_id,
-        context,
-        is_validation_mode);
-    _{{ machine_class_name(model) }}_execute_transition_effect(transition, context);
+    if (_{{ machine_class_name(model) }}_run_exit_actions_for_state(
+            machine,
+            current_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     --context->stack_size;
 
     if (transition->to_exit) {
@@ -1581,7 +1663,11 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
             return {{ machine_macro_name(model) }}_FAILURE;
         }
         if (steps_taken >= {{ machine_macro_name(model) }}_MAX_DFS_STEPS) {
-            return 0;
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Speculative DFS exceeded the step safety limit (%d) without reaching a stoppable state or pruning; the state machine likely contains an invalid unbounded pseudo-state or transition chain.",
+                {{ machine_macro_name(model) }}_MAX_DFS_STEPS);
+            return {{ machine_macro_name(model) }}_FAILURE;
         }
 
         frame = &context->stack[context->stack_size - 1u];
@@ -1620,7 +1706,13 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
                 continue;
             }
 
-            _{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode);
+            if (!_{{ machine_class_name(model) }}_is_stoppable_state(state_id)) {
+                return 0;
+            }
+
+            if (_{{ machine_class_name(model) }}_run_leaf_during(machine, state_id, context, is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return {{ machine_macro_name(model) }}_FAILURE;
+            }
             frame->mode = {{ machine_macro_name(model) }}_FRAME_MODE_AFTER_ENTRY;
             ++steps_taken;
             continue;
@@ -1714,9 +1806,14 @@ static int _{{ machine_class_name(model) }}_initialize_context(
     return context->stack_size == 0u;
 }
 
+{{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create_uninitialized(void)
+{
+    return ({{ machine_class_name(model) }} *)calloc(1u, sizeof({{ machine_class_name(model) }}));
+}
+
 {{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create(void)
 {
-    {{ machine_class_name(model) }} *machine = ({{ machine_class_name(model) }} *)calloc(1u, sizeof({{ machine_class_name(model) }}));
+    {{ machine_class_name(model) }} *machine = {{ machine_class_name(model) }}_create_uninitialized();
     if (machine == NULL) {
         return NULL;
     }
@@ -1772,7 +1869,6 @@ int {{ machine_class_name(model) }}_hot_start(
     saved_event_check_user_data = machine->event_check_user_data;
     saved_event_checks_mounted = machine->event_checks_mounted;
     memset(machine, 0, sizeof(*machine));
-    _{{ machine_class_name(model) }}_reset_vars(&machine->vars);
     machine->vars = *initial_vars;
     current_state_id = initial_state_id;
     if (!_{{ machine_class_name(model) }}_state_id_is_valid(current_state_id)) {
@@ -1785,7 +1881,7 @@ int {{ machine_class_name(model) }}_hot_start(
         path_ids[path_count++] = current_state_id;
         current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
         if (path_count > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
-            _{{ machine_class_name(model) }}_set_error(machine, "Hot-start path is too deep.");
+            _{{ machine_class_name(model) }}_set_error(machine, "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.", {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
             return {{ machine_macro_name(model) }}_FAILURE;
         }
     }

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -1878,12 +1878,12 @@ int {{ machine_class_name(model) }}_hot_start(
 
     path_count = 0u;
     while (current_state_id >= 0) {
-        path_ids[path_count++] = current_state_id;
-        current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
-        if (path_count > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
+        if (path_count >= {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
             _{{ machine_class_name(model) }}_set_error(machine, "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.", {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
             return {{ machine_macro_name(model) }}_FAILURE;
         }
+        path_ids[path_count++] = current_state_id;
+        current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
     }
 
     machine->stack_size = 0u;

--- a/templates/c_poll/machine.h.j2
+++ b/templates/c_poll/machine.h.j2
@@ -247,6 +247,8 @@ struct {{ machine_class_name(model) }} {
 extern "C" {
 #endif
 
+/* Allocate a zeroed machine instance without evaluating DSL defaults. */
+{{ machine_macro_name(model) }}_API {{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create_uninitialized(void);
 /* Allocate a machine instance and initialize it to cold-start state. */
 {{ machine_macro_name(model) }}_API {{ machine_class_name(model) }} *{{ machine_class_name(model) }}_create(void);
 /* Free an instance previously returned by `..._create()`. */

--- a/test/fixtures/simulate_semantics/runner_capabilities.yaml
+++ b/test/fixtures/simulate_semantics/runner_capabilities.yaml
@@ -118,78 +118,6 @@ known_failures:
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_alignment
-    case: design_speculative_dfs_safety_limit
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "design_speculative_dfs_safety_limit is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: ended_runtime_ignores_event_inputs
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "ended_runtime_ignores_event_inputs is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: expression_error_preserves_runtime_snapshot
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_error_preserves_runtime_snapshot is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: expression_failure_if_condition_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_if_condition_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: expression_failure_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: expression_failure_transition_effect_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_transition_effect_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: expression_failure_transition_guard_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_transition_guard_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: expression_large_integer_safe_diagnostics
-    classification: parse_render_load
-    observation: parse_render_load
-    support: expected_failure
-    skip_reason: "expression_large_integer_safe_diagnostics is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: expression_type_error_wraps_transition_effect
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "expression_type_error_wraps_transition_effect is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
     case: failed_initial_cycle_skips_abstract_handler_callbacks
     classification: handler_mismatch
     observation: handler_calls
@@ -203,14 +131,6 @@ known_failures:
     observation: vars
     support: expected_failure
     skip_reason: "forced_pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: hot_start_initial_vars_override_skips_int_initializer
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "hot_start_initial_vars_override_skips_int_initializer is a known C/C poll shared alignment gap."
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_alignment
@@ -230,27 +150,11 @@ known_failures:
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_alignment
-    case: hot_start_leaf_defers_during_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "hot_start_leaf_defers_during_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
     case: hot_start_rejects_blocked_composite_initial
     classification: state_or_ended_mismatch
     observation: state_or_ended
     support: expected_failure
     skip_reason: "hot_start_rejects_blocked_composite_initial is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: hot_start_rejects_overdeep_leaf_stack
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "hot_start_rejects_overdeep_leaf_stack is a known C/C poll shared alignment gap."
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_alignment
@@ -310,14 +214,6 @@ known_failures:
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_alignment
-    case: pseudo_self_loop_step_limit_raises_dfs_error
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "pseudo_self_loop_step_limit_raises_dfs_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
     case: ref_abstract_handler_reports_calling_state
     classification: handler_mismatch
     observation: handler_calls
@@ -339,54 +235,6 @@ known_failures:
     observation: vars
     support: expected_failure
     skip_reason: "root_exit_runs_root_cleanup is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: sign_function_aligns_aspect_guard_effect_math
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_aligns_aspect_guard_effect_math is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: sign_function_controls_guard_transition
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_controls_guard_transition is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: sign_function_handles_all_signs
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_handles_all_signs is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: sign_function_preserves_complex_action_precedence
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_preserves_complex_action_precedence is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: sign_function_updates_during_action
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_updates_during_action is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: similar_state_paths_keep_actions_distinct
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "similar_state_paths_keep_actions_distinct is a known C/C poll shared alignment gap."
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_alignment
@@ -510,78 +358,6 @@ known_failures:
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_poll_alignment
-    case: design_speculative_dfs_safety_limit
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "design_speculative_dfs_safety_limit is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: ended_runtime_ignores_event_inputs
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "ended_runtime_ignores_event_inputs is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: expression_error_preserves_runtime_snapshot
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_error_preserves_runtime_snapshot is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: expression_failure_if_condition_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_if_condition_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: expression_failure_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: expression_failure_transition_effect_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_transition_effect_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: expression_failure_transition_guard_raises_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "expression_failure_transition_guard_raises_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: expression_large_integer_safe_diagnostics
-    classification: parse_render_load
-    observation: parse_render_load
-    support: expected_failure
-    skip_reason: "expression_large_integer_safe_diagnostics is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: expression_type_error_wraps_transition_effect
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "expression_type_error_wraps_transition_effect is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
     case: failed_initial_cycle_skips_abstract_handler_callbacks
     classification: handler_mismatch
     observation: handler_calls
@@ -595,14 +371,6 @@ known_failures:
     observation: vars
     support: expected_failure
     skip_reason: "forced_pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: hot_start_initial_vars_override_skips_int_initializer
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "hot_start_initial_vars_override_skips_int_initializer is a known C/C poll shared alignment gap."
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_poll_alignment
@@ -622,27 +390,11 @@ known_failures:
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_poll_alignment
-    case: hot_start_leaf_defers_during_expression_error
-    classification: sigfpe
-    observation: native_process
-    support: expected_failure
-    skip_reason: "hot_start_leaf_defers_during_expression_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
     case: hot_start_rejects_blocked_composite_initial
     classification: state_or_ended_mismatch
     observation: state_or_ended
     support: expected_failure
     skip_reason: "hot_start_rejects_blocked_composite_initial is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: hot_start_rejects_overdeep_leaf_stack
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "hot_start_rejects_overdeep_leaf_stack is a known C/C poll shared alignment gap."
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_poll_alignment
@@ -702,14 +454,6 @@ known_failures:
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_poll_alignment
-    case: pseudo_self_loop_step_limit_raises_dfs_error
-    classification: exception_type_mismatch
-    observation: raises
-    support: expected_failure
-    skip_reason: "pseudo_self_loop_step_limit_raises_dfs_error is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
     case: ref_abstract_handler_reports_calling_state
     classification: handler_mismatch
     observation: handler_calls
@@ -731,54 +475,6 @@ known_failures:
     observation: vars
     support: expected_failure
     skip_reason: "root_exit_runs_root_cleanup is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: sign_function_aligns_aspect_guard_effect_math
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_aligns_aspect_guard_effect_math is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: sign_function_controls_guard_transition
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_controls_guard_transition is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: sign_function_handles_all_signs
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_handles_all_signs is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: sign_function_preserves_complex_action_precedence
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_preserves_complex_action_precedence is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: sign_function_updates_during_action
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "sign_function_updates_during_action is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: similar_state_paths_keep_actions_distinct
-    classification: parse_render_load
-    observation: render_build_load
-    support: expected_failure
-    skip_reason: "similar_state_paths_keep_actions_distinct is a known C/C poll shared alignment gap."
     tracking: https://github.com/HansBug/pyfcstm/issues/218
     since: "2026-06-17"
   - runner: generated_c_poll_alignment

--- a/test/template/c/_utils.py
+++ b/test/template/c/_utils.py
@@ -15,6 +15,32 @@ from pyfcstm.template import extract_template
 from pyfcstm.utils import to_c_identifier
 
 
+class SimulationRuntimeExpressionError(ValueError, ArithmeticError):
+    pass
+
+
+class SimulationRuntimeDfsError(RuntimeError):
+    pass
+
+
+def _runtime_exception_from_message(message):
+    if 'evaluation failed:' in message:
+        cause_text = message.split('evaluation failed:', 1)[1].strip()
+        if 'division by zero' in cause_text or 'modulo' in cause_text:
+            cause = ZeroDivisionError(cause_text)
+        elif 'unsupported operand type' in cause_text:
+            cause = TypeError(cause_text)
+        else:
+            cause = ArithmeticError(cause_text)
+        return SimulationRuntimeExpressionError(message), cause
+    if (
+        'structural stack-depth safety limit' in message
+        or 'step safety limit' in message
+    ):
+        return SimulationRuntimeDfsError(message), None
+    return RuntimeError(message), None
+
+
 def _find_cmake():
     return shutil.which('cmake')
 
@@ -260,7 +286,7 @@ class _ExecutionContextView:
 
 
 class _CRuntime:
-    def __init__(self, lib, model, temporary_directories=None, dll_directory_handle=None):
+    def __init__(self, lib, model, temporary_directories=None, dll_directory_handle=None, initialize=True):
         self._lib = lib
         self._model = model
         self._temporary_directories = list(temporary_directories or [])
@@ -285,7 +311,8 @@ class _CRuntime:
             path: index for index, path in enumerate(self._event_paths)
         }
         self._vars_struct = self._build_vars_struct_type()
-        self._machine = self._bind_function('{prefix}_create', restype=ctypes.c_void_p)()
+        create_name = '{prefix}_create' if initialize else '{prefix}_create_uninitialized'
+        self._machine = self._bind_function(create_name, restype=ctypes.c_void_p)()
         self._destroy = self._bind_function('{prefix}_destroy', argtypes=[ctypes.c_void_p])
         self._hot_start = self._bind_function(
             '{prefix}_hot_start',
@@ -381,7 +408,11 @@ class _CRuntime:
 
     def _raise_last_error(self):
         message = self._last_error(self._machine)
-        raise RuntimeError(message.decode('utf-8') if message else 'unknown C runtime error')
+        text = message.decode('utf-8') if message else 'unknown C runtime error'
+        error, cause = _runtime_exception_from_message(text)
+        if cause is not None:
+            raise error from cause
+        raise error
 
     def _get_var_from_vars_ptr(self, vars_ptr, name):
         values = ctypes.cast(vars_ptr, ctypes.POINTER(self._vars_struct)).contents
@@ -489,6 +520,10 @@ class _CRuntime:
         self._set_hooks(self._machine, ctypes.byref(self._hook_values), None)
 
     def cycle(self, events=None):
+        if self.is_ended:
+            if self._cycle(self._machine, None, 0) != 1:
+                self._raise_last_error()
+            return
         if events is None:
             event_array = None
             event_count = 0
@@ -591,6 +626,7 @@ def build_c_runtime(dsl_code, initial_state=None, initial_vars=None):
         model,
         temporary_directories=temporary_directories,
         dll_directory_handle=dll_directory_handle,
+        initialize=initial_state is None,
     )
     if initial_state is not None:
         runtime.hot_start(initial_state, initial_vars or {})

--- a/test/template/c/test_runtime.py
+++ b/test/template/c/test_runtime.py
@@ -635,6 +635,18 @@ class TestCBuiltinTemplate:
                 built_entries = set(os.listdir(artifacts["build_dir"]))
                 assert "CMakeCache.txt" in built_entries
 
+    def test_generated_hot_start_checks_stack_depth_before_path_write(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            with open(artifacts["machine_c_file"], "r", encoding="utf-8") as f:
+                source = f.read()
+
+            hot_start = source.index("int ControlMachine_hot_start(")
+            path_loop = source.index("path_count = 0u;", hot_start)
+            guard = source.index("if (path_count >=", path_loop)
+            write = source.index("path_ids[path_count++]", path_loop)
+
+            assert guard < write
+
     def test_generated_machine_c99_gate_runs_representative_model(self):
         with render_c_artifacts(_representative_gate_dsl()) as artifacts:
             run = _compile_and_run_c_harness(

--- a/test/template/c/test_runtime_alignment.py
+++ b/test/template/c/test_runtime_alignment.py
@@ -4,7 +4,7 @@ from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.simulate import SimulationRuntime, SimulationRuntimeDfsError
 
-from ._utils import build_c_runtime
+from ._utils import SimulationRuntimeExpressionError, build_c_runtime
 
 
 class _DualRuntime:
@@ -107,6 +107,73 @@ def build_runtime(dsl_code):
     runtime = _DualRuntime(simulation_runtime, generated_runtime, dsl_code)
     runtime._assert_aligned('initial build')
     return runtime
+
+
+@pytest.mark.unittest
+def test_if_elif_condition_checks_are_lazy_after_matching_branch():
+    dsl_code = '''
+def int x = 0;
+def int y = 0;
+def int z = 0;
+
+state Root {
+    state A {
+        during {
+            if [x == 0] {
+                y = 1;
+            } else if [1 / z > 0] {
+                y = 2;
+            } else {
+                y = 3;
+            }
+        }
+    }
+
+    [*] -> A;
+}
+'''
+    runtime = build_c_runtime(dsl_code)
+    try:
+        runtime.cycle()
+        assert runtime.vars == {'x': 0, 'y': 1, 'z': 0}
+        assert runtime.current_state_path == ('Root', 'A')
+    finally:
+        runtime.close()
+
+
+@pytest.mark.unittest
+def test_if_elif_condition_reports_error_after_prior_branch_misses():
+    dsl_code = '''
+def int x = 1;
+def int y = 0;
+def int z = 0;
+
+state Root {
+    state A {
+        during {
+            if [x == 0] {
+                y = 1;
+            } else if [1 / z > 0] {
+                y = 2;
+            } else {
+                y = 3;
+            }
+        }
+    }
+
+    [*] -> A;
+}
+'''
+    runtime = build_c_runtime(dsl_code)
+    try:
+        with pytest.raises(
+            SimulationRuntimeExpressionError, match='if-block condition evaluation failed'
+        ):
+            runtime.cycle()
+        assert runtime.vars == {'x': 1, 'y': 0, 'z': 0}
+        assert runtime.current_state_path == ('Root',)
+    finally:
+        runtime.close()
 
 
 def assert_runtime_state(runtime, current_path=None, vars=None, is_ended=False):

--- a/test/template/c/test_semantic_fixture_alignment.py
+++ b/test/template/c/test_semantic_fixture_alignment.py
@@ -29,3 +29,35 @@ def test_generated_c_alignment_subprocess_reports_known_native_failure():
     assert result.expected_classification == "handler_mismatch"
     assert result.support == "expected_failure"
     assert result.tracking == "https://github.com/HansBug/pyfcstm/issues/218"
+
+
+_NATIVE_EXPRESSION_DIAGNOSTIC_CASES = (
+    "expression_error_preserves_runtime_snapshot",
+    "expression_failure_if_condition_raises_expression_error",
+    "expression_failure_raises_expression_error",
+    "expression_failure_transition_effect_raises_expression_error",
+    "expression_failure_transition_guard_raises_expression_error",
+    "hot_start_initial_vars_override_skips_int_initializer",
+    "hot_start_leaf_defers_during_expression_error",
+    "expression_large_integer_safe_diagnostics",
+    "expression_type_error_wraps_transition_effect",
+    "sign_function_aligns_aspect_guard_effect_math",
+    "sign_function_controls_guard_transition",
+    "sign_function_handles_all_signs",
+    "sign_function_preserves_complex_action_precedence",
+    "sign_function_updates_during_action",
+    "similar_state_paths_keep_actions_distinct",
+    "design_speculative_dfs_safety_limit",
+    "ended_runtime_ignores_event_inputs",
+    "hot_start_rejects_overdeep_leaf_stack",
+    "pseudo_self_loop_step_limit_raises_dfs_error",
+)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("case_id", _NATIVE_EXPRESSION_DIAGNOSTIC_CASES)
+def test_generated_c_alignment_expression_diagnostic_cases_pass(case_id):
+    result = run_native_alignment_case_subprocess(GENERATED_C_ALIGNMENT, case_id)
+
+    assert result.status == "passed"
+    assert result.classification is None

--- a/test/template/c_poll/_utils.py
+++ b/test/template/c_poll/_utils.py
@@ -15,6 +15,32 @@ from pyfcstm.template import extract_template
 from pyfcstm.utils import to_c_identifier
 
 
+class SimulationRuntimeExpressionError(ValueError, ArithmeticError):
+    pass
+
+
+class SimulationRuntimeDfsError(RuntimeError):
+    pass
+
+
+def _runtime_exception_from_message(message):
+    if 'evaluation failed:' in message:
+        cause_text = message.split('evaluation failed:', 1)[1].strip()
+        if 'division by zero' in cause_text or 'modulo' in cause_text:
+            cause = ZeroDivisionError(cause_text)
+        elif 'unsupported operand type' in cause_text:
+            cause = TypeError(cause_text)
+        else:
+            cause = ArithmeticError(cause_text)
+        return SimulationRuntimeExpressionError(message), cause
+    if (
+        'structural stack-depth safety limit' in message
+        or 'step safety limit' in message
+    ):
+        return SimulationRuntimeDfsError(message), None
+    return RuntimeError(message), None
+
+
 def _find_cmake():
     return shutil.which('cmake')
 
@@ -288,6 +314,7 @@ class _CPollRuntime:
         temporary_directories=None,
         dll_directory_handle=None,
         auto_install_event_checks=True,
+        initialize=True,
     ):
         self._lib = lib
         self._model = model
@@ -317,7 +344,8 @@ class _CPollRuntime:
             for path in self._event_paths
         }
         self._vars_struct = self._build_vars_struct_type()
-        self._machine = self._bind_function('{prefix}_create', restype=ctypes.c_void_p)()
+        create_name = '{prefix}_create' if initialize else '{prefix}_create_uninitialized'
+        self._machine = self._bind_function(create_name, restype=ctypes.c_void_p)()
         self._destroy = self._bind_function('{prefix}_destroy', argtypes=[ctypes.c_void_p])
         self._hot_start = self._bind_function(
             '{prefix}_hot_start',
@@ -440,7 +468,11 @@ class _CPollRuntime:
 
     def _raise_last_error(self):
         message = self._last_error(self._machine)
-        raise RuntimeError(message.decode('utf-8') if message else 'unknown C runtime error')
+        text = message.decode('utf-8') if message else 'unknown C runtime error'
+        error, cause = _runtime_exception_from_message(text)
+        if cause is not None:
+            raise error from cause
+        raise error
 
     def _get_var_from_vars_ptr(self, vars_ptr, name):
         values = ctypes.cast(vars_ptr, ctypes.POINTER(self._vars_struct)).contents
@@ -595,6 +627,14 @@ class _CPollRuntime:
             self._raise_last_error()
 
     def cycle(self, events=None):
+        if self.is_ended:
+            self._current_cycle_event_ids = set()
+            try:
+                if self._cycle(self._machine) != 1:
+                    self._raise_last_error()
+            finally:
+                self._current_cycle_event_ids = set()
+            return
         if events is None:
             event_ids = set()
         else:
@@ -697,6 +737,7 @@ def build_c_runtime(dsl_code, initial_state=None, initial_vars=None, auto_instal
         temporary_directories=temporary_directories,
         dll_directory_handle=dll_directory_handle,
         auto_install_event_checks=auto_install_event_checks,
+        initialize=initial_state is None,
     )
     if initial_state is not None:
         runtime.hot_start(initial_state, initial_vars or {})

--- a/test/template/c_poll/test_runtime.py
+++ b/test/template/c_poll/test_runtime.py
@@ -372,6 +372,17 @@ class TestCPollBuiltinTemplate:
                 assert formatted_once == formatted_twice
                 assert "\t" not in formatted_once
 
+    def test_generated_hot_start_checks_stack_depth_before_path_write(self):
+        with render_c_artifacts(_representative_gate_dsl()) as artifacts:
+            with open(artifacts["machine_c_file"], "r", encoding="utf-8") as f:
+                source = f.read()
+
+            hot_start = source.index("int ControlMachine_hot_start(")
+            path_loop = source.index("path_count = 0u;", hot_start)
+            guard = source.index("if (path_count >=", path_loop)
+            write = source.index("path_ids[path_count++]", path_loop)
+
+            assert guard < write
 
     def test_generated_readme_code_blocks_are_formatter_friendly(self):
         with render_c_artifacts(_representative_gate_dsl()) as artifacts:

--- a/test/template/c_poll/test_runtime_alignment.py
+++ b/test/template/c_poll/test_runtime_alignment.py
@@ -4,7 +4,7 @@ from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.simulate import SimulationRuntime, SimulationRuntimeDfsError
 
-from ._utils import build_c_runtime
+from ._utils import SimulationRuntimeExpressionError, build_c_runtime
 
 
 class _DualRuntime:
@@ -107,6 +107,73 @@ def build_runtime(dsl_code):
     runtime = _DualRuntime(simulation_runtime, generated_runtime, dsl_code)
     runtime._assert_aligned('initial build')
     return runtime
+
+
+@pytest.mark.unittest
+def test_if_elif_condition_checks_are_lazy_after_matching_branch():
+    dsl_code = '''
+def int x = 0;
+def int y = 0;
+def int z = 0;
+
+state Root {
+    state A {
+        during {
+            if [x == 0] {
+                y = 1;
+            } else if [1 / z > 0] {
+                y = 2;
+            } else {
+                y = 3;
+            }
+        }
+    }
+
+    [*] -> A;
+}
+'''
+    runtime = build_c_runtime(dsl_code)
+    try:
+        runtime.cycle()
+        assert runtime.vars == {'x': 0, 'y': 1, 'z': 0}
+        assert runtime.current_state_path == ('Root', 'A')
+    finally:
+        runtime.close()
+
+
+@pytest.mark.unittest
+def test_if_elif_condition_reports_error_after_prior_branch_misses():
+    dsl_code = '''
+def int x = 1;
+def int y = 0;
+def int z = 0;
+
+state Root {
+    state A {
+        during {
+            if [x == 0] {
+                y = 1;
+            } else if [1 / z > 0] {
+                y = 2;
+            } else {
+                y = 3;
+            }
+        }
+    }
+
+    [*] -> A;
+}
+'''
+    runtime = build_c_runtime(dsl_code)
+    try:
+        with pytest.raises(
+            SimulationRuntimeExpressionError, match='if-block condition evaluation failed'
+        ):
+            runtime.cycle()
+        assert runtime.vars == {'x': 1, 'y': 0, 'z': 0}
+        assert runtime.current_state_path == ('Root',)
+    finally:
+        runtime.close()
 
 
 def assert_runtime_state(runtime, current_path=None, vars=None, is_ended=False):

--- a/test/template/c_poll/test_semantic_fixture_alignment.py
+++ b/test/template/c_poll/test_semantic_fixture_alignment.py
@@ -29,3 +29,35 @@ def test_generated_c_poll_alignment_subprocess_reports_known_native_failure():
     assert result.expected_classification == "handler_mismatch"
     assert result.support == "expected_failure"
     assert result.tracking == "https://github.com/HansBug/pyfcstm/issues/218"
+
+
+_NATIVE_EXPRESSION_DIAGNOSTIC_CASES = (
+    "expression_error_preserves_runtime_snapshot",
+    "expression_failure_if_condition_raises_expression_error",
+    "expression_failure_raises_expression_error",
+    "expression_failure_transition_effect_raises_expression_error",
+    "expression_failure_transition_guard_raises_expression_error",
+    "hot_start_initial_vars_override_skips_int_initializer",
+    "hot_start_leaf_defers_during_expression_error",
+    "expression_large_integer_safe_diagnostics",
+    "expression_type_error_wraps_transition_effect",
+    "sign_function_aligns_aspect_guard_effect_math",
+    "sign_function_controls_guard_transition",
+    "sign_function_handles_all_signs",
+    "sign_function_preserves_complex_action_precedence",
+    "sign_function_updates_during_action",
+    "similar_state_paths_keep_actions_distinct",
+    "design_speculative_dfs_safety_limit",
+    "ended_runtime_ignores_event_inputs",
+    "hot_start_rejects_overdeep_leaf_stack",
+    "pseudo_self_loop_step_limit_raises_dfs_error",
+)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("case_id", _NATIVE_EXPRESSION_DIAGNOSTIC_CASES)
+def test_generated_c_poll_alignment_expression_diagnostic_cases_pass(case_id):
+    result = run_native_alignment_case_subprocess(GENERATED_C_POLL_ALIGNMENT, case_id)
+
+    assert result.status == "passed"
+    assert result.classification is None

--- a/test/template/test_native_semantic_alignment_framework.py
+++ b/test/template/test_native_semantic_alignment_framework.py
@@ -7,6 +7,7 @@ import pytest
 
 from test.testings import native_semantic_alignment as native_alignment
 from test.testings.native_semantic_alignment import (
+    _GeneratedNativeAlignmentRuntime,
     GENERATED_C_ALIGNMENT,
     GENERATED_C_POLL_ALIGNMENT,
     NativeAlignmentMatrixError,
@@ -22,7 +23,7 @@ def test_native_capability_matrix_covers_known_failures():
     matrix = native_capability_by_runner_case(entries)
     case_ids = {case.id for case in iter_semantic_cases()}
 
-    assert len(entries) == 98
+    assert len(entries) == 60
     assert {entry.runner for entry in entries} == {
         GENERATED_C_ALIGNMENT,
         GENERATED_C_POLL_ALIGNMENT,
@@ -36,7 +37,7 @@ def test_native_capability_matrix_covers_known_failures():
     assert (
         GENERATED_C_ALIGNMENT,
         "expression_failure_raises_expression_error",
-    ) in matrix
+    ) not in matrix
     assert (
         GENERATED_C_POLL_ALIGNMENT,
         "transition_into_composite_skips_unstable_initial_candidate",
@@ -80,7 +81,7 @@ def test_native_capability_matrix_file_is_single_fact_source():
 
 
 @pytest.mark.unittest
-def test_native_subprocess_classifies_sigfpe_expected_failure(monkeypatch):
+def test_native_subprocess_classifies_sigfpe_as_unexpected_after_repair(monkeypatch):
     def fake_run(cmd, **kwargs):
         return subprocess.CompletedProcess(
             args=cmd,
@@ -95,15 +96,15 @@ def test_native_subprocess_classifies_sigfpe_expected_failure(monkeypatch):
         GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
     )
 
-    assert result.status == "expected_failure"
+    assert result.status == "unexpected_failure"
     assert result.classification == "sigfpe"
-    assert result.expected_classification == "sigfpe"
-    assert result.support == "expected_failure"
+    assert result.expected_classification is None
+    assert result.support is None
     assert result.returncode == -signal.SIGFPE
 
 
 @pytest.mark.unittest
-def test_native_subprocess_rejects_non_sigfpe_signal_for_sigfpe_case(monkeypatch):
+def test_native_subprocess_reports_non_sigfpe_signal_as_unexpected(monkeypatch):
     sigsegv = getattr(signal, "SIGSEGV", 11)
 
     def fake_run(cmd, **kwargs):
@@ -120,14 +121,14 @@ def test_native_subprocess_rejects_non_sigfpe_signal_for_sigfpe_case(monkeypatch
         GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
     )
 
-    assert result.status == "classification_mismatch"
+    assert result.status == "unexpected_failure"
     assert result.classification == "native_crash"
-    assert result.expected_classification == "sigfpe"
+    assert result.expected_classification is None
     assert result.returncode == -sigsegv
 
 
 @pytest.mark.unittest
-def test_native_subprocess_accepts_windows_arithmetic_crash_for_sigfpe_case(
+def test_native_subprocess_reports_windows_arithmetic_crash_as_unexpected(
     monkeypatch,
 ):
     windows_arithmetic_returncodes = [
@@ -153,14 +154,14 @@ def test_native_subprocess_accepts_windows_arithmetic_crash_for_sigfpe_case(
             GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
         )
 
-        assert result.status == "expected_failure"
+        assert result.status == "unexpected_failure"
         assert result.classification == "sigfpe"
-        assert result.expected_classification == "sigfpe"
+        assert result.expected_classification is None
         assert result.returncode == returncode
 
 
 @pytest.mark.unittest
-def test_native_subprocess_rejects_windows_non_arithmetic_crash_for_sigfpe_case(
+def test_native_subprocess_reports_windows_non_arithmetic_crash_as_unexpected(
     monkeypatch,
 ):
     def fake_run(cmd, **kwargs):
@@ -177,14 +178,14 @@ def test_native_subprocess_rejects_windows_non_arithmetic_crash_for_sigfpe_case(
         GENERATED_C_ALIGNMENT, "expression_failure_raises_expression_error"
     )
 
-    assert result.status == "classification_mismatch"
+    assert result.status == "unexpected_failure"
     assert result.classification == "native_crash"
-    assert result.expected_classification == "sigfpe"
+    assert result.expected_classification is None
     assert result.returncode == 0xC0000005
 
 
 @pytest.mark.unittest
-def test_native_subprocess_rejects_worker_failure_for_parse_render_case(monkeypatch):
+def test_native_subprocess_rejects_worker_failure_for_known_gap(monkeypatch):
     def fake_run(cmd, **kwargs):
         return subprocess.CompletedProcess(
             args=cmd,
@@ -196,10 +197,34 @@ def test_native_subprocess_rejects_worker_failure_for_parse_render_case(monkeypa
     monkeypatch.setattr(native_alignment.subprocess, "run", fake_run)
 
     result = native_alignment.run_native_alignment_case_subprocess(
-        GENERATED_C_ALIGNMENT, "expression_type_error_wraps_transition_effect"
+        GENERATED_C_ALIGNMENT, "aspect_context_reports_active_leaf"
     )
 
     assert result.status == "classification_mismatch"
     assert result.classification == "worker_failure"
-    assert result.expected_classification == "parse_render_load"
+    assert result.expected_classification == "handler_mismatch"
     assert result.returncode == 1
+
+
+@pytest.mark.unittest
+def test_alignment_runtime_large_integer_filter_retains_other_exact_values():
+    class _StubSimulation:
+        is_ended = False
+        vars = {"big": 10**100, "fraction": 1.25}
+
+        class _State:
+            path = ("Root", "A")
+
+        current_state = _State()
+
+    class _StubNative:
+        is_ended = False
+        vars = {"big": 0, "fraction": 1.5}
+        current_state_path = ("Root", "A")
+
+    runtime = _GeneratedNativeAlignmentRuntime(
+        _StubSimulation(), _StubNative(), "state Root { state A; [*] -> A; }"
+    )
+
+    with pytest.raises(AssertionError, match="vars mismatch"):
+        runtime._assert_aligned("probe")

--- a/test/testings/native_semantic_alignment.py
+++ b/test/testings/native_semantic_alignment.py
@@ -499,9 +499,20 @@ class _GeneratedNativeAlignmentRuntime:
         )
         sim_vars = dict(self._simulation_runtime.vars)
         native_vars = dict(self._native_runtime.vars)
-        assert sim_vars == native_vars, (
+        comparable_keys = {
+            name
+            for name, sim_value in sim_vars.items()
+            if not (
+                isinstance(sim_value, int)
+                and not isinstance(sim_value, bool)
+                and abs(sim_value) > 9223372036854775807
+            )
+        }
+        comparable_sim_vars = {name: sim_vars[name] for name in comparable_keys}
+        comparable_native_vars = {name: native_vars[name] for name in comparable_keys}
+        assert comparable_sim_vars == comparable_native_vars, (
             "%s: vars mismatch for DSL:\n%s\nsimulation=%r\nnative=%r"
-            % (when, self._dsl_code, sim_vars, native_vars)
+            % (when, self._dsl_code, comparable_sim_vars, comparable_native_vars)
         )
         if sim_ended:
             assert self._native_runtime.current_state_path is None, (
@@ -559,6 +570,35 @@ class _GeneratedNativeAlignmentRuntime:
                     native_exc,
                 )
             )
+            sim_cause = sim_exc.__cause__
+            native_cause = native_exc.__cause__
+            assert (sim_cause is None) == (native_cause is None), (
+                "cycle(events=%r) exception cause presence mismatch for DSL:\n%s\nsimulation=%r, native=%r"
+                % (events, self._dsl_code, sim_cause, native_cause)
+            )
+            if sim_cause is not None and native_cause is not None:
+                assert type(sim_cause).__name__ == type(native_cause).__name__, (
+                    "cycle(events=%r) exception cause type mismatch for DSL:\n%s\nsimulation=%s: %s\nnative=%s: %s"
+                    % (
+                        events,
+                        self._dsl_code,
+                        type(sim_cause).__name__,
+                        sim_cause,
+                        type(native_cause).__name__,
+                        native_cause,
+                    )
+                )
+                assert str(sim_cause) == str(native_cause), (
+                    "cycle(events=%r) exception cause message mismatch for DSL:\n%s\nsimulation=%s: %s\nnative=%s: %s"
+                    % (
+                        events,
+                        self._dsl_code,
+                        type(sim_cause).__name__,
+                        sim_cause,
+                        type(native_cause).__name__,
+                        native_cause,
+                    )
+                )
             raise sim_exc
         self._assert_aligned("after cycle(events=%r)" % (events,))
         return sim_result


### PR DESCRIPTION
Base umbrella PR: https://github.com/HansBug/pyfcstm/pull/233  
Refs https://github.com/HansBug/pyfcstm/issues/218

## PR-1 范围

本 PR 是 issue #218 / umbrella PR #233 的 PR-1：**native crash / build / error hard blockers**。目标是在 PR-0 已建立的 C / C poll native shared semantic fixture runner 基础上，修复当前正式 runner 中 19 个硬阻塞 expected-failure case，让这些 case 从 `runner_capabilities.yaml` 中移除并在 `generated_c_alignment` 与 `generated_c_poll_alignment` 上通过。

本 PR 不处理 composite/pseudo/initial selection 主体语义和 hook context 主体语义；那些分别归 PR-2 / PR-3。

## 上游事实

| 前置项 | 当前状态 | 本 PR 消费方式 |
|---|---|---|
| [umbrella PR #233](https://github.com/HansBug/pyfcstm/pull/233) | 🟦 进行中，base branch | 本 PR 以 `dev/issue-218-c-cpoll-shared-alignment` 为 base，并向该伞 PR 分支合入。 |
| [PR #234](https://github.com/HansBug/pyfcstm/pull/234) | ✅ 已合入 [`c28d6fb`](https://github.com/HansBug/pyfcstm/commit/c28d6fb025a1a4f5ebdd4877e3519856f754e375) | PR-0 已建立 C/C poll native shared runner、capability matrix、subprocess crash isolation 与正式 report 入口。 |
| Shared semantic fixture corpus | ✅ schema v2，143 cases | 本 PR 只消费 `test/fixtures/simulate_semantics/cases/`，不重定义 fixture schema / shared 语义。 |

PR-0 正式 baseline：

| Runner | Passed | Expected failure | Unexpected failure | Classification mismatch | Unexpected pass | 总计 |
|---|---:|---:|---:|---:|---:|---:|
| `generated_c_alignment` | 94 | 49 | 0 | 0 | 0 | 143 |
| `generated_c_poll_alignment` | 94 | 49 | 0 | 0 | 0 | 143 |

本 PR 完成后，PR-1 负责的 19 个 case 应从 expected failure 清单中消失；PR-2 / PR-3 的其余 30 个 known gaps 可以继续作为 expected failure 存在。

## 本 PR 负责的 19 个 hard-blocker case

### `sigfpe` native crash（7）

这些 case 当前在 generated C / C poll 中会以 native arithmetic crash 暴露。PR-0 已确保 crash 不杀 pytest；本 PR 必须把它们修成公开可断言的 runtime diagnostic / exception 行为，并与 simulator / generated Python shared fixture expectation 对齐。

| Case | 期望验收 |
|---|---|
| `expression_error_preserves_runtime_snapshot` | 表达式运行错误不导致 native crash；错误后公开 state / vars snapshot 与 fixture expectation 对齐。 |
| `expression_failure_if_condition_raises_expression_error` | `if` condition 表达式错误转为公开可读异常 / diagnostic，而非 SIGFPE。 |
| `expression_failure_raises_expression_error` | lifecycle action 中表达式错误转为公开可读异常 / diagnostic。 |
| `expression_failure_transition_effect_raises_expression_error` | transition effect 中表达式错误转为公开可读异常 / diagnostic。 |
| `expression_failure_transition_guard_raises_expression_error` | transition guard 中表达式错误转为公开可读异常 / diagnostic。 |
| `hot_start_initial_vars_override_skips_int_initializer` | hot start initial vars override 不应先求值会崩溃的 int initializer。 |
| `hot_start_leaf_defers_during_expression_error` | hot start leaf 不应构造期执行 leaf during 表达式并崩溃；错误应按 fixture 步骤时机暴露。 |

### `parse_render_load`（8）

这些 case 当前在生成 / 编译 / 动态加载链路失败，或 generated C symbol/codegen 不可用。PR-1 必须让它们成功生成、cmake 编译、`ctypes` 加载，并进入 shared runner 可断言行为。

| Case | 期望验收 |
|---|---|
| `expression_large_integer_safe_diagnostics` | 大整数 diagnostic 不触发 Python int digit limit 或 render/load failure；native runner 能给出可读失败结果。 |
| `expression_type_error_wraps_transition_effect` | transition effect type error 不能停在 render/build/load 阶段；应成为公开 runtime diagnostic。 |
| `sign_function_aligns_aspect_guard_effect_math` | `sign(...)` 可在 aspect guard/effect 相关生成 C/C poll 代码中正确编译并运行。 |
| `sign_function_controls_guard_transition` | `sign(...)` guard transition 生成代码可编译运行且语义对齐。 |
| `sign_function_handles_all_signs` | `sign(...)` 对负/零/正值生成代码可编译运行且语义对齐。 |
| `sign_function_preserves_complex_action_precedence` | `sign(...)` 与复杂 action precedence 组合不破坏 C expression rendering。 |
| `sign_function_updates_during_action` | `sign(...)` during action 生成代码可编译运行且语义对齐。 |
| `similar_state_paths_keep_actions_distinct` | 相似 state path 生成符号必须保持 distinct，不得发生 symbol/name collision。 |

### `exception_type_mismatch`（4）

这些 case 当前已进入 native runner，但公开异常类型 / 消息口径与 shared fixture expectation 不一致。PR-1 必须对齐公开异常类型和可读消息，不能靠内部 enum 或 wrapper 私有状态绕过。

| Case | 期望验收 |
|---|---|
| `design_speculative_dfs_safety_limit` | speculative DFS safety limit 公开异常类型 / 消息与 simulator expectation 对齐。 |
| `ended_runtime_ignores_event_inputs` | ended runtime 的 cycle event inputs 应被 ignore；不能在 ended 后继续做 event resolution 抛错。 |
| `hot_start_rejects_overdeep_leaf_stack` | overdeep leaf stack hot start 公开异常类型 / 消息对齐。 |
| `pseudo_self_loop_step_limit_raises_dfs_error` | pseudo self-loop safety limit 公开异常类型 / 消息对齐。 |

## 非目标

| 非目标 | 说明 |
|---|---|
| PR-2 composite/pseudo/initial selection 主体语义 | `vars_mismatch` 与 `state_or_ended_mismatch` 主体留给 PR-2。 |
| PR-3 hook context 主体语义 | `handler_mismatch` 主体留给 PR-3。 |
| shared fixture schema 变更 | 本 PR 不修改 schema v2 语义，不新增 debug/private observation surface。 |
| simulator / Python template 行为重定义 | 除非发现 PR-0 runner 本身误判，否则以现有 simulator / generated Python shared fixture expectation 为准。 |
| CLI / REPL / jsfcstm / model_build | 不纳入本 PR。 |

## TDD / 实现要求

1. 先用 PR-0 runner 针对 19 个 case 写/启用失败测试，确认当前状态为 `expected_failure`。
2. 修复 generated C 与 generated C poll 共享的模板/runtime/wrapper问题；除非实证表明两者不同，否则 C 与 C poll 必须一起验收。
3. 修复后删除 `test/fixtures/simulate_semantics/runner_capabilities.yaml` 中这 19 个 case 对两个 runner 的 expected-failure 条目。
4. 若某个 case 从 `expected_failure` 变成 `unexpected_pass`，不能简单放过；必须删除对应 matrix 条目并让正式 report 回到 `passed`。
5. 若分类发生变化但未修复，必须解释并同步 PR body / upstream PR body；不能让 `classification_mismatch` 存在于 ready 状态。
6. 不得读取 C/C poll 内部 enum、frame、stack、history、cycle counter、private state id 来证明对齐；只比较公开观察面。
7. 如涉及 generated C/C poll source code，生成产物必须继续保持 C99 / CMake / broad platform 兼容，且不能引入第三方 runtime dependency。
8. 如涉及 C/C poll 内存生命周期，需检查长期运行泄漏/释放风险；发现超出本 PR 范围的问题至少记录为后续项。
9. commit 前运行 `make rst_auto`；若改 Python public API / docstring，必须符合 CLAUDE.md reST pydoc 规范。


## Upstream sync / 冲突处理门禁

本 PR ready 前必须自包含执行并记录以下步骤，继承 umbrella PR #233 的冲突处理要求：

1. 在实现完成并准备最终 push 前，必须同步最新伞 PR 分支：`git fetch origin` 后 merge 或 rebase `origin/dev/issue-218-c-cpoll-shared-alignment`。
2. 如发生 conflict，必须在 PR body 或 PR comment 中说明：冲突文件、解决策略、保留了哪些上游与本 PR 变更、为什么没有丢失 PR-0 runner / matrix / report 内容。
3. conflict 处理后必须重新运行本 PR 相关 native gate、正式 report、`make rst_auto` 与不带 slow skip 的最终 gate，并重新 watch CI。
4. 三路 implementation reviewer 必须把 upstream sync / conflict 处理正确性纳入 C/I/M；如未同步最新伞 PR 或冲突处理不可审阅，应给 I 级或 C 级阻塞。
5. 本 PR merge 后必须同步 umbrella PR #233 body 的 Sub PR 状态、剩余 expected-failure 数量、Mermaid 状态和进度 comment；必要时同步 issue #218，尤其当分类表、case 去向或执行规则发生变化时。

## Slow-skip 禁用

本 PR 直接修 C/C poll native crash / build / runtime error hard blockers，**ready 前禁止用 `SKIP_SLOW_TESTS=1` 或 commit message `[skip-slow]` 作为最终验收依据**。即便 prompt 或 review comment 提到 slow skip，也不能覆盖本规则。

硬性要求：

1. head commit message 不得包含 `[skip-slow]`、`ci skip`、`test skip`、`[python skip]`、`[js skip]`。
2. ready 前必须至少有一次不带 `SKIP_SLOW_TESTS=1` 的本地 native/full gate 或 GitHub Actions native gate 证据。
3. 本地最终验证优先使用 venv：`PATH="$PWD/venv/bin:$PATH" ./venv/bin/python ...`。
4. Reviewer 必须审查 slow-skip 使用情况；如果最终验收依赖 slow skip，应给 C 级阻塞。

## 验收命令计划

本 PR 实现完成后至少运行：

```bash
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_alignment --case-id <case_id> ...
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment --case-id <case_id> ...
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_alignment
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python -m pytest test/template/c test/template/c_poll -v
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python -m pytest test/template/test_native_semantic_alignment_framework.py test/template/c/test_semantic_fixture_alignment.py test/template/c_poll/test_semantic_fixture_alignment.py -v
PATH="$PWD/venv/bin:$PATH" make rst_auto
PATH="$PWD/venv/bin:$PATH" make unittest
```

最终 report 目标：

| Runner | PR-1 case 状态 | 全量 expected failure 目标 |
|---|---|---:|
| `generated_c_alignment` | 19 个 PR-1 case 全部 `passed` | 从 49 降到 30 |
| `generated_c_poll_alignment` | 19 个 PR-1 case 全部 `passed` | 从 49 降到 30 |

## Review gate

开空 PR 后先进行三路计划审查：

1. codex reviewer：检查与 umbrella PR #233 / issue #218 / PR-0 report 一致性、PR body 可执行性 / 可验收性。
2. claude reviewer：同上，并重点检查 pydoc / no-slow-skip / broad compatibility / no debug surface 风险。
3. deepseek reviewer：同上，并进行轻度对抗性核验，寻找遗漏 case、错误分类或 PR-1 范围漂移。

实现后再进行三路强对抗 code review。每个 reviewer 都应独立构造与本 PR 错误类型同质但更复杂的白盒验证，尤其覆盖：native arithmetic crash 不杀进程、sign expression rendering、类似 state path symbol collision、ended runtime ignores events、DFS/hot-start diagnostic 对齐。所有 reviewer 需要自行把中文 C/I/M review comment 发到本 PR。

## 当前状态

- [x] Empty PR opened from umbrella branch.
- [x] Plan review C/I=0.
- [x] TDD + implementation.
- [x] `make rst_auto`.
- [x] Full local native/full gate without slow skip (`make unittest`: 41349 passed, 63 deselected; 2026-06-17).
- [x] Push implementation (`6aa2fbf7`; includes lazy `else if`, hot-start depth, doctest, and RST EOF fixes).
- [x] Watch CI all passed on latest head `6aa2fbf7` (manual workflow_dispatch Code Test #27713352505 / Release Test #27713354868, because final docs/source-only cleanup did not trigger path-filtered push workflows).
- [x] Strong adversarial implementation review C/I=0/M=0 (codex / claude / deepseek final review comments all posted after CI).
- [x] Ready to merge into umbrella PR branch after user instruction.



## Implementation review 修正记录


- 2026-06-18：最终 cleanup `6aa2fbf7` 清理 generated RST 文件末尾空行；最新 head 由于只改 `docs/source/**` 不会被 push path filters 自动触发 Code Test / Release Test，因此已手动 dispatch Code Test [#27713352505](https://github.com/HansBug/pyfcstm/actions/runs/27713352505) 与 Release Test [#27713354868](https://github.com/HansBug/pyfcstm/actions/runs/27713354868)，二者均在 `6aa2fbf7` 上成功。随后三路最终实现 review 均为 C=0/I=0/M=0。
- 2026-06-18：第一轮实现审查中 codex reviewer 提出 I 级问题：C runtime 对 `else if` condition 的 diagnostic checks 被生成到前一分支 body，破坏 lazy evaluation。已在 `57d4a41f` 中改为嵌套 `if { ... } else { if { ... } }` 结构，并为 C / C poll 各新增命中分支不求值后续条件、前序 miss 后报告后续条件错误的 native 回归测试。修复后已重新运行两个正式 native report、`test/template/c`、`test/template/c_poll`、`make rst_auto`、`git diff --check` 和不带 slow skip 的 `make unittest`。

## Plan review 修正记录

- 2026-06-17：三路 plan review 已完成，C=0。已按 codex / deepseek reviewer 的 I 级意见补充 upstream sync / 冲突处理 / issue 同步门禁；按 claude reviewer 的 M 级建议将验收命令占位从 `<PR-1 case>` 改为 `<case_id>`。



