### PR TITLE
实现：D4b 扩展原生工具链公共矩阵与静态检查入口

### DIFF
--- a/.github/workflows/native-toolchain.yml
+++ b/.github/workflows/native-toolchain.yml
@@ -49,34 +49,82 @@ on:
         default: linux-gcc-o2
         type: choice
         options:
+          - linux-gcc-o0
           - linux-gcc-o2
+          - linux-gcc-o3
+          - linux-gcc-os
+          - linux-clang-o0
           - linux-clang-o2
+          - linux-clang-o3
+          - linux-clang-os
+          - linux-gcc-m32-o2
+          - linux-gcc-m32-os
+          - linux-aarch64-gcc-o2
+          - linux-aarch64-gcc-os
+          - arm-none-eabi-gcc-o2
+          - arm-none-eabi-gcc-os
+          - macos-appleclang-o2
+          - windows-mingw-o2
+          - windows-msvc-o2
+          - windows-clangcl-o2
+          - linux-clang-asan-ubsan
+          - linux-cppcheck
+          - linux-clang-tidy
 
 jobs:
-  native-toolchain:
+  native-linux:
     name: native-toolchain / ${{ matrix.profile }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 60
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["linux-gcc-o0","linux-gcc-o2","linux-gcc-o3","linux-gcc-os","linux-clang-o0","linux-clang-o2","linux-clang-o3","linux-clang-os","linux-gcc-m32-o2","linux-gcc-m32-os","linux-aarch64-gcc-o2","linux-aarch64-gcc-os","arm-none-eabi-gcc-o2","arm-none-eabi-gcc-os","linux-clang-asan-ubsan","linux-cppcheck","linux-clang-tidy"]'), inputs.profile)
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
-        profile: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.profile) || '["linux-gcc-o2", "linux-clang-o2"]') }}
+        profile: ${{ fromJSON(github.event_name == 'workflow_dispatch' && contains(fromJSON('["linux-gcc-o0","linux-gcc-o2","linux-gcc-o3","linux-gcc-os","linux-clang-o0","linux-clang-o2","linux-clang-o3","linux-clang-os","linux-gcc-m32-o2","linux-gcc-m32-os","linux-aarch64-gcc-o2","linux-aarch64-gcc-os","arm-none-eabi-gcc-o2","arm-none-eabi-gcc-os","linux-clang-asan-ubsan","linux-cppcheck","linux-clang-tidy"]'), inputs.profile) && format('["{0}"]', inputs.profile) || github.event_name == 'workflow_dispatch' && '["linux-gcc-o2"]' || '["linux-gcc-o0","linux-gcc-o2","linux-gcc-o3","linux-gcc-os","linux-clang-o0","linux-clang-o2","linux-clang-o3","linux-clang-os","linux-gcc-m32-o2","linux-gcc-m32-os","linux-aarch64-gcc-o2","linux-aarch64-gcc-os","arm-none-eabi-gcc-o2","arm-none-eabi-gcc-os","linux-clang-asan-ubsan","linux-cppcheck","linux-clang-tidy"]') }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       - name: Install native tools
+        env:
+          PROFILE: ${{ matrix.profile }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cmake gcc g++ clang
+          case "$PROFILE" in
+            linux-gcc-o*|linux-gcc-os)
+              packages="cmake gcc g++"
+              ;;
+            linux-clang-o*|linux-clang-os|linux-clang-asan-ubsan)
+              packages="cmake clang"
+              ;;
+            linux-gcc-m32-*)
+              packages="cmake gcc g++ gcc-multilib g++-multilib"
+              ;;
+            linux-aarch64-*)
+              packages="cmake gcc-aarch64-linux-gnu g++-aarch64-linux-gnu qemu-user"
+              ;;
+            arm-none-eabi-*)
+              packages="gcc-arm-none-eabi libnewlib-arm-none-eabi"
+              ;;
+            linux-cppcheck)
+              packages="cppcheck"
+              ;;
+            linux-clang-tidy)
+              packages="clang-tidy"
+              ;;
+            *)
+              echo "Unknown native toolchain profile: $PROFILE" >&2
+              exit 1
+              ;;
+          esac
+          sudo apt-get install -y --no-install-recommends $packages
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt -r requirements-dev.txt
-          python -m pip install pytest-cov pytest-timeout
+          python -m pip install -r requirements.txt -r requirements-test.txt
       - name: Package templates
-        run: make tpl
+        run: python -m tools.package_templates --source templates --output pyfcstm/template
       - name: Run native toolchain alignment
         env:
           PYFCSTM_RUN_NATIVE_TOOLCHAIN: '1'
@@ -86,6 +134,99 @@ jobs:
           pytest -m native_toolchain \
             test/template/c/test_native_toolchain_alignment.py \
             test/template/c_poll/test_native_toolchain_alignment.py \
