### PR TITLE
实现：D5c 接入 cpp 与 cpp_poll 共享语义 fixture 对齐

### DIFF
--- a/templates/cpp/README.md
+++ b/templates/cpp/README.md
@@ -37,6 +37,13 @@ RTTI-free, and free of STL container requirements. Runtime behavior must remain
 in the generated C core; the wrapper should call only the public C API from
 `machine.h` and should not inspect runtime-owned struct fields directly.
 
+Shared semantic fixture alignment for this template must exercise the
+`machine.hpp` / `machine.cpp` wrapper surface. Fixture harnesses may compile
+`machine.c` and include it in the final executable, but the test entrypoint must
+be the C++ wrapper: harness sources should directly include only `machine.hpp`,
+use `Wrapper::...` aliases for generated runtime types, and call wrapper public
+methods instead of direct `...Machine_*` C functions.
+
 Generated README examples are part of the template contract. When changing the
 wrapper API or compile guidance, update both generated README templates and
 verify representative commands through template tests.

--- a/templates/cpp/README_zh.md
+++ b/templates/cpp/README_zh.md
@@ -34,5 +34,10 @@ environment。
 或 STL 容器。运行时行为必须继续位于生成出的 C core 中；wrapper 应只调用
 `machine.h` 公开 C API，不应直接查看运行时拥有的结构体字段。
 
+共享语义 fixture 对齐必须测试 `machine.hpp` / `machine.cpp` wrapper 表面。fixture
+harness 可以编译 `machine.c` 并把它链接进最终可执行文件，但测试入口必须是 C++ wrapper：
+harness 源码只应直接 include `machine.hpp`，用 `Wrapper::...` aliases 访问生成运行时
+类型，并调用 wrapper public methods，而不是直接调用 `...Machine_*` C 函数。
+
 生成 README 示例属于模板契约。修改 wrapper API 或编译说明时，需要同步更新两份生成
 README 模板，并通过模板测试验证代表性命令。

--- a/templates/cpp/machine.hpp.j2
+++ b/templates/cpp/machine.hpp.j2
@@ -24,6 +24,7 @@ public:
     typedef {{ machine_class_name(model) }}StateId StateId;
     typedef {{ machine_class_name(model) }}EventId EventId;
     typedef {{ machine_class_name(model) }}Hooks Hooks;
+    typedef {{ machine_class_name(model) }}ExecutionContext ExecutionContext;
 
     MachineWrapper();
 

--- a/templates/cpp/machine.hpp.j2
+++ b/templates/cpp/machine.hpp.j2
@@ -23,6 +23,7 @@ public:
     typedef {{ machine_class_name(model) }}Vars Vars;
     typedef {{ machine_class_name(model) }}StateId StateId;
     typedef {{ machine_class_name(model) }}EventId EventId;
+    typedef {{ machine_class_name(model) }}Int Int;
     typedef {{ machine_class_name(model) }}Hooks Hooks;
     typedef {{ machine_class_name(model) }}ExecutionContext ExecutionContext;
 

--- a/templates/cpp_poll/README.md
+++ b/templates/cpp_poll/README.md
@@ -37,6 +37,13 @@ RTTI-free, and free of STL container requirements. Runtime behavior must remain
 in the generated C poll core; the wrapper should call only the public C poll API
 from `machine.h` and should not inspect runtime-owned struct fields directly.
 
+Shared semantic fixture alignment for this template must exercise the
+`machine.hpp` / `machine.cpp` wrapper surface. Fixture harnesses may compile
+`machine.c` and include it in the final executable, but the test entrypoint must
+be the C++ wrapper: harness sources should directly include only `machine.hpp`,
+use `Wrapper::...` aliases for generated runtime types, and call wrapper public
+methods instead of direct `...Machine_*` C functions.
+
 Generated README examples are part of the template contract. When changing the
 wrapper API or compile guidance, update both generated README templates and
 verify representative commands through template tests.

--- a/templates/cpp_poll/README_zh.md
+++ b/templates/cpp_poll/README_zh.md
@@ -33,5 +33,10 @@ renderer environment。
 或 STL 容器。运行时行为必须继续位于生成出的 C poll core 中；wrapper 应只调用
 `machine.h` 公开 C poll API，不应直接查看运行时拥有的结构体字段。
 
+共享语义 fixture 对齐必须测试 `machine.hpp` / `machine.cpp` wrapper 表面。fixture
+harness 可以编译 `machine.c` 并把它链接进最终可执行文件，但测试入口必须是 C++ wrapper：
+harness 源码只应直接 include `machine.hpp`，用 `Wrapper::...` aliases 访问生成运行时
+类型，并调用 wrapper public methods，而不是直接调用 `...Machine_*` C 函数。
+
 生成 README 示例属于模板契约。修改 wrapper API 或编译说明时，需要同步更新两份生成
 README 模板，并通过模板测试验证代表性命令。

--- a/templates/cpp_poll/machine.hpp.j2
+++ b/templates/cpp_poll/machine.hpp.j2
@@ -25,6 +25,8 @@ public:
     typedef {{ machine_class_name(model) }}EventId EventId;
     typedef {{ machine_class_name(model) }}Hooks Hooks;
     typedef {{ machine_class_name(model) }}EventChecks EventChecks;
+    typedef {{ machine_class_name(model) }}ExecutionContext ExecutionContext;
+    typedef {{ machine_class_name(model) }}EventContext EventContext;
 
     MachineWrapper();
 

--- a/templates/cpp_poll/machine.hpp.j2
+++ b/templates/cpp_poll/machine.hpp.j2
@@ -23,6 +23,7 @@ public:
     typedef {{ machine_class_name(model) }}Vars Vars;
     typedef {{ machine_class_name(model) }}StateId StateId;
     typedef {{ machine_class_name(model) }}EventId EventId;
+    typedef {{ machine_class_name(model) }}Int Int;
     typedef {{ machine_class_name(model) }}Hooks Hooks;
     typedef {{ machine_class_name(model) }}EventChecks EventChecks;
     typedef {{ machine_class_name(model) }}ExecutionContext ExecutionContext;

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -7,6 +7,8 @@ from hbutils.testing import TextAligner
 _SLOW_TEST_PATH_PREFIXES = (
     os.path.join("test", "template", "c", ""),
     os.path.join("test", "template", "c_poll", ""),
+    os.path.join("test", "template", "cpp", ""),
+    os.path.join("test", "template", "cpp_poll", ""),
 )
 
 
@@ -82,9 +84,9 @@ def pytest_generate_tests(metafunc):
 def pytest_collection_modifyitems(config, items):
     """Auto-mark native C-family template tests and apply skip gates.
 
-    ``SKIP_SLOW_TESTS=1`` skips ordinary C/C poll template tests by path, but
-    explicitly enabled ``native_toolchain`` items take priority so explicit
-    native toolchain workflow runs are not accidentally converted into
+    ``SKIP_SLOW_TESTS=1`` skips ordinary native C-family template tests by
+    path, but explicitly enabled ``native_toolchain`` items take priority so
+    explicit native toolchain workflow runs are not accidentally converted into
     false-green skips.
     """
     from test.testings.native_toolchain_alignment.profiles import (
@@ -100,7 +102,7 @@ def pytest_collection_modifyitems(config, items):
         "on",
     )
     skip_marker = pytest.mark.skip(
-        reason="SKIP_SLOW_TESTS=1 — native-toolchain template tests skipped"
+        reason="SKIP_SLOW_TESTS=1 — native C-family template tests skipped"
     )
     native_disabled_marker = pytest.mark.skip(
         reason="native toolchain matrix requires explicit opt-in"

--- a/test/template/cpp/test_semantic_fixture_alignment.py
+++ b/test/template/cpp/test_semantic_fixture_alignment.py
@@ -1,0 +1,36 @@
+import re
+from pathlib import Path
+
+import pytest
+
+from test.template.cpp_shared import run_cpp_alignment_case
+from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_case
+
+
+@pytest.mark.unittest
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "case",
+    iter_semantic_cases(),
+    ids=lambda case: case.id,
+)
+def test_generated_cpp_alignment_semantic_fixture(case, tmp_path):
+    run_cpp_alignment_case("cpp", case, str(tmp_path / case.id))
+
+
+@pytest.mark.unittest
+@pytest.mark.slow
+def test_generated_cpp_alignment_harness_uses_wrapper_api(tmp_path):
+    case = load_semantic_case("design_basic_simple_transition")
+    artifacts = run_cpp_alignment_case("cpp", case, str(tmp_path / case.id))
+    harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
+        encoding="utf-8"
+    )
+
+    assert '#include "machine.hpp"' in harness_source
+    assert '#include "machine.h"' not in harness_source
+    assert "native_handle" not in harness_source
+    assert not re.search(
+        r"\b[A-Za-z_][A-Za-z0-9_]*Machine_(init|hot_start|cycle|set_hooks)\s*\(",
+        harness_source,
+    )

--- a/test/template/cpp/test_semantic_fixture_alignment.py
+++ b/test/template/cpp/test_semantic_fixture_alignment.py
@@ -1,8 +1,8 @@
-import re
 from pathlib import Path
 
 import pytest
 
+from test.template.cpp_shared import _assert_wrapper_only_harness
 from test.template.cpp_shared import run_cpp_alignment_case
 from test.testings.native_toolchain_alignment.report import read_observations_jsonl
 from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_case
@@ -31,18 +31,8 @@ def test_generated_cpp_alignment_harness_uses_wrapper_api(tmp_path):
     observations = read_observations_jsonl(artifacts.observations_path)
     assert all(item["api_return"] is None for item in observations)
 
-    assert '#include "machine.hpp"' in harness_source
-    assert '#include "machine.h"' not in harness_source
-    assert "native_handle" not in harness_source
+    _assert_wrapper_only_harness(harness_source)
     assert "Wrapper::Vars" in harness_source
     assert "Wrapper::EventId" in harness_source
     assert "Wrapper::Hooks" in harness_source
     assert "Wrapper::ExecutionContext" in harness_source
-    assert not re.search(
-        r"\b[A-Za-z_][A-Za-z0-9_]*Machine(Vars|EventId|Hooks|EventChecks|ExecutionContext|EventContext)\b",
-        harness_source,
-    )
-    assert not re.search(
-        r"\b[A-Za-z_][A-Za-z0-9_]*Machine_(init|hot_start|cycle|set_hooks)\s*\(",
-        harness_source,
-    )

--- a/test/template/cpp/test_semantic_fixture_alignment.py
+++ b/test/template/cpp/test_semantic_fixture_alignment.py
@@ -22,7 +22,7 @@ def test_generated_cpp_alignment_semantic_fixture(case, tmp_path):
 @pytest.mark.unittest
 @pytest.mark.slow
 def test_generated_cpp_alignment_harness_uses_wrapper_api(tmp_path):
-    case = load_semantic_case("design_basic_simple_transition")
+    case = load_semantic_case("abstract_hook_ref_context_reports_callsite_metadata")
     artifacts = run_cpp_alignment_case("cpp", case, str(tmp_path / case.id))
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
         encoding="utf-8"
@@ -34,6 +34,14 @@ def test_generated_cpp_alignment_harness_uses_wrapper_api(tmp_path):
     assert '#include "machine.hpp"' in harness_source
     assert '#include "machine.h"' not in harness_source
     assert "native_handle" not in harness_source
+    assert "Wrapper::Vars" in harness_source
+    assert "Wrapper::EventId" in harness_source
+    assert "Wrapper::Hooks" in harness_source
+    assert "Wrapper::ExecutionContext" in harness_source
+    assert not re.search(
+        r"\b[A-Za-z_][A-Za-z0-9_]*Machine(Vars|EventId|Hooks|EventChecks|ExecutionContext|EventContext)\b",
+        harness_source,
+    )
     assert not re.search(
         r"\b[A-Za-z_][A-Za-z0-9_]*Machine_(init|hot_start|cycle|set_hooks)\s*\(",
         harness_source,

--- a/test/template/cpp/test_semantic_fixture_alignment.py
+++ b/test/template/cpp/test_semantic_fixture_alignment.py
@@ -16,12 +16,41 @@ from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_
     ids=lambda case: case.id,
 )
 def test_generated_cpp_alignment_semantic_fixture(case, tmp_path):
+    """
+    Align one shared semantic fixture through the generated C++ wrapper.
+
+    :param case: Shared semantic fixture case to render, compile, execute, and
+        compare.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
     run_cpp_alignment_case("cpp", case, str(tmp_path))
 
 
 @pytest.mark.unittest
 @pytest.mark.slow
 def test_generated_cpp_alignment_harness_uses_wrapper_api(tmp_path):
+    """
+    Verify the C++ fixture harness uses only the wrapper public API.
+
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> _assert_wrapper_only_harness('#include "machine.hpp"\\n')
+    """
     case = load_semantic_case("abstract_hook_ref_context_reports_callsite_metadata")
     artifacts = run_cpp_alignment_case("cpp", case, str(tmp_path))
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(

--- a/test/template/cpp/test_semantic_fixture_alignment.py
+++ b/test/template/cpp/test_semantic_fixture_alignment.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from test.template.cpp_shared import run_cpp_alignment_case
+from test.testings.native_toolchain_alignment.report import read_observations_jsonl
 from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_case
 
 
@@ -26,6 +27,9 @@ def test_generated_cpp_alignment_harness_uses_wrapper_api(tmp_path):
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
         encoding="utf-8"
     )
+
+    observations = read_observations_jsonl(artifacts.observations_path)
+    assert all(item["api_return"] is None for item in observations)
 
     assert '#include "machine.hpp"' in harness_source
     assert '#include "machine.h"' not in harness_source

--- a/test/template/cpp/test_semantic_fixture_alignment.py
+++ b/test/template/cpp/test_semantic_fixture_alignment.py
@@ -16,14 +16,14 @@ from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_
     ids=lambda case: case.id,
 )
 def test_generated_cpp_alignment_semantic_fixture(case, tmp_path):
-    run_cpp_alignment_case("cpp", case, str(tmp_path / case.id))
+    run_cpp_alignment_case("cpp", case, str(tmp_path))
 
 
 @pytest.mark.unittest
 @pytest.mark.slow
 def test_generated_cpp_alignment_harness_uses_wrapper_api(tmp_path):
     case = load_semantic_case("abstract_hook_ref_context_reports_callsite_metadata")
-    artifacts = run_cpp_alignment_case("cpp", case, str(tmp_path / case.id))
+    artifacts = run_cpp_alignment_case("cpp", case, str(tmp_path))
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
         encoding="utf-8"
     )

--- a/test/template/cpp_poll/test_semantic_fixture_alignment.py
+++ b/test/template/cpp_poll/test_semantic_fixture_alignment.py
@@ -22,7 +22,7 @@ def test_generated_cpp_poll_alignment_semantic_fixture(case, tmp_path):
 @pytest.mark.unittest
 @pytest.mark.slow
 def test_generated_cpp_poll_alignment_harness_uses_wrapper_api(tmp_path):
-    case = load_semantic_case("design_basic_simple_transition")
+    case = load_semantic_case("abstract_hook_ref_context_reports_callsite_metadata")
     artifacts = run_cpp_alignment_case("cpp_poll", case, str(tmp_path / case.id))
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
         encoding="utf-8"
@@ -34,6 +34,16 @@ def test_generated_cpp_poll_alignment_harness_uses_wrapper_api(tmp_path):
     assert '#include "machine.hpp"' in harness_source
     assert '#include "machine.h"' not in harness_source
     assert "native_handle" not in harness_source
+    assert "Wrapper::Vars" in harness_source
+    assert "Wrapper::EventId" in harness_source
+    assert "Wrapper::Hooks" in harness_source
+    assert "Wrapper::EventChecks" in harness_source
+    assert "Wrapper::ExecutionContext" in harness_source
+    assert "Wrapper::EventContext" in harness_source
+    assert not re.search(
+        r"\b[A-Za-z_][A-Za-z0-9_]*Machine(Vars|EventId|Hooks|EventChecks|ExecutionContext|EventContext)\b",
+        harness_source,
+    )
     assert not re.search(
         r"\b[A-Za-z_][A-Za-z0-9_]*Machine_(init|hot_start|cycle|set_hooks|set_event_checks)\s*\(",
         harness_source,

--- a/test/template/cpp_poll/test_semantic_fixture_alignment.py
+++ b/test/template/cpp_poll/test_semantic_fixture_alignment.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import pytest
 
 from test.template.cpp_shared import run_cpp_alignment_case
+from test.testings.native_toolchain_alignment.report import read_observations_jsonl
 from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_case
 
 
@@ -26,6 +27,9 @@ def test_generated_cpp_poll_alignment_harness_uses_wrapper_api(tmp_path):
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
         encoding="utf-8"
     )
+
+    observations = read_observations_jsonl(artifacts.observations_path)
+    assert all(item["api_return"] is None for item in observations)
 
     assert '#include "machine.hpp"' in harness_source
     assert '#include "machine.h"' not in harness_source

--- a/test/template/cpp_poll/test_semantic_fixture_alignment.py
+++ b/test/template/cpp_poll/test_semantic_fixture_alignment.py
@@ -16,14 +16,14 @@ from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_
     ids=lambda case: case.id,
 )
 def test_generated_cpp_poll_alignment_semantic_fixture(case, tmp_path):
-    run_cpp_alignment_case("cpp_poll", case, str(tmp_path / case.id))
+    run_cpp_alignment_case("cpp_poll", case, str(tmp_path))
 
 
 @pytest.mark.unittest
 @pytest.mark.slow
 def test_generated_cpp_poll_alignment_harness_uses_wrapper_api(tmp_path):
     case = load_semantic_case("abstract_hook_ref_context_reports_callsite_metadata")
-    artifacts = run_cpp_alignment_case("cpp_poll", case, str(tmp_path / case.id))
+    artifacts = run_cpp_alignment_case("cpp_poll", case, str(tmp_path))
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
         encoding="utf-8"
     )

--- a/test/template/cpp_poll/test_semantic_fixture_alignment.py
+++ b/test/template/cpp_poll/test_semantic_fixture_alignment.py
@@ -16,12 +16,41 @@ from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_
     ids=lambda case: case.id,
 )
 def test_generated_cpp_poll_alignment_semantic_fixture(case, tmp_path):
+    """
+    Align one shared semantic fixture through the generated C++ poll wrapper.
+
+    :param case: Shared semantic fixture case to render, compile, execute, and
+        compare.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
     run_cpp_alignment_case("cpp_poll", case, str(tmp_path))
 
 
 @pytest.mark.unittest
 @pytest.mark.slow
 def test_generated_cpp_poll_alignment_harness_uses_wrapper_api(tmp_path):
