### PR TITLE
实现：修复 render 输出路径与嵌套资源契约

### DIFF
--- a/docs/source/api_doc/render/c_runtime.rst
+++ b/docs/source/api_doc/render/c_runtime.rst
@@ -28,3 +28,5 @@ render\_c\_condition\_body
 -----------------------------------------------------
 
 .. autofunction:: render_c_condition_body
+
+

--- a/docs/source/api_doc/render/c_runtime.rst
+++ b/docs/source/api_doc/render/c_runtime.rst
@@ -28,5 +28,3 @@ render\_c\_condition\_body
 -----------------------------------------------------
 
 .. autofunction:: render_c_condition_body
-
-

--- a/pyfcstm/render/render.py
+++ b/pyfcstm/render/render.py
@@ -71,6 +71,24 @@ from ..model import StateMachine
 from ..utils import auto_decode
 
 
+def _ensure_output_parent_dir(output_file: str) -> None:
+    """
+    Create the parent directory for an output file when one is present.
+
+    :param output_file: Path of the file that will be rendered or copied.
+    :type output_file: str
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> _ensure_output_parent_dir('generated/machine.py')
+    """
+    parent_dir = os.path.dirname(output_file)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+
+
 class StateMachineCodeRenderer:
     """
     Renderer for generating code from state machine models using templates.
@@ -301,9 +319,7 @@ class StateMachineCodeRenderer:
             name: define.type for name, define in model.defines.items()
         }
         tp = self.env.from_string(auto_decode(pathlib.Path(template_file).read_bytes()))
-        if os.path.dirname(output_file):
-            os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
-        os.makedirs(os.path.dirname(output_file), exist_ok=True)
+        _ensure_output_parent_dir(output_file)
         try:
             rendered = tp.render(model=model)
             if os.path.basename(template_file) == 'machine.py.j2':
@@ -342,8 +358,7 @@ class StateMachineCodeRenderer:
         :raises IOError: If there is an error copying the file
         """
         _ = model
-        if os.path.dirname(output_file):
-            os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
+        _ensure_output_parent_dir(output_file)
         shutil.copyfile(src_file, output_file)
 
     def render(self, model: StateMachine, output_dir: str, clear_previous_directory: bool = False) -> None:

--- a/pyfcstm/render/render.py
+++ b/pyfcstm/render/render.py
@@ -82,11 +82,40 @@ def _ensure_output_parent_dir(output_file: str) -> None:
 
     Example::
 
