### PR TITLE
fix(template): align C composite initial semantics

### DIFF
--- a/docs/source/api_doc/render/c_runtime.rst
+++ b/docs/source/api_doc/render/c_runtime.rst
@@ -18,6 +18,12 @@ render\_c\_action\_body
 .. autofunction:: render_c_action_body
 
 
+render\_c\_reset\_vars\_body
+-----------------------------------------------------
+
+.. autofunction:: render_c_reset_vars_body
+
+
 render\_c\_condition\_body
 -----------------------------------------------------
 

--- a/pyfcstm/render/c_runtime.py
+++ b/pyfcstm/render/c_runtime.py
@@ -9,6 +9,7 @@ compile errors.
 
 The module contains:
 
+* :func:`render_c_reset_vars_body` - Render default persistent-variable setup.
 * :func:`render_c_action_body` - Render operation statements as a fallible C body.
 * :func:`render_c_condition_body` - Render a fallible C guard/condition body.
 
@@ -623,6 +624,37 @@ def _render_statement_sequence(
                     )
                 if inferred_type is not None:
                     current_types[statement.name] = inferred_type
+            if state_types.get(statement.name) == "int" and expr.value_type == "float":
+                temp_name = "__pyfcstm_value_%d" % len(lines)
+                _line(lines, indent, level, "double %s = %s;" % (temp_name, expr.text))
+                _line(
+                    lines,
+                    indent,
+                    level,
+                    "if (%s != (double)((PYFCSTM_GENERATED_INT64)%s)) {"
+                    % (temp_name, temp_name),
+                )
+                _line(
+                    lines,
+                    indent,
+                    level + 1,
+                    (
+                        "%s(machine, "
+                        "\"Variable '%s' is int type, cannot assign float %%.15g; "
+                        "non-integer float from operation block writeback\", "
+                        "%s);"
+                    )
+                    % (names.set_error, statement.name, temp_name),
+                )
+                _line(lines, indent, level + 1, "return %s;" % names.failure)
+                _line(lines, indent, level, "}")
+                _line(
+                    lines,
+                    indent,
+                    level,
+                    "%s = (PYFCSTM_GENERATED_INT64)%s;" % (target, temp_name),
+                )
+                continue
             _line(lines, indent, level, "%s = %s;" % (target, expr.text))
             continue
 
@@ -731,6 +763,98 @@ def render_c_action_body(
     ]
     body, _ = _render_statement_sequence(nodes, state_types, {}, names, indent, 1)
     lines.extend(body)
+    lines.append("%sreturn %s;" % (indent, names.success))
+    return "\n".join(lines)
+
+
+def render_c_reset_vars_body(
+    var_defines: Mapping[str, Any],
+    machine_class_name: str,
+    machine_macro_name: str,
+    indent: str = "    ",
+) -> str:
+    """
+    Render C statements for default persistent-variable initialization.
+
+    The emitted body evaluates ``def`` initializers in declaration order and
+    applies the same persistent ``int`` writeback boundary used by operation
+    blocks. Integer defaults therefore accept integer-valued floats but report a
+    generated runtime error for non-integer floats instead of relying on C's
+    implicit narrowing conversion.
+
+    :param var_defines: Model variable definitions keyed by DSL variable name.
+    :type var_defines: typing.Mapping[str, typing.Any]
+    :param machine_class_name: Generated machine class name.
+    :type machine_class_name: str
+    :param machine_macro_name: Generated macro prefix.
+    :type machine_macro_name: str
+    :param indent: Indentation unit used for generated C code, defaults to four
+        spaces.
+    :type indent: str, optional
+    :return: C statements ending in a generated success return.
+    :rtype: str
+
+    Example::
+
+        >>> body = render_c_reset_vars_body({}, "Demo", "DEMO")
+        >>> body.strip().endswith("return DEMO_SUCCESS;")
+        True
+    """
+    state_types = _normalise_var_types(var_defines)
+    names = _CNames(machine_class_name, machine_macro_name)
+    lines = [
+        "%s(void)machine;" % indent,
+        "%s(void)scope;" % indent,
+    ]
+    for name, define in var_defines.items():
+        expr = _render_expr(define.init, state_types, state_types.keys())
+        checks: List[str] = []
+        safe = _emit_expr_checks(
+            checks,
+            define.init,
+            state_types,
+            state_types.keys(),
+            names,
+            "variable '%s' initializer" % name,
+            indent,
+            1,
+        )
+        lines.extend(checks)
+        if not safe:
+            continue
+        target = "scope->%s" % to_c_identifier(name)
+        if state_types.get(name) == "int" and expr.value_type == "float":
+            temp_name = "__pyfcstm_init_%d" % len(lines)
+            _line(lines, indent, 1, "double %s = %s;" % (temp_name, expr.text))
+            _line(
+                lines,
+                indent,
+                1,
+                "if (%s != (double)((PYFCSTM_GENERATED_INT64)%s)) {"
+                % (temp_name, temp_name),
+            )
+            _line(
+                lines,
+                indent,
+                2,
+                (
+                    "%s(machine, "
+                    "\"Variable '%s' is int type, cannot assign float %%.15g; "
+                    "non-integer float from variable '%s' initializer\", "
+                    "%s);"
+                )
+                % (names.set_error, name, name, temp_name),
+            )
+            _line(lines, indent, 2, "return %s;" % names.failure)
+            _line(lines, indent, 1, "}")
+            _line(
+                lines,
+                indent,
+                1,
+                "%s = (PYFCSTM_GENERATED_INT64)%s;" % (target, temp_name),
+            )
+            continue
+        _line(lines, indent, 1, "%s = %s;" % (target, expr.text))
     lines.append("%sreturn %s;" % (indent, names.success))
     return "\n".join(lines)
 

--- a/pyfcstm/render/render.py
+++ b/pyfcstm/render/render.py
@@ -61,7 +61,11 @@ from .statement import (
     _KNOWN_STMT_STYLES, _normalize_stmt_style,
 )
 from .func import process_item_to_object
-from .c_runtime import render_c_action_body, render_c_condition_body
+from .c_runtime import (
+    render_c_action_body,
+    render_c_condition_body,
+    render_c_reset_vars_body,
+)
 from ..dsl import node as dsl_nodes
 from ..model import StateMachine
 from ..utils import auto_decode
@@ -232,6 +236,7 @@ class StateMachineCodeRenderer:
         self.env.filters['stmts_render'] = _fn_stmts_render
         self.env.globals['render_c_action_body'] = render_c_action_body
         self.env.globals['render_c_condition_body'] = render_c_condition_body
+        self.env.globals['render_c_reset_vars_body'] = render_c_reset_vars_body
 
         globals_ = config_info.pop('globals', None) or {}
         for name, value in globals_.items():

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -2138,6 +2138,8 @@ int {{ machine_class_name(model) }}_cycle(
         _{{ machine_class_name(model) }}_set_error(machine, "Machine is not initialized; call {{ machine_class_name(model) }}_init(...) or {{ machine_class_name(model) }}_hot_start(...) before cycle().");
         return {{ machine_macro_name(model) }}_FAILURE;
     }
