### PR TITLE
chore(template): remove residual native expected-failure fallback

### DIFF
--- a/test/fixtures/simulate_semantics/runner_capabilities.yaml
+++ b/test/fixtures/simulate_semantics/runner_capabilities.yaml
@@ -1,6 +1,0 @@
-# Native shared semantic alignment capability matrix.
-# This file is the single test-side fact source for C/C poll shared
-# alignment expected failures. The list must remain empty when the native
-# generated runtimes match the shared semantic fixture corpus.
-version: 1
-known_failures: []

--- a/test/template/c/test_semantic_fixture_alignment.py
+++ b/test/template/c/test_semantic_fixture_alignment.py
@@ -18,6 +18,3 @@ def test_generated_c_alignment_semantic_fixture(case):
 
     assert result.status == "passed", result.message
     assert result.classification is None
-    assert result.expected_classification is None
-    assert result.support is None
-    assert result.tracking is None

--- a/test/template/c_poll/test_semantic_fixture_alignment.py
+++ b/test/template/c_poll/test_semantic_fixture_alignment.py
@@ -18,6 +18,3 @@ def test_generated_c_poll_alignment_semantic_fixture(case):
 
     assert result.status == "passed", result.message
     assert result.classification is None
-    assert result.expected_classification is None
-    assert result.support is None
-    assert result.tracking is None

--- a/test/template/test_native_semantic_alignment_framework.py
+++ b/test/template/test_native_semantic_alignment_framework.py
@@ -1,5 +1,3 @@
-import datetime as _dt
-import os
 import signal
 import subprocess
 
@@ -9,59 +7,31 @@ from test.testings import native_semantic_alignment as native_alignment
 from test.testings.native_semantic_alignment import (
     _GeneratedNativeAlignmentRuntime,
     GENERATED_C_ALIGNMENT,
-    NativeAlignmentMatrixError,
-    load_native_capability_matrix,
-    native_capability_by_runner_case,
 )
-from test.testings.simulate_semantics import iter_semantic_cases
 
 
 @pytest.mark.unittest