-        >>> _ensure_output_parent_dir('generated/machine.py')
+        >>> import os
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as td:
+        ...     output_file = os.path.join(td, 'generated', 'machine.py')
+        ...     _ensure_output_parent_dir(output_file)
+        ...     os.path.isdir(os.path.dirname(output_file))
+        True
     """
     parent_dir = os.path.dirname(output_file)
     if parent_dir:
         os.makedirs(parent_dir, exist_ok=True)
+
+
+def _normalize_template_relpath(rel_file: str) -> str:
+    """
+    Normalize a template-relative path for ignore matching and output mapping.
+
+    On Windows this converts native backslash separators to forward slashes so
+    gitignore-style patterns match consistently. POSIX paths are returned
+    unchanged so literal backslashes in POSIX file names are not rewritten.
+
+    :param rel_file: Relative path produced while walking the template tree.
+    :type rel_file: str
+    :return: The relative path with POSIX separators.
+    :rtype: str
+
+    Example::
+
+        >>> _normalize_template_relpath('assets/nested/static.txt')
+        'assets/nested/static.txt'
+    """
+    if os.sep != '/':
+        rel_file = rel_file.replace(os.sep, '/')
+    return rel_file
 
 
 class StateMachineCodeRenderer:
@@ -284,7 +313,9 @@ class StateMachineCodeRenderer:
             for file in files:
                 _, ext = os.path.splitext(file)
                 current_file = os.path.abspath(os.path.join(root, file))
-                rel_file = os.path.relpath(current_file, self.template_dir)
+                rel_file = _normalize_template_relpath(
+                    os.path.relpath(current_file, self.template_dir)
+                )
                 if self._path_spec.match_file(rel_file):
                     continue
                 if ext == '.j2':

--- a/pyfcstm/render/render.py
+++ b/pyfcstm/render/render.py
@@ -102,6 +102,8 @@ def _normalize_template_relpath(rel_file: str) -> str:
     On Windows this converts native backslash separators to forward slashes so
     gitignore-style patterns match consistently. POSIX paths are returned
     unchanged so literal backslashes in POSIX file names are not rewritten.
+    For example, when ``os.sep`` is ``'\\'``, the Windows-style path
+    ``'assets\\nested\\static.txt'`` becomes ``'assets/nested/static.txt'``.
 
     :param rel_file: Relative path produced while walking the template tree.
     :type rel_file: str

--- a/test/render/test_render.py
+++ b/test/render/test_render.py
@@ -259,6 +259,7 @@ class TestRenderRender:
 
     def test_output_path_helpers_handle_nested_and_separator_edges(self):
         assert _normalize_template_relpath('assets/nested/static.txt') == 'assets/nested/static.txt'
+        assert _normalize_template_relpath('assets\\nested\\static.txt') == 'assets\\nested\\static.txt'
         with mock.patch('pyfcstm.render.render.os.sep', '\\'):
             assert _normalize_template_relpath('assets\\nested\\static.txt') == 'assets/nested/static.txt'
 

--- a/test/render/test_render.py
+++ b/test/render/test_render.py
@@ -144,7 +144,6 @@ class TestRenderRender:
         assert b'\r\n' not in data
         assert data == b'line1\nTrafficLight\nline3'
 
-
     def test_renderer_handles_nested_outputs_and_ignores(self, sample_model):
         with TemporaryDirectory() as template_dir:
             nested_template_dir = os.path.join(template_dir, 'nested')

--- a/test/render/test_render.py
+++ b/test/render/test_render.py
@@ -144,6 +144,39 @@ class TestRenderRender:
         assert b'\r\n' not in data
         assert data == b'line1\nTrafficLight\nline3'
 
+
+    def test_renderer_handles_nested_outputs_and_ignores(self, sample_model):
+        with TemporaryDirectory() as template_dir:
+            nested_template_dir = os.path.join(template_dir, 'nested')
+            nested_static_dir = os.path.join(template_dir, 'assets', 'nested')
+            ignored_dir = os.path.join(template_dir, 'assets', 'ignored')
+            os.makedirs(nested_template_dir, exist_ok=True)
+            os.makedirs(nested_static_dir, exist_ok=True)
+            os.makedirs(ignored_dir, exist_ok=True)
+
+            with open(os.path.join(template_dir, 'config.yaml'), 'w') as f:
+                f.write("ignores:\n  - 'assets/ignored/**'\n")
+            with open(os.path.join(nested_template_dir, 'rendered.txt.j2'), 'w') as f:
+                f.write('state={{ model.root_state.name }}')
+            with open(os.path.join(nested_static_dir, 'static.txt'), 'w') as f:
+                f.write('static asset')
+            with open(os.path.join(ignored_dir, 'skip.txt'), 'w') as f:
+                f.write('ignored asset')
+
+            renderer = StateMachineCodeRenderer(template_dir)
+
+            with TemporaryDirectory() as output_dir:
+                renderer.render(model=sample_model, output_dir=output_dir)
+
+                with open(os.path.join(output_dir, 'nested', 'rendered.txt'), 'r') as f:
+                    rendered = f.read()
+                with open(os.path.join(output_dir, 'assets', 'nested', 'static.txt'), 'r') as f:
+                    static = f.read()
+
+                assert rendered == 'state=TrafficLight'
+                assert static == 'static asset'
+                assert not os.path.exists(os.path.join(output_dir, 'assets', 'ignored', 'skip.txt'))
+
     def test_renderer_expr_render_supports_language_aliases(self, sample_model):
         with TemporaryDirectory() as template_dir:
             with open(os.path.join(template_dir, 'config.yaml'), 'w') as f:

--- a/test/render/test_render.py
+++ b/test/render/test_render.py
@@ -259,7 +259,8 @@ class TestRenderRender:
 
     def test_output_path_helpers_handle_nested_and_separator_edges(self):
         assert _normalize_template_relpath('assets/nested/static.txt') == 'assets/nested/static.txt'
-        assert _normalize_template_relpath('assets\\nested\\static.txt') == 'assets\\nested\\static.txt'
+        with mock.patch('pyfcstm.render.render.os.sep', '/'):
+            assert _normalize_template_relpath('assets\\nested\\static.txt') == 'assets\\nested\\static.txt'
         with mock.patch('pyfcstm.render.render.os.sep', '\\'):
             assert _normalize_template_relpath('assets\\nested\\static.txt') == 'assets/nested/static.txt'
 

--- a/test/render/test_render.py
+++ b/test/render/test_render.py
@@ -1,5 +1,6 @@
 import os.path
 import shutil
+from unittest import mock
 
 import pytest
 from hbutils.system import TemporaryDirectory
@@ -7,6 +8,7 @@ from hbutils.system import TemporaryDirectory
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.render import StateMachineCodeRenderer
+from pyfcstm.render.render import _ensure_output_parent_dir, _normalize_template_relpath
 from ..testings import get_testfile, dir_compare, walk_files
 
 
@@ -175,6 +177,100 @@ class TestRenderRender:
                 assert rendered == 'state=TrafficLight'
                 assert static == 'static asset'
                 assert not os.path.exists(os.path.join(output_dir, 'assets', 'ignored', 'skip.txt'))
+
+    def test_renderer_recreates_nested_output_dirs_after_clear(self, sample_model):
+        with TemporaryDirectory() as template_dir:
+            nested_template_dir = os.path.join(template_dir, 'nested')
+            nested_static_dir = os.path.join(template_dir, 'assets', 'nested')
+            os.makedirs(nested_template_dir, exist_ok=True)
+            os.makedirs(nested_static_dir, exist_ok=True)
+
+            with open(os.path.join(template_dir, 'config.yaml'), 'w') as f:
+                f.write('{}\n')
+            with open(os.path.join(nested_template_dir, 'rendered.txt.j2'), 'w') as f:
+                f.write('state={{ model.root_state.name }}')
+            with open(os.path.join(nested_static_dir, 'static.txt'), 'w') as f:
+                f.write('static asset')
+
+            renderer = StateMachineCodeRenderer(template_dir)
+
+            with TemporaryDirectory() as output_dir:
+                renderer.render(model=sample_model, output_dir=output_dir)
+                stale_file = os.path.join(output_dir, 'nested', 'stale.txt')
+                with open(stale_file, 'w') as f:
+                    f.write('stale')
+
+                renderer.render(
+                    model=sample_model,
+                    output_dir=output_dir,
+                    clear_previous_directory=True,
+                )
+
+                with open(os.path.join(output_dir, 'nested', 'rendered.txt'), 'r') as f:
+                    rendered = f.read()
+                with open(os.path.join(output_dir, 'assets', 'nested', 'static.txt'), 'r') as f:
+                    static = f.read()
+
+                assert rendered == 'state=TrafficLight'
+                assert static == 'static asset'
+                assert not os.path.exists(stale_file)
+
+    def test_renderer_normalizes_template_relative_paths_for_ignores(self, sample_model):
+        with TemporaryDirectory() as template_dir:
+            nested_template_dir = os.path.join(template_dir, 'nested')
+            nested_static_dir = os.path.join(template_dir, 'assets', 'nested')
+            ignored_dir = os.path.join(template_dir, 'assets', 'ignored')
+            os.makedirs(nested_template_dir, exist_ok=True)
+            os.makedirs(nested_static_dir, exist_ok=True)
+            os.makedirs(ignored_dir, exist_ok=True)
+
+            with open(os.path.join(template_dir, 'config.yaml'), 'w') as f:
+                f.write("ignores:\n  - 'assets/ignored/**'\n")
+            with open(os.path.join(nested_template_dir, 'rendered.txt.j2'), 'w') as f:
+                f.write('state={{ model.root_state.name }}')
+            with open(os.path.join(nested_static_dir, 'static.txt'), 'w') as f:
+                f.write('static asset')
+            with open(os.path.join(ignored_dir, 'skip.txt'), 'w') as f:
+                f.write('ignored asset')
+
+            original_relpath = os.path.relpath
+            original_sep = os.sep
+
+            def _windows_relpath(path, start=None):
+                return original_relpath(path, start).replace(original_sep, '\\')
+
+            with mock.patch('pyfcstm.render.render.os.sep', '\\'), mock.patch(
+                    'pyfcstm.render.render.os.path.relpath',
+                    side_effect=_windows_relpath,
+            ):
+                renderer = StateMachineCodeRenderer(template_dir)
+
+            assert 'nested/rendered.txt' in renderer._file_mappings
+            assert 'assets/nested/static.txt' in renderer._file_mappings
+            assert 'assets/ignored/skip.txt' not in renderer._file_mappings
+            assert all('\\' not in rel_file for rel_file in renderer._file_mappings)
+
+            with TemporaryDirectory() as output_dir:
+                renderer.render(model=sample_model, output_dir=output_dir)
+
+                assert os.path.exists(os.path.join(output_dir, 'nested', 'rendered.txt'))
+                assert os.path.exists(os.path.join(output_dir, 'assets', 'nested', 'static.txt'))
+                assert not os.path.exists(os.path.join(output_dir, 'assets', 'ignored', 'skip.txt'))
+
+    def test_output_path_helpers_handle_nested_and_separator_edges(self):
+        assert _normalize_template_relpath('assets/nested/static.txt') == 'assets/nested/static.txt'
+        with mock.patch('pyfcstm.render.render.os.sep', '\\'):
+            assert _normalize_template_relpath('assets\\nested\\static.txt') == 'assets/nested/static.txt'
+
+        with TemporaryDirectory() as output_dir:
+            output_file = os.path.join(output_dir, 'nested', 'rendered.txt')
+
+            _ensure_output_parent_dir(output_file)
+            assert os.path.isdir(os.path.dirname(output_file))
+            assert not os.path.exists(output_file)
+
+            _ensure_output_parent_dir(output_file)
+            _ensure_output_parent_dir('bare-file.txt')
 
     def test_renderer_expr_render_supports_language_aliases(self, sample_model):
         with TemporaryDirectory() as template_dir:


### PR DESCRIPTION
## 背景

本 PR 是 [伞 PR #263](https://github.com/HansBug/pyfcstm/pull/263) 的子 PR 1，范围只覆盖 **渲染输出路径与静态资源契约修复**。

当前 `pyfcstm/render/render.py` 有两处历史遗留问题：

1. `render_one_file()` 在输出文件父目录存在时会先错误地调用 `os.makedirs(os.path.dirname(self.config_file), ...)`，随后又按 `output_file` 正确建目录，所以实际渲染路径通常可用，但存在误导性冗余错误调用。
2. `copy_one_file()` 在复制静态资源前同样错误地按 `self.config_file` 父目录建目录；当静态资源位于嵌套目录且输出父目录尚不存在时，`shutil.copyfile()` 会确定性触发 `FileNotFoundError`。

## 目标

- 让渲染文件和静态文件复制都只按 `output_file` 的父目录创建目录。
- 用回归测试覆盖嵌套 `.j2` 渲染、嵌套静态资源复制、以及嵌套 ignore 规则。
- 不触碰 Python 模板 `machine.py.j2` 特判、不处理 config 白名单、不处理 C helper 下沉；这些分别属于 #263 的后续子 PR。

## 范围 / 非目标

范围：

- 仅修改 `pyfcstm/render/render.py` 中 `render_one_file()` / `copy_one_file()` 的输出父目录创建逻辑。
- 仅新增或更新 `test/render` 中嵌套 `.j2` 渲染、嵌套静态资源复制、嵌套 ignore 的回归测试。

非目标：

- 不移除 Python 模板 `machine.py.j2` 特判。
- 不处理 config 顶层 key 白名单或 `type: import` 文档边界。
- 不处理 C helper 下沉或 C/C++ 模板行为。

## 技术方案

1. 先写失败测试，并作为独立 TDD commit 提交。测试构造临时 template，包含：
   - `nested/rendered.txt.j2`
   - `assets/nested/static.txt`
   - 被 `ignores` 排除的嵌套静态文件
2. 在修复前运行新增测试，确认嵌套静态资源复制场景在当前代码上可复现 `FileNotFoundError`，修复 commit 后同一测试转绿。
3. 父目录创建逻辑应等价于：`parent = os.path.dirname(output_file); if parent: os.makedirs(parent, exist_ok=True)`。该逻辑只接收 `output_file`，不接触 `model`、`config_file` 或 `template_dir`，空父目录时 no-op。
4. 删除 `render_one_file()` 中包裹错误调用的 `if os.path.dirname(output_file):` guard 及其内部 `os.makedirs(os.path.dirname(self.config_file), exist_ok=True)`；仅保留现有按 `output_file` 父目录创建目录的逻辑。
5. 修复 `copy_one_file()`，保留 `if os.path.dirname(output_file):` guard，但 guard 内改为创建 `os.path.dirname(output_file)`，不再误用 `self.config_file`。

## 验收标准

- `pytest test/render -v` 通过。
- `SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=render` 通过。
- `rg -F 'os.path.dirname(self.config_file)' pyfcstm/render/render.py` 返回 0 结果（包括注释行也不得保留该历史错误模式）。
- 新增测试能证明：修复前嵌套静态资源复制会失败，修复后能成功复制；PR commit 历史应能区分“测试先行”和“修复”两个阶段。
- 嵌套 `.j2` 渲染输出、嵌套静态资源复制、嵌套 ignore 排除行为都被测试锁住。

## 与上游伞 PR 的一致性

| 上游 #263 子项 | 本 PR 覆盖情况 |
|---|---|
| 子 PR 1：渲染输出路径与静态资源契约修复 | 完整覆盖 |
| 子 PR 2：移除 Python 模板文件名特判 | 不覆盖 |
| 子 PR 3：配置与上下文边界收束 | 不覆盖 |
| #261/#262 C helper 下沉兼容 | 不覆盖 |

## 本 PR 准出后动作

本 PR ready 后合入 `dev/render-boundary-cleanup-umbrella`，并更新 [伞 PR #263](https://github.com/HansBug/pyfcstm/pull/263) 的进度与评论。