+
+    _{{ machine_class_name(model) }}_clear_error(machine);
     if (machine->ended) {
         return {{ machine_macro_name(model) }}_SUCCESS;
     }

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -260,15 +260,11 @@ static const {{ machine_class_name(model) }}Vars *_{{ machine_class_name(model) 
 }
 
 /* Reset persistent variables to the DSL `def ... = ...;` defaults. */
-static void _{{ machine_class_name(model) }}_reset_vars({{ machine_class_name(model) }}Vars *vars)
+static int _{{ machine_class_name(model) }}_reset_vars(
+    {{ machine_class_name(model) }} *machine,
+    {{ machine_class_name(model) }}Vars *scope)
 {
-{% if model.defines.values() | list -%}
-{% for def_item in model.defines.values() -%}
-{{ '    ' }}vars->{{ def_item.name | to_c_identifier }} = {{ def_item.init.to_ast_node() | expr_render(style='c') }};
-{% endfor -%}
-{% else -%}
-    vars->_unused_placeholder = 0;
-{% endif -%}
+{{ render_c_reset_vars_body(model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_transition(
@@ -277,12 +273,32 @@ static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_tr
     int transition_id,
     const _{{ machine_class_name(model) }}EventSet *event_set);
 
+static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_initial_transition(
+    {{ machine_class_name(model) }} *machine,
+    const _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set);
+
+static int _{{ machine_class_name(model) }}_execute_transition_effect(
+    {{ machine_class_name(model) }} *machine,
+    const _{{ machine_class_name(model) }}TransitionInfo *transition,
+    _{{ machine_class_name(model) }}RuntimeContext *context);
+
+static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set,
+    int is_validation_mode,
+    int attempt_nested_initial);
+
 static int _{{ machine_class_name(model) }}_enter_state(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int state_id,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int is_validation_mode);
+    int is_validation_mode,
+    int attempt_initial_transition);
 
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_event_set_has(
     const _{{ machine_class_name(model) }}EventSet *event_set,
@@ -930,7 +946,6 @@ _{{ machine_class_name(model) }}_event_set_has(event_set, {{ all_events.items.in
 {% endif -%}
 {%- endset %}
 {% set branch_body -%}
-{% if state.is_leaf_state and not state.is_pseudo -%}
 if (validate_stoppable) {
     int is_valid = _{{ machine_class_name(model) }}_validate_transition(
         machine,
@@ -947,9 +962,6 @@ if (validate_stoppable) {
 } else {
     return {{ normal_transition_id(state, loop.index) }};
 }
-{% else -%}
-return {{ normal_transition_id(state, loop.index) }};
-{% endif -%}
 {%- endset %}
     if ({{ event_condition | trim | replace('\n', ' ') }}) {
 {% if transition.guard is not none %}
@@ -993,20 +1005,29 @@ _{{ machine_class_name(model) }}_event_set_has(event_set, {{ all_events.items.in
 {% endif -%}
 {%- endset %}
 {% set init_body -%}
-{% if transition.effects %}
-if ({{ init_effect_method_name(state, loop.index) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
-    return 0;
-}
-{% endif %}
-if (_{{ machine_class_name(model) }}_enter_state(
+{
+    int is_valid = _{{ machine_class_name(model) }}_validate_initial_transition(
         machine,
         context,
-        {{ state_enum(state.substates[transition.to_state]) }},
-        event_set,
-        is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
-    return 0;
+        {{ init_transition_id(state, loop.index) }},
+        event_set);
+    if (!is_valid) {
+        if (machine != NULL && machine->last_error[0] != '\0') {
+            return 0;
+        }
+    } else {
+        if (_{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+                machine,
+                context,
+                {{ init_transition_id(state, loop.index) }},
+                event_set,
+                is_validation_mode,
+                !is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return 0;
+        }
+        return 1;
+    }
 }
-return 1;
 {%- endset %}
     if ({{ event_condition | trim | replace('\n', ' ') }}) {
 {% if transition.guard is not none %}
@@ -1116,6 +1137,58 @@ static const _{{ machine_class_name(model) }}TransitionInfo _{{ machine_class_na
 {% endfor %}
 };
 
+static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set,
+    int is_validation_mode,
+    int attempt_nested_initial)
+{
+    const _{{ machine_class_name(model) }}TransitionInfo *transition;
+    int composite_state_id;
+
+    if (context->stack_size == 0u) {
+        return 0;
+    }
+
+    transition = &_{{ machine_class_name(model) }}_transitions[transition_id];
+    composite_state_id = context->stack[context->stack_size - 1u].state_id;
+    if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (context->stack_size > 0u && context->stack[context->stack_size - 1u].plain_before_pending) {
+        int pending_state_id = context->stack[context->stack_size - 1u].state_id;
+        if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+                machine,
+                pending_state_id,
+                context,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        context->stack[context->stack_size - 1u].plain_before_pending = 0;
+    }
+    if (_{{ machine_class_name(model) }}_enter_state(
+            machine,
+            context,
+            transition->target_state_id,
+            event_set,
+            is_validation_mode,
+            attempt_nested_initial) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (context->stack_size > 0u) {
+        size_t frame_index;
+        for (frame_index = context->stack_size; frame_index > 0u; --frame_index) {
+            if (context->stack[frame_index - 1u].state_id == composite_state_id) {
+                context->stack[frame_index - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_ACTIVE;
+                break;
+            }
+        }
+    }
+    return {{ machine_macro_name(model) }}_SUCCESS;
+}
+
 static int _{{ machine_class_name(model) }}_state_id_is_valid(int state_id)
 {
     return state_id >= 0 && state_id < {{ machine_macro_name(model) }}_STATE_COUNT;
@@ -1125,7 +1198,6 @@ static int _{{ machine_class_name(model) }}_event_id_is_valid(int event_id)
 {
     return event_id >= 0 && event_id < {{ machine_macro_name(model) }}_EVENT_COUNT;
 }
-
 static void _{{ machine_class_name(model) }}_event_set_reset(
     _{{ machine_class_name(model) }}EventSet *event_set,
     size_t input_count)
@@ -1226,6 +1298,21 @@ static int _{{ machine_class_name(model) }}_normalize_events(
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
+static int _{{ machine_class_name(model) }}_event_set_activate_all(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}EventSet *event_set)
+{
+    int event_id;
+
+    _{{ machine_class_name(model) }}_event_set_reset(event_set, {{ machine_macro_name(model) }}_EVENT_COUNT);
+    for (event_id = 0; event_id < {{ machine_macro_name(model) }}_EVENT_COUNT; ++event_id) {
+        if (_{{ machine_class_name(model) }}_event_set_add(machine, event_set, event_id) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+    }
+    return {{ machine_macro_name(model) }}_SUCCESS;
+}
+
 static void _{{ machine_class_name(model) }}_copy_context(
     _{{ machine_class_name(model) }}RuntimeContext *dst,
     const _{{ machine_class_name(model) }}RuntimeContext *src)
@@ -1267,6 +1354,7 @@ static int _{{ machine_class_name(model) }}_push_frame(
     }
     context->stack[context->stack_size].state_id = state_id;
     context->stack[context->stack_size].mode = mode;
+    context->stack[context->stack_size].plain_before_pending = 0;
     ++context->stack_size;
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
@@ -1399,6 +1487,20 @@ static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_tr
     int transition_id,
     const _{{ machine_class_name(model) }}EventSet *event_set);
 
+static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_initial_transition(
+    {{ machine_class_name(model) }} *machine,
+    const _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set);
+
+static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set,
+    int is_validation_mode,
+    int attempt_nested_initial);
+
 static int _{{ machine_class_name(model) }}_select_transition(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1434,12 +1536,15 @@ static int _{{ machine_class_name(model) }}_enter_state(
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int state_id,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int is_validation_mode)
+    int is_validation_mode,
+    int attempt_initial_transition)
 {
     const _{{ machine_class_name(model) }}StateInfo *state_info;
     int init_result;
+    size_t pushed_index;
 
     state_info = &_{{ machine_class_name(model) }}_state_info[state_id];
+    pushed_index = context->stack_size;
     if (_{{ machine_class_name(model) }}_push_frame(machine, context, state_id, {{ machine_macro_name(model) }}_FRAME_MODE_ACTIVE) != {{ machine_macro_name(model) }}_SUCCESS) {
         if (is_validation_mode) {
             _{{ machine_class_name(model) }}_set_error(
@@ -1466,17 +1571,13 @@ static int _{{ machine_class_name(model) }}_enter_state(
         return {{ machine_macro_name(model) }}_SUCCESS;
     }
 
-    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
-            machine,
-            state_id,
-            context,
-            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
-        return {{ machine_macro_name(model) }}_FAILURE;
-    }
-    context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
-    init_result = _{{ machine_class_name(model) }}_attempt_init_transition(machine, context, event_set, is_validation_mode);
-    if (init_result != {{ machine_macro_name(model) }}_SUCCESS && machine != NULL && machine->last_error[0] != '\0') {
-        return {{ machine_macro_name(model) }}_FAILURE;
+    context->stack[pushed_index].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
+    context->stack[pushed_index].plain_before_pending = 1;
+    if (attempt_initial_transition) {
+        init_result = _{{ machine_class_name(model) }}_attempt_init_transition(machine, context, event_set, is_validation_mode);
+        if (init_result != {{ machine_macro_name(model) }}_SUCCESS && machine != NULL && machine->last_error[0] != '\0') {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
     }
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
@@ -1518,6 +1619,20 @@ static int _{{ machine_class_name(model) }}_finalize_exit_to_parent(
 
     parent_state_id = context->stack[context->stack_size - 1u].state_id;
     if (parent_state_id == {{ state_enum(model.root_state) }}) {
+        if (_{{ machine_class_name(model) }}_run_during_after_actions_for_state(
+                machine,
+                parent_state_id,
+                context,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        if (_{{ machine_class_name(model) }}_run_exit_actions_for_state(
+                machine,
+                parent_state_id,
+                context,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
         context->stack_size = 0u;
         return 1;
     }
@@ -1567,7 +1682,8 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
             context,
             transition->target_state_id,
             event_set,
-            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            is_validation_mode,
+            1) != {{ machine_macro_name(model) }}_SUCCESS) {
         return {{ machine_macro_name(model) }}_FAILURE;
     }
     return 0;
@@ -1719,6 +1835,18 @@ static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_tr
 {
     _{{ machine_class_name(model) }}RuntimeContext sim_context;
     int ended;
+    int result;
+
+    if (machine != NULL) {
+        if (machine->validation_depth >= {{ machine_macro_name(model) }}_MAX_DFS_STEPS) {
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Speculative DFS exceeded the step safety limit (%d) without reaching a stoppable state or pruning; the state machine likely contains an invalid unbounded pseudo-state or transition chain.",
+                {{ machine_macro_name(model) }}_MAX_DFS_STEPS);
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        ++machine->validation_depth;
+    }
 
     _{{ machine_class_name(model) }}_copy_context(&sim_context, context);
     ended = _{{ machine_class_name(model) }}_execute_transition_on_context(
@@ -1728,18 +1856,74 @@ static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_tr
         event_set,
         1);
     if (machine != NULL && machine->last_error[0] != '\0') {
-        return {{ machine_macro_name(model) }}_FAILURE;
+        result = {{ machine_macro_name(model) }}_FAILURE;
+    } else if (ended) {
+        result = 1;
+    } else {
+        result = _{{ machine_class_name(model) }}_run_cycle_on_context(
+            machine,
+            &sim_context,
+            event_set,
+            &ended,
+            1,
+            1);
     }
-    if (ended) {
-        return 1;
+
+    if (machine != NULL && machine->validation_depth > 0) {
+        --machine->validation_depth;
     }
-    return _{{ machine_class_name(model) }}_run_cycle_on_context(
-        machine,
-        &sim_context,
-        event_set,
-        &ended,
-        0,
-        1);
+    return result;
+}
+
+static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_initial_transition(
+    {{ machine_class_name(model) }} *machine,
+    const _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set)
+{
+    _{{ machine_class_name(model) }}RuntimeContext sim_context;
+    int ended;
+    int result;
+
+    if (machine != NULL) {
+        if (machine->validation_depth >= {{ machine_macro_name(model) }}_MAX_DFS_STEPS) {
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Speculative DFS exceeded the step safety limit (%d) without reaching a stoppable state or pruning; the state machine likely contains an invalid unbounded pseudo-state or transition chain.",
+                {{ machine_macro_name(model) }}_MAX_DFS_STEPS);
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        ++machine->validation_depth;
+    }
+
+    _{{ machine_class_name(model) }}_copy_context(&sim_context, context);
+    if (_{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+            machine,
+            &sim_context,
+            transition_id,
+            event_set,
+            1,
+            0) != {{ machine_macro_name(model) }}_SUCCESS) {
+        result = {{ machine_macro_name(model) }}_FAILURE;
+    } else {
+        ended = sim_context.stack_size == 0u;
+        if (ended) {
+            result = 1;
+        } else {
+            result = _{{ machine_class_name(model) }}_run_cycle_on_context(
+                machine,
+                &sim_context,
+                event_set,
+                &ended,
+                1,
+                1);
+        }
+    }
+
+    if (machine != NULL && machine->validation_depth > 0) {
+        --machine->validation_depth;
+    }
+    return result;
 }
 
 static int _{{ machine_class_name(model) }}_initialize_context(
@@ -1748,7 +1932,9 @@ static int _{{ machine_class_name(model) }}_initialize_context(
     const _{{ machine_class_name(model) }}EventSet *event_set)
 {
     context->stack_size = 0u;
-    _{{ machine_class_name(model) }}_enter_state(machine, context, {{ state_enum(model.root_state) }}, event_set, 0);
+    if (_{{ machine_class_name(model) }}_enter_state(machine, context, {{ state_enum(model.root_state) }}, event_set, 0, 1) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return 0;
+    }
     return context->stack_size == 0u;
 }
 
@@ -1779,7 +1965,9 @@ int {{ machine_class_name(model) }}_init({{ machine_class_name(model) }} *machin
     }
 
     memset(machine, 0, sizeof(*machine));
-    _{{ machine_class_name(model) }}_reset_vars(&machine->vars);
+    if (_{{ machine_class_name(model) }}_reset_vars(machine, &machine->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     machine->stack_size = 1u;
     machine->stack[0].state_id = {{ state_enum(model.root_state) }};
     machine->stack[0].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
@@ -1797,9 +1985,14 @@ int {{ machine_class_name(model) }}_hot_start(
 {
     const {{ machine_class_name(model) }}Hooks *saved_hooks;
     void *saved_hook_user_data;
+    _{{ machine_class_name(model) }}RuntimeContext validation_context;
+    _{{ machine_class_name(model) }}EventSet validation_event_set;
+    int validation_ended;
+    int validation_success;
     int path_ids[{{ machine_macro_name(model) }}_MAX_STACK_DEPTH];
     size_t path_count;
     int current_state_id;
+    int target_state_id;
     size_t i;
 
     if (machine == NULL || initial_vars == NULL) {
@@ -1810,6 +2003,7 @@ int {{ machine_class_name(model) }}_hot_start(
     saved_hook_user_data = machine->hook_user_data;
     memset(machine, 0, sizeof(*machine));
     machine->vars = *initial_vars;
+    target_state_id = initial_state_id;
     current_state_id = initial_state_id;
     if (!_{{ machine_class_name(model) }}_state_id_is_valid(current_state_id)) {
         _{{ machine_class_name(model) }}_set_error(machine, "Invalid state id: %d", initial_state_id);
@@ -1839,6 +2033,7 @@ int {{ machine_class_name(model) }}_hot_start(
         }
         machine->stack[machine->stack_size].state_id = state_id;
         machine->stack[machine->stack_size].mode = mode;
+        machine->stack[machine->stack_size].plain_before_pending = 0;
         ++machine->stack_size;
     }
     machine->entered_root = 1;
@@ -1847,6 +2042,38 @@ int {{ machine_class_name(model) }}_hot_start(
     machine->hooks = saved_hooks;
     machine->hook_user_data = saved_hook_user_data;
     _{{ machine_class_name(model) }}_clear_error(machine);
+    if (machine->stack_size > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
+        _{{ machine_class_name(model) }}_set_error(
+            machine,
+            "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.",
+            {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (!_{{ machine_class_name(model) }}_is_stoppable_state(target_state_id)) {
+        if (_{{ machine_class_name(model) }}_event_set_activate_all(machine, &validation_event_set) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        _{{ machine_class_name(model) }}_copy_from_machine(&validation_context, machine);
+        validation_ended = 0;
+        validation_success = _{{ machine_class_name(model) }}_run_cycle_on_context(
+            machine,
+            &validation_context,
+            &validation_event_set,
+            &validation_ended,
+            1,
+            1);
+        if (!validation_success && machine->last_error[0] != '\0') {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        if (!validation_success) {
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Hot start target '%s' cannot reach a stoppable state",
+                _{{ machine_class_name(model) }}_state_info[target_state_id].path);
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        _{{ machine_class_name(model) }}_clear_error(machine);
+    }
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
 

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -1973,6 +1973,7 @@ int {{ machine_class_name(model) }}_init({{ machine_class_name(model) }} *machin
     machine->stack[0].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
     machine->ended = 0;
     machine->entered_root = 0;
+    machine->initialized = 1;
     machine->_active_vars = NULL;
     _{{ machine_class_name(model) }}_clear_error(machine);
     return {{ machine_macro_name(model) }}_SUCCESS;
@@ -2038,6 +2039,7 @@ int {{ machine_class_name(model) }}_hot_start(
     }
     machine->entered_root = 1;
     machine->ended = 0;
+    machine->initialized = 1;
     machine->_active_vars = NULL;
     machine->hooks = saved_hooks;
     machine->hook_user_data = saved_hook_user_data;
@@ -2101,6 +2103,10 @@ int {{ machine_class_name(model) }}_cycle(
     int success;
 
     if (machine == NULL) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (!machine->initialized) {
+        _{{ machine_class_name(model) }}_set_error(machine, "Machine is not initialized; call {{ machine_class_name(model) }}_init(...) or {{ machine_class_name(model) }}_hot_start(...) before cycle().");
         return {{ machine_macro_name(model) }}_FAILURE;
     }
     if (machine->ended) {

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -230,6 +230,18 @@ static const char *_{{ machine_class_name(model) }}_dsl_source =
 {% endif -%}
 
 /* Error helpers used by the public API wrappers. */
+static void _{{ machine_class_name(model) }}_format_error_text(char *buffer, size_t buffer_size, const char *fmt, ...)
+{
+    va_list ap;
+    if (buffer == NULL || buffer_size == 0u) {
+        return;
+    }
+    va_start(ap, fmt);
+    PYFCSTM_GENERATED_VSNPRINTF(buffer, buffer_size, fmt, ap);
+    buffer[buffer_size - 1u] = '\0';
+    va_end(ap);
+}
+
 static void _{{ machine_class_name(model) }}_set_error({{ machine_class_name(model) }} *machine, const char *fmt, ...)
 {
     va_list ap;
@@ -1984,8 +1996,8 @@ int {{ machine_class_name(model) }}_hot_start(
     {{ machine_class_name(model) }}StateId initial_state_id,
     const {{ machine_class_name(model) }}Vars *initial_vars)
 {
-    const {{ machine_class_name(model) }}Hooks *saved_hooks;
-    void *saved_hook_user_data;
+    {{ machine_class_name(model) }} saved_machine;
+    char hot_start_error[sizeof(machine->last_error)];
     _{{ machine_class_name(model) }}RuntimeContext validation_context;
     _{{ machine_class_name(model) }}EventSet validation_event_set;
     int validation_ended;
@@ -2000,22 +2012,30 @@ int {{ machine_class_name(model) }}_hot_start(
         return {{ machine_macro_name(model) }}_FAILURE;
     }
 
-    saved_hooks = machine->hooks;
-    saved_hook_user_data = machine->hook_user_data;
+    saved_machine = *machine;
+    hot_start_error[0] = '\0';
     memset(machine, 0, sizeof(*machine));
     machine->vars = *initial_vars;
     target_state_id = initial_state_id;
     current_state_id = initial_state_id;
     if (!_{{ machine_class_name(model) }}_state_id_is_valid(current_state_id)) {
-        _{{ machine_class_name(model) }}_set_error(machine, "Invalid state id: %d", initial_state_id);
-        return {{ machine_macro_name(model) }}_FAILURE;
+        _{{ machine_class_name(model) }}_format_error_text(
+            hot_start_error,
+            sizeof(hot_start_error),
+            "Invalid state id: %d",
+            initial_state_id);
+        goto hot_start_failure;
     }
 
     path_count = 0u;
     while (current_state_id >= 0) {
         if (path_count >= {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
-            _{{ machine_class_name(model) }}_set_error(machine, "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.", {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
-            return {{ machine_macro_name(model) }}_FAILURE;
+            _{{ machine_class_name(model) }}_format_error_text(
+                hot_start_error,
+                sizeof(hot_start_error),
+                "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.",
+                {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
+            goto hot_start_failure;
         }
         path_ids[path_count++] = current_state_id;
         current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
@@ -2041,19 +2061,21 @@ int {{ machine_class_name(model) }}_hot_start(
     machine->ended = 0;
     machine->initialized = 1;
     machine->_active_vars = NULL;
-    machine->hooks = saved_hooks;
-    machine->hook_user_data = saved_hook_user_data;
+    machine->hooks = saved_machine.hooks;
+    machine->hook_user_data = saved_machine.hook_user_data;
     _{{ machine_class_name(model) }}_clear_error(machine);
     if (machine->stack_size > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
-        _{{ machine_class_name(model) }}_set_error(
-            machine,
+        _{{ machine_class_name(model) }}_format_error_text(
+            hot_start_error,
+            sizeof(hot_start_error),
             "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.",
             {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
-        return {{ machine_macro_name(model) }}_FAILURE;
+        goto hot_start_failure;
     }
     if (!_{{ machine_class_name(model) }}_is_stoppable_state(target_state_id)) {
         if (_{{ machine_class_name(model) }}_event_set_activate_all(machine, &validation_event_set) != {{ machine_macro_name(model) }}_SUCCESS) {
-            return {{ machine_macro_name(model) }}_FAILURE;
+            _{{ machine_class_name(model) }}_format_error_text(hot_start_error, sizeof(hot_start_error), "%s", machine->last_error);
+            goto hot_start_failure;
         }
         _{{ machine_class_name(model) }}_copy_from_machine(&validation_context, machine);
         validation_ended = 0;
@@ -2065,18 +2087,25 @@ int {{ machine_class_name(model) }}_hot_start(
             1,
             1);
         if (!validation_success && machine->last_error[0] != '\0') {
-            return {{ machine_macro_name(model) }}_FAILURE;
+            _{{ machine_class_name(model) }}_format_error_text(hot_start_error, sizeof(hot_start_error), "%s", machine->last_error);
+            goto hot_start_failure;
         }
         if (!validation_success) {
-            _{{ machine_class_name(model) }}_set_error(
-                machine,
+            _{{ machine_class_name(model) }}_format_error_text(
+                hot_start_error,
+                sizeof(hot_start_error),
                 "Hot start target '%s' cannot reach a stoppable state",
                 _{{ machine_class_name(model) }}_state_info[target_state_id].path);
-            return {{ machine_macro_name(model) }}_FAILURE;
+            goto hot_start_failure;
         }
         _{{ machine_class_name(model) }}_clear_error(machine);
     }
     return {{ machine_macro_name(model) }}_SUCCESS;
+
+hot_start_failure:
+    *machine = saved_machine;
+    _{{ machine_class_name(model) }}_set_error(machine, "%s", hot_start_error);
+    return {{ machine_macro_name(model) }}_FAILURE;
 }
 
 void {{ machine_class_name(model) }}_set_hooks(

--- a/templates/c/machine.h.j2
+++ b/templates/c/machine.h.j2
@@ -190,6 +190,7 @@ struct {{ machine_class_name(model) }} {
     size_t stack_size;
     int ended;
     int entered_root;
+    int initialized;
     int validation_depth;
     const {{ machine_class_name(model) }}Hooks *hooks;
     void *hook_user_data;

--- a/templates/c/machine.h.j2
+++ b/templates/c/machine.h.j2
@@ -160,6 +160,7 @@ typedef struct {{ machine_class_name(model) }}Hooks {
 typedef struct {{ machine_class_name(model) }}Frame {
     int state_id;
     int mode;
+    int plain_before_pending;
 } {{ machine_class_name(model) }}Frame;
 
 /*
@@ -189,6 +190,7 @@ struct {{ machine_class_name(model) }} {
     size_t stack_size;
     int ended;
     int entered_root;
+    int validation_depth;
     const {{ machine_class_name(model) }}Hooks *hooks;
     void *hook_user_data;
     char last_error[512];

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -2011,6 +2011,7 @@ int {{ machine_class_name(model) }}_init({{ machine_class_name(model) }} *machin
     machine->stack[0].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
     machine->ended = 0;
     machine->entered_root = 0;
+    machine->initialized = 1;
     machine->_active_vars = NULL;
     _{{ machine_class_name(model) }}_clear_error(machine);
     return {{ machine_macro_name(model) }}_SUCCESS;
@@ -2082,6 +2083,7 @@ int {{ machine_class_name(model) }}_hot_start(
     }
     machine->entered_root = 1;
     machine->ended = 0;
+    machine->initialized = 1;
     machine->_active_vars = NULL;
     machine->hooks = saved_hooks;
     machine->hook_user_data = saved_hook_user_data;
@@ -2167,6 +2169,10 @@ int {{ machine_class_name(model) }}_cycle(
     int success;
 
     if (machine == NULL) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (!machine->initialized) {
+        _{{ machine_class_name(model) }}_set_error(machine, "Machine is not initialized; call {{ machine_class_name(model) }}_init(...) or {{ machine_class_name(model) }}_hot_start(...) before cycle().");
         return {{ machine_macro_name(model) }}_FAILURE;
     }
     if (machine->ended) {

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -355,15 +355,11 @@ static const {{ machine_class_name(model) }}Vars *_{{ machine_class_name(model) 
 }
 
 /* Reset persistent variables to the DSL `def ... = ...;` defaults. */
-static void _{{ machine_class_name(model) }}_reset_vars({{ machine_class_name(model) }}Vars *vars)
+static int _{{ machine_class_name(model) }}_reset_vars(
+    {{ machine_class_name(model) }} *machine,
+    {{ machine_class_name(model) }}Vars *scope)
 {
-{% if model.defines.values() | list -%}
-{% for def_item in model.defines.values() -%}
-{{ '    ' }}vars->{{ def_item.name | to_c_identifier }} = {{ def_item.init.to_ast_node() | expr_render(style='c') }};
-{% endfor -%}
-{% else -%}
-    vars->_unused_placeholder = 0;
-{% endif -%}
+{{ render_c_reset_vars_body(model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_transition(
@@ -372,12 +368,32 @@ static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_tr
     int transition_id,
     const _{{ machine_class_name(model) }}EventSet *event_set);
 
+static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_initial_transition(
+    {{ machine_class_name(model) }} *machine,
+    const _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set);
+
+static int _{{ machine_class_name(model) }}_execute_transition_effect(
+    {{ machine_class_name(model) }} *machine,
+    const _{{ machine_class_name(model) }}TransitionInfo *transition,
+    _{{ machine_class_name(model) }}RuntimeContext *context);
+
+static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set,
+    int is_validation_mode,
+    int attempt_nested_initial);
+
 static int _{{ machine_class_name(model) }}_enter_state(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int state_id,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int is_validation_mode);
+    int is_validation_mode,
+    int attempt_initial_transition);
 
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_event_set_has(
     {{ machine_class_name(model) }} *machine,
@@ -1027,7 +1043,6 @@ _{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ a
 {% endif -%}
 {%- endset %}
 {% set branch_body -%}
-{% if state.is_leaf_state and not state.is_pseudo -%}
 if (validate_stoppable) {
     int is_valid = _{{ machine_class_name(model) }}_validate_transition(
         machine,
@@ -1044,9 +1059,6 @@ if (validate_stoppable) {
 } else {
     return {{ normal_transition_id(state, loop.index) }};
 }
-{% else -%}
-return {{ normal_transition_id(state, loop.index) }};
-{% endif -%}
 {%- endset %}
     if ({{ event_condition | trim | replace('\n', ' ') }}) {
 {% if transition.guard is not none %}
@@ -1090,20 +1102,29 @@ _{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ a
 {% endif -%}
 {%- endset %}
 {% set init_body -%}
-{% if transition.effects %}
-if ({{ init_effect_method_name(state, loop.index) }}(machine, &context->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
-    return 0;
-}
-{% endif %}
-if (_{{ machine_class_name(model) }}_enter_state(
+{
+    int is_valid = _{{ machine_class_name(model) }}_validate_initial_transition(
         machine,
         context,
-        {{ state_enum(state.substates[transition.to_state]) }},
-        event_set,
-        is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
-    return 0;
+        {{ init_transition_id(state, loop.index) }},
+        event_set);
+    if (!is_valid) {
+        if (machine != NULL && machine->last_error[0] != '\0') {
+            return 0;
+        }
+    } else {
+        if (_{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+                machine,
+                context,
+                {{ init_transition_id(state, loop.index) }},
+                event_set,
+                is_validation_mode,
+                !is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return 0;
+        }
+        return 1;
+    }
 }
-return 1;
 {%- endset %}
     if ({{ event_condition | trim | replace('\n', ' ') }}) {
 {% if transition.guard is not none %}
@@ -1213,6 +1234,58 @@ static const _{{ machine_class_name(model) }}TransitionInfo _{{ machine_class_na
 {% endfor %}
 };
 
+static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set,
+    int is_validation_mode,
+    int attempt_nested_initial)
+{
+    const _{{ machine_class_name(model) }}TransitionInfo *transition;
+    int composite_state_id;
+
+    if (context->stack_size == 0u) {
+        return 0;
+    }
+
+    transition = &_{{ machine_class_name(model) }}_transitions[transition_id];
+    composite_state_id = context->stack[context->stack_size - 1u].state_id;
+    if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (context->stack_size > 0u && context->stack[context->stack_size - 1u].plain_before_pending) {
+        int pending_state_id = context->stack[context->stack_size - 1u].state_id;
+        if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+                machine,
+                pending_state_id,
+                context,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        context->stack[context->stack_size - 1u].plain_before_pending = 0;
+    }
+    if (_{{ machine_class_name(model) }}_enter_state(
+            machine,
+            context,
+            transition->target_state_id,
+            event_set,
+            is_validation_mode,
+            attempt_nested_initial) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (context->stack_size > 0u) {
+        size_t frame_index;
+        for (frame_index = context->stack_size; frame_index > 0u; --frame_index) {
+            if (context->stack[frame_index - 1u].state_id == composite_state_id) {
+                context->stack[frame_index - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_ACTIVE;
+                break;
+            }
+        }
+    }
+    return {{ machine_macro_name(model) }}_SUCCESS;
+}
+
 static int _{{ machine_class_name(model) }}_state_id_is_valid(int state_id)
 {
     return state_id >= 0 && state_id < {{ machine_macro_name(model) }}_STATE_COUNT;
@@ -1280,6 +1353,18 @@ static int _{{ machine_class_name(model) }}_normalize_events(
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
 
+static void _{{ machine_class_name(model) }}_event_set_activate_all(
+    _{{ machine_class_name(model) }}EventSet *event_set)
+{
+    size_t i;
+
+    _{{ machine_class_name(model) }}_event_set_reset(event_set);
+    for (i = 0u; i < sizeof(event_set->active_bitset) / sizeof(event_set->active_bitset[0]); ++i) {
+        event_set->active_bitset[i] = ~0ul;
+        event_set->evaluated_bitset[i] = ~0ul;
+    }
+}
+
 static void _{{ machine_class_name(model) }}_copy_context(
     _{{ machine_class_name(model) }}RuntimeContext *dst,
     const _{{ machine_class_name(model) }}RuntimeContext *src)
@@ -1321,6 +1406,7 @@ static int _{{ machine_class_name(model) }}_push_frame(
     }
     context->stack[context->stack_size].state_id = state_id;
     context->stack[context->stack_size].mode = mode;
+    context->stack[context->stack_size].plain_before_pending = 0;
     ++context->stack_size;
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
@@ -1488,12 +1574,15 @@ static int _{{ machine_class_name(model) }}_enter_state(
     _{{ machine_class_name(model) }}RuntimeContext *context,
     int state_id,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int is_validation_mode)
+    int is_validation_mode,
+    int attempt_initial_transition)
 {
     const _{{ machine_class_name(model) }}StateInfo *state_info;
     int init_result;
+    size_t pushed_index;
 
     state_info = &_{{ machine_class_name(model) }}_state_info[state_id];
+    pushed_index = context->stack_size;
     if (_{{ machine_class_name(model) }}_push_frame(machine, context, state_id, {{ machine_macro_name(model) }}_FRAME_MODE_ACTIVE) != {{ machine_macro_name(model) }}_SUCCESS) {
         if (is_validation_mode) {
             _{{ machine_class_name(model) }}_set_error(
@@ -1520,17 +1609,13 @@ static int _{{ machine_class_name(model) }}_enter_state(
         return {{ machine_macro_name(model) }}_SUCCESS;
     }
 
-    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
-            machine,
-            state_id,
-            context,
-            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
-        return {{ machine_macro_name(model) }}_FAILURE;
-    }
-    context->stack[context->stack_size - 1u].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
-    init_result = _{{ machine_class_name(model) }}_attempt_init_transition(machine, context, event_set, is_validation_mode);
-    if (init_result != {{ machine_macro_name(model) }}_SUCCESS && machine != NULL && machine->last_error[0] != '\0') {
-        return {{ machine_macro_name(model) }}_FAILURE;
+    context->stack[pushed_index].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
+    context->stack[pushed_index].plain_before_pending = 1;
+    if (attempt_initial_transition) {
+        init_result = _{{ machine_class_name(model) }}_attempt_init_transition(machine, context, event_set, is_validation_mode);
+        if (init_result != {{ machine_macro_name(model) }}_SUCCESS && machine != NULL && machine->last_error[0] != '\0') {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
     }
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
@@ -1572,6 +1657,20 @@ static int _{{ machine_class_name(model) }}_finalize_exit_to_parent(
 
     parent_state_id = context->stack[context->stack_size - 1u].state_id;
     if (parent_state_id == {{ state_enum(model.root_state) }}) {
+        if (_{{ machine_class_name(model) }}_run_during_after_actions_for_state(
+                machine,
+                parent_state_id,
+                context,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        if (_{{ machine_class_name(model) }}_run_exit_actions_for_state(
+                machine,
+                parent_state_id,
+                context,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
         context->stack_size = 0u;
         return 1;
     }
@@ -1621,7 +1720,8 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
             context,
             transition->target_state_id,
             event_set,
-            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            is_validation_mode,
+            1) != {{ machine_macro_name(model) }}_SUCCESS) {
         return {{ machine_macro_name(model) }}_FAILURE;
     }
     return 0;
@@ -1773,6 +1873,18 @@ static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_tr
 {
     _{{ machine_class_name(model) }}RuntimeContext sim_context;
     int ended;
+    int result;
+
+    if (machine != NULL) {
+        if (machine->validation_depth >= {{ machine_macro_name(model) }}_MAX_DFS_STEPS) {
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Speculative DFS exceeded the step safety limit (%d) without reaching a stoppable state or pruning; the state machine likely contains an invalid unbounded pseudo-state or transition chain.",
+                {{ machine_macro_name(model) }}_MAX_DFS_STEPS);
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        ++machine->validation_depth;
+    }
 
     _{{ machine_class_name(model) }}_copy_context(&sim_context, context);
     ended = _{{ machine_class_name(model) }}_execute_transition_on_context(
@@ -1782,18 +1894,74 @@ static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_tr
         event_set,
         1);
     if (machine != NULL && machine->last_error[0] != '\0') {
-        return {{ machine_macro_name(model) }}_FAILURE;
+        result = {{ machine_macro_name(model) }}_FAILURE;
+    } else if (ended) {
+        result = 1;
+    } else {
+        result = _{{ machine_class_name(model) }}_run_cycle_on_context(
+            machine,
+            &sim_context,
+            event_set,
+            &ended,
+            1,
+            1);
     }
-    if (ended) {
-        return 1;
+
+    if (machine != NULL && machine->validation_depth > 0) {
+        --machine->validation_depth;
     }
-    return _{{ machine_class_name(model) }}_run_cycle_on_context(
-        machine,
-        &sim_context,
-        event_set,
-        &ended,
-        0,
-        1);
+    return result;
+}
+
+static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_initial_transition(
+    {{ machine_class_name(model) }} *machine,
+    const _{{ machine_class_name(model) }}RuntimeContext *context,
+    int transition_id,
+    const _{{ machine_class_name(model) }}EventSet *event_set)
+{
+    _{{ machine_class_name(model) }}RuntimeContext sim_context;
+    int ended;
+    int result;
+
+    if (machine != NULL) {
+        if (machine->validation_depth >= {{ machine_macro_name(model) }}_MAX_DFS_STEPS) {
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Speculative DFS exceeded the step safety limit (%d) without reaching a stoppable state or pruning; the state machine likely contains an invalid unbounded pseudo-state or transition chain.",
+                {{ machine_macro_name(model) }}_MAX_DFS_STEPS);
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        ++machine->validation_depth;
+    }
+
+    _{{ machine_class_name(model) }}_copy_context(&sim_context, context);
+    if (_{{ machine_class_name(model) }}_execute_initial_transition_on_context(
+            machine,
+            &sim_context,
+            transition_id,
+            event_set,
+            1,
+            0) != {{ machine_macro_name(model) }}_SUCCESS) {
+        result = {{ machine_macro_name(model) }}_FAILURE;
+    } else {
+        ended = sim_context.stack_size == 0u;
+        if (ended) {
+            result = 1;
+        } else {
+            result = _{{ machine_class_name(model) }}_run_cycle_on_context(
+                machine,
+                &sim_context,
+                event_set,
+                &ended,
+                1,
+                1);
+        }
+    }
+
+    if (machine != NULL && machine->validation_depth > 0) {
+        --machine->validation_depth;
+    }
+    return result;
 }
 
 static int _{{ machine_class_name(model) }}_initialize_context(
@@ -1802,7 +1970,9 @@ static int _{{ machine_class_name(model) }}_initialize_context(
     const _{{ machine_class_name(model) }}EventSet *event_set)
 {
     context->stack_size = 0u;
-    _{{ machine_class_name(model) }}_enter_state(machine, context, {{ state_enum(model.root_state) }}, event_set, 0);
+    if (_{{ machine_class_name(model) }}_enter_state(machine, context, {{ state_enum(model.root_state) }}, event_set, 0, 1) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return 0;
+    }
     return context->stack_size == 0u;
 }
 
@@ -1833,7 +2003,9 @@ int {{ machine_class_name(model) }}_init({{ machine_class_name(model) }} *machin
     }
 
     memset(machine, 0, sizeof(*machine));
-    _{{ machine_class_name(model) }}_reset_vars(&machine->vars);
+    if (_{{ machine_class_name(model) }}_reset_vars(machine, &machine->vars) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
     machine->stack_size = 1u;
     machine->stack[0].state_id = {{ state_enum(model.root_state) }};
     machine->stack[0].mode = {{ machine_macro_name(model) }}_FRAME_MODE_INIT_WAIT;
@@ -1854,9 +2026,14 @@ int {{ machine_class_name(model) }}_hot_start(
     const {{ machine_class_name(model) }}EventChecks *saved_event_checks;
     void *saved_event_check_user_data;
     int saved_event_checks_mounted;
+    _{{ machine_class_name(model) }}RuntimeContext validation_context;
+    _{{ machine_class_name(model) }}EventSet validation_event_set;
+    int validation_ended;
+    int validation_success;
     int path_ids[{{ machine_macro_name(model) }}_MAX_STACK_DEPTH];
     size_t path_count;
     int current_state_id;
+    int target_state_id;
     size_t i;
 
     if (machine == NULL || initial_vars == NULL) {
@@ -1870,6 +2047,7 @@ int {{ machine_class_name(model) }}_hot_start(
     saved_event_checks_mounted = machine->event_checks_mounted;
     memset(machine, 0, sizeof(*machine));
     machine->vars = *initial_vars;
+    target_state_id = initial_state_id;
     current_state_id = initial_state_id;
     if (!_{{ machine_class_name(model) }}_state_id_is_valid(current_state_id)) {
         _{{ machine_class_name(model) }}_set_error(machine, "Invalid state id: %d", initial_state_id);
@@ -1899,6 +2077,7 @@ int {{ machine_class_name(model) }}_hot_start(
         }
         machine->stack[machine->stack_size].state_id = state_id;
         machine->stack[machine->stack_size].mode = mode;
+        machine->stack[machine->stack_size].plain_before_pending = 0;
         ++machine->stack_size;
     }
     machine->entered_root = 1;
@@ -1910,6 +2089,36 @@ int {{ machine_class_name(model) }}_hot_start(
     machine->event_check_user_data = saved_event_check_user_data;
     machine->event_checks_mounted = saved_event_checks_mounted;
     _{{ machine_class_name(model) }}_clear_error(machine);
+    if (machine->stack_size > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
+        _{{ machine_class_name(model) }}_set_error(
+            machine,
+            "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.",
+            {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    if (!_{{ machine_class_name(model) }}_is_stoppable_state(target_state_id)) {
+        _{{ machine_class_name(model) }}_event_set_activate_all(&validation_event_set);
+        _{{ machine_class_name(model) }}_copy_from_machine(&validation_context, machine);
+        validation_ended = 0;
+        validation_success = _{{ machine_class_name(model) }}_run_cycle_on_context(
+            machine,
+            &validation_context,
+            &validation_event_set,
+            &validation_ended,
+            1,
+            1);
+        if (!validation_success && machine->last_error[0] != '\0') {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        if (!validation_success) {
+            _{{ machine_class_name(model) }}_set_error(
+                machine,
+                "Hot start target '%s' cannot reach a stoppable state",
+                _{{ machine_class_name(model) }}_state_info[target_state_id].path);
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
+        _{{ machine_class_name(model) }}_clear_error(machine);
+    }
     return {{ machine_macro_name(model) }}_SUCCESS;
 }
 

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -231,6 +231,18 @@ static const char *_{{ machine_class_name(model) }}_dsl_source =
 {% endif -%}
 
 /* Error helpers used by the public API wrappers. */
+static void _{{ machine_class_name(model) }}_format_error_text(char *buffer, size_t buffer_size, const char *fmt, ...)
+{
+    va_list ap;
+    if (buffer == NULL || buffer_size == 0u) {
+        return;
+    }
+    va_start(ap, fmt);
+    PYFCSTM_GENERATED_VSNPRINTF(buffer, buffer_size, fmt, ap);
+    buffer[buffer_size - 1u] = '\0';
+    va_end(ap);
+}
+
 static void _{{ machine_class_name(model) }}_set_error({{ machine_class_name(model) }} *machine, const char *fmt, ...)
 {
     va_list ap;
@@ -2022,11 +2034,8 @@ int {{ machine_class_name(model) }}_hot_start(
     {{ machine_class_name(model) }}StateId initial_state_id,
     const {{ machine_class_name(model) }}Vars *initial_vars)
 {
-    const {{ machine_class_name(model) }}Hooks *saved_hooks;
-    void *saved_hook_user_data;
-    const {{ machine_class_name(model) }}EventChecks *saved_event_checks;
-    void *saved_event_check_user_data;
-    int saved_event_checks_mounted;
+    {{ machine_class_name(model) }} saved_machine;
+    char hot_start_error[sizeof(machine->last_error)];
     _{{ machine_class_name(model) }}RuntimeContext validation_context;
     _{{ machine_class_name(model) }}EventSet validation_event_set;
     int validation_ended;
@@ -2041,25 +2050,30 @@ int {{ machine_class_name(model) }}_hot_start(
         return {{ machine_macro_name(model) }}_FAILURE;
     }
 
-    saved_hooks = machine->hooks;
-    saved_hook_user_data = machine->hook_user_data;
-    saved_event_checks = machine->event_checks;
-    saved_event_check_user_data = machine->event_check_user_data;
-    saved_event_checks_mounted = machine->event_checks_mounted;
+    saved_machine = *machine;
+    hot_start_error[0] = '\0';
     memset(machine, 0, sizeof(*machine));
     machine->vars = *initial_vars;
     target_state_id = initial_state_id;
     current_state_id = initial_state_id;
     if (!_{{ machine_class_name(model) }}_state_id_is_valid(current_state_id)) {
-        _{{ machine_class_name(model) }}_set_error(machine, "Invalid state id: %d", initial_state_id);
-        return {{ machine_macro_name(model) }}_FAILURE;
+        _{{ machine_class_name(model) }}_format_error_text(
+            hot_start_error,
+            sizeof(hot_start_error),
+            "Invalid state id: %d",
+            initial_state_id);
+        goto hot_start_failure;
     }
 
     path_count = 0u;
     while (current_state_id >= 0) {
         if (path_count >= {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
-            _{{ machine_class_name(model) }}_set_error(machine, "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.", {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
-            return {{ machine_macro_name(model) }}_FAILURE;
+            _{{ machine_class_name(model) }}_format_error_text(
+                hot_start_error,
+                sizeof(hot_start_error),
+                "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.",
+                {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
+            goto hot_start_failure;
         }
         path_ids[path_count++] = current_state_id;
         current_state_id = _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id;
@@ -2085,18 +2099,19 @@ int {{ machine_class_name(model) }}_hot_start(
     machine->ended = 0;
     machine->initialized = 1;
     machine->_active_vars = NULL;
-    machine->hooks = saved_hooks;
-    machine->hook_user_data = saved_hook_user_data;
-    machine->event_checks = saved_event_checks;
-    machine->event_check_user_data = saved_event_check_user_data;
-    machine->event_checks_mounted = saved_event_checks_mounted;
+    machine->hooks = saved_machine.hooks;
+    machine->hook_user_data = saved_machine.hook_user_data;
+    machine->event_checks = saved_machine.event_checks;
+    machine->event_check_user_data = saved_machine.event_check_user_data;
+    machine->event_checks_mounted = saved_machine.event_checks_mounted;
     _{{ machine_class_name(model) }}_clear_error(machine);
     if (machine->stack_size > {{ machine_macro_name(model) }}_MAX_STACK_DEPTH) {
-        _{{ machine_class_name(model) }}_set_error(
-            machine,
+        _{{ machine_class_name(model) }}_format_error_text(
+            hot_start_error,
+            sizeof(hot_start_error),
             "Hot start target exceeds the structural stack-depth safety limit (%d) before execution; choose a shallower target state or simplify the state hierarchy.",
             {{ machine_macro_name(model) }}_MAX_STACK_DEPTH);
-        return {{ machine_macro_name(model) }}_FAILURE;
+        goto hot_start_failure;
     }
     if (!_{{ machine_class_name(model) }}_is_stoppable_state(target_state_id)) {
         _{{ machine_class_name(model) }}_event_set_activate_all(&validation_event_set);
@@ -2110,18 +2125,25 @@ int {{ machine_class_name(model) }}_hot_start(
             1,
             1);
         if (!validation_success && machine->last_error[0] != '\0') {
-            return {{ machine_macro_name(model) }}_FAILURE;
+            _{{ machine_class_name(model) }}_format_error_text(hot_start_error, sizeof(hot_start_error), "%s", machine->last_error);
+            goto hot_start_failure;
         }
         if (!validation_success) {
-            _{{ machine_class_name(model) }}_set_error(
-                machine,
+            _{{ machine_class_name(model) }}_format_error_text(
+                hot_start_error,
+                sizeof(hot_start_error),
                 "Hot start target '%s' cannot reach a stoppable state",
                 _{{ machine_class_name(model) }}_state_info[target_state_id].path);
-            return {{ machine_macro_name(model) }}_FAILURE;
+            goto hot_start_failure;
         }
         _{{ machine_class_name(model) }}_clear_error(machine);
     }
     return {{ machine_macro_name(model) }}_SUCCESS;
+
+hot_start_failure:
+    *machine = saved_machine;
+    _{{ machine_class_name(model) }}_set_error(machine, "%s", hot_start_error);
+    return {{ machine_macro_name(model) }}_FAILURE;
 }
 
 void {{ machine_class_name(model) }}_set_hooks(

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -2197,6 +2197,8 @@ int {{ machine_class_name(model) }}_cycle(
         _{{ machine_class_name(model) }}_set_error(machine, "Machine is not initialized; call {{ machine_class_name(model) }}_init(...) or {{ machine_class_name(model) }}_hot_start(...) before cycle().");
         return {{ machine_macro_name(model) }}_FAILURE;
     }
+
+    _{{ machine_class_name(model) }}_clear_error(machine);
     if (machine->ended) {
         return {{ machine_macro_name(model) }}_SUCCESS;
     }

--- a/templates/c_poll/machine.h.j2
+++ b/templates/c_poll/machine.h.j2
@@ -193,6 +193,7 @@ typedef struct {{ machine_class_name(model) }}EventChecks {
 typedef struct {{ machine_class_name(model) }}Frame {
     int state_id;
     int mode;
+    int plain_before_pending;
 } {{ machine_class_name(model) }}Frame;
 
 /*
@@ -235,6 +236,7 @@ struct {{ machine_class_name(model) }} {
     size_t stack_size;
     int ended;
     int entered_root;
+    int validation_depth;
     const {{ machine_class_name(model) }}Hooks *hooks;
     void *hook_user_data;
     const {{ machine_class_name(model) }}EventChecks *event_checks;

--- a/templates/c_poll/machine.h.j2
+++ b/templates/c_poll/machine.h.j2
@@ -236,6 +236,7 @@ struct {{ machine_class_name(model) }} {
     size_t stack_size;
     int ended;
     int entered_root;
+    int initialized;
     int validation_depth;
     const {{ machine_class_name(model) }}Hooks *hooks;
     void *hook_user_data;

--- a/test/fixtures/simulate_semantics/runner_capabilities.yaml
+++ b/test/fixtures/simulate_semantics/runner_capabilities.yaml
@@ -5,483 +5,131 @@
 # use tracking URLs for issue/PR provenance.
 version: 1
 known_failures:
-  - runner: generated_c_alignment
-    case: abstract_hook_context_hot_start_leaf
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "abstract_hook_context_hot_start_leaf is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: abstract_hook_ref_context_reports_callsite_metadata
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "abstract_hook_ref_context_reports_callsite_metadata is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: aspect_context_reports_active_leaf
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "aspect_context_reports_active_leaf is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_guard_after_event_transition_uses_pre_before_vars
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_after_event_transition_uses_pre_before_vars is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_guard_after_leaf_transition_uses_enter_state
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_after_leaf_transition_uses_enter_state is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_guard_after_named_ref_before_uses_pre_ref_vars
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_after_named_ref_before_uses_pre_ref_vars is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_guard_can_select_terminal_branch_before_plain_before
-    classification: state_or_ended_mismatch
-    observation: state_or_ended
-    support: expected_failure
-    skip_reason: "composite_initial_guard_can_select_terminal_branch_before_plain_before is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_guard_uses_enter_state_before_plain_before
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_uses_enter_state_before_plain_before is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_guard_with_effect_runs_before_plain_before
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_with_effect_runs_before_plain_before is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_handler_log_after_transition_uses_selected_child
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_handler_log_after_transition_uses_selected_child is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_handler_log_keeps_stable_branch_before_exit_branch
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_handler_log_keeps_stable_branch_before_exit_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_handler_log_uses_enter_selected_child
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_handler_log_uses_enter_selected_child is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_nested_entry_order_survives_deep_choice
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_nested_entry_order_survives_deep_choice is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: composite_initial_skips_unstable_candidates_root_entry
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_skips_unstable_candidates_root_entry is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: failed_initial_cycle_skips_abstract_handler_callbacks
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "failed_initial_cycle_skips_abstract_handler_callbacks is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: forced_pseudo_candidate_skips_unstable_branch
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "forced_pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: hot_start_initial_vars_reject_bool_values
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "hot_start_initial_vars_reject_bool_values is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: hot_start_initial_vars_reject_string_values
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "hot_start_initial_vars_reject_string_values is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: hot_start_rejects_blocked_composite_initial
-    classification: state_or_ended_mismatch
-    observation: state_or_ended
-    support: expected_failure
-    skip_reason: "hot_start_rejects_blocked_composite_initial is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: hot_start_rejects_unstable_pseudo_leaf
-    classification: state_or_ended_mismatch
-    observation: state_or_ended
-    support: expected_failure
-    skip_reason: "hot_start_rejects_unstable_pseudo_leaf is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: lifecycle_ref_chain_resolves_long_acyclic_chain
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "lifecycle_ref_chain_resolves_long_acyclic_chain is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: named_ref_context_reports_callsite
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "named_ref_context_reports_callsite is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: persistent_default_int_initializer_rejects_non_integer_float
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "persistent_default_int_initializer_rejects_non_integer_float is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: persistent_operation_writeback_rejects_float_and_rolls_back
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "persistent_operation_writeback_rejects_float_and_rolls_back is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: post_child_exit_continuation_skips_unstable_candidates
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "post_child_exit_continuation_skips_unstable_candidates is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: pseudo_candidate_skips_unstable_branch
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: ref_abstract_handler_reports_calling_state
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "ref_abstract_handler_reports_calling_state is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: ref_context_uses_callsite_stage
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "ref_context_uses_callsite_stage is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: root_exit_runs_root_cleanup
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "root_exit_runs_root_cleanup is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_alignment
-    case: transition_into_composite_skips_unstable_initial_candidate
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "transition_into_composite_skips_unstable_initial_candidate is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: abstract_hook_context_hot_start_leaf
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "abstract_hook_context_hot_start_leaf is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: abstract_hook_ref_context_reports_callsite_metadata
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "abstract_hook_ref_context_reports_callsite_metadata is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: aspect_context_reports_active_leaf
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "aspect_context_reports_active_leaf is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_guard_after_event_transition_uses_pre_before_vars
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_after_event_transition_uses_pre_before_vars is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_guard_after_leaf_transition_uses_enter_state
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_after_leaf_transition_uses_enter_state is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_guard_after_named_ref_before_uses_pre_ref_vars
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_after_named_ref_before_uses_pre_ref_vars is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_guard_can_select_terminal_branch_before_plain_before
-    classification: state_or_ended_mismatch
-    observation: state_or_ended
-    support: expected_failure
-    skip_reason: "composite_initial_guard_can_select_terminal_branch_before_plain_before is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_guard_uses_enter_state_before_plain_before
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_uses_enter_state_before_plain_before is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_guard_with_effect_runs_before_plain_before
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_guard_with_effect_runs_before_plain_before is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_handler_log_after_transition_uses_selected_child
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_handler_log_after_transition_uses_selected_child is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_handler_log_keeps_stable_branch_before_exit_branch
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_handler_log_keeps_stable_branch_before_exit_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_handler_log_uses_enter_selected_child
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_handler_log_uses_enter_selected_child is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_nested_entry_order_survives_deep_choice
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_nested_entry_order_survives_deep_choice is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: composite_initial_skips_unstable_candidates_root_entry
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "composite_initial_skips_unstable_candidates_root_entry is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: failed_initial_cycle_skips_abstract_handler_callbacks
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "failed_initial_cycle_skips_abstract_handler_callbacks is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: forced_pseudo_candidate_skips_unstable_branch
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "forced_pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: hot_start_initial_vars_reject_bool_values
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "hot_start_initial_vars_reject_bool_values is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: hot_start_initial_vars_reject_string_values
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "hot_start_initial_vars_reject_string_values is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: hot_start_rejects_blocked_composite_initial
-    classification: state_or_ended_mismatch
-    observation: state_or_ended
-    support: expected_failure
-    skip_reason: "hot_start_rejects_blocked_composite_initial is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: hot_start_rejects_unstable_pseudo_leaf
-    classification: state_or_ended_mismatch
-    observation: state_or_ended
-    support: expected_failure
-    skip_reason: "hot_start_rejects_unstable_pseudo_leaf is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: lifecycle_ref_chain_resolves_long_acyclic_chain
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "lifecycle_ref_chain_resolves_long_acyclic_chain is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: named_ref_context_reports_callsite
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "named_ref_context_reports_callsite is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: persistent_default_int_initializer_rejects_non_integer_float
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "persistent_default_int_initializer_rejects_non_integer_float is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: persistent_operation_writeback_rejects_float_and_rolls_back
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "persistent_operation_writeback_rejects_float_and_rolls_back is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: post_child_exit_continuation_skips_unstable_candidates
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "post_child_exit_continuation_skips_unstable_candidates is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: pseudo_candidate_skips_unstable_branch
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "pseudo_candidate_skips_unstable_branch is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: ref_abstract_handler_reports_calling_state
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "ref_abstract_handler_reports_calling_state is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: ref_context_uses_callsite_stage
-    classification: handler_mismatch
-    observation: handler_calls
-    support: expected_failure
-    skip_reason: "ref_context_uses_callsite_stage is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: root_exit_runs_root_cleanup
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "root_exit_runs_root_cleanup is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
-  - runner: generated_c_poll_alignment
-    case: transition_into_composite_skips_unstable_initial_candidate
-    classification: vars_mismatch
-    observation: vars
-    support: expected_failure
-    skip_reason: "transition_into_composite_skips_unstable_initial_candidate is a known C/C poll shared alignment gap."
-    tracking: https://github.com/HansBug/pyfcstm/issues/218
-    since: "2026-06-17"
+- runner: generated_c_alignment
+  case: abstract_hook_context_hot_start_leaf
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: abstract_hook_context_hot_start_leaf is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_alignment
+  case: abstract_hook_ref_context_reports_callsite_metadata
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: abstract_hook_ref_context_reports_callsite_metadata is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_alignment
+  case: aspect_context_reports_active_leaf
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: aspect_context_reports_active_leaf is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_alignment
+  case: failed_initial_cycle_skips_abstract_handler_callbacks
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: failed_initial_cycle_skips_abstract_handler_callbacks is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_alignment
+  case: lifecycle_ref_chain_resolves_long_acyclic_chain
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: lifecycle_ref_chain_resolves_long_acyclic_chain is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_alignment
+  case: named_ref_context_reports_callsite
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: named_ref_context_reports_callsite is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_alignment
+  case: ref_abstract_handler_reports_calling_state
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: ref_abstract_handler_reports_calling_state is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_alignment
+  case: ref_context_uses_callsite_stage
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: ref_context_uses_callsite_stage is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: abstract_hook_context_hot_start_leaf
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: abstract_hook_context_hot_start_leaf is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: abstract_hook_ref_context_reports_callsite_metadata
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: abstract_hook_ref_context_reports_callsite_metadata is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: aspect_context_reports_active_leaf
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: aspect_context_reports_active_leaf is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: failed_initial_cycle_skips_abstract_handler_callbacks
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: failed_initial_cycle_skips_abstract_handler_callbacks is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: lifecycle_ref_chain_resolves_long_acyclic_chain
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: lifecycle_ref_chain_resolves_long_acyclic_chain is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: named_ref_context_reports_callsite
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: named_ref_context_reports_callsite is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: ref_abstract_handler_reports_calling_state
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: ref_abstract_handler_reports_calling_state is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'
+- runner: generated_c_poll_alignment
+  case: ref_context_uses_callsite_stage
+  classification: handler_mismatch
+  observation: handler_calls
+  support: expected_failure
+  skip_reason: ref_context_uses_callsite_stage is a known C/C poll shared alignment gap.
+  tracking: https://github.com/HansBug/pyfcstm/issues/218
+  since: '2026-06-17'

--- a/test/template/c/_utils.py
+++ b/test/template/c/_utils.py
@@ -1,4 +1,5 @@
 import ctypes
+import math
 import os
 import shutil
 import subprocess
@@ -38,6 +39,14 @@ def _runtime_exception_from_message(message):
         or 'step safety limit' in message
     ):
         return SimulationRuntimeDfsError(message), None
+    if (
+        'non-integer float' in message
+        or 'must not be bool' in message
+        or 'must be int or float' in message
+        or 'must be finite' in message
+        or 'cannot reach a stoppable state' in message
+    ):
+        return ValueError(message), None
     return RuntimeError(message), None
 
 
@@ -342,6 +351,12 @@ class _CRuntime:
         self._last_error = self._bind_function(
             '{prefix}_last_error', argtypes=[ctypes.c_void_p], restype=ctypes.c_char_p
         )
+        if self._machine is None:
+            raise MemoryError('failed to allocate generated C runtime machine.')
+        if initialize:
+            message = self._last_error(self._machine)
+            if message and message.decode('utf-8'):
+                self._raise_last_error()
 
         class _ContextStruct(ctypes.Structure):
             _fields_ = [
@@ -487,6 +502,36 @@ class _CRuntime:
         if not self._var_names:
             values._unused_placeholder = 0
         for name, value in initial_vars.items():
+            source = "initial_vars[{!r}]".format(name)
+            if type(value) is bool:
+                raise ValueError('{} must not be bool'.format(source))
+            if type(value) not in (int, float):
+                raise ValueError(
+                    '{} must be int or float, got {}'.format(
+                        source, type(value).__name__
+                    )
+                )
+            if type(value) is float and not math.isfinite(value):
+                raise ValueError(
+                    '{} for variable {!r} declared {} must be finite, got {!r}'.format(
+                        source, name, self._var_types[name], value
+                    )
+                )
+            if self._var_types[name] == 'int' and type(value) is float:
+                if value != int(value):
+                    raise ValueError(
+                        "Variable {!r} is int type, cannot assign float {!r}; "
+                        "non-integer float from {}".format(name, value, source)
+                    )
+                value = int(value)
+            elif self._var_types[name] == 'float':
+                value = float(value)
+                if not math.isfinite(value):
+                    raise ValueError(
+                        '{} for variable {!r} declared float must be finite, got {!r}'.format(
+                            source, name, value
+                        )
+                    )
             setattr(values, self._generated_var_names[name], value)
         return values
 

--- a/test/template/c/test_runtime.py
+++ b/test/template/c/test_runtime.py
@@ -166,6 +166,63 @@ class TestCBuiltinTemplate:
             assert runtime.current_state_path == ('System', 'Running')
             assert runtime.vars == {'counter': 111}
 
+    def test_generated_machine_create_failure_cannot_be_cycled(self):
+        dsl_code = """
+        def int counter = 1.5;
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+
+        with render_c_artifacts(dsl_code) as artifacts:
+            run = _compile_and_run_c_harness(
+                artifacts,
+                'create_failure_cycle_guard_test',
+                textwrap.dedent(
+                    r'''
+                    #include "machine.h"
+                    #include <string.h>
+
+                    int main(void)
+                    {
+                        RootMachine *machine = RootMachine_create();
+                        const char *message;
+
+                        if (machine == NULL) {
+                            return 10;
+                        }
+                        message = RootMachine_last_error(machine);
+                        if (message == NULL || strstr(message, "non-integer float") == NULL) {
+                            RootMachine_destroy(machine);
+                            return 11;
+                        }
+                        if (RootMachine_current_state_path(machine) != NULL) {
+                            RootMachine_destroy(machine);
+                            return 12;
+                        }
+                        if (RootMachine_cycle(machine, NULL, 0u)) {
+                            RootMachine_destroy(machine);
+                            return 13;
+                        }
+                        message = RootMachine_last_error(machine);
+                        if (message == NULL || strstr(message, "not initialized") == NULL) {
+                            RootMachine_destroy(machine);
+                            return 14;
+                        }
+                        if (RootMachine_current_state_path(machine) != NULL) {
+                            RootMachine_destroy(machine);
+                            return 15;
+                        }
+
+                        RootMachine_destroy(machine);
+                        return 0;
+                    }
+                    '''
+                ),
+            )
+            assert run.returncode == 0, run.stderr
+
     def test_generated_machine_supports_hot_start_and_hook_registration(self):
         dsl_code = """
         def int counter = 0;

--- a/test/template/c/test_runtime.py
+++ b/test/template/c/test_runtime.py
@@ -296,6 +296,11 @@ class TestCBuiltinTemplate:
             assert runtime.vars == before_vars
             assert runtime.is_ended is before_ended
 
+            runtime.cycle()
+            assert runtime.current_state_path == before_state
+            assert runtime.vars == {'trace': before_vars['trace'] + 1}
+            assert runtime.is_ended is before_ended
+
     def test_generated_machine_exposes_read_only_hook_context(self):
         dsl_code = """
         def int counter = 0;

--- a/test/template/c/test_runtime.py
+++ b/test/template/c/test_runtime.py
@@ -269,6 +269,33 @@ class TestCBuiltinTemplate:
             assert runtime.vars == {'counter': 1}
             assert cold_calls == [('cold', 'Root', 'enter', 0)]
 
+
+    def test_failed_hot_start_preserves_public_runtime_snapshot(self):
+        dsl_code = """
+        def int trace = 0;
+        state Root {
+            state Idle { during { trace = trace + 1; } }
+            state Composite {
+                state Blocked;
+                [*] -> Blocked : if [false];
+            }
+            [*] -> Idle;
+        }
+        """
+
+        with render_c_runtime(dsl_code) as (runtime, _):
+            runtime.cycle()
+            before_state = runtime.current_state_path
+            before_vars = dict(runtime.vars)
+            before_ended = runtime.is_ended
+
+            with pytest.raises(ValueError, match='cannot reach a stoppable state'):
+                runtime.hot_start('Root.Composite', {'trace': 5})
+
+            assert runtime.current_state_path == before_state
+            assert runtime.vars == before_vars
+            assert runtime.is_ended is before_ended
+
     def test_generated_machine_exposes_read_only_hook_context(self):
         dsl_code = """
         def int counter = 0;

--- a/test/template/c_poll/_utils.py
+++ b/test/template/c_poll/_utils.py
@@ -1,4 +1,5 @@
 import ctypes
+import math
 import os
 import shutil
 import subprocess
@@ -38,6 +39,14 @@ def _runtime_exception_from_message(message):
         or 'step safety limit' in message
     ):
         return SimulationRuntimeDfsError(message), None
+    if (
+        'non-integer float' in message
+        or 'must not be bool' in message
+        or 'must be int or float' in message
+        or 'must be finite' in message
+        or 'cannot reach a stoppable state' in message
+    ):
+        return ValueError(message), None
     return RuntimeError(message), None
 
 
@@ -379,6 +388,12 @@ class _CPollRuntime:
         self._last_error = self._bind_function(
             '{prefix}_last_error', argtypes=[ctypes.c_void_p], restype=ctypes.c_char_p
         )
+        if self._machine is None:
+            raise MemoryError('failed to allocate generated C poll runtime machine.')
+        if initialize:
+            message = self._last_error(self._machine)
+            if message and message.decode('utf-8'):
+                self._raise_last_error()
 
         class _ContextStruct(ctypes.Structure):
             _fields_ = [
@@ -547,6 +562,36 @@ class _CPollRuntime:
         if not self._var_names:
             values._unused_placeholder = 0
         for name, value in initial_vars.items():
+            source = "initial_vars[{!r}]".format(name)
+            if type(value) is bool:
+                raise ValueError('{} must not be bool'.format(source))
+            if type(value) not in (int, float):
+                raise ValueError(
+                    '{} must be int or float, got {}'.format(
+                        source, type(value).__name__
+                    )
+                )
+            if type(value) is float and not math.isfinite(value):
+                raise ValueError(
+                    '{} for variable {!r} declared {} must be finite, got {!r}'.format(
+                        source, name, self._var_types[name], value
+                    )
+                )
+            if self._var_types[name] == 'int' and type(value) is float:
+                if value != int(value):
+                    raise ValueError(
+                        "Variable {!r} is int type, cannot assign float {!r}; "
+                        "non-integer float from {}".format(name, value, source)
+                    )
+                value = int(value)
+            elif self._var_types[name] == 'float':
+                value = float(value)
+                if not math.isfinite(value):
+                    raise ValueError(
+                        '{} for variable {!r} declared float must be finite, got {!r}'.format(
+                            source, name, value
+                        )
+                    )
             setattr(values, self._generated_var_names[name], value)
         return values
 

--- a/test/template/c_poll/test_runtime.py
+++ b/test/template/c_poll/test_runtime.py
@@ -301,6 +301,11 @@ class TestCPollBuiltinTemplate:
             assert runtime.vars == before_vars
             assert runtime.is_ended is before_ended
 
+            runtime.cycle()
+            assert runtime.current_state_path == before_state
+            assert runtime.vars == {'trace': before_vars['trace'] + 1}
+            assert runtime.is_ended is before_ended
+
     def test_generated_machine_exposes_read_only_event_check_context(self):
         dsl_code = """
         def int counter = 0;

--- a/test/template/c_poll/test_runtime.py
+++ b/test/template/c_poll/test_runtime.py
@@ -274,6 +274,33 @@ class TestCPollBuiltinTemplate:
             assert runtime.vars == {'counter': 1}
             assert cold_calls == [('cold', 'Root', 'enter', 0)]
 
+
+    def test_failed_hot_start_preserves_public_runtime_snapshot(self):
+        dsl_code = """
+        def int trace = 0;
+        state Root {
+            state Idle { during { trace = trace + 1; } }
+            state Composite {
+                state Blocked;
+                [*] -> Blocked : if [false];
+            }
+            [*] -> Idle;
+        }
+        """
+
+        with render_c_runtime(dsl_code) as (runtime, _):
+            runtime.cycle()
+            before_state = runtime.current_state_path
+            before_vars = dict(runtime.vars)
+            before_ended = runtime.is_ended
+
+            with pytest.raises(ValueError, match='cannot reach a stoppable state'):
+                runtime.hot_start('Root.Composite', {'trace': 5})
+
+            assert runtime.current_state_path == before_state
+            assert runtime.vars == before_vars
+            assert runtime.is_ended is before_ended
+
     def test_generated_machine_exposes_read_only_event_check_context(self):
         dsl_code = """
         def int counter = 0;

--- a/test/template/c_poll/test_runtime.py
+++ b/test/template/c_poll/test_runtime.py
@@ -154,6 +154,63 @@ class TestCPollBuiltinTemplate:
             assert runtime.current_state_path == ('System', 'Running')
             assert runtime.vars == {'counter': 111}
 
+    def test_generated_machine_create_failure_cannot_be_cycled(self):
+        dsl_code = """
+        def int counter = 1.5;
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+
+        with render_c_artifacts(dsl_code) as artifacts:
+            run = _compile_and_run_c_harness(
+                artifacts,
+                'create_failure_cycle_guard_test',
+                textwrap.dedent(
+                    r'''
+                    #include "machine.h"
+                    #include <string.h>
+
+                    int main(void)
+                    {
+                        RootMachine *machine = RootMachine_create();
+                        const char *message;
+
+                        if (machine == NULL) {
+                            return 10;
+                        }
+                        message = RootMachine_last_error(machine);
+                        if (message == NULL || strstr(message, "non-integer float") == NULL) {
+                            RootMachine_destroy(machine);
+                            return 11;
+                        }
+                        if (RootMachine_current_state_path(machine) != NULL) {
+                            RootMachine_destroy(machine);
+                            return 12;
+                        }
+                        if (RootMachine_cycle(machine)) {
+                            RootMachine_destroy(machine);
+                            return 13;
+                        }
+                        message = RootMachine_last_error(machine);
+                        if (message == NULL || strstr(message, "not initialized") == NULL) {
+                            RootMachine_destroy(machine);
+                            return 14;
+                        }
+                        if (RootMachine_current_state_path(machine) != NULL) {
+                            RootMachine_destroy(machine);
+                            return 15;
+                        }
+
+                        RootMachine_destroy(machine);
+                        return 0;
+                    }
+                    '''
+                ),
+            )
+            assert run.returncode == 0, run.stderr
+
     def test_generated_machine_requires_event_checks_before_cycle(self):
         dsl_code = """
         def int counter = 0;

--- a/test/template/test_native_semantic_alignment_framework.py
+++ b/test/template/test_native_semantic_alignment_framework.py
@@ -23,14 +23,28 @@ def test_native_capability_matrix_covers_known_failures():
     matrix = native_capability_by_runner_case(entries)
     case_ids = {case.id for case in iter_semantic_cases()}
 
-    assert len(entries) == 60
+    remaining_known_gap_cases = {
+        "abstract_hook_context_hot_start_leaf",
+        "abstract_hook_ref_context_reports_callsite_metadata",
+        "aspect_context_reports_active_leaf",
+        "failed_initial_cycle_skips_abstract_handler_callbacks",
+        "lifecycle_ref_chain_resolves_long_acyclic_chain",
+        "named_ref_context_reports_callsite",
+        "ref_abstract_handler_reports_calling_state",
+        "ref_context_uses_callsite_stage",
+    }
+
+    assert len(entries) == len(remaining_known_gap_cases) * 2
     assert {entry.runner for entry in entries} == {
         GENERATED_C_ALIGNMENT,
         GENERATED_C_POLL_ALIGNMENT,
     }
+    assert {entry.case for entry in entries} == remaining_known_gap_cases
     for entry in entries:
         assert entry.case in case_ids
         assert entry.support == "expected_failure"
+        assert entry.classification == "handler_mismatch"
+        assert entry.observation == "handler_calls"
         assert entry.skip_reason
         assert entry.tracking.startswith("https://github.com/HansBug/pyfcstm/")
         assert entry.since
@@ -41,6 +55,10 @@ def test_native_capability_matrix_covers_known_failures():
     assert (
         GENERATED_C_POLL_ALIGNMENT,
         "transition_into_composite_skips_unstable_initial_candidate",
+    ) not in matrix
+    assert (
+        GENERATED_C_ALIGNMENT,
+        "aspect_context_reports_active_leaf",
     ) in matrix
 
 


### PR DESCRIPTION
Base umbrella PR: https://github.com/HansBug/pyfcstm/pull/233  
Refs https://github.com/HansBug/pyfcstm/issues/218  
Depends on PR-0 https://github.com/HansBug/pyfcstm/pull/234 and PR-1 https://github.com/HansBug/pyfcstm/pull/238

## PR-2 范围

本 PR 是 issue #218 / umbrella PR #233 的 PR-2：**composite / pseudo / initial selection 语义修复**。目标是在 PR-0 native shared runner 与 PR-1 hard blocker 修复之后，处理 C / C poll generated runtime 当前剩余的 22 个公开状态 / 变量 / ended 观察面 mismatch。

本 PR 只修复 composite initial selection、pseudo candidate pruning、transition into composite、post-child continuation、root exit cleanup、hot-start blocked / unstable composite initial 这些执行语义；不处理 PR-3 hook context / handler callsite / handler context snapshot 主体问题。

## 上游事实

| 前置项 | 当前状态 | 本 PR 消费方式 |
|---|---|---|
| [umbrella PR #233](https://github.com/HansBug/pyfcstm/pull/233) | 🟦 进行中，base branch | 本 PR 以 `dev/issue-218-c-cpoll-shared-alignment` 为 base，并向该伞 PR 分支合入。 |
| [PR #234](https://github.com/HansBug/pyfcstm/pull/234) | ✅ 已合入 [`c28d6fb`](https://github.com/HansBug/pyfcstm/commit/c28d6fb025a1a4f5ebdd4877e3519856f754e375) | PR-0 已建立 C/C poll native shared runner、capability matrix、subprocess crash isolation 与正式 report 入口。 |
| [PR #238](https://github.com/HansBug/pyfcstm/pull/238) | ✅ 已合入 [`efa669c`](https://github.com/HansBug/pyfcstm/commit/efa669c5899fa423202a22a13fcd90c6a5163af9) | PR-1 已修复 19 个 native crash / build / error hard blocker；两个 runner 当前为 113 passed / 30 expected_failure / 143 total。 |
| Shared semantic fixture corpus | ✅ schema v2，143 cases | 本 PR 只消费 `test/fixtures/simulate_semantics/cases/`，不重定义 fixture schema / shared 语义。 |

PR-1 后正式 baseline：

| Runner | Passed | Expected failure | Unexpected failure | Classification mismatch | Unexpected pass | 总计 |
|---|---:|---:|---:|---:|---:|---:|
| `generated_c_alignment` | 113 | 30 | 0 | 0 | 0 | 143 |
| `generated_c_poll_alignment` | 113 | 30 | 0 | 0 | 0 | 143 |

本 PR 完成后，PR-2 负责的 22 个 case 应从 `runner_capabilities.yaml` 中消失；PR-3 的 8 个 `handler_mismatch` 可以继续作为 expected failure 存在。

## 本 PR 负责的 22 个 semantic mismatch case

### `vars_mismatch`（19）

这些 case 当前已能生成、编译、加载并运行，但 C / C poll generated runtime 的公开变量快照与 simulator / generated Python expectation 不一致。

| Case | 期望验收 |
|---|---|
| `composite_initial_guard_after_event_transition_uses_pre_before_vars` | event transition 进入 composite 后，initial guard 应使用进入 composite / plain before 正确顺序下的变量快照。 |
| `composite_initial_guard_after_leaf_transition_uses_enter_state` | leaf transition 进入 composite 后，initial guard 应在 composite enter 后、plain before 相关时机下看到正确状态/变量。 |
| `composite_initial_guard_after_named_ref_before_uses_pre_ref_vars` | named ref before 与 composite initial guard 的求值顺序必须与 simulator 对齐。 |
| `composite_initial_guard_uses_enter_state_before_plain_before` | composite initial guard 应在 composite enter 后、plain during before 前按 simulator 顺序求值。 |
| `composite_initial_guard_with_effect_runs_before_plain_before` | initial transition effect 应先于 plain during before 中的相关变量变化。 |
| `composite_initial_handler_log_after_transition_uses_selected_child` | transition into composite 后的公开变量/handler log 语义应反映被选中的 initial child。 |
| `composite_initial_handler_log_keeps_stable_branch_before_exit_branch` | stable candidate 应优先保持，不应错误执行后续 exit/unstable branch。 |
| `composite_initial_handler_log_uses_enter_selected_child` | composite entry handler/log 相关变量应基于实际 selected child。 |
| `composite_initial_nested_entry_order_survives_deep_choice` | 深层 composite initial choice 的 entry/order/vars 必须稳定对齐。 |
| `composite_initial_skips_unstable_candidates_root_entry` | root entry 时 unstable initial candidate 必须被跳过并选择可稳定候选。 |
| `forced_pseudo_candidate_skips_unstable_branch` | forced pseudo candidate 选择时应跳过无法稳定的分支。 |
| `hot_start_initial_vars_reject_bool_values` | hot start initial vars bool 值归一化/拒绝行为与 simulator 对齐。 |
| `hot_start_initial_vars_reject_string_values` | hot start initial vars string 值归一化/拒绝行为与 simulator 对齐。 |
| `persistent_default_int_initializer_rejects_non_integer_float` | persistent int initializer 的非整数 float 拒绝行为与 simulator 对齐。 |
| `persistent_operation_writeback_rejects_float_and_rolls_back` | persistent int 写回非整数 float 时应报错并 rollback 到公开预期快照。 |
| `post_child_exit_continuation_skips_unstable_candidates` | child exit 后 continuation 的 candidate selection 应跳过 unstable branch。 |
| `pseudo_candidate_skips_unstable_branch` | ordinary pseudo candidate selection 应跳过 unstable branch。 |
| `root_exit_runs_root_cleanup` | root exit cleanup 应在 terminal / ended 路径中按 simulator 执行并反映到 vars。 |
| `transition_into_composite_skips_unstable_initial_candidate` | transition into composite 时应跳过 unstable initial candidate 并执行正确 effect / during 顺序。 |

### `state_or_ended_mismatch`（3）

这些 case 当前公开 state 或 ended 状态不一致；PR-2 必须对齐公开 state / ended，不得通过读取内部 frame / private enum 规避。

| Case | 期望验收 |
|---|---|
| `composite_initial_guard_can_select_terminal_branch_before_plain_before` | composite initial guard 可以选择 terminal branch；ended / state 应与 simulator 对齐。 |
| `hot_start_rejects_blocked_composite_initial` | hot start 到 blocked composite initial 应以公开可读异常拒绝，而不是进入错误 state。 |
| `hot_start_rejects_unstable_pseudo_leaf` | hot start 到 unstable pseudo leaf 应以公开可读异常拒绝，而不是接受错误 leaf / ended。 |

## 非目标

| 非目标 | 说明 |
|---|---|
| PR-3 hook context 主体语义 | 8 个 `handler_mismatch` 留给 PR-3。 |
| PR-1 hard blocker 返工 | `sigfpe` / `parse_render_load` / `exception_type_mismatch` 已在 PR #238 通过；若回归必须修复，但不重新定义范围。 |
| shared fixture schema 变更 | 本 PR 不修改 schema v2 语义，不新增 debug/private observation surface。 |
| simulator / generated Python 行为重定义 | 除非发现 runner 误判，否则以现有 simulator / generated Python shared fixture expectation 为准。 |
| CLI / REPL / jsfcstm / model_build | 不纳入本 PR。 |

## TDD / 实现要求

1. 先用正式 native runner 针对 22 个 case 确认当前状态为 `expected_failure`，再修模板/runtime。
2. C 与 C poll 当前失败分布同构，除非有实证差异，否则必须一起修复、一起验收。
3. 修复后删除 `test/fixtures/simulate_semantics/runner_capabilities.yaml` 中这 22 个 case 对两个 runner 的 expected-failure 条目。
4. 若某个 case 从 `expected_failure` 变成 `unexpected_pass`，不能简单放过；必须删除对应 matrix 条目并让正式 report 回到 `passed`。
5. 若分类发生变化但未修复，必须解释并同步 PR body / upstream PR body；ready 状态不得存在 `classification_mismatch`。
6. 不得读取 C/C poll 内部 enum、frame、stack、history、cycle counter、private state id 来证明对齐；只比较公开观察面。
7. 本 PR 需要重点白盒检查 composite initial selection 的 speculative / rollback / candidate pruning / entry ordering；应构造比 fixture 更复杂的多层 composite、pseudo branch、terminal branch、root exit、hot-start blocked/unstable 反例。
8. 如涉及 generated C/C poll source code，必须保持 C99 / CMake / broad platform 兼容，不引入第三方 runtime dependency。
9. 如涉及 C/C poll 内存生命周期，需检查长期运行泄漏/释放风险；发现超出本 PR 范围的问题至少记录为后续项。
10. commit 前运行 `make rst_auto`；若改 Python public API / docstring，必须符合 CLAUDE.md reST pydoc 规范。

## Upstream sync / 冲突处理门禁

1. ready 前必须同步最新伞 PR 分支：`git fetch origin` 后 merge 或 rebase `origin/dev/issue-218-c-cpoll-shared-alignment`。
2. 如发生 conflict，必须在 PR body 或 PR comment 中说明：冲突文件、解决策略、保留了哪些上游与本 PR 变更、为什么没有丢失 PR-0 / PR-1 runner、matrix、report 内容。
3. conflict 处理后必须重新运行本 PR 相关 native gate、正式 report、`make rst_auto` 与不带 slow skip 的最终 gate，并重新 watch CI。
4. 三路 implementation reviewer 必须把 upstream sync / conflict 处理正确性纳入 C/I/M；如未同步最新伞 PR 或冲突处理不可审阅，应给 I 级或 C 级阻塞。
5. 本 PR merge 后必须同步 umbrella PR #233 body 的 Sub PR 状态、剩余 expected-failure 数量、Mermaid 状态和进度 comment；必要时同步 issue #218。

## Slow-skip 禁用

本 PR 直接修 C/C poll generated runtime 执行语义，**ready 前禁止用 `SKIP_SLOW_TESTS=1` 或 commit message `[skip-slow]` 作为最终验收依据**。即便 prompt 或 review comment 提到 slow skip，也不能覆盖本规则。

硬性要求：

1. head commit message 不得包含 `[skip-slow]`、`ci skip`、`test skip`、`[python skip]`、`[js skip]`。
2. ready 前必须至少有一次不带 `SKIP_SLOW_TESTS=1` 的本地 native/full gate 或 GitHub Actions native gate 证据。
3. 本地最终验证优先使用 venv：`PATH="$PWD/venv/bin:$PATH" ./venv/bin/python ...`。
4. Reviewer 必须审查 slow-skip 使用情况；如果最终验收依赖 slow skip，应给 C 级阻塞。

## 验收命令计划

本 PR 实现完成后至少运行。下面 `<case_id>` 占位必须在实现后替换为 PR-2 22-case subset 的真实命令 / 输出；PR-2 22-case subset 应在实现后替换为具体 case list 或全量 report 证据。

```bash
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_alignment --case-id <case_id> ...
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment --case-id <case_id> ...
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_alignment
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python -m pytest test/template/c test/template/c_poll -v
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python -m pytest test/template/test_native_semantic_alignment_framework.py test/template/c/test_semantic_fixture_alignment.py test/template/c_poll/test_semantic_fixture_alignment.py -v
PATH="$PWD/venv/bin:$PATH" make rst_auto
PATH="$PWD/venv/bin:$PATH" make unittest
```

最终 report 目标：

| Runner | PR-2 case 状态 | 全量 expected failure 目标 |
|---|---|---:|
| `generated_c_alignment` | 22 个 PR-2 case 全部 `passed` | 从 30 降到 8 |
| `generated_c_poll_alignment` | 22 个 PR-2 case 全部 `passed` | 从 30 降到 8 |

## Review gate

开空 PR 后先进行三路计划审查：

1. codex reviewer：检查与 umbrella PR #233 / issue #218 / PR-1 后 report 一致性、PR body 可执行性 / 可验收性。
2. claude reviewer：同上，并重点检查 pydoc / no-slow-skip / broad compatibility / no debug surface 风险。
3. deepseek reviewer：同上，并进行轻度对抗性核验，寻找遗漏 case、错误分类或 PR-2 范围漂移。

实现后再进行三路强对抗 code review。每个 reviewer 都应独立构造与本 PR 错误类型同质但更复杂的白盒验证，尤其覆盖：多层 composite initial candidate pruning、pseudo unstable branch pruning、terminal initial branch before plain before、root exit cleanup、hot-start blocked composite initial、hot-start unstable pseudo leaf、persistent int normalization rollback。所有 reviewer 需要自行把中文 C/I/M review comment 发到本 PR。

## 当前状态

- [x] Empty PR opened from umbrella branch.
- [ ] Plan review C/I=0.
- [ ] TDD + implementation.
- [ ] `make rst_auto`.
- [ ] Full local native/full gate without slow skip.
- [ ] Push implementation.
- [ ] Watch CI all passed.
- [ ] Strong adversarial implementation review C/I=0.
- [ ] Ready to merge into umbrella PR branch; do not merge without user instruction.


## Plan review 修正记录

- 2026-06-18：三路 plan review 已完成，C=0/I=0。按 M 级建议补强以下执行口径：
  1. 本 PR 的 oracle 明确为 simulator / generated Python 已通过的 shared fixture expectation；除非证明 runner 误判，否则不得重定义 simulator 语义。
  2. Worker / harness failure 不能被 `vars_mismatch` 或 `state_or_ended_mismatch` expected-failure 吸收；若修复过程中出现 worker failure、native crash 或 non-zero subprocess failure，必须表现为 `classification_mismatch` / unexpected failure 并阻塞 ready。
  3. C/C poll 生成代码不得引入 C11+ only 特性、compiler extension、非普适库或第三方 runtime dependency；默认保持 C99 / CMake / broad platform。
  4. 22 个 case 的验收命令必须在实现后用正式 runner case subset 或全量 report 给出真实输出；不能只用表格声明。