-def test_native_capability_matrix_has_no_expected_failures_after_alignment():
-    entries = load_native_capability_matrix()
-    matrix = native_capability_by_runner_case(entries)
-    case_ids = {case.id for case in iter_semantic_cases()}
-
-    assert entries == ()
-    assert matrix == {}
-    assert "aspect_context_reports_active_leaf" in case_ids
-    assert "failed_initial_cycle_skips_abstract_handler_callbacks" in case_ids
-
-
-@pytest.mark.unittest
-def test_native_capability_matrix_uses_stable_schema_fields():
-    entries = load_native_capability_matrix()
-    assert all(hasattr(entry, "since") for entry in entries)
-    assert not any(hasattr(entry, "since_pr") for entry in entries)
-    assert all(_dt.date.fromisoformat(entry.since) for entry in entries)
-
-
-@pytest.mark.unittest
-def test_native_capability_matrix_rejects_missing_tracking(tmp_path):
-    matrix_file = tmp_path / "runner_capabilities.yaml"
-    matrix_file.write_text(
-        "version: 1\n"
-        "known_failures:\n"
-        "  - runner: generated_c_alignment\n"
-        "    case: design_basic_simple_transition\n"
-        "    classification: state_or_ended_mismatch\n"
-        "    observation: state_or_ended\n"
-        "    support: expected_failure\n"
-        "    skip_reason: known gap\n"
-        "    since: '2026-06-17'\n",
-        encoding="utf-8",
+def test_native_alignment_hard_failure_results_have_no_legacy_metadata():
+    result = native_alignment.NativeAlignmentResult(
+        GENERATED_C_ALIGNMENT,
+        "design_basic_simple_transition",
+        "failed",
+        "state_or_ended_mismatch",
+        "state mismatch",
     )
 
-    with pytest.raises(NativeAlignmentMatrixError, match="missing fields"):
-        load_native_capability_matrix(str(matrix_file))
+    hard_failure = native_alignment._hard_failure_result(result)
 
-
-@pytest.mark.unittest
-def test_native_capability_matrix_file_is_single_fact_source():
-    path = os.path.join(
-        "test", "fixtures", "simulate_semantics", "runner_capabilities.yaml"
-    )
-    assert os.path.isfile(path)
+    assert hard_failure.status == "unexpected_failure"
+    assert hard_failure.classification == "state_or_ended_mismatch"
+    assert set(hard_failure.to_dict()) == {
+        "case_id",
+        "classification",
+        "message",
+        "returncode",
+        "runner",
+        "status",
+    }
 
 
 @pytest.mark.unittest
@@ -82,8 +52,6 @@ def test_native_subprocess_classifies_sigfpe_as_unexpected_after_repair(monkeypa
 
     assert result.status == "unexpected_failure"
     assert result.classification == "sigfpe"
-    assert result.expected_classification is None
-    assert result.support is None
     assert result.returncode == -signal.SIGFPE
 
 
@@ -107,7 +75,6 @@ def test_native_subprocess_reports_non_sigfpe_signal_as_unexpected(monkeypatch):
 
     assert result.status == "unexpected_failure"
     assert result.classification == "native_crash"
-    assert result.expected_classification is None
     assert result.returncode == -sigsegv
 
 
@@ -140,7 +107,6 @@ def test_native_subprocess_reports_windows_arithmetic_crash_as_unexpected(
 
         assert result.status == "unexpected_failure"
         assert result.classification == "sigfpe"
-        assert result.expected_classification is None
         assert result.returncode == returncode
 
 
@@ -164,7 +130,6 @@ def test_native_subprocess_reports_windows_non_arithmetic_crash_as_unexpected(
 
     assert result.status == "unexpected_failure"
     assert result.classification == "native_crash"
-    assert result.expected_classification is None
     assert result.returncode == 0xC0000005
 
 
@@ -186,7 +151,6 @@ def test_native_subprocess_reports_worker_failure_as_unexpected(monkeypatch):
 
     assert result.status == "unexpected_failure"
     assert result.classification == "worker_failure"
-    assert result.expected_classification is None
     assert result.returncode == 1
 
 

--- a/test/testings/native_semantic_alignment.py
+++ b/test/testings/native_semantic_alignment.py
@@ -2,16 +2,14 @@
 Native generated-runtime alignment helpers for semantic fixtures.
 
 This module adapts the schema v2 shared semantic fixture corpus to the built-in
-C and C poll templates. It owns the test-side runner names, capability-matrix
-validation, native public-observation adapter, and subprocess report helpers
-used by the C-family template alignment tests.
+C and C poll templates. It owns the test-side runner names, native
+public-observation adapter, subprocess crash isolation, and hard-failure report
+helpers used by the C-family template alignment tests.
 
 The module contains:
 
-* :class:`NativeCapabilityEntry` - One known native alignment capability row.
 * :class:`NativeAlignmentResult` - Serializable outcome of one native case run.
 * :class:`NativeAlignmentReport` - Aggregate report for one native runner.
-* :func:`load_native_capability_matrix` - Load and validate the matrix YAML.
 * :func:`run_native_alignment_case` - Execute one case in-process.
 * :func:`run_native_alignment_case_subprocess` - Execute one case safely in a
   child process so native crashes do not terminate pytest.
@@ -32,9 +30,7 @@ import signal
 import subprocess
 import sys
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
-
-import yaml
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from pyfcstm.simulate import (
     SimulationRuntimeActionReferenceError,
@@ -53,38 +49,9 @@ from test.testings.simulate_semantics import (
 GENERATED_C_ALIGNMENT = "generated_c_alignment"
 GENERATED_C_POLL_ALIGNMENT = "generated_c_poll_alignment"
 NATIVE_ALIGNMENT_RUNNERS = (GENERATED_C_ALIGNMENT, GENERATED_C_POLL_ALIGNMENT)
-CAPABILITY_MATRIX_PATH = os.path.abspath(
-    os.path.join(
-        os.path.dirname(__file__),
-        os.pardir,
-        "fixtures",
-        "simulate_semantics",
-        "runner_capabilities.yaml",
-    )
-)
-_REQUIRED_CAPABILITY_FIELDS = {
-    "runner",
-    "case",
-    "classification",
-    "observation",
-    "support",
-    "skip_reason",
-    "tracking",
-    "since",
-}
-_ALLOWED_CLASSIFICATIONS = {
-    "event_resolution",
-    "exception_type_mismatch",
-    "handler_mismatch",
-    "native_crash",
-    "native_timeout",
-    "parse_render_load",
-    "sigfpe",
-    "state_or_ended_mismatch",
-    "vars_mismatch",
-}
-# Worker failures are intentionally not allowed in the capability matrix:
-# harness/worker bugs must surface as unexpected or mismatched results.
+
+# Worker failures must surface as hard failures rather than being masked by
+# any external allow-list data.
 _WORKER_FAILURE_CLASSIFICATION = "worker_failure"
 # Windows reports native arithmetic traps as positive NTSTATUS values instead
 # of POSIX-style negative signals; these codes are equivalent to SIGFPE for
@@ -130,72 +97,6 @@ _SIMULATION_RUNTIME_EXCEPTIONS = (
 )
 
 
-class NativeAlignmentMatrixError(ValueError):
-    """
-    Raised when the native alignment capability matrix is malformed.
-
-    :param args: Positional message arguments accepted by :class:`ValueError`.
-    :type args: object
-
-    Example::
-
-        >>> err = NativeAlignmentMatrixError("bad native matrix")
-        >>> "matrix" in str(err)
-        True
-    """
-
-
-@dataclass(frozen=True)
-class NativeCapabilityEntry:
-    """
-    Known native alignment capability or expected-failure entry.
-
-    :param runner: Native alignment runner name.
-    :type runner: str
-    :param case: Shared semantic fixture case id.
-    :type case: str
-    :param classification: Stable failure classification for the case.
-    :type classification: str
-    :param observation: Public observation family affected by the entry.
-    :type observation: str
-    :param support: Support status, currently ``"expected_failure"`` for
-        native semantic alignment staging entries.
-    :type support: str
-    :param skip_reason: Human-readable reason for not treating the case as a
-        passing gate yet.
-    :type skip_reason: str
-    :param tracking: URL that tracks the native alignment gap.
-    :type tracking: str
-    :param since: Stable date, version, or commit for when the entry became
-        applicable. This is deliberately not named after a PR or roadmap item.
-    :type since: str
-
-    Example::
-
-        >>> entry = NativeCapabilityEntry(
-        ...     runner="generated_c_alignment",
-        ...     case="demo",
-        ...     classification="state_or_ended_mismatch",
-        ...     observation="state_or_ended",
-        ...     support="expected_failure",
-        ...     skip_reason="known gap",
-        ...     tracking="https://github.com/HansBug/pyfcstm/",
-        ...     since="2026-06-17",
-        ... )
-        >>> entry.runner
-        'generated_c_alignment'
-    """
-
-    runner: str
-    case: str
-    classification: str
-    observation: str
-    support: str
-    skip_reason: str
-    tracking: str
-    since: str
-
-
 @dataclass(frozen=True)
 class NativeAlignmentResult:
     """
@@ -209,13 +110,6 @@ class NativeAlignmentResult:
     :type status: str
     :param classification: Optional failure classification.
     :type classification: str, optional
-    :param expected_classification: Optional known-failure classification from
-        the capability matrix.
-    :type expected_classification: str, optional
-    :param support: Optional capability support state for the case.
-    :type support: str, optional
-    :param tracking: Optional URL that tracks the known native gap.
-    :type tracking: str, optional
     :param message: Short diagnostic message.
     :type message: str
     :param returncode: Subprocess return code when a child process was used.
@@ -234,9 +128,6 @@ class NativeAlignmentResult:
     classification: Optional[str]
     message: str
     returncode: Optional[int] = None
-    expected_classification: Optional[str] = None
-    support: Optional[str] = None
-    tracking: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """
@@ -310,110 +201,9 @@ class NativeAlignmentReport:
         }
 
 
-def _matrix_error(message: str) -> NativeAlignmentMatrixError:
-    return NativeAlignmentMatrixError("native capability matrix: %s" % message)
-
-
 def _validate_runner_name(runner: str) -> None:
     if runner not in NATIVE_ALIGNMENT_RUNNERS:
         raise ValueError("unknown native alignment runner: %r" % runner)
-
-
-def load_native_capability_matrix(
-    path: str = CAPABILITY_MATRIX_PATH,
-) -> Tuple[NativeCapabilityEntry, ...]:
-    """
-    Load and validate the native runner capability matrix.
-
-    :param path: Path to the capability YAML file, defaults to the shared
-        fixture matrix path.
-    :type path: str, optional
-    :return: Validated capability entries.
-    :rtype: tuple[test.testings.native_semantic_alignment.NativeCapabilityEntry, ...]
-    :raises NativeAlignmentMatrixError: If the YAML schema is invalid.
-
-    Example::
-
-        >>> entries = load_native_capability_matrix()
-        >>> bool(entries)
-        False
-    """
-    with open(path, "r", encoding="utf-8") as file:
-        data = yaml.safe_load(file)
-    if not isinstance(data, dict):
-        raise _matrix_error("root must be a mapping")
-    if data.get("version") != 1:
-        raise _matrix_error("version must be 1")
-    raw_entries = data.get("known_failures")
-    if not isinstance(raw_entries, list):
-        raise _matrix_error("known_failures must be a list")
-
-    case_ids = {case.id for case in iter_semantic_cases()}
-    seen = set()
-    entries = []
-    for index, item in enumerate(raw_entries):
-        if not isinstance(item, dict):
-            raise _matrix_error("known_failures[%d] must be a mapping" % index)
-        missing = _REQUIRED_CAPABILITY_FIELDS - set(item.keys())
-        if missing:
-            raise _matrix_error(
-                "known_failures[%d] missing fields: %r" % (index, sorted(missing))
-            )
-        unknown = set(item.keys()) - _REQUIRED_CAPABILITY_FIELDS
-        if unknown:
-            raise _matrix_error(
-                "known_failures[%d] has unknown fields: %r" % (index, sorted(unknown))
-            )
-        entry = NativeCapabilityEntry(**item)
-        _validate_runner_name(entry.runner)
-        if entry.case not in case_ids:
-            raise _matrix_error(
-                "known_failures[%d] references unknown case %r" % (index, entry.case)
-            )
-        if entry.classification not in _ALLOWED_CLASSIFICATIONS:
-            raise _matrix_error(
-                "known_failures[%d] has unknown classification %r"
-                % (index, entry.classification)
-            )
-        if entry.support != "expected_failure":
-            raise _matrix_error(
-                "known_failures[%d].support must be 'expected_failure'" % index
-            )
-        if not entry.skip_reason:
-            raise _matrix_error("known_failures[%d].skip_reason is required" % index)
-        if not entry.tracking.startswith("https://github.com/HansBug/pyfcstm/"):
-            raise _matrix_error(
-                "known_failures[%d].tracking must be a pyfcstm URL" % index
-            )
-        if not entry.since:
-            raise _matrix_error("known_failures[%d].since is required" % index)
-        key = (entry.runner, entry.case)
-        if key in seen:
-            raise _matrix_error("duplicate entry for runner/case: %r" % (key,))
-        seen.add(key)
-        entries.append(entry)
-    return tuple(entries)
-
-
-def native_capability_by_runner_case(
-    entries: Optional[Iterable[NativeCapabilityEntry]] = None,
-) -> Dict[Tuple[str, str], NativeCapabilityEntry]:
-    """
-    Index capability entries by ``(runner, case_id)``.
-
-    :param entries: Optional entries to index, defaults to loading the matrix.
-    :type entries: typing.Iterable[NativeCapabilityEntry], optional
-    :return: Mapping from runner/case pairs to entries.
-    :rtype: dict
-
-    Example::
-
-        >>> matrix = native_capability_by_runner_case()
-        >>> matrix
-        {}
-    """
-    source = tuple(entries) if entries is not None else load_native_capability_matrix()
-    return {(entry.runner, entry.case): entry for entry in source}
 
 
 def _native_utils_for_runner(runner: str):
@@ -660,63 +450,17 @@ def _classify_exception(error: BaseException) -> str:
     return "state_or_ended_mismatch"
 
 
-def _apply_capability_entry(result: NativeAlignmentResult) -> NativeAlignmentResult:
-    if result.status not in {"passed", "failed"}:
-        return result
-
-    entry = native_capability_by_runner_case().get((result.runner, result.case_id))
-    if entry is None:
-        if result.status == "failed":
-            return NativeAlignmentResult(
-                result.runner,
-                result.case_id,
-                "unexpected_failure",
-                result.classification,
-                result.message,
-                result.returncode,
-            )
-        return result
-
-    if result.status == "passed":
+def _hard_failure_result(result: NativeAlignmentResult) -> NativeAlignmentResult:
+    if result.status == "failed":
         return NativeAlignmentResult(
             result.runner,
             result.case_id,
-            "unexpected_pass",
-            result.classification,
-            "known native alignment gap passed; update the capability matrix",
-            result.returncode,
-            expected_classification=entry.classification,
-            support=entry.support,
-            tracking=entry.tracking,
-        )
-
-    if result.classification == entry.classification:
-        return NativeAlignmentResult(
-            result.runner,
-            result.case_id,
-            "expected_failure",
+            "unexpected_failure",
             result.classification,
             result.message,
             result.returncode,
-            expected_classification=entry.classification,
-            support=entry.support,
-            tracking=entry.tracking,
         )
-
-    return NativeAlignmentResult(
-        result.runner,
-        result.case_id,
-        "classification_mismatch",
-        result.classification,
-        (
-            "%s; expected known-failure classification %s"
-            % (result.message, entry.classification)
-        ),
-        result.returncode,
-        expected_classification=entry.classification,
-        support=entry.support,
-        tracking=entry.tracking,
-    )
+    return result
 
 
 def _raw_native_alignment_case(
@@ -809,7 +553,7 @@ def run_native_alignment_case(runner: str, case: SemanticCase) -> NativeAlignmen
         >>> run_native_alignment_case("generated_c_alignment", case).status
         'passed'
     """
-    return _apply_capability_entry(_raw_native_alignment_case(runner, case))
+    return _hard_failure_result(_raw_native_alignment_case(runner, case))
 
 
 def _signal_name(returncode: int) -> str:
@@ -903,7 +647,7 @@ def run_native_alignment_case_subprocess(
             timeout=timeout,
         )
     except subprocess.TimeoutExpired as err:
-        return _apply_capability_entry(
+        return _hard_failure_result(
             NativeAlignmentResult(
                 runner,
                 case_id,
@@ -917,7 +661,7 @@ def run_native_alignment_case_subprocess(
         completed.returncode
     )
     if crash_classification != _WORKER_FAILURE_CLASSIFICATION:
-        return _apply_capability_entry(
+        return _hard_failure_result(
             NativeAlignmentResult(
                 runner,
                 case_id,
@@ -928,7 +672,7 @@ def run_native_alignment_case_subprocess(
             )
         )
     if completed.returncode != 0:
-        return _apply_capability_entry(
+        return _hard_failure_result(
             NativeAlignmentResult(
                 runner,
                 case_id,
@@ -940,7 +684,7 @@ def run_native_alignment_case_subprocess(
         )
     lines = [line for line in completed.stdout.splitlines() if line.strip()]
     if not lines:
-        return _apply_capability_entry(
+        return _hard_failure_result(
             NativeAlignmentResult(
                 runner,
                 case_id,
@@ -955,7 +699,7 @@ def run_native_alignment_case_subprocess(
     except json.JSONDecodeError as err:
         # json.loads raises JSONDecodeError when the worker exits successfully
         # but does not emit the expected final JSON result line.
-        return _apply_capability_entry(
+        return _hard_failure_result(
             NativeAlignmentResult(
                 runner,
                 case_id,
@@ -965,7 +709,7 @@ def run_native_alignment_case_subprocess(
                 completed.returncode,
             )
         )
-    return _apply_capability_entry(NativeAlignmentResult(**data))
+    return _hard_failure_result(NativeAlignmentResult(**data))
 
 
 def run_native_alignment_report(


### PR DESCRIPTION
Refs https://github.com/HansBug/pyfcstm/pull/233
Refs https://github.com/HansBug/pyfcstm/issues/218

## 背景

本 PR 是 umbrella PR #233 下新增的 PR-6 计划型空 PR，用于一次性清除 PR-0~PR-5 后仍残留的 native alignment expected-failure / capability-matrix 历史痕迹。

PR-5 已完成旧 C/C poll 手写 `test_runtime_alignment.py` 平行账本删除、full shared native gate 常态化，并把正式 native alignment 收敛到 `143 passed / 0 expected_failure`。随后复查发现：虽然 `known_failures` 已为空，仓库内仍保留完整 capability-matrix YAML、loader、result metadata 与 fallback 状态转换机制。这会让后续维护者误以为可以重新通过 matrix 把 native 对齐失败降级成 expected failure，因此需要单独 cleanup。

## 当前实现状态

- 实现 commit：`c5530eba8dc4dbc3320dd22ce2317136aa9e6cde` (`test(template): remove native expected-failure fallback`)。
- 已删除 `test/fixtures/simulate_semantics/runner_capabilities.yaml`。
- 已删除 native capability matrix 类型、loader/indexer、`_apply_capability_entry()` 与 `expected_failure` / `unexpected_pass` / `classification_mismatch` 降级路径。
- 已删除 `NativeAlignmentResult` 的 `expected_classification` / `support` / `tracking` metadata，以及 C / C poll semantic fixture tests 中对应断言。
- `unexpected_failure` 仅保留为真实 native hard-failure status 名称；不再表示 matrix 差异、已知失败或可接受降级。
- shared fixture schema / inventory / negative tests 中拒绝 `expected_failure` 字段的保护网保留。
- 本 PR 未改 `pyfcstm/`、`templates/`、C runtime 或 C poll runtime 语义；只清理 native alignment test infrastructure。

## 已完成验收

- `python -m py_compile test/testings/native_semantic_alignment.py test/template/test_native_semantic_alignment_framework.py test/template/c/test_semantic_fixture_alignment.py test/template/c_poll/test_semantic_fixture_alignment.py`：通过。
- `pytest test/template/test_native_semantic_alignment_framework.py test/template/c/test_semantic_fixture_alignment.py test/template/c_poll/test_semantic_fixture_alignment.py -v`：`293 passed`。
- `python tools/native_semantic_alignment_report.py --runner generated_c_alignment`：`143 passed / 143 total`。
- `python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment`：`143 passed / 143 total`。
- `pytest test/template/c test/template/c_poll -v`：`336 passed`。
- `make rst_auto`：通过且无 RST diff。
- `make unittest`（未使用 slow-skip）：`41468 passed, 63 deselected`。
- `ruff check`（changed Python test/helper files）：通过。
- GitHub Actions：PR #243 所有 visible checks 全绿（Ubuntu / Windows / macOS code tests、CLI Build、jsfcstm）。
- Codecov / coverage：未发现独立 Codecov bot comment 或 coverage status；三路 implementation reviewers 已记录该事实。

## 实现审查结论

CI 全绿后已完成三路实现审查，三个 reviewer 均已自行评论到本 PR：

| Reviewer | 结论 | C | I | M |
|---|---:|---:|---:|---:|
| claude reviewer | PASS | 0 | 0 | 0 |
| codex reviewer | PASS | 0 | 0 | 0 |
| deepseek reviewer | PASS | 0 | 0 | 0 |

当前状态：PR-6 ready to merge；按流程等待用户下一步合并指示。

## 当前已确认的残留

| 残留项 | 位置 | 当前事实 | 清理目标 |
|---|---|---|---|
| 空 expected-failure YAML | `test/fixtures/simulate_semantics/runner_capabilities.yaml` | 文件仍存在，内容为 `version: 1` + `known_failures: []` | 删除该文件；native gate 不再有 expected-failure fact source。 |
| capability matrix 类型与 loader | `test/testings/native_semantic_alignment.py` | 仍有 `NativeCapabilityEntry`、`NativeAlignmentMatrixError`、`load_native_capability_matrix()`、`native_capability_by_runner_case()` | 删除 matrix 类型、loader、schema validation 与相关 imports/docstring。 |
| fallback 状态转换 | `test/testings/native_semantic_alignment.py` | `_apply_capability_entry()` 仍可产生 `expected_failure`、`unexpected_pass`、`classification_mismatch`，并把普通 `failed` 转成 `unexpected_failure` | 删除 fallback 机制；native mismatch/crash/timeout/worker failure 直接硬失败，不得被 matrix mask。 |
| known-failure result metadata | `NativeAlignmentResult`、C/C poll semantic fixture tests、framework tests | `expected_classification`、`support`、`tracking` 字段仍存在，测试还断言它们为 `None` | 删除这些字段和对应断言；保留 `runner`、`case_id`、`status`、`classification`、`message`、`returncode`。 |
| matrix 维护测试 | `test/template/test_native_semantic_alignment_framework.py` | 仍有 matrix 空文件、stable schema、missing tracking 等测试 | 删除 matrix 维护测试，改为测试 native crash/worker/JSON 分类均直接 hard-fail。 |
| 文档/注释残留 | `test/testings/native_semantic_alignment.py` module docstring、umbrella PR #233、issue #218 等 | 仍描述 “capability-matrix validation”、known native gap，或暗示 “capability matrix 为空即可” | 改为说明本模块只负责 native runner、public observation adapter、subprocess crash isolation 与 hard-failure report；issue/umbrella 进度叙事同步改成“没有 native expected-failure matrix”。 |

## 明确非目标 / 不应清理

| 非目标 | 原因 |
|---|---|
| shared fixture schema 中拒绝 `expected_failure` 字段的约束 | 这是防止 expected failure 回流 shared corpus 的保护网，必须保留。 |
| `tools/inventory_simulate_semantics.py` 对 `expected_failure` top-level field 的拒绝 | 同上，属于 shared fixture 合法性约束，不是 native capability matrix。 |
| `test/simulate/test_semantic_fixtures.py` 里拒绝 `expected_failure` 的负例测试 | 同上，应继续保证 shared fixture 不支持 expected-failure 标记。 |
| fixture `origin.files` 中指向旧 Python template alignment 测试的 provenance | 这些是行为来源记录，不是 C/C poll native expected-failure fallback。 |
| `test/template/c/test_runtime.py` / `test/template/c_poll/test_runtime.py` 中 smoke/API/native compile-run 覆盖 | 这些是非重复 native template 保护，PR-6 不做删除。 |
| C/C poll generated runtime 语义 | PR-6 只清理 test infrastructure / docs / PR/issue wording；如发现新的 runtime mismatch，必须作为 hard failure 暴露并另行处理，禁止在 cleanup PR 中静默修 C/C poll generated runtime 逻辑。 |

## 执行计划

1. 删除 `test/fixtures/simulate_semantics/runner_capabilities.yaml`。
2. 简化 `test/testings/native_semantic_alignment.py`：
   - 删除 `yaml` import、capability path 常量、matrix schema 常量、`NativeCapabilityEntry`、`NativeAlignmentMatrixError`、matrix loader/indexer 与 `_apply_capability_entry()`。
   - 更新 module docstring 与 `NativeAlignmentResult` docstring。
   - 移除 `expected_classification` / `support` / `tracking` 字段。
   - 让 `run_native_alignment_case()` 和 `run_native_alignment_case_subprocess()` 直接返回 hard-failure result。保留 `unexpected_failure` 作为 subprocess/native hard-failure status 名称，但它只表示真实失败需要修复，不再表示 matrix 差异或可接受降级。
3. 更新测试：
   - 删除 matrix-specific tests。
   - 保留并调整 subprocess crash / Windows arithmetic crash / worker failure / JSON failure 等 hard-failure 分类测试。
   - 更新 C/C poll full shared fixture tests，删除 known-failure metadata 断言。
4. 更新 umbrella PR #233 / issue #218 相关文字：
   - 不再声称 “capability matrix 为空” 是最终事实源。
   - issue #218 的进度表、状态叙事和 closure 文案也必须同步追加 PR-6 去向，不能继续写成 “capability matrix 当前无 expected failure”。
   - 改成 “没有 native expected-failure matrix；full shared native gate 是唯一对齐事实源；所有 native alignment mismatch/crash/timeout/worker failure 都是 hard failure”。
5. 验证 targeted grep：
   - `runner_capabilities`、`NativeCapability`、`NativeAlignmentMatrixError`、`load_native_capability_matrix`、`native_capability_by_runner_case`、`_apply_capability_entry`、`known_failures`、`unexpected_pass`、`classification_mismatch`、`expected_classification` 在 `test/testings` / `test/template` / `test/fixtures/simulate_semantics` / `tools` 中应无残留。
   - `support` / `tracking` 在 `test/testings/native_semantic_alignment.py`、C/C poll semantic fixture tests 和 native alignment framework tests 中不应作为 known-failure metadata 残留；shared fixture schema 中的 ordinary wording / unrelated fields 不属于 native known-failure metadata。
   - `expected_failure` 只应保留在 shared fixture schema/inventory/negative tests 等“拒绝该字段”的保护网中，以及与本轮无关的 solver expected failure 文档语义中。

## 验收命令

本 PR 修改 native C/C poll alignment test infrastructure，最终验收不得使用 slow-skip。

```bash
PATH="$PWD/venv/bin:$PATH" ./venv/bin/pytest \
  test/template/test_native_semantic_alignment_framework.py \
  test/template/c/test_semantic_fixture_alignment.py \
  test/template/c_poll/test_semantic_fixture_alignment.py \
  -v

PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_alignment
PATH="$PWD/venv/bin:$PATH" ./venv/bin/python tools/native_semantic_alignment_report.py --runner generated_c_poll_alignment

PATH="$PWD/venv/bin:$PATH" ./venv/bin/pytest test/template/c test/template/c_poll -v
make rst_auto
make unittest
```

如果本地全量 `make unittest` 因环境中缺少 native toolchain 失败，必须在 PR comment 中贴出具体失败证据，并以 GitHub Actions no-slow-skip 全绿作为最终门禁；不得用 `SKIP_SLOW_TESTS=1` 代替最终 native gate。

## 计划审查要求

本 empty PR 先接受三路计划审查：

- codex reviewer
- claude reviewer
- deepseek reviewer

每个 reviewer 必须中文亮明身份、按 C/I/M 分级，并自行评论到本 PR。若出现 C/I 级问题，必须先修改本 PR title/body 到计划 ready，再进入 TDD + cleanup 实现。