+    """
+    Verify the C++ poll fixture harness uses only the wrapper public API.
+
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> _assert_wrapper_only_harness('#include "machine.hpp"\\n')
+    """
     case = load_semantic_case("abstract_hook_ref_context_reports_callsite_metadata")
     artifacts = run_cpp_alignment_case("cpp_poll", case, str(tmp_path))
     harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(

--- a/test/template/cpp_poll/test_semantic_fixture_alignment.py
+++ b/test/template/cpp_poll/test_semantic_fixture_alignment.py
@@ -1,8 +1,8 @@
-import re
 from pathlib import Path
 
 import pytest
 
+from test.template.cpp_shared import _assert_wrapper_only_harness
 from test.template.cpp_shared import run_cpp_alignment_case
 from test.testings.native_toolchain_alignment.report import read_observations_jsonl
 from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_case
@@ -31,20 +31,10 @@ def test_generated_cpp_poll_alignment_harness_uses_wrapper_api(tmp_path):
     observations = read_observations_jsonl(artifacts.observations_path)
     assert all(item["api_return"] is None for item in observations)
 
-    assert '#include "machine.hpp"' in harness_source
-    assert '#include "machine.h"' not in harness_source
-    assert "native_handle" not in harness_source
+    _assert_wrapper_only_harness(harness_source)
     assert "Wrapper::Vars" in harness_source
     assert "Wrapper::EventId" in harness_source
     assert "Wrapper::Hooks" in harness_source
     assert "Wrapper::EventChecks" in harness_source
     assert "Wrapper::ExecutionContext" in harness_source
     assert "Wrapper::EventContext" in harness_source
-    assert not re.search(
-        r"\b[A-Za-z_][A-Za-z0-9_]*Machine(Vars|EventId|Hooks|EventChecks|ExecutionContext|EventContext)\b",
-        harness_source,
-    )
-    assert not re.search(
-        r"\b[A-Za-z_][A-Za-z0-9_]*Machine_(init|hot_start|cycle|set_hooks|set_event_checks)\s*\(",
-        harness_source,
-    )

--- a/test/template/cpp_poll/test_semantic_fixture_alignment.py
+++ b/test/template/cpp_poll/test_semantic_fixture_alignment.py
@@ -1,0 +1,36 @@
+import re
+from pathlib import Path
+
+import pytest
+
+from test.template.cpp_shared import run_cpp_alignment_case
+from test.testings.simulate_semantics import iter_semantic_cases, load_semantic_case
+
+
+@pytest.mark.unittest
+@pytest.mark.slow
+@pytest.mark.parametrize(
+    "case",
+    iter_semantic_cases(),
+    ids=lambda case: case.id,
+)
+def test_generated_cpp_poll_alignment_semantic_fixture(case, tmp_path):
+    run_cpp_alignment_case("cpp_poll", case, str(tmp_path / case.id))
+
+
+@pytest.mark.unittest
+@pytest.mark.slow
+def test_generated_cpp_poll_alignment_harness_uses_wrapper_api(tmp_path):
+    case = load_semantic_case("design_basic_simple_transition")
+    artifacts = run_cpp_alignment_case("cpp_poll", case, str(tmp_path / case.id))
+    harness_source = Path(artifacts.harness_dir, "harness.cpp").read_text(
+        encoding="utf-8"
+    )
+
+    assert '#include "machine.hpp"' in harness_source
+    assert '#include "machine.h"' not in harness_source
+    assert "native_handle" not in harness_source
+    assert not re.search(
+        r"\b[A-Za-z_][A-Za-z0-9_]*Machine_(init|hot_start|cycle|set_hooks|set_event_checks)\s*\(",
+        harness_source,
+    )

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -57,7 +57,11 @@ _DIRECT_C_API_RE = re.compile(
     r"current_state_path|current_state_name|last_error|dsl_source)"
     r"\s*(?:\(|[,;=)\]&])"
 )
+_WRAPPER_HEADER_BASENAME = "machine.hpp"
+_CONTEXT_TEMPLATE_MAP = {"cpp": "c", "cpp_poll": "c_poll"}
 
+# Harness sections: wrapper aliases, hook/event recording helpers, JSON writers,
+# initialization or hot-start code, then shared fixture step execution.
 _CPP_TEMPLATE = r"""
 #include "machine.hpp"
 
@@ -375,6 +379,8 @@ int main(int argc, char **argv)
 }
 """
 
+# The poll harness mirrors ``_CPP_TEMPLATE`` but routes events through
+# ``set_event_checks()`` before invoking the zero-argument wrapper cycle.
 _CPP_POLL_TEMPLATE = r"""
 #include "machine.hpp"
 
@@ -726,6 +732,8 @@ int main(int argc, char **argv)
 }
 """
 
+_TEMPLATE_TEXT_MAP = {"cpp": _CPP_TEMPLATE, "cpp_poll": _CPP_POLL_TEMPLATE}
+
 _CMAKE_TEMPLATE = r"""
 cmake_minimum_required(VERSION 3.5)
 project(pyfcstm_cpp_shared_fixture_harness C CXX)
@@ -791,17 +799,58 @@ class CppAlignmentArtifacts:
 
 
 def _validate_template_name(template_name: str) -> None:
-    if template_name not in ("cpp", "cpp_poll"):
+    """
+    Validate that a C++ alignment helper received a supported template name.
+
+    :param template_name: Candidate template name.
+    :type template_name: str
+    :return: ``None``.
+    :rtype: None
+    :raises ValueError: If ``template_name`` is not ``"cpp"`` or
+        ``"cpp_poll"``.
+
+    Example::
+
+        >>> _validate_template_name("cpp")
+    """
+    if template_name not in _CONTEXT_TEMPLATE_MAP:
         raise ValueError("unsupported C++ alignment template: %r" % template_name)
 
 
 def _cmake_generator_args() -> List[str]:
+    """
+    Return platform-specific CMake generator arguments for fixture builds.
+
+    Windows CI uses MinGW for these generated wrapper harness tests, while
+    POSIX platforms can use CMake's default generator.
+
+    :return: Extra arguments for the CMake configure command.
+    :rtype: list[str]
+
+    Example::
+
+        >>> isinstance(_cmake_generator_args(), list)
+        True
+    """
     if os.name == "nt":
         return ["-G", "MinGW Makefiles"]
     return []
 
 
 def _find_cmake() -> str:
+    """
+    Locate the CMake executable required by generated C++ harness tests.
+
+    :return: Path to the ``cmake`` executable.
+    :rtype: str
+    :raises pytest.skip.Exception: If CMake is unavailable in the current
+        environment.
+
+    Example::
+
+        >>> bool(_find_cmake())  # doctest: +SKIP
+        True
+    """
     cmake = shutil.which("cmake")
     if cmake is None:
         pytest.skip("cmake is required for generated C++ alignment tests.")
@@ -809,6 +858,18 @@ def _find_cmake() -> str:
 
 
 def _environment() -> Environment:
+    """
+    Create the strict Jinja2 environment used for harness source templates.
+
+    :return: Jinja2 environment with the ``tojson`` filter registered.
+    :rtype: jinja2.Environment
+
+    Example::
+
+        >>> env = _environment()
+        >>> env.from_string('{{ value | tojson }}').render(value='x')
+        '"x"'
+    """
     env = Environment(
         undefined=StrictUndefined,
         autoescape=False,
@@ -822,6 +883,26 @@ def _environment() -> Environment:
 def _render_generated_template(
     template_name: str, case: SemanticCase, generated_dir: str
 ) -> None:
+    """
+    Render a built-in C++ wrapper template for one semantic fixture case.
+
+    :param template_name: Template under test, either ``"cpp"`` or
+        ``"cpp_poll"``.
+    :type template_name: str
+    :param case: Shared semantic fixture case used to build the state machine.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param generated_dir: Directory where generated template files are written.
+    :type generated_dir: str
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> from test.testings.simulate_semantics import load_semantic_case
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
     model = simulate_semantics.build_state_machine_from_case(case)
     template_root = os.path.join(os.path.dirname(generated_dir), "template-src")
     template_dir = extract_template(template_name, template_root)
@@ -829,16 +910,70 @@ def _render_generated_template(
 
 
 def _render_harness(template_name: str, case: SemanticCase, harness_path: str) -> None:
-    base_context = build_harness_context(
-        "c_poll" if template_name == "cpp_poll" else "c", case
-    )
+    """
+    Render the C++98 fixture harness for one generated wrapper template.
+
+    The C++ wrapper templates reuse the existing C-family harness context, but
+    the mapping is explicit so new template variants cannot silently fall back
+    to the plain C context.
+
+    :param template_name: Template under test, either ``"cpp"`` or
+        ``"cpp_poll"``.
+    :type template_name: str
+    :param case: Shared semantic fixture case.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param harness_path: Path where ``harness.cpp`` is written.
+    :type harness_path: str
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If the rendered harness bypasses the C++ wrapper
+        entrypoint.
+    :raises ValueError: If ``template_name`` is unsupported.
+
+    Example::
+
+        >>> from test.testings.simulate_semantics import load_semantic_case
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
+    _validate_template_name(template_name)
+    context_template_name = _CONTEXT_TEMPLATE_MAP[template_name]
+    base_context = build_harness_context(context_template_name, case)
     context = replace(base_context, template_name=template_name)
-    template_text = _CPP_POLL_TEMPLATE if template_name == "cpp_poll" else _CPP_TEMPLATE
+    template_text = _TEMPLATE_TEXT_MAP[template_name]
     rendered = _environment().from_string(template_text).render(context=context)
     _assert_wrapper_only_harness(rendered)
     os.makedirs(os.path.dirname(harness_path), exist_ok=True)
     with open(harness_path, "w", encoding="utf-8") as f:
         f.write(rendered)
+
+
+def _has_wrapper_header_include(source: str) -> bool:
+    """
+    Return whether a harness directly includes the C++ wrapper header.
+
+    The check uses preprocessor include directives rather than substring
+    matching, so comments and string literals cannot satisfy the wrapper-entry
+    contract accidentally.
+
+    :param source: Rendered C++ harness source.
+    :type source: str
+    :return: Whether the source includes ``machine.hpp`` through a directive.
+    :rtype: bool
+
+    Example::
+
+        >>> _has_wrapper_header_include('#include "machine.hpp"\n')
+        True
+        >>> _has_wrapper_header_include('// #include "machine.hpp"\n')
+        False
+    """
+    for match in _INCLUDE_DIRECTIVE_RE.finditer(source):
+        target = match.group(1).replace("\\", "/")
+        if os.path.basename(target) == _WRAPPER_HEADER_BASENAME:
+            return True
+    return False
 
 
 def _has_direct_machine_header_include(source: str) -> bool:
@@ -888,7 +1023,7 @@ def _assert_wrapper_only_harness(source: str) -> None:
 
         >>> _assert_wrapper_only_harness('#include "machine.hpp"\\n')
     """
-    assert '#include "machine.hpp"' in source
+    assert _has_wrapper_header_include(source)
     assert not _has_direct_machine_header_include(source)
     assert "native_handle" not in source
     assert not _DIRECT_C_TYPE_RE.search(source)
@@ -896,6 +1031,26 @@ def _assert_wrapper_only_harness(source: str) -> None:
 
 
 def _render_cmake(artifacts: CppAlignmentArtifacts, harness_path: str) -> None:
+    """
+    Render the CMake project that compiles a generated wrapper harness.
+
+    The project always builds the generated C core, generated C++ wrapper, and
+    synthetic fixture harness together so fixture execution validates the same
+    wrapper entrypoint that downstream users compile.
+
+    :param artifacts: Artifact paths for this fixture run.
+    :type artifacts: CppAlignmentArtifacts
+    :param harness_path: Path to the rendered ``harness.cpp`` source file.
+    :type harness_path: str
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> artifacts = CppAlignmentArtifacts("cpp", "demo", "/tmp/a", "/tmp/a/g", "/tmp/a/h", "/tmp/a/b", "/tmp/a/o.jsonl")
+        >>> artifacts.harness_dir
+        '/tmp/a/h'
+    """
     text = (
         _environment()
         .from_string(_CMAKE_TEMPLATE)
@@ -919,6 +1074,29 @@ def _render_cmake(artifacts: CppAlignmentArtifacts, harness_path: str) -> None:
 def _prepare_artifacts(
     template_name: str, case: SemanticCase, artifact_root: str
 ) -> CppAlignmentArtifacts:
+    """
+    Create generated sources, harness files, and build directories for a case.
+
+    :param template_name: Template under test, either ``"cpp"`` or
+        ``"cpp_poll"``.
+    :type template_name: str
+    :param case: Shared semantic fixture case.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param artifact_root: Root directory for all run artifacts.
+    :type artifact_root: str
+    :return: Paths for generated sources, harness files, build output, and
+        observations.
+    :rtype: CppAlignmentArtifacts
+    :raises AssertionError: If the generated harness bypasses wrapper APIs.
+    :raises ValueError: If ``template_name`` is unsupported.
+
+    Example::
+
+        >>> from test.testings.simulate_semantics import load_semantic_case
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
     generated_dir = os.path.join(artifact_root, "generated")
     harness_dir = os.path.join(artifact_root, "harness")
     build_dir = os.path.join(artifact_root, "build")
@@ -945,6 +1123,28 @@ def _prepare_artifacts(
 def _run_command(
     command: Sequence[str], cwd: str, stdout_path: str, stderr_path: str
 ) -> subprocess.CompletedProcess:
+    """
+    Run a command and persist command, stdout, and stderr logs.
+
+    :param command: Command arguments to execute.
+    :type command: collections.abc.Sequence[str]
+    :param cwd: Working directory for the child process.
+    :type cwd: str
+    :param stdout_path: File path receiving captured standard output.
+    :type stdout_path: str
+    :param stderr_path: File path receiving captured standard error.
+    :type stderr_path: str
+    :return: Completed process object with captured output.
+    :rtype: subprocess.CompletedProcess
+
+    Example::
+
+        >>> import tempfile
+        >>> root = tempfile.mkdtemp()
+        >>> result = _run_command(["python", "-c", "print('ok')"], root, os.path.join(root, "x.stdout.txt"), os.path.join(root, "x.stderr.txt"))
+        >>> result.returncode
+        0
+    """
     command_path = stdout_path.replace(".stdout.txt", ".command.txt")
     with open(command_path, "w", encoding="utf-8") as f:
         f.write(" ".join(command) + "\n")
@@ -976,6 +1176,33 @@ def _fail_command(
     stdout_path: str,
     stderr_path: str,
 ) -> None:
+    """
+    Raise an assertion with persisted log paths and bounded output tails.
+
+    :param stage: Human-readable stage name, such as ``"CMake build"``.
+    :type stage: str
+    :param command: Command arguments that failed.
+    :type command: collections.abc.Sequence[str]
+    :param completed: Completed process returned by :func:`_run_command`.
+    :type completed: subprocess.CompletedProcess
+    :param stdout_path: Path to the captured stdout log.
+    :type stdout_path: str
+    :param stderr_path: Path to the captured stderr log.
+    :type stderr_path: str
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: Always, with command diagnostics.
+
+    Example::
+
+        >>> import subprocess
+        >>> proc = subprocess.CompletedProcess(["false"], 1, "", "boom")
+        >>> _fail_command("demo", ["false"], proc, "out", "err")
+        Traceback (most recent call last):
+        ...
+        AssertionError: demo failed with return code 1.
+        ...
+    """
     raise AssertionError(
         "{stage} failed with return code {returncode}.\n"
         "command: {command}\n"
@@ -995,6 +1222,23 @@ def _fail_command(
 
 
 def _find_executable(build_dir: str) -> str:
+    """
+    Locate the generated C++ harness executable under a CMake build tree.
+
+    :param build_dir: CMake build directory.
+    :type build_dir: str
+    :return: Path to the harness executable.
+    :rtype: str
+    :raises FileNotFoundError: If no platform-specific executable candidate
+        exists.
+
+    Example::
+
+        >>> _find_executable("/path/that/does/not/exist")
+        Traceback (most recent call last):
+        ...
+        FileNotFoundError: Cannot find C++ shared fixture harness executable under '/path/that/does/not/exist'.
+    """
     candidates = [
         os.path.join(build_dir, "cpp_shared_fixture_harness"),
         os.path.join(build_dir, "cpp_shared_fixture_harness.exe"),
@@ -1010,6 +1254,25 @@ def _find_executable(build_dir: str) -> str:
 
 
 def _build_and_run(artifacts: CppAlignmentArtifacts) -> None:
+    """
+    Configure, build, and execute a generated C++ fixture harness.
+
+    :param artifacts: Paths produced by :func:`_prepare_artifacts`.
+    :type artifacts: CppAlignmentArtifacts
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If CMake configure, CMake build, or harness
+        execution exits with a non-zero status.
+    :raises FileNotFoundError: If the harness executable cannot be located
+        after a successful build.
+    :raises pytest.skip.Exception: If CMake is unavailable.
+
+    Example::
+
+        >>> artifacts = CppAlignmentArtifacts("cpp", "demo", "/tmp/a", "/tmp/a/g", "/tmp/a/h", "/tmp/a/b", "/tmp/a/o.jsonl")
+        >>> artifacts.template_name
+        'cpp'
+    """
     cmake = _find_cmake()
     logs_dir = os.path.join(artifacts.root_dir, "logs")
     os.makedirs(logs_dir, exist_ok=True)
@@ -1084,7 +1347,8 @@ def run_cpp_alignment_case(
 
     Example::
 
-        >>> case = simulate_semantics.load_semantic_case("design_basic_simple_transition")
+        >>> from test.testings.simulate_semantics import load_semantic_case
+        >>> case = load_semantic_case("design_basic_simple_transition")
         >>> case.id
         'design_basic_simple_transition'
     """

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -3,9 +3,11 @@ Shared C++ wrapper semantic-fixture alignment helpers.
 
 This module renders the built-in ``cpp`` and ``cpp_poll`` templates for one
 schema-v2 semantic fixture, generates a C++98 harness that drives only the
-public ``machine.hpp`` wrapper API, builds the generated C core plus C++ wrapper
-with CMake, and compares emitted public observations with the existing shared
-fixture expectations.
+public ``machine.hpp`` wrapper API, builds the generated C core plus C++
+wrapper with CMake, and compares emitted public observations with the existing
+shared fixture expectations. The generated harness intentionally includes only
+``machine.hpp`` directly and calls wrapper methods rather than the underlying
+``machine.h`` C entry points.
 
 The module contains:
 
@@ -22,6 +24,7 @@ Example::
     'design_basic_simple_transition'
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -49,7 +52,7 @@ _CPP_TEMPLATE = r"""
 
 typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp::MachineWrapper Wrapper;
 
-static {{ context.machine_class_name }}Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
+static Wrapper::Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
 static const char *state_paths[] = {
 {% for state in context.states %}    {{ state.path | tojson }},
 {% endfor %}};
@@ -135,7 +138,7 @@ static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int val
     }
 }
 
-static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
+static void write_vars(FILE *out, const Wrapper::Vars *vars)
 {
     fputc('{', out);
 {% for variable in context.variables %}    if ({{ loop.index0 }} > 0) {
@@ -187,7 +190,7 @@ static void write_handler_calls(FILE *out)
 }
 
 {% if context.hooks %}extern "C" {
-static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
+static void record_hook(Wrapper::Machine *machine_ptr, const Wrapper::ExecutionContext *ctx, void *user_data)
 {
     struct HandlerCall *call;
     (void)machine_ptr;
@@ -214,7 +217,7 @@ static void install_hooks(Wrapper *wrapper)
 {% endfor %}    wrapper->set_hooks(&hooks, NULL);
 }
 
-static int run_cycle(Wrapper *wrapper, const {{ context.machine_class_name }}EventId *events, size_t event_count)
+static int run_cycle(Wrapper *wrapper, const Wrapper::EventId *events, size_t event_count)
 {
     return wrapper->cycle(events, event_count);
 }
@@ -223,7 +226,7 @@ static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int c
 {
     size_t i;
     const char *state_path = wrapper->current_state_path();
-    const {{ context.machine_class_name }}Vars *vars = wrapper->vars();
+    const Wrapper::Vars *vars = wrapper->vars();
     fputc('{', out);
     fputs("\"schema_version\":\"1\"", out);
     fputs(",\"case_id\":", out);
@@ -303,7 +306,7 @@ int main(int argc, char **argv)
 {% else %}    fclose(out);
     return 4;
 {% endif %}{% else %}    {
-        {{ context.machine_class_name }}Vars initial_vars;
+        Wrapper::Vars initial_vars;
         memset(&initial_vars, 0, sizeof(initial_vars));
 {% for assignment in context.initial.assignments %}        initial_vars.{{ assignment.field }} = {{ assignment.value }};
 {% endfor %}        if (!wrapper.hot_start({{ context.machine_macro_name }}_{{ context.initial.state_macro }}, &initial_vars)) {
@@ -335,7 +338,7 @@ int main(int argc, char **argv)
         last_error = {{ step.pre_error_message | tojson }};
 {% elif step.cycle_count == 0 %}        api_return = 1;
         last_error = NULL;
-{% else %}{% if step.events %}        {{ context.machine_class_name }}EventId event_ids[] = {
+{% else %}{% if step.events %}        Wrapper::EventId event_ids[] = {
 {% for event in step.events %}            {{ context.machine_macro_name }}_{{ event.macro }},
 {% endfor %}        };
 {% endif %}        api_return = 1;
@@ -366,10 +369,10 @@ _CPP_POLL_TEMPLATE = r"""
 
 typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp_poll::MachineWrapper Wrapper;
 
-static {{ context.machine_class_name }}Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
-static {{ context.machine_class_name }}EventId active_events[64];
+static Wrapper::Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
+static Wrapper::EventId active_events[64];
 static size_t active_event_count = 0u;
-static {{ context.machine_class_name }}EventChecks event_checks = {{ context.machine_class_name.upper() }}_EVENT_CHECKS_INIT;
+static Wrapper::EventChecks event_checks = {{ context.machine_class_name.upper() }}_EVENT_CHECKS_INIT;
 
 static const char *state_paths[] = {
 {% for state in context.states %}    {{ state.path | tojson }},
@@ -456,7 +459,7 @@ static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int val
     }
 }
 
-static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
+static void write_vars(FILE *out, const Wrapper::Vars *vars)
 {
     fputc('{', out);
 {% for variable in context.variables %}    if ({{ loop.index0 }} > 0) {
@@ -508,7 +511,7 @@ static void write_handler_calls(FILE *out)
 }
 
 {% if context.hooks %}extern "C" {
-static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
+static void record_hook(Wrapper::Machine *machine_ptr, const Wrapper::ExecutionContext *ctx, void *user_data)
 {
     struct HandlerCall *call;
     (void)machine_ptr;
@@ -536,7 +539,7 @@ static void install_hooks(Wrapper *wrapper)
 }
 
 extern "C" {
-static int check_event({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}EventContext *ctx, void *user_data)
+static int check_event(Wrapper::Machine *machine_ptr, const Wrapper::EventContext *ctx, void *user_data)
 {
     size_t i;
     (void)machine_ptr;
@@ -556,7 +559,7 @@ static void install_event_checks(Wrapper *wrapper)
 {% endfor %}    wrapper->set_event_checks(&event_checks, NULL);
 }
 
-static int run_cycle(Wrapper *wrapper, const {{ context.machine_class_name }}EventId *events, size_t event_count)
+static int run_cycle(Wrapper *wrapper, const Wrapper::EventId *events, size_t event_count)
 {
     size_t i;
     if (event_count > sizeof(active_events) / sizeof(active_events[0])) {
@@ -573,7 +576,7 @@ static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int c
 {
     size_t i;
     const char *state_path = wrapper->current_state_path();
-    const {{ context.machine_class_name }}Vars *vars = wrapper->vars();
+    const Wrapper::Vars *vars = wrapper->vars();
     fputc('{', out);
     fputs("\"schema_version\":\"1\"", out);
     fputs(",\"case_id\":", out);
@@ -654,7 +657,7 @@ int main(int argc, char **argv)
 {% else %}    fclose(out);
     return 4;
 {% endif %}{% else %}    {
-        {{ context.machine_class_name }}Vars initial_vars;
+        Wrapper::Vars initial_vars;
         memset(&initial_vars, 0, sizeof(initial_vars));
 {% for assignment in context.initial.assignments %}        initial_vars.{{ assignment.field }} = {{ assignment.value }};
 {% endfor %}        if (!wrapper.hot_start({{ context.machine_macro_name }}_{{ context.initial.state_macro }}, &initial_vars)) {
@@ -686,7 +689,7 @@ int main(int argc, char **argv)
         last_error = {{ step.pre_error_message | tojson }};
 {% elif step.cycle_count == 0 %}        api_return = 1;
         last_error = NULL;
-{% else %}{% if step.events %}        {{ context.machine_class_name }}EventId event_ids[] = {
+{% else %}{% if step.events %}        Wrapper::EventId event_ids[] = {
 {% for event in step.events %}            {{ context.machine_macro_name }}_{{ event.macro }},
 {% endfor %}        };
 {% endif %}        api_return = 1;
@@ -798,6 +801,7 @@ def _environment() -> Environment:
         trim_blocks=True,
         lstrip_blocks=True,
     )
+    env.filters["tojson"] = json.dumps
     return env
 
 

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -45,7 +45,10 @@ from test.testings.native_toolchain_alignment.runner import (
 )
 from test.testings.simulate_semantics import SemanticCase
 
-_INCLUDE_DIRECTIVE_RE = re.compile(r"^\s*#\s*include\s*[<\"]([^>\"]+)[>\"]", re.M)
+_INCLUDE_DIRECTIVE_RE = re.compile(r"^\s*#\s*include\s*(?P<target>[^\n]+)", re.M)
+_INCLUDE_LITERAL_RE = re.compile(r'(?:(?:"([^"\n]+)")|(?:<([^>\n]+)>))')
+_NATIVE_HANDLE_CALL_RE = re.compile(r"\bnative_handle\s*\(")
+_TOKEN_PASTE_RE = re.compile(r"##")
 _DIRECT_C_TYPE_RE = re.compile(
     r"\b[A-Za-z_][A-Za-z0-9_]*Machine"
     r"(Vars|StateId|EventId|Int|Hooks|EventChecks|ExecutionContext|EventContext)?\b"
@@ -54,8 +57,7 @@ _DIRECT_C_API_RE = re.compile(
     r"\b[A-Za-z_][A-Za-z0-9_]*Machine_"
     r"(create_uninitialized|create|destroy|init|hot_start|set_hooks|"
     r"set_event_checks|cycle|vars|is_ended|current_state_id|"
-    r"current_state_path|current_state_name|last_error|dsl_source)"
-    r"\s*(?:\(|[,;=)\]&])"
+    r"current_state_path|current_state_name|last_error|dsl_source)\b"
 )
 _WRAPPER_HEADER_BASENAME = "machine.hpp"
 _CONTEXT_TEMPLATE_MAP = {"cpp": "c", "cpp_poll": "c_poll"}
@@ -949,6 +951,110 @@ def _render_harness(template_name: str, case: SemanticCase, harness_path: str) -
         f.write(rendered)
 
 
+def _mask_cpp_comments_and_literals(source: str, mask_literals: bool) -> str:
+    """
+    Replace C++ comments and optionally literals with whitespace.
+
+    Newlines are preserved so preprocessor directive checks still operate on
+    the same logical lines after block comments are removed. Include checks keep
+    literals intact because header names live in ``#include "..."`` tokens;
+    symbol checks mask literals so diagnostic strings cannot satisfy or trip
+    wrapper-only guard patterns.
+
+    :param source: C++ source text to inspect.
+    :type source: str
+    :param mask_literals: Whether string and character literals should also be
+        replaced by whitespace.
+    :type mask_literals: bool
+    :return: Source text with comments, and optionally literals, masked.
+    :rtype: str
+
+    Example::
+
+        >>> _mask_cpp_comments_and_literals('// #include "machine.hpp"\n', False)
+        '\n'
+        >>> _mask_cpp_comments_and_literals('"RootMachine_cycle"', True)
+        '                   '
+    """
+    output = []
+    index = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        next_char = source[index + 1] if index + 1 < length else ""
+
+        if char == "/" and next_char == "/":
+            index += 2
+            while index < length and source[index] != "\n":
+                index += 1
+            if index < length:
+                output.append("\n")
+                index += 1
+        elif char == "/" and next_char == "*":
+            output.append(" ")
+            output.append(" ")
+            index += 2
+            while index < length:
+                current = source[index]
+                following = source[index + 1] if index + 1 < length else ""
+                if current == "*" and following == "/":
+                    output.append(" ")
+                    output.append(" ")
+                    index += 2
+                    break
+                output.append("\n" if current == "\n" else " ")
+                index += 1
+        elif mask_literals and char in {'"', "'"}:
+            quote = char
+            output.append(" ")
+            index += 1
+            while index < length:
+                current = source[index]
+                output.append("\n" if current == "\n" else " ")
+                index += 1
+                if current == "\\" and index < length:
+                    escaped = source[index]
+                    output.append("\n" if escaped == "\n" else " ")
+                    index += 1
+                elif current == quote:
+                    break
+        else:
+            output.append(char)
+            index += 1
+    return "".join(output)
+
+
+def _iter_include_targets(source: str) -> List[str]:
+    """
+    Return literal include targets from comment-masked C++ source.
+
+    Macro include directives are represented by an empty string so callers can
+    reject them conservatively without implementing a preprocessor.
+
+    :param source: C++ source text to inspect.
+    :type source: str
+    :return: Include targets; ``""`` means a non-literal include directive.
+    :rtype: list[str]
+
+    Example::
+
+        >>> _iter_include_targets('#include "machine.hpp"\n')
+        ['machine.hpp']
+        >>> _iter_include_targets('#include HEADER\n')
+        ['']
+    """
+    directive_source = _mask_cpp_comments_and_literals(source, mask_literals=False)
+    targets = []
+    for match in _INCLUDE_DIRECTIVE_RE.finditer(directive_source):
+        raw_target = match.group("target").strip()
+        literal_match = _INCLUDE_LITERAL_RE.match(raw_target)
+        if literal_match:
+            targets.append(literal_match.group(1) or literal_match.group(2))
+        else:
+            targets.append("")
+    return targets
+
+
 def _has_wrapper_header_include(source: str) -> bool:
     """
     Return whether a harness directly includes the C++ wrapper header.
@@ -969,9 +1075,9 @@ def _has_wrapper_header_include(source: str) -> bool:
         >>> _has_wrapper_header_include('// #include "machine.hpp"\n')
         False
     """
-    for match in _INCLUDE_DIRECTIVE_RE.finditer(source):
-        target = match.group(1).replace("\\", "/")
-        if os.path.basename(target) == _WRAPPER_HEADER_BASENAME:
+    for target in _iter_include_targets(source):
+        normalized_target = target.replace("\\", "/")
+        if os.path.basename(normalized_target).lower() == _WRAPPER_HEADER_BASENAME:
             return True
     return False
 
@@ -997,9 +1103,9 @@ def _has_direct_machine_header_include(source: str) -> bool:
         >>> _has_direct_machine_header_include('#include "machine.hpp"\n')
         False
     """
-    for match in _INCLUDE_DIRECTIVE_RE.finditer(source):
-        target = match.group(1).replace("\\", "/")
-        if os.path.basename(target) == "machine.h":
+    for target in _iter_include_targets(source):
+        normalized_target = target.replace("\\", "/")
+        if os.path.basename(normalized_target).lower() == "machine.h":
             return True
     return False
 
@@ -1010,8 +1116,15 @@ def _assert_wrapper_only_harness(source: str) -> None:
 
     Fixture-alignment harnesses are allowed to include only ``machine.hpp``
     directly. They may observe state through ``Wrapper::...`` aliases and
-    wrapper methods, but they must not directly include ``machine.h``, bind C
-    runtime typedef names, or call generated ``...Machine_*`` C functions.
+    wrapper methods, but they must not directly include ``machine.h``, use macro
+    includes, use token-paste macros, bind C runtime typedef names, or call
+    generated ``...Machine_*`` C functions.
+
+    .. note::
+       This is a conservative source-level gate, not a complete C++ parser or
+       preprocessor. It masks comments and string literals before symbol checks,
+       rejects every non-literal ``#include`` directive, and rejects token-paste
+       macros because fixture harnesses do not need those constructs.
 
     :param source: Rendered C++ harness source.
     :type source: str
@@ -1023,11 +1136,15 @@ def _assert_wrapper_only_harness(source: str) -> None:
 
         >>> _assert_wrapper_only_harness('#include "machine.hpp"\\n')
     """
+    include_targets = _iter_include_targets(source)
+    symbol_source = _mask_cpp_comments_and_literals(source, mask_literals=True)
+    assert include_targets and all(include_targets)
     assert _has_wrapper_header_include(source)
     assert not _has_direct_machine_header_include(source)
-    assert "native_handle" not in source
-    assert not _DIRECT_C_TYPE_RE.search(source)
-    assert not _DIRECT_C_API_RE.search(source)
+    assert not _TOKEN_PASTE_RE.search(symbol_source)
+    assert not _NATIVE_HANDLE_CALL_RE.search(symbol_source)
+    assert not _DIRECT_C_TYPE_RE.search(symbol_source)
+    assert not _DIRECT_C_API_RE.search(symbol_source)
 
 
 def _render_cmake(artifacts: CppAlignmentArtifacts, harness_path: str) -> None:

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -45,7 +45,7 @@ from test.testings.native_toolchain_alignment.runner import (
 )
 from test.testings.simulate_semantics import SemanticCase
 
-_INCLUDE_DIRECTIVE_RE = re.compile(r"^\s*#\s*include\s+[<\"]([^>\"]+)[>\"]", re.M)
+_INCLUDE_DIRECTIVE_RE = re.compile(r"^\s*#\s*include\s*[<\"]([^>\"]+)[>\"]", re.M)
 _DIRECT_C_TYPE_RE = re.compile(
     r"\b[A-Za-z_][A-Za-z0-9_]*Machine"
     r"(Vars|StateId|EventId|Int|Hooks|EventChecks|ExecutionContext|EventContext)?\b"
@@ -54,7 +54,8 @@ _DIRECT_C_API_RE = re.compile(
     r"\b[A-Za-z_][A-Za-z0-9_]*Machine_"
     r"(create_uninitialized|create|destroy|init|hot_start|set_hooks|"
     r"set_event_checks|cycle|vars|is_ended|current_state_id|"
-    r"current_state_path|current_state_name|last_error|dsl_source)\s*\("
+    r"current_state_path|current_state_name|last_error|dsl_source)"
+    r"\s*(?:\(|[,;=)\]&])"
 )
 
 _CPP_TEMPLATE = r"""

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -968,8 +968,9 @@ def _splice_cpp_line_continuations(source: str) -> str:
 
     Example::
 
-        >>> _splice_cpp_line_continuations('#\\\ninclude "machine.hpp"\n')
-        '#include "machine.hpp"\n'
+        >>> source = '#' + chr(92) + chr(10) + 'include "machine.hpp"' + chr(10)
+        >>> _splice_cpp_line_continuations(source) == '#include "machine.hpp"' + chr(10)
+        True
     """
     return _LINE_CONTINUATION_RE.sub("", source)
 
@@ -994,8 +995,9 @@ def _mask_cpp_comments_and_literals(source: str, mask_literals: bool) -> str:
 
     Example::
 
-        >>> _mask_cpp_comments_and_literals('// #include "machine.hpp"\n', False)
-        '\n'
+        >>> source = '// #include \"machine.hpp\"' + chr(10)
+        >>> _mask_cpp_comments_and_literals(source, False) == chr(10)
+        True
         >>> _mask_cpp_comments_and_literals('"RootMachine_cycle"', True)
         '                   '
     """
@@ -1062,9 +1064,9 @@ def _iter_include_targets(source: str) -> List[str]:
 
     Example::
 
-        >>> _iter_include_targets('#include "machine.hpp"\n')
+        >>> _iter_include_targets('#include \"machine.hpp\"' + chr(10))
         ['machine.hpp']
-        >>> _iter_include_targets('#include HEADER\n')
+        >>> _iter_include_targets('#include HEADER' + chr(10))
         ['']
     """
     directive_source = _mask_cpp_comments_and_literals(source, mask_literals=False)
@@ -1094,9 +1096,9 @@ def _has_wrapper_header_include(source: str) -> bool:
 
     Example::
 
-        >>> _has_wrapper_header_include('#include "machine.hpp"\n')
+        >>> _has_wrapper_header_include('#include \"machine.hpp\"' + chr(10))
         True
-        >>> _has_wrapper_header_include('// #include "machine.hpp"\n')
+        >>> _has_wrapper_header_include('// #include \"machine.hpp\"' + chr(10))
         False
     """
     for target in _iter_include_targets(source):
@@ -1122,9 +1124,9 @@ def _has_direct_machine_header_include(source: str) -> bool:
 
     Example::
 
-        >>> _has_direct_machine_header_include('#include "machine.h"\n')
+        >>> _has_direct_machine_header_include('#include \"machine.h\"' + chr(10))
         True
-        >>> _has_direct_machine_header_include('#include "machine.hpp"\n')
+        >>> _has_direct_machine_header_include('#include \"machine.hpp\"' + chr(10))
         False
     """
     for target in _iter_include_targets(source):
@@ -1158,7 +1160,7 @@ def _assert_wrapper_only_harness(source: str) -> None:
 
     Example::
 
-        >>> _assert_wrapper_only_harness('#include "machine.hpp"\\n')
+        >>> _assert_wrapper_only_harness('#include \"machine.hpp\"' + chr(10))
     """
     include_targets = _iter_include_targets(source)
     symbol_source = _mask_cpp_comments_and_literals(source, mask_literals=True)

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -1,0 +1,940 @@
+"""
+Shared C++ wrapper semantic-fixture alignment helpers.
+
+This module renders the built-in ``cpp`` and ``cpp_poll`` templates for one
+schema-v2 semantic fixture, generates a C++98 harness that drives only the
+public ``machine.hpp`` wrapper API, builds the generated C core plus C++ wrapper
+with CMake, and compares emitted public observations with the existing shared
+fixture expectations.
+
+The module contains:
+
+* :class:`CppAlignmentArtifacts` - Paths produced while building one fixture
+  harness.
+* :func:`run_cpp_alignment_case` - Execute a fixture against ``cpp`` or
+  ``cpp_poll`` generated wrapper artifacts.
+
+Example::
+
+    >>> from test.testings.simulate_semantics import load_semantic_case
+    >>> case = load_semantic_case("design_basic_simple_transition")
+    >>> case.id
+    'design_basic_simple_transition'
+"""
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass, replace
+from typing import List, Sequence
+
+import pytest
+from jinja2 import Environment, StrictUndefined
+
+from pyfcstm.render import StateMachineCodeRenderer
+from pyfcstm.template import extract_template
+from test.testings import simulate_semantics
+from test.testings.native_toolchain_alignment.harness import build_harness_context
+from test.testings.native_toolchain_alignment.report import read_observations_jsonl
+from test.testings.native_toolchain_alignment.runner import (
+    assert_observations_match_case,
+)
+from test.testings.simulate_semantics import SemanticCase
+
+_CPP_TEMPLATE = r"""
+#include "machine.hpp"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp::MachineWrapper Wrapper;
+
+static {{ context.machine_class_name }}Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
+static const char *state_paths[] = {
+{% for state in context.states %}    {{ state.path | tojson }},
+{% endfor %}};
+{% if context.actions %}static const char *action_paths[] = {
+{% for action in context.actions %}    {{ action.path | tojson }},
+{% endfor %}};
+{% else %}static const char **action_paths = NULL;
+{% endif %}static const char *stage_names[] = {"enter", "during", "exit"};
+
+struct HandlerCall {
+    int action_id;
+    int state_id;
+    int stage_id;
+    int active_leaf_id;
+    int call_stage_id;
+    int abstract_target_id;
+    int named_ref_id;
+{% for variable in context.variables %}    {{ context.machine_class_name }}Int {{ variable.field }}_is_int;
+    double {{ variable.field }}_is_float;
+{% endfor %}};
+
+static struct HandlerCall handler_calls[512];
+static size_t handler_call_count = 0u;
+
+static const char *lookup_string(const char **items, size_t count, int id)
+{
+    if (id < 0 || (size_t)id >= count) {
+        return NULL;
+    }
+    return items[id];
+}
+
+static void json_string(FILE *out, const char *value)
+{
+    const unsigned char *cursor;
+    if (value == NULL) {
+        fputs("null", out);
+        return;
+    }
+    fputc('"', out);
+    for (cursor = (const unsigned char *)value; *cursor != '\0'; ++cursor) {
+        if (*cursor == '"' || *cursor == '\\') {
+            fputc('\\', out);
+            fputc((int)*cursor, out);
+        } else if (*cursor == '\n') {
+            fputs("\\n", out);
+        } else if (*cursor == '\r') {
+            fputs("\\r", out);
+        } else if (*cursor == '\t') {
+            fputs("\\t", out);
+        } else {
+            fputc((int)*cursor, out);
+        }
+    }
+    fputc('"', out);
+}
+
+static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
+{
+    fputc('{', out);
+{% for variable in context.variables %}    if ({{ loop.index0 }} > 0) {
+        fputc(',', out);
+    }
+    json_string(out, {{ variable.name | tojson }});
+    fputc(':', out);
+{% if variable.type == 'int' %}    fprintf(out, "%lld", (long long)vars->{{ variable.field }});
+{% else %}    fprintf(out, "%.17g", vars->{{ variable.field }});
+{% endif %}{% endfor %}    fputc('}', out);
+}
+
+static void write_handler_calls(FILE *out)
+{
+    size_t i;
+    fputc('[', out);
+    for (i = 0u; i < handler_call_count; ++i) {
+        const struct HandlerCall *call = &handler_calls[i];
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        fputc('{', out);
+        fputs("\"action\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->action_id));
+        fputs(",\"state\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->state_id));
+        fputs(",\"stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->stage_id));
+        fputs(",\"vars\":{", out);
+{% for variable in context.variables %}        if ({{ loop.index0 }} > 0) {
+            fputc(',', out);
+        }
+        json_string(out, {{ variable.name | tojson }});
+        fputc(':', out);
+{% if variable.type == 'int' %}        fprintf(out, "%lld", (long long)call->{{ variable.field }}_is_int);
+{% else %}        fprintf(out, "%.17g", call->{{ variable.field }}_is_float);
+{% endif %}{% endfor %}        fputs("}", out);
+        fputs(",\"active_leaf\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->active_leaf_id));
+        fputs(",\"call_stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->call_stage_id));
+        fputs(",\"abstract_target\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->abstract_target_id));
+        fputs(",\"named_ref\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->named_ref_id));
+        fputc('}', out);
+    }
+    fputc(']', out);
+}
+
+{% if context.hooks %}static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
+{
+    struct HandlerCall *call;
+    (void)machine_ptr;
+    (void)user_data;
+    if (handler_call_count >= sizeof(handler_calls) / sizeof(handler_calls[0])) {
+        return;
+    }
+    call = &handler_calls[handler_call_count++];
+    call->action_id = ctx->action_id;
+    call->state_id = ctx->state_id;
+    call->stage_id = ctx->action_stage_id;
+    call->active_leaf_id = ctx->active_leaf_state_id;
+    call->call_stage_id = ctx->call_stage_id;
+    call->abstract_target_id = ctx->abstract_target_id;
+    call->named_ref_id = ctx->named_ref_id;
+{% for variable in context.variables %}{% if variable.type == 'int' %}    call->{{ variable.field }}_is_int = ctx->vars->{{ variable.field }};
+{% else %}    call->{{ variable.field }}_is_float = ctx->vars->{{ variable.field }};
+{% endif %}{% endfor %}}
+{% endif %}
+static void install_hooks(Wrapper *wrapper)
+{
+{% for hook in context.hooks %}    hooks.{{ hook.field }} = record_hook;
+{% endfor %}    wrapper->set_hooks(&hooks, NULL);
+}
+
+static int run_cycle(Wrapper *wrapper, const {{ context.machine_class_name }}EventId *events, size_t event_count)
+{
+    return wrapper->cycle(events, event_count);
+}
+
+static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, int api_return, const char *last_error)
+{
+    size_t i;
+    const char *state_path = wrapper->current_state_path();
+    const {{ context.machine_class_name }}Vars *vars = wrapper->vars();
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"step\"", out);
+    fprintf(out, ",\"step_index\":%d,\"cycle_index\":%d", step_index, cycle_index);
+    fputs(",\"events\":[", out);
+    for (i = 0u; i < event_count; ++i) {
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        json_string(out, event_names[i]);
+    }
+    fputs("]", out);
+    fputs(",\"current_state\":", out);
+    json_string(out, state_path);
+    fputs(",\"is_ended\":", out);
+    fputs(wrapper->is_ended() ? "true" : "false", out);
+    fputs(",\"vars\":", out);
+    write_vars(out, vars);
+    fputs(",\"handler_calls\":", out);
+    write_handler_calls(out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fprintf(out, ",\"api_return\":%d", api_return);
+    fputs("}\n", out);
+}
+
+static void write_initial_error(FILE *out, const char *last_error)
+{
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"init\"", out);
+    fputs(",\"step_index\":null,\"cycle_index\":null", out);
+    fputs(",\"events\":[]", out);
+    fputs(",\"current_state\":null", out);
+    fputs(",\"is_ended\":false", out);
+    fputs(",\"vars\":{}", out);
+    fputs(",\"handler_calls\":[]", out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fputs(",\"api_return\":0", out);
+    fputs("}\n", out);
+}
+
+int main(int argc, char **argv)
+{
+    FILE *out;
+    Wrapper wrapper;
+    int api_return;
+    size_t cycle_iter;
+    const char *last_error;
+    if (argc < 2) {
+        return 2;
+    }
+    out = fopen(argv[1], "w");
+    if (out == NULL) {
+        return 2;
+    }
+{% if not context.initial %}    if (!wrapper.init()) {
+{% if context.initial_expect %}        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+{% else %}        fclose(out);
+        return 3;
+{% endif %}    }
+{% endif %}    install_hooks(&wrapper);
+{% if context.initial %}{% if context.initial.synthetic_error %}{% if context.initial_expect %}    write_initial_error(out, {{ context.initial.error_message | tojson }});
+    fclose(out);
+    return 0;
+{% else %}    fclose(out);
+    return 4;
+{% endif %}{% else %}    {
+        {{ context.machine_class_name }}Vars initial_vars;
+        memset(&initial_vars, 0, sizeof(initial_vars));
+{% for assignment in context.initial.assignments %}        initial_vars.{{ assignment.field }} = {{ assignment.value }};
+{% endfor %}        if (!wrapper.hot_start({{ context.machine_macro_name }}_{{ context.initial.state_macro }}, &initial_vars)) {
+{% if context.initial_expect %}            write_initial_error(out, wrapper.last_error());
+            fclose(out);
+            return 0;
+{% else %}            fclose(out);
+            return 5;
+{% endif %}        }
+{% if context.initial_expect %}        write_initial_error(out, "Expected initial failure but hot start succeeded");
+        fclose(out);
+        return 0;
+{% endif %}    }
+{% endif %}{% elif context.initial_expect %}    if (wrapper.last_error() != NULL && wrapper.last_error()[0] != '\0') {
+        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+    }
+    write_initial_error(out, "Expected initial failure but initialization succeeded");
+    fclose(out);
+    return 0;
+{% endif %}
+{% for step in context.steps %}    {
+{% if step.events %}        const char *event_names[] = {
+{% for event in step.events %}            {{ event.path | tojson }},
+{% endfor %}        };
+{% else %}        const char **event_names = NULL;
+{% endif %}{% if step.pre_error_message %}        api_return = 0;
+        last_error = {{ step.pre_error_message | tojson }};
+{% elif step.cycle_count == 0 %}        api_return = 1;
+        last_error = NULL;
+{% else %}{% if step.events %}        {{ context.machine_class_name }}EventId event_ids[] = {
+{% for event in step.events %}            {{ context.machine_macro_name }}_{{ event.macro }},
+{% endfor %}        };
+{% endif %}        api_return = 1;
+        last_error = NULL;
+        for (cycle_iter = 0u; cycle_iter < {{ step.cycle_count }}u; ++cycle_iter) {
+{% if step.events %}            api_return = run_cycle(&wrapper, event_ids, {{ step.events | length }}u);
+{% else %}            api_return = run_cycle(&wrapper, NULL, 0u);
+{% endif %}            if (!api_return) {
+                last_error = wrapper.last_error();
+                break;
+            }
+        }
+{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, api_return, last_error);
+    }
+{% endfor %}    fclose(out);
+    return 0;
+}
+"""
+
+_CPP_POLL_TEMPLATE = r"""
+#include "machine.hpp"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp_poll::MachineWrapper Wrapper;
+
+static {{ context.machine_class_name }}Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
+static {{ context.machine_class_name }}EventId active_events[64];
+static size_t active_event_count = 0u;
+static {{ context.machine_class_name }}EventChecks event_checks = {{ context.machine_class_name.upper() }}_EVENT_CHECKS_INIT;
+
+static const char *state_paths[] = {
+{% for state in context.states %}    {{ state.path | tojson }},
+{% endfor %}};
+{% if context.actions %}static const char *action_paths[] = {
+{% for action in context.actions %}    {{ action.path | tojson }},
+{% endfor %}};
+{% else %}static const char **action_paths = NULL;
+{% endif %}static const char *stage_names[] = {"enter", "during", "exit"};
+
+struct HandlerCall {
+    int action_id;
+    int state_id;
+    int stage_id;
+    int active_leaf_id;
+    int call_stage_id;
+    int abstract_target_id;
+    int named_ref_id;
+{% for variable in context.variables %}    {{ context.machine_class_name }}Int {{ variable.field }}_is_int;
+    double {{ variable.field }}_is_float;
+{% endfor %}};
+
+static struct HandlerCall handler_calls[512];
+static size_t handler_call_count = 0u;
+
+static const char *lookup_string(const char **items, size_t count, int id)
+{
+    if (id < 0 || (size_t)id >= count) {
+        return NULL;
+    }
+    return items[id];
+}
+
+static void json_string(FILE *out, const char *value)
+{
+    const unsigned char *cursor;
+    if (value == NULL) {
+        fputs("null", out);
+        return;
+    }
+    fputc('"', out);
+    for (cursor = (const unsigned char *)value; *cursor != '\0'; ++cursor) {
+        if (*cursor == '"' || *cursor == '\\') {
+            fputc('\\', out);
+            fputc((int)*cursor, out);
+        } else if (*cursor == '\n') {
+            fputs("\\n", out);
+        } else if (*cursor == '\r') {
+            fputs("\\r", out);
+        } else if (*cursor == '\t') {
+            fputs("\\t", out);
+        } else {
+            fputc((int)*cursor, out);
+        }
+    }
+    fputc('"', out);
+}
+
+static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
+{
+    fputc('{', out);
+{% for variable in context.variables %}    if ({{ loop.index0 }} > 0) {
+        fputc(',', out);
+    }
+    json_string(out, {{ variable.name | tojson }});
+    fputc(':', out);
+{% if variable.type == 'int' %}    fprintf(out, "%lld", (long long)vars->{{ variable.field }});
+{% else %}    fprintf(out, "%.17g", vars->{{ variable.field }});
+{% endif %}{% endfor %}    fputc('}', out);
+}
+
+static void write_handler_calls(FILE *out)
+{
+    size_t i;
+    fputc('[', out);
+    for (i = 0u; i < handler_call_count; ++i) {
+        const struct HandlerCall *call = &handler_calls[i];
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        fputc('{', out);
+        fputs("\"action\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->action_id));
+        fputs(",\"state\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->state_id));
+        fputs(",\"stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->stage_id));
+        fputs(",\"vars\":{", out);
+{% for variable in context.variables %}        if ({{ loop.index0 }} > 0) {
+            fputc(',', out);
+        }
+        json_string(out, {{ variable.name | tojson }});
+        fputc(':', out);
+{% if variable.type == 'int' %}        fprintf(out, "%lld", (long long)call->{{ variable.field }}_is_int);
+{% else %}        fprintf(out, "%.17g", call->{{ variable.field }}_is_float);
+{% endif %}{% endfor %}        fputs("}", out);
+        fputs(",\"active_leaf\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->active_leaf_id));
+        fputs(",\"call_stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->call_stage_id));
+        fputs(",\"abstract_target\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->abstract_target_id));
+        fputs(",\"named_ref\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->named_ref_id));
+        fputc('}', out);
+    }
+    fputc(']', out);
+}
+
+{% if context.hooks %}static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
+{
+    struct HandlerCall *call;
+    (void)machine_ptr;
+    (void)user_data;
+    if (handler_call_count >= sizeof(handler_calls) / sizeof(handler_calls[0])) {
+        return;
+    }
+    call = &handler_calls[handler_call_count++];
+    call->action_id = ctx->action_id;
+    call->state_id = ctx->state_id;
+    call->stage_id = ctx->action_stage_id;
+    call->active_leaf_id = ctx->active_leaf_state_id;
+    call->call_stage_id = ctx->call_stage_id;
+    call->abstract_target_id = ctx->abstract_target_id;
+    call->named_ref_id = ctx->named_ref_id;
+{% for variable in context.variables %}{% if variable.type == 'int' %}    call->{{ variable.field }}_is_int = ctx->vars->{{ variable.field }};
+{% else %}    call->{{ variable.field }}_is_float = ctx->vars->{{ variable.field }};
+{% endif %}{% endfor %}}
+{% endif %}
+static void install_hooks(Wrapper *wrapper)
+{
+{% for hook in context.hooks %}    hooks.{{ hook.field }} = record_hook;
+{% endfor %}    wrapper->set_hooks(&hooks, NULL);
+}
+
+static int check_event({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}EventContext *ctx, void *user_data)
+{
+    size_t i;
+    (void)machine_ptr;
+    (void)user_data;
+    for (i = 0u; i < active_event_count; ++i) {
+        if (active_events[i] == ctx->event_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void install_event_checks(Wrapper *wrapper)
+{
+{% for event in context.events %}    event_checks.{{ event.field }} = check_event;
+{% endfor %}    wrapper->set_event_checks(&event_checks, NULL);
+}
+
+static int run_cycle(Wrapper *wrapper, const {{ context.machine_class_name }}EventId *events, size_t event_count)
+{
+    size_t i;
+    active_event_count = event_count;
+    for (i = 0u; i < event_count; ++i) {
+        active_events[i] = events[i];
+    }
+    return wrapper->cycle();
+}
+
+static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, int api_return, const char *last_error)
+{
+    size_t i;
+    const char *state_path = wrapper->current_state_path();
+    const {{ context.machine_class_name }}Vars *vars = wrapper->vars();
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"step\"", out);
+    fprintf(out, ",\"step_index\":%d,\"cycle_index\":%d", step_index, cycle_index);
+    fputs(",\"events\":[", out);
+    for (i = 0u; i < event_count; ++i) {
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        json_string(out, event_names[i]);
+    }
+    fputs("]", out);
+    fputs(",\"current_state\":", out);
+    json_string(out, state_path);
+    fputs(",\"is_ended\":", out);
+    fputs(wrapper->is_ended() ? "true" : "false", out);
+    fputs(",\"vars\":", out);
+    write_vars(out, vars);
+    fputs(",\"handler_calls\":", out);
+    write_handler_calls(out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fprintf(out, ",\"api_return\":%d", api_return);
+    fputs("}\n", out);
+}
+
+static void write_initial_error(FILE *out, const char *last_error)
+{
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"init\"", out);
+    fputs(",\"step_index\":null,\"cycle_index\":null", out);
+    fputs(",\"events\":[]", out);
+    fputs(",\"current_state\":null", out);
+    fputs(",\"is_ended\":false", out);
+    fputs(",\"vars\":{}", out);
+    fputs(",\"handler_calls\":[]", out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fputs(",\"api_return\":0", out);
+    fputs("}\n", out);
+}
+
+int main(int argc, char **argv)
+{
+    FILE *out;
+    Wrapper wrapper;
+    int api_return;
+    size_t cycle_iter;
+    const char *last_error;
+    if (argc < 2) {
+        return 2;
+    }
+    out = fopen(argv[1], "w");
+    if (out == NULL) {
+        return 2;
+    }
+{% if not context.initial %}    if (!wrapper.init()) {
+{% if context.initial_expect %}        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+{% else %}        fclose(out);
+        return 3;
+{% endif %}    }
+{% endif %}    install_hooks(&wrapper);
+    install_event_checks(&wrapper);
+{% if context.initial %}{% if context.initial.synthetic_error %}{% if context.initial_expect %}    write_initial_error(out, {{ context.initial.error_message | tojson }});
+    fclose(out);
+    return 0;
+{% else %}    fclose(out);
+    return 4;
+{% endif %}{% else %}    {
+        {{ context.machine_class_name }}Vars initial_vars;
+        memset(&initial_vars, 0, sizeof(initial_vars));
+{% for assignment in context.initial.assignments %}        initial_vars.{{ assignment.field }} = {{ assignment.value }};
+{% endfor %}        if (!wrapper.hot_start({{ context.machine_macro_name }}_{{ context.initial.state_macro }}, &initial_vars)) {
+{% if context.initial_expect %}            write_initial_error(out, wrapper.last_error());
+            fclose(out);
+            return 0;
+{% else %}            fclose(out);
+            return 5;
+{% endif %}        }
+{% if context.initial_expect %}        write_initial_error(out, "Expected initial failure but hot start succeeded");
+        fclose(out);
+        return 0;
+{% endif %}    }
+{% endif %}{% elif context.initial_expect %}    if (wrapper.last_error() != NULL && wrapper.last_error()[0] != '\0') {
+        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+    }
+    write_initial_error(out, "Expected initial failure but initialization succeeded");
+    fclose(out);
+    return 0;
+{% endif %}
+{% for step in context.steps %}    {
+{% if step.events %}        const char *event_names[] = {
+{% for event in step.events %}            {{ event.path | tojson }},
+{% endfor %}        };
+{% else %}        const char **event_names = NULL;
+{% endif %}{% if step.pre_error_message %}        api_return = 0;
+        last_error = {{ step.pre_error_message | tojson }};
+{% elif step.cycle_count == 0 %}        api_return = 1;
+        last_error = NULL;
+{% else %}{% if step.events %}        {{ context.machine_class_name }}EventId event_ids[] = {
+{% for event in step.events %}            {{ context.machine_macro_name }}_{{ event.macro }},
+{% endfor %}        };
+{% endif %}        api_return = 1;
+        last_error = NULL;
+        for (cycle_iter = 0u; cycle_iter < {{ step.cycle_count }}u; ++cycle_iter) {
+{% if step.events %}            api_return = run_cycle(&wrapper, event_ids, {{ step.events | length }}u);
+{% else %}            api_return = run_cycle(&wrapper, NULL, 0u);
+{% endif %}            if (!api_return) {
+                last_error = wrapper.last_error();
+                break;
+            }
+        }
+{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, api_return, last_error);
+    }
+{% endfor %}    fclose(out);
+    return 0;
+}
+"""
+
+_CMAKE_TEMPLATE = r"""
+cmake_minimum_required(VERSION 3.5)
+project(pyfcstm_cpp_shared_fixture_harness C CXX)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+include_directories("{{ source_dir }}")
+
+add_executable(cpp_shared_fixture_harness
+    "{{ machine_c }}"
+    "{{ machine_cpp }}"
+    "{{ harness_cpp }}"
+)
+
+if(NOT WIN32)
+    target_link_libraries(cpp_shared_fixture_harness m)
+endif()
+"""
+
+
+@dataclass(frozen=True)
+class CppAlignmentArtifacts:
+    """
+    Paths produced by one C++ shared-fixture harness run.
+
+    :param template_name: Template under test, either ``"cpp"`` or
+        ``"cpp_poll"``.
+    :type template_name: str
+    :param case_id: Semantic fixture case id.
+    :type case_id: str
+    :param root_dir: Root artifact directory for this fixture run.
+    :type root_dir: str
+    :param generated_dir: Rendered generated-source directory.
+    :type generated_dir: str
+    :param harness_dir: Directory containing ``harness.cpp`` and
+        ``CMakeLists.txt``.
+    :type harness_dir: str
+    :param build_dir: CMake build directory.
+    :type build_dir: str
+    :param observations_path: JSON Lines observation file emitted by the
+        harness executable.
+    :type observations_path: str
+
+    Example::
+
+        >>> artifacts = CppAlignmentArtifacts("cpp", "demo", "/tmp/a", "/tmp/a/g", "/tmp/a/h", "/tmp/a/b", "/tmp/a/o.jsonl")
+        >>> artifacts.template_name
+        'cpp'
+    """
+
+    template_name: str
+    case_id: str
+    root_dir: str
+    generated_dir: str
+    harness_dir: str
+    build_dir: str
+    observations_path: str
+
+
+def _validate_template_name(template_name: str) -> None:
+    if template_name not in ("cpp", "cpp_poll"):
+        raise ValueError("unsupported C++ alignment template: %r" % template_name)
+
+
+def _cmake_generator_args() -> List[str]:
+    if os.name == "nt":
+        return ["-G", "MinGW Makefiles"]
+    return []
+
+
+def _find_cmake() -> str:
+    cmake = shutil.which("cmake")
+    if cmake is None:
+        pytest.skip("cmake is required for generated C++ alignment tests.")
+    return cmake
+
+
+def _environment() -> Environment:
+    env = Environment(
+        undefined=StrictUndefined,
+        autoescape=False,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    return env
+
+
+def _render_generated_template(
+    template_name: str, case: SemanticCase, generated_dir: str
+) -> None:
+    model = simulate_semantics.build_state_machine_from_case(case)
+    template_root = os.path.join(os.path.dirname(generated_dir), "template-src")
+    template_dir = extract_template(template_name, template_root)
+    StateMachineCodeRenderer(template_dir).render(model=model, output_dir=generated_dir)
+
+
+def _render_harness(template_name: str, case: SemanticCase, harness_path: str) -> None:
+    base_context = build_harness_context(
+        "c_poll" if template_name == "cpp_poll" else "c", case
+    )
+    context = replace(base_context, template_name=template_name)
+    template_text = _CPP_POLL_TEMPLATE if template_name == "cpp_poll" else _CPP_TEMPLATE
+    rendered = _environment().from_string(template_text).render(context=context)
+    os.makedirs(os.path.dirname(harness_path), exist_ok=True)
+    with open(harness_path, "w", encoding="utf-8") as f:
+        f.write(rendered)
+
+
+def _render_cmake(artifacts: CppAlignmentArtifacts, harness_path: str) -> None:
+    text = (
+        _environment()
+        .from_string(_CMAKE_TEMPLATE)
+        .render(
+            source_dir=artifacts.generated_dir.replace("\\", "/"),
+            machine_c=os.path.join(artifacts.generated_dir, "machine.c").replace(
+                "\\", "/"
+            ),
+            machine_cpp=os.path.join(artifacts.generated_dir, "machine.cpp").replace(
+                "\\", "/"
+            ),
+            harness_cpp=harness_path.replace("\\", "/"),
+        )
+    )
+    with open(
+        os.path.join(artifacts.harness_dir, "CMakeLists.txt"), "w", encoding="utf-8"
+    ) as f:
+        f.write(text)
+
+
+def _prepare_artifacts(
+    template_name: str, case: SemanticCase, artifact_root: str
+) -> CppAlignmentArtifacts:
+    generated_dir = os.path.join(artifact_root, "generated")
+    harness_dir = os.path.join(artifact_root, "harness")
+    build_dir = os.path.join(artifact_root, "build")
+    observations_path = os.path.join(artifact_root, "observations.jsonl")
+    os.makedirs(generated_dir, exist_ok=True)
+    os.makedirs(harness_dir, exist_ok=True)
+    os.makedirs(build_dir, exist_ok=True)
+    _render_generated_template(template_name, case, generated_dir)
+    artifacts = CppAlignmentArtifacts(
+        template_name,
+        case.id,
+        artifact_root,
+        generated_dir,
+        harness_dir,
+        build_dir,
+        observations_path,
+    )
+    harness_path = os.path.join(harness_dir, "harness.cpp")
+    _render_harness(template_name, case, harness_path)
+    _render_cmake(artifacts, harness_path)
+    return artifacts
+
+
+def _run_command(
+    command: Sequence[str], cwd: str, stdout_path: str, stderr_path: str
+) -> subprocess.CompletedProcess:
+    command_path = stdout_path.replace(".stdout.txt", ".command.txt")
+    with open(command_path, "w", encoding="utf-8") as f:
+        f.write(" ".join(command) + "\n")
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    with open(stdout_path, "w", encoding="utf-8") as f:
+        f.write(completed.stdout or "")
+    with open(stderr_path, "w", encoding="utf-8") as f:
+        f.write(completed.stderr or "")
+    return completed
+
+
+def _fail_command(
+    stage: str,
+    command: Sequence[str],
+    completed: subprocess.CompletedProcess,
+    stdout_path: str,
+    stderr_path: str,
+) -> None:
+    raise AssertionError(
+        "{stage} failed with return code {returncode}.\n"
+        "command: {command}\nstdout: {stdout}\nstderr: {stderr}".format(
+            stage=stage,
+            returncode=completed.returncode,
+            command=" ".join(command),
+            stdout=stdout_path,
+            stderr=stderr_path,
+        )
+    )
+
+
+def _find_executable(build_dir: str) -> str:
+    candidates = [
+        os.path.join(build_dir, "cpp_shared_fixture_harness"),
+        os.path.join(build_dir, "cpp_shared_fixture_harness.exe"),
+        os.path.join(build_dir, "Release", "cpp_shared_fixture_harness.exe"),
+        os.path.join(build_dir, "Debug", "cpp_shared_fixture_harness.exe"),
+    ]
+    for candidate in candidates:
+        if os.path.exists(candidate):
+            return candidate
+    raise FileNotFoundError(
+        "Cannot find C++ shared fixture harness executable under %r." % build_dir
+    )
+
+
+def _build_and_run(artifacts: CppAlignmentArtifacts) -> None:
+    cmake = _find_cmake()
+    logs_dir = os.path.join(artifacts.root_dir, "logs")
+    os.makedirs(logs_dir, exist_ok=True)
+    configure_command = (
+        [cmake]
+        + _cmake_generator_args()
+        + [
+            "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
+            os.path.abspath(artifacts.harness_dir),
+        ]
+    )
+    configure_stdout = os.path.join(logs_dir, "configure.stdout.txt")
+    configure_stderr = os.path.join(logs_dir, "configure.stderr.txt")
+    configure_result = _run_command(
+        configure_command, artifacts.build_dir, configure_stdout, configure_stderr
+    )
+    if configure_result.returncode != 0:
+        _fail_command(
+            "CMake configure",
+            configure_command,
+            configure_result,
+            configure_stdout,
+            configure_stderr,
+        )
+
+    build_command = [cmake, "--build", ".", "--config", "Release"]
+    build_stdout = os.path.join(logs_dir, "build.stdout.txt")
+    build_stderr = os.path.join(logs_dir, "build.stderr.txt")
+    build_result = _run_command(
+        build_command, artifacts.build_dir, build_stdout, build_stderr
+    )
+    if build_result.returncode != 0:
+        _fail_command(
+            "CMake build", build_command, build_result, build_stdout, build_stderr
+        )
+
+    run_command = [_find_executable(artifacts.build_dir), artifacts.observations_path]
+    run_stdout = os.path.join(logs_dir, "run.stdout.txt")
+    run_stderr = os.path.join(logs_dir, "run.stderr.txt")
+    run_result = _run_command(run_command, artifacts.build_dir, run_stdout, run_stderr)
+    if run_result.returncode != 0:
+        _fail_command(
+            "C++ harness run", run_command, run_result, run_stdout, run_stderr
+        )
+
+
+def run_cpp_alignment_case(
+    template_name: str, case: SemanticCase, artifact_root: str
+) -> CppAlignmentArtifacts:
+    """
+    Execute one semantic fixture against a generated C++ wrapper template.
+
+    The generated harness includes only ``machine.hpp`` directly and drives the
+    state machine through wrapper methods such as ``init()``, ``hot_start()``,
+    ``cycle()``, ``vars()``, ``is_ended()``, and ``current_state_path()``. It
+    writes JSON Lines observations that are compared with the existing shared
+    semantic fixture expectations.
+
+    :param template_name: Template under test, either ``"cpp"`` or
+        ``"cpp_poll"``.
+    :type template_name: str
+    :param case: Shared semantic fixture case.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param artifact_root: Directory where generated sources, harness files,
+        build logs, and observations are written.
+    :type artifact_root: str
+    :return: Artifact paths for the completed run.
+    :rtype: CppAlignmentArtifacts
+    :raises AssertionError: If configure, build, run, or observation alignment
+        fails.
+    :raises ValueError: If ``template_name`` is unsupported.
+
+    Example::
+
+        >>> case = simulate_semantics.load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
+    _validate_template_name(template_name)
+    artifacts = _prepare_artifacts(template_name, case, artifact_root)
+    _build_and_run(artifacts)
+    observations = read_observations_jsonl(artifacts.observations_path)
+    assert_observations_match_case(template_name, case, observations)
+    return artifacts

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -109,15 +109,30 @@ static void json_string(FILE *out, const char *value)
 
 static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int value)
 {
-#if defined(_MSC_VER) && !defined(__clang__)
-    fprintf(out, "%I64d", (__int64)value);
-#elif defined(__SIZEOF_LONG__) && (__SIZEOF_LONG__ >= 8)
-    fprintf(out, "%ld", (long)value);
-#elif defined(__GNUC__) || defined(__clang__)
-    fprintf(out, "%lld", (long long)value);
-#else
-    fprintf(out, "%ld", (long)value);
-#endif
+    char digits[64];
+    size_t count = 0u;
+    {{ context.machine_class_name }}Int quotient = value;
+
+    if (quotient == 0) {
+        fputc('0', out);
+        return;
+    }
+    if (quotient < 0) {
+        fputc('-', out);
+        while (quotient != 0) {
+            {{ context.machine_class_name }}Int next = quotient / 10;
+            digits[count++] = (char)('0' + (int)(next * 10 - quotient));
+            quotient = next;
+        }
+    } else {
+        while (quotient != 0) {
+            digits[count++] = (char)('0' + (int)(quotient % 10));
+            quotient = quotient / 10;
+        }
+    }
+    while (count > 0u) {
+        fputc((int)digits[--count], out);
+    }
 }
 
 static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
@@ -410,15 +425,30 @@ static void json_string(FILE *out, const char *value)
 
 static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int value)
 {
-#if defined(_MSC_VER) && !defined(__clang__)
-    fprintf(out, "%I64d", (__int64)value);
-#elif defined(__SIZEOF_LONG__) && (__SIZEOF_LONG__ >= 8)
-    fprintf(out, "%ld", (long)value);
-#elif defined(__GNUC__) || defined(__clang__)
-    fprintf(out, "%lld", (long long)value);
-#else
-    fprintf(out, "%ld", (long)value);
-#endif
+    char digits[64];
+    size_t count = 0u;
+    {{ context.machine_class_name }}Int quotient = value;
+
+    if (quotient == 0) {
+        fputc('0', out);
+        return;
+    }
+    if (quotient < 0) {
+        fputc('-', out);
+        while (quotient != 0) {
+            {{ context.machine_class_name }}Int next = quotient / 10;
+            digits[count++] = (char)('0' + (int)(next * 10 - quotient));
+            quotient = next;
+        }
+    } else {
+        while (quotient != 0) {
+            digits[count++] = (char)('0' + (int)(quotient % 10));
+            quotient = quotient / 10;
+        }
+    }
+    while (count > 0u) {
+        fputc((int)digits[--count], out);
+    }
 }
 
 static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
@@ -845,6 +875,12 @@ def _run_command(
     return completed
 
 
+def _command_output_tail(output: str, limit: int = 4000) -> str:
+    if len(output) <= limit:
+        return output
+    return "...<truncated>\n" + output[-limit:]
+
+
 def _fail_command(
     stage: str,
     command: Sequence[str],
@@ -854,12 +890,18 @@ def _fail_command(
 ) -> None:
     raise AssertionError(
         "{stage} failed with return code {returncode}.\n"
-        "command: {command}\nstdout: {stdout}\nstderr: {stderr}".format(
+        "command: {command}\n"
+        "stdout: {stdout}\n"
+        "stderr: {stderr}\n"
+        "stdout tail:\n{stdout_tail}\n"
+        "stderr tail:\n{stderr_tail}".format(
             stage=stage,
             returncode=completed.returncode,
             command=" ".join(command),
             stdout=stdout_path,
             stderr=stderr_path,
+            stdout_tail=_command_output_tail(completed.stdout or ""),
+            stderr_tail=_command_output_tail(completed.stderr or ""),
         )
     )
 

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -26,6 +26,7 @@ Example::
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass, replace
@@ -43,6 +44,18 @@ from test.testings.native_toolchain_alignment.runner import (
     assert_observations_match_case,
 )
 from test.testings.simulate_semantics import SemanticCase
+
+_DIRECT_MACHINE_HEADER_RE = re.compile(r'^\s*#\s*include\s+"machine\.h"\s*$', re.M)
+_DIRECT_C_TYPE_RE = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*Machine"
+    r"(Vars|StateId|EventId|Int|Hooks|EventChecks|ExecutionContext|EventContext)\b"
+)
+_DIRECT_C_API_RE = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*Machine_"
+    r"(create_uninitialized|create|destroy|init|hot_start|set_hooks|"
+    r"set_event_checks|cycle|vars|is_ended|current_state_id|"
+    r"current_state_path|current_state_name|last_error|dsl_source)\s*\("
+)
 
 _CPP_TEMPLATE = r"""
 #include "machine.hpp"
@@ -70,7 +83,7 @@ struct HandlerCall {
     int call_stage_id;
     int abstract_target_id;
     int named_ref_id;
-{% for variable in context.variables %}    {{ context.machine_class_name }}Int {{ variable.field }}_is_int;
+{% for variable in context.variables %}    Wrapper::Int {{ variable.field }}_is_int;
     double {{ variable.field }}_is_float;
 {% endfor %}};
 
@@ -110,11 +123,11 @@ static void json_string(FILE *out, const char *value)
     fputc('"', out);
 }
 
-static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int value)
+static void write_machine_int(FILE *out, Wrapper::Int value)
 {
     char digits[64];
     size_t count = 0u;
-    {{ context.machine_class_name }}Int quotient = value;
+    Wrapper::Int quotient = value;
 
     if (quotient == 0) {
         fputc('0', out);
@@ -123,7 +136,7 @@ static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int val
     if (quotient < 0) {
         fputc('-', out);
         while (quotient != 0) {
-            {{ context.machine_class_name }}Int next = quotient / 10;
+            Wrapper::Int next = quotient / 10;
             digits[count++] = (char)('0' + (int)(next * 10 - quotient));
             quotient = next;
         }
@@ -391,7 +404,7 @@ struct HandlerCall {
     int call_stage_id;
     int abstract_target_id;
     int named_ref_id;
-{% for variable in context.variables %}    {{ context.machine_class_name }}Int {{ variable.field }}_is_int;
+{% for variable in context.variables %}    Wrapper::Int {{ variable.field }}_is_int;
     double {{ variable.field }}_is_float;
 {% endfor %}};
 
@@ -431,11 +444,11 @@ static void json_string(FILE *out, const char *value)
     fputc('"', out);
 }
 
-static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int value)
+static void write_machine_int(FILE *out, Wrapper::Int value)
 {
     char digits[64];
     size_t count = 0u;
-    {{ context.machine_class_name }}Int quotient = value;
+    Wrapper::Int quotient = value;
 
     if (quotient == 0) {
         fputc('0', out);
@@ -444,7 +457,7 @@ static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int val
     if (quotient < 0) {
         fputc('-', out);
         while (quotient != 0) {
-            {{ context.machine_class_name }}Int next = quotient / 10;
+            Wrapper::Int next = quotient / 10;
             digits[count++] = (char)('0' + (int)(next * 10 - quotient));
             quotient = next;
         }
@@ -821,9 +834,36 @@ def _render_harness(template_name: str, case: SemanticCase, harness_path: str) -
     context = replace(base_context, template_name=template_name)
     template_text = _CPP_POLL_TEMPLATE if template_name == "cpp_poll" else _CPP_TEMPLATE
     rendered = _environment().from_string(template_text).render(context=context)
+    _assert_wrapper_only_harness(rendered)
     os.makedirs(os.path.dirname(harness_path), exist_ok=True)
     with open(harness_path, "w", encoding="utf-8") as f:
         f.write(rendered)
+
+
+def _assert_wrapper_only_harness(source: str) -> None:
+    """
+    Assert that generated fixture harnesses enter through the C++ wrapper.
+
+    Fixture-alignment harnesses are allowed to include only ``machine.hpp``
+    directly. They may observe state through ``Wrapper::...`` aliases and
+    wrapper methods, but they must not directly include ``machine.h``, bind C
+    runtime typedef names, or call generated ``...Machine_*`` C functions.
+
+    :param source: Rendered C++ harness source.
+    :type source: str
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If the harness bypasses the C++ wrapper entrypoint.
+
+    Example::
+
+        >>> _assert_wrapper_only_harness('#include "machine.hpp"\\n')
+    """
+    assert '#include "machine.hpp"' in source
+    assert not _DIRECT_MACHINE_HEADER_RE.search(source)
+    assert "native_handle" not in source
+    assert not _DIRECT_C_TYPE_RE.search(source)
+    assert not _DIRECT_C_API_RE.search(source)
 
 
 def _render_cmake(artifacts: CppAlignmentArtifacts, harness_path: str) -> None:

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -186,7 +186,8 @@ static void write_handler_calls(FILE *out)
     fputc(']', out);
 }
 
-{% if context.hooks %}static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
+{% if context.hooks %}extern "C" {
+static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
 {
     struct HandlerCall *call;
     (void)machine_ptr;
@@ -205,6 +206,7 @@ static void write_handler_calls(FILE *out)
 {% for variable in context.variables %}{% if variable.type == 'int' %}    call->{{ variable.field }}_is_int = ctx->vars->{{ variable.field }};
 {% else %}    call->{{ variable.field }}_is_float = ctx->vars->{{ variable.field }};
 {% endif %}{% endfor %}}
+}
 {% endif %}
 static void install_hooks(Wrapper *wrapper)
 {
@@ -217,7 +219,7 @@ static int run_cycle(Wrapper *wrapper, const {{ context.machine_class_name }}Eve
     return wrapper->cycle(events, event_count);
 }
 
-static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, int api_return, const char *last_error)
+static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, const char *last_error)
 {
     size_t i;
     const char *state_path = wrapper->current_state_path();
@@ -248,7 +250,7 @@ static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int c
     write_handler_calls(out);
     fputs(",\"last_error\":", out);
     json_string(out, last_error);
-    fprintf(out, ",\"api_return\":%d", api_return);
+    fputs(",\"api_return\":null", out);
     fputs("}\n", out);
 }
 
@@ -269,7 +271,7 @@ static void write_initial_error(FILE *out, const char *last_error)
     fputs(",\"handler_calls\":[]", out);
     fputs(",\"last_error\":", out);
     json_string(out, last_error);
-    fputs(",\"api_return\":0", out);
+    fputs(",\"api_return\":null", out);
     fputs("}\n", out);
 }
 
@@ -343,10 +345,13 @@ int main(int argc, char **argv)
 {% else %}            api_return = run_cycle(&wrapper, NULL, 0u);
 {% endif %}            if (!api_return) {
                 last_error = wrapper.last_error();
+                if (last_error == NULL || last_error[0] == '\0') {
+                    last_error = "Generated C++ wrapper cycle returned failure without diagnostic";
+                }
                 break;
             }
         }
-{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, api_return, last_error);
+{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, last_error);
     }
 {% endfor %}    fclose(out);
     return 0;
@@ -502,7 +507,8 @@ static void write_handler_calls(FILE *out)
     fputc(']', out);
 }
 
-{% if context.hooks %}static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
+{% if context.hooks %}extern "C" {
+static void record_hook({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}ExecutionContext *ctx, void *user_data)
 {
     struct HandlerCall *call;
     (void)machine_ptr;
@@ -521,6 +527,7 @@ static void write_handler_calls(FILE *out)
 {% for variable in context.variables %}{% if variable.type == 'int' %}    call->{{ variable.field }}_is_int = ctx->vars->{{ variable.field }};
 {% else %}    call->{{ variable.field }}_is_float = ctx->vars->{{ variable.field }};
 {% endif %}{% endfor %}}
+}
 {% endif %}
 static void install_hooks(Wrapper *wrapper)
 {
@@ -528,6 +535,7 @@ static void install_hooks(Wrapper *wrapper)
 {% endfor %}    wrapper->set_hooks(&hooks, NULL);
 }
 
+extern "C" {
 static int check_event({{ context.machine_class_name }} *machine_ptr, const {{ context.machine_class_name }}EventContext *ctx, void *user_data)
 {
     size_t i;
@@ -540,6 +548,7 @@ static int check_event({{ context.machine_class_name }} *machine_ptr, const {{ c
     }
     return 0;
 }
+}
 
 static void install_event_checks(Wrapper *wrapper)
 {
@@ -550,6 +559,9 @@ static void install_event_checks(Wrapper *wrapper)
 static int run_cycle(Wrapper *wrapper, const {{ context.machine_class_name }}EventId *events, size_t event_count)
 {
     size_t i;
+    if (event_count > sizeof(active_events) / sizeof(active_events[0])) {
+        return 0;
+    }
     active_event_count = event_count;
     for (i = 0u; i < event_count; ++i) {
         active_events[i] = events[i];
@@ -557,7 +569,7 @@ static int run_cycle(Wrapper *wrapper, const {{ context.machine_class_name }}Eve
     return wrapper->cycle();
 }
 
-static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, int api_return, const char *last_error)
+static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, const char *last_error)
 {
     size_t i;
     const char *state_path = wrapper->current_state_path();
@@ -588,7 +600,7 @@ static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int c
     write_handler_calls(out);
     fputs(",\"last_error\":", out);
     json_string(out, last_error);
-    fprintf(out, ",\"api_return\":%d", api_return);
+    fputs(",\"api_return\":null", out);
     fputs("}\n", out);
 }
 
@@ -609,7 +621,7 @@ static void write_initial_error(FILE *out, const char *last_error)
     fputs(",\"handler_calls\":[]", out);
     fputs(",\"last_error\":", out);
     json_string(out, last_error);
-    fputs(",\"api_return\":0", out);
+    fputs(",\"api_return\":null", out);
     fputs("}\n", out);
 }
 
@@ -684,10 +696,13 @@ int main(int argc, char **argv)
 {% else %}            api_return = run_cycle(&wrapper, NULL, 0u);
 {% endif %}            if (!api_return) {
                 last_error = wrapper.last_error();
+                if (last_error == NULL || last_error[0] == '\0') {
+                    last_error = "Generated C++ wrapper cycle returned failure without diagnostic";
+                }
                 break;
             }
         }
-{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, api_return, last_error);
+{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, last_error);
     }
 {% endfor %}    fclose(out);
     return 0;

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -1164,6 +1164,23 @@ def _run_command(
 
 
 def _command_output_tail(output: str, limit: int = 4000) -> str:
+    """
+    Return a bounded diagnostic tail for command output.
+
+    :param output: Captured command output.
+    :type output: str
+    :param limit: Maximum number of trailing characters to keep, defaults to
+        ``4000``.
+    :type limit: int, optional
+    :return: Full output when short enough, otherwise a truncation marker plus
+        the trailing output segment.
+    :rtype: str
+
+    Example::
+
+        >>> _command_output_tail("abcdef", limit=3)
+        '...<truncated>\\ndef'
+    """
     if len(output) <= limit:
         return output
     return "...<truncated>\n" + output[-limit:]

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -45,10 +45,10 @@ from test.testings.native_toolchain_alignment.runner import (
 )
 from test.testings.simulate_semantics import SemanticCase
 
-_DIRECT_MACHINE_HEADER_RE = re.compile(r'^\s*#\s*include\s+"machine\.h"\s*$', re.M)
+_INCLUDE_DIRECTIVE_RE = re.compile(r"^\s*#\s*include\s+[<\"]([^>\"]+)[>\"]", re.M)
 _DIRECT_C_TYPE_RE = re.compile(
     r"\b[A-Za-z_][A-Za-z0-9_]*Machine"
-    r"(Vars|StateId|EventId|Int|Hooks|EventChecks|ExecutionContext|EventContext)\b"
+    r"(Vars|StateId|EventId|Int|Hooks|EventChecks|ExecutionContext|EventContext)?\b"
 )
 _DIRECT_C_API_RE = re.compile(
     r"\b[A-Za-z_][A-Za-z0-9_]*Machine_"
@@ -840,6 +840,34 @@ def _render_harness(template_name: str, case: SemanticCase, harness_path: str) -
         f.write(rendered)
 
 
+def _has_direct_machine_header_include(source: str) -> bool:
+    """
+    Return whether a harness directly includes the generated C header.
+
+    Direct harness entry must go through ``machine.hpp``. This helper rejects
+    quote, angle-bracket, and relative include spellings whose normalized
+    basename is ``machine.h`` while leaving ordinary standard-library includes
+    untouched.
+
+    :param source: Rendered C++ harness source.
+    :type source: str
+    :return: Whether the source directly includes ``machine.h``.
+    :rtype: bool
+
+    Example::
+
+        >>> _has_direct_machine_header_include('#include "machine.h"\n')
+        True
+        >>> _has_direct_machine_header_include('#include "machine.hpp"\n')
+        False
+    """
+    for match in _INCLUDE_DIRECTIVE_RE.finditer(source):
+        target = match.group(1).replace("\\", "/")
+        if os.path.basename(target) == "machine.h":
+            return True
+    return False
+
+
 def _assert_wrapper_only_harness(source: str) -> None:
     """
     Assert that generated fixture harnesses enter through the C++ wrapper.
@@ -860,7 +888,7 @@ def _assert_wrapper_only_harness(source: str) -> None:
         >>> _assert_wrapper_only_harness('#include "machine.hpp"\\n')
     """
     assert '#include "machine.hpp"' in source
-    assert not _DIRECT_MACHINE_HEADER_RE.search(source)
+    assert not _has_direct_machine_header_include(source)
     assert "native_handle" not in source
     assert not _DIRECT_C_TYPE_RE.search(source)
     assert not _DIRECT_C_API_RE.search(source)

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -107,6 +107,19 @@ static void json_string(FILE *out, const char *value)
     fputc('"', out);
 }
 
+static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int value)
+{
+#if defined(_MSC_VER) && !defined(__clang__)
+    fprintf(out, "%I64d", (__int64)value);
+#elif defined(__SIZEOF_LONG__) && (__SIZEOF_LONG__ >= 8)
+    fprintf(out, "%ld", (long)value);
+#elif defined(__GNUC__) || defined(__clang__)
+    fprintf(out, "%lld", (long long)value);
+#else
+    fprintf(out, "%ld", (long)value);
+#endif
+}
+
 static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
 {
     fputc('{', out);
@@ -115,7 +128,7 @@ static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *va
     }
     json_string(out, {{ variable.name | tojson }});
     fputc(':', out);
-{% if variable.type == 'int' %}    fprintf(out, "%lld", (long long)vars->{{ variable.field }});
+{% if variable.type == 'int' %}    write_machine_int(out, vars->{{ variable.field }});
 {% else %}    fprintf(out, "%.17g", vars->{{ variable.field }});
 {% endif %}{% endfor %}    fputc('}', out);
 }
@@ -142,7 +155,7 @@ static void write_handler_calls(FILE *out)
         }
         json_string(out, {{ variable.name | tojson }});
         fputc(':', out);
-{% if variable.type == 'int' %}        fprintf(out, "%lld", (long long)call->{{ variable.field }}_is_int);
+{% if variable.type == 'int' %}        write_machine_int(out, call->{{ variable.field }}_is_int);
 {% else %}        fprintf(out, "%.17g", call->{{ variable.field }}_is_float);
 {% endif %}{% endfor %}        fputs("}", out);
         fputs(",\"active_leaf\":", out);
@@ -395,6 +408,19 @@ static void json_string(FILE *out, const char *value)
     fputc('"', out);
 }
 
+static void write_machine_int(FILE *out, {{ context.machine_class_name }}Int value)
+{
+#if defined(_MSC_VER) && !defined(__clang__)
+    fprintf(out, "%I64d", (__int64)value);
+#elif defined(__SIZEOF_LONG__) && (__SIZEOF_LONG__ >= 8)
+    fprintf(out, "%ld", (long)value);
+#elif defined(__GNUC__) || defined(__clang__)
+    fprintf(out, "%lld", (long long)value);
+#else
+    fprintf(out, "%ld", (long)value);
+#endif
+}
+
 static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *vars)
 {
     fputc('{', out);
@@ -403,7 +429,7 @@ static void write_vars(FILE *out, const {{ context.machine_class_name }}Vars *va
     }
     json_string(out, {{ variable.name | tojson }});
     fputc(':', out);
-{% if variable.type == 'int' %}    fprintf(out, "%lld", (long long)vars->{{ variable.field }});
+{% if variable.type == 'int' %}    write_machine_int(out, vars->{{ variable.field }});
 {% else %}    fprintf(out, "%.17g", vars->{{ variable.field }});
 {% endif %}{% endfor %}    fputc('}', out);
 }
@@ -430,7 +456,7 @@ static void write_handler_calls(FILE *out)
         }
         json_string(out, {{ variable.name | tojson }});
         fputc(':', out);
-{% if variable.type == 'int' %}        fprintf(out, "%lld", (long long)call->{{ variable.field }}_is_int);
+{% if variable.type == 'int' %}        write_machine_int(out, call->{{ variable.field }}_is_int);
 {% else %}        fprintf(out, "%.17g", call->{{ variable.field }}_is_float);
 {% endif %}{% endfor %}        fputs("}", out);
         fputs(",\"active_leaf\":", out);

--- a/test/template/cpp_shared.py
+++ b/test/template/cpp_shared.py
@@ -47,6 +47,7 @@ from test.testings.simulate_semantics import SemanticCase
 
 _INCLUDE_DIRECTIVE_RE = re.compile(r"^\s*#\s*include\s*(?P<target>[^\n]+)", re.M)
 _INCLUDE_LITERAL_RE = re.compile(r'(?:(?:"([^"\n]+)")|(?:<([^>\n]+)>))')
+_LINE_CONTINUATION_RE = re.compile(r"\\\r?\n")
 _NATIVE_HANDLE_CALL_RE = re.compile(r"\bnative_handle\s*\(")
 _TOKEN_PASTE_RE = re.compile(r"##")
 _DIRECT_C_TYPE_RE = re.compile(
@@ -951,6 +952,28 @@ def _render_harness(template_name: str, case: SemanticCase, harness_path: str) -
         f.write(rendered)
 
 
+def _splice_cpp_line_continuations(source: str) -> str:
+    """
+    Remove C/C++ backslash-newline continuations before source checks.
+
+    The C preprocessor performs this splice before it recognizes comments or
+    directives. The wrapper-only guard mirrors that phase so split forms with
+    a trailing backslash before a newline cannot hide a direct ``machine.h``
+    include.
+
+    :param source: C++ source text to inspect.
+    :type source: str
+    :return: Source text after line-continuation splicing.
+    :rtype: str
+
+    Example::
+
+        >>> _splice_cpp_line_continuations('#\\\ninclude "machine.hpp"\n')
+        '#include "machine.hpp"\n'
+    """
+    return _LINE_CONTINUATION_RE.sub("", source)
+
+
 def _mask_cpp_comments_and_literals(source: str, mask_literals: bool) -> str:
     """
     Replace C++ comments and optionally literals with whitespace.
@@ -976,6 +999,7 @@ def _mask_cpp_comments_and_literals(source: str, mask_literals: bool) -> str:
         >>> _mask_cpp_comments_and_literals('"RootMachine_cycle"', True)
         '                   '
     """
+    source = _splice_cpp_line_continuations(source)
     output = []
     index = 0
     length = len(source)
@@ -1047,7 +1071,7 @@ def _iter_include_targets(source: str) -> List[str]:
     targets = []
     for match in _INCLUDE_DIRECTIVE_RE.finditer(directive_source):
         raw_target = match.group("target").strip()
-        literal_match = _INCLUDE_LITERAL_RE.match(raw_target)
+        literal_match = _INCLUDE_LITERAL_RE.fullmatch(raw_target)
         if literal_match:
             targets.append(literal_match.group(1) or literal_match.group(2))
         else:

--- a/test/template/test_cpp_wrapper_harness_guard.py
+++ b/test/template/test_cpp_wrapper_harness_guard.py
@@ -10,7 +10,7 @@ corpus for fixture harness discipline, not a full C++ static analyzer.
 Example::
 
     >>> from test.template.cpp_shared import _assert_wrapper_only_harness
-    >>> _assert_wrapper_only_harness('#include "machine.hpp"\n')
+    >>> _assert_wrapper_only_harness('#include \"machine.hpp\"' + chr(10))
 """
 
 import pytest
@@ -25,6 +25,10 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
 
     :return: ``None``.
     :rtype: None
+
+    Example::
+
+        >>> _assert_wrapper_only_harness('#include "machine.hpp"' + chr(10))
     """
     _assert_wrapper_only_harness(
         '#include "machine.hpp"\n'
@@ -146,6 +150,11 @@ def test_cpp_wrapper_harness_rejects_direct_c_runtime_entrypoints(source):
     :type source: str
     :return: ``None``.
     :rtype: None
+
+    Example::
+
+        >>> with pytest.raises(AssertionError):
+        ...     _assert_wrapper_only_harness('#include "machine.h"' + chr(10))
     """
     with pytest.raises(AssertionError):
         _assert_wrapper_only_harness(source)

--- a/test/template/test_cpp_wrapper_harness_guard.py
+++ b/test/template/test_cpp_wrapper_harness_guard.py
@@ -1,0 +1,92 @@
+"""
+Guard C++ fixture harnesses against bypassing wrapper entrypoints.
+
+The tests exercise the lightweight source gate used before generated
+``harness.cpp`` files are written for C++ shared semantic fixture alignment.
+They keep the fixture runner focused on ``machine.hpp`` wrapper APIs instead
+of direct ``machine.h`` C runtime entrypoints.
+
+Example::
+
+    >>> from test.template.cpp_shared import _assert_wrapper_only_harness
+    >>> _assert_wrapper_only_harness('#include "machine.hpp"\n')
+"""
+
+import pytest
+
+from test.template.cpp_shared import _assert_wrapper_only_harness
+
+
+@pytest.mark.unittest
+def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
+    """
+    Accept harnesses that include only the C++ wrapper machine header.
+
+    :return: ``None``.
+    :rtype: None
+    """
+    _assert_wrapper_only_harness(
+        '#include "machine.hpp"\n'
+        "#include <stdio.h>\n"
+        "typedef pyfcstm_generated::Root_cpp::MachineWrapper Wrapper;\n"
+        "static void use_wrapper(Wrapper *wrapper) { (void)wrapper->cycle(); }\n"
+    )
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(
+            '#include "machine.hpp"\n#include "machine.h"\n',
+            id="quoted-machine-header",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#include <machine.h>\n',
+            id="angle-machine-header",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#include "./machine.h"\n',
+            id="relative-machine-header",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#include "generated/machine.h" // direct C header\n',
+            id="nested-machine-header-with-comment",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\nRootMachine root;\n',
+            id="bare-c-machine-object",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\nRootMachine *root;\n',
+            id="bare-c-machine-pointer",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\ntypedef RootMachine Alias;\n',
+            id="bare-c-machine-alias",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\nRootMachineVars vars;\n',
+            id="c-vars-typedef",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\nRootMachine_cycle(root, events, count);\n',
+            id="direct-c-api-call",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\nwrapper.native_handle();\n',
+            id="native-handle-access",
+        ),
+    ],
+)
+def test_cpp_wrapper_harness_rejects_direct_c_runtime_entrypoints(source):
+    """
+    Reject harnesses that bypass the C++ wrapper surface.
+
+    :param source: Invalid rendered C++ harness source.
+    :type source: str
+    :return: ``None``.
+    :rtype: None
+    """
+    with pytest.raises(AssertionError):
+        _assert_wrapper_only_harness(source)

--- a/test/template/test_cpp_wrapper_harness_guard.py
+++ b/test/template/test_cpp_wrapper_harness_guard.py
@@ -42,6 +42,10 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
             id="quoted-machine-header",
         ),
         pytest.param(
+            '#include "machine.hpp"\n#include"machine.h"\n',
+            id="quoted-machine-header-without-space",
+        ),
+        pytest.param(
             '#include "machine.hpp"\n#include <machine.h>\n',
             id="angle-machine-header",
         ),
@@ -72,6 +76,10 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
         pytest.param(
             '#include "machine.hpp"\nRootMachine_cycle(root, events, count);\n',
             id="direct-c-api-call",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\nvoid (*fn)(void) = &RootMachine_cycle;\n',
+            id="direct-c-api-address",
         ),
         pytest.param(
             '#include "machine.hpp"\nwrapper.native_handle();\n',

--- a/test/template/test_cpp_wrapper_harness_guard.py
+++ b/test/template/test_cpp_wrapper_harness_guard.py
@@ -85,6 +85,14 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
             '#include "machine.hpp"\nwrapper.native_handle();\n',
             id="native-handle-access",
         ),
+        pytest.param(
+            '// #include "machine.hpp"\nstatic void use_wrapper(void) {}\n',
+            id="commented-wrapper-header-only",
+        ),
+        pytest.param(
+            'const char *header = "machine.hpp";\nstatic void use_wrapper(void) {}\n',
+            id="string-literal-wrapper-header-only",
+        ),
     ],
 )
 def test_cpp_wrapper_harness_rejects_direct_c_runtime_entrypoints(source):

--- a/test/template/test_cpp_wrapper_harness_guard.py
+++ b/test/template/test_cpp_wrapper_harness_guard.py
@@ -4,7 +4,8 @@ Guard C++ fixture harnesses against bypassing wrapper entrypoints.
 The tests exercise the lightweight source gate used before generated
 ``harness.cpp`` files are written for C++ shared semantic fixture alignment.
 They keep the fixture runner focused on ``machine.hpp`` wrapper APIs instead
-of direct ``machine.h`` C runtime entrypoints.
+of direct ``machine.h`` C runtime entrypoints. This is a closed regression
+corpus for fixture harness discipline, not a full C++ static analyzer.
 
 Example::
 
@@ -28,6 +29,8 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
     _assert_wrapper_only_harness(
         '#include "machine.hpp"\n'
         "#include <stdio.h>\n"
+        "// native_handle and RootMachine_cycle are diagnostic words only.\n"
+        'const char *diagnostic = "RootMachine_cycle";\n'
         "typedef pyfcstm_generated::Root_cpp::MachineWrapper Wrapper;\n"
         "static void use_wrapper(Wrapper *wrapper) { (void)wrapper->cycle(); }\n"
     )
@@ -58,6 +61,18 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
             id="nested-machine-header-with-comment",
         ),
         pytest.param(
+            '#include "machine.hpp"\n#include "MACHINE.H"\n',
+            id="case-variant-machine-header",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n/* temporary */ #include "machine.h"\n',
+            id="block-comment-prefix-machine-header",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#define HEADER "machine.h"\n#include HEADER\n',
+            id="macro-indirect-machine-header",
+        ),
+        pytest.param(
             '#include "machine.hpp"\nRootMachine root;\n',
             id="bare-c-machine-object",
         ),
@@ -80,6 +95,18 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
         pytest.param(
             '#include "machine.hpp"\nvoid (*fn)(void) = &RootMachine_cycle;\n',
             id="direct-c-api-address",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#define C_API(name) RootMachine_##name\nC_API(cycle)(root, events, count);\n',
+            id="token-paste-c-api-suffix",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#define CYCLE RootMachine_cycle\nCYCLE(root, events, count);\n',
+            id="macro-alias-c-api-token",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#define CALL(name) name##Machine_cycle(0, 0, 0)\nCALL(Root);\n',
+            id="token-paste-c-api-prefix",
         ),
         pytest.param(
             '#include "machine.hpp"\nwrapper.native_handle();\n',

--- a/test/template/test_cpp_wrapper_harness_guard.py
+++ b/test/template/test_cpp_wrapper_harness_guard.py
@@ -73,6 +73,18 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
             id="macro-indirect-machine-header",
         ),
         pytest.param(
+            '#include "machine.hpp"\n#\\\ninclude "machine.h"\n',
+            id="line-continued-include-directive",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#include "machine.\\\nh"\n',
+            id="line-continued-machine-header-name",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\n#include "machine" ".h"\n',
+            id="split-machine-header-string-tokens",
+        ),
+        pytest.param(
             '#include "machine.hpp"\nRootMachine root;\n',
             id="bare-c-machine-object",
         ),
@@ -103,6 +115,10 @@ def test_cpp_wrapper_harness_accepts_wrapper_entrypoint_only():
         pytest.param(
             '#include "machine.hpp"\n#define CYCLE RootMachine_cycle\nCYCLE(root, events, count);\n',
             id="macro-alias-c-api-token",
+        ),
+        pytest.param(
+            '#include "machine.hpp"\nRootMachine_\\\ncycle(root, events, count);\n',
+            id="line-continued-c-api-token",
         ),
         pytest.param(
             '#include "machine.hpp"\n#define CALL(name) name##Machine_cycle(0, 0, 0)\nCALL(Root);\n',

--- a/test/testings/native_toolchain_alignment/runner.py
+++ b/test/testings/native_toolchain_alignment/runner.py
@@ -130,9 +130,9 @@ class _ObservationRuntime:
 
 
 def _template_utils(template_name: str):
-    if template_name == "c":
+    if template_name in ("c", "cpp"):
         from test.template.c import _utils as template_utils
-    elif template_name == "c_poll":
+    elif template_name in ("c_poll", "cpp_poll"):
         from test.template.c_poll import _utils as template_utils
     else:
         raise ValueError("unsupported native toolchain template: %r" % template_name)

--- a/test/testings/native_toolchain_alignment/runner.py
+++ b/test/testings/native_toolchain_alignment/runner.py
@@ -441,15 +441,16 @@ def assert_observations_match_case(
                 template_name,
             )
         else:
-            assert observation.get("api_return") == 1, (
-                "%s step %d expected successful API return, got %r last_error=%r"
-                % (
-                    case.id,
-                    index,
-                    observation.get("api_return"),
-                    observation.get("last_error"),
-                )
+            assert observation.get("last_error") in (None, ""), (
+                "%s step %d expected no native runtime error, got last_error=%r"
+                % (case.id, index, observation.get("last_error"))
             )
+            api_return = observation.get("api_return")
+            if api_return is not None:
+                assert api_return == 1, (
+                    "%s step %d expected successful native API return, got %r"
+                    % (case.id, index, api_return)
+                )
         runtime = _ObservationRuntime(observation)
         simulate_semantics._assert_runtime_expectation(
             runtime,

--- a/test/testings/native_toolchain_alignment/runner.py
+++ b/test/testings/native_toolchain_alignment/runner.py
@@ -374,6 +374,53 @@ def _assert_expected_exception_from_observation(
         simulate_semantics._assert_exception(error, expect, case, field_path)
 
 
+def _assert_successful_api_return(
+    template_name: str,
+    case: SemanticCase,
+    step_index: int,
+    observation: Mapping[str, Any],
+) -> None:
+    """
+    Assert the native harness API-return observation for a successful step.
+
+    C and C polling harnesses expose the raw C runtime return code as part of
+    their public fixture observation, so a successful step must emit
+    ``api_return == 1``. C++ wrapper harnesses intentionally route through the
+    wrapper observation surface and do not expose the low-level C API return in
+    shared fixture records, so they must emit ``null`` instead.
+
+    :param template_name: Native template that emitted the observation.
+    :type template_name: str
+    :param case: Shared semantic fixture case.
+    :type case: test.testings.simulate_semantics.SemanticCase
+    :param step_index: Zero-based fixture step index.
+    :type step_index: int
+    :param observation: Parsed native observation record.
+    :type observation: typing.Mapping[str, typing.Any]
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If the observation violates the expected
+        template-specific API-return contract.
+
+    Example::
+
+        >>> case = simulate_semantics.load_semantic_case("design_basic_simple_transition")
+        >>> _assert_successful_api_return("cpp", case, 0, {"api_return": None})
+    """
+    api_return = observation.get("api_return")
+    if template_name in ("cpp", "cpp_poll"):
+        assert api_return is None, (
+            "%s step %d expected C++ wrapper harness to omit raw API return, got %r"
+            % (case.id, step_index, api_return)
+        )
+        return
+
+    assert api_return == 1, (
+        "%s step %d expected successful native API return, got %r"
+        % (case.id, step_index, api_return)
+    )
+
+
 def assert_observations_match_case(
     template_name: str, case: SemanticCase, observations: Sequence[Mapping[str, Any]]
 ) -> None:
@@ -445,12 +492,7 @@ def assert_observations_match_case(
                 "%s step %d expected no native runtime error, got last_error=%r"
                 % (case.id, index, observation.get("last_error"))
             )
-            api_return = observation.get("api_return")
-            if api_return is not None:
-                assert api_return == 1, (
-                    "%s step %d expected successful native API return, got %r"
-                    % (case.id, index, api_return)
-                )
+            _assert_successful_api_return(template_name, case, index, observation)
         runtime = _ObservationRuntime(observation)
         simulate_semantics._assert_runtime_expectation(
             runtime,

--- a/test/testings/native_toolchain_alignment/test_report_and_profiles.py
+++ b/test/testings/native_toolchain_alignment/test_report_and_profiles.py
@@ -26,9 +26,11 @@ from test.testings.native_toolchain_alignment.report import (
 from test.testings.native_toolchain_alignment.runner import (
     _analysis_argv,
     _analysis_targets,
+    _assert_successful_api_return,
     _case_artifact_dir,
     _tool_stem,
 )
+from test.testings.simulate_semantics import load_semantic_case
 
 
 @pytest.mark.unittest
@@ -179,6 +181,37 @@ def test_observation_schema_requires_version_and_public_fields():
     data["phase"] = "unknown"
     with pytest.raises(ValueError, match="phase"):
         validate_observation_data(data)
+
+
+@pytest.mark.unittest
+def test_native_observation_api_return_contract_is_template_specific():
+    """
+    Verify the successful-step API return contract for C and C++ harnesses.
+
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
+    case = load_semantic_case("design_basic_simple_transition")
+
+    _assert_successful_api_return("c", case, 0, {"api_return": 1})
+    _assert_successful_api_return("c_poll", case, 0, {"api_return": 1})
+    _assert_successful_api_return("cpp", case, 0, {"api_return": None})
+    _assert_successful_api_return("cpp_poll", case, 0, {"api_return": None})
+
+    with pytest.raises(AssertionError, match="expected successful native API return"):
+        _assert_successful_api_return("c", case, 0, {"api_return": None})
+    with pytest.raises(AssertionError, match="expected successful native API return"):
+        _assert_successful_api_return("c_poll", case, 0, {"api_return": None})
+    with pytest.raises(AssertionError, match="expected C\\+\\+ wrapper harness"):
+        _assert_successful_api_return("cpp", case, 0, {"api_return": 1})
+    with pytest.raises(AssertionError, match="expected C\\+\\+ wrapper harness"):
+        _assert_successful_api_return("cpp_poll", case, 0, {"api_return": 1})
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
## 背景

本 PR 是 [D5 C++ 模板伞 PR #261](https://github.com/HansBug/pyfcstm/pull/261) 的 **PR-D5c：共享语义 fixture wrapper 对齐**。上游已通过 [PR #262](https://github.com/HansBug/pyfcstm/pull/262) 完成 `cpp` / `cpp_poll` 模板骨架、packaged asset 自包含与 C-family helper 下沉，并通过 [PR #265](https://github.com/HansBug/pyfcstm/pull/265) 完成 `machine.hpp` / `machine.cpp` 的 C++98-compatible wrapper API。

本 PR 的目标是在 D5b 的 wrapper API 基础上，把现有共享语义 fixture 跑到 `cpp` / `cpp_poll` 的 C++ wrapper 层：测试必须通过 `machine.hpp` 暴露的 C++ API 驱动生成物，而不是绕回底层 C API。这样才能确认 C++ 模板不仅“能编译”，而且在公共观察面上与仿真器、Python 模板、C 模板和 C poll 模板保持同一套 shared fixture 语义。

## 与上游 PR-D5c 的对应关系

| 上游 #261 的 PR-D5c 要求 | 本 PR 落地口径 |
|---|---|
| 为 `cpp` / `cpp_poll` 接入共享语义 fixture。 | 新增 `test/template/cpp/test_semantic_fixture_alignment.py` 与 `test/template/cpp_poll/test_semantic_fixture_alignment.py`，对现有 shared semantic fixture corpus 做参数化对齐。 |
| 新增 C++ harness 通过 wrapper API 而不是直接 C API 执行用例。 | 新增 `test/template/cpp_shared.py` 生成 C++98 harness；harness 只直接 include `machine.hpp`，构造 wrapper class，并调用 `init()` / `hot_start()` / `cycle()` / `vars()` / `is_ended()` / `current_state_path()` / hook 或 event-check wrapper 方法。 |
| 不新增 C++ 专用 shared fixture 语法。 | fixture YAML schema 不扩展；C++ runner 复用现有 fixture loader、公共期望与 native observation assertion。 |
| 失败报告区分 `cpp` / `cpp_poll`。 | pytest node id、临时构建目录、CMake 日志、运行日志和 observation 记录均携带 `cpp` 或 `cpp_poll` runner 名称。 |
| C compiler 编译 `machine.c`，C++ compiler 编译 `machine.cpp` 与 C++ harness，最终用 C++ linker 链接。 | harness CMake project 同时声明 C/CXX，设置 C99 与 C++98，`add_executable()` 同时接入 `machine.c`、`machine.cpp`、`harness.cpp`，由 CMake 按文件语言选择 C/C++ 编译器并用 C++ 链接。 |
| 覆盖构造 / 热启动、cycle 后状态与变量、abstract hook 调用、`is_ended`、`current_state_path`、公开 `vars`。 | 复用现有共享语义用例的公共观察面；C++ runner 只读取 wrapper public API，不访问 C runtime 私有运行栈或内部字段。 |

## 代码实现摘要

1. **C++ shared fixture runner**
   - 新增 `test/template/cpp_shared.py`，集中负责模板渲染、C++ harness 生成、CMake configure/build/run、JSONL observation 读取与 shared fixture 断言。
   - `run_cpp_alignment_case(template_name, case, artifact_root)` 支持 `cpp` 与 `cpp_poll`，返回 `CppAlignmentArtifacts`，便于失败时定位 generated source、harness、build、logs 与 observations。
   - `cpp` 与 `cpp_poll` 诊断映射复用现有 `c` / `c_poll` native runtime mapping，避免复制异常分类逻辑。

2. **C++ wrapper-only harness**
   - harness 只能直接 `#include "machine.hpp"`；测试明确断言 harness 不直接 include `machine.h`，并覆盖 quoted / angle-bracket / relative include 变体。
   - fixture alignment 的执行入口必须是 `cpp` / `cpp_poll` 生成的 `machine.hpp` / `machine.cpp` wrapper 层；不允许测试 harness 绕过 wrapper 去调用 `machine.h` / `machine.c` 的 C 入口。
   - harness 不直接调用 `RootMachine_init`、`RootMachine_hot_start`、`RootMachine_cycle`、`RootMachine_set_hooks`、`RootMachine_set_event_checks` 等底层执行入口；测试用正则保护该约束。
   - harness 中的状态机类型也通过 `Wrapper::Vars`、`Wrapper::EventId`、`Wrapper::Hooks`、`Wrapper::ExecutionContext`、`Wrapper::EventChecks` / `Wrapper::EventContext` 等 C++ wrapper aliases 进入，避免直接绑定 C 侧 typedef 名称；guard 同时拒绝裸 `RootMachine` object / pointer / alias 等绕过形式。
   - `cpp` harness 通过 wrapper `cycle(events, count)` / `cycle()` 驱动事件集合或无事件 cycle。
   - `cpp_poll` harness 通过 wrapper `set_event_checks(...)` 安装 event-check 表，再通过 poll-style `cycle()` 驱动事件检查。
   - abstract hook 行为通过 wrapper `set_hooks(...)` 接入口安装，hook callback 只读取公开 execution context 与 vars 快照。

3. **共享语义 fixture 对齐测试**
   - `test/template/cpp/test_semantic_fixture_alignment.py` 覆盖全部可共享语义 fixture，并检查 harness 的 wrapper-only API 约束。
   - `test/template/cpp_poll/test_semantic_fixture_alignment.py` 覆盖全部可共享语义 fixture，并检查 poll wrapper-only API 约束。
   - `_render_harness()` 在写出任一 generated `harness.cpp` 前统一调用 `_assert_wrapper_only_harness()`；因此不是只抽查一个 guard case，而是每个 shared semantic fixture 的 `cpp` / `cpp_poll` harness 都会经过 `machine.hpp`-only、`Wrapper::...` aliases、禁止直接 C typedef / `...Machine_*` C 函数的集中 gate。
   - 新增 `test/template/test_cpp_wrapper_harness_guard.py`，专门回归 quoted / angle-bracket / relative / 大小写 `machine.h` include、宏 include、line-continuation include、裸 C machine typedef、直接 C API、macro alias C API、line-continuation C API、token-paste C API 与 `native_handle()` 绕过。
   - `templates/cpp/README*` 与 `templates/cpp_poll/README*` 补充维护纪律：shared semantic fixture alignment 必须测试 `machine.hpp` / `machine.cpp` wrapper surface；测试 harness 可编译 `machine.c` / `machine.h` 底层 core，但直接入口必须是 C++ wrapper，不能直接 include `machine.h` 或直接调用 C API。
   - `test/conftest.py` 的 `SKIP_SLOW_TESTS=1` 慢测路径扩展到 `test/template/cpp/` 与 `test/template/cpp_poll/`，使后续默认快速迭代能跳过 C-family native template tests；本 PR 自身验证不使用 slow skip。

## 公共观察面对齐范围

- 保留并对齐：`current_state_path`、公开 `vars`、`is_ended`、构造 / 热启动结果、每次 `cycle` 后状态与变量、abstract hook 调用日志、公开错误诊断映射。
- 不带回 shared fixture：`history`、`cycle_count`、`brief_stack`、cycle return value 等非公共跨实现契约。
- 不新增 C++ 专用 fixture 分支或 YAML schema 字段。

## 开发约定与上游同步

- base 分支保持为 `dev/issue-247-d5-cpp-template-umbrella`，不是 `main`。
- 已确认当前 `origin/dev/issue-247-d5-cpp-template-umbrella` 是本分支祖先；本 PR 相对上游只前进本 PR 代码。
- 本 PR 的 commit message 不使用慢测跳过触发词，本地验证也不设置 `SKIP_SLOW_TESTS=1`。

## 本地验证

- [x] `pytest test/template/cpp/test_semantic_fixture_alignment.py -q`：144 passed。
- [x] `pytest test/template/cpp_poll/test_semantic_fixture_alignment.py -q`：144 passed。
- [x] `pytest test/template/cpp/test_semantic_fixture_alignment.py test/template/cpp_poll/test_semantic_fixture_alignment.py -q`：288 passed，用于确认两侧 shared fixture 均走 wrapper-only harness。
- [x] `pytest test/template/cpp_shared.py --doctest-modules -q`：21 passed, 1 skipped，用于确认新增 pydoc 示例可被 doctest 解析。
- [x] `pytest test/template/test_cpp_wrapper_harness_guard.py --doctest-modules -q`：28 passed，用于确认 guard test 模块与函数 pydoc 示例可被 doctest 解析。
- [x] `pytest test/template/test_cpp_wrapper_harness_guard.py -q`：25 passed，用于确认 wrapper-only guard 拒绝 `machine.h` include 变体、裸 C machine typedef、直接 C API 与 `native_handle()` 绕过。
- [x] `pytest test/template/cpp test/template/cpp_poll -q`：299 passed, 6 skipped。
- [x] `pytest test/testings/native_toolchain_alignment/test_report_and_profiles.py -q`：15 passed。
- [x] `pytest test/template/c/test_semantic_fixture_alignment.py::test_generated_c_alignment_semantic_fixture[design_basic_simple_transition] test/template/c_poll/test_semantic_fixture_alignment.py::test_generated_c_poll_alignment_semantic_fixture[design_basic_simple_transition] -q`：2 passed。
- [x] `SKIP_SLOW_TESTS=1 pytest test/template/cpp/test_semantic_fixture_alignment.py test/template/cpp_poll/test_semantic_fixture_alignment.py -q`：288 skipped，用于确认慢测门控覆盖新增 C++ 路径。
- [x] `python -m ruff check ...` 与 `python -m ruff format --check ...`。
- [x] `make tpl`。
- [x] `make rst_auto`。
- [x] `make unittest`：41806 passed, 8 skipped, 65 deselected。

## 合入前验收清单

- [x] `cpp` shared fixture alignment 测试覆盖现有可共享语义 fixture，并通过 C++ wrapper API 执行。
- [x] `cpp_poll` shared fixture alignment 测试覆盖现有可共享语义 fixture，并通过 C++ wrapper API 执行。
- [x] harness 不直接调用底层 C API 执行状态机动作；状态机动作入口来自 C++ wrapper public API。
- [x] harness 只直接 include `machine.hpp`，不直接 include `machine.h`，并且 fixture alignment 用到的状态机类型通过 `Wrapper::...` aliases 进入。
- [x] harness 不读取 C runtime 私有字段、运行栈或模板内部结构；只使用 `current_state_path()`、`vars()`、`is_ended()`、wrapper hook/event-check 接口等公共观察面。
- [x] pytest 失败信息、artifact 目录和日志能区分 `cpp` 与 `cpp_poll`。
- [x] 不新增 shared fixture YAML 语法，不引入 C++ 专用 fixture 分支。
- [x] 不把 `history`、`cycle_count`、`brief_stack`、cycle return value 等非公共契约带回 shared fixture。
- [x] `make tpl` 已运行，`pyfcstm/template/` packaged assets 与 `templates/` 同步且无非预期 diff。
- [x] `make rst_auto` 已运行；没有 public Python API RST 非预期 diff。
- [x] 本地执行全量 `make unittest`，不设置 `SKIP_SLOW_TESTS=1`。
- [ ] 最新 CI 全部通过；本 PR 不使用慢测跳过 commit message 触发慢测跳过。当前 `a3945b42` 已完成本轮 wrapper guard 与 pydoc/doctest 修复的本地目标验证，GitHub Actions 正在重新运行。上一轮 `81334c51` 之前已完成本地全量 `make unittest`。
- [ ] 三路 reviewer（codex reviewer / claude reviewer / deepseek reviewer）对代码最终状态复审 C/I 清零。

## 非目标

- 不实现新的 C++ 状态机算法运行时；执行语义仍委托底层 C core。
- 不扩展 shared fixture schema；C++ runner 只能适配现有公共观察面。
- 不推进 D5d 的跨平台原生工具链矩阵扩展；本 PR 只做 pytest shared fixture wrapper 对齐，复杂矩阵留给后续 D5d。
- 不修改 renderer 的 symlink 处理逻辑；symlink/stub 消解仍属于 template packaging 层。
- 不引入 C++11+ API、异常、RTTI、STL 容器或默认堆分配。







