### PR TITLE
实现：D5d 扩展 cpp 原生工具链矩阵

### DIFF
--- a/.github/workflows/native-toolchain.yml
+++ b/.github/workflows/native-toolchain.yml
@@ -13,6 +13,8 @@ on:
       - pyfcstm/utils/**
       - templates/c/**
       - templates/c_poll/**
+      - templates/cpp/**
+      - templates/cpp_poll/**
       - tools/package_templates.py
       - test/conftest.py
       - pytest.ini
@@ -21,6 +23,8 @@ on:
       - test/testings/native_toolchain_alignment/**
       - test/template/c/test_native_toolchain_alignment.py
       - test/template/c_poll/test_native_toolchain_alignment.py
+      - test/template/cpp/test_native_toolchain_alignment.py
+      - test/template/cpp_poll/test_native_toolchain_alignment.py
       - test/fixtures/simulate_semantics/**
       - requirements*.txt
   pull_request:
@@ -33,6 +37,8 @@ on:
       - pyfcstm/utils/**
       - templates/c/**
       - templates/c_poll/**
+      - templates/cpp/**
+      - templates/cpp_poll/**
       - tools/package_templates.py
       - test/conftest.py
       - pytest.ini
@@ -41,6 +47,8 @@ on:
       - test/testings/native_toolchain_alignment/**
       - test/template/c/test_native_toolchain_alignment.py
       - test/template/c_poll/test_native_toolchain_alignment.py
+      - test/template/cpp/test_native_toolchain_alignment.py
+      - test/template/cpp_poll/test_native_toolchain_alignment.py
       - test/fixtures/simulate_semantics/**
       - requirements*.txt
   workflow_dispatch:
@@ -136,6 +144,8 @@ jobs:
           pytest -m native_toolchain \
             test/template/c/test_native_toolchain_alignment.py \
             test/template/c_poll/test_native_toolchain_alignment.py \
+            test/template/cpp/test_native_toolchain_alignment.py \
+            test/template/cpp_poll/test_native_toolchain_alignment.py \
             --run-native-toolchain -q
       - name: Upload native artifacts
         if: always()
@@ -173,6 +183,8 @@ jobs:
           pytest -m native_toolchain \
             test/template/c/test_native_toolchain_alignment.py \
             test/template/c_poll/test_native_toolchain_alignment.py \
+            test/template/cpp/test_native_toolchain_alignment.py \
+            test/template/cpp_poll/test_native_toolchain_alignment.py \
             --run-native-toolchain -q
       - name: Upload native artifacts
         if: always()
@@ -229,6 +241,8 @@ jobs:
           pytest -m native_toolchain `
             test/template/c/test_native_toolchain_alignment.py `
             test/template/c_poll/test_native_toolchain_alignment.py `
+            test/template/cpp/test_native_toolchain_alignment.py `
+            test/template/cpp_poll/test_native_toolchain_alignment.py `
             --run-native-toolchain -q
       - name: Upload native artifacts
         if: always()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,25 +4,63 @@ import pytest
 from hbutils.testing import TextAligner
 
 
-_SLOW_TEST_PATH_PREFIXES = (
+_SKIP_SLOW_TEST_PATH_PREFIXES = (
     os.path.join("test", "template", "c", ""),
     os.path.join("test", "template", "c_poll", ""),
-    os.path.join("test", "template", "cpp", ""),
-    os.path.join("test", "template", "cpp_poll", ""),
+    os.path.join("test", "template", "cpp", "test_semantic_fixture_alignment.py"),
+    os.path.join(
+        "test", "template", "cpp_poll", "test_semantic_fixture_alignment.py"
+    ),
+    os.path.join("test", "template", "cpp", "test_native_toolchain_alignment.py"),
+    os.path.join(
+        "test", "template", "cpp_poll", "test_native_toolchain_alignment.py"
+    ),
 )
+_SLOW_TEST_PATH_PREFIXES = _SKIP_SLOW_TEST_PATH_PREFIXES
 
 
-def _is_slow_path(nodeid: str) -> bool:
+def _matches_path_prefix(nodeid: str, prefixes) -> bool:
+    """Return whether a pytest node id belongs to one path prefix.
+
+    :param nodeid: Pytest item node id.
+    :type nodeid: str
+    :param prefixes: Path prefixes using the platform separator.
+    :type prefixes: collections.abc.Sequence[str]
+    :return: ``True`` when ``nodeid`` starts with or contains a prefix.
+    :rtype: bool
+    """
     norm = nodeid.replace("\\", "/").replace("/", os.sep)
-    for prefix in _SLOW_TEST_PATH_PREFIXES:
+    for prefix in prefixes:
         if norm.startswith(prefix) or norm.startswith(prefix.replace(os.sep, "/")):
             return True
     if any(
         prefix.replace(os.sep, "/") in nodeid.replace("\\", "/")
-        for prefix in _SLOW_TEST_PATH_PREFIXES
+        for prefix in prefixes
     ):
         return True
     return False
+
+
+def _is_slow_path(nodeid: str) -> bool:
+    """Return whether a pytest node id should be marked slow.
+
+    :param nodeid: Pytest item node id.
+    :type nodeid: str
+    :return: ``True`` when the item belongs to a slow template path.
+    :rtype: bool
+    """
+    return _matches_path_prefix(nodeid, _SLOW_TEST_PATH_PREFIXES)
+
+
+def _is_skip_slow_path(nodeid: str) -> bool:
+    """Return whether ``SKIP_SLOW_TESTS`` should skip a pytest node id.
+
+    :param nodeid: Pytest item node id.
+    :type nodeid: str
+    :return: ``True`` when the item belongs to the fast-path skip set.
+    :rtype: bool
+    """
+    return _matches_path_prefix(nodeid, _SKIP_SLOW_TEST_PATH_PREFIXES)
 
 
 def pytest_addoption(parser):
@@ -84,10 +122,12 @@ def pytest_generate_tests(metafunc):
 def pytest_collection_modifyitems(config, items):
     """Auto-mark native C-family template tests and apply skip gates.
 
-    ``SKIP_SLOW_TESTS=1`` skips ordinary native C-family template tests by
+    ``SKIP_SLOW_TESTS=1`` skips ordinary C-family native-template tests by
     path, but explicitly enabled ``native_toolchain`` items take priority so
     explicit native toolchain workflow runs are not accidentally converted into
-    false-green skips.
+    false-green skips. C++ wrapper smoke tests remain outside the broad skip
+    path, so fast template iterations still exercise the wrapper APIs without
+    the all-fixture native build cost.
     """
     from test.testings.native_toolchain_alignment.profiles import (
         native_toolchain_enabled,
@@ -114,8 +154,8 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(native_disabled_marker)
         if _is_slow_path(item.nodeid):
             item.add_marker(slow_marker)
-            if skip_slow and not is_native_toolchain:
-                item.add_marker(skip_marker)
+        if skip_slow and _is_skip_slow_path(item.nodeid) and not is_native_toolchain:
+            item.add_marker(skip_marker)
 
 
 @pytest.fixture(scope="session")

--- a/test/template/cpp/test_native_toolchain_alignment.py
+++ b/test/template/cpp/test_native_toolchain_alignment.py
@@ -1,0 +1,51 @@
+import os
+
+import pytest
+
+from test.testings.native_toolchain_alignment import (
+    ARTIFACT_DIR_ENV_VAR,
+    resolve_selected_profile,
+    run_native_toolchain_case,
+)
+from test.testings.simulate_semantics import load_semantic_case
+
+
+@pytest.mark.native_toolchain
+def test_generated_cpp_native_toolchain_alignment(
+    native_semantic_case_id, request, tmp_path
+):
+    """
+    Align a shared semantic fixture through the C++ native toolchain matrix.
+
+    :param native_semantic_case_id: Shared semantic fixture case id selected by
+        the native matrix pytest parametrization.
+    :type native_semantic_case_id: str
+    :param request: Pytest request object used for profile resolution.
+    :type request: pytest.FixtureRequest
+    :param tmp_path: Temporary artifact root for this pytest invocation.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
+    profile = resolve_selected_profile(request.config)
+    artifact_root = os.environ.get(ARTIFACT_DIR_ENV_VAR) or str(tmp_path / "artifacts")
+    result = run_native_toolchain_case(
+        "cpp",
+        load_semantic_case(native_semantic_case_id),
+        profile,
+        artifact_root,
+    )
+
+    assert result["status"] == "passed", result["message"]
+    expected_classification = (
+        "analysis_report_only" if result.get("report_only") else "passed"
+    )
+    assert result["classification"] == expected_classification
+    assert "harness" in result["artifact_paths"]
+    assert "generated" in result["artifact_paths"]

--- a/test/template/cpp_poll/test_native_toolchain_alignment.py
+++ b/test/template/cpp_poll/test_native_toolchain_alignment.py
@@ -1,0 +1,51 @@
+import os
+
+import pytest
+
+from test.testings.native_toolchain_alignment import (
+    ARTIFACT_DIR_ENV_VAR,
+    resolve_selected_profile,
+    run_native_toolchain_case,
+)
+from test.testings.simulate_semantics import load_semantic_case
+
+
+@pytest.mark.native_toolchain
+def test_generated_cpp_poll_native_toolchain_alignment(
+    native_semantic_case_id, request, tmp_path
+):
+    """
+    Align a shared semantic fixture through the C++ poll native matrix.
+
+    :param native_semantic_case_id: Shared semantic fixture case id selected by
+        the native matrix pytest parametrization.
+    :type native_semantic_case_id: str
+    :param request: Pytest request object used for profile resolution.
+    :type request: pytest.FixtureRequest
+    :param tmp_path: Temporary artifact root for this pytest invocation.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
+    profile = resolve_selected_profile(request.config)
+    artifact_root = os.environ.get(ARTIFACT_DIR_ENV_VAR) or str(tmp_path / "artifacts")
+    result = run_native_toolchain_case(
+        "cpp_poll",
+        load_semantic_case(native_semantic_case_id),
+        profile,
+        artifact_root,
+    )
+
+    assert result["status"] == "passed", result["message"]
+    expected_classification = (
+        "analysis_report_only" if result.get("report_only") else "passed"
+    )
+    assert result["classification"] == expected_classification
+    assert "harness" in result["artifact_paths"]
+    assert "generated" in result["artifact_paths"]

--- a/test/testings/native_toolchain_alignment/__init__.py
+++ b/test/testings/native_toolchain_alignment/__init__.py
@@ -14,7 +14,7 @@ small module map for tests and reviewers.
      - Explicit opt-in switch handling, public profile registry, manual
        self-hosted profile registry, and build-mode constants.
    * - ``harness``
-     - Case-specific C harness and CMake project rendering.
+     - Case-specific C/C++ harness and CMake project rendering.
    * - ``runner``
      - Configure/build/run, compile-only, analyze-only, and observation checks.
    * - ``report``

--- a/test/testings/native_toolchain_alignment/harness.py
+++ b/test/testings/native_toolchain_alignment/harness.py
@@ -1,16 +1,18 @@
 """
-Standalone C harness generation for native toolchain semantic alignment.
+Standalone C-family harness generation for native toolchain alignment.
 
 This module converts a shared semantic fixture and rendered C-family runtime
-metadata into a small case-specific ``harness.c`` file. The harness uses only
-public generated APIs, executes fixture steps, writes public observations as
-JSON Lines, and leaves semantic assertion logic in Python.
+metadata into a small case-specific harness source file. C harnesses call the
+public generated C APIs through ``machine.h``. C++ harnesses call only the
+generated wrapper APIs through ``machine.hpp``. Each harness executes fixture
+steps, writes public observations as JSON Lines, and leaves semantic assertion
+logic in Python.
 
 The module contains:
 
 * :class:`HarnessContext` - Template context for one generated harness.
 * :func:`build_harness_context` - Convert a semantic case into template data.
-* :func:`render_harness` - Render ``harness.c`` for ``c`` or ``c_poll``.
+* :func:`render_harness` - Render ``harness.c`` or ``harness.cpp``.
 * :func:`render_cmake_project` - Render the native CMake project files.
 
 Example::
@@ -25,6 +27,7 @@ Example::
 import json
 import math
 import os
+import re
 from dataclasses import dataclass
 from typing import Any, Dict, List, Mapping, Optional, Sequence
 
@@ -42,14 +45,29 @@ from test.testings import simulate_semantics
 from test.testings.simulate_semantics import SemanticCase
 
 _TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "harness_templates")
+_INCLUDE_DIRECTIVE_RE = re.compile(r"^\s*#\s*include\s*(?P<target>[^\n]+)", re.M)
+_INCLUDE_LITERAL_RE = re.compile(r'(?:(?:"([^"\n]+)")|(?:<([^>\n]+)>))')
+_LINE_CONTINUATION_RE = re.compile(r"\\\r?\n")
+_TOKEN_PASTE_RE = re.compile(r"##")
+_NATIVE_HANDLE_CALL_RE = re.compile(r"\bnative_handle\s*\(")
+_DIRECT_C_TYPE_RE = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*Machine"
+    r"(Vars|StateId|EventId|Int|Hooks|EventChecks|ExecutionContext|EventContext)?\b"
+)
+_DIRECT_C_API_RE = re.compile(
+    r"\b[A-Za-z_][A-Za-z0-9_]*Machine_"
+    r"(create_uninitialized|create|destroy|init|hot_start|set_hooks|"
+    r"set_event_checks|cycle|vars|is_ended|current_state_id|"
+    r"current_state_path|current_state_name|last_error|dsl_source)\b"
+)
 
 
 @dataclass(frozen=True)
 class HarnessContext:
     """
-    Template context for one native toolchain C harness.
+    Template context for one native toolchain harness.
 
-    :param template_name: Template under test, either ``"c"`` or ``"c_poll"``.
+    :param template_name: Template under test, such as ``"c"`` or ``"cpp"``.
     :type template_name: str
     :param case_id: Shared semantic fixture case id.
     :type case_id: str
@@ -71,6 +89,16 @@ class HarnessContext:
     :type steps: typing.Sequence[typing.Mapping[str, typing.Any]]
     :param initial: Initial hot-start descriptor, if any.
     :type initial: typing.Mapping[str, typing.Any], optional
+    :param initial_expect: Expected initial failure descriptor, if any.
+    :type initial_expect: typing.Mapping[str, typing.Any], optional
+    :param harness_source_name: Harness source filename.
+    :type harness_source_name: str
+    :param machine_source_names: Generated machine sources copied into the
+        harness project.
+    :type machine_source_names: typing.Sequence[str]
+    :param wrapper_namespace_suffix: Generated C++ wrapper namespace suffix,
+        if the harness uses a C++ wrapper.
+    :type wrapper_namespace_suffix: str, optional
 
     Example::
 
@@ -92,6 +120,51 @@ class HarnessContext:
     steps: Sequence[Mapping[str, Any]]
     initial: Optional[Mapping[str, Any]] = None
     initial_expect: Optional[Mapping[str, Any]] = None
+    harness_source_name: str = "harness.c"
+    machine_source_names: Sequence[str] = ("machine.c",)
+    wrapper_namespace_suffix: Optional[str] = None
+
+    @property
+    def uses_cpp_wrapper(self) -> bool:
+        """
+        Return whether this context renders a C++ wrapper harness.
+
+        :return: ``True`` for ``cpp`` and ``cpp_poll`` harnesses.
+        :rtype: bool
+
+        Example::
+
+            >>> build_harness_context("cpp", simulate_semantics.load_semantic_case("design_basic_simple_transition")).uses_cpp_wrapper
+            True
+        """
+        return self.wrapper_namespace_suffix is not None
+
+
+_CONTEXT_TEMPLATE_NAMES = {
+    "c": "c",
+    "c_poll": "c_poll",
+    "cpp": "c",
+    "cpp_poll": "c_poll",
+}
+_HARNESS_TEMPLATE_FILES = {
+    "c": "c_main.c.j2",
+    "c_poll": "c_poll_main.c.j2",
+    "cpp": "cpp_main.cpp.j2",
+    "cpp_poll": "cpp_poll_main.cpp.j2",
+}
+_HARNESS_SOURCE_NAMES = {
+    "c": "harness.c",
+    "c_poll": "harness.c",
+    "cpp": "harness.cpp",
+    "cpp_poll": "harness.cpp",
+}
+_MACHINE_SOURCE_NAMES = {
+    "c": ("machine.c",),
+    "c_poll": ("machine.c",),
+    "cpp": ("machine.c", "machine.cpp"),
+    "cpp_poll": ("machine.c", "machine.cpp"),
+}
+_WRAPPER_NAMESPACE_SUFFIX = {"cpp": "cpp", "cpp_poll": "cpp_poll"}
 
 
 def _parse_model(case: SemanticCase):
@@ -347,9 +420,9 @@ def _step_contexts(
 
 def build_harness_context(template_name: str, case: SemanticCase) -> HarnessContext:
     """
-    Build a C harness template context for a semantic fixture.
+    Build a native harness template context for a semantic fixture.
 
-    :param template_name: Template name, either ``"c"`` or ``"c_poll"``.
+    :param template_name: Template name, such as ``"c"`` or ``"cpp_poll"``.
     :type template_name: str
     :param case: Shared semantic fixture case.
     :type case: test.testings.simulate_semantics.SemanticCase
@@ -363,7 +436,7 @@ def build_harness_context(template_name: str, case: SemanticCase) -> HarnessCont
         >>> build_harness_context("c", case).template_name
         'c'
     """
-    if template_name not in ("c", "c_poll"):
+    if template_name not in _CONTEXT_TEMPLATE_NAMES:
         raise ValueError("unsupported native toolchain template: %r" % template_name)
     model = _parse_model(case)
     states = _state_rows(model)
@@ -395,6 +468,9 @@ def build_harness_context(template_name: str, case: SemanticCase) -> HarnessCont
             case.data.get("initial") or {}, state_macros, variables, initial_expect
         ),
         initial_expect=initial_expect,
+        harness_source_name=_HARNESS_SOURCE_NAMES[template_name],
+        machine_source_names=_MACHINE_SOURCE_NAMES[template_name],
+        wrapper_namespace_suffix=_WRAPPER_NAMESPACE_SUFFIX.get(template_name),
     )
 
 
@@ -410,17 +486,132 @@ def _environment() -> Environment:
     return env
 
 
+def _mask_cpp_comments_and_literals(source: str, mask_literals: bool) -> str:
+    """Replace C++ comments and optionally literals with whitespace.
+
+    :param source: C++ source text to inspect.
+    :type source: str
+    :param mask_literals: Whether string and character literals should also be
+        replaced by whitespace.
+    :type mask_literals: bool
+    :return: Source text with comments, and optionally literals, masked.
+    :rtype: str
+
+    Example::
+
+        >>> _mask_cpp_comments_and_literals('// #include "machine.h"\\n', False)
+        '\\n'
+    """
+    source = _LINE_CONTINUATION_RE.sub("", source)
+    output = []
+    index = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        next_char = source[index + 1] if index + 1 < length else ""
+        if char == "/" and next_char == "/":
+            index += 2
+            while index < length and source[index] != "\n":
+                index += 1
+            if index < length:
+                output.append("\n")
+                index += 1
+        elif char == "/" and next_char == "*":
+            output.extend((" ", " "))
+            index += 2
+            while index < length:
+                current = source[index]
+                following = source[index + 1] if index + 1 < length else ""
+                if current == "*" and following == "/":
+                    output.extend((" ", " "))
+                    index += 2
+                    break
+                output.append("\n" if current == "\n" else " ")
+                index += 1
+        elif mask_literals and char in {'"', "'"}:
+            quote = char
+            output.append(" ")
+            index += 1
+            while index < length:
+                current = source[index]
+                output.append("\n" if current == "\n" else " ")
+                index += 1
+                if current == "\\" and index < length:
+                    escaped = source[index]
+                    output.append("\n" if escaped == "\n" else " ")
+                    index += 1
+                elif current == quote:
+                    break
+        else:
+            output.append(char)
+            index += 1
+    return "".join(output)
+
+
+def _iter_include_targets(source: str) -> List[str]:
+    """Return literal include targets from comment-masked C++ source.
+
+    :param source: C++ source text to inspect.
+    :type source: str
+    :return: Include targets; ``""`` means a non-literal include directive.
+    :rtype: list[str]
+
+    Example::
+
+        >>> _iter_include_targets('#include "machine.hpp"\\n')
+        ['machine.hpp']
+    """
+    directive_source = _mask_cpp_comments_and_literals(source, mask_literals=False)
+    targets = []
+    for match in _INCLUDE_DIRECTIVE_RE.finditer(directive_source):
+        raw_target = match.group("target").strip()
+        literal_match = _INCLUDE_LITERAL_RE.fullmatch(raw_target)
+        targets.append(
+            (literal_match.group(1) or literal_match.group(2)) if literal_match else ""
+        )
+    return targets
+
+
+def _assert_cpp_wrapper_harness_source(source: str) -> None:
+    """Assert that a C++ native harness enters through ``machine.hpp``.
+
+    :param source: Rendered C++ harness source.
+    :type source: str
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If the source bypasses the C++ wrapper surface.
+
+    Example::
+
+        >>> _assert_cpp_wrapper_harness_source('#include "machine.hpp"\\n')
+    """
+    include_targets = _iter_include_targets(source)
+    normalized_includes = [
+        os.path.basename(target.replace("\\", "/")).lower()
+        for target in include_targets
+    ]
+    symbol_source = _mask_cpp_comments_and_literals(source, mask_literals=True)
+    assert include_targets and all(include_targets)
+    assert "machine.hpp" in normalized_includes
+    assert "machine.h" not in normalized_includes
+    assert not _TOKEN_PASTE_RE.search(symbol_source)
+    assert not _NATIVE_HANDLE_CALL_RE.search(symbol_source)
+    symbol_source_without_alias = symbol_source.replace("MachineWrapper", "            ")
+    assert not _DIRECT_C_TYPE_RE.search(symbol_source_without_alias)
+    assert not _DIRECT_C_API_RE.search(symbol_source)
+
+
 def render_harness(
     template_name: str, case: SemanticCase, output_path: str
 ) -> HarnessContext:
     """
-    Render a native C harness source file.
+    Render a native C-family harness source file.
 
-    :param template_name: Template name, either ``"c"`` or ``"c_poll"``.
+    :param template_name: Template name, such as ``"c"`` or ``"cpp_poll"``.
     :type template_name: str
     :param case: Shared semantic fixture case.
     :type case: test.testings.simulate_semantics.SemanticCase
-    :param output_path: Destination ``harness.c`` path.
+    :param output_path: Destination harness source path.
     :type output_path: str
     :return: Harness context used for rendering.
     :rtype: HarnessContext
@@ -435,8 +626,10 @@ def render_harness(
         'design_basic_simple_transition'
     """
     context = build_harness_context(template_name, case)
-    template_file = "c_poll_main.c.j2" if template_name == "c_poll" else "c_main.c.j2"
+    template_file = _HARNESS_TEMPLATE_FILES[template_name]
     text = _environment().get_template(template_file).render(context=context)
+    if context.uses_cpp_wrapper:
+        _assert_cpp_wrapper_harness_source(text)
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, "w", encoding="utf-8") as f:
         f.write(text)

--- a/test/testings/native_toolchain_alignment/harness.py
+++ b/test/testings/native_toolchain_alignment/harness.py
@@ -51,7 +51,7 @@ _LINE_CONTINUATION_RE = re.compile(r"\\\r?\n")
 _TOKEN_PASTE_RE = re.compile(r"##")
 _NATIVE_HANDLE_CALL_RE = re.compile(r"\bnative_handle\s*\(")
 _DIRECT_C_TYPE_RE = re.compile(
-    r"\b[A-Za-z_][A-Za-z0-9_]*Machine"
+    r"(?<!Wrapper::)\b(?:[A-Za-z_][A-Za-z0-9_]*Machine|Machine)"
     r"(Vars|StateId|EventId|Int|Hooks|EventChecks|ExecutionContext|EventContext)?\b"
 )
 _DIRECT_C_API_RE = re.compile(
@@ -596,7 +596,9 @@ def _assert_cpp_wrapper_harness_source(source: str) -> None:
     assert "machine.h" not in normalized_includes
     assert not _TOKEN_PASTE_RE.search(symbol_source)
     assert not _NATIVE_HANDLE_CALL_RE.search(symbol_source)
-    symbol_source_without_alias = symbol_source.replace("MachineWrapper", "            ")
+    symbol_source_without_alias = symbol_source.replace(
+        "MachineWrapper", "            "
+    )
     assert not _DIRECT_C_TYPE_RE.search(symbol_source_without_alias)
     assert not _DIRECT_C_API_RE.search(symbol_source)
 

--- a/test/testings/native_toolchain_alignment/harness_templates/CMakeLists.txt.j2
+++ b/test/testings/native_toolchain_alignment/harness_templates/CMakeLists.txt.j2
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 project(pyfcstm_native_toolchain_harness C CXX)
 
 set(PYFCSTM_NATIVE_C_STANDARD "99" CACHE STRING "C standard used for the native harness")
-set(PYFCSTM_NATIVE_CXX_STANDARD "98" CACHE STRING "C++ standard used for the header probe")
+set(PYFCSTM_NATIVE_CXX_STANDARD "98" CACHE STRING "C++ standard used for wrapper harnesses and header probes")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 set(CMAKE_C_STANDARD ${PYFCSTM_NATIVE_C_STANDARD})
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -21,8 +22,19 @@ if(PYFCSTM_NATIVE_CXX_FLAGS)
 else()
     set(PYFCSTM_NATIVE_CXX_FLAGS_LIST "")
 endif()
-add_executable(native_harness harness.c machine.c)
+add_executable(native_harness
+{% for source_name in ([context.harness_source_name] + (context.machine_source_names | list)) %}    {{ source_name }}
+{% endfor %})
+{% if context.uses_cpp_wrapper %}set_source_files_properties(
+    machine.c
+    PROPERTIES COMPILE_FLAGS "${PYFCSTM_NATIVE_C_FLAGS}")
+set_source_files_properties(
+    {{ context.harness_source_name }}
+    machine.cpp
+    PROPERTIES COMPILE_FLAGS "${PYFCSTM_NATIVE_CXX_FLAGS}")
+{% else %}
 target_compile_options(native_harness PRIVATE ${PYFCSTM_NATIVE_C_FLAGS_LIST})
+{% endif %}
 if(PYFCSTM_NATIVE_LINK_FLAGS)
     set_target_properties(native_harness PROPERTIES LINK_FLAGS "${PYFCSTM_NATIVE_LINK_FLAGS}")
 endif()
@@ -30,6 +42,6 @@ if(NOT WIN32)
     target_link_libraries(native_harness m)
 endif()
 
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cxx_header_probe.cpp" "#include \"${CMAKE_CURRENT_SOURCE_DIR}/machine.h\"\n")
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cxx_header_probe.cpp" "#include \"${CMAKE_CURRENT_SOURCE_DIR}/{% if context.uses_cpp_wrapper %}machine.hpp{% else %}machine.h{% endif %}\"\n")
 add_library(cxx_header_probe OBJECT "${CMAKE_CURRENT_BINARY_DIR}/cxx_header_probe.cpp")
 target_compile_options(cxx_header_probe PRIVATE ${PYFCSTM_NATIVE_CXX_FLAGS_LIST})

--- a/test/testings/native_toolchain_alignment/harness_templates/cpp_main.cpp.j2
+++ b/test/testings/native_toolchain_alignment/harness_templates/cpp_main.cpp.j2
@@ -1,0 +1,314 @@
+#include "machine.hpp"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp::MachineWrapper Wrapper;
+
+static Wrapper::Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
+static const char *state_paths[] = {
+{% for state in context.states %}    {{ state.path | tojson }},
+{% endfor %}};
+{% if context.actions %}static const char *action_paths[] = {
+{% for action in context.actions %}    {{ action.path | tojson }},
+{% endfor %}};
+{% else %}static const char **action_paths = NULL;
+{% endif %}static const char *stage_names[] = {"enter", "during", "exit"};
+
+struct HandlerCall {
+    int action_id;
+    int state_id;
+    int stage_id;
+    int active_leaf_id;
+    int call_stage_id;
+    int abstract_target_id;
+    int named_ref_id;
+{% for variable in context.variables %}    Wrapper::Int {{ variable.field }}_is_int;
+    double {{ variable.field }}_is_float;
+{% endfor %}};
+
+static struct HandlerCall handler_calls[512];
+static size_t handler_call_count = 0u;
+
+static const char *lookup_string(const char **items, size_t count, int id)
+{
+    if (id < 0 || (size_t)id >= count) {
+        return NULL;
+    }
+    return items[id];
+}
+
+static void json_string(FILE *out, const char *value)
+{
+    const unsigned char *cursor;
+    if (value == NULL) {
+        fputs("null", out);
+        return;
+    }
+    fputc('"', out);
+    for (cursor = (const unsigned char *)value; *cursor != '\0'; ++cursor) {
+        if (*cursor == '"' || *cursor == '\\') {
+            fputc('\\', out);
+            fputc((int)*cursor, out);
+        } else if (*cursor == '\n') {
+            fputs("\\n", out);
+        } else if (*cursor == '\r') {
+            fputs("\\r", out);
+        } else if (*cursor == '\t') {
+            fputs("\\t", out);
+        } else {
+            fputc((int)*cursor, out);
+        }
+    }
+    fputc('"', out);
+}
+
+static void write_machine_int(FILE *out, Wrapper::Int value)
+{
+    char digits[64];
+    size_t count = 0u;
+    Wrapper::Int quotient = value;
+
+    if (quotient == 0) {
+        fputc('0', out);
+        return;
+    }
+    if (quotient < 0) {
+        fputc('-', out);
+        while (quotient != 0) {
+            Wrapper::Int next = quotient / 10;
+            digits[count++] = (char)('0' + (int)(next * 10 - quotient));
+            quotient = next;
+        }
+    } else {
+        while (quotient != 0) {
+            digits[count++] = (char)('0' + (int)(quotient % 10));
+            quotient = quotient / 10;
+        }
+    }
+    while (count > 0u) {
+        fputc((int)digits[--count], out);
+    }
+}
+
+static void write_vars(FILE *out, const Wrapper::Vars *vars)
+{
+    fputc('{', out);
+{% for variable in context.variables %}    if ({{ loop.index0 }} > 0) {
+        fputc(',', out);
+    }
+    json_string(out, {{ variable.name | tojson }});
+    fputc(':', out);
+{% if variable.type == 'int' %}    write_machine_int(out, vars->{{ variable.field }});
+{% else %}    fprintf(out, "%.17g", vars->{{ variable.field }});
+{% endif %}{% endfor %}    fputc('}', out);
+}
+
+static void write_handler_calls(FILE *out)
+{
+    size_t i;
+    fputc('[', out);
+    for (i = 0u; i < handler_call_count; ++i) {
+        const struct HandlerCall *call = &handler_calls[i];
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        fputc('{', out);
+        fputs("\"action\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->action_id));
+        fputs(",\"state\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->state_id));
+        fputs(",\"stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->stage_id));
+        fputs(",\"vars\":{", out);
+{% for variable in context.variables %}        if ({{ loop.index0 }} > 0) {
+            fputc(',', out);
+        }
+        json_string(out, {{ variable.name | tojson }});
+        fputc(':', out);
+{% if variable.type == 'int' %}        write_machine_int(out, call->{{ variable.field }}_is_int);
+{% else %}        fprintf(out, "%.17g", call->{{ variable.field }}_is_float);
+{% endif %}{% endfor %}        fputs("}", out);
+        fputs(",\"active_leaf\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->active_leaf_id));
+        fputs(",\"call_stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->call_stage_id));
+        fputs(",\"abstract_target\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->abstract_target_id));
+        fputs(",\"named_ref\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->named_ref_id));
+        fputc('}', out);
+    }
+    fputc(']', out);
+}
+
+{% if context.hooks %}extern "C" {
+static void record_hook(Wrapper::Machine *machine_ptr, const Wrapper::ExecutionContext *ctx, void *user_data)
+{
+    struct HandlerCall *call;
+    (void)machine_ptr;
+    (void)user_data;
+    if (handler_call_count >= sizeof(handler_calls) / sizeof(handler_calls[0])) {
+        return;
+    }
+    call = &handler_calls[handler_call_count++];
+    call->action_id = ctx->action_id;
+    call->state_id = ctx->state_id;
+    call->stage_id = ctx->action_stage_id;
+    call->active_leaf_id = ctx->active_leaf_state_id;
+    call->call_stage_id = ctx->call_stage_id;
+    call->abstract_target_id = ctx->abstract_target_id;
+    call->named_ref_id = ctx->named_ref_id;
+{% for variable in context.variables %}{% if variable.type == 'int' %}    call->{{ variable.field }}_is_int = ctx->vars->{{ variable.field }};
+{% else %}    call->{{ variable.field }}_is_float = ctx->vars->{{ variable.field }};
+{% endif %}{% endfor %}}
+}
+{% endif %}
+static void install_hooks(Wrapper *wrapper)
+{
+{% for hook in context.hooks %}    hooks.{{ hook.field }} = record_hook;
+{% endfor %}    wrapper->set_hooks(&hooks, NULL);
+}
+
+static int run_cycle(Wrapper *wrapper, const Wrapper::EventId *events, size_t event_count)
+{
+    return wrapper->cycle(events, event_count);
+}
+
+static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, const char *last_error)
+{
+    size_t i;
+    const char *state_path = wrapper->current_state_path();
+    const Wrapper::Vars *vars = wrapper->vars();
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"step\"", out);
+    fprintf(out, ",\"step_index\":%d,\"cycle_index\":%d", step_index, cycle_index);
+    fputs(",\"events\":[", out);
+    for (i = 0u; i < event_count; ++i) {
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        json_string(out, event_names[i]);
+    }
+    fputs("]", out);
+    fputs(",\"current_state\":", out);
+    json_string(out, state_path);
+    fputs(",\"is_ended\":", out);
+    fputs(wrapper->is_ended() ? "true" : "false", out);
+    fputs(",\"vars\":", out);
+    write_vars(out, vars);
+    fputs(",\"handler_calls\":", out);
+    write_handler_calls(out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fputs(",\"api_return\":null", out);
+    fputs("}\n", out);
+}
+
+static void write_initial_error(FILE *out, const char *last_error)
+{
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"init\"", out);
+    fputs(",\"step_index\":null,\"cycle_index\":null", out);
+    fputs(",\"events\":[]", out);
+    fputs(",\"current_state\":null", out);
+    fputs(",\"is_ended\":false", out);
+    fputs(",\"vars\":{}", out);
+    fputs(",\"handler_calls\":[]", out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fputs(",\"api_return\":null", out);
+    fputs("}\n", out);
+}
+
+int main(int argc, char **argv)
+{
+    FILE *out;
+    Wrapper wrapper;
+    int api_return;
+    size_t cycle_iter;
+    const char *last_error;
+    if (argc < 2) {
+        return 2;
+    }
+    out = fopen(argv[1], "w");
+    if (out == NULL) {
+        return 2;
+    }
+{% if not context.initial %}    if (!wrapper.init()) {
+{% if context.initial_expect %}        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+{% else %}        fclose(out);
+        return 3;
+{% endif %}    }
+{% endif %}    install_hooks(&wrapper);
+{% if context.initial %}{% if context.initial.synthetic_error %}{% if context.initial_expect %}    write_initial_error(out, {{ context.initial.error_message | tojson }});
+    fclose(out);
+    return 0;
+{% else %}    fclose(out);
+    return 4;
+{% endif %}{% else %}    {
+        Wrapper::Vars initial_vars;
+        memset(&initial_vars, 0, sizeof(initial_vars));
+{% for assignment in context.initial.assignments %}        initial_vars.{{ assignment.field }} = {{ assignment.value }};
+{% endfor %}        if (!wrapper.hot_start({{ context.machine_macro_name }}_{{ context.initial.state_macro }}, &initial_vars)) {
+{% if context.initial_expect %}            write_initial_error(out, wrapper.last_error());
+            fclose(out);
+            return 0;
+{% else %}            fclose(out);
+            return 5;
+{% endif %}        }
+{% if context.initial_expect %}        write_initial_error(out, "Expected initial failure but hot start succeeded");
+        fclose(out);
+        return 0;
+{% endif %}    }
+{% endif %}{% elif context.initial_expect %}    if (wrapper.last_error() != NULL && wrapper.last_error()[0] != '\0') {
+        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+    }
+    write_initial_error(out, "Expected initial failure but initialization succeeded");
+    fclose(out);
+    return 0;
+{% endif %}
+{% for step in context.steps %}    {
+{% if step.events %}        const char *event_names[] = {
+{% for event in step.events %}            {{ event.path | tojson }},
+{% endfor %}        };
+{% else %}        const char **event_names = NULL;
+{% endif %}{% if step.pre_error_message %}        api_return = 0;
+        last_error = {{ step.pre_error_message | tojson }};
+{% elif step.cycle_count == 0 %}        api_return = 1;
+        last_error = NULL;
+{% else %}{% if step.events %}        Wrapper::EventId event_ids[] = {
+{% for event in step.events %}            {{ context.machine_macro_name }}_{{ event.macro }},
+{% endfor %}        };
+{% endif %}        api_return = 1;
+        last_error = NULL;
+        for (cycle_iter = 0u; cycle_iter < {{ step.cycle_count }}u; ++cycle_iter) {
+{% if step.events %}            api_return = run_cycle(&wrapper, event_ids, {{ step.events | length }}u);
+{% else %}            api_return = run_cycle(&wrapper, NULL, 0u);
+{% endif %}            if (!api_return) {
+                last_error = wrapper.last_error();
+                if (last_error == NULL || last_error[0] == '\0') {
+                    last_error = "Generated C++ wrapper cycle returned failure without diagnostic";
+                }
+                break;
+            }
+        }
+{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, last_error);
+    }
+{% endfor %}    fclose(out);
+    return 0;
+}

--- a/test/testings/native_toolchain_alignment/harness_templates/cpp_main.cpp.j2
+++ b/test/testings/native_toolchain_alignment/harness_templates/cpp_main.cpp.j2
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp::MachineWrapper Wrapper;
+typedef pyfcstm_generated::{{ context.machine_class_name }}_{{ context.wrapper_namespace_suffix }}::MachineWrapper Wrapper;
 
 static Wrapper::Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
 static const char *state_paths[] = {

--- a/test/testings/native_toolchain_alignment/harness_templates/cpp_poll_main.cpp.j2
+++ b/test/testings/native_toolchain_alignment/harness_templates/cpp_poll_main.cpp.j2
@@ -1,0 +1,348 @@
+#include "machine.hpp"
+
+#include <stdio.h>
+#include <string.h>
+
+typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp_poll::MachineWrapper Wrapper;
+
+static Wrapper::Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
+static Wrapper::EventId active_events[64];
+static size_t active_event_count = 0u;
+static Wrapper::EventChecks event_checks = {{ context.machine_class_name.upper() }}_EVENT_CHECKS_INIT;
+
+static const char *state_paths[] = {
+{% for state in context.states %}    {{ state.path | tojson }},
+{% endfor %}};
+{% if context.actions %}static const char *action_paths[] = {
+{% for action in context.actions %}    {{ action.path | tojson }},
+{% endfor %}};
+{% else %}static const char **action_paths = NULL;
+{% endif %}static const char *stage_names[] = {"enter", "during", "exit"};
+
+struct HandlerCall {
+    int action_id;
+    int state_id;
+    int stage_id;
+    int active_leaf_id;
+    int call_stage_id;
+    int abstract_target_id;
+    int named_ref_id;
+{% for variable in context.variables %}    Wrapper::Int {{ variable.field }}_is_int;
+    double {{ variable.field }}_is_float;
+{% endfor %}};
+
+static struct HandlerCall handler_calls[512];
+static size_t handler_call_count = 0u;
+
+static const char *lookup_string(const char **items, size_t count, int id)
+{
+    if (id < 0 || (size_t)id >= count) {
+        return NULL;
+    }
+    return items[id];
+}
+
+static void json_string(FILE *out, const char *value)
+{
+    const unsigned char *cursor;
+    if (value == NULL) {
+        fputs("null", out);
+        return;
+    }
+    fputc('"', out);
+    for (cursor = (const unsigned char *)value; *cursor != '\0'; ++cursor) {
+        if (*cursor == '"' || *cursor == '\\') {
+            fputc('\\', out);
+            fputc((int)*cursor, out);
+        } else if (*cursor == '\n') {
+            fputs("\\n", out);
+        } else if (*cursor == '\r') {
+            fputs("\\r", out);
+        } else if (*cursor == '\t') {
+            fputs("\\t", out);
+        } else {
+            fputc((int)*cursor, out);
+        }
+    }
+    fputc('"', out);
+}
+
+static void write_machine_int(FILE *out, Wrapper::Int value)
+{
+    char digits[64];
+    size_t count = 0u;
+    Wrapper::Int quotient = value;
+
+    if (quotient == 0) {
+        fputc('0', out);
+        return;
+    }
+    if (quotient < 0) {
+        fputc('-', out);
+        while (quotient != 0) {
+            Wrapper::Int next = quotient / 10;
+            digits[count++] = (char)('0' + (int)(next * 10 - quotient));
+            quotient = next;
+        }
+    } else {
+        while (quotient != 0) {
+            digits[count++] = (char)('0' + (int)(quotient % 10));
+            quotient = quotient / 10;
+        }
+    }
+    while (count > 0u) {
+        fputc((int)digits[--count], out);
+    }
+}
+
+static void write_vars(FILE *out, const Wrapper::Vars *vars)
+{
+    fputc('{', out);
+{% for variable in context.variables %}    if ({{ loop.index0 }} > 0) {
+        fputc(',', out);
+    }
+    json_string(out, {{ variable.name | tojson }});
+    fputc(':', out);
+{% if variable.type == 'int' %}    write_machine_int(out, vars->{{ variable.field }});
+{% else %}    fprintf(out, "%.17g", vars->{{ variable.field }});
+{% endif %}{% endfor %}    fputc('}', out);
+}
+
+static void write_handler_calls(FILE *out)
+{
+    size_t i;
+    fputc('[', out);
+    for (i = 0u; i < handler_call_count; ++i) {
+        const struct HandlerCall *call = &handler_calls[i];
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        fputc('{', out);
+        fputs("\"action\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->action_id));
+        fputs(",\"state\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->state_id));
+        fputs(",\"stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->stage_id));
+        fputs(",\"vars\":{", out);
+{% for variable in context.variables %}        if ({{ loop.index0 }} > 0) {
+            fputc(',', out);
+        }
+        json_string(out, {{ variable.name | tojson }});
+        fputc(':', out);
+{% if variable.type == 'int' %}        write_machine_int(out, call->{{ variable.field }}_is_int);
+{% else %}        fprintf(out, "%.17g", call->{{ variable.field }}_is_float);
+{% endif %}{% endfor %}        fputs("}", out);
+        fputs(",\"active_leaf\":", out);
+        json_string(out, lookup_string(state_paths, sizeof(state_paths) / sizeof(state_paths[0]), call->active_leaf_id));
+        fputs(",\"call_stage\":", out);
+        json_string(out, lookup_string(stage_names, sizeof(stage_names) / sizeof(stage_names[0]), call->call_stage_id));
+        fputs(",\"abstract_target\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->abstract_target_id));
+        fputs(",\"named_ref\":", out);
+        json_string(out, lookup_string(action_paths, {{ context.actions | length }}u, call->named_ref_id));
+        fputc('}', out);
+    }
+    fputc(']', out);
+}
+
+{% if context.hooks %}extern "C" {
+static void record_hook(Wrapper::Machine *machine_ptr, const Wrapper::ExecutionContext *ctx, void *user_data)
+{
+    struct HandlerCall *call;
+    (void)machine_ptr;
+    (void)user_data;
+    if (handler_call_count >= sizeof(handler_calls) / sizeof(handler_calls[0])) {
+        return;
+    }
+    call = &handler_calls[handler_call_count++];
+    call->action_id = ctx->action_id;
+    call->state_id = ctx->state_id;
+    call->stage_id = ctx->action_stage_id;
+    call->active_leaf_id = ctx->active_leaf_state_id;
+    call->call_stage_id = ctx->call_stage_id;
+    call->abstract_target_id = ctx->abstract_target_id;
+    call->named_ref_id = ctx->named_ref_id;
+{% for variable in context.variables %}{% if variable.type == 'int' %}    call->{{ variable.field }}_is_int = ctx->vars->{{ variable.field }};
+{% else %}    call->{{ variable.field }}_is_float = ctx->vars->{{ variable.field }};
+{% endif %}{% endfor %}}
+}
+{% endif %}
+static void install_hooks(Wrapper *wrapper)
+{
+{% for hook in context.hooks %}    hooks.{{ hook.field }} = record_hook;
+{% endfor %}    wrapper->set_hooks(&hooks, NULL);
+}
+
+extern "C" {
+static int check_event(Wrapper::Machine *machine_ptr, const Wrapper::EventContext *ctx, void *user_data)
+{
+    size_t i;
+    (void)machine_ptr;
+    (void)user_data;
+    for (i = 0u; i < active_event_count; ++i) {
+        if (active_events[i] == ctx->event_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+}
+
+static void install_event_checks(Wrapper *wrapper)
+{
+{% for event in context.events %}    event_checks.{{ event.field }} = check_event;
+{% endfor %}    wrapper->set_event_checks(&event_checks, NULL);
+}
+
+static int run_cycle(Wrapper *wrapper, const Wrapper::EventId *events, size_t event_count)
+{
+    size_t i;
+    if (event_count > sizeof(active_events) / sizeof(active_events[0])) {
+        return 0;
+    }
+    active_event_count = event_count;
+    for (i = 0u; i < event_count; ++i) {
+        active_events[i] = events[i];
+    }
+    return wrapper->cycle();
+}
+
+static void write_observation(FILE *out, Wrapper *wrapper, int step_index, int cycle_index, const char **event_names, size_t event_count, const char *last_error)
+{
+    size_t i;
+    const char *state_path = wrapper->current_state_path();
+    const Wrapper::Vars *vars = wrapper->vars();
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"step\"", out);
+    fprintf(out, ",\"step_index\":%d,\"cycle_index\":%d", step_index, cycle_index);
+    fputs(",\"events\":[", out);
+    for (i = 0u; i < event_count; ++i) {
+        if (i > 0u) {
+            fputc(',', out);
+        }
+        json_string(out, event_names[i]);
+    }
+    fputs("]", out);
+    fputs(",\"current_state\":", out);
+    json_string(out, state_path);
+    fputs(",\"is_ended\":", out);
+    fputs(wrapper->is_ended() ? "true" : "false", out);
+    fputs(",\"vars\":", out);
+    write_vars(out, vars);
+    fputs(",\"handler_calls\":", out);
+    write_handler_calls(out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fputs(",\"api_return\":null", out);
+    fputs("}\n", out);
+}
+
+static void write_initial_error(FILE *out, const char *last_error)
+{
+    fputc('{', out);
+    fputs("\"schema_version\":\"1\"", out);
+    fputs(",\"case_id\":", out);
+    json_string(out, {{ context.case_id | tojson }});
+    fputs(",\"template_name\":", out);
+    json_string(out, {{ context.template_name | tojson }});
+    fputs(",\"phase\":\"init\"", out);
+    fputs(",\"step_index\":null,\"cycle_index\":null", out);
+    fputs(",\"events\":[]", out);
+    fputs(",\"current_state\":null", out);
+    fputs(",\"is_ended\":false", out);
+    fputs(",\"vars\":{}", out);
+    fputs(",\"handler_calls\":[]", out);
+    fputs(",\"last_error\":", out);
+    json_string(out, last_error);
+    fputs(",\"api_return\":null", out);
+    fputs("}\n", out);
+}
+
+int main(int argc, char **argv)
+{
+    FILE *out;
+    Wrapper wrapper;
+    int api_return;
+    size_t cycle_iter;
+    const char *last_error;
+    if (argc < 2) {
+        return 2;
+    }
+    out = fopen(argv[1], "w");
+    if (out == NULL) {
+        return 2;
+    }
+{% if not context.initial %}    if (!wrapper.init()) {
+{% if context.initial_expect %}        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+{% else %}        fclose(out);
+        return 3;
+{% endif %}    }
+{% endif %}    install_hooks(&wrapper);
+    install_event_checks(&wrapper);
+{% if context.initial %}{% if context.initial.synthetic_error %}{% if context.initial_expect %}    write_initial_error(out, {{ context.initial.error_message | tojson }});
+    fclose(out);
+    return 0;
+{% else %}    fclose(out);
+    return 4;
+{% endif %}{% else %}    {
+        Wrapper::Vars initial_vars;
+        memset(&initial_vars, 0, sizeof(initial_vars));
+{% for assignment in context.initial.assignments %}        initial_vars.{{ assignment.field }} = {{ assignment.value }};
+{% endfor %}        if (!wrapper.hot_start({{ context.machine_macro_name }}_{{ context.initial.state_macro }}, &initial_vars)) {
+{% if context.initial_expect %}            write_initial_error(out, wrapper.last_error());
+            fclose(out);
+            return 0;
+{% else %}            fclose(out);
+            return 5;
+{% endif %}        }
+{% if context.initial_expect %}        write_initial_error(out, "Expected initial failure but hot start succeeded");
+        fclose(out);
+        return 0;
+{% endif %}    }
+{% endif %}{% elif context.initial_expect %}    if (wrapper.last_error() != NULL && wrapper.last_error()[0] != '\0') {
+        write_initial_error(out, wrapper.last_error());
+        fclose(out);
+        return 0;
+    }
+    write_initial_error(out, "Expected initial failure but initialization succeeded");
+    fclose(out);
+    return 0;
+{% endif %}
+{% for step in context.steps %}    {
+{% if step.events %}        const char *event_names[] = {
+{% for event in step.events %}            {{ event.path | tojson }},
+{% endfor %}        };
+{% else %}        const char **event_names = NULL;
+{% endif %}{% if step.pre_error_message %}        api_return = 0;
+        last_error = {{ step.pre_error_message | tojson }};
+{% elif step.cycle_count == 0 %}        api_return = 1;
+        last_error = NULL;
+{% else %}{% if step.events %}        Wrapper::EventId event_ids[] = {
+{% for event in step.events %}            {{ context.machine_macro_name }}_{{ event.macro }},
+{% endfor %}        };
+{% endif %}        api_return = 1;
+        last_error = NULL;
+        for (cycle_iter = 0u; cycle_iter < {{ step.cycle_count }}u; ++cycle_iter) {
+{% if step.events %}            api_return = run_cycle(&wrapper, event_ids, {{ step.events | length }}u);
+{% else %}            api_return = run_cycle(&wrapper, NULL, 0u);
+{% endif %}            if (!api_return) {
+                last_error = wrapper.last_error();
+                if (last_error == NULL || last_error[0] == '\0') {
+                    last_error = "Generated C++ wrapper cycle returned failure without diagnostic";
+                }
+                break;
+            }
+        }
+{% endif %}        write_observation(out, &wrapper, {{ step.index }}, 0, event_names, {{ step.events | length }}u, last_error);
+    }
+{% endfor %}    fclose(out);
+    return 0;
+}

--- a/test/testings/native_toolchain_alignment/harness_templates/cpp_poll_main.cpp.j2
+++ b/test/testings/native_toolchain_alignment/harness_templates/cpp_poll_main.cpp.j2
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 
-typedef pyfcstm_generated::{{ context.machine_class_name }}_cpp_poll::MachineWrapper Wrapper;
+typedef pyfcstm_generated::{{ context.machine_class_name }}_{{ context.wrapper_namespace_suffix }}::MachineWrapper Wrapper;
 
 static Wrapper::Hooks hooks = {{ context.machine_class_name.upper() }}_HOOKS_INIT;
 static Wrapper::EventId active_events[64];

--- a/test/testings/native_toolchain_alignment/profiles.py
+++ b/test/testings/native_toolchain_alignment/profiles.py
@@ -231,7 +231,15 @@ def _host_profile(
 ) -> ToolchainProfile:
     required = tuple(required_binaries or ("cmake", cc, cxx))
     c_flags = ("-std=c99", optimization, "-Wall", "-Wextra", "-pedantic")
-    cxx_flags = ("-std=c++98", optimization, "-Wall", "-Wextra", "-pedantic")
+    cxx_flags = (
+        "-std=c++98",
+        "-fno-exceptions",
+        "-fno-rtti",
+        optimization,
+        "-Wall",
+        "-Wextra",
+        "-pedantic",
+    )
     return ToolchainProfile(
         name=name,
         build_mode=BUILD_MODE_CMAKE_RUN
@@ -261,7 +269,7 @@ def _msvc_profile(name: str, cc: str, cxx: str, optimization: str) -> ToolchainP
         cc=(cc,),
         cxx=(cxx,),
         c_flags=(optimization, "/W4"),
-        cxx_flags=(optimization, "/W4", "/TP", "/permissive-"),
+        cxx_flags=(optimization, "/W4", "/TP", "/permissive-", "/GR-"),
         required_binaries=("cmake", "ninja", cc, cxx),
         missing_tool_message=(
             "Install CMake, Ninja, and the Visual Studio C/C++ tools before running %s."
@@ -283,7 +291,15 @@ def _compile_only_profile(
         cc=(cc,),
         cxx=(cxx,),
         c_flags=("-std=c99", optimization, "-Wall", "-Wextra", "-pedantic"),
-        cxx_flags=("-std=c++98", optimization, "-Wall", "-Wextra", "-pedantic"),
+        cxx_flags=(
+            "-std=c++98",
+            "-fno-exceptions",
+            "-fno-rtti",
+            optimization,
+            "-Wall",
+            "-Wextra",
+            "-pedantic",
+        ),
         required_binaries=tuple(required_binaries),
         missing_tool_message="Install %s before running %s."
         % (
@@ -330,7 +346,7 @@ def _manual_compile_profile(name: str, cc: str, cxx: str) -> ToolchainProfile:
         cc=(cc,),
         cxx=(cxx,),
         c_flags=("-std=c99", "-O2"),
-        cxx_flags=("-std=c++98", "-O2"),
+        cxx_flags=("-std=c++98", "-fno-exceptions", "-fno-rtti", "-O2"),
         required_binaries=(cc, cxx),
         missing_tool_message=(
             "Run this manual native toolchain profile only on a self-hosted runner "
@@ -438,7 +454,6 @@ _ANALYSIS_PROFILES = (
         "cppcheck",
         (
             "--enable=warning,style,performance,portability",
-            "--std=c99",
             "--inline-suppr",
         ),
         "cppcheck warning/style/performance/portability report-only",
@@ -451,7 +466,6 @@ _ANALYSIS_PROFILES = (
             "--checks=bugprone-*,clang-analyzer-*,performance-*",
             "-header-filter=.*",
             "--",
-            "-std=c99",
             "-Iharness",
         ),
         "clang-tidy bugprone/clang-analyzer/performance report-only",

--- a/test/testings/native_toolchain_alignment/profiles.py
+++ b/test/testings/native_toolchain_alignment/profiles.py
@@ -278,7 +278,14 @@ def _msvc_profile(name: str, cc: str, cxx: str, optimization: str) -> ToolchainP
         optimization=optimization,
         timeout_seconds=300,
         cmake_generator="Ninja",
-        cmake_args=("-DPYFCSTM_NATIVE_C_STANDARD=11",),
+        cmake_args=(
+            "-DPYFCSTM_NATIVE_C_STANDARD=11",
+            # MSVC and clang-cl do not provide a real C++98 mode. GNU-like
+            # profiles enforce C++98 directly; MSVC-family profiles request
+            # the oldest widely supported CMake dialect knob instead of
+            # relying on CMake accepting an unsupported C++98 requirement.
+            "-DPYFCSTM_NATIVE_CXX_STANDARD=14",
+        ),
     )
 
 

--- a/test/testings/native_toolchain_alignment/report.py
+++ b/test/testings/native_toolchain_alignment/report.py
@@ -3,7 +3,7 @@ JSON report contracts for native toolchain semantic alignment.
 
 This module defines the first-version result, command, and observation schema
 used by the native toolchain pytest helper. The schema is intentionally test
-local: generated C/C poll artifacts write public observations, and Python-side
+local: generated C-family artifacts write public observations, and Python-side
 pytest code stores command logs and summary results beside the build artifacts.
 
 The module contains:
@@ -103,7 +103,9 @@ COMMAND_STAGE_VALUES = {
     "run",
     "compile",
     "compile-machine-c",
+    "compile-machine-cpp",
     "compile-harness-c",
+    "compile-harness-cpp",
     "compile-header-cxx",
     "analyze",
 }

--- a/test/testings/native_toolchain_alignment/report.py
+++ b/test/testings/native_toolchain_alignment/report.py
@@ -108,6 +108,8 @@ COMMAND_STAGE_VALUES = {
     "compile-harness-cpp",
     "compile-header-cxx",
     "analyze",
+    "analyze-c",
+    "analyze-cxx",
 }
 OBSERVATION_PHASE_VALUES = {"init", "step", "error", "finish"}
 

--- a/test/testings/native_toolchain_alignment/runner.py
+++ b/test/testings/native_toolchain_alignment/runner.py
@@ -2,9 +2,9 @@
 Pytest runner for native toolchain semantic alignment.
 
 This module drives one shared semantic fixture through a generated C-family
-runtime, a case-specific C harness, a concrete native toolchain profile, and a
-Python-side public-observation assertion pass. The runner is opt-in only and is
-used by template-side ``native_toolchain`` pytest files.
+runtime, a case-specific C or C++ harness, a concrete native toolchain profile,
+and a Python-side public-observation assertion pass. The runner is opt-in only
+and is used by template-side ``native_toolchain`` pytest files.
 
 The module contains:
 
@@ -34,6 +34,7 @@ from pyfcstm.render import StateMachineCodeRenderer
 from pyfcstm.template import extract_template
 from test.testings import simulate_semantics
 from test.testings.native_toolchain_alignment.harness import (
+    HarnessContext,
     render_cmake_project,
     render_harness,
 )
@@ -514,18 +515,29 @@ def _render_generated_template(
 
 def _prepare_artifacts(
     template_name: str, case: SemanticCase, artifact_dir: str
-) -> None:
+) -> HarnessContext:
     generated_dir = os.path.join(artifact_dir, "generated")
     harness_dir = os.path.join(artifact_dir, "harness")
     _render_generated_template(template_name, case, generated_dir)
+    harness_source_name = (
+        "harness.cpp" if template_name in ("cpp", "cpp_poll") else "harness.c"
+    )
     context = render_harness(
-        template_name, case, os.path.join(harness_dir, "harness.c")
+        template_name, case, os.path.join(harness_dir, harness_source_name)
     )
     render_cmake_project(context, os.path.join(harness_dir, "CMakeLists.txt"))
-    for name in ("machine.c", "machine.h", "README.md", "README_zh.md"):
+    for name in (
+        "machine.c",
+        "machine.h",
+        "machine.cpp",
+        "machine.hpp",
+        "README.md",
+        "README_zh.md",
+    ):
         src = os.path.join(generated_dir, name)
         if os.path.exists(src):
             shutil.copy2(src, os.path.join(harness_dir, name))
+    return context
 
 
 def _cmake_configure_args(
@@ -624,6 +636,7 @@ def _run_compile_only_case(
     artifact_dir: str,
     logs_dir: str,
     build_dir: str,
+    context: HarnessContext,
     commands: List[NativeCommandRecord],
     compiler_version: Optional[str],
     primary_tool_version: Optional[str],
@@ -659,29 +672,66 @@ def _run_compile_only_case(
                 os.path.join(artifact_dir, "harness", "machine.c"),
             ],
             os.path.join(build_dir, "machine.o"),
-        ),
-        (
-            "compile-harness-c",
-            list(profile.cc)
-            + list(profile.c_flags)
-            + [
-                include_flag,
-                compile_flag,
-                os.path.join(artifact_dir, "harness", "harness.c"),
-            ],
-            os.path.join(build_dir, "harness.o"),
-        ),
+            c_output,
+        )
+    ]
+    if context.uses_cpp_wrapper:
+        compile_items.extend(
+            [
+                (
+                    "compile-machine-cpp",
+                    list(profile.cxx)
+                    + list(profile.cxx_flags)
+                    + [
+                        include_flag,
+                        compile_flag,
+                        os.path.join(artifact_dir, "harness", "machine.cpp"),
+                    ],
+                    os.path.join(build_dir, "machine_cpp.o"),
+                    cxx_output,
+                ),
+                (
+                    "compile-harness-cpp",
+                    list(profile.cxx)
+                    + list(profile.cxx_flags)
+                    + [
+                        include_flag,
+                        compile_flag,
+                        os.path.join(artifact_dir, "harness", "harness.cpp"),
+                    ],
+                    os.path.join(build_dir, "harness.o"),
+                    cxx_output,
+                ),
+            ]
+        )
+        header_name = "machine.hpp"
+    else:
+        compile_items.append(
+            (
+                "compile-harness-c",
+                list(profile.cc)
+                + list(profile.c_flags)
+                + [
+                    include_flag,
+                    compile_flag,
+                    os.path.join(artifact_dir, "harness", "harness.c"),
+                ],
+                os.path.join(build_dir, "harness.o"),
+                c_output,
+            )
+        )
+        header_name = "machine.h"
+    compile_items.append(
         (
             "compile-header-cxx",
-            list(profile.cxx)
-            + list(profile.cxx_flags)
-            + [include_flag, compile_flag, "-"],
+            list(profile.cxx) + list(profile.cxx_flags) + [include_flag],
             os.path.join(build_dir, "cxx_header_probe.o"),
-        ),
-    ]
-    header_probe = '#include "machine.h"\nint main(void) { return 0; }\n'
-    for stage, argv, output_path in compile_items:
-        argv = list(argv) + c_output(output_path)
+            cxx_output,
+        )
+    )
+    header_probe = '#include "%s"\nint main(void) { return 0; }\n' % header_name
+    for stage, argv, output_path, output_args in compile_items:
+        argv = list(argv) + output_args(output_path)
         if stage == "compile-header-cxx":
             probe_path = os.path.join(build_dir, "cxx_header_probe.cpp")
             _write_text(probe_path, header_probe)
@@ -689,7 +739,7 @@ def _run_compile_only_case(
                 list(profile.cxx)
                 + list(profile.cxx_flags)
                 + [include_flag, compile_flag, probe_path]
-                + cxx_output(output_path)
+                + output_args(output_path)
             )
         _run_compile_command(
             profile,
@@ -726,13 +776,14 @@ def _run_compile_only_case(
 def _analysis_targets(artifact_dir: str) -> List[str]:
     """Return generated and harness source files for static-analysis profiles."""
     targets = []
+    extensions = {".c", ".h", ".cpp", ".hpp"}
     for relative_dir in ("generated", "harness"):
         root = os.path.join(artifact_dir, relative_dir)
         if not os.path.isdir(root):
             continue
         for dirpath, _, filenames in os.walk(root):
             for filename in sorted(filenames):
-                if os.path.splitext(filename)[1].lower() in {".c", ".h"}:
+                if os.path.splitext(filename)[1].lower() in extensions:
                     targets.append(os.path.join(dirpath, filename))
     return sorted(targets)
 
@@ -743,12 +794,18 @@ def _analysis_argv(profile: ToolchainProfile, artifact_dir: str) -> List[str]:
     if "--" not in args:
         return list(profile.analysis_tool) + args + targets
     separator_index = args.index("--")
+    compile_args = ["-Iharness"]
     return (
         list(profile.analysis_tool)
         + args[:separator_index]
         + targets
         + ["--"]
-        + args[separator_index + 1 :]
+        + compile_args
+        + [
+            arg
+            for arg in args[separator_index + 1 :]
+            if arg not in ("-std=c99", "-std=c++98", "-Iharness")
+        ]
     )
 
 
@@ -764,6 +821,18 @@ def _run_analyze_only_case(
 ) -> Dict[str, Any]:
     report_path = os.path.join(artifact_dir, "analysis-report.txt")
     argv = _analysis_argv(profile, artifact_dir)
+    if not _analysis_targets(artifact_dir):
+        _failure_result(
+            case,
+            template_name,
+            profile,
+            "analysis_failure",
+            "static analysis targets are empty for %s/%s" % (template_name, case.id),
+            commands,
+            artifact_dir,
+            duration_seconds=time.time() - start,
+            primary_tool_version=primary_tool_version,
+        )
     completed = _run_command(
         "analyze",
         argv,
@@ -1045,7 +1114,7 @@ def run_native_toolchain_case(
             duration_seconds=time.time() - start,
         )
 
-    _prepare_artifacts(template_name, case, artifact_dir)
+    context = _prepare_artifacts(template_name, case, artifact_dir)
     compiler_version = _version_text(
         profile.cc, logs_dir, artifact_dir, commands, profile.timeout_seconds
     )
@@ -1082,6 +1151,7 @@ def run_native_toolchain_case(
             artifact_dir,
             logs_dir,
             build_dir,
+            context,
             commands,
             compiler_version,
             primary_tool_version,

--- a/test/testings/native_toolchain_alignment/runner.py
+++ b/test/testings/native_toolchain_alignment/runner.py
@@ -28,7 +28,7 @@ import os
 import shutil
 import subprocess
 import time
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 from pyfcstm.render import StateMachineCodeRenderer
 from pyfcstm.template import extract_template
@@ -220,6 +220,27 @@ def _run_command(
         )
     )
     return completed
+
+
+def _analysis_stage(language: str) -> str:
+    """
+    Return the command-record stage for one static-analysis language bucket.
+
+    :param language: Static-analysis language bucket.
+    :type language: str
+    :return: Command stage name.
+    :rtype: str
+
+    Example::
+
+        >>> _analysis_stage("cxx")
+        'analyze-cxx'
+    """
+    if language == "c":
+        return "analyze-c"
+    if language == "cxx":
+        return "analyze-cxx"
+    raise ValueError("unsupported static-analysis language: %r" % language)
 
 
 def _version_text(
@@ -773,10 +794,31 @@ def _run_compile_only_case(
     return _write_result(artifact_dir, result)
 
 
-def _analysis_targets(artifact_dir: str) -> List[str]:
-    """Return generated and harness source files for static-analysis profiles."""
+def _analysis_targets(artifact_dir: str, language: Optional[str] = None) -> List[str]:
+    """
+    Return generated and harness source files for static-analysis profiles.
+
+    :param artifact_dir: Native toolchain artifact directory.
+    :type artifact_dir: str
+    :param language: Optional language bucket, either ``"c"`` or ``"cxx"``.
+    :type language: str, optional
+    :return: Sorted source paths selected for analysis.
+    :rtype: list[str]
+
+    Example::
+
+        >>> isinstance(_analysis_targets("/path/that/does/not/exist"), list)
+        True
+    """
     targets = []
-    extensions = {".c", ".h", ".cpp", ".hpp"}
+    if language == "c":
+        extensions = {".c", ".h"}
+    elif language == "cxx":
+        extensions = {".cpp", ".hpp"}
+    elif language is None:
+        extensions = {".c", ".h", ".cpp", ".hpp"}
+    else:
+        raise ValueError("unsupported static-analysis language: %r" % language)
     for relative_dir in ("generated", "harness"):
         root = os.path.join(artifact_dir, relative_dir)
         if not os.path.isdir(root):
@@ -788,13 +830,97 @@ def _analysis_targets(artifact_dir: str) -> List[str]:
     return sorted(targets)
 
 
-def _analysis_argv(profile: ToolchainProfile, artifact_dir: str) -> List[str]:
+def _analysis_compile_args(language: Optional[str]) -> List[str]:
+    """
+    Return compiler-style arguments for one static-analysis language bucket.
+
+    Mixed C/C++ analysis profiles are split by extension before execution so
+    clang-tidy and similar tools observe the same language-standard envelope as
+    the native build profiles. ``None`` keeps the historical mixed-target shape
+    for helper tests and callers that only need target insertion.
+
+    :param language: Optional language bucket, either ``"c"`` or ``"cxx"``.
+    :type language: str, optional
+    :return: Compile arguments passed after an analyzer's ``--`` separator.
+    :rtype: list[str]
+
+    Example::
+
+        >>> _analysis_compile_args("c")
+        ['-Iharness', '-x', 'c', '-std=c99']
+        >>> _analysis_compile_args("cxx")[-1]
+        '-std=c++98'
+    """
+    if language == "c":
+        return ["-Iharness", "-x", "c", "-std=c99"]
+    if language == "cxx":
+        return ["-Iharness", "-x", "c++", "-std=c++98"]
+    if language is None:
+        return ["-Iharness"]
+    raise ValueError("unsupported static-analysis language: %r" % language)
+
+
+def _analysis_standard_args(
+    profile: ToolchainProfile, language: Optional[str]
+) -> List[str]:
+    """
+    Return analyzer-native standard arguments for tools without ``--``.
+
+    :param profile: Static-analysis profile being executed.
+    :type profile: test.testings.native_toolchain_alignment.profiles.ToolchainProfile
+    :param language: Optional language bucket, either ``"c"`` or ``"cxx"``.
+    :type language: str, optional
+    :return: Tool-specific standard flags placed before targets.
+    :rtype: list[str]
+
+    Example::
+
+        >>> from test.testings.native_toolchain_alignment.profiles import get_profile
+        >>> _analysis_standard_args(get_profile("linux-cppcheck"), "c")
+        ['--std=c99']
+    """
+    if _tool_stem(profile.analysis_tool) != "cppcheck":
+        return []
+    if language == "c":
+        return ["--std=c99"]
+    if language == "cxx":
+        return ["--std=c++03"]
+    return []
+
+
+def _analysis_argv(
+    profile: ToolchainProfile, artifact_dir: str, language: Optional[str] = None
+) -> List[str]:
+    """
+    Build a static-analysis command for one language bucket.
+
+    :param profile: Static-analysis profile being executed.
+    :type profile: test.testings.native_toolchain_alignment.profiles.ToolchainProfile
+    :param artifact_dir: Native toolchain artifact directory.
+    :type artifact_dir: str
+    :param language: Optional language bucket, either ``"c"`` or ``"cxx"``.
+    :type language: str, optional
+    :return: Analyzer command line.
+    :rtype: list[str]
+
+    Example::
+
+        >>> from test.testings.native_toolchain_alignment.profiles import get_profile
+        >>> profile = get_profile("linux-clang-tidy")
+        >>> "--" in _analysis_argv(profile, "/path/that/does/not/exist", "cxx")
+        True
+    """
     args = list(profile.analysis_args)
-    targets = _analysis_targets(artifact_dir)
+    targets = _analysis_targets(artifact_dir, language)
     if "--" not in args:
-        return list(profile.analysis_tool) + args + targets
+        return (
+            list(profile.analysis_tool)
+            + args
+            + _analysis_standard_args(profile, language)
+            + targets
+        )
     separator_index = args.index("--")
-    compile_args = ["-Iharness"]
+    compile_args = _analysis_compile_args(language)
     return (
         list(profile.analysis_tool)
         + args[:separator_index]
@@ -804,9 +930,46 @@ def _analysis_argv(profile: ToolchainProfile, artifact_dir: str) -> List[str]:
         + [
             arg
             for arg in args[separator_index + 1 :]
-            if arg not in ("-std=c99", "-std=c++98", "-Iharness")
+            if arg
+            not in (
+                "-std=c99",
+                "-std=c++98",
+                "-std=c++03",
+                "-Iharness",
+                "-x",
+                "c",
+                "c++",
+            )
         ]
     )
+
+
+def _analysis_invocations(
+    profile: ToolchainProfile, artifact_dir: str
+) -> List[Tuple[str, List[str]]]:
+    """
+    Return static-analysis invocations split by source-language bucket.
+
+    :param profile: Static-analysis profile being executed.
+    :type profile: test.testings.native_toolchain_alignment.profiles.ToolchainProfile
+    :param artifact_dir: Native toolchain artifact directory.
+    :type artifact_dir: str
+    :return: ``(language, argv)`` pairs for non-empty C and C++ target sets.
+    :rtype: list[tuple[str, list[str]]]
+
+    Example::
+
+        >>> from test.testings.native_toolchain_alignment.profiles import get_profile
+        >>> _analysis_invocations(get_profile("linux-clang-tidy"), "/missing")
+        []
+    """
+    invocations = []
+    for language in ("c", "cxx"):
+        if _analysis_targets(artifact_dir, language):
+            invocations.append(
+                (language, _analysis_argv(profile, artifact_dir, language))
+            )
+    return invocations
 
 
 def _run_analyze_only_case(
@@ -820,7 +983,6 @@ def _run_analyze_only_case(
     start: float,
 ) -> Dict[str, Any]:
     report_path = os.path.join(artifact_dir, "analysis-report.txt")
-    argv = _analysis_argv(profile, artifact_dir)
     if not _analysis_targets(artifact_dir):
         _failure_result(
             case,
@@ -833,57 +995,60 @@ def _run_analyze_only_case(
             duration_seconds=time.time() - start,
             primary_tool_version=primary_tool_version,
         )
-    completed = _run_command(
-        "analyze",
-        argv,
-        artifact_dir,
-        logs_dir,
-        artifact_dir,
-        commands,
-        profile.timeout_seconds,
-    )
-    stdout_rel = commands[-1].stdout_path if commands else None
-    stderr_rel = commands[-1].stderr_path if commands else None
+    completed = None
+    for language, argv in _analysis_invocations(profile, artifact_dir):
+        completed = _run_command(
+            _analysis_stage(language),
+            argv,
+            artifact_dir,
+            logs_dir,
+            artifact_dir,
+            commands,
+            profile.timeout_seconds,
+        )
+        timed_out = commands[-1].timed_out if commands else False
+        if timed_out or completed.returncode is None:
+            _failure_result(
+                case,
+                template_name,
+                profile,
+                "analysis_timeout",
+                "static analysis timed out for %s/%s %s sources"
+                % (template_name, case.id, language),
+                commands,
+                artifact_dir,
+                completed.returncode,
+                time.time() - start,
+                primary_tool_version=primary_tool_version,
+            )
+        if completed.returncode not in (0,):
+            _failure_result(
+                case,
+                template_name,
+                profile,
+                "analysis_failure",
+                "static analysis failed for %s/%s %s sources with return code %r"
+                % (template_name, case.id, language, completed.returncode),
+                commands,
+                artifact_dir,
+                completed.returncode,
+                time.time() - start,
+                primary_tool_version=primary_tool_version,
+            )
     report_parts = []
-    for rel_path in (stdout_rel, stderr_rel):
-        if rel_path is None:
+    for command in commands:
+        if not command.stage.startswith("analyze"):
             continue
-        path = os.path.join(artifact_dir, rel_path)
-        if os.path.exists(path):
-            with open(path, "r", encoding="utf-8") as f:
-                report_parts.append(f.read())
+        report_parts.append("## %s" % " ".join(command.argv))
+        for rel_path in (command.stdout_path, command.stderr_path):
+            if rel_path is None:
+                continue
+            path = os.path.join(artifact_dir, rel_path)
+            if os.path.exists(path):
+                with open(path, "r", encoding="utf-8") as f:
+                    report_parts.append(f.read())
     _write_text(report_path, "\n".join(report_parts))
     report_rel = _relative(report_path, artifact_dir)
-    timed_out = commands[-1].timed_out if commands else False
-    if timed_out or completed.returncode is None:
-        _failure_result(
-            case,
-            template_name,
-            profile,
-            "analysis_timeout",
-            "static analysis timed out for %s/%s" % (template_name, case.id),
-            commands,
-            artifact_dir,
-            completed.returncode,
-            time.time() - start,
-            primary_tool_version=primary_tool_version,
-            analysis_report_path=report_rel,
-        )
-    if completed.returncode not in (0,):
-        _failure_result(
-            case,
-            template_name,
-            profile,
-            "analysis_failure",
-            "static analysis failed for %s/%s with return code %r"
-            % (template_name, case.id, completed.returncode),
-            commands,
-            artifact_dir,
-            completed.returncode,
-            time.time() - start,
-            primary_tool_version=primary_tool_version,
-            analysis_report_path=report_rel,
-        )
     if not os.path.exists(report_path):
         _failure_result(
             case,
@@ -893,7 +1058,7 @@ def _run_analyze_only_case(
             "static analysis report is missing for %s/%s" % (template_name, case.id),
             commands,
             artifact_dir,
-            completed.returncode,
+            completed.returncode if completed is not None else None,
             time.time() - start,
             primary_tool_version=primary_tool_version,
             analysis_report_path=report_rel,
@@ -906,7 +1071,7 @@ def _run_analyze_only_case(
         "analysis_report_only",
         "static analysis report-only profile completed",
         commands,
-        completed.returncode,
+        completed.returncode if completed is not None else 0,
         time.time() - start,
         compiler_version=None,
         primary_tool_version=primary_tool_version,

--- a/test/testings/native_toolchain_alignment/test_report_and_profiles.py
+++ b/test/testings/native_toolchain_alignment/test_report_and_profiles.py
@@ -32,6 +32,8 @@ from test.testings.native_toolchain_alignment.report import (
 from test.testings.native_toolchain_alignment.runner import (
     _analysis_argv,
     _analysis_targets,
+    _analysis_invocations,
+    _analysis_stage,
     _assert_successful_api_return,
     _case_artifact_dir,
     _tool_stem,
@@ -75,6 +77,9 @@ def test_profiles_cover_public_matrix_and_manual_entries():
     assert "-fno-rtti" in get_profile("linux-gcc-o2").cxx_flags
     assert "/GR-" in get_profile("windows-msvc-o2").cxx_flags
     assert "-DPYFCSTM_NATIVE_C_STANDARD=11" in get_profile("windows-msvc-o2").cmake_args
+    assert (
+        "-DPYFCSTM_NATIVE_CXX_STANDARD=14" in get_profile("windows-msvc-o2").cmake_args
+    )
     assert all(profile.public_required for profile in iter_profiles())
     assert all(not profile.public_required for profile in iter_manual_profiles())
     assert get_profile("manual-armclang-compile") in iter_all_profiles()
@@ -267,7 +272,7 @@ def test_result_schema_rejects_unknown_classification(tmp_path):
 
 @pytest.mark.unittest
 def test_report_schema_accepts_compile_and_analysis_classifications():
-    command = NativeCommandRecord("analyze", ["cppcheck", "machine.c"], "/tmp")
+    command = NativeCommandRecord("analyze-c", ["cppcheck", "machine.c"], "/tmp")
     result = NativeToolchainResult(
         "case",
         "c",
@@ -302,6 +307,8 @@ def test_report_schema_accepts_compile_stage_variants():
         "compile-harness-c",
         "compile-harness-cpp",
         "compile-header-cxx",
+        "analyze-c",
+        "analyze-cxx",
     ]:
         validate_command_data(
             NativeCommandRecord(stage, ["cc", "-c", "machine.c"], "/tmp").to_dict()
@@ -336,6 +343,7 @@ def test_cpp_harness_context_and_source_are_wrapper_only(tmp_path):
     assert '#include "machine.hpp"' in source
     assert '#include "machine.h"' not in source
     assert "Wrapper::EventId" in source
+    assert "RootMachine_cpp::MachineWrapper" in source
     assert '\\"api_return\\":null' in source
 
 
@@ -363,6 +371,37 @@ def test_cpp_harness_wrapper_only_guard_rejects_direct_c_entrypoints():
         _assert_cpp_wrapper_harness_source(
             '#include "machine.hpp"\nvoid *x = wrapper.native_handle();\n'
         )
+    with pytest.raises(AssertionError):
+        _assert_cpp_wrapper_harness_source(
+            '#include "machine.hpp"\ntypedef struct Machine Machine;\n'
+        )
+
+
+@pytest.mark.unittest
+def test_cpp_harness_wrapper_only_guard_accepts_wrapper_hook_types(tmp_path):
+    """
+    Verify wrapper-only guard allows hook callbacks through wrapper types.
+
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("abstract_handler_context_metadata")
+        >>> case.id
+        'abstract_handler_context_metadata'
+    """
+    case = load_semantic_case("abstract_handler_context_metadata")
+    harness_path = tmp_path / "harness.cpp"
+
+    context = render_harness("cpp", case, str(harness_path))
+    source = harness_path.read_text(encoding="utf-8")
+
+    assert context.hooks
+    assert "Wrapper::Machine" in source
+    assert "record_hook" in source
 
 
 @pytest.mark.unittest
@@ -393,6 +432,7 @@ def test_cpp_poll_harness_context_exposes_event_checks(tmp_path):
     render_harness("cpp_poll", case, str(harness_path))
     source = harness_path.read_text(encoding="utf-8")
     assert "Wrapper::EventChecks" in source
+    assert "RootMachine_cpp_poll::MachineWrapper" in source
     assert "wrapper->set_event_checks" in source
     assert '#include "machine.h"' not in source
 
@@ -426,7 +466,7 @@ def test_cmake_project_lists_cpp_wrapper_sources(tmp_path):
     assert "harness.cpp" in text
     assert "machine.c" in text
     assert "machine.cpp" in text
-    assert "#include \\\"${CMAKE_CURRENT_SOURCE_DIR}/machine.hpp\\\"" in text
+    assert '#include \\"${CMAKE_CURRENT_SOURCE_DIR}/machine.hpp\\"' in text
 
 
 @pytest.mark.unittest
@@ -506,8 +546,62 @@ def test_analysis_argv_inserts_targets_before_compile_separator(tmp_path):
     assert str(artifact_dir / "harness" / "harness.c") in argv[:separator]
     assert str(artifact_dir / "harness" / "machine.cpp") in argv[:separator]
     assert str(artifact_dir / "harness" / "harness.cpp") in argv[:separator]
-    assert "-std=c99" not in argv[separator + 1 :]
     assert "-Iharness" in argv[separator + 1 :]
+    assert "-std=c99" not in argv[separator + 1 :]
+
+
+@pytest.mark.unittest
+def test_analysis_invocations_split_c_and_cpp_standards(tmp_path):
+    """
+    Verify static-analysis commands use language-specific standards.
+
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> profile = get_profile("linux-clang-tidy")
+        >>> profile.name
+        'linux-clang-tidy'
+    """
+    artifact_dir = tmp_path / "artifact"
+    for relative_path in [
+        "generated/machine.c",
+        "generated/machine.h",
+        "generated/machine.cpp",
+        "generated/machine.hpp",
+    ]:
+        path = artifact_dir / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("/* sentinel */\n", encoding="utf-8")
+
+    invocations = _analysis_invocations(
+        get_profile("linux-clang-tidy"), str(artifact_dir)
+    )
+
+    assert [language for language, _ in invocations] == ["c", "cxx"]
+    c_argv = invocations[0][1]
+    cxx_argv = invocations[1][1]
+    assert "-std=c99" in c_argv[c_argv.index("--") + 1 :]
+    assert "-std=c++98" in cxx_argv[cxx_argv.index("--") + 1 :]
+    assert str(artifact_dir / "generated" / "machine.c") in c_argv[: c_argv.index("--")]
+    assert (
+        str(artifact_dir / "generated" / "machine.cpp")
+        in cxx_argv[: cxx_argv.index("--")]
+    )
+
+    cppcheck_invocations = _analysis_invocations(
+        get_profile("linux-cppcheck"), str(artifact_dir)
+    )
+    assert "--std=c99" in cppcheck_invocations[0][1]
+    assert "--std=c++03" in cppcheck_invocations[1][1]
+    assert _analysis_stage("c") == "analyze-c"
+    assert _analysis_stage("cxx") == "analyze-cxx"
+
+    with pytest.raises(ValueError, match="unsupported static-analysis language"):
+        _analysis_stage("rust")
 
 
 @pytest.mark.unittest