+            --run-native-toolchain -q
+      - name: Upload native artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-toolchain-${{ matrix.profile }}
+          path: native-toolchain-artifacts
+          if-no-files-found: ignore
+
+  native-macos:
+    name: native-toolchain / macos-appleclang-o2
+    runs-on: macos-14
+    timeout-minutes: 90
+    if: github.event_name != 'workflow_dispatch' || inputs.profile == 'macos-appleclang-o2'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install native tools
+        run: |
+          brew install cmake || true
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-test.txt
+      - name: Package templates
+        run: python -m tools.package_templates --source templates --output pyfcstm/template
+      - name: Run native toolchain alignment
+        env:
+          PYFCSTM_RUN_NATIVE_TOOLCHAIN: '1'
+          PYFCSTM_NATIVE_TOOLCHAIN_PROFILE: macos-appleclang-o2
+          PYFCSTM_NATIVE_TOOLCHAIN_ARTIFACT_DIR: native-toolchain-artifacts
+        run: |
+          pytest -m native_toolchain \
+            test/template/c/test_native_toolchain_alignment.py \
+            test/template/c_poll/test_native_toolchain_alignment.py \
+            --run-native-toolchain -q
+      - name: Upload native artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-toolchain-macos-appleclang-o2
+          path: native-toolchain-artifacts
+          if-no-files-found: ignore
+
+  native-windows:
+    name: native-toolchain / ${{ matrix.profile }}
+    runs-on: windows-2022
+    timeout-minutes: 90
+    if: github.event_name != 'workflow_dispatch' || contains(fromJSON('["windows-mingw-o2","windows-msvc-o2","windows-clangcl-o2"]'), inputs.profile)
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: ${{ fromJSON(github.event_name == 'workflow_dispatch' && format('["{0}"]', inputs.profile) || '["windows-mingw-o2","windows-msvc-o2","windows-clangcl-o2"]') }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: msys2/setup-msys2@v2
+        if: matrix.profile == 'windows-mingw-o2'
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-ninja
+          path-type: inherit
+      - name: Install Windows host tools
+        shell: pwsh
+        run: |
+          choco install ninja -y --no-progress
+      - name: Install Python dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-test.txt
+      - name: Package templates
+        shell: pwsh
+        run: python -m tools.package_templates --source templates --output pyfcstm/template
+      - name: Run native toolchain alignment
+        shell: pwsh
+        env:
+          PYFCSTM_RUN_NATIVE_TOOLCHAIN: '1'
+          PYFCSTM_NATIVE_TOOLCHAIN_PROFILE: ${{ matrix.profile }}
+          PYFCSTM_NATIVE_TOOLCHAIN_ARTIFACT_DIR: native-toolchain-artifacts
+        run: |
+          pytest -m native_toolchain `
+            test/template/c/test_native_toolchain_alignment.py `
+            test/template/c_poll/test_native_toolchain_alignment.py `
             --run-native-toolchain -q
       - name: Upload native artifacts
         if: always()

--- a/.github/workflows/native-toolchain.yml
+++ b/.github/workflows/native-toolchain.yml
@@ -10,6 +10,7 @@ on:
       - pyfcstm/model/**
       - pyfcstm/render/**
       - pyfcstm/template/**
+      - pyfcstm/utils/**
       - templates/c/**
       - templates/c_poll/**
       - tools/package_templates.py
@@ -29,6 +30,7 @@ on:
       - pyfcstm/model/**
       - pyfcstm/render/**
       - pyfcstm/template/**
+      - pyfcstm/utils/**
       - templates/c/**
       - templates/c_poll/**
       - tools/package_templates.py

--- a/pyfcstm/render/c_runtime.py
+++ b/pyfcstm/render/c_runtime.py
@@ -287,6 +287,63 @@ def _infer_expr_type(
     return None
 
 
+def _is_static_zero(expr: dsl_nodes.Expr) -> bool:
+    """
+    Return whether an expression is syntactically a zero literal.
+
+    The C runtime emitter uses this narrow check to keep generated code
+    compileable on toolchains that reject constant division or modulo by zero at
+    compile time. It deliberately does not fold arbitrary expressions: broader
+    arithmetic reasoning belongs in the inspect/verify layers, while code
+    generation only needs to mask denominator literals that are already guarded
+    by generated runtime diagnostics.
+
+    :param expr: Expression to inspect.
+    :type expr: pyfcstm.dsl.node.Expr
+    :return: ``True`` when the expression is a parenthesized or signed zero
+        literal.
+    :rtype: bool
+
+    Example::
+
+        >>> _is_static_zero(dsl_nodes.Integer("0"))
+        True
+        >>> _is_static_zero(dsl_nodes.BinaryOp(dsl_nodes.Integer("1"), "-", dsl_nodes.Integer("1")))
+        False
+    """
+    expr = _coerce_expr(expr)
+    if isinstance(expr, dsl_nodes.Paren):
+        return _is_static_zero(expr.expr)
+    if isinstance(expr, dsl_nodes.UnaryOp) and expr.op in {"+", "-"}:
+        return _is_static_zero(expr.expr)
+    if isinstance(expr, (dsl_nodes.Integer, dsl_nodes.HexInt)):
+        return expr.value == 0
+    if isinstance(expr, dsl_nodes.Float):
+        return expr.value == 0.0
+    return False
+
+
+def _safe_static_zero_result(value_type: Optional[str]) -> str:
+    """
+    Return a harmless placeholder for a statically failing expression.
+
+    :param value_type: Coarse DSL value type of the expression being replaced.
+    :type value_type: str, optional
+    :return: C literal with the requested coarse type.
+    :rtype: str
+
+    Example::
+
+        >>> _safe_static_zero_result("float")
+        '0.0'
+        >>> _safe_static_zero_result("int")
+        '0'
+    """
+    if value_type == "float":
+        return "0.0"
+    return "0"
+
+
 def _render_expr(
     expr: dsl_nodes.Expr,
     known_types: Mapping[str, str],
@@ -342,7 +399,10 @@ def _render_expr(
     if isinstance(expr, dsl_nodes.BinaryOp):
         left = _render_expr(expr.expr1, known_types, state_name_set)
         right = _render_expr(expr.expr2, known_types, state_name_set)
-        if expr.op in _INT_OPERATORS and (
+        value_type = _infer_expr_type(expr, known_types)
+        if expr.op in {"/", "%"} and _is_static_zero(expr.expr2):
+            text = _safe_static_zero_result(value_type)
+        elif expr.op in _INT_OPERATORS and (
             left.value_type == "float" or right.value_type == "float"
         ):
             text = "0"
@@ -362,7 +422,7 @@ def _render_expr(
             text = "((%s) == (%s))" % (left.text, right.text)
         else:
             text = "((%s) %s (%s))" % (left.text, expr.op, right.text)
-        return _ExprRenderResult(text, _infer_expr_type(expr, known_types))
+        return _ExprRenderResult(text, value_type)
     if isinstance(expr, dsl_nodes.ConditionalOp):
         cond = _render_expr(expr.cond, known_types, state_name_set)
         value_true = _render_expr(expr.value_true, known_types, state_name_set)
@@ -641,7 +701,7 @@ def _render_statement_sequence(
                     (
                         "%s(machine, "
                         "\"Variable '%s' is int type, cannot assign float %%.15g; "
-                        "non-integer float from operation block writeback\", "
+                        'non-integer float from operation block writeback", '
                         "%s);"
                     )
                     % (names.set_error, statement.name, temp_name),

--- a/templates/c/README.md
+++ b/templates/c/README.md
@@ -92,6 +92,31 @@ Native template tests must continue to use CMake as the build driver. User
 README files may show gcc / clang style one-command examples, but pytest should
 not grow a parallel handwritten host-compiler orchestration layer.
 
+
+### Native toolchain matrix discipline
+
+The native toolchain pytest matrix is the cross-implementation evidence gate for
+`c` generated artifacts. It uses the same shared semantic fixtures as the
+simulator and template-alignment tests, then swaps the backend to concrete
+compiler profiles. Keep profile names descriptive of the toolchain behavior,
+such as `linux-gcc-o2`, `linux-aarch64-gcc-o2`, `arm-none-eabi-gcc-o2`, or
+`linux-cppcheck`; do not put roadmap slice names into code identifiers, test
+ids, pydoc, or runtime messages.
+
+The public matrix has three levels:
+
+| Level | Examples | Meaning |
+| --- | --- | --- |
+| Runnable hosted / emulated profiles | Linux GCC/Clang optimization profiles, Linux 32-bit, AArch64+QEMU, macOS AppleClang, Windows MinGW/MSVC/clang-cl, sanitizer profiles | Compile, run the standalone harness for every shared semantic fixture, and compare public observations. |
+| Compile-only profiles | ARM bare-metal GCC and future licensed self-hosted toolchains | Compile each generated `machine.c`, `harness.c`, and a C++ header probe to non-empty object files; do not pretend this is runtime evidence. |
+| Analyze-only profiles | `cppcheck`, `clang-tidy` | Scan each generated runtime plus harness and keep report-only artifacts; tool crashes, parse failures, and missing reports are failures. |
+
+When extending the matrix, update the profile registry, workflow trigger list,
+artifact expectations, and this handbook together. Public GitHub-hosted profiles
+must fail on missing tools rather than silently skipping. Licensed or vendor
+profiles must remain manual/self-hosted and must not block public CI unless a
+runner is explicitly configured.
+
 ## Public integration surface
 
 `machine.h` is the public integration surface and should stay small, clear, and

--- a/templates/c/README.md.j2
+++ b/templates/c/README.md.j2
@@ -267,6 +267,29 @@ g++ -x c++ -std=c++98 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o mac
 g++ -x c++ -std=c++17 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o machine.o
 ```
 
+
+### Native Toolchain Evidence
+
+The repository-level native toolchain matrix builds representative generated
+`c` and `c_poll` artifacts through pytest with the same shared semantic fixture
+corpus used by the simulator and template-alignment tests. Public profiles cover
+hosted GCC / Clang optimization levels, 32-bit Linux, AArch64 with QEMU,
+AppleClang, Windows MinGW / MSVC / clang-cl, sanitizer runs, compile-only ARM
+bare-metal checks, and report-only static analysis such as `cppcheck` and
+`clang-tidy`.
+
+Those profiles are an engineering compatibility baseline, not a certification
+claim. Treat them as reproducible evidence that the generated public API and
+shared semantics survive common compiler families and build modes. Safety
+standards, coding-rule sign-off, board support packages, linker scripts, and
+project-specific warning policies remain the responsibility of the downstream
+integration process.
+
+When a native matrix job fails, inspect the uploaded `result.json`,
+`commands.json`, command logs, generated files, and harness files. Runnable
+profiles also include `observations.jsonl`; compile-only and analyze-only
+profiles intentionally do not produce runtime observations.
+
 ### Boundary Notes
 
 - The no-heap profile only removes generated heap allocation helpers. It is not

--- a/templates/c/README_zh.md
+++ b/templates/c/README_zh.md
@@ -70,6 +70,22 @@ Generated C runtime 可能被嵌入长期稳定运行的控制系统，因此内
 模板本机测试必须继续使用 CMake 作为构建驱动。用户 README 可以展示 gcc / clang 风格
 单命令示例，但 pytest 中不要新增一套手写宿主编译器调度层。
 
+
+
+### 原生工具链矩阵维护纪律
+
+原生工具链 pytest 矩阵是 `c` 生成产物的跨实现证据门禁。它使用与仿真器和模板对齐测试相同的共享语义用例，只是把后端换成具体编译器 profile。Profile 名称应描述工具链行为，例如 `linux-gcc-o2`、`linux-aarch64-gcc-o2`、`arm-none-eabi-gcc-o2` 或 `linux-cppcheck`；不要把路线代号、PR 名称或流程阶段写进代码标识符、测试 id、pydoc 或 runtime message。
+
+公开矩阵分三层：
+
+| 层级 | 示例 | 含义 |
+| --- | --- | --- |
+| 可运行宿主 / 仿真 profile | Linux GCC/Clang 优化等级、Linux 32 位、AArch64+QEMU、macOS AppleClang、Windows MinGW/MSVC/clang-cl、sanitizer profile | 编译 standalone harness，运行每个共享语义用例，并比较公开观察面。 |
+| compile-only profile | ARM bare-metal GCC 和后续专有自托管工具链 | 编译每个 generated `machine.c`、`harness.c` 和 C++ header probe 到非空目标文件；不要把它包装成 runtime evidence。 |
+| analyze-only profile | `cppcheck`、`clang-tidy` | 扫描每个 generated runtime 与 harness，并保留 report-only artifacts；工具崩溃、解析失败和报告缺失仍然是失败。 |
+
+扩展矩阵时，profile registry、workflow 触发列表、artifact 预期和本维护手册必须一起更新。公共 GitHub-hosted profile 缺工具时必须失败，不能静默 skip。授权或厂商 profile 应保持 manual / self-hosted，除非显式配置 runner，否则不得阻塞公共 CI。
+
 ## 公开集成面
 
 `machine.h` 是公开集成面，应保持小、清楚且稳定。它负责：

--- a/templates/c/README_zh.md.j2
+++ b/templates/c/README_zh.md.j2
@@ -248,6 +248,15 @@ g++ -x c++ -std=c++98 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o mac
 g++ -x c++ -std=c++17 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o machine.o
 ```
 
+
+### 原生工具链证据
+
+仓库级原生工具链矩阵会在 pytest 中生成代表性的 `c` 和 `c_poll` 产物，并复用仿真器与模板对齐测试使用的同一套共享语义用例。公开 profile 覆盖宿主 GCC / Clang 优化等级、Linux 32 位、AArch64 + QEMU、AppleClang、Windows MinGW / MSVC / clang-cl、sanitizer 运行、ARM bare-metal compile-only 检查，以及 `cppcheck`、`clang-tidy` 这类 report-only 静态分析。
+
+这些 profile 是工程兼容性基线，不是认证声明。它们只能作为可复现证据，说明 generated public API 和共享语义在常见编译器族与构建模式下保持稳定。安全标准、编码规则签核、板级支持包、链接脚本和项目自己的 warning policy 仍然属于下游集成流程。
+
+如果 native matrix job 失败，应检查上传的 `result.json`、`commands.json`、命令日志、生成文件和 harness 文件。可运行 profile 还会包含 `observations.jsonl`；compile-only 和 analyze-only profile 按设计不会产生运行时观察记录。
+
 ### 边界说明
 
 - 无堆剖面只移除生成的堆分配辅助函数，不等于严格 freestanding 保证；生成运行时仍可能使用

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -301,6 +301,12 @@ static int _{{ machine_class_name(model) }}_reset_vars(
 {{ render_c_reset_vars_body(model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
+static int _{{ machine_class_name(model) }}_is_stoppable_state(int state_id);
+
+static int _{{ machine_class_name(model) }}_is_self_transition(
+    int state_id,
+    int transition_id);
+
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_transition(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -988,13 +994,46 @@ static int {{ select_transition_state_name(state) }}(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int validate_stoppable)
+    int validate_stoppable,
+    int is_validation_mode)
 {
     (void)machine;
     (void)context;
     (void)event_set;
     (void)validate_stoppable;
+    (void)is_validation_mode;
 {% if state.transitions_from | list -%}
+    if (validate_stoppable && is_validation_mode && context->stack_size > 0u && !_{{ machine_class_name(model) }}_is_stoppable_state(context->stack[context->stack_size - 1u].state_id)) {
+        int enabled_count = 0;
+        int enabled_transition_id = -1;
+{% for transition in state.transitions_from -%}
+{% set event_condition -%}
+{% if transition.event is not none -%}
+_{{ machine_class_name(model) }}_event_set_has(event_set, {{ all_events.items.index(transition.event.path_name) }})
+{% else -%}
+1
+{% endif -%}
+{%- endset %}
+        if ({{ event_condition | trim | replace('\n', ' ') }}) {
+{% if transition.guard is not none %}
+            int guard_result = 0;
+            if ({{ transition_guard_method_name(state, loop.index) }}(machine, &context->vars, &guard_result) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return -1;
+            }
+            if (guard_result) {
+                ++enabled_count;
+                enabled_transition_id = {{ normal_transition_id(state, loop.index) }};
+            }
+{% else %}
+            ++enabled_count;
+            enabled_transition_id = {{ normal_transition_id(state, loop.index) }};
+{% endif %}
+        }
+{% endfor -%}
+        if (enabled_count == 1) {
+            return enabled_transition_id;
+        }
+    }
 {% for transition in state.transitions_from -%}
 {% set event_condition -%}
 {% if transition.event is not none -%}
@@ -1005,17 +1044,23 @@ _{{ machine_class_name(model) }}_event_set_has(event_set, {{ all_events.items.in
 {%- endset %}
 {% set branch_body -%}
 if (validate_stoppable) {
-    int is_valid = _{{ machine_class_name(model) }}_validate_transition(
-        machine,
-        context,
-        {{ normal_transition_id(state, loop.index) }},
-        event_set);
-    if (!is_valid) {
-        if (machine != NULL && machine->last_error[0] != '\0') {
-            return -1;
-        }
-    } else {
+    if (is_validation_mode && _{{ machine_class_name(model) }}_is_self_transition(
+            context->stack[context->stack_size - 1u].state_id,
+            {{ normal_transition_id(state, loop.index) }})) {
         return {{ normal_transition_id(state, loop.index) }};
+    } else {
+        int is_valid = _{{ machine_class_name(model) }}_validate_transition(
+            machine,
+            context,
+            {{ normal_transition_id(state, loop.index) }},
+            event_set);
+        if (!is_valid) {
+            if (machine != NULL && machine->last_error[0] != '\0') {
+                return -1;
+            }
+        } else {
+            return {{ normal_transition_id(state, loop.index) }};
+        }
     }
 } else {
     return {{ normal_transition_id(state, loop.index) }};
@@ -1552,6 +1597,14 @@ static int _{{ machine_class_name(model) }}_is_stoppable_state(int state_id)
     return state_info->is_leaf && !state_info->is_pseudo;
 }
 
+static int _{{ machine_class_name(model) }}_is_self_transition(
+    int state_id,
+    int transition_id)
+{
+    const _{{ machine_class_name(model) }}TransitionInfo *transition = &_{{ machine_class_name(model) }}_transitions[transition_id];
+    return !transition->to_exit && transition->target_state_id == state_id;
+}
+
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_transition(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1576,7 +1629,8 @@ static int _{{ machine_class_name(model) }}_select_transition(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int validate_stoppable)
+    int validate_stoppable,
+    int is_validation_mode)
 {
     if (context->stack_size == 0u) {
         return -1;
@@ -1589,7 +1643,8 @@ static int _{{ machine_class_name(model) }}_select_transition(
                 machine,
                 context,
                 event_set,
-                validate_stoppable);
+                validate_stoppable,
+                is_validation_mode);
 {% endfor %}
         default:
             return -1;
@@ -1821,7 +1876,8 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
                 machine,
                 context,
                 event_set,
-                1);
+                1,
+                is_validation_mode);
             if (transition_id < 0 && machine != NULL && machine->last_error[0] != '\0') {
                 return {{ machine_macro_name(model) }}_FAILURE;
             }
@@ -1867,7 +1923,8 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
                 machine,
                 context,
                 event_set,
-                validate_post_child_exit);
+                validate_post_child_exit,
+                is_validation_mode);
             if (transition_id < 0 && machine != NULL && machine->last_error[0] != '\0') {
                 return {{ machine_macro_name(model) }}_FAILURE;
             }

--- a/templates/c/machine.h.j2
+++ b/templates/c/machine.h.j2
@@ -29,7 +29,7 @@ typedef __int64 PYFCSTM_GENERATED_INT64;
 #if defined(__SIZEOF_LONG__) && (__SIZEOF_LONG__ >= 8)
 typedef long PYFCSTM_GENERATED_INT64;
 #elif defined(__GNUC__)
-typedef __extension__ long long PYFCSTM_GENERATED_INT64;
+typedef long long PYFCSTM_GENERATED_INT64;
 #else
 typedef long PYFCSTM_GENERATED_INT64;
 #endif

--- a/templates/c_poll/README.md
+++ b/templates/c_poll/README.md
@@ -96,6 +96,31 @@ Native template tests must continue to use CMake as the build driver. User
 README files may show gcc / clang style one-command examples, but pytest should
 not grow a parallel handwritten host-compiler orchestration layer.
 
+
+### Native toolchain matrix discipline
+
+The native toolchain pytest matrix is the cross-implementation evidence gate for
+`c_poll` generated artifacts. It uses the same shared semantic fixtures as the
+simulator and template-alignment tests, then swaps the backend to concrete
+compiler profiles. Keep profile names descriptive of the toolchain behavior,
+such as `linux-gcc-o2`, `linux-aarch64-gcc-o2`, `arm-none-eabi-gcc-o2`, or
+`linux-cppcheck`; do not put roadmap slice names into code identifiers, test
+ids, pydoc, or runtime messages.
+
+The public matrix has three levels:
+
+| Level | Examples | Meaning |
+| --- | --- | --- |
+| Runnable hosted / emulated profiles | Linux GCC/Clang optimization profiles, Linux 32-bit, AArch64+QEMU, macOS AppleClang, Windows MinGW/MSVC/clang-cl, sanitizer profiles | Compile, run the standalone harness for every shared semantic fixture, and compare public observations including event-check behavior. |
+| Compile-only profiles | ARM bare-metal GCC and future licensed self-hosted toolchains | Compile each generated `machine.c`, `harness.c`, and a C++ header probe to non-empty object files; do not pretend this is runtime evidence. |
+| Analyze-only profiles | `cppcheck`, `clang-tidy` | Scan each generated runtime plus harness and keep report-only artifacts; tool crashes, parse failures, and missing reports are failures. |
+
+When extending the matrix, update the profile registry, workflow trigger list,
+artifact expectations, and this handbook together. Public GitHub-hosted profiles
+must fail on missing tools rather than silently skipping. Licensed or vendor
+profiles must remain manual/self-hosted and must not block public CI unless a
+runner is explicitly configured.
+
 ## Public integration surface
 
 `machine.h` owns the stable integration contract:

--- a/templates/c_poll/README.md.j2
+++ b/templates/c_poll/README.md.j2
@@ -294,6 +294,29 @@ g++ -x c++ -std=c++98 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o mac
 g++ -x c++ -std=c++17 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o machine.o
 ```
 
+
+### Native Toolchain Evidence
+
+The repository-level native toolchain matrix builds representative generated
+`c` and `c_poll` artifacts through pytest with the same shared semantic fixture
+corpus used by the simulator and template-alignment tests. Public profiles cover
+hosted GCC / Clang optimization levels, 32-bit Linux, AArch64 with QEMU,
+AppleClang, Windows MinGW / MSVC / clang-cl, sanitizer runs, compile-only ARM
+bare-metal checks, and report-only static analysis such as `cppcheck` and
+`clang-tidy`.
+
+Those profiles are an engineering compatibility baseline, not a certification
+claim. Treat them as reproducible evidence that the generated public API and
+shared semantics survive common compiler families and build modes. Safety
+standards, coding-rule sign-off, board support packages, linker scripts, and
+project-specific warning policies remain the responsibility of the downstream
+integration process.
+
+When a native matrix job fails, inspect the uploaded `result.json`,
+`commands.json`, command logs, generated files, and harness files. Runnable
+profiles also include `observations.jsonl`; compile-only and analyze-only
+profiles intentionally do not produce runtime observations.
+
 ### Boundary Notes
 
 - The no-heap profile only removes generated heap allocation helpers. It is not

--- a/templates/c_poll/README_zh.md
+++ b/templates/c_poll/README_zh.md
@@ -70,6 +70,22 @@ Generated `c_poll` runtime 可能在控制应用中长期运行。因此资源 o
 模板本机测试必须继续使用 CMake 作为构建驱动。用户 README 可以展示 gcc / clang 风格
 单命令示例，但 pytest 中不要新增一套手写宿主编译器调度层。
 
+
+
+### 原生工具链矩阵维护纪律
+
+原生工具链 pytest 矩阵是 `c` 生成产物的跨实现证据门禁。它使用与仿真器和模板对齐测试相同的共享语义用例，只是把后端换成具体编译器 profile。Profile 名称应描述工具链行为，例如 `linux-gcc-o2`、`linux-aarch64-gcc-o2`、`arm-none-eabi-gcc-o2` 或 `linux-cppcheck`；不要把路线代号、PR 名称或流程阶段写进代码标识符、测试 id、pydoc 或 runtime message。
+
+公开矩阵分三层：
+
+| 层级 | 示例 | 含义 |
+| --- | --- | --- |
+| 可运行宿主 / 仿真 profile | Linux GCC/Clang 优化等级、Linux 32 位、AArch64+QEMU、macOS AppleClang、Windows MinGW/MSVC/clang-cl、sanitizer profile | 编译 standalone harness，运行每个共享语义用例，并比较公开观察面。 |
+| compile-only profile | ARM bare-metal GCC 和后续专有自托管工具链 | 编译每个 generated `machine.c`、`harness.c` 和 C++ header probe 到非空目标文件；不要把它包装成 runtime evidence。 |
+| analyze-only profile | `cppcheck`、`clang-tidy` | 扫描每个 generated runtime 与 harness，并保留 report-only artifacts；工具崩溃、解析失败和报告缺失仍然是失败。 |
+
+扩展矩阵时，profile registry、workflow 触发列表、artifact 预期和本维护手册必须一起更新。公共 GitHub-hosted profile 缺工具时必须失败，不能静默 skip。授权或厂商 profile 应保持 manual / self-hosted，除非显式配置 runner，否则不得阻塞公共 CI。
+
 ## 公开集成面
 
 `machine.h` 负责稳定集成契约：

--- a/templates/c_poll/README_zh.md.j2
+++ b/templates/c_poll/README_zh.md.j2
@@ -267,6 +267,15 @@ g++ -x c++ -std=c++98 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o mac
 g++ -x c++ -std=c++17 -Wall -Wextra -Werror -pedantic-errors -c machine.c -o machine.o
 ```
 
+
+### 原生工具链证据
+
+仓库级原生工具链矩阵会在 pytest 中生成代表性的 `c` 和 `c_poll` 产物，并复用仿真器与模板对齐测试使用的同一套共享语义用例。公开 profile 覆盖宿主 GCC / Clang 优化等级、Linux 32 位、AArch64 + QEMU、AppleClang、Windows MinGW / MSVC / clang-cl、sanitizer 运行、ARM bare-metal compile-only 检查，以及 `cppcheck`、`clang-tidy` 这类 report-only 静态分析。
+
+这些 profile 是工程兼容性基线，不是认证声明。它们只能作为可复现证据，说明 generated public API 和共享语义在常见编译器族与构建模式下保持稳定。安全标准、编码规则签核、板级支持包、链接脚本和项目自己的 warning policy 仍然属于下游集成流程。
+
+如果 native matrix job 失败，应检查上传的 `result.json`、`commands.json`、命令日志、生成文件和 harness 文件。可运行 profile 还会包含 `observations.jsonl`；compile-only 和 analyze-only profile 按设计不会产生运行时观察记录。
+
 ### 边界说明
 
 - 无堆剖面只移除生成的堆分配辅助函数，不等于严格 freestanding 保证；生成运行时仍可能使用

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -398,6 +398,12 @@ static int _{{ machine_class_name(model) }}_reset_vars(
 {{ render_c_reset_vars_body(model.defines, machine_class_name(model), machine_macro_name(model)) }}
 }
 
+static int _{{ machine_class_name(model) }}_is_stoppable_state(int state_id);
+
+static int _{{ machine_class_name(model) }}_is_self_transition(
+    int state_id,
+    int transition_id);
+
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_transition(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1087,13 +1093,46 @@ static int {{ select_transition_state_name(state) }}(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int validate_stoppable)
+    int validate_stoppable,
+    int is_validation_mode)
 {
     (void)machine;
     (void)context;
     (void)event_set;
     (void)validate_stoppable;
+    (void)is_validation_mode;
 {% if state.transitions_from | list -%}
+    if (validate_stoppable && is_validation_mode && context->stack_size > 0u && !_{{ machine_class_name(model) }}_is_stoppable_state(context->stack[context->stack_size - 1u].state_id)) {
+        int enabled_count = 0;
+        int enabled_transition_id = -1;
+{% for transition in state.transitions_from -%}
+{% set event_condition -%}
+{% if transition.event is not none -%}
+_{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ all_events.items.index(transition.event.path_name) }})
+{% else -%}
+1
+{% endif -%}
+{%- endset %}
+        if ({{ event_condition | trim | replace('\n', ' ') }}) {
+{% if transition.guard is not none %}
+            int guard_result = 0;
+            if ({{ transition_guard_method_name(state, loop.index) }}(machine, &context->vars, &guard_result) != {{ machine_macro_name(model) }}_SUCCESS) {
+                return -1;
+            }
+            if (guard_result) {
+                ++enabled_count;
+                enabled_transition_id = {{ normal_transition_id(state, loop.index) }};
+            }
+{% else %}
+            ++enabled_count;
+            enabled_transition_id = {{ normal_transition_id(state, loop.index) }};
+{% endif %}
+        }
+{% endfor -%}
+        if (enabled_count == 1) {
+            return enabled_transition_id;
+        }
+    }
 {% for transition in state.transitions_from -%}
 {% set event_condition -%}
 {% if transition.event is not none -%}
@@ -1104,17 +1143,23 @@ _{{ machine_class_name(model) }}_event_set_has(machine, context, event_set, {{ a
 {%- endset %}
 {% set branch_body -%}
 if (validate_stoppable) {
-    int is_valid = _{{ machine_class_name(model) }}_validate_transition(
-        machine,
-        context,
-        {{ normal_transition_id(state, loop.index) }},
-        event_set);
-    if (!is_valid) {
-        if (machine != NULL && machine->last_error[0] != '\0') {
-            return -1;
-        }
-    } else {
+    if (is_validation_mode && _{{ machine_class_name(model) }}_is_self_transition(
+            context->stack[context->stack_size - 1u].state_id,
+            {{ normal_transition_id(state, loop.index) }})) {
         return {{ normal_transition_id(state, loop.index) }};
+    } else {
+        int is_valid = _{{ machine_class_name(model) }}_validate_transition(
+            machine,
+            context,
+            {{ normal_transition_id(state, loop.index) }},
+            event_set);
+        if (!is_valid) {
+            if (machine != NULL && machine->last_error[0] != '\0') {
+                return -1;
+            }
+        } else {
+            return {{ normal_transition_id(state, loop.index) }};
+        }
     }
 } else {
     return {{ normal_transition_id(state, loop.index) }};
@@ -1606,6 +1651,14 @@ static int _{{ machine_class_name(model) }}_is_stoppable_state(int state_id)
     return state_info->is_leaf && !state_info->is_pseudo;
 }
 
+static int _{{ machine_class_name(model) }}_is_self_transition(
+    int state_id,
+    int transition_id)
+{
+    const _{{ machine_class_name(model) }}TransitionInfo *transition = &_{{ machine_class_name(model) }}_transitions[transition_id];
+    return !transition->to_exit && transition->target_state_id == state_id;
+}
+
 static PYFCSTM_GENERATED_UNUSED int _{{ machine_class_name(model) }}_validate_transition(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1616,7 +1669,8 @@ static int _{{ machine_class_name(model) }}_select_transition(
     {{ machine_class_name(model) }} *machine,
     const _{{ machine_class_name(model) }}RuntimeContext *context,
     const _{{ machine_class_name(model) }}EventSet *event_set,
-    int validate_stoppable)
+    int validate_stoppable,
+    int is_validation_mode)
 {
     if (context->stack_size == 0u) {
         return -1;
@@ -1629,7 +1683,8 @@ static int _{{ machine_class_name(model) }}_select_transition(
                 machine,
                 context,
                 event_set,
-                validate_stoppable);
+                validate_stoppable,
+                is_validation_mode);
 {% endfor %}
         default:
             return -1;
@@ -1861,7 +1916,8 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
                 machine,
                 context,
                 event_set,
-                1);
+                1,
+                is_validation_mode);
             if (transition_id < 0 && machine != NULL && machine->last_error[0] != '\0') {
                 return {{ machine_macro_name(model) }}_FAILURE;
             }
@@ -1907,7 +1963,8 @@ static int _{{ machine_class_name(model) }}_run_cycle_on_context(
                 machine,
                 context,
                 event_set,
-                validate_post_child_exit);
+                validate_post_child_exit,
+                is_validation_mode);
             if (transition_id < 0 && machine != NULL && machine->last_error[0] != '\0') {
                 return {{ machine_macro_name(model) }}_FAILURE;
             }

--- a/templates/c_poll/machine.h.j2
+++ b/templates/c_poll/machine.h.j2
@@ -29,7 +29,7 @@ typedef __int64 PYFCSTM_GENERATED_INT64;
 #if defined(__SIZEOF_LONG__) && (__SIZEOF_LONG__ >= 8)
 typedef long PYFCSTM_GENERATED_INT64;
 #elif defined(__GNUC__)
-typedef __extension__ long long PYFCSTM_GENERATED_INT64;
+typedef long long PYFCSTM_GENERATED_INT64;
 #else
 typedef long PYFCSTM_GENERATED_INT64;
 #endif

--- a/test/render/test_c_runtime.py
+++ b/test/render/test_c_runtime.py
@@ -1,0 +1,72 @@
+import pytest
+
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.render.c_runtime import (
+    render_c_action_body,
+    render_c_condition_body,
+    render_c_reset_vars_body,
+)
+
+
+def _model_from_dsl(dsl_code):
+    ast_node = parse_with_grammar_entry(dsl_code, entry_name="state_machine_dsl")
+    return parse_dsl_node_to_state_machine(ast_node)
+
+
+@pytest.mark.unittest
+class TestCRuntimeRendering:
+    def test_static_zero_division_initializer_keeps_generated_c_compileable(self):
+        model = _model_from_dsl(
+            """
+            def float recovered = 1.0 / 0.0;
+            state Root {
+                state A;
+                [*] -> A;
+            }
+            """
+        )
+
+        body = render_c_reset_vars_body(model.defines, "RootMachine", "ROOT_MACHINE")
+
+        assert "float division by zero" in body
+        assert "return ROOT_MACHINE_FAILURE;" in body
+        assert "/ (0.0)" not in body
+        assert "scope->recovered = 0.0;" in body
+
+    def test_static_zero_modulo_operation_keeps_generated_c_compileable(self):
+        statements = parse_with_grammar_entry(
+            """
+            counter = counter % 0;
+            """,
+            entry_name="operational_statement_set",
+        )
+
+        body = render_c_action_body(
+            statements,
+            {"counter": "int"},
+            "RootMachine",
+            "ROOT_MACHINE",
+        )
+
+        assert "integer modulo by zero" in body
+        assert "return ROOT_MACHINE_FAILURE;" in body
+        assert "% (0)" not in body
+        assert "scope->counter = 0;" in body
+
+    def test_dynamic_zero_division_guard_keeps_runtime_denominator_check(self):
+        expr = parse_with_grammar_entry(
+            "counter / divisor > 0",
+            entry_name="cond_expression",
+        )
+
+        body = render_c_condition_body(
+            expr,
+            {"counter": "int", "divisor": "int"},
+            "RootMachine",
+            "ROOT_MACHINE",
+            "transition guard",
+        )
+
+        assert "if ((scope->divisor) == 0)" in body
+        assert "((double)(scope->counter)) / (scope->divisor)" in body

--- a/test/template/c/test_native_toolchain_alignment.py
+++ b/test/template/c/test_native_toolchain_alignment.py
@@ -24,4 +24,7 @@ def test_generated_c_native_toolchain_alignment(
     )
 
     assert result["status"] == "passed", result["message"]
-    assert result["classification"] == "passed"
+    expected_classification = (
+        "analysis_report_only" if result.get("report_only") else "passed"
+    )
+    assert result["classification"] == expected_classification

--- a/test/template/c_poll/test_native_toolchain_alignment.py
+++ b/test/template/c_poll/test_native_toolchain_alignment.py
@@ -24,4 +24,7 @@ def test_generated_c_poll_native_toolchain_alignment(
     )
 
     assert result["status"] == "passed", result["message"]
-    assert result["classification"] == "passed"
+    expected_classification = (
+        "analysis_report_only" if result.get("report_only") else "passed"
+    )
+    assert result["classification"] == expected_classification

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -293,6 +293,7 @@ def _assert_rendered_template_contracts(rendered_templates):
             _read_text(rendered_templates[name] / "README_zh.md"),
         ]:
             _assert_source_context_terms(generated_text)
+        assert "__extension__ long long" not in header_source
         _assert_c_runtime_includes_are_self_contained(header_source)
         _assert_c_runtime_includes_are_self_contained(runtime_source)
 

--- a/test/testings/native_toolchain_alignment/__init__.py
+++ b/test/testings/native_toolchain_alignment/__init__.py
@@ -11,14 +11,27 @@ small module map for tests and reviewers.
    * - Module
      - Responsibility
    * - ``profiles``
-     - Explicit opt-in switch handling and native profile registry.
+     - Explicit opt-in switch handling, public profile registry, manual
+       self-hosted profile registry, and build-mode constants.
    * - ``harness``
      - Case-specific C harness and CMake project rendering.
    * - ``runner``
-     - Configure/build/run orchestration and observation checks.
+     - Configure/build/run, compile-only, analyze-only, and observation checks.
    * - ``report``
      - ``commands.json``, ``result.json``, and ``observations.jsonl`` schema
        helpers.
+
+.. list-table:: Runner families
+   :header-rows: 1
+
+   * - Family
+     - Profile examples
+   * - Runnable hosted / emulated
+     - ``linux-gcc-o2``, ``linux-aarch64-gcc-o2``, ``windows-msvc-o2``.
+   * - Compile only
+     - ``arm-none-eabi-gcc-o2`` and manual licensed-toolchain entries.
+   * - Analyze only
+     - ``linux-cppcheck`` and ``linux-clang-tidy``.
 
 Example::
 
@@ -29,12 +42,19 @@ Example::
 
 from .profiles import (
     ARTIFACT_DIR_ENV_VAR,
+    BUILD_MODE_ANALYZE_ONLY,
+    BUILD_MODE_CMAKE_RUN,
+    BUILD_MODE_COMPILE_ONLY,
+    BUILD_MODE_CROSS_QEMU_RUN,
+    BUILD_MODE_SELF_HOSTED_COMPILE,
     PROFILE_ENV_VAR,
     RUN_ENV_VAR,
     ProfileSelectionError,
     ToolchainMissingError,
     ToolchainProfile,
     get_profile,
+    iter_all_profiles,
+    iter_manual_profiles,
     iter_profiles,
     native_toolchain_enabled,
     resolve_selected_profile,
@@ -43,6 +63,11 @@ from .runner import NativeToolchainExecutionError, run_native_toolchain_case
 
 __all__ = [
     "ARTIFACT_DIR_ENV_VAR",
+    "BUILD_MODE_ANALYZE_ONLY",
+    "BUILD_MODE_CMAKE_RUN",
+    "BUILD_MODE_COMPILE_ONLY",
+    "BUILD_MODE_CROSS_QEMU_RUN",
+    "BUILD_MODE_SELF_HOSTED_COMPILE",
     "PROFILE_ENV_VAR",
     "RUN_ENV_VAR",
     "NativeToolchainExecutionError",
@@ -50,6 +75,8 @@ __all__ = [
     "ToolchainMissingError",
     "ToolchainProfile",
     "get_profile",
+    "iter_all_profiles",
+    "iter_manual_profiles",
     "iter_profiles",
     "native_toolchain_enabled",
     "resolve_selected_profile",

--- a/test/testings/native_toolchain_alignment/harness_templates/CMakeLists.txt.j2
+++ b/test/testings/native_toolchain_alignment/harness_templates/CMakeLists.txt.j2
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(pyfcstm_native_toolchain_harness C CXX)
 
-set(CMAKE_C_STANDARD 99)
+set(PYFCSTM_NATIVE_C_STANDARD "99" CACHE STRING "C standard used for the native harness")
+set(PYFCSTM_NATIVE_CXX_STANDARD "98" CACHE STRING "C++ standard used for the header probe")
+
+set(CMAKE_C_STANDARD ${PYFCSTM_NATIVE_C_STANDARD})
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
-set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD ${PYFCSTM_NATIVE_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/test/testings/native_toolchain_alignment/profiles.py
+++ b/test/testings/native_toolchain_alignment/profiles.py
@@ -1,35 +1,67 @@
 """
 Native toolchain profile registry for native toolchain pytest alignment.
 
-Profiles describe how pytest should configure, build, and run generated C-family
-artifacts under a concrete native toolchain. The initial registry deliberately starts with two
-public Linux CMake profiles and keeps the registry small so later matrix work can
-extend the profiles without changing the selection contract.
+Profiles describe how pytest should configure, build, run, or analyze generated
+C-family artifacts under concrete host, cross, sanitizer, compile-only, and
+static-analysis toolchains. The registry is test-local and intentionally keeps
+all toolchain knowledge outside production APIs: tests select exactly one
+profile through the environment, then the runner applies that profile to every
+shared semantic fixture.
 
 The module contains:
 
 * :class:`ToolchainProfile` - Immutable profile configuration.
 * :class:`ProfileSelectionError` - Raised for missing or unknown profile names.
-* :class:`ToolchainMissingError` - Raised when a public profile lacks a tool.
-* :func:`native_toolchain_enabled` - Check the pytest option / environment flag.
+* :class:`ToolchainMissingError` - Raised when a selected profile lacks tools.
+* :func:`iter_profiles` - Iterate public and manual profile definitions.
 * :func:`resolve_selected_profile` - Resolve the selected profile by name.
+
+.. list-table:: Profile families
+   :header-rows: 1
+
+   * - Family
+     - Representative profile
+     - Runner behavior
+   * - Hosted CMake run
+     - ``linux-gcc-o2``
+     - Configure, build, execute, and compare public observations.
+   * - Cross run
+     - ``linux-aarch64-gcc-o2``
+     - Cross-compile and execute through a configured emulator prefix.
+   * - Compile only
+     - ``arm-none-eabi-gcc-o2``
+     - Compile generated runtime, harness, and C++ header probe without linking.
+   * - Static analysis
+     - ``linux-cppcheck``
+     - Scan generated runtime plus harness and store a report-only artifact.
+   * - Manual self-hosted
+     - ``manual-armclang-compile``
+     - Provide non-public entry points for licensed or self-hosted toolchains.
 
 Example::
 
     >>> profile = get_profile("linux-gcc-o2")
     >>> profile.optimization
     '-O2'
+    >>> get_profile("linux-cppcheck").build_mode
+    'analyze-only'
 """
 
 import os
 import shutil
 from dataclasses import dataclass, field
-from typing import Iterable, List, Optional, Sequence
+from typing import Iterable, List, Mapping, Optional, Sequence
 
 RUN_ENV_VAR = "PYFCSTM_RUN_NATIVE_TOOLCHAIN"
 PROFILE_ENV_VAR = "PYFCSTM_NATIVE_TOOLCHAIN_PROFILE"
 ARTIFACT_DIR_ENV_VAR = "PYFCSTM_NATIVE_TOOLCHAIN_ARTIFACT_DIR"
 _ENABLE_VALUES = {"1", "true", "yes", "on"}
+
+BUILD_MODE_CMAKE_RUN = "cmake-run"
+BUILD_MODE_CROSS_QEMU_RUN = "cross-qemu-run"
+BUILD_MODE_COMPILE_ONLY = "compile-only"
+BUILD_MODE_ANALYZE_ONLY = "analyze-only"
+BUILD_MODE_SELF_HOSTED_COMPILE = "self-hosted-compile"
 
 
 class ProfileSelectionError(ValueError):
@@ -48,7 +80,7 @@ class ProfileSelectionError(ValueError):
 
 class ToolchainMissingError(RuntimeError):
     """
-    Raised when a public native toolchain profile cannot find required tools.
+    Raised when a native toolchain profile cannot find required tools.
 
     :param args: Error message arguments accepted by :class:`RuntimeError`.
     :type args: object
@@ -65,17 +97,24 @@ class ToolchainProfile:
     """
     Native toolchain profile used by native toolchain pytest alignment.
 
+    A profile is a concrete toolchain configuration rather than a production
+    API. Runnable profiles compile and execute the generated harness;
+    compile-only profiles stop after non-empty object files are produced;
+    analyze-only profiles scan the generated runtime and harness while writing a
+    report artifact.
+
     :param name: Unique profile name, such as ``"linux-gcc-o2"``.
     :type name: str
-    :param build_mode: Build mode, currently ``"cmake-run"`` for native run profiles.
+    :param build_mode: Build mode, such as ``"cmake-run"`` or
+        ``"compile-only"``.
     :type build_mode: str
     :param cc: C compiler command in argv-list form.
     :type cc: typing.Sequence[str]
     :param cxx: C++ compiler command in argv-list form.
     :type cxx: typing.Sequence[str]
-    :param c_flags: Extra C flags passed through CMake.
+    :param c_flags: Extra C flags passed to the C compiler.
     :type c_flags: typing.Sequence[str]
-    :param cxx_flags: Extra C++ flags passed through CMake.
+    :param cxx_flags: Extra C++ flags passed to the C++ compiler.
     :type cxx_flags: typing.Sequence[str]
     :param link_flags: Extra link flags, defaults to an empty sequence.
     :type link_flags: typing.Sequence[str], optional
@@ -85,11 +124,29 @@ class ToolchainProfile:
         missing.
     :type missing_tool_message: str
     :param optimization: Optimization flag name.
-    :type optimization: str
-    :param public_required: Whether missing tools are hard failures.
+    :type optimization: str, optional
+    :param public_required: Whether missing tools are hard failures. Public
+        profiles use ``True``; licensed self-hosted placeholders use ``False``.
     :type public_required: bool
     :param timeout_seconds: Per-command timeout.
     :type timeout_seconds: int
+    :param cmake_generator: Optional CMake generator name.
+    :type cmake_generator: str, optional
+    :param cmake_args: Additional CMake configure arguments.
+    :type cmake_args: typing.Sequence[str], optional
+    :param run_prefix: Command prefix used to execute a cross-built binary.
+    :type run_prefix: typing.Sequence[str], optional
+    :param run_environment: Environment variables added while running a binary.
+    :type run_environment: typing.Mapping[str, str], optional
+    :param analysis_tool: Static-analysis command in argv-list form.
+    :type analysis_tool: typing.Sequence[str], optional
+    :param analysis_args: Additional static-analysis arguments.
+    :type analysis_args: typing.Sequence[str], optional
+    :param analysis_ruleset: Human-readable static-analysis ruleset name.
+    :type analysis_ruleset: str, optional
+    :param report_only: Whether analyzer findings are recorded without turning
+        ordinary diagnostics into failures.
+    :type report_only: bool
 
     Example::
 
@@ -113,6 +170,14 @@ class ToolchainProfile:
     optimization: Optional[str] = None
     public_required: bool = True
     timeout_seconds: int = 240
+    cmake_generator: Optional[str] = None
+    cmake_args: Sequence[str] = field(default_factory=tuple)
+    run_prefix: Sequence[str] = field(default_factory=tuple)
+    run_environment: Mapping[str, str] = field(default_factory=dict)
+    analysis_tool: Sequence[str] = field(default_factory=tuple)
+    analysis_args: Sequence[str] = field(default_factory=tuple)
+    analysis_ruleset: Optional[str] = None
+    report_only: bool = False
 
     @property
     def compiler(self) -> Optional[str]:
@@ -134,42 +199,289 @@ class ToolchainProfile:
         """
         Return the primary tool used in reports.
 
-        :return: Compiler name for native CMake-run profiles.
+        :return: Analyzer command, compiler command, or profile name.
         :rtype: str
 
         Example::
 
             >>> get_profile("linux-clang-o2").primary_tool
             'clang'
+            >>> get_profile("linux-cppcheck").primary_tool
+            'cppcheck'
         """
+        if self.analysis_tool:
+            return self.analysis_tool[0]
         return self.compiler or self.name
 
 
-_PUBLIC_PROFILES = (
-    ToolchainProfile(
-        name="linux-gcc-o2",
-        build_mode="cmake-run",
-        cc=("gcc",),
-        cxx=("g++",),
-        c_flags=("-std=c99", "-O2", "-Wall", "-Wextra", "-pedantic"),
-        cxx_flags=("-std=c++98", "-O2", "-Wall", "-Wextra", "-pedantic"),
+def _host_profile(
+    name: str,
+    cc: str,
+    cxx: str,
+    optimization: str,
+    extra_c_flags: Sequence[str] = (),
+    extra_cxx_flags: Sequence[str] = (),
+    link_flags: Sequence[str] = (),
+    required_binaries: Optional[Sequence[str]] = None,
+    cmake_generator: Optional[str] = None,
+    cmake_args: Sequence[str] = (),
+    run_prefix: Sequence[str] = (),
+    run_environment: Optional[Mapping[str, str]] = None,
+    timeout_seconds: int = 240,
+) -> ToolchainProfile:
+    required = tuple(required_binaries or ("cmake", cc, cxx))
+    c_flags = ("-std=c99", optimization, "-Wall", "-Wextra", "-pedantic")
+    cxx_flags = ("-std=c++98", optimization, "-Wall", "-Wextra", "-pedantic")
+    return ToolchainProfile(
+        name=name,
+        build_mode=BUILD_MODE_CMAKE_RUN
+        if not run_prefix
+        else BUILD_MODE_CROSS_QEMU_RUN,
+        cc=(cc,),
+        cxx=(cxx,),
+        c_flags=c_flags + tuple(extra_c_flags),
+        cxx_flags=cxx_flags + tuple(extra_cxx_flags),
+        link_flags=tuple(link_flags),
+        required_binaries=required,
+        missing_tool_message="Install %s before running %s."
+        % (", ".join(required), name),
+        optimization=optimization,
+        timeout_seconds=timeout_seconds,
+        cmake_generator=cmake_generator,
+        cmake_args=tuple(cmake_args),
+        run_prefix=tuple(run_prefix),
+        run_environment=dict(run_environment or {}),
+    )
+
+
+def _msvc_profile(name: str, cc: str, cxx: str, optimization: str) -> ToolchainProfile:
+    return ToolchainProfile(
+        name=name,
+        build_mode=BUILD_MODE_CMAKE_RUN,
+        cc=(cc,),
+        cxx=(cxx,),
+        c_flags=(optimization, "/W4"),
+        cxx_flags=(optimization, "/W4", "/TP", "/permissive-"),
+        required_binaries=("cmake", "ninja", cc, cxx),
+        missing_tool_message=(
+            "Install CMake, Ninja, and the Visual Studio C/C++ tools before running %s."
+            % name
+        ),
+        optimization=optimization,
+        timeout_seconds=300,
+        cmake_generator="Ninja",
+        cmake_args=("-DPYFCSTM_NATIVE_C_STANDARD=11",),
+    )
+
+
+def _compile_only_profile(
+    name: str, cc: str, cxx: str, optimization: str, required_binaries: Sequence[str]
+) -> ToolchainProfile:
+    return ToolchainProfile(
+        name=name,
+        build_mode=BUILD_MODE_COMPILE_ONLY,
+        cc=(cc,),
+        cxx=(cxx,),
+        c_flags=("-std=c99", optimization, "-Wall", "-Wextra", "-pedantic"),
+        cxx_flags=("-std=c++98", optimization, "-Wall", "-Wextra", "-pedantic"),
+        required_binaries=tuple(required_binaries),
+        missing_tool_message="Install %s before running %s."
+        % (
+            ", ".join(required_binaries),
+            name,
+        ),
+        optimization=optimization,
+        timeout_seconds=240,
+    )
+
+
+def _analysis_profile(
+    name: str,
+    tool: str,
+    args: Sequence[str],
+    ruleset: str,
+    required_binaries: Sequence[str],
+) -> ToolchainProfile:
+    return ToolchainProfile(
+        name=name,
+        build_mode=BUILD_MODE_ANALYZE_ONLY,
+        cc=(),
+        cxx=(),
+        c_flags=("-std=c99",),
+        cxx_flags=("-std=c++98",),
+        required_binaries=tuple(required_binaries),
+        missing_tool_message="Install %s before running %s."
+        % (
+            ", ".join(required_binaries),
+            name,
+        ),
+        timeout_seconds=240,
+        analysis_tool=(tool,),
+        analysis_args=tuple(args),
+        analysis_ruleset=ruleset,
+        report_only=True,
+    )
+
+
+def _manual_compile_profile(name: str, cc: str, cxx: str) -> ToolchainProfile:
+    return ToolchainProfile(
+        name=name,
+        build_mode=BUILD_MODE_SELF_HOSTED_COMPILE,
+        cc=(cc,),
+        cxx=(cxx,),
+        c_flags=("-std=c99", "-O2"),
+        cxx_flags=("-std=c++98", "-O2"),
+        required_binaries=(cc, cxx),
+        missing_tool_message=(
+            "Run this manual native toolchain profile only on a self-hosted runner "
+            "where the licensed compiler is installed."
+        ),
+        optimization="-O2",
+        public_required=False,
+        timeout_seconds=300,
+    )
+
+
+_GCC_PROFILES = tuple(
+    _host_profile("linux-gcc-%s" % suffix, "gcc", "g++", flag)
+    for suffix, flag in (("o0", "-O0"), ("o2", "-O2"), ("o3", "-O3"), ("os", "-Os"))
+)
+_CLANG_PROFILES = tuple(
+    _host_profile("linux-clang-%s" % suffix, "clang", "clang++", flag)
+    for suffix, flag in (("o0", "-O0"), ("o2", "-O2"), ("o3", "-O3"), ("os", "-Os"))
+)
+_M32_PROFILES = tuple(
+    _host_profile(
+        "linux-gcc-m32-%s" % suffix,
+        "gcc",
+        "g++",
+        flag,
+        extra_c_flags=("-m32",),
+        extra_cxx_flags=("-m32",),
+        link_flags=("-m32",),
         required_binaries=("cmake", "gcc", "g++"),
-        missing_tool_message="Install cmake, gcc, and g++ before running linux-gcc-o2.",
-        optimization="-O2",
-    ),
-    ToolchainProfile(
-        name="linux-clang-o2",
-        build_mode="cmake-run",
-        cc=("clang",),
-        cxx=("clang++",),
-        c_flags=("-std=c99", "-O2", "-Wall", "-Wextra", "-pedantic"),
-        cxx_flags=("-std=c++98", "-O2", "-Wall", "-Wextra", "-pedantic"),
+    )
+    for suffix, flag in (("o2", "-O2"), ("os", "-Os"))
+)
+_AARCH64_PROFILES = tuple(
+    _host_profile(
+        "linux-aarch64-gcc-%s" % suffix,
+        "aarch64-linux-gnu-gcc",
+        "aarch64-linux-gnu-g++",
+        flag,
+        required_binaries=(
+            "cmake",
+            "aarch64-linux-gnu-gcc",
+            "aarch64-linux-gnu-g++",
+            "qemu-aarch64",
+        ),
+        cmake_args=("-DCMAKE_SYSTEM_NAME=Linux", "-DCMAKE_SYSTEM_PROCESSOR=aarch64"),
+        run_prefix=("qemu-aarch64", "-L", "/usr/aarch64-linux-gnu"),
+        timeout_seconds=360,
+    )
+    for suffix, flag in (("o2", "-O2"), ("os", "-Os"))
+)
+_ARM_COMPILE_PROFILES = tuple(
+    _compile_only_profile(
+        "arm-none-eabi-gcc-%s" % suffix,
+        "arm-none-eabi-gcc",
+        "arm-none-eabi-g++",
+        flag,
+        ("arm-none-eabi-gcc", "arm-none-eabi-g++"),
+    )
+    for suffix, flag in (("o2", "-O2"), ("os", "-Os"))
+)
+_MACOS_PROFILES = tuple(
+    _host_profile("macos-appleclang-%s" % suffix, "clang", "clang++", flag)
+    for suffix, flag in (("o0", "-O0"), ("o2", "-O2"), ("o3", "-O3"), ("os", "-Os"))
+)
+_MINGW_PROFILES = tuple(
+    _host_profile(
+        "windows-mingw-%s" % suffix,
+        "gcc",
+        "g++",
+        flag,
+        required_binaries=("cmake", "ninja", "gcc", "g++"),
+        cmake_generator="Ninja",
+        timeout_seconds=300,
+    )
+    for suffix, flag in (("o0", "-O0"), ("o2", "-O2"), ("o3", "-O3"))
+)
+_MSVC_PROFILES = (
+    _msvc_profile("windows-msvc-od", "cl", "cl", "/Od"),
+    _msvc_profile("windows-msvc-o2", "cl", "cl", "/O2"),
+)
+_CLANGCL_PROFILES = (
+    _msvc_profile("windows-clangcl-od", "clang-cl", "clang-cl", "/Od"),
+    _msvc_profile("windows-clangcl-o2", "clang-cl", "clang-cl", "/O2"),
+)
+_SANITIZER_PROFILES = (
+    _host_profile(
+        "linux-clang-asan-ubsan",
+        "clang",
+        "clang++",
+        "-O1",
+        extra_c_flags=("-fsanitize=address,undefined", "-fno-omit-frame-pointer"),
+        extra_cxx_flags=("-fsanitize=address,undefined", "-fno-omit-frame-pointer"),
+        link_flags=("-fsanitize=address,undefined",),
         required_binaries=("cmake", "clang", "clang++"),
-        missing_tool_message="Install cmake, clang, and clang++ before running linux-clang-o2.",
-        optimization="-O2",
+        run_environment=(
+            ("ASAN_OPTIONS", "detect_leaks=1:strict_string_checks=1"),
+            ("UBSAN_OPTIONS", "print_stacktrace=1"),
+        ),
+        timeout_seconds=360,
     ),
 )
-PROFILES = {profile.name: profile for profile in _PUBLIC_PROFILES}
+_ANALYSIS_PROFILES = (
+    _analysis_profile(
+        "linux-cppcheck",
+        "cppcheck",
+        (
+            "--enable=warning,style,performance,portability",
+            "--std=c99",
+            "--inline-suppr",
+        ),
+        "cppcheck warning/style/performance/portability report-only",
+        ("cppcheck",),
+    ),
+    _analysis_profile(
+        "linux-clang-tidy",
+        "clang-tidy",
+        (
+            "--checks=bugprone-*,clang-analyzer-*,performance-*",
+            "-header-filter=.*",
+            "--",
+            "-std=c99",
+            "-Iharness",
+        ),
+        "clang-tidy bugprone/clang-analyzer/performance report-only",
+        ("clang-tidy",),
+    ),
+)
+_MANUAL_PROFILES = (
+    _manual_compile_profile("manual-armclang-compile", "armclang", "armclang"),
+    _manual_compile_profile("manual-iar-compile", "iccarm", "iccarm"),
+    _manual_compile_profile("manual-ti-clang-compile", "tiarmclang", "tiarmclang"),
+    _manual_compile_profile("manual-greenhills-compile", "ccarm", "cxarm"),
+    _manual_compile_profile("manual-tasking-compile", "ctc", "cptc"),
+    _manual_compile_profile("manual-qnx-qcc-compile", "qcc", "q++"),
+)
+
+_PUBLIC_PROFILES = (
+    _GCC_PROFILES
+    + _CLANG_PROFILES
+    + _M32_PROFILES
+    + _AARCH64_PROFILES
+    + _ARM_COMPILE_PROFILES
+    + _MACOS_PROFILES
+    + _MINGW_PROFILES
+    + _MSVC_PROFILES
+    + _CLANGCL_PROFILES
+    + _SANITIZER_PROFILES
+    + _ANALYSIS_PROFILES
+)
+_ALL_PROFILES = _PUBLIC_PROFILES + _MANUAL_PROFILES
+PROFILES = {profile.name: profile for profile in _ALL_PROFILES}
 
 
 def _env_enabled() -> bool:
@@ -183,7 +495,8 @@ def native_toolchain_enabled(config=None) -> bool:
     :param config: Optional pytest config object that may expose
         ``--run-native-toolchain``.
     :type config: typing.Any, optional
-    :return: ``True`` when the pytest option or environment flag enables native toolchain tests.
+    :return: ``True`` when the pytest option or environment flag enables native
+        toolchain tests.
     :rtype: bool
 
     Example::
@@ -199,17 +512,51 @@ def native_toolchain_enabled(config=None) -> bool:
 
 def iter_profiles() -> Sequence[ToolchainProfile]:
     """
-    Return the public native toolchain profiles in registry order.
+    Return public native toolchain profiles in registry order.
 
-    :return: Tuple-like sequence of profiles.
+    :return: Tuple-like sequence of public profiles.
     :rtype: typing.Sequence[ToolchainProfile]
 
     Example::
 
-        >>> [profile.name for profile in iter_profiles()]
-        ['linux-gcc-o2', 'linux-clang-o2']
+        >>> iter_profiles()[0].name
+        'linux-gcc-o0'
+        >>> get_profile("linux-aarch64-gcc-o2").run_prefix[:1]
+        ('qemu-aarch64',)
+        >>> get_profile("linux-gcc-o2") in iter_profiles()
+        True
     """
     return _PUBLIC_PROFILES
+
+
+def iter_manual_profiles() -> Sequence[ToolchainProfile]:
+    """
+    Return non-public self-hosted native toolchain profiles.
+
+    :return: Tuple-like sequence of manual profiles.
+    :rtype: typing.Sequence[ToolchainProfile]
+
+    Example::
+
+        >>> iter_manual_profiles()[0].public_required
+        False
+    """
+    return _MANUAL_PROFILES
+
+
+def iter_all_profiles() -> Sequence[ToolchainProfile]:
+    """
+    Return public and manual profiles in registry order.
+
+    :return: Tuple-like sequence of every registered profile.
+    :rtype: typing.Sequence[ToolchainProfile]
+
+    Example::
+
+        >>> get_profile("manual-armclang-compile") in iter_all_profiles()
+        True
+    """
+    return _ALL_PROFILES
 
 
 def get_profile(name: str) -> ToolchainProfile:
@@ -321,7 +668,7 @@ def missing_required_tools(profile: ToolchainProfile) -> List[str]:
 
 def ensure_required_tools(profile: ToolchainProfile) -> None:
     """
-    Fail if a public native toolchain profile lacks required tools.
+    Fail if a native toolchain profile lacks required tools.
 
     :param profile: Toolchain profile to validate.
     :type profile: ToolchainProfile
@@ -335,10 +682,11 @@ def ensure_required_tools(profile: ToolchainProfile) -> None:
         ...     "demo", "cmake-run", (), (), (), (),
         ...     required_binaries=("definitely-not-pyfcstm-cc",),
         ... )
-        >>> ensure_required_tools(profile)
-        Traceback (most recent call last):
-        ...
-        test.testings.native_toolchain_alignment.profiles.ToolchainMissingError: ...
+        >>> try:
+        ...     ensure_required_tools(profile)
+        ... except ToolchainMissingError as err:
+        ...     "definitely-not-pyfcstm-cc" in str(err)
+        True
     """
     missing = missing_required_tools(profile)
     if missing:

--- a/test/testings/native_toolchain_alignment/report.py
+++ b/test/testings/native_toolchain_alignment/report.py
@@ -84,14 +84,29 @@ RESULT_CLASSIFICATION_VALUES = {
     "tool_missing",
     "configure_failure",
     "configure_timeout",
+    "compile_failure",
+    "compile_timeout",
     "build_failure",
     "build_timeout",
     "run_failure",
     "run_timeout",
     "runtime_mismatch",
     "native_crash",
+    "analysis_failure",
+    "analysis_timeout",
+    "analysis_report_only",
 }
-COMMAND_STAGE_VALUES = {"version", "configure", "build", "run", "compile", "analyze"}
+COMMAND_STAGE_VALUES = {
+    "version",
+    "configure",
+    "build",
+    "run",
+    "compile",
+    "compile-machine-c",
+    "compile-harness-c",
+    "compile-header-cxx",
+    "analyze",
+}
 OBSERVATION_PHASE_VALUES = {"init", "step", "error", "finish"}
 
 
@@ -177,7 +192,8 @@ class NativeToolchainResult:
     :type template_name: str
     :param profile_name: Native toolchain profile name.
     :type profile_name: str
-    :param build_mode: Build mode, currently ``"cmake-run"`` for native run profiles.
+    :param build_mode: Build mode, such as ``"cmake-run"``,
+        ``"compile-only"``, or ``"analyze-only"``.
     :type build_mode: str
     :param compiler: C compiler command or ``None``.
     :type compiler: str, optional

--- a/test/testings/native_toolchain_alignment/runner.py
+++ b/test/testings/native_toolchain_alignment/runner.py
@@ -8,7 +8,8 @@ used by template-side ``native_toolchain`` pytest files.
 
 The module contains:
 
-* :class:`NativeToolchainExecutionError` - Wrapper for native build/run failures.
+* :class:`NativeToolchainExecutionError` - Wrapper for native build, run, and
+  analysis failures.
 * :func:`run_native_toolchain_case` - Execute one case/profile/template tuple.
 * :func:`assert_observations_match_case` - Compare harness observations with the
   shared public fixture expectations.
@@ -37,6 +38,11 @@ from test.testings.native_toolchain_alignment.harness import (
     render_harness,
 )
 from test.testings.native_toolchain_alignment.profiles import (
+    BUILD_MODE_ANALYZE_ONLY,
+    BUILD_MODE_CMAKE_RUN,
+    BUILD_MODE_COMPILE_ONLY,
+    BUILD_MODE_CROSS_QEMU_RUN,
+    BUILD_MODE_SELF_HOSTED_COMPILE,
     ToolchainMissingError,
     ToolchainProfile,
     ensure_required_tools,
@@ -125,11 +131,16 @@ def _run_command(
     artifact_root: str,
     commands: List[NativeCommandRecord],
     timeout: int,
+    env: Optional[Mapping[str, str]] = None,
 ) -> subprocess.CompletedProcess:
     start = time.time()
     stdout_path = os.path.join(logs_dir, "%s.stdout.txt" % stage)
     stderr_path = os.path.join(logs_dir, "%s.stderr.txt" % stage)
     timed_out = False
+    run_env = None
+    if env:
+        run_env = os.environ.copy()
+        run_env.update(env)
     try:
         completed = subprocess.run(
             list(argv),
@@ -138,8 +149,12 @@ def _run_command(
             stderr=subprocess.PIPE,
             text=True,
             timeout=timeout,
+            env=run_env,
         )
     except subprocess.TimeoutExpired as err:
+        # TimeoutExpired: subprocess.run raises it when the configured command
+        # timeout expires; the timeout itself is an expected native-profile
+        # outcome and is converted into a structured command record.
         timed_out = True
         stdout = err.stdout or ""
         stderr = err.stderr or ""
@@ -173,9 +188,15 @@ def _version_text(
     commands: List[NativeCommandRecord],
     timeout: int,
 ) -> Optional[str]:
+    if not argv:
+        return None
+    if shutil.which(argv[0]) is None:
+        return None
+    executable = os.path.basename(argv[0]).lower()
+    version_flag = "/?" if executable in {"cl", "clang-cl"} else "--version"
     completed = _run_command(
         "version",
-        list(argv) + ["--version"],
+        list(argv) + [version_flag],
         logs_dir,
         logs_dir,
         artifact_root,
@@ -194,7 +215,9 @@ def _write_result(artifact_dir: str, result: NativeToolchainResult) -> Dict[str,
     return data
 
 
-def _artifact_paths(observations_path: Optional[str] = None) -> Sequence[str]:
+def _artifact_paths(
+    observations_path: Optional[str] = None, analysis_report_path: Optional[str] = None
+) -> Sequence[str]:
     paths = [
         "generated",
         "harness",
@@ -205,7 +228,50 @@ def _artifact_paths(observations_path: Optional[str] = None) -> Sequence[str]:
     ]
     if observations_path is not None:
         paths.append(observations_path)
+    if analysis_report_path is not None:
+        paths.append(analysis_report_path)
     return paths
+
+
+def _result_payload(
+    case: SemanticCase,
+    template_name: str,
+    profile: ToolchainProfile,
+    status: str,
+    classification: str,
+    message: str,
+    commands: Sequence[NativeCommandRecord],
+    returncode: Optional[int] = None,
+    duration_seconds: float = 0.0,
+    compiler_version: Optional[str] = None,
+    primary_tool_version: Optional[str] = None,
+    run_attempted: bool = False,
+    observations_path: Optional[str] = None,
+    analysis_report_path: Optional[str] = None,
+) -> NativeToolchainResult:
+    return NativeToolchainResult(
+        case_id=case.id,
+        template_name=template_name,
+        profile_name=profile.name,
+        build_mode=profile.build_mode,
+        compiler=profile.compiler,
+        compiler_version=compiler_version,
+        primary_tool=profile.primary_tool,
+        primary_tool_version=primary_tool_version,
+        optimization=profile.optimization,
+        status=status,
+        classification=classification,
+        message=message,
+        returncode=returncode,
+        duration_seconds=duration_seconds,
+        commands=commands,
+        artifact_paths=_artifact_paths(observations_path, analysis_report_path),
+        run_attempted=run_attempted,
+        observations_path=observations_path,
+        analysis_ruleset=profile.analysis_ruleset,
+        analysis_report_path=analysis_report_path,
+        report_only=profile.report_only,
+    )
 
 
 def _failure_result(
@@ -218,28 +284,27 @@ def _failure_result(
     artifact_dir: str,
     returncode: Optional[int] = None,
     duration_seconds: float = 0.0,
+    compiler_version: Optional[str] = None,
+    primary_tool_version: Optional[str] = None,
     run_attempted: bool = False,
     observations_path: Optional[str] = None,
+    analysis_report_path: Optional[str] = None,
 ) -> Dict[str, Any]:
-    result = NativeToolchainResult(
-        case_id=case.id,
-        template_name=template_name,
-        profile_name=profile.name,
-        build_mode=profile.build_mode,
-        compiler=profile.compiler,
-        compiler_version=None,
-        primary_tool=profile.primary_tool,
-        primary_tool_version=None,
-        optimization=profile.optimization,
-        status="failed",
-        classification=classification,
-        message=message,
-        returncode=returncode,
-        duration_seconds=duration_seconds,
-        commands=commands,
-        artifact_paths=_artifact_paths(observations_path),
-        run_attempted=run_attempted,
-        observations_path=observations_path,
+    result = _result_payload(
+        case,
+        template_name,
+        profile,
+        "failed",
+        classification,
+        message,
+        commands,
+        returncode,
+        duration_seconds,
+        compiler_version,
+        primary_tool_version,
+        run_attempted,
+        observations_path,
+        analysis_report_path,
     )
     _write_result(artifact_dir, result)
     raise NativeToolchainExecutionError(
@@ -288,10 +353,11 @@ def assert_observations_match_case(
     Example::
 
         >>> case = simulate_semantics.load_semantic_case("design_basic_simple_transition")
-        >>> assert_observations_match_case("c", case, [])
-        Traceback (most recent call last):
-        ...
-        AssertionError: ...
+        >>> try:
+        ...     assert_observations_match_case("c", case, [])
+        ... except AssertionError as err:
+        ...     "observation count mismatch" in str(err)
+        True
     """
     initial_expect = simulate_semantics._initial_constructor_expect(case)
     init_observations = [item for item in observations if item.get("phase") == "init"]
@@ -379,86 +445,334 @@ def _prepare_artifacts(
             shutil.copy2(src, os.path.join(harness_dir, name))
 
 
-def run_native_toolchain_case(
-    template_name: str,
-    case: SemanticCase,
-    profile: ToolchainProfile,
-    artifact_root: str,
-) -> Dict[str, Any]:
-    """
-    Execute one shared semantic fixture under a native toolchain profile.
-
-    :param template_name: Template name, either ``"c"`` or ``"c_poll"``.
-    :type template_name: str
-    :param case: Shared semantic fixture case.
-    :type case: test.testings.simulate_semantics.SemanticCase
-    :param profile: Selected native toolchain profile.
-    :type profile: test.testings.native_toolchain_alignment.profiles.ToolchainProfile
-    :param artifact_root: Root directory for result artifacts.
-    :type artifact_root: str
-    :return: Parsed ``result.json`` data for a passed case.
-    :rtype: dict
-    :raises NativeToolchainExecutionError: If profile setup, build, run, or
-        semantic assertion fails.
-
-    Example::
-
-        >>> from test.testings.native_toolchain_alignment.profiles import get_profile
-        >>> profile = get_profile("linux-gcc-o2")
-        >>> profile.build_mode
-        'cmake-run'
-    """
-    start = time.time()
-    artifact_dir = _case_artifact_dir(
-        artifact_root, template_name, profile.name, case.id
+def _cmake_configure_args(
+    profile: ToolchainProfile, harness_dir: str, build_dir: str
+) -> List[str]:
+    args = ["cmake", "-S", harness_dir, "-B", build_dir]
+    if profile.cmake_generator is not None:
+        args.extend(["-G", profile.cmake_generator])
+    args.extend(
+        [
+            "-DCMAKE_BUILD_TYPE=Release",
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+            "-DCMAKE_C_COMPILER=%s" % profile.cc[0],
+            "-DCMAKE_CXX_COMPILER=%s" % profile.cxx[0],
+            "-DPYFCSTM_NATIVE_C_FLAGS=%s" % " ".join(profile.c_flags),
+            "-DPYFCSTM_NATIVE_CXX_FLAGS=%s" % " ".join(profile.cxx_flags),
+            "-DPYFCSTM_NATIVE_LINK_FLAGS=%s" % " ".join(profile.link_flags),
+        ]
     )
-    logs_dir = os.path.join(artifact_dir, "logs")
-    build_dir = os.path.join(artifact_dir, "build")
-    harness_dir = os.path.join(artifact_dir, "harness")
-    os.makedirs(logs_dir, exist_ok=True)
-    os.makedirs(build_dir, exist_ok=True)
-    commands: List[NativeCommandRecord] = []
+    args.extend(profile.cmake_args)
+    return args
 
-    try:
-        ensure_required_tools(profile)
-    except ToolchainMissingError as err:
-        # ToolchainMissingError: ensure_required_tools reports public profile
-        # binaries that are absent from PATH. Other exceptions indicate a bug in
-        # profile validation and should propagate.
+
+def _executable_path(build_dir: str) -> str:
+    candidates = [
+        os.path.join(build_dir, "native_harness"),
+        os.path.join(build_dir, "native_harness.exe"),
+        os.path.join(build_dir, "Release", "native_harness.exe"),
+        os.path.join(build_dir, "Debug", "native_harness.exe"),
+    ]
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    return candidates[1] if os.name == "nt" else candidates[0]
+
+
+def _run_compile_command(
+    profile: ToolchainProfile,
+    stage: str,
+    argv: Sequence[str],
+    artifact_dir: str,
+    logs_dir: str,
+    commands: List[NativeCommandRecord],
+    output_path: str,
+    start: float,
+    case: SemanticCase,
+    template_name: str,
+    compiler_version: Optional[str],
+    primary_tool_version: Optional[str],
+) -> None:
+    completed = _run_command(
+        stage,
+        argv,
+        artifact_dir,
+        logs_dir,
+        artifact_dir,
+        commands,
+        profile.timeout_seconds,
+    )
+    timed_out = commands[-1].timed_out if commands else False
+    if completed.returncode != 0:
         _failure_result(
             case,
             template_name,
             profile,
-            "tool_missing",
-            "%s" % err,
+            "compile_timeout" if timed_out else "compile_failure",
+            "%s failed for %s/%s" % (stage, template_name, case.id),
             commands,
             artifact_dir,
-            duration_seconds=time.time() - start,
+            completed.returncode,
+            time.time() - start,
+            compiler_version,
+            primary_tool_version,
+        )
+    if not os.path.exists(output_path) or os.path.getsize(output_path) <= 0:
+        _failure_result(
+            case,
+            template_name,
+            profile,
+            "compile_failure",
+            "%s did not produce a non-empty object for %s/%s"
+            % (stage, template_name, case.id),
+            commands,
+            artifact_dir,
+            completed.returncode,
+            time.time() - start,
+            compiler_version,
+            primary_tool_version,
         )
 
-    _prepare_artifacts(template_name, case, artifact_dir)
-    compiler_version = _version_text(
-        profile.cc, logs_dir, artifact_dir, commands, profile.timeout_seconds
-    )
-    primary_tool_version = compiler_version
 
-    configure_args = [
-        "cmake",
-        "-S",
-        harness_dir,
-        "-B",
-        build_dir,
-        "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
-        "-DCMAKE_C_COMPILER=%s" % profile.cc[0],
-        "-DCMAKE_CXX_COMPILER=%s" % profile.cxx[0],
-        "-DPYFCSTM_NATIVE_C_FLAGS=%s" % " ".join(profile.c_flags),
-        "-DPYFCSTM_NATIVE_CXX_FLAGS=%s" % " ".join(profile.cxx_flags),
-        "-DPYFCSTM_NATIVE_LINK_FLAGS=%s" % " ".join(profile.link_flags),
+def _run_compile_only_case(
+    template_name: str,
+    case: SemanticCase,
+    profile: ToolchainProfile,
+    artifact_dir: str,
+    logs_dir: str,
+    build_dir: str,
+    commands: List[NativeCommandRecord],
+    compiler_version: Optional[str],
+    primary_tool_version: Optional[str],
+    start: float,
+) -> Dict[str, Any]:
+    include_dir = os.path.join(artifact_dir, "harness")
+    if os.path.basename(profile.cc[0]).lower() in {"cl", "clang-cl"}:
+        include_flag = "/I" + include_dir
+
+        def c_output(path):
+            return ["/Fo" + path]
+
+        cxx_output = c_output
+        compile_flag = "/c"
+    else:
+        include_flag = "-I" + include_dir
+
+        def c_output(path):
+            return ["-o", path]
+
+        cxx_output = c_output
+        compile_flag = "-c"
+    compile_items = [
+        (
+            "compile-machine-c",
+            list(profile.cc)
+            + list(profile.c_flags)
+            + [
+                include_flag,
+                compile_flag,
+                os.path.join(artifact_dir, "harness", "machine.c"),
+            ],
+            os.path.join(build_dir, "machine.o"),
+        ),
+        (
+            "compile-harness-c",
+            list(profile.cc)
+            + list(profile.c_flags)
+            + [
+                include_flag,
+                compile_flag,
+                os.path.join(artifact_dir, "harness", "harness.c"),
+            ],
+            os.path.join(build_dir, "harness.o"),
+        ),
+        (
+            "compile-header-cxx",
+            list(profile.cxx)
+            + list(profile.cxx_flags)
+            + [include_flag, compile_flag, "-"],
+            os.path.join(build_dir, "cxx_header_probe.o"),
+        ),
     ]
+    header_probe = '#include "machine.h"\nint main(void) { return 0; }\n'
+    for stage, argv, output_path in compile_items:
+        argv = list(argv) + c_output(output_path)
+        if stage == "compile-header-cxx":
+            probe_path = os.path.join(build_dir, "cxx_header_probe.cpp")
+            _write_text(probe_path, header_probe)
+            argv = (
+                list(profile.cxx)
+                + list(profile.cxx_flags)
+                + [include_flag, compile_flag, probe_path]
+                + cxx_output(output_path)
+            )
+        _run_compile_command(
+            profile,
+            stage,
+            argv,
+            artifact_dir,
+            logs_dir,
+            commands,
+            output_path,
+            start,
+            case,
+            template_name,
+            compiler_version,
+            primary_tool_version,
+        )
+    result = _result_payload(
+        case,
+        template_name,
+        profile,
+        "passed",
+        "passed",
+        "compile-only passed",
+        commands,
+        0,
+        time.time() - start,
+        compiler_version,
+        primary_tool_version,
+        run_attempted=False,
+        observations_path=None,
+    )
+    return _write_result(artifact_dir, result)
+
+
+def _analysis_targets(artifact_dir: str) -> List[str]:
+    harness_dir = os.path.join(artifact_dir, "harness")
+    return [
+        os.path.join(harness_dir, "machine.c"),
+        os.path.join(harness_dir, "harness.c"),
+    ]
+
+
+def _analysis_argv(profile: ToolchainProfile, artifact_dir: str) -> List[str]:
+    args = list(profile.analysis_args)
+    targets = _analysis_targets(artifact_dir)
+    if "--" not in args:
+        return list(profile.analysis_tool) + args + targets
+    separator_index = args.index("--")
+    return (
+        list(profile.analysis_tool)
+        + args[:separator_index]
+        + targets
+        + ["--"]
+        + args[separator_index + 1 :]
+    )
+
+
+def _run_analyze_only_case(
+    template_name: str,
+    case: SemanticCase,
+    profile: ToolchainProfile,
+    artifact_dir: str,
+    logs_dir: str,
+    commands: List[NativeCommandRecord],
+    primary_tool_version: Optional[str],
+    start: float,
+) -> Dict[str, Any]:
+    report_path = os.path.join(artifact_dir, "analysis-report.txt")
+    argv = _analysis_argv(profile, artifact_dir)
+    completed = _run_command(
+        "analyze",
+        argv,
+        artifact_dir,
+        logs_dir,
+        artifact_dir,
+        commands,
+        profile.timeout_seconds,
+    )
+    stdout_rel = commands[-1].stdout_path if commands else None
+    stderr_rel = commands[-1].stderr_path if commands else None
+    report_parts = []
+    for rel_path in (stdout_rel, stderr_rel):
+        if rel_path is None:
+            continue
+        path = os.path.join(artifact_dir, rel_path)
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                report_parts.append(f.read())
+    _write_text(report_path, "\n".join(report_parts))
+    report_rel = _relative(report_path, artifact_dir)
+    timed_out = commands[-1].timed_out if commands else False
+    if timed_out or completed.returncode is None:
+        _failure_result(
+            case,
+            template_name,
+            profile,
+            "analysis_timeout",
+            "static analysis timed out for %s/%s" % (template_name, case.id),
+            commands,
+            artifact_dir,
+            completed.returncode,
+            time.time() - start,
+            primary_tool_version=primary_tool_version,
+            analysis_report_path=report_rel,
+        )
+    if completed.returncode not in (0,):
+        _failure_result(
+            case,
+            template_name,
+            profile,
+            "analysis_failure",
+            "static analysis failed for %s/%s with return code %r"
+            % (template_name, case.id, completed.returncode),
+            commands,
+            artifact_dir,
+            completed.returncode,
+            time.time() - start,
+            primary_tool_version=primary_tool_version,
+            analysis_report_path=report_rel,
+        )
+    if not os.path.exists(report_path):
+        _failure_result(
+            case,
+            template_name,
+            profile,
+            "analysis_failure",
+            "static analysis report is missing for %s/%s" % (template_name, case.id),
+            commands,
+            artifact_dir,
+            completed.returncode,
+            time.time() - start,
+            primary_tool_version=primary_tool_version,
+            analysis_report_path=report_rel,
+        )
+    result = _result_payload(
+        case,
+        template_name,
+        profile,
+        "passed",
+        "analysis_report_only",
+        "static analysis report-only profile completed",
+        commands,
+        completed.returncode,
+        time.time() - start,
+        compiler_version=None,
+        primary_tool_version=primary_tool_version,
+        run_attempted=False,
+        observations_path=None,
+        analysis_report_path=report_rel,
+    )
+    return _write_result(artifact_dir, result)
+
+
+def _run_cmake_case(
+    template_name: str,
+    case: SemanticCase,
+    profile: ToolchainProfile,
+    artifact_dir: str,
+    logs_dir: str,
+    build_dir: str,
+    harness_dir: str,
+    commands: List[NativeCommandRecord],
+    compiler_version: Optional[str],
+    primary_tool_version: Optional[str],
+    start: float,
+) -> Dict[str, Any]:
     completed = _run_command(
         "configure",
-        configure_args,
+        _cmake_configure_args(profile, harness_dir, build_dir),
         artifact_dir,
         logs_dir,
         artifact_dir,
@@ -477,6 +791,8 @@ def run_native_toolchain_case(
             artifact_dir,
             completed.returncode,
             time.time() - start,
+            compiler_version,
+            primary_tool_version,
         )
 
     completed = _run_command(
@@ -500,21 +816,24 @@ def run_native_toolchain_case(
             artifact_dir,
             completed.returncode,
             time.time() - start,
+            compiler_version,
+            primary_tool_version,
         )
 
-    exe_path = os.path.join(build_dir, "native_harness")
-    if os.name == "nt":
-        exe_path += ".exe"
+    exe_path = _executable_path(build_dir)
     observations_path = os.path.join(artifact_dir, "observations.jsonl")
+    run_argv = list(profile.run_prefix) + [exe_path, observations_path]
     completed = _run_command(
         "run",
-        [exe_path, observations_path],
+        run_argv,
         artifact_dir,
         logs_dir,
         artifact_dir,
         commands,
         profile.timeout_seconds,
+        env=profile.run_environment,
     )
+    observations_rel = _relative(observations_path, artifact_dir)
     if completed.returncode != 0:
         timed_out = commands[-1].timed_out if commands else False
         if timed_out:
@@ -534,8 +853,10 @@ def run_native_toolchain_case(
             artifact_dir,
             completed.returncode,
             time.time() - start,
+            compiler_version,
+            primary_tool_version,
             run_attempted=True,
-            observations_path=_relative(observations_path, artifact_dir),
+            observations_path=observations_rel,
         )
 
     observations = read_observations_jsonl(observations_path)
@@ -552,28 +873,149 @@ def run_native_toolchain_case(
             artifact_dir,
             completed.returncode,
             time.time() - start,
+            compiler_version,
+            primary_tool_version,
             run_attempted=True,
-            observations_path=_relative(observations_path, artifact_dir),
+            observations_path=observations_rel,
         )
 
-    result = NativeToolchainResult(
-        case_id=case.id,
-        template_name=template_name,
-        profile_name=profile.name,
-        build_mode=profile.build_mode,
-        compiler=profile.compiler,
-        compiler_version=compiler_version,
-        primary_tool=profile.primary_tool,
-        primary_tool_version=primary_tool_version,
-        optimization=profile.optimization,
-        status="passed",
-        classification="passed",
-        message="passed",
-        returncode=completed.returncode,
-        duration_seconds=time.time() - start,
-        commands=commands,
-        artifact_paths=_artifact_paths("observations.jsonl"),
+    result = _result_payload(
+        case,
+        template_name,
+        profile,
+        "passed",
+        "passed",
+        "passed",
+        commands,
+        completed.returncode,
+        time.time() - start,
+        compiler_version,
+        primary_tool_version,
         run_attempted=True,
-        observations_path=_relative(observations_path, artifact_dir),
+        observations_path=observations_rel,
     )
     return _write_result(artifact_dir, result)
+
+
+def run_native_toolchain_case(
+    template_name: str,
+    case: SemanticCase,
+    profile: ToolchainProfile,
+    artifact_root: str,
+) -> Dict[str, Any]:
+    """
+    Execute one shared semantic fixture under a native toolchain profile.
+
+    :param template_name: Template name, either ``"c"`` or ``"c_poll"``.
+    :type template_name: str
+    :param case: Shared semantic fixture case.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param profile: Selected native toolchain profile.
+    :type profile: test.testings.native_toolchain_alignment.profiles.ToolchainProfile
+    :param artifact_root: Root directory for result artifacts.
+    :type artifact_root: str
+    :return: Parsed ``result.json`` data for a passed case.
+    :rtype: dict
+    :raises NativeToolchainExecutionError: If profile setup, build, run,
+        analysis, or semantic assertion fails.
+
+    Example::
+
+        >>> from test.testings.native_toolchain_alignment.profiles import get_profile
+        >>> profile = get_profile("linux-gcc-o2")
+        >>> profile.build_mode
+        'cmake-run'
+    """
+    start = time.time()
+    artifact_dir = _case_artifact_dir(
+        artifact_root, template_name, profile.name, case.id
+    )
+    logs_dir = os.path.join(artifact_dir, "logs")
+    build_dir = os.path.join(artifact_dir, "build")
+    harness_dir = os.path.join(artifact_dir, "harness")
+    os.makedirs(logs_dir, exist_ok=True)
+    os.makedirs(build_dir, exist_ok=True)
+    commands: List[NativeCommandRecord] = []
+
+    try:
+        ensure_required_tools(profile)
+    except ToolchainMissingError as err:
+        # ToolchainMissingError: ensure_required_tools reports profile binaries
+        # that are absent from PATH. Other exceptions indicate a bug in profile
+        # validation and should propagate.
+        _failure_result(
+            case,
+            template_name,
+            profile,
+            "tool_missing",
+            "%s" % err,
+            commands,
+            artifact_dir,
+            duration_seconds=time.time() - start,
+        )
+
+    _prepare_artifacts(template_name, case, artifact_dir)
+    compiler_version = _version_text(
+        profile.cc, logs_dir, artifact_dir, commands, profile.timeout_seconds
+    )
+    if profile.analysis_tool:
+        primary_tool_version = _version_text(
+            profile.analysis_tool,
+            logs_dir,
+            artifact_dir,
+            commands,
+            profile.timeout_seconds,
+        )
+    else:
+        primary_tool_version = compiler_version
+
+    if profile.build_mode in (BUILD_MODE_CMAKE_RUN, BUILD_MODE_CROSS_QEMU_RUN):
+        return _run_cmake_case(
+            template_name,
+            case,
+            profile,
+            artifact_dir,
+            logs_dir,
+            build_dir,
+            harness_dir,
+            commands,
+            compiler_version,
+            primary_tool_version,
+            start,
+        )
+    if profile.build_mode in (BUILD_MODE_COMPILE_ONLY, BUILD_MODE_SELF_HOSTED_COMPILE):
+        return _run_compile_only_case(
+            template_name,
+            case,
+            profile,
+            artifact_dir,
+            logs_dir,
+            build_dir,
+            commands,
+            compiler_version,
+            primary_tool_version,
+            start,
+        )
+    if profile.build_mode == BUILD_MODE_ANALYZE_ONLY:
+        return _run_analyze_only_case(
+            template_name,
+            case,
+            profile,
+            artifact_dir,
+            logs_dir,
+            commands,
+            primary_tool_version,
+            start,
+        )
+    _failure_result(
+        case,
+        template_name,
+        profile,
+        "profile_error",
+        "unsupported native toolchain build mode: %s" % profile.build_mode,
+        commands,
+        artifact_dir,
+        duration_seconds=time.time() - start,
+        compiler_version=compiler_version,
+        primary_tool_version=primary_tool_version,
+    )

--- a/test/testings/native_toolchain_alignment/runner.py
+++ b/test/testings/native_toolchain_alignment/runner.py
@@ -82,14 +82,48 @@ class _ObservationRuntime:
 
     @property
     def vars(self) -> Mapping[str, Any]:
+        """
+        Return the public variable snapshot from one native observation.
+
+        :return: Mapping from variable name to observed value.
+        :rtype: typing.Mapping[str, typing.Any]
+
+        Example::
+
+            >>> _ObservationRuntime({"vars": {"counter": 1}, "is_ended": False, "current_state": None}).vars
+            {'counter': 1}
+        """
         return self._observation["vars"]
 
     @property
     def is_ended(self) -> bool:
+        """
+        Return whether the native runtime reported terminal completion.
+
+        :return: ``True`` when the observation represents an ended machine.
+        :rtype: bool
+
+        Example::
+
+            >>> _ObservationRuntime({"vars": {}, "is_ended": True, "current_state": None}).is_ended
+            True
+        """
         return bool(self._observation["is_ended"])
 
     @property
     def current_state(self) -> Optional[_StateView]:
+        """
+        Return the observed active state path as a lightweight state view.
+
+        :return: State view for active machines, or ``None`` for ended machines.
+        :rtype: _StateView or None
+
+        Example::
+
+            >>> runtime = _ObservationRuntime({"vars": {}, "is_ended": False, "current_state": "Root.A"})
+            >>> runtime.current_state.path
+            ('Root', 'A')
+        """
         if self.is_ended or self._observation["current_state"] is None:
             return None
         return _StateView(self._observation["current_state"])
@@ -121,6 +155,12 @@ def _write_text(path: str, text: str) -> None:
     os.makedirs(os.path.dirname(path), exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         f.write(text)
+
+
+def _tool_stem(argv: Sequence[str]) -> str:
+    if not argv:
+        return ""
+    return os.path.splitext(os.path.basename(argv[0]))[0].lower()
 
 
 def _run_command(
@@ -192,12 +232,12 @@ def _version_text(
         return None
     if shutil.which(argv[0]) is None:
         return None
-    executable = os.path.basename(argv[0]).lower()
+    executable = _tool_stem(argv)
     version_flag = "/?" if executable in {"cl", "clang-cl"} else "--version"
     completed = _run_command(
         "version",
         list(argv) + [version_flag],
-        logs_dir,
+        artifact_root,
         logs_dir,
         artifact_root,
         commands,
@@ -547,10 +587,11 @@ def _run_compile_only_case(
     start: float,
 ) -> Dict[str, Any]:
     include_dir = os.path.join(artifact_dir, "harness")
-    if os.path.basename(profile.cc[0]).lower() in {"cl", "clang-cl"}:
+    if _tool_stem(profile.cc) in {"cl", "clang-cl"}:
         include_flag = "/I" + include_dir
 
         def c_output(path):
+            """Return an MSVC-style output argument for one object file."""
             return ["/Fo" + path]
 
         cxx_output = c_output
@@ -559,6 +600,7 @@ def _run_compile_only_case(
         include_flag = "-I" + include_dir
 
         def c_output(path):
+            """Return a GCC-style output argument for one object file."""
             return ["-o", path]
 
         cxx_output = c_output
@@ -639,11 +681,17 @@ def _run_compile_only_case(
 
 
 def _analysis_targets(artifact_dir: str) -> List[str]:
-    harness_dir = os.path.join(artifact_dir, "harness")
-    return [
-        os.path.join(harness_dir, "machine.c"),
-        os.path.join(harness_dir, "harness.c"),
-    ]
+    """Return generated and harness source files for static-analysis profiles."""
+    targets = []
+    for relative_dir in ("generated", "harness"):
+        root = os.path.join(artifact_dir, relative_dir)
+        if not os.path.isdir(root):
+            continue
+        for dirpath, _, filenames in os.walk(root):
+            for filename in sorted(filenames):
+                if os.path.splitext(filename)[1].lower() in {".c", ".h"}:
+                    targets.append(os.path.join(dirpath, filename))
+    return sorted(targets)
 
 
 def _analysis_argv(profile: ToolchainProfile, artifact_dir: str) -> List[str]:

--- a/test/testings/native_toolchain_alignment/test_report_and_profiles.py
+++ b/test/testings/native_toolchain_alignment/test_report_and_profiles.py
@@ -283,7 +283,7 @@ def test_analysis_targets_cover_generated_and_harness_sources(tmp_path):
         path.write_text("/* sentinel */\n", encoding="utf-8")
 
     targets = {
-        str(path.relative_to(artifact_dir))
+        path.relative_to(artifact_dir).as_posix()
         for path in map(Path, _analysis_targets(str(artifact_dir)))
     }
 

--- a/test/testings/native_toolchain_alignment/test_report_and_profiles.py
+++ b/test/testings/native_toolchain_alignment/test_report_and_profiles.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -24,7 +25,9 @@ from test.testings.native_toolchain_alignment.report import (
 )
 from test.testings.native_toolchain_alignment.runner import (
     _analysis_argv,
+    _analysis_targets,
     _case_artifact_dir,
+    _tool_stem,
 )
 
 
@@ -264,18 +267,64 @@ def test_case_artifact_directory_normalizes_relative_root(tmp_path, monkeypatch)
 
 
 @pytest.mark.unittest
+def test_analysis_targets_cover_generated_and_harness_sources(tmp_path):
+    artifact_dir = tmp_path / "artifact"
+    for relative_path in [
+        "generated/machine.c",
+        "generated/machine.h",
+        "generated/future_runtime.cpp",
+        "harness/machine.c",
+        "harness/machine.h",
+        "harness/harness.c",
+        "harness/readme.txt",
+    ]:
+        path = artifact_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("/* sentinel */\n", encoding="utf-8")
+
+    targets = {
+        str(path.relative_to(artifact_dir))
+        for path in map(Path, _analysis_targets(str(artifact_dir)))
+    }
+
+    assert targets == {
+        "generated/machine.c",
+        "generated/machine.h",
+        "harness/harness.c",
+        "harness/machine.c",
+        "harness/machine.h",
+    }
+
+
+@pytest.mark.unittest
 def test_analysis_argv_inserts_targets_before_compile_separator(tmp_path):
     artifact_dir = tmp_path / "artifact"
-    harness_dir = artifact_dir / "harness"
-    harness_dir.mkdir(parents=True)
+    for relative_path in [
+        "generated/machine.c",
+        "generated/machine.h",
+        "harness/machine.c",
+        "harness/harness.c",
+    ]:
+        path = artifact_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("/* sentinel */\n", encoding="utf-8")
     profile = get_profile("linux-clang-tidy")
 
     argv = _analysis_argv(profile, str(artifact_dir))
 
     separator = argv.index("--")
-    assert str(harness_dir / "machine.c") in argv[:separator]
-    assert str(harness_dir / "harness.c") in argv[:separator]
+    assert str(artifact_dir / "generated" / "machine.c") in argv[:separator]
+    assert str(artifact_dir / "generated" / "machine.h") in argv[:separator]
+    assert str(artifact_dir / "harness" / "machine.c") in argv[:separator]
+    assert str(artifact_dir / "harness" / "harness.c") in argv[:separator]
     assert "-std=c99" in argv[separator + 1 :]
+
+
+@pytest.mark.unittest
+def test_tool_stem_accepts_windows_executable_suffixes():
+    assert _tool_stem(("cl",)) == "cl"
+    assert _tool_stem(("cl.exe",)) == "cl"
+    assert _tool_stem(("C:/VS/VC/Tools/MSVC/bin/clang-cl.exe",)) == "clang-cl"
 
 
 @pytest.mark.unittest

--- a/test/testings/native_toolchain_alignment/test_report_and_profiles.py
+++ b/test/testings/native_toolchain_alignment/test_report_and_profiles.py
@@ -8,6 +8,8 @@ from test.testings.native_toolchain_alignment.profiles import (
     ProfileSelectionError,
     ToolchainProfile,
     get_profile,
+    iter_all_profiles,
+    iter_manual_profiles,
     iter_profiles,
     missing_required_tools,
     native_toolchain_enabled,
@@ -20,16 +22,45 @@ from test.testings.native_toolchain_alignment.report import (
     validate_observation_data,
     validate_result_data,
 )
-from test.testings.native_toolchain_alignment.runner import _case_artifact_dir
+from test.testings.native_toolchain_alignment.runner import (
+    _analysis_argv,
+    _case_artifact_dir,
+)
 
 
 @pytest.mark.unittest
-def test_profiles_freeze_initial_public_profile_names():
-    assert [profile.name for profile in iter_profiles()] == [
+def test_profiles_cover_public_matrix_and_manual_entries():
+    profile_names = [profile.name for profile in iter_profiles()]
+
+    assert profile_names[:4] == [
+        "linux-gcc-o0",
         "linux-gcc-o2",
-        "linux-clang-o2",
+        "linux-gcc-o3",
+        "linux-gcc-os",
     ]
+    for name in [
+        "linux-clang-o0",
+        "linux-clang-o2",
+        "linux-gcc-m32-o2",
+        "linux-aarch64-gcc-o2",
+        "arm-none-eabi-gcc-o2",
+        "macos-appleclang-o2",
+        "windows-mingw-o2",
+        "windows-msvc-o2",
+        "windows-clangcl-o2",
+        "linux-clang-asan-ubsan",
+        "linux-cppcheck",
+        "linux-clang-tidy",
+    ]:
+        assert name in profile_names
     assert get_profile("linux-gcc-o2").build_mode == "cmake-run"
+    assert get_profile("arm-none-eabi-gcc-o2").build_mode == "compile-only"
+    assert get_profile("linux-cppcheck").build_mode == "analyze-only"
+    assert get_profile("linux-cppcheck").report_only is True
+    assert "-DPYFCSTM_NATIVE_C_STANDARD=11" in get_profile("windows-msvc-o2").cmake_args
+    assert all(profile.public_required for profile in iter_profiles())
+    assert all(not profile.public_required for profile in iter_manual_profiles())
+    assert get_profile("manual-armclang-compile") in iter_all_profiles()
 
 
 @pytest.mark.unittest
@@ -187,9 +218,70 @@ def test_result_schema_rejects_unknown_classification(tmp_path):
 
 
 @pytest.mark.unittest
+def test_report_schema_accepts_compile_and_analysis_classifications():
+    command = NativeCommandRecord("analyze", ["cppcheck", "machine.c"], "/tmp")
+    result = NativeToolchainResult(
+        "case",
+        "c",
+        "linux-cppcheck",
+        "analyze-only",
+        None,
+        None,
+        "cppcheck",
+        "cppcheck 2",
+        None,
+        "passed",
+        "analysis_report_only",
+        "report",
+        commands=[command],
+        analysis_ruleset="demo",
+        analysis_report_path="analysis-report.txt",
+        report_only=True,
+    ).to_dict()
+
+    validate_result_data(result)
+
+    result["classification"] = "compile_failure"
+    result["status"] = "failed"
+    validate_result_data(result)
+
+
+@pytest.mark.unittest
+def test_report_schema_accepts_compile_stage_variants():
+    for stage in ["compile-machine-c", "compile-harness-c", "compile-header-cxx"]:
+        validate_command_data(
+            NativeCommandRecord(stage, ["cc", "-c", "machine.c"], "/tmp").to_dict()
+        )
+
+
+@pytest.mark.unittest
 def test_case_artifact_directory_normalizes_relative_root(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     artifact_dir = _case_artifact_dir("artifacts", "c", "linux-gcc-o2", "case")
 
     assert artifact_dir == str(tmp_path / "artifacts" / "c" / "linux-gcc-o2" / "case")
+
+
+@pytest.mark.unittest
+def test_analysis_argv_inserts_targets_before_compile_separator(tmp_path):
+    artifact_dir = tmp_path / "artifact"
+    harness_dir = artifact_dir / "harness"
+    harness_dir.mkdir(parents=True)
+    profile = get_profile("linux-clang-tidy")
+
+    argv = _analysis_argv(profile, str(artifact_dir))
+
+    separator = argv.index("--")
+    assert str(harness_dir / "machine.c") in argv[:separator]
+    assert str(harness_dir / "harness.c") in argv[:separator]
+    assert "-std=c99" in argv[separator + 1 :]
+
+
+@pytest.mark.unittest
+def test_compile_only_profile_records_non_running_contract():
+    profile = get_profile("arm-none-eabi-gcc-o2")
+
+    assert profile.build_mode == "compile-only"
+    assert profile.run_prefix == ()
+    assert profile.compiler == "arm-none-eabi-gcc"


### PR DESCRIPTION
## 背景

本 PR 是 [PR #256](https://github.com/HansBug/pyfcstm/pull/256) 规划中的 **PR-D4b**，依赖已经合入上游伞 PR 的 [PR #257](https://github.com/HansBug/pyfcstm/pull/257)。D4a 已经把原生工具链测试放进 pytest 体系，并固定了 `native_toolchain` 标记、显式开关、profile 注册、case-specific harness、`result.json` / `commands.json` / `observations.jsonl` 制品契约和基础 `linux-gcc-o2` / `linux-clang-o2` 路径。

本 PR 的目标是在不改变 D4a 契约、不减少共享语义用例、不把重矩阵塞进默认 `make unittest` 的前提下，把 D4 原生工具链矩阵从“骨架可用”推进到“公共矩阵可扩展、专有入口不阻塞、静态检查有证据”的状态。实现时必须继续遵守仓库约定：PR 名称、路线代号和流程阶段只出现在 PR / issue 文本中，不写入代码标识符、运行时消息、测试 id 或 pydoc / docstring。

## 范围

| 类别 | 本 PR 要做什么 | 验收方式 | 状态 |
|---|---|---|---|
| Linux GCC / Clang host profile | 扩展 Linux GCC / Clang 的优化等级 profile，覆盖 `-O0`、`-O2`、`-O3`、`-Os`；保持一个 job 一个 profile。 | 每个可运行 profile 都跑完整 `c` + `c_poll` 共享语义用例，不允许减少用例制造假绿；失败制品保留完整 profile、case、命令和日志。 | 🟨 待实现 |
| Linux 32 位 profile | 增加 `linux-gcc-m32-o2` / `linux-gcc-m32-os` 或等价公开可复现 32 位 profile，不能依赖 Python `ctypes` 加载目标产物。 | 通过 standalone harness 编译并运行完整共享语义用例；运行阶段必须生成 `observations.jsonl` 并完成公开观察面对齐。 | 🟨 待实现 |
| AArch64 + QEMU profile | 增加 `linux-aarch64-gcc-o2` / `linux-aarch64-gcc-os` 或等价 AArch64 GCC + QEMU user-mode profile。 | 交叉编译并通过 QEMU 运行完整共享语义用例；QEMU 崩溃、工具缺失、运行失败或语义不一致均失败。 | 🟨 待实现 |
| ARM bare-metal compile-only | 增加 `arm-none-eabi-gcc-o2` / `arm-none-eabi-gcc-os` 或等价 ARM bare-metal compile-only profile。 | 对完整共享语义用例的每个 case 编译 `machine.c`、`harness.c` 和公开头文件 C++ 探针；`result.json` 表达 `run_attempted=false`、`observations_path=null`，并保留非空目标文件与命令日志。 | 🟨 待实现 |
| macOS AppleClang profile | 增加 macOS runner 上的 AppleClang profile，至少覆盖 `-O2`，并为 `-O0`、`-O3`、`-Os` 留在同一 profile 注册机制内扩展。 | 在 macOS runner 上编译并运行完整 `c` + `c_poll` 共享语义用例；制品契约与 Linux profile 一致。 | 🟨 待实现 |
| Windows MinGW profile | 增加 Windows runner 上的 MinGW profile，至少覆盖一个优化等级，并保持可扩展到 `-O0`、`-O2`、`-O3`。 | 在 Windows runner 上编译并运行完整共享语义用例；路径、命令日志和 JSON 制品跨平台可解析。 | 🟨 待实现 |
| Windows MSVC / clang-cl profile | 增加 Windows runner 上的 MSVC `cl` 与 `clang-cl` profile，覆盖 `/Od` 或 `/O2` 的至少一个可运行代表。 | C 编译路径与 C++ 集成探针都覆盖；MSVC / clang-cl 的选项差异写入 profile，不污染共享 fixture 语义。 | 🟨 待实现 |
| sanitizer profile | 增加公开可跑的 Clang sanitizer profile，第一阶段至少覆盖 ASan + UBSan，并评估 LSan 可用性；不把结果宣称为认证。 | 编译并运行完整共享语义用例；工具报错、sanitizer 报错、运行崩溃或语义不一致均失败。 | 🟨 待实现 |
| 静态检查 profile | 增加 analyze-only profile，优先使用公共 runner 可安装的 `cppcheck` 与 `clang-tidy`。 | 对完整共享语义用例的生成产物和 harness 扫描；第一阶段可 report-only，但工具崩溃、无法解析、报告缺失或制品缺失必须失败。 | 🟨 待实现 |
| 专有工具链入口 | 为 armclang、IAR、TI、Green Hills、TASKING、QNX SDP 等专有工具链保留非阻塞手动 / 自托管入口。 | 未显式启用时不得创建会卡住公共 CI 的必过 job；启用时仍使用统一 profile、命令日志和制品契约。 | 🟨 待实现 |
| workflow | 扩展 `.github/workflows/native-toolchain.yml`，但业务逻辑仍留在 pytest helper 内。 | workflow 只安装工具、选择 profile、调用 pytest、上传制品；新增或修改的 job 必须在本 PR 阶段真实触发并被 watch 到最终结论。 | 🟨 待实现 |
| 文档与维护纪律 | 更新生成产物 / 模板维护说明中关于 native 矩阵、失败制品、profile 扩展和非认证边界的说明，并同步 [issue #247](https://github.com/HansBug/pyfcstm/issues/247) 状态。 | 文档说明哪些检查是工程质量基线，不能宣称认证或标准合规证明；模板维护 README 说明新增 profile 的维护纪律和扩展入口。 | 🟨 待实现 |

## 非目标

- 不修改共享 fixture 语义，不新增 D4 专用 fixture include / exclude 规则。
- 不把 D4 重矩阵加入默认 `make unittest` 或现有普通 `test.yml` 的 Python 全版本矩阵。
- 不把专有编译器作为公共 GitHub-hosted runner 的必过检查。
- 不把 sanitizer、静态检查或 compile-only 结果写成安全认证、标准认证或形式化证明。
- 不在本 PR 重新处理 D2/D3 数值语义治理；相关工作继续分流到 [issue #253](https://github.com/HansBug/pyfcstm/issues/253)、[issue #254](https://github.com/HansBug/pyfcstm/issues/254)、[issue #255](https://github.com/HansBug/pyfcstm/issues/255)。
- 不通过减少共享语义用例、关闭公开观察面断言或改写 fixture 期望来换取矩阵通过。

## profile 粒度验收

| profile 类别 | 最低验收 |
|---|---|
| Linux GCC / Clang 优化等级 | `-O0`、`-O2`、`-O3`、`-Os` profile 均可被 `PYFCSTM_NATIVE_TOOLCHAIN_PROFILE=<name>` 单独选择；公共工具缺失、profile 拼写错误和编译失败均 fail。 |
| Linux 32 位 | 通过 standalone harness 运行完整共享语义用例；不得使用 Python `ctypes` 加载 32 位产物。 |
| AArch64 + QEMU | 交叉编译、QEMU 运行、观察记录解析和语义断言均纳入同一 pytest runner。 |
| ARM bare-metal compile-only | 对完整共享语义用例全量生成、编译并输出非空目标文件；不要求链接、启动文件或板级内存布局证明。 |
| macOS / Windows host | 至少一个代表 profile 进入 PR 阶段真实 CI；路径、换行、命令日志和 artifact 路径在对应系统上可用。 |
| MSVC / clang-cl | C 编译和 C++ 集成探针都通过；Windows 专有选项只放在 profile 内。 |
| sanitizer | ASan + UBSan 运行完整共享语义用例；若 LSan 在 runner 上可用则作为同一类 profile 的可选扩展，若不可用需在文档中说明边界。 |
| 静态检查 | `cppcheck` / `clang-tidy` 对完整生成产物和 harness 生成报告；report-only 只影响是否拦截具体 lint 诊断，不影响工具崩溃、解析失败和报告缺失的失败判定。 |
| 专有入口 | 手动 / 自托管入口不会阻塞公共 CI；启用后仍产出 `result.json`、`commands.json` 和日志制品。 |

## 验收清单

- [ ] D4b 分支已经包含上游 PR #256 最新内容，若有冲突已正确处理且未丢失 D4a 内容。
- [ ] 默认 `make unittest` 仍不执行 native 重矩阵，也不触发 profile/toolchain discovery。
- [ ] `SKIP_SLOW_TESTS=1 make unittest` 通过；涉及 native workflow 的代表 profile 另行显式运行，不能只依赖 skip slow。
- [ ] `make rst_auto` 已执行，生成的 RST 变更已按需纳入。
- [ ] 新增 / 修改的公开 Python helper pydoc 符合仓库规范：reST、参数/返回/异常、`Example::`；`__init__.py` 保持模块地图作用。
- [ ] 所有 profile 仍通过单一 `PYFCSTM_NATIVE_TOOLCHAIN_PROFILE` 选择；profile 缺失、拼错、公共工具缺失必须 fail，不得 skip 假绿。
- [ ] 可运行 profile 跑完整共享语义用例，不能靠减少 case 数控制耗时。
- [ ] compile-only / analyze-only profile 使用与运行 profile 同一套 case-specific harness 和制品契约。
- [ ] `result.json`、`commands.json`、`observations.jsonl` 只做兼容扩展，不破坏 D4a 已固定字段语义。
- [ ] 新增 / 修改的 workflow job 已在本 PR 阶段真实触发并被 watch 到最终结论；未触发的 job 视为未验证。
- [ ] workflow 上传的 artifact 包含失败复现所需的生成产物、harness、命令、日志、`result.json`、`commands.json`，运行 profile 还包含 `observations.jsonl`。
- [ ] CI 全部通过后完成三路强对抗 review；C/I 级问题必须修复，M 级不阻塞但可顺手处理。

## 当前检查计划

本 PR 开始时先建立空 PR，并由三路 reviewer 核对本正文是否与 #256 的 D4b 范围一致、是否可执行、是否可验收。正文一致后再进入 TDD 和实现。