--- a/test/testings/native_toolchain_alignment/test_report_and_profiles.py
+++ b/test/testings/native_toolchain_alignment/test_report_and_profiles.py
@@ -16,6 +16,12 @@ from test.testings.native_toolchain_alignment.profiles import (
     native_toolchain_enabled,
     resolve_selected_profile,
 )
+from test.testings.native_toolchain_alignment.harness import (
+    _assert_cpp_wrapper_harness_source,
+    build_harness_context,
+    render_cmake_project,
+    render_harness,
+)
 from test.testings.native_toolchain_alignment.report import (
     NativeCommandRecord,
     NativeToolchainResult,
@@ -62,6 +68,12 @@ def test_profiles_cover_public_matrix_and_manual_entries():
     assert get_profile("arm-none-eabi-gcc-o2").build_mode == "compile-only"
     assert get_profile("linux-cppcheck").build_mode == "analyze-only"
     assert get_profile("linux-cppcheck").report_only is True
+    assert "--std=c99" not in get_profile("linux-cppcheck").analysis_args
+    assert "-std=c99" not in get_profile("linux-clang-tidy").analysis_args
+    assert "-std=c++98" in get_profile("linux-gcc-o2").cxx_flags
+    assert "-fno-exceptions" in get_profile("linux-gcc-o2").cxx_flags
+    assert "-fno-rtti" in get_profile("linux-gcc-o2").cxx_flags
+    assert "/GR-" in get_profile("windows-msvc-o2").cxx_flags
     assert "-DPYFCSTM_NATIVE_C_STANDARD=11" in get_profile("windows-msvc-o2").cmake_args
     assert all(profile.public_required for profile in iter_profiles())
     assert all(not profile.public_required for profile in iter_manual_profiles())
@@ -284,10 +296,137 @@ def test_report_schema_accepts_compile_and_analysis_classifications():
 
 @pytest.mark.unittest
 def test_report_schema_accepts_compile_stage_variants():
-    for stage in ["compile-machine-c", "compile-harness-c", "compile-header-cxx"]:
+    for stage in [
+        "compile-machine-c",
+        "compile-machine-cpp",
+        "compile-harness-c",
+        "compile-harness-cpp",
+        "compile-header-cxx",
+    ]:
         validate_command_data(
             NativeCommandRecord(stage, ["cc", "-c", "machine.c"], "/tmp").to_dict()
         )
+
+
+@pytest.mark.unittest
+def test_cpp_harness_context_and_source_are_wrapper_only(tmp_path):
+    """
+    Verify native toolchain C++ harness generation enters through the wrapper.
+
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> case.id
+        'design_basic_simple_transition'
+    """
+    case = load_semantic_case("design_basic_simple_transition")
+    harness_path = tmp_path / "harness.cpp"
+
+    context = render_harness("cpp", case, str(harness_path))
+    source = harness_path.read_text(encoding="utf-8")
+
+    assert context.template_name == "cpp"
+    assert context.harness_source_name == "harness.cpp"
+    assert context.machine_source_names == ("machine.c", "machine.cpp")
+    assert '#include "machine.hpp"' in source
+    assert '#include "machine.h"' not in source
+    assert "Wrapper::EventId" in source
+    assert '\\"api_return\\":null' in source
+
+
+@pytest.mark.unittest
+def test_cpp_harness_wrapper_only_guard_rejects_direct_c_entrypoints():
+    """
+    Verify the C++ native harness guard rejects direct C API bypasses.
+
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> _assert_cpp_wrapper_harness_source('#include "machine.hpp"\\n')
+    """
+    _assert_cpp_wrapper_harness_source('#include "machine.hpp"\n')
+
+    with pytest.raises(AssertionError):
+        _assert_cpp_wrapper_harness_source('#include "machine.h"\n')
+    with pytest.raises(AssertionError):
+        _assert_cpp_wrapper_harness_source(
+            '#include "machine.hpp"\nint x = RootMachine_cycle(0, 0, 0);\n'
+        )
+    with pytest.raises(AssertionError):
+        _assert_cpp_wrapper_harness_source(
+            '#include "machine.hpp"\nvoid *x = wrapper.native_handle();\n'
+        )
+
+
+@pytest.mark.unittest
+def test_cpp_poll_harness_context_exposes_event_checks(tmp_path):
+    """
+    Verify native toolchain C++ poll harness uses wrapper event checks.
+
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> build_harness_context("cpp_poll", case).template_name
+        'cpp_poll'
+    """
+    case = load_semantic_case("design_basic_simple_transition")
+    context = build_harness_context("cpp_poll", case)
+
+    assert context.template_name == "cpp_poll"
+    assert context.harness_source_name == "harness.cpp"
+    assert context.machine_source_names == ("machine.c", "machine.cpp")
+    assert context.wrapper_namespace_suffix == "cpp_poll"
+
+    harness_path = tmp_path / "harness.cpp"
+    render_harness("cpp_poll", case, str(harness_path))
+    source = harness_path.read_text(encoding="utf-8")
+    assert "Wrapper::EventChecks" in source
+    assert "wrapper->set_event_checks" in source
+    assert '#include "machine.h"' not in source
+
+
+@pytest.mark.unittest
+def test_cmake_project_lists_cpp_wrapper_sources(tmp_path):
+    """
+    Verify native CMake project generation includes C and C++ wrapper sources.
+
+    :param tmp_path: Temporary artifact directory provided by pytest.
+    :type tmp_path: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> build_harness_context("cpp", case).machine_source_names
+        ('machine.c', 'machine.cpp')
+    """
+    case = load_semantic_case("design_basic_simple_transition")
+    context = build_harness_context("cpp", case)
+    cmake_path = tmp_path / "CMakeLists.txt"
+
+    render_cmake_project(context, str(cmake_path))
+    text = cmake_path.read_text(encoding="utf-8")
+
+    assert "project(pyfcstm_native_toolchain_harness C CXX)" in text
+    assert "set(CMAKE_EXPORT_COMPILE_COMMANDS ON)" in text
+    assert "add_executable(native_harness" in text
+    assert "harness.cpp" in text
+    assert "machine.c" in text
+    assert "machine.cpp" in text
+    assert "#include \\\"${CMAKE_CURRENT_SOURCE_DIR}/machine.hpp\\\"" in text
 
 
 @pytest.mark.unittest
@@ -305,10 +444,14 @@ def test_analysis_targets_cover_generated_and_harness_sources(tmp_path):
     for relative_path in [
         "generated/machine.c",
         "generated/machine.h",
-        "generated/future_runtime.cpp",
+        "generated/machine.cpp",
+        "generated/machine.hpp",
         "harness/machine.c",
         "harness/machine.h",
         "harness/harness.c",
+        "harness/machine.cpp",
+        "harness/machine.hpp",
+        "harness/harness.cpp",
         "harness/readme.txt",
     ]:
         path = artifact_dir / relative_path
@@ -323,9 +466,14 @@ def test_analysis_targets_cover_generated_and_harness_sources(tmp_path):
     assert targets == {
         "generated/machine.c",
         "generated/machine.h",
+        "generated/machine.cpp",
+        "generated/machine.hpp",
         "harness/harness.c",
+        "harness/harness.cpp",
         "harness/machine.c",
         "harness/machine.h",
+        "harness/machine.cpp",
+        "harness/machine.hpp",
     }
 
 
@@ -335,8 +483,12 @@ def test_analysis_argv_inserts_targets_before_compile_separator(tmp_path):
     for relative_path in [
         "generated/machine.c",
         "generated/machine.h",
+        "generated/machine.cpp",
+        "generated/machine.hpp",
         "harness/machine.c",
         "harness/harness.c",
+        "harness/machine.cpp",
+        "harness/harness.cpp",
     ]:
         path = artifact_dir / relative_path
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -348,9 +500,14 @@ def test_analysis_argv_inserts_targets_before_compile_separator(tmp_path):
     separator = argv.index("--")
     assert str(artifact_dir / "generated" / "machine.c") in argv[:separator]
     assert str(artifact_dir / "generated" / "machine.h") in argv[:separator]
+    assert str(artifact_dir / "generated" / "machine.cpp") in argv[:separator]
+    assert str(artifact_dir / "generated" / "machine.hpp") in argv[:separator]
     assert str(artifact_dir / "harness" / "machine.c") in argv[:separator]
     assert str(artifact_dir / "harness" / "harness.c") in argv[:separator]
-    assert "-std=c99" in argv[separator + 1 :]
+    assert str(artifact_dir / "harness" / "machine.cpp") in argv[:separator]
+    assert str(artifact_dir / "harness" / "harness.cpp") in argv[:separator]
+    assert "-std=c99" not in argv[separator + 1 :]
+    assert "-Iharness" in argv[separator + 1 :]
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
## 背景

本 PR 是 D5 伞 PR [#261](https://github.com/HansBug/pyfcstm/pull/261) 的子 PR-D5d，基于已完成的：

- PR-D5a [#262](https://github.com/HansBug/pyfcstm/pull/262)：`cpp` / `cpp_poll` 模板骨架、打包自包含与 C-family helper 下沉；
- PR-D5b [#265](https://github.com/HansBug/pyfcstm/pull/265)：C++98-compatible wrapper API；
- PR-D5c [#267](https://github.com/HansBug/pyfcstm/pull/267)：`cpp` / `cpp_poll` 共享语义 fixture wrapper 对齐。

D5d 的目标是把 D4 已建立的原生工具链矩阵扩展到 `cpp` / `cpp_poll`，确保 C++ wrapper 不是只在普通单元测试里被本机默认编译器验证，而是在控制系统更接近真实部署的多编译器矩阵里被系统性编译、链接、运行和分析。

## 范围

本 PR 只做原生工具链矩阵扩展，不修改 C++ wrapper 公开 API，不重写 `c` / `c_poll` core，不新增 shared fixture 语法。

需要覆盖：

1. `test/template/cpp/` 与 `test/template/cpp_poll/` 新增 native toolchain alignment 测试。
2. pytest native toolchain helper 复用或小幅扩展现有 `ToolchainProfile` 的 `cc` / `cxx` / flags / analyze-only 能力。
3. 明确扩展现有 `.github/workflows/native-toolchain.yml`，不另起并行 workflow。
4. 默认本地 `make unittest` 不应被新增 C++ native 重矩阵拖慢；但本 PR 本地验收和 CI 不允许使用 slow skip，需要确认 `c` / `c_poll` / `cpp` / `cpp_poll` slow 范围划分正确。
5. 产物必须能证明 `.c/.h/.cpp/.hpp`、C core object、C++ wrapper object、C++ harness、命令与日志均被覆盖。

## 当前代码约束与实现决策

三路 body review 后，D5d 明确采用以下实现决策：

1. **C++ native harness 必须是 wrapper-only。** 现有 `test/testings/native_toolchain_alignment/harness.py` 只支持 `c` / `c_poll`，且现有 C harness 直接调用 `machine.h` C API。D5d 需要新增 C++ harness 生成路径，生成 `harness.cpp` 并只 include `machine.hpp`，不直接 include `machine.h`，也不直接调用 C API。
2. **优先扩展现有 native runner，而不是另造 runner。** 推荐路径是在 `test/testings/native_toolchain_alignment/` 内补充 C++ harness 模板 / 上下文，让既有 profile → generate → CMake → run → compare → artifact 流水线同时支持 `c` / `c_poll` / `cpp` / `cpp_poll`。
3. **CMake 项目必须支持 C + CXX 混合构建。** C++ native 用例需要 C compiler 编译 `machine.c`，C++ compiler 编译 `machine.cpp` 与 `harness.cpp`，再由 C++ linker 链接。
4. **命名上下文需要区分 C core 与 C++ wrapper。** C++ harness 上下文需要提供 wrapper namespace / class 前缀，确保 `Hooks`、`EventChecks`、`Int`、`Float`、`EventId` 等类型通过 wrapper API 访问。
5. **workflow path 触发必须同步扩展。** `.github/workflows/native-toolchain.yml` 的 `push.paths` / `pull_request.paths` 需要加入 `templates/cpp/**`、`templates/cpp_poll/**`、`test/template/cpp/test_native_toolchain_alignment.py`、`test/template/cpp_poll/test_native_toolchain_alignment.py`，以及 C++ harness helper 相关测试文件路径。
6. **slow skip 范围必须精准。** C++ 共享语义 fixture alignment 和 native toolchain alignment 属于会编译全量 fixture 的慢路径，可以进入 `SKIP_SLOW_TESTS=1` 快速迭代跳过范围；但既有轻量 wrapper smoke / API 测试必须继续在默认 `make unittest` 与 `SKIP_SLOW_TESTS=1 make unittest` 路径中运行，不能被新增 native skip 边界误伤。
7. **sanitizer 与 static analysis 都属于 D5d。** 上游 #261 写明 sanitizer / cppcheck / clang-tidy 根据可用性覆盖 C++ 产物；D5d 不能只做普通 compile-only，也不能让 analyze-only profile 因目标为空而 false green。

## 计划

| 步骤 | 内容 | 可验收结果 |
|---|---|---|
| 1 | 盘点 D4 native helper 与 D5c C++ wrapper harness 现状 | 明确复用 `test/testings/native_toolchain_alignment/` 还是 `test/template/cpp_shared.py`；确认 `test/conftest.py` 的 cpp/cpp_poll slow 范围；不重复造 runner。 |
| 2 | 新增 C++ wrapper-only harness 生成路径 | `cpp` / `cpp_poll` native 用例生成 `harness.cpp`；直接 include 只有 `machine.hpp`；通过 token / include guard 测试防止直接 include `machine.h` 或直接调用 C API。 |
| 3 | 扩展 native runner 上下文和 CMake 模板 | `build_harness_context` 或等价上下文支持 `cpp` / `cpp_poll`；CMake 模板支持 `LANGUAGES C CXX`、分离 `CMAKE_C_FLAGS` / `CMAKE_CXX_FLAGS`、列出 `machine.c` / `machine.cpp` / `harness.cpp`；导出 compile commands。 |
| 4 | 为 `cpp` / `cpp_poll` 增加 native toolchain 测试入口 | 新增 `test/template/cpp/test_native_toolchain_alignment.py` 与 `test/template/cpp_poll/test_native_toolchain_alignment.py`；默认普通 `make unittest` 不运行重矩阵，仅在 native workflow / 显式环境变量启用时运行。 |
| 5 | 扩展 workflow 和 profile 映射 | 扩展 `.github/workflows/native-toolchain.yml` 的 paths 与 pytest 命令；Linux GCC/G++、Clang/Clang++、macOS AppleClang、Windows MSVC / clang-cl / MinGW 代表 profile 真实触发。 |
| 6 | 补齐 C++ profile flags | GCC/Clang 至少一档使用 `-std=c++98 -fno-exceptions -fno-rtti`；MSVC / clang-cl 使用可用等效项（例如 `/GR-`，异常开关如无法完全等价则在 artifact 中记录差异）；不把 GCC-only flags 套到 MSVC。 |
| 7 | 覆盖 sanitizer 和 static analysis | `linux-clang-asan-ubsan` 覆盖 C++ executable / harness；cppcheck / clang-tidy 等 analyze-only profile 必须至少证明扫描目标非空；工具或 compile database 不可用时必须记录明确 skip reason，不能静默成功。 |
| 8 | 证据与 artifact | 失败报告和 artifact 中包含 template 名称、profile、命令、stdout/stderr、生成的 `machine.c/.h/.cpp/.hpp`、`harness.cpp`、构建产物路径、观察日志和 compile database 或等价证据；runner 侧将 `generated/` 下的 `.c/.h/.cpp/.hpp` 与 `harness/` 下的 `.cpp` 复制到 artifact 目录。 |
| 9 | 文档和维护纪律 | 相关测试 / workflow 说明写清 C++ native matrix 是显式 opt-in，不进默认快速单测路径；后续模板需按同模式接入。 |

## 验收标准

- [ ] `cpp` 与 `cpp_poll` 均进入 native toolchain alignment 测试。
- [ ] C++ native 测试必须通过 wrapper API，不允许绕过 `machine.hpp` 直接 include `machine.h` 或直接调用 C API。
- [ ] C++ native runner 能生成并构建 `harness.cpp`，且 CMake 使用 C + CXX 混合项目。
- [ ] `.github/workflows/native-toolchain.yml` 的 `paths` 和 pytest 命令均覆盖 `cpp` / `cpp_poll` 模板、测试与 C++ harness helper 路径。
- [ ] GCC/G++ 与 Clang/Clang++ 至少一档显式覆盖 `-std=c++98 -fno-exceptions -fno-rtti`。
- [ ] Windows C++ profile（MSVC / clang-cl / MinGW）在 CI 中真实触发；MSVC / clang-cl 的 no-RTTI / no-exception 差异通过 flags 或 artifact 说明记录清楚。
- [ ] Linux、macOS、Windows 的代表 C++ 编译器 profile 在 CI 中真实触发。
- [ ] sanitizer profile（尤其 `linux-clang-asan-ubsan`）覆盖 C++ executable / harness。
- [ ] analyze-only profile 覆盖 C++ 产物；cppcheck / clang-tidy 目标不得为空；如工具或 compile database 不可用，artifact 必须记录明确 skip reason。
- [ ] artifact 包含生成的 `machine.c/.h/.cpp/.hpp`、`harness.cpp`、命令、stdout/stderr、观察日志和 compile database 或等价证据。
- [ ] 默认 `make unittest` 不新增重矩阵耗时；本 PR 本地验收跑全量 `make unittest`，不使用 `SKIP_SLOW_TESTS=1`。
- [ ] `test/template/cpp/` 与 `test/template/cpp_poll/` 下既有轻量 wrapper smoke / API 测试在默认 `make unittest` 和 `SKIP_SLOW_TESTS=1 make unittest` 路径中仍可运行；全量共享语义 fixture alignment 与 native toolchain alignment 属于慢路径，可由无 slow skip 的全量测试或显式 native workflow 覆盖。
- [ ] 本地至少显式跑一个代表性 C++ native profile（例如 `linux-gcc-o2` 或本机可用等价 profile），并在 PR 评论或最终汇报中附结果摘要。
- [ ] `make rst_auto` 已运行，若生成 RST 有变更则随 PR 提交。
- [ ] GitHub `Code Test`、`CLI Build`、`Native toolchain matrix` 全绿。
- [ ] 三路 reviewer 强对抗复审 C/I 清零。

## 非目标

- 不改变 `cpp` / `cpp_poll` wrapper API。
- 不把 native matrix 放进默认快速单测路径。
- 不新增 C++ 专用 shared fixture 语法。
- 不宣称 MISRA、AUTOSAR、DO-178C、IEC 61508、ISO 26262 等认证就绪。
- 不推进 D5e 文档总收口；D5e 在本 PR 完成后继续处理。

## 当前状态

🟨 已完成实现并推送到 `00aa7936`；三路实现复审后已澄清 slow-skip 验收口径：轻量 wrapper smoke / API 测试保留在 fast path，全量 C++ 共享语义 fixture alignment 与 native toolchain alignment 保留在慢路径。

本地验收摘要：

- `make rst_auto`：通过，无生成文档差异。
- `git diff --check`：通过。
- `pytest test/testings/native_toolchain_alignment/test_report_and_profiles.py -q`：`22 passed`。
- 代表性 native smoke：`linux-gcc-o2` 下 `c` / `c_poll` / `cpp` / `cpp_poll` 的 `design_basic_simple_transition` 均通过。
- 全量 `make unittest`（未设置 `SKIP_SLOW_TESTS`）：`41857 passed, 8 skipped, 67 deselected`。

当前等待 GitHub Actions：`Code Test`、`CLI Build`、`jsfcstm test` 与 `Native toolchain matrix` 在最新 head `00aa7936` 上全部完成。CI 绿且复审 C/I 清零后即可合入上游 D5 伞 PR。



