### PR TITLE
规划：落地 inspect 数值诊断

### DIFF
--- a/docs/source/api_doc/diagnostics/analyzers/index.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/index.rst
@@ -13,6 +13,7 @@ pyfcstm.diagnostics.analyzers
     data_flow
     design_health
     naming
+    numeric
     redundancy
     structural
     thresholds

--- a/docs/source/api_doc/diagnostics/analyzers/numeric.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/numeric.rst
@@ -10,5 +10,3 @@ collect\_numeric\_warnings
 -----------------------------------------------------
 
 .. autofunction:: collect_numeric_warnings
-
-

--- a/docs/source/api_doc/diagnostics/analyzers/numeric.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/numeric.rst
@@ -1,0 +1,14 @@
+pyfcstm.diagnostics.analyzers.numeric
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.analyzers.numeric
+
+.. automodule:: pyfcstm.diagnostics.analyzers.numeric
+
+
+collect\_numeric\_warnings
+-----------------------------------------------------
+
+.. autofunction:: collect_numeric_warnings
+
+

--- a/docs/source/api_doc/diagnostics/codes.rst
+++ b/docs/source/api_doc/diagnostics/codes.rst
@@ -22,7 +22,7 @@ CodeFieldSpec
 -----------------------------------------------------
 
 .. autoclass:: CodeFieldSpec
-    :members: name,type,required,description,enum
+    :members: name,type,required,description,enum,item_enum,exact_values
 
 
 ForLlmSpec

--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -13,6 +13,7 @@ import {refsWithSuggestedFix} from '../suggested-fix';
 import {collectConstFoldWarnings} from './const-fold';
 import {collectDataFlowWarnings} from './data-flow';
 import {collectNamingWarnings} from './naming';
+import {collectNumericWarnings} from './numeric';
 import {collectRedundancyWarnings} from './redundancy';
 import {collectStructuralWarnings} from './structural';
 import {collectThresholdWarnings, type ThresholdOptions} from './thresholds';
@@ -53,6 +54,7 @@ export function collectDesignHealthWarnings(
         ...collectNamingWarnings(actions),
         ...collectTypeWarnings(variables),
         ...collectDataFlowWarnings(variables, machine),
+        ...(machine ? collectNumericWarnings(machine) : []),
         ...collectRedundancyWarnings(transitions, events, states),
         ...collectTransitionInfos(states, transitions),
     ];

--- a/editors/jsfcstm/src/diagnostics/analyzers/index.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/index.ts
@@ -5,6 +5,7 @@ export {
 } from './const-fold';
 export {collectDesignHealthWarnings} from './design-health';
 export {collectNamingWarnings} from './naming';
+export {collectNumericWarnings} from './numeric';
 export {collectThresholdWarnings} from './thresholds';
 export {collectTransitionInfos} from './transition-info';
 export {collectTypeWarnings} from './type-shape';

--- a/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
@@ -1,0 +1,486 @@
+import {
+    BinaryOp,
+    BooleanExpr,
+    ConditionalOp,
+    Float,
+    IfBlock,
+    Integer,
+    Operation,
+    OperationStatement,
+    StateMachine,
+    UFunc,
+    UnaryOp,
+    Variable,
+    type Expr,
+    type OnAspect,
+    type OnStage,
+} from '../../model/runtime';
+import {exprText, type ModelDiagnosticJson} from '../inspect';
+import {foldNumericExpression} from './const-fold';
+
+const TARGET_FAMILY = 'c_family';
+const TARGET_TEMPLATES = ['c', 'c_poll', 'cpp', 'cpp_poll'];
+const TARGET_BITS = 64;
+const MIN_SIGNED_INT64_TEXT = '-9223372036854775808';
+const MAX_SIGNED_INT64_TEXT = '9223372036854775807';
+const BITWISE_OPERATORS = new Set(['&', '^', '|', '<<', '>>']);
+const ZERO_OPERATORS = new Set(['/', '%']);
+const SHIFT_OPERATORS = new Set(['<<', '>>']);
+const C_FAMILY_INTEGER_UFUNCS = new Set(['ceil', 'floor', 'int', 'round', 'sign', 'trunc']);
+const C_FAMILY_CONDITION_OPERATORS = new Set([
+    '&&',
+    '||',
+    '=>',
+    'xor',
+    'iff',
+    '==',
+    '!=',
+    '<',
+    '<=',
+    '>',
+    '>=',
+]);
+
+const RUNTIME_NOTES: Record<string, string> = {
+    W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
+        'C/C++ deployment profile risk: the default C-family templates use '
+        + 'PYFCSTM_GENERATED_INT64, while Python generated runtimes may not have '
+        + 'the same fixed-width integer carrying risk.',
+    W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
+        'C/C++ deployment profile risk: generated C/C++ code needs an explicit '
+        + 'division-by-zero or modulo-by-zero policy, while Python generated '
+        + 'runtimes use different exception semantics.',
+    W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
+        'C/C++ deployment profile risk: the default C-family integer width is '
+        + '64 bits, while Python generated runtimes may not have the same '
+        + 'fixed-width shift risk.',
+    W_NUMERIC_FLOAT_BITWISE:
+        'C/C++ integer-operation profile risk: bitwise and shift operators are '
+        + 'integer operations in the generated C-family templates; Python '
+        + 'generated runtimes may fail for a different reason.',
+};
+
+interface ExpressionContext {
+    expr: Expr;
+    context: 'var_initializer' | 'guard' | 'transition_effect' | 'lifecycle_action';
+    statementKind?: 'operation_assignment';
+    varName?: string;
+}
+
+interface SignedIntegerLiteral {
+    text: string;
+    decimalText: string;
+}
+
+type NumericType = 'int' | 'float' | 'unknown';
+type NumericTypeSource = 'literal' | 'declared_var' | 'local_expression';
+
+/**
+ * Collect C/C++ deployment-profile numeric warnings for a model.
+ */
+export function collectNumericWarnings(machine: StateMachine | null | undefined): ModelDiagnosticJson[] {
+    if (!machine) return [];
+    const varTypes = variableTypes(machine);
+    const diagnostics: ModelDiagnosticJson[] = [];
+    for (const context of expressionContexts(machine)) {
+        diagnostics.push(...diagnosticsForExpression(context, varTypes));
+    }
+    return diagnostics;
+}
+
+function variableTypes(machine: StateMachine): Record<string, 'int' | 'float'> {
+    const out: Record<string, 'int' | 'float'> = {};
+    for (const [name, definition] of Object.entries(machine.defines)) {
+        out[name] = definition.type;
+    }
+    return out;
+}
+
+function diagnosticsForExpression(
+    context: ExpressionContext,
+    varTypes: Record<string, 'int' | 'float'>,
+): ModelDiagnosticJson[] {
+    const diagnostics: ModelDiagnosticJson[] = [];
+    const signedLiteralChildren = signedLiteralChildIds(context.expr);
+    for (const expr of walkExpressions(context.expr)) {
+        if (!signedLiteralChildren.has(expr)) {
+            diagnostics.push(...literalRangeDiagnostic(context, expr));
+        }
+        diagnostics.push(...constantZeroDivisionDiagnostic(context, expr));
+        diagnostics.push(...shiftCountDiagnostic(context, expr));
+        diagnostics.push(...floatBitwiseDiagnostic(context, expr, varTypes));
+    }
+    return diagnostics;
+}
+
+function* expressionContexts(machine: StateMachine): Generator<ExpressionContext, void, void> {
+    for (const [varName, definition] of Object.entries(machine.defines)) {
+        yield {
+            expr: definition.init,
+            context: 'var_initializer',
+            varName,
+        };
+    }
+
+    for (const state of machine.allStates) {
+        for (const transition of state.transitions) {
+            if (transition.guard) {
+                yield {
+                    expr: transition.guard,
+                    context: 'guard',
+                };
+            }
+            for (const statement of transition.effects) {
+                yield* statementExpressionContexts(statement, 'transition_effect');
+            }
+        }
+        for (const action of concreteActions([
+            ...state.onEnters,
+            ...state.onDurings,
+            ...state.onExits,
+            ...state.onDuringAspects,
+        ])) {
+            for (const statement of action.operations) {
+                yield* statementExpressionContexts(statement, 'lifecycle_action');
+            }
+        }
+    }
+}
+
+function* concreteActions(actions: Array<OnStage | OnAspect>): Generator<OnStage | OnAspect, void, void> {
+    for (const action of actions) {
+        if (action.isAbstract || action.isRef) continue;
+        yield action;
+    }
+}
+
+function* statementExpressionContexts(
+    statement: OperationStatement,
+    context: ExpressionContext['context'],
+): Generator<ExpressionContext, void, void> {
+    if (statement instanceof Operation) {
+        yield {
+            expr: statement.expr,
+            context,
+            statementKind: 'operation_assignment',
+            varName: statement.varName,
+        };
+        return;
+    }
+    if (statement instanceof IfBlock) {
+        for (const branch of statement.branches) {
+            if (branch.condition) {
+                yield {
+                    expr: branch.condition,
+                    context,
+                };
+            }
+            for (const inner of branch.statements) {
+                yield* statementExpressionContexts(inner, context);
+            }
+        }
+    }
+}
+
+function* walkExpressions(expr: Expr): Generator<Expr, void, void> {
+    yield expr;
+    if (expr instanceof UnaryOp) {
+        yield* walkExpressions(expr.x);
+    } else if (expr instanceof BinaryOp) {
+        yield* walkExpressions(expr.x);
+        yield* walkExpressions(expr.y);
+    } else if (expr instanceof ConditionalOp) {
+        yield* walkExpressions(expr.cond);
+        yield* walkExpressions(expr.ifTrue);
+        yield* walkExpressions(expr.ifFalse);
+    } else if (expr instanceof UFunc) {
+        yield* walkExpressions(expr.x);
+    }
+}
+
+function signedLiteralChildIds(expr: Expr): Set<Expr> {
+    const out = new Set<Expr>();
+    for (const item of walkExpressions(expr)) {
+        if (item instanceof UnaryOp && (item.op === '+' || item.op === '-') && item.x instanceof Integer) {
+            out.add(item.x);
+        }
+    }
+    return out;
+}
+
+function literalRangeDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
+    const literal = signedIntegerLiteral(expr);
+    if (!literal || isSignedInt64Literal(literal.decimalText)) return [];
+    const refs = baseRefs('W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE', context, exprText(expr));
+    refs.literal_text = literal.text;
+    refs.target_bits = TARGET_BITS;
+    refs.signed = true;
+    refs.min_value_text = MIN_SIGNED_INT64_TEXT;
+    refs.max_value_text = MAX_SIGNED_INT64_TEXT;
+    if (context.varName) {
+        refs.var_name = context.varName;
+    }
+    return [diagnostic(
+        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+        `C/C++ default deployment profile risk: integer literal ${literal.text} is outside the `
+            + `PYFCSTM_GENERATED_INT64 range [${MIN_SIGNED_INT64_TEXT}, ${MAX_SIGNED_INT64_TEXT}]; `
+            + 'Python generated runtimes may not have the same fixed-width risk.',
+        refs,
+    )];
+}
+
+function constantZeroDivisionDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
+    if (!(expr instanceof BinaryOp) || !ZERO_OPERATORS.has(expr.op)) return [];
+    const rhsValue = foldNumericExpression(expr.y);
+    if (rhsValue !== 0) return [];
+    const refs = baseRefs('W_NUMERIC_CONSTANT_DIVISION_BY_ZERO', context, exprText(expr));
+    refs.operator = expr.op;
+    refs.rhs_text = exprText(expr.y) ?? '';
+    return [diagnostic(
+        'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+        `C/C++ default deployment profile risk: the RHS of operator ${JSON.stringify(expr.op)} `
+            + 'folds to 0; generated C/C++ code needs an explicit failure policy, '
+            + 'while Python runtime exception semantics differ.',
+        refs,
+    )];
+}
+
+function shiftCountDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
+    if (!(expr instanceof BinaryOp) || !SHIFT_OPERATORS.has(expr.op)) return [];
+    const rhsValue = foldNumericExpression(expr.y);
+    if (
+        typeof rhsValue !== 'number'
+        || !Number.isFinite(rhsValue)
+        || !(rhsValue < 0 || rhsValue >= TARGET_BITS)
+    ) {
+        return [];
+    }
+    const refs = baseRefs('W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE', context, exprText(expr));
+    refs.operator = expr.op;
+    refs.target_bits = TARGET_BITS;
+    refs.shift_count_text = numberText(rhsValue);
+    return [diagnostic(
+        'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+        `C/C++ default deployment profile risk: the shift count of operator ${JSON.stringify(expr.op)} `
+            + `folds to ${numberText(rhsValue)}, outside 0 <= count < ${TARGET_BITS}; `
+            + 'Python generated runtimes do not represent the same fixed-width shift contract.',
+        refs,
+    )];
+}
+
+function floatBitwiseDiagnostic(
+    context: ExpressionContext,
+    expr: Expr,
+    varTypes: Record<string, 'int' | 'float'>,
+): ModelDiagnosticJson[] {
+    if (!(expr instanceof BinaryOp) || !BITWISE_OPERATORS.has(expr.op)) return [];
+    const left = inferNumericType(expr.x, varTypes);
+    const right = inferNumericType(expr.y, varTypes);
+    if (left[0] !== 'float' && right[0] !== 'float') return [];
+    const refs = baseRefs('W_NUMERIC_FLOAT_BITWISE', context, exprText(expr));
+    refs.operator = expr.op;
+    refs.operand_types = [left[0], right[0]];
+    refs.operand_type_sources = [left[1], right[1]];
+    return [diagnostic(
+        'W_NUMERIC_FLOAT_BITWISE',
+        `C/C++ default deployment profile risk: a float-shaped operand participates in integer `
+            + `bitwise or shift operator ${JSON.stringify(expr.op)}; C-family templates generate `
+            + 'integer operations, while Python runtime failures have different semantics.',
+        refs,
+    )];
+}
+
+function inferNumericType(
+    expr: Expr,
+    varTypes: Record<string, 'int' | 'float'>,
+): [NumericType, NumericTypeSource] {
+    if (expr instanceof BooleanExpr || expr instanceof Integer) {
+        return ['int', 'literal'];
+    }
+    if (expr instanceof Float) {
+        return ['float', 'literal'];
+    }
+    if (expr instanceof Variable) {
+        const declared = varTypes[expr.name];
+        if (declared === 'float') return ['float', 'declared_var'];
+        if (declared === 'int') return ['int', 'declared_var'];
+        return ['unknown', 'declared_var'];
+    }
+    if (expr instanceof UnaryOp) {
+        const inner = inferNumericType(expr.x, varTypes);
+        return inner[0] === 'int' || inner[0] === 'float' ? inner : ['unknown', 'local_expression'];
+    }
+    if (expr instanceof UFunc) {
+        if (C_FAMILY_INTEGER_UFUNCS.has(expr.func)) {
+            return ['int', 'local_expression'];
+        }
+        if (expr.func === 'abs') {
+            const inner = inferNumericType(expr.x, varTypes);
+            return inner[0] === 'int' || inner[0] === 'float'
+                ? [inner[0], 'local_expression']
+                : ['unknown', 'local_expression'];
+        }
+        return ['float', 'local_expression'];
+    }
+    if (expr instanceof BinaryOp) {
+        if (BITWISE_OPERATORS.has(expr.op) || C_FAMILY_CONDITION_OPERATORS.has(expr.op)) {
+            return ['int', 'local_expression'];
+        }
+        if (expr.op === '/') {
+            return ['float', 'local_expression'];
+        }
+        const left = inferNumericType(expr.x, varTypes);
+        const right = inferNumericType(expr.y, varTypes);
+        return [mergeNumericTypes(left[0], right[0]), 'local_expression'];
+    }
+    if (expr instanceof ConditionalOp) {
+        const ifTrue = inferNumericType(expr.ifTrue, varTypes);
+        const ifFalse = inferNumericType(expr.ifFalse, varTypes);
+        return [mergeNumericTypes(ifTrue[0], ifFalse[0]), 'local_expression'];
+    }
+    return ['unknown', 'local_expression'];
+}
+
+function mergeNumericTypes(typeA: NumericType, typeB: NumericType): NumericType {
+    if (typeA === 'float' || typeB === 'float') return 'float';
+    if (typeA === 'int' && typeB === 'int') return 'int';
+    return 'unknown';
+}
+
+function signedIntegerLiteral(expr: Expr): SignedIntegerLiteral | null {
+    if (expr instanceof Integer) {
+        const digits = unsignedIntegerDecimalText(expr.text);
+        return digits === null ? null : {text: expr.text.trim(), decimalText: digits};
+    }
+    if (expr instanceof UnaryOp && (expr.op === '+' || expr.op === '-') && expr.x instanceof Integer) {
+        const digits = unsignedIntegerDecimalText(expr.x.text);
+        if (digits === null) return null;
+        const sign = expr.op === '-' ? '-' : '+';
+        return {
+            text: `${sign}${expr.x.text.trim()}`,
+            decimalText: expr.op === '-' && digits !== '0' ? `-${digits}` : digits,
+        };
+    }
+    return null;
+}
+
+function unsignedIntegerDecimalText(rawText: string): string | null {
+    const raw = rawText.trim();
+    if (/^\d+$/.test(raw)) {
+        return normalizeDecimalDigits(raw);
+    }
+    if (/^0[xX][0-9a-fA-F]+$/.test(raw)) {
+        return convertRadixDigitsToDecimal(raw.slice(2), 16);
+    }
+    if (/^0[bB][01]+$/.test(raw)) {
+        return convertRadixDigitsToDecimal(raw.slice(2), 2);
+    }
+    return null;
+}
+
+function isSignedInt64Literal(signedDecimalText: string): boolean {
+    const normalized = normalizeSignedDecimal(signedDecimalText);
+    if (normalized.startsWith('-')) {
+        return compareUnsignedDecimal(normalized.slice(1), MIN_SIGNED_INT64_TEXT.slice(1)) <= 0;
+    }
+    return compareUnsignedDecimal(normalized, MAX_SIGNED_INT64_TEXT) <= 0;
+}
+
+function normalizeSignedDecimal(raw: string): string {
+    if (raw.startsWith('-')) {
+        const digits = normalizeDecimalDigits(raw.slice(1));
+        return digits === '0' ? '0' : `-${digits}`;
+    }
+    if (raw.startsWith('+')) {
+        return normalizeDecimalDigits(raw.slice(1));
+    }
+    return normalizeDecimalDigits(raw);
+}
+
+function normalizeDecimalDigits(raw: string): string {
+    const normalized = raw.replace(/^0+/, '');
+    return normalized.length > 0 ? normalized : '0';
+}
+
+function compareUnsignedDecimal(left: string, right: string): number {
+    const leftNormalized = normalizeDecimalDigits(left);
+    const rightNormalized = normalizeDecimalDigits(right);
+    if (leftNormalized.length !== rightNormalized.length) {
+        return leftNormalized.length < rightNormalized.length ? -1 : 1;
+    }
+    if (leftNormalized === rightNormalized) return 0;
+    return leftNormalized < rightNormalized ? -1 : 1;
+}
+
+function addSmallDecimal(raw: string, value: number): string {
+    if (value === 0) return raw;
+    let carry = value;
+    const out: string[] = [];
+    for (let index = raw.length - 1; index >= 0; index -= 1) {
+        const total = Number(raw[index]) + carry;
+        out.push(String(total % 10));
+        carry = Math.floor(total / 10);
+    }
+    while (carry > 0) {
+        out.push(String(carry % 10));
+        carry = Math.floor(carry / 10);
+    }
+    return out.reverse().join('');
+}
+
+function multiplySmallDecimal(raw: string, factor: number): string {
+    if (raw === '0' || factor === 0) return '0';
+    let carry = 0;
+    const out: string[] = [];
+    for (let index = raw.length - 1; index >= 0; index -= 1) {
+        const total = Number(raw[index]) * factor + carry;
+        out.push(String(total % 10));
+        carry = Math.floor(total / 10);
+    }
+    while (carry > 0) {
+        out.push(String(carry % 10));
+        carry = Math.floor(carry / 10);
+    }
+    return out.reverse().join('');
+}
+
+function convertRadixDigitsToDecimal(digits: string, radix: number): string {
+    let value = '0';
+    for (const char of digits.toLowerCase()) {
+        const digit = parseInt(char, radix);
+        value = addSmallDecimal(multiplySmallDecimal(value, radix), digit);
+    }
+    return normalizeDecimalDigits(value);
+}
+
+function baseRefs(
+    code: keyof typeof RUNTIME_NOTES,
+    context: ExpressionContext,
+    renderedExpr: string | null,
+): Record<string, unknown> {
+    const refs: Record<string, unknown> = {
+        target_family: TARGET_FAMILY,
+        target_templates: [...TARGET_TEMPLATES],
+        runtime_note: RUNTIME_NOTES[code],
+        context: context.context,
+        expr_text: renderedExpr ?? '',
+    };
+    if (context.statementKind) {
+        refs.statement_kind = context.statementKind;
+    }
+    return refs;
+}
+
+function diagnostic(code: string, message: string, refs: Record<string, unknown>): ModelDiagnosticJson {
+    return {
+        code,
+        severity: 'warning',
+        message,
+        span: null,
+        refs,
+    };
+}
+
+function numberText(value: number): string {
+    return Number.isInteger(value) ? String(Math.trunc(value)) : String(value);
+}

--- a/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
@@ -75,6 +75,12 @@ interface SignedIntegerLiteral {
 type NumericType = 'int' | 'float' | 'unknown';
 type NumericTypeSource = 'literal' | 'declared_var' | 'local_expression';
 
+interface FoldedExactInteger {
+    kind: 'exactInteger';
+    sign: -1 | 1;
+    digits: string;
+}
+
 /**
  * Collect C/C++ deployment-profile numeric warnings for a model.
  */
@@ -247,22 +253,16 @@ function constantZeroDivisionDiagnostic(context: ExpressionContext, expr: Expr):
 
 function shiftCountDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
     if (!(expr instanceof BinaryOp) || !SHIFT_OPERATORS.has(expr.op)) return [];
-    const rhsValue = foldNumericExpression(expr.y);
-    if (
-        typeof rhsValue !== 'number'
-        || !Number.isFinite(rhsValue)
-        || !(rhsValue < 0 || rhsValue >= TARGET_BITS)
-    ) {
-        return [];
-    }
+    const shiftCountText = outOfRangeShiftCountText(foldNumericExpression(expr.y));
+    if (shiftCountText === null) return [];
     const refs = baseRefs('W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE', context, exprText(expr));
     refs.operator = expr.op;
     refs.target_bits = TARGET_BITS;
-    refs.shift_count_text = numberText(rhsValue);
+    refs.shift_count_text = shiftCountText;
     return [diagnostic(
         'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
         `C/C++ default deployment profile risk: the shift count of operator ${JSON.stringify(expr.op)} `
-            + `folds to ${numberText(rhsValue)}, outside 0 <= count < ${TARGET_BITS}; `
+            + `folds to ${shiftCountText}, outside 0 <= count < ${TARGET_BITS}; `
             + 'Python generated runtimes do not represent the same fixed-width shift contract.',
         refs,
     )];
@@ -342,8 +342,9 @@ function inferNumericType(
 }
 
 function mergeNumericTypes(typeA: NumericType, typeB: NumericType): NumericType {
-    if (typeA === 'float' || typeB === 'float') return 'float';
-    if (typeA === 'int' && typeB === 'int') return 'int';
+    const known = new Set([typeA, typeB].filter((type): type is Exclude<NumericType, 'unknown'> => type !== 'unknown'));
+    if (known.has('float')) return 'float';
+    if (known.size === 1 && known.has('int')) return 'int';
     return 'unknown';
 }
 
@@ -410,6 +411,35 @@ function compareUnsignedDecimal(left: string, right: string): number {
     }
     if (leftNormalized === rightNormalized) return 0;
     return leftNormalized < rightNormalized ? -1 : 1;
+}
+
+function outOfRangeShiftCountText(value: unknown): string | null {
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value) || !(value < 0 || value >= TARGET_BITS)) return null;
+        return numberText(value);
+    }
+
+    const exactInteger = foldedExactInteger(value);
+    if (exactInteger === null) return null;
+    if (exactInteger.sign < 0 && exactInteger.digits !== '0') {
+        return `-${exactInteger.digits}`;
+    }
+    return compareUnsignedDecimal(exactInteger.digits, String(TARGET_BITS)) >= 0
+        ? exactInteger.digits
+        : null;
+}
+
+function foldedExactInteger(value: unknown): FoldedExactInteger | null {
+    if (typeof value !== 'object' || value === null) return null;
+    const maybe = value as Record<string, unknown>;
+    if (maybe.kind !== 'exactInteger') return null;
+    if (maybe.sign !== -1 && maybe.sign !== 1) return null;
+    if (typeof maybe.digits !== 'string' || !/^\d+$/.test(maybe.digits)) return null;
+    return {
+        kind: 'exactInteger',
+        sign: maybe.sign,
+        digits: normalizeDecimalDigits(maybe.digits),
+    };
 }
 
 function addSmallDecimal(raw: string, value: number): string {

--- a/editors/jsfcstm/src/diagnostics/codes.ts
+++ b/editors/jsfcstm/src/diagnostics/codes.ts
@@ -65,6 +65,12 @@ export interface CodeSpec {
     description: string;
     refs?: Record<string, CodeFieldSpec>;
     capability?: 'pure_static' | 'const_fold' | 'requires_solver' | 'requires_simulation';
+    emit_tier?:
+        | 'static_pipeline'
+        | 'lookup_api'
+        | 'partial_static_pipeline'
+        | 'verify_pipeline'
+        | 'catalog_only';
     for_llm?: ForLlmSpec;
     suggested_fix?: SuggestedFixSpec;
     example_dsl?: string;

--- a/editors/jsfcstm/src/diagnostics/codes.ts
+++ b/editors/jsfcstm/src/diagnostics/codes.ts
@@ -22,6 +22,8 @@ export interface CodeFieldSpec {
     required?: boolean;
     description?: string;
     enum?: readonly string[];
+    item_enum?: readonly string[];
+    exact_values?: readonly string[];
 }
 
 /**

--- a/editors/jsfcstm/test/diagnostics-numeric.test.ts
+++ b/editors/jsfcstm/test/diagnostics-numeric.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../src/diagnostics';
 import {buildStateMachineModel} from '../src/model';
 import {parseAstDocument} from '../src/ast';
-import {createDocument, packageModule} from './support';
+import {createDocument, packageModule, sliceByRange} from './support';
 
 const MIN_SIGNED_INT64_TEXT = '-9223372036854775808';
 const MAX_SIGNED_INT64_TEXT = '9223372036854775807';
@@ -139,6 +139,26 @@ state Root { state A; [*] -> A; }
             assert.equal(diagnostic.refs.target_bits, 64);
             assert.equal(diagnostic.refs.signed, true);
         }
+    });
+
+    it('surfaces numeric warnings through collectDocumentDiagnostics with refs and non-fallback source range', async () => {
+        const source = `
+def int value = ${TOO_LARGE_SIGNED_INT64_TEXT};
+state Root { state A; [*] -> A; }
+`;
+        const document = createDocument(source, '/tmp/diagnostics-numeric-editor-surface.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE');
+
+        assert.ok(diagnostic, 'expected collectDocumentDiagnostics to surface numeric warning');
+        assert.equal(diagnostic.message.includes('C/C++'), true);
+        assert.equal(diagnostic.message.includes('Python'), true);
+        assert.equal(diagnostic.data?.target_family, 'c_family');
+        assert.deepEqual(diagnostic.data?.target_templates, C_FAMILY_TARGET_TEMPLATES);
+        assert.equal(String(diagnostic.data?.runtime_note).includes('C/C++'), true);
+        assert.equal(String(diagnostic.data?.runtime_note).includes('Python'), true);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.equal(sliceByRange(source, diagnostic.range).includes(TOO_LARGE_SIGNED_INT64_TEXT), true);
     });
 
     it('deduplicates signed integer child literals under unary operators', async () => {

--- a/editors/jsfcstm/test/diagnostics-numeric.test.ts
+++ b/editors/jsfcstm/test/diagnostics-numeric.test.ts
@@ -1,0 +1,308 @@
+import assert from 'node:assert/strict';
+
+import {
+    collectNumericWarnings,
+} from '../src/diagnostics/analyzers/numeric';
+import {
+    inspectModel,
+    refsWithSuggestedFix,
+    type ModelDiagnosticJson,
+} from '../src/diagnostics';
+import {buildStateMachineModel} from '../src/model';
+import {parseAstDocument} from '../src/ast';
+import {createDocument, packageModule} from './support';
+
+const MIN_SIGNED_INT64_TEXT = '-9223372036854775808';
+const MAX_SIGNED_INT64_TEXT = '9223372036854775807';
+const TOO_LARGE_SIGNED_INT64_TEXT = '9223372036854775808';
+const TOO_SMALL_SIGNED_INT64_TEXT = '-9223372036854775809';
+
+const NUMERIC_CODES = new Set([
+    'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+    'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_FLOAT_BITWISE',
+]);
+
+const C_FAMILY_TARGET_TEMPLATES = ['c', 'c_poll', 'cpp', 'cpp_poll'];
+
+async function buildMachine(src: string) {
+    const document = createDocument(src, '/tmp/diagnostics-numeric.fcstm');
+    const ast = await parseAstDocument(document);
+    const machine = buildStateMachineModel(ast);
+    if (!machine) {
+        throw new Error('buildStateMachineModel returned null');
+    }
+    return machine;
+}
+
+async function numericDiagnostics(source: string): Promise<ModelDiagnosticJson[]> {
+    const report = inspectModel(await buildMachine(source));
+    return report.diagnostics.filter(item => NUMERIC_CODES.has(item.code));
+}
+
+function diagnosticsFor(diagnostics: ModelDiagnosticJson[], code: string): ModelDiagnosticJson[] {
+    return diagnostics.filter(item => item.code === code);
+}
+
+function assertRegistryRefs(diagnostic: ModelDiagnosticJson): void {
+    const registry = packageModule.loadCodesRegistry();
+    const spec = registry[diagnostic.code];
+    assert.ok(spec, `${diagnostic.code} missing from bundled registry`);
+    assert.equal(diagnostic.severity, spec.severity);
+    const refsSpec = spec.refs ?? {};
+    for (const [fieldName, fieldSpec] of Object.entries(refsSpec)) {
+        if (fieldSpec.required) {
+            assert.ok(
+                Object.prototype.hasOwnProperty.call(diagnostic.refs, fieldName),
+                `${diagnostic.code} refs missing required ${fieldName}`,
+            );
+        }
+        const value = diagnostic.refs[fieldName];
+        if (value === undefined) continue;
+        if (fieldSpec.enum) {
+            assert.equal(typeof value, 'string', `${diagnostic.code}.${fieldName} must be a string enum`);
+            assert.ok(fieldSpec.enum.includes(value), `${diagnostic.code}.${fieldName} has invalid enum value ${value}`);
+        }
+        if (fieldSpec.item_enum || fieldSpec.exact_values) {
+            assert.ok(Array.isArray(value), `${diagnostic.code}.${fieldName} must be an array`);
+        }
+        if (fieldSpec.item_enum && Array.isArray(value)) {
+            for (const item of value) {
+                assert.equal(typeof item, 'string', `${diagnostic.code}.${fieldName} item must be a string`);
+                assert.ok(fieldSpec.item_enum.includes(item), `${diagnostic.code}.${fieldName} invalid item ${item}`);
+            }
+        }
+        if (fieldSpec.exact_values) {
+            assert.deepEqual(value, fieldSpec.exact_values, `${diagnostic.code}.${fieldName} exact values drifted`);
+        }
+    }
+
+    const refsWithoutSuggestedFix = {...diagnostic.refs};
+    delete refsWithoutSuggestedFix.suggested_fix;
+    assert.deepEqual(
+        diagnostic.refs,
+        refsWithSuggestedFix(diagnostic.code, refsWithoutSuggestedFix),
+        `${diagnostic.code} bypassed refsWithSuggestedFix() normalization`,
+    );
+}
+
+function assertTargetProfileRefs(diagnostic: ModelDiagnosticJson): void {
+    assertRegistryRefs(diagnostic);
+    assert.equal(diagnostic.refs.target_family, 'c_family');
+    assert.deepEqual(diagnostic.refs.target_templates, C_FAMILY_TARGET_TEMPLATES);
+    assert.equal(String(diagnostic.message).includes('C/C++'), true);
+    assert.equal(String(diagnostic.message).includes('Python'), true);
+    assert.equal(String(diagnostic.refs.runtime_note).includes('C/C++'), true);
+    assert.equal(String(diagnostic.refs.runtime_note).includes('Python'), true);
+}
+
+describe('diagnostics/numeric', () => {
+    it('keeps nullable analyzer entry as a no-op', () => {
+        assert.deepEqual(collectNumericWarnings(null), []);
+        assert.deepEqual(collectNumericWarnings(undefined), []);
+    });
+
+    it('reports signed int64 literal range boundaries for C-family templates', async () => {
+        for (const [literalText, shouldWarn] of [
+            [TOO_LARGE_SIGNED_INT64_TEXT, true],
+            [`+${TOO_LARGE_SIGNED_INT64_TEXT}`, true],
+            [MIN_SIGNED_INT64_TEXT, false],
+            [MAX_SIGNED_INT64_TEXT, false],
+            [TOO_SMALL_SIGNED_INT64_TEXT, true],
+        ] as const) {
+            const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int value = ${literalText};
+state Root { state A; [*] -> A; }
+`), 'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE');
+
+            if (!shouldWarn) {
+                assert.deepEqual(diagnostics, [], literalText);
+                continue;
+            }
+
+            assert.equal(diagnostics.length, 1, literalText);
+            const diagnostic = diagnostics[0];
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.context, 'var_initializer');
+            assert.equal(diagnostic.refs.var_name, 'value');
+            assert.equal(diagnostic.refs.literal_text, literalText);
+            assert.equal(diagnostic.refs.min_value_text, MIN_SIGNED_INT64_TEXT);
+            assert.equal(diagnostic.refs.max_value_text, MAX_SIGNED_INT64_TEXT);
+            assert.equal(diagnostic.refs.target_bits, 64);
+            assert.equal(diagnostic.refs.signed, true);
+        }
+    });
+
+    it('uses RHS-only constant folding for division and modulo by zero', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int result = 0;
+def int input = 1;
+def int denom = 0;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B effect {
+        result = input / (1 - 1);
+        result = input % (2 - 2);
+        result = input / denom;
+    };
+}
+`), 'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO');
+
+        assert.deepEqual(
+            diagnostics.map(item => [item.refs.operator, item.refs.rhs_text]),
+            [['/', '1 - 1'], ['%', '2 - 2']],
+        );
+        for (const diagnostic of diagnostics) {
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.context, 'transition_effect');
+            assert.equal(diagnostic.refs.statement_kind, 'operation_assignment');
+        }
+    });
+
+    it('reports only constant shift counts outside the 64-bit C-family profile', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+def int amount = 64;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B effect {
+        flags = flags << -1;
+        flags = flags >> 64;
+        flags = flags << 0;
+        flags = flags << 63;
+        flags = flags << amount;
+    };
+}
+`), 'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE');
+
+        assert.deepEqual(
+            diagnostics.map(item => [item.refs.operator, item.refs.shift_count_text]),
+            [['<<', '-1'], ['>>', '64']],
+        );
+        for (const diagnostic of diagnostics) {
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.target_bits, 64);
+            assert.equal(diagnostic.refs.context, 'transition_effect');
+            assert.equal(diagnostic.refs.statement_kind, 'operation_assignment');
+        }
+    });
+
+    it('reports float-shaped operands in C-family bitwise and shift expressions', async () => {
+        for (const [expr, expectedTypes, expectedSources] of [
+            ['1.5 & flags', ['float', 'int'], ['literal', 'declared_var']],
+            ['gain | flags', ['float', 'int'], ['declared_var', 'declared_var']],
+            ['(gain + 1.0) ^ flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['(1 / 2) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['sin(1) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['abs(gain) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['((flags > 0) ? 1.0 : 0) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+        ] as const) {
+            const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+def float gain = 1.5;
+state Root {
+    state A { during { flags = ${expr}; } }
+    [*] -> A;
+}
+`), 'W_NUMERIC_FLOAT_BITWISE');
+
+            assert.equal(diagnostics.length, 1, expr);
+            const diagnostic = diagnostics[0];
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.operator, expr.includes('<<') ? '<<' : expr.match(/[&^|]/)![0]);
+            assert.deepEqual(diagnostic.refs.operand_types, expectedTypes, expr);
+            assert.deepEqual(diagnostic.refs.operand_type_sources, expectedSources, expr);
+        }
+    });
+
+    it('does not report int-shaped local expressions as float bitwise risks', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+state Root {
+    state A {
+        during {
+            flags = (1 + 2) & flags;
+            flags = sign(1.5) & flags;
+            flags = ceil(1.5) & flags;
+        }
+    }
+    [*] -> A;
+}
+`), 'W_NUMERIC_FLOAT_BITWISE');
+
+        assert.deepEqual(diagnostics, []);
+    });
+
+    it('allows float shift expressions to overlap with shift-count warnings', async () => {
+        const diagnostics = await numericDiagnostics(`
+def int flags = 1;
+def float gain = 1.5;
+state Root {
+    state A { during { flags = gain << 64; } }
+    [*] -> A;
+}
+`);
+
+        assert.equal(diagnosticsFor(diagnostics, 'W_NUMERIC_FLOAT_BITWISE').length, 1);
+        assert.equal(diagnosticsFor(diagnostics, 'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE').length, 1);
+    });
+
+    it('scans public expression contexts, if conditions, and nested assignments', async () => {
+        const diagnostics = await numericDiagnostics(`
+def int initialized = 1 / 0;
+def int flags = 1;
+state Root {
+    state A {
+        during {
+            if [flags / 0 > 0] {
+                if [flags > 0] {
+                    flags = flags << 64;
+                }
+            }
+        }
+    }
+    state B;
+    [*] -> A;
+    A -> B : if [flags / 0 > 0];
+    B -> A effect { flags = flags / 0; };
+}
+`);
+
+        const divisionContexts = diagnosticsFor(diagnostics, 'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO')
+            .map(item => [item.refs.context, item.refs.statement_kind ?? null]);
+        assert.deepEqual(divisionContexts, [
+            ['var_initializer', null],
+            ['guard', null],
+            ['transition_effect', 'operation_assignment'],
+            ['lifecycle_action', null],
+        ]);
+
+        const shiftDiagnostics = diagnosticsFor(diagnostics, 'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE');
+        assert.equal(shiftDiagnostics.length, 1);
+        assert.equal(shiftDiagnostics[0].refs.context, 'lifecycle_action');
+        assert.equal(shiftDiagnostics[0].refs.statement_kind, 'operation_assignment');
+    });
+
+    it('does not duplicate diagnostics through abstract or ref lifecycle actions', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int value = 1;
+state Root {
+    state A {
+        enter abstract HardwareInit;
+        enter Inline { value = value / 0; }
+        enter ref Inline;
+    }
+    [*] -> A;
+}
+`), 'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO');
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(diagnostics[0].refs.context, 'lifecycle_action');
+        assert.equal(diagnostics[0].refs.statement_kind, 'operation_assignment');
+    });
+});

--- a/editors/jsfcstm/test/diagnostics-numeric.test.ts
+++ b/editors/jsfcstm/test/diagnostics-numeric.test.ts
@@ -97,6 +97,13 @@ function assertTargetProfileRefs(diagnostic: ModelDiagnosticJson): void {
     assert.equal(String(diagnostic.refs.runtime_note).includes('Python'), true);
 }
 
+function expectedBitwiseOperator(expr: string): string {
+    for (const operator of ['<<', '>>', '&', '^', '|']) {
+        if (expr.includes(operator)) return operator;
+    }
+    throw new Error(`missing bitwise operator in ${expr}`);
+}
+
 describe('diagnostics/numeric', () => {
     it('keeps nullable analyzer entry as a no-op', () => {
         assert.deepEqual(collectNumericWarnings(null), []);
@@ -132,6 +139,16 @@ state Root { state A; [*] -> A; }
             assert.equal(diagnostic.refs.target_bits, 64);
             assert.equal(diagnostic.refs.signed, true);
         }
+    });
+
+    it('deduplicates signed integer child literals under unary operators', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int value = ${TOO_SMALL_SIGNED_INT64_TEXT};
+state Root { state A; [*] -> A; }
+`), 'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE');
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(diagnostics[0].refs.literal_text, TOO_SMALL_SIGNED_INT64_TEXT);
     });
 
     it('uses RHS-only constant folding for division and modulo by zero', async () => {
@@ -173,6 +190,8 @@ state Root {
     A -> B effect {
         flags = flags << -1;
         flags = flags >> 64;
+        flags = flags << -9223372036854775808;
+        flags = flags >> 9223372036854775808;
         flags = flags << 0;
         flags = flags << 63;
         flags = flags << amount;
@@ -182,7 +201,12 @@ state Root {
 
         assert.deepEqual(
             diagnostics.map(item => [item.refs.operator, item.refs.shift_count_text]),
-            [['<<', '-1'], ['>>', '64']],
+            [
+                ['<<', '-1'],
+                ['>>', '64'],
+                ['<<', '-9223372036854775808'],
+                ['>>', '9223372036854775808'],
+            ],
         );
         for (const diagnostic of diagnostics) {
             assertTargetProfileRefs(diagnostic);
@@ -196,6 +220,7 @@ state Root {
         for (const [expr, expectedTypes, expectedSources] of [
             ['1.5 & flags', ['float', 'int'], ['literal', 'declared_var']],
             ['gain | flags', ['float', 'int'], ['declared_var', 'declared_var']],
+            ['gain >> flags', ['float', 'int'], ['declared_var', 'declared_var']],
             ['(gain + 1.0) ^ flags', ['float', 'int'], ['local_expression', 'declared_var']],
             ['(1 / 2) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
             ['sin(1) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
@@ -214,10 +239,25 @@ state Root {
             assert.equal(diagnostics.length, 1, expr);
             const diagnostic = diagnostics[0];
             assertTargetProfileRefs(diagnostic);
-            assert.equal(diagnostic.refs.operator, expr.includes('<<') ? '<<' : expr.match(/[&^|]/)![0]);
+            assert.equal(diagnostic.refs.operator, expectedBitwiseOperator(expr));
             assert.deepEqual(diagnostic.refs.operand_types, expectedTypes, expr);
             assert.deepEqual(diagnostic.refs.operand_type_sources, expectedSources, expr);
         }
+    });
+
+    it('keeps known int evidence when local expressions contain unknown variables', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+def float gain = 1.5;
+state Root {
+    state A { during { tmp = 1; flags = (tmp + 1) & gain; } }
+    [*] -> A;
+}
+`), 'W_NUMERIC_FLOAT_BITWISE');
+
+        assert.equal(diagnostics.length, 1);
+        assert.deepEqual(diagnostics[0].refs.operand_types, ['int', 'float']);
+        assert.deepEqual(diagnostics[0].refs.operand_type_sources, ['local_expression', 'declared_var']);
     });
 
     it('does not report int-shaped local expressions as float bitwise risks', async () => {

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -90,7 +90,7 @@ describe('diagnostics resources (PR-A)', () => {
             }
         });
 
-        it('contains C/C++ numeric partial-static diagnostics', () => {
+        it('contains C/C++ numeric static-pipeline diagnostics', () => {
             const registry = loadCodesRegistry();
             for (const code of numericCodes) {
                 const spec = registry[code];
@@ -98,8 +98,8 @@ describe('diagnostics resources (PR-A)', () => {
                 assert.equal(spec.severity, 'warning', `${code} must stay warning-level`);
                 assert.equal(
                     spec.emit_tier,
-                    'partial_static_pipeline',
-                    `${code} is emitted by the Python inspect analyzer before jsfcstm parity lands`
+                    'static_pipeline',
+                    `${code} must stay in the complete static inspect pipeline`
                 );
                 assert.equal(spec.span_object, 'expression', `${code} must identify an expression`);
                 assert.ok(spec.example_dsl, `${code} must keep a parseable example DSL contract`);

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -4,6 +4,16 @@ import {packageModule} from './support';
 
 const {loadCodesRegistry, loadInspectModelSchema} = packageModule;
 
+const numericCodes = [
+    'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+    'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_FLOAT_BITWISE',
+] as const;
+
+const cFamilyTargetTemplates = ['c', 'c_poll', 'cpp', 'cpp_poll'];
+const numericContexts = ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action'];
+
 describe('diagnostics resources (PR-A)', () => {
     describe('schema.json bundled', () => {
         it('loads as a valid JSON schema document', () => {
@@ -76,6 +86,67 @@ describe('diagnostics resources (PR-A)', () => {
             ]) {
                 assert.ok(registry[code], `${code} missing from bundled codes registry`);
             }
+        });
+
+        it('contains C/C++ numeric catalog-only diagnostics', () => {
+            const registry = loadCodesRegistry();
+            for (const code of numericCodes) {
+                const spec = registry[code];
+                assert.ok(spec, `${code} missing from bundled codes registry`);
+                assert.equal(spec.severity, 'warning', `${code} must stay warning-level`);
+                assert.equal(spec.emit_tier, 'catalog_only', `${code} must not emit before analyzers land`);
+                assert.equal(spec.span_object, 'expression', `${code} must identify an expression`);
+                assert.ok(spec.example_dsl, `${code} must keep a parseable example DSL contract`);
+                assert.ok(spec.for_llm, `${code} must keep LLM-facing guidance`);
+            }
+        });
+
+        it('locks numeric target-profile refs fields', () => {
+            const registry = loadCodesRegistry();
+            for (const code of numericCodes) {
+                const refs = registry[code].refs ?? {};
+                for (const field of ['target_family', 'target_templates', 'runtime_note', 'context', 'expr_text']) {
+                    assert.ok(refs[field], `${code} refs missing ${field}`);
+                    assert.equal(refs[field].required, true, `${code}.${field} must be required`);
+                }
+                assert.deepEqual(refs.target_family.enum, ['c_family']);
+                assert.equal(refs.target_templates.type, 'list[str]');
+                assert.deepEqual(refs.context.enum, numericContexts);
+            }
+        });
+
+        it('locks numeric rule-specific refs fields', () => {
+            const registry = loadCodesRegistry();
+
+            const literalRefs = registry.W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE.refs ?? {};
+            for (const field of ['literal_text', 'target_bits', 'signed', 'min_value_text', 'max_value_text']) {
+                assert.equal(literalRefs[field]?.required, true, `literal range refs missing required ${field}`);
+            }
+
+            const divRefs = registry.W_NUMERIC_CONSTANT_DIVISION_BY_ZERO.refs ?? {};
+            assert.equal(divRefs.operator?.required, true);
+            assert.deepEqual(divRefs.operator?.enum, ['/', '%']);
+            assert.equal(divRefs.rhs_text?.required, true);
+
+            const shiftRefs = registry.W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE.refs ?? {};
+            assert.equal(shiftRefs.operator?.required, true);
+            assert.deepEqual(shiftRefs.operator?.enum, ['<<', '>>']);
+            assert.equal(shiftRefs.target_bits?.required, true);
+            assert.equal(shiftRefs.shift_count_text?.required, true);
+
+            const bitwiseRefs = registry.W_NUMERIC_FLOAT_BITWISE.refs ?? {};
+            assert.equal(bitwiseRefs.operator?.required, true);
+            assert.deepEqual(bitwiseRefs.operator?.enum, ['&', '^', '|', '<<', '>>']);
+            assert.equal(bitwiseRefs.operand_types?.required, true);
+            assert.equal(bitwiseRefs.operand_type_sources?.required, true);
+            assert.deepEqual(bitwiseRefs.statement_kind?.enum, ['operation_assignment']);
+        });
+
+        it('does not predeclare deferred verify-guidance numeric codes', () => {
+            const registry = loadCodesRegistry();
+            assert.equal(registry.W_NUMERIC_SHIFT_REQUIRES_PROOF, undefined);
+            assert.equal(registry.I_NUMERIC_VERIFY_RECOMMENDED, undefined);
+            assert.deepEqual(cFamilyTargetTemplates, ['c', 'c_poll', 'cpp', 'cpp_poll']);
         });
     });
 });

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -90,13 +90,17 @@ describe('diagnostics resources (PR-A)', () => {
             }
         });
 
-        it('contains C/C++ numeric catalog-only diagnostics', () => {
+        it('contains C/C++ numeric partial-static diagnostics', () => {
             const registry = loadCodesRegistry();
             for (const code of numericCodes) {
                 const spec = registry[code];
                 assert.ok(spec, `${code} missing from bundled codes registry`);
                 assert.equal(spec.severity, 'warning', `${code} must stay warning-level`);
-                assert.equal(spec.emit_tier, 'catalog_only', `${code} must not emit before analyzers land`);
+                assert.equal(
+                    spec.emit_tier,
+                    'partial_static_pipeline',
+                    `${code} is emitted by the Python inspect analyzer before jsfcstm parity lands`
+                );
                 assert.equal(spec.span_object, 'expression', `${code} must identify an expression`);
                 assert.ok(spec.example_dsl, `${code} must keep a parseable example DSL contract`);
                 assert.ok(spec.for_llm, `${code} must keep LLM-facing guidance`);

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -13,6 +13,8 @@ const numericCodes = [
 
 const cFamilyTargetTemplates = ['c', 'c_poll', 'cpp', 'cpp_poll'];
 const numericContexts = ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action'];
+const operandTypes = ['int', 'float', 'unknown'];
+const operandTypeSources = ['literal', 'declared_var', 'local_expression'];
 
 describe('diagnostics resources (PR-A)', () => {
     describe('schema.json bundled', () => {
@@ -111,6 +113,9 @@ describe('diagnostics resources (PR-A)', () => {
                 }
                 assert.deepEqual(refs.target_family.enum, ['c_family']);
                 assert.equal(refs.target_templates.type, 'list[str]');
+                assert.deepEqual(refs.target_templates.item_enum, cFamilyTargetTemplates);
+                assert.deepEqual(refs.target_templates.exact_values, cFamilyTargetTemplates);
+                assert.ok(!refs.target_templates.exact_values?.includes('python'));
                 assert.deepEqual(refs.context.enum, numericContexts);
             }
         });
@@ -138,7 +143,9 @@ describe('diagnostics resources (PR-A)', () => {
             assert.equal(bitwiseRefs.operator?.required, true);
             assert.deepEqual(bitwiseRefs.operator?.enum, ['&', '^', '|', '<<', '>>']);
             assert.equal(bitwiseRefs.operand_types?.required, true);
+            assert.deepEqual(bitwiseRefs.operand_types?.item_enum, operandTypes);
             assert.equal(bitwiseRefs.operand_type_sources?.required, true);
+            assert.deepEqual(bitwiseRefs.operand_type_sources?.item_enum, operandTypeSources);
             assert.deepEqual(bitwiseRefs.statement_kind?.enum, ['operation_assignment']);
         });
 
@@ -146,7 +153,6 @@ describe('diagnostics resources (PR-A)', () => {
             const registry = loadCodesRegistry();
             assert.equal(registry.W_NUMERIC_SHIFT_REQUIRES_PROOF, undefined);
             assert.equal(registry.I_NUMERIC_VERIFY_RECOMMENDED, undefined);
-            assert.deepEqual(cFamilyTargetTemplates, ['c', 'c_poll', 'cpp', 'cpp_poll']);
         });
     });
 });

--- a/pyfcstm/diagnostics/README.md
+++ b/pyfcstm/diagnostics/README.md
@@ -66,3 +66,67 @@ object that the primary problem range is expected to identify. Some diagnostics
 allow reasonable precision differences across implementations: one side may
 cover an identifier while the other covers the containing declaration or
 transition, but both source slices must still hit the same problem object.
+
+## C/C++ deployment profile numeric contract
+
+The numeric diagnostics catalog also declares a target-specific contract for the
+current C/C++ family templates. This contract is intentionally separate from the
+core FCSTM model semantics: it describes risks that matter when a model is
+rendered into C/C++ generated code, not target-independent model errors.
+
+The default C/C++ deployment profile is:
+
+- `target_family`: `c_family`
+- `target_templates`: `c`, `c_poll`, `cpp`, `cpp_poll` in that order
+- DSL `int`: `PYFCSTM_GENERATED_INT64`, a 64-bit signed integer with range
+  `[-9223372036854775808, 9223372036854775807]`
+- DSL `float`: C/C++ `double`
+
+Python generated runtimes may not have the same risks. For example, Python
+integers are not bounded to this 64-bit C-family profile, and Python exception
+semantics for division by zero are not the same as a C/C++ deployment failure
+policy. Numeric diagnostic messages and `refs` payloads therefore must state the
+C/C++ target profile explicitly instead of reporting a generic FCSTM model
+error.
+
+### Numeric `refs` fields
+
+Every C/C++ numeric warning in the shared catalog carries these target fields:
+
+| Field | Contract |
+|---|---|
+| `target_family` | The string `c_family`. |
+| `target_templates` | The ordered list `c`, `c_poll`, `cpp`, `cpp_poll`; Python is not included. |
+| `runtime_note` | Human-readable note that distinguishes C/C++ deployment risk from Python generated runtime behavior. |
+| `context` | One of `var_initializer`, `guard`, `transition_effect`, `lifecycle_action`. |
+| `statement_kind` | Optional `operation_assignment` when the expression is an assignment right-hand side. |
+| `expr_text` | Source text for the expression shape being diagnosed. |
+
+Rule-specific fields are declared in `codes.yaml`. The first C/C++ numeric
+contract covers:
+
+- integer literals outside the default signed 64-bit range;
+- constant `/` or `%` with a right-hand side that folds to zero;
+- constant shift counts outside `0 <= count < 64`;
+- float-shaped operands in bitwise or shift operators.
+
+For the signed 64-bit boundary, a unary sign is interpreted together with the
+literal for contract classification: `9223372036854775808` is outside the upper
+bound, `-9223372036854775808` is the legal lower bound spelling, and
+`-9223372036854775809` is below the lower bound.
+
+### Lightweight constant folding boundary
+
+The numeric contract only assumes a lightweight, literal-only constant folder.
+It may fold numeric literals, unary `+` / `-`, parentheses, and literal-only
+uses of `+`, `-`, `*`, `/`, `%`, `<<`, `>>`, `&`, `^`, and `|` when both ends can
+represent the result consistently. It must not fold through division by zero,
+negative shifts, oversized shifts, variables, function calls, cross-statement
+constant propagation, block-local temporary inference, or algebraic rewrites such
+as `a - a` and `0 * x`.
+
+The shared catalog may contain `catalog_only` numeric codes. Those entries freeze
+code names and `refs` payloads before pyfcstm or jsfcstm emitters exist. They are
+not expected from `inspect_model()` or jsfcstm diagnostics until the corresponding
+analyzers land; tests for those entries should validate the catalog contract and
+parseable examples, not runtime emission.

--- a/pyfcstm/diagnostics/README.md
+++ b/pyfcstm/diagnostics/README.md
@@ -125,9 +125,10 @@ negative shifts, oversized shifts, variables, function calls, cross-statement
 constant propagation, block-local temporary inference, or algebraic rewrites such
 as `a - a` and `0 * x`.
 
-The first Python numeric analyzer emits these warnings from `inspect_model()`
-under `emit_tier: partial_static_pipeline`. In this tier, the Python static
-inspect pipeline has landed while jsfcstm parity is still a follow-up task. Tests
-for these entries must therefore validate both the shared catalog contract and
-Python runtime emission, while jsfcstm-side behavior stays out of scope until its
-matching analyzer lands.
+The numeric analyzer now emits these warnings under
+`emit_tier: static_pipeline` on both pyfcstm and jsfcstm. Tests for these entries
+must validate the shared catalog contract, Python `inspect_model()` /
+`build_inspect_json()` output, jsfcstm `inspectModel()` output, and the
+`collectDocumentDiagnostics()` editor surface. Numeric warnings are still
+C/C++ deployment-profile diagnostics: Python generated runtimes are documented as
+a different target semantics rather than part of the C/C++ target set.

--- a/pyfcstm/diagnostics/README.md
+++ b/pyfcstm/diagnostics/README.md
@@ -125,8 +125,9 @@ negative shifts, oversized shifts, variables, function calls, cross-statement
 constant propagation, block-local temporary inference, or algebraic rewrites such
 as `a - a` and `0 * x`.
 
-The shared catalog may contain `catalog_only` numeric codes. Those entries freeze
-code names and `refs` payloads before pyfcstm or jsfcstm emitters exist. They are
-not expected from `inspect_model()` or jsfcstm diagnostics until the corresponding
-analyzers land; tests for those entries should validate the catalog contract and
-parseable examples, not runtime emission.
+The first Python numeric analyzer emits these warnings from `inspect_model()`
+under `emit_tier: partial_static_pipeline`. In this tier, the Python static
+inspect pipeline has landed while jsfcstm parity is still a follow-up task. Tests
+for these entries must therefore validate both the shared catalog contract and
+Python runtime emission, while jsfcstm-side behavior stays out of scope until its
+matching analyzer lands.

--- a/pyfcstm/diagnostics/analyzers/__init__.py
+++ b/pyfcstm/diagnostics/analyzers/__init__.py
@@ -1,4 +1,34 @@
-"""Analyzer helpers for :mod:`pyfcstm.diagnostics.inspect`."""
+"""
+Inspect analyzer package map.
+
+This package groups the small, composable analyzers used by
+:func:`pyfcstm.diagnostics.inspect.inspect_model`. Each analyzer owns one
+well-bounded diagnostic concern and returns structured
+:class:`pyfcstm.utils.validate.ModelDiagnostic` objects for the design-health
+pipeline.
+
+.. list-table:: Analyzer modules
+   :header-rows: 1
+
+   * - Module
+     - Responsibility
+   * - :mod:`pyfcstm.diagnostics.analyzers.const_fold`
+     - Literal-only constant-folding diagnostics.
+   * - :mod:`pyfcstm.diagnostics.analyzers.numeric`
+     - C/C++ deployment-profile numeric diagnostics.
+   * - :mod:`pyfcstm.diagnostics.analyzers.design_health`
+     - Aggregates analyzer outputs into the default inspect warning set.
+   * - :mod:`pyfcstm.diagnostics.analyzers.data_flow`
+     - Variable read/write and guard-affect data-flow diagnostics.
+   * - :mod:`pyfcstm.diagnostics.analyzers.structural`
+     - State and transition topology diagnostics.
+
+Example::
+
+    >>> from pyfcstm.diagnostics.analyzers import collect_numeric_warnings
+    >>> collect_numeric_warnings(None)
+    []
+"""
 
 from .const_fold import (
     collect_const_fold_warnings,
@@ -7,6 +37,7 @@ from .const_fold import (
 )
 from .design_health import collect_design_health_warnings
 from .naming import collect_naming_warnings
+from .numeric import collect_numeric_warnings
 from .thresholds import collect_threshold_warnings
 from .transition_info import collect_transition_infos
 from .type_shape import collect_type_warnings
@@ -18,6 +49,7 @@ __all__ = [
     'fold_condition_expression',
     'fold_numeric_expression',
     'collect_naming_warnings',
+    'collect_numeric_warnings',
     'collect_threshold_warnings',
     'collect_transition_infos',
     'collect_type_warnings',

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -9,6 +9,7 @@ from ...utils.validate import ModelDiagnostic
 from .const_fold import collect_const_fold_warnings
 from .data_flow import collect_data_flow_warnings
 from .naming import collect_naming_warnings
+from .numeric import collect_numeric_warnings
 from .redundancy import collect_redundancy_warnings
 from .structural import collect_structural_warnings
 from .thresholds import collect_threshold_warnings
@@ -83,6 +84,7 @@ def collect_design_health_warnings(
     diagnostics.extend(collect_data_flow_warnings(variables, machine))
     diagnostics.extend(collect_redundancy_warnings(transitions, events, states))
     diagnostics.extend(collect_transition_infos(states, transitions))
+    diagnostics.extend(collect_numeric_warnings(machine))
     return _with_suggested_fixes(diagnostics)
 
 

--- a/pyfcstm/diagnostics/analyzers/numeric.py
+++ b/pyfcstm/diagnostics/analyzers/numeric.py
@@ -1,0 +1,476 @@
+"""
+C/C++ deployment-profile numeric diagnostics.
+
+This module implements the lightweight numeric analyzer used by
+:func:`pyfcstm.diagnostics.inspect.inspect_model`. The analyzer is target
+profile aware: each warning describes a risk for the default C/C++ generated
+runtime profile rather than a target-independent FCSTM model error.
+
+The module contains:
+
+* :func:`collect_numeric_warnings` - Collect deterministic numeric warnings
+  from a state-machine model.
+
+.. note::
+   The analyzer deliberately avoids variable range solving, cross-statement
+   propagation, SMT checks, and generated-code policy changes. Those belong
+   to the verify and code-generation tracks.
+"""
+
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
+
+from ...utils.validate import ModelDiagnostic, Span
+from .const_fold import fold_numeric_expression
+
+if TYPE_CHECKING:  # pragma: no cover - type-checking imports only.
+    from ...model.expr import Expr
+    from ...model.model import OperationStatement, StateMachine
+
+
+_TARGET_FAMILY = "c_family"
+_TARGET_TEMPLATES = ["c", "c_poll", "cpp", "cpp_poll"]
+_TARGET_BITS = 64
+_MIN_SIGNED_INT64 = -(2**63)
+_MAX_SIGNED_INT64 = 2**63 - 1
+_MIN_SIGNED_INT64_TEXT = str(_MIN_SIGNED_INT64)
+_MAX_SIGNED_INT64_TEXT = str(_MAX_SIGNED_INT64)
+_BITWISE_OPERATORS = {"&", "^", "|", "<<", ">>"}
+_NUMERIC_RESULT_OPERATORS = {"+", "-", "*", "/", "%", "**", "&", "^", "|", "<<", ">>"}
+_ZERO_OPERATORS = {"/", "%"}
+_SHIFT_OPERATORS = {"<<", ">>"}
+_RUNTIME_NOTES = {
+    "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE": (
+        "C/C++ deployment profile risk: the default C-family templates use "
+        "PYFCSTM_GENERATED_INT64, while Python generated runtimes may not have "
+        "the same fixed-width integer carrying risk."
+    ),
+    "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO": (
+        "C/C++ deployment profile risk: generated C/C++ code needs an explicit "
+        "division-by-zero or modulo-by-zero policy, while Python generated "
+        "runtimes use different exception semantics."
+    ),
+    "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE": (
+        "C/C++ deployment profile risk: the default C-family integer width is "
+        "64 bits, while Python generated runtimes may not have the same "
+        "fixed-width shift risk."
+    ),
+    "W_NUMERIC_FLOAT_BITWISE": (
+        "C/C++ integer-operation profile risk: bitwise and shift operators are "
+        "integer operations in the generated C-family templates; Python "
+        "generated runtimes may fail for a different reason."
+    ),
+}
+
+
+class _Context:
+    """One expression location scanned by the numeric analyzer."""
+
+    def __init__(
+        self,
+        expr: "Expr",
+        context: str,
+        span: Optional[Span],
+        statement_kind: Optional[str] = None,
+        var_name: Optional[str] = None,
+    ) -> None:
+        self.expr = expr
+        self.context = context
+        self.span = span
+        self.statement_kind = statement_kind
+        self.var_name = var_name
+
+
+def collect_numeric_warnings(
+    machine: Optional["StateMachine"],
+) -> List[ModelDiagnostic]:
+    """
+    Collect C/C++ deployment-profile numeric warnings for a model.
+
+    :param machine: State-machine model to inspect. ``None`` is accepted so
+        callers can mirror other analyzer entry points during defensive
+        composition.
+    :type machine: Optional[pyfcstm.model.StateMachine]
+    :return: Numeric warnings in model traversal order.
+    :rtype: List[pyfcstm.utils.validate.ModelDiagnostic]
+
+    Examples::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... def int too_large = 9223372036854775808;
+        ... state Root { state A; [*] -> A; }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, 'state_machine_dsl')
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> collect_numeric_warnings(machine)[0].code
+        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE'
+    """
+    if machine is None:
+        return []
+    var_types = {name: var_define.type for name, var_define in machine.defines.items()}
+    diagnostics: List[ModelDiagnostic] = []
+    for context in _iter_expression_contexts(machine):
+        diagnostics.extend(_diagnostics_for_expr(context, var_types))
+    return diagnostics
+
+
+def _diagnostics_for_expr(
+    context: _Context,
+    var_types: Dict[str, str],
+) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    signed_literal_children = _signed_literal_child_ids(context.expr)
+    for expr in _walk_expressions(context.expr):
+        if id(expr) not in signed_literal_children:
+            diagnostics.extend(_literal_range_diagnostic(context, expr))
+        diagnostics.extend(_constant_zero_division_diagnostic(context, expr))
+        diagnostics.extend(_shift_count_diagnostic(context, expr))
+        diagnostics.extend(_float_bitwise_diagnostic(context, expr, var_types))
+    return diagnostics
+
+
+def _iter_expression_contexts(machine: "StateMachine") -> Iterable[_Context]:
+    for var_name, var_define in machine.defines.items():
+        yield _Context(
+            var_define.init,
+            "var_initializer",
+            getattr(var_define, "_span", None),
+            var_name=var_name,
+        )
+
+    for state in machine.walk_states():
+        for transition in state.transitions:
+            if transition.guard is not None:
+                yield _Context(
+                    transition.guard,
+                    "guard",
+                    getattr(transition, "_span", None),
+                )
+            for stmt in transition.effects:
+                yield from _iter_statement_expression_contexts(
+                    stmt,
+                    "transition_effect",
+                )
+        for action in _iter_concrete_actions(state):
+            for stmt in action.operations:
+                yield from _iter_statement_expression_contexts(
+                    stmt,
+                    "lifecycle_action",
+                )
+
+
+def _iter_concrete_actions(state):
+    for collection in (
+        state.on_enters,
+        state.on_durings,
+        state.on_exits,
+        state.on_during_aspects,
+    ):
+        for action in collection:
+            if action.is_abstract or action.is_ref:
+                continue
+            yield action
+
+
+def _iter_statement_expression_contexts(
+    stmt: "OperationStatement",
+    context: str,
+) -> Iterable[_Context]:
+    from ...model.model import IfBlock, Operation
+
+    if isinstance(stmt, Operation):
+        yield _Context(
+            stmt.expr,
+            context,
+            getattr(stmt, "_span", None),
+            statement_kind="operation_assignment",
+            var_name=stmt.var_name,
+        )
+        return
+    if isinstance(stmt, IfBlock):
+        for branch in stmt.branches:
+            if branch.condition is not None:
+                yield _Context(
+                    branch.condition,
+                    context,
+                    getattr(branch, "_span", None),
+                )
+            for inner in branch.statements:
+                yield from _iter_statement_expression_contexts(inner, context)
+
+
+def _walk_expressions(expr: "Expr") -> Iterable["Expr"]:
+    yield expr
+    for child in expr._iter_subs():
+        yield from _walk_expressions(child)
+
+
+def _signed_literal_child_ids(expr: "Expr") -> set:
+    from ...model.expr import Integer, UnaryOp
+
+    out = set()
+    for item in _walk_expressions(expr):
+        if (
+            isinstance(item, UnaryOp)
+            and item.op in {"+", "-"}
+            and isinstance(item.x, Integer)
+        ):
+            out.add(id(item.x))
+    return out
+
+
+def _literal_range_diagnostic(
+    context: _Context,
+    expr: "Expr",
+) -> List[ModelDiagnostic]:
+    literal = _signed_integer_literal(expr)
+    if literal is None:
+        return []
+    literal_text, literal_value = literal
+    if _MIN_SIGNED_INT64 <= literal_value <= _MAX_SIGNED_INT64:
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "literal_text": literal_text,
+            "target_bits": _TARGET_BITS,
+            "signed": True,
+            "min_value_text": _MIN_SIGNED_INT64_TEXT,
+            "max_value_text": _MAX_SIGNED_INT64_TEXT,
+        }
+    )
+    if context.var_name is not None:
+        refs["var_name"] = context.var_name
+    return [
+        _diagnostic(
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            (
+                "C/C++ default deployment profile risk: integer literal "
+                f"{literal_text} is outside the PYFCSTM_GENERATED_INT64 range "
+                f"[{_MIN_SIGNED_INT64_TEXT}, {_MAX_SIGNED_INT64_TEXT}]; "
+                "Python generated runtimes may not have the same fixed-width risk."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _constant_zero_division_diagnostic(
+    context: _Context,
+    expr: "Expr",
+) -> List[ModelDiagnostic]:
+    from ...model.expr import BinaryOp
+
+    if not isinstance(expr, BinaryOp) or expr.op not in _ZERO_OPERATORS:
+        return []
+    rhs_value = fold_numeric_expression(expr.y)
+    if rhs_value is None or rhs_value != 0:
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "operator": expr.op,
+            "rhs_text": _expr_text(expr.y),
+        }
+    )
+    return [
+        _diagnostic(
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            (
+                "C/C++ default deployment profile risk: the RHS of operator "
+                f"{expr.op!r} folds to 0; generated C/C++ code needs an explicit "
+                "failure policy, while Python runtime exception semantics differ."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _shift_count_diagnostic(
+    context: _Context,
+    expr: "Expr",
+) -> List[ModelDiagnostic]:
+    from ...model.expr import BinaryOp
+
+    if not isinstance(expr, BinaryOp) or expr.op not in _SHIFT_OPERATORS:
+        return []
+    rhs_value = fold_numeric_expression(expr.y)
+    if (
+        rhs_value is None
+        or not _plain_number(rhs_value)
+        or not (rhs_value < 0 or rhs_value >= _TARGET_BITS)
+    ):
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "operator": expr.op,
+            "target_bits": _TARGET_BITS,
+            "shift_count_text": _number_text(rhs_value),
+        }
+    )
+    return [
+        _diagnostic(
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            (
+                "C/C++ default deployment profile risk: the shift count of "
+                f"operator {expr.op!r} folds to {_number_text(rhs_value)}, "
+                f"outside 0 <= count < {_TARGET_BITS}; Python generated runtimes "
+                "do not represent the same fixed-width shift contract."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _float_bitwise_diagnostic(
+    context: _Context,
+    expr: "Expr",
+    var_types: Dict[str, str],
+) -> List[ModelDiagnostic]:
+    from ...model.expr import BinaryOp
+
+    if not isinstance(expr, BinaryOp) or expr.op not in _BITWISE_OPERATORS:
+        return []
+    left = _infer_numeric_type(expr.x, var_types)
+    right = _infer_numeric_type(expr.y, var_types)
+    if left[0] != "float" and right[0] != "float":
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_FLOAT_BITWISE",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "operator": expr.op,
+            "operand_types": [left[0], right[0]],
+            "operand_type_sources": [left[1], right[1]],
+        }
+    )
+    return [
+        _diagnostic(
+            "W_NUMERIC_FLOAT_BITWISE",
+            (
+                "C/C++ default deployment profile risk: a float-shaped operand "
+                f"participates in integer bitwise or shift operator {expr.op!r}; "
+                "C-family templates generate integer operations, while Python "
+                "runtime failures have different semantics."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _infer_numeric_type(
+    expr: "Expr",
+    var_types: Dict[str, str],
+) -> Tuple[str, str]:
+    from ...model.expr import BinaryOp, Float, Integer, UnaryOp, Variable
+
+    if isinstance(expr, Float):
+        return "float", "literal"
+    if isinstance(expr, Integer):
+        return "int", "literal"
+    if isinstance(expr, Variable):
+        declared = var_types.get(expr.name)
+        if declared == "float":
+            return "float", "declared_var"
+        if declared == "int":
+            return "int", "declared_var"
+        return "unknown", "declared_var"
+    if isinstance(expr, UnaryOp) and expr.op in {"+", "-"}:
+        inner_type, inner_source = _infer_numeric_type(expr.x, var_types)
+        if inner_type in {"int", "float"}:
+            return inner_type, inner_source
+        return "unknown", "local_expression"
+    if isinstance(expr, BinaryOp):
+        if expr.op not in _NUMERIC_RESULT_OPERATORS:
+            return "unknown", "local_expression"
+        left_type, _ = _infer_numeric_type(expr.x, var_types)
+        right_type, _ = _infer_numeric_type(expr.y, var_types)
+        if left_type == "float" or right_type == "float":
+            return "float", "local_expression"
+        if left_type == "int" and right_type == "int":
+            if expr.op in {"/", "**"}:
+                return "unknown", "local_expression"
+            return "int", "local_expression"
+    return "unknown", "local_expression"
+
+
+def _signed_integer_literal(expr: "Expr") -> Optional[Tuple[str, int]]:
+    from ...model.expr import Integer, UnaryOp
+
+    if isinstance(expr, Integer):
+        return str(expr.value), expr.value
+    if isinstance(expr, UnaryOp) and isinstance(expr.x, Integer):
+        if expr.op == "-":
+            return "-" + str(expr.x.value), -expr.x.value
+        if expr.op == "+":
+            return "+" + str(expr.x.value), expr.x.value
+    return None
+
+
+def _base_refs(
+    code: str,
+    context: _Context,
+    expr_text: Optional[str],
+) -> Dict[str, object]:
+    refs: Dict[str, object] = {
+        "target_family": _TARGET_FAMILY,
+        "target_templates": list(_TARGET_TEMPLATES),
+        "runtime_note": _RUNTIME_NOTES[code],
+        "context": context.context,
+        "expr_text": expr_text or "",
+    }
+    if context.statement_kind is not None:
+        refs["statement_kind"] = context.statement_kind
+    return refs
+
+
+def _diagnostic(
+    code: str,
+    message: str,
+    span: Optional[Span],
+    refs: Dict[str, object],
+) -> ModelDiagnostic:
+    return ModelDiagnostic(
+        code=code,
+        severity="warning",
+        message=message,
+        span=span,
+        refs=refs,
+    )
+
+
+def _expr_text(expr: Optional["Expr"]) -> Optional[str]:
+    from ..inspect import _expr_text as render_expr_text
+
+    return render_expr_text(expr)
+
+
+def _plain_number(value) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _number_text(value) -> str:
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)

--- a/pyfcstm/diagnostics/analyzers/numeric.py
+++ b/pyfcstm/diagnostics/analyzers/numeric.py
@@ -35,8 +35,21 @@ _MAX_SIGNED_INT64 = 2**63 - 1
 _MIN_SIGNED_INT64_TEXT = str(_MIN_SIGNED_INT64)
 _MAX_SIGNED_INT64_TEXT = str(_MAX_SIGNED_INT64)
 _BITWISE_OPERATORS = {"&", "^", "|", "<<", ">>"}
-_NUMERIC_RESULT_OPERATORS = {"+", "-", "*", "/", "%", "**", "&", "^", "|", "<<", ">>"}
 _ZERO_OPERATORS = {"/", "%"}
+_C_FAMILY_INTEGER_UFUNCS = {"ceil", "floor", "int", "round", "sign", "trunc"}
+_C_FAMILY_CONDITION_OPERATORS = {
+    "&&",
+    "||",
+    "=>",
+    "xor",
+    "iff",
+    "==",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+}
 _SHIFT_OPERATORS = {"<<", ">>"}
 _RUNTIME_NOTES = {
     "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE": (
@@ -383,12 +396,13 @@ def _infer_numeric_type(
     expr: "Expr",
     var_types: Dict[str, str],
 ) -> Tuple[str, str]:
-    from ...model.expr import BinaryOp, Float, Integer, UnaryOp, Variable
+    from ...model.expr import BinaryOp, Boolean, ConditionalOp, Float, Integer
+    from ...model.expr import UnaryOp, UFunc, Variable
 
+    if isinstance(expr, (Boolean, Integer)):
+        return "int", "literal"
     if isinstance(expr, Float):
         return "float", "literal"
-    if isinstance(expr, Integer):
-        return "int", "literal"
     if isinstance(expr, Variable):
         declared = var_types.get(expr.name)
         if declared == "float":
@@ -396,23 +410,42 @@ def _infer_numeric_type(
         if declared == "int":
             return "int", "declared_var"
         return "unknown", "declared_var"
-    if isinstance(expr, UnaryOp) and expr.op in {"+", "-"}:
+    if isinstance(expr, UnaryOp):
         inner_type, inner_source = _infer_numeric_type(expr.x, var_types)
         if inner_type in {"int", "float"}:
             return inner_type, inner_source
         return "unknown", "local_expression"
-    if isinstance(expr, BinaryOp):
-        if expr.op not in _NUMERIC_RESULT_OPERATORS:
-            return "unknown", "local_expression"
-        left_type, _ = _infer_numeric_type(expr.x, var_types)
-        right_type, _ = _infer_numeric_type(expr.y, var_types)
-        if left_type == "float" or right_type == "float":
-            return "float", "local_expression"
-        if left_type == "int" and right_type == "int":
-            if expr.op in {"/", "**"}:
-                return "unknown", "local_expression"
+    if isinstance(expr, UFunc):
+        if expr.func in _C_FAMILY_INTEGER_UFUNCS:
             return "int", "local_expression"
+        if expr.func == "abs":
+            inner_type, _inner_source = _infer_numeric_type(expr.x, var_types)
+            if inner_type in {"int", "float"}:
+                return inner_type, "local_expression"
+            return "unknown", "local_expression"
+        return "float", "local_expression"
+    if isinstance(expr, BinaryOp):
+        if expr.op in _BITWISE_OPERATORS or expr.op in _C_FAMILY_CONDITION_OPERATORS:
+            return "int", "local_expression"
+        if expr.op == "/":
+            return "float", "local_expression"
+        left_type, _left_source = _infer_numeric_type(expr.x, var_types)
+        right_type, _right_source = _infer_numeric_type(expr.y, var_types)
+        return _merge_numeric_types(left_type, right_type), "local_expression"
+    if isinstance(expr, ConditionalOp):
+        true_type, _true_source = _infer_numeric_type(expr.if_true, var_types)
+        false_type, _false_source = _infer_numeric_type(expr.if_false, var_types)
+        return _merge_numeric_types(true_type, false_type), "local_expression"
     return "unknown", "local_expression"
+
+
+def _merge_numeric_types(type_a: str, type_b: str) -> str:
+    known = {type_a, type_b} - {"unknown"}
+    if "float" in known:
+        return "float"
+    if known == {"int"}:
+        return "int"
+    return "unknown"
 
 
 def _signed_integer_literal(expr: "Expr") -> Optional[Tuple[str, int]]:

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -98,11 +98,16 @@ _ALLOWED_CAPABILITIES = (
 #: * ``verify_pipeline`` — emitted only by the optional Python verify /
 #:   inspect adapter path. These codes are not part of the default static
 #:   inspect output and are not expected from jsfcstm.
+#: * ``catalog_only`` — declared in the shared catalog as a cross-end
+#:   contract but not emitted by any runtime pipeline yet. This is used when
+#:   a diagnostic contract must be frozen before the concrete pyfcstm /
+#:   jsfcstm analyzers land.
 _ALLOWED_EMIT_TIERS = (
     'static_pipeline',
     'lookup_api',
     'partial_static_pipeline',
     'verify_pipeline',
+    'catalog_only',
 )
 
 _ALLOWED_SUGGESTED_FIX_KINDS = ('insert', 'delete', 'replace')
@@ -288,8 +293,9 @@ class CodeSpec:
         end only (typically jsfcstm) — downstream LLM consumers should
         not block waiting for the missing end. ``'verify_pipeline'`` marks
         diagnostics emitted only by optional Python verify integration.
-        The field lets dispatchers register handlers based on the actual
-        emit channel.
+        ``'catalog_only'`` marks a shared catalog contract that no runtime
+        pipeline emits yet. The field lets dispatchers register handlers
+        based on the actual emit channel.
     :type emit_tier: str, optional
     :param span_object: Semantic source object identified by the primary
         diagnostic span. Repository entries declare this to make source-slice

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -193,6 +193,26 @@ class CodeFieldSpec:
         runtime validator) checks that ``refs[field]`` is a member of the
         tuple. ``None`` means the field has no enumeration constraint.
     :type enum: Optional[Tuple[str, ...]]
+    :param item_enum: Optional tuple of allowed string values for items in a
+        ``list[str]`` field. ``None`` means list members are unconstrained
+        beyond being strings.
+    :type item_enum: Optional[Tuple[str, ...]]
+    :param exact_values: Optional exact ordered value contract for a
+        ``list[str]`` field. ``None`` means the list may contain any ordered
+        members allowed by ``item_enum`` and the base type token.
+    :type exact_values: Optional[Tuple[str, ...]]
+
+    Example::
+
+        >>> spec = CodeFieldSpec(
+        ...     name='target_templates',
+        ...     type='list[str]',
+        ...     required=True,
+        ...     description='Target templates.',
+        ...     exact_values=('c', 'c_poll'),
+        ... )
+        >>> spec.exact_values
+        ('c', 'c_poll')
     """
 
     name: str
@@ -200,6 +220,8 @@ class CodeFieldSpec:
     required: bool
     description: str
     enum: Optional[Tuple[str, ...]] = None
+    item_enum: Optional[Tuple[str, ...]] = None
+    exact_values: Optional[Tuple[str, ...]] = None
 
 
 @dataclass(frozen=True)
@@ -328,6 +350,67 @@ def _ctx(path: str, *bits: str) -> str:
     return f"codes.yaml at {path!r}: " + " ".join(bits)
 
 
+def _validate_string_list_field(
+        path: str,
+        code: str,
+        field_name: str,
+        raw: Mapping[str, Any],
+        key: str,
+) -> Optional[Tuple[str, ...]]:
+    """
+    Validate an optional string-list schema attribute.
+
+    :param path: Filesystem path for diagnostics in error messages.
+    :type path: str
+    :param code: Diagnostic code currently being loaded.
+    :type code: str
+    :param field_name: Refs field name currently being loaded.
+    :type field_name: str
+    :param raw: Raw YAML mapping for the refs field.
+    :type raw: Mapping[str, Any]
+    :param key: Attribute name to validate.
+    :type key: str
+    :return: Tuple of string values when present, otherwise ``None``.
+    :rtype: Optional[Tuple[str, ...]]
+    :raises CodesSchemaError: If ``key`` is present but is not a non-empty
+        YAML list of strings.
+
+    Example::
+
+        >>> _validate_string_list_field(
+        ...     'codes.yaml',
+        ...     'W_DEMO',
+        ...     'target_templates',
+        ...     {'exact_values': ['c', 'c_poll']},
+        ...     'exact_values',
+        ... )
+        ('c', 'c_poll')
+    """
+    raw_values = raw.get(key)
+    if raw_values is None:
+        return None
+    if not isinstance(raw_values, list):
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} {key!r} must be a list "
+            f"when present, got {type(raw_values).__name__}.",
+        ))
+    if not raw_values:
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} {key!r} must be non-empty "
+            f"when present.",
+        ))
+    for value in raw_values:
+        if not isinstance(value, str):
+            raise CodesSchemaError(_ctx(
+                path,
+                f"code {code!r} field {field_name!r} {key!r} members must "
+                f"be strings, got {type(value).__name__}: {value!r}.",
+            ))
+    return tuple(raw_values)
+
+
 def _validate_field(path: str, code: str, field_name: str, raw: Any) -> CodeFieldSpec:
     if not isinstance(raw, dict):
         raise CodesSchemaError(_ctx(
@@ -359,30 +442,41 @@ def _validate_field(path: str, code: str, field_name: str, raw: Any) -> CodeFiel
         ))
     description = str(raw.get('description', ''))
 
-    raw_enum = raw.get('enum')
-    field_enum: Optional[Tuple[str, ...]] = None
-    if raw_enum is not None:
-        if not isinstance(raw_enum, list):
+    field_enum = _validate_string_list_field(path, code, field_name, raw, 'enum')
+    item_enum = _validate_string_list_field(path, code, field_name, raw, 'item_enum')
+    exact_values = _validate_string_list_field(
+        path,
+        code,
+        field_name,
+        raw,
+        'exact_values',
+    )
+    if field_enum is not None and field_type != 'str':
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} 'enum' may only be used "
+            f"with type 'str', got {field_type!r}.",
+        ))
+    if item_enum is not None and field_type != 'list[str]':
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} 'item_enum' may only be "
+            f"used with type 'list[str]', got {field_type!r}.",
+        ))
+    if exact_values is not None and field_type != 'list[str]':
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} 'exact_values' may only be "
+            f"used with type 'list[str]', got {field_type!r}.",
+        ))
+    if item_enum is not None and exact_values is not None:
+        extra = set(exact_values) - set(item_enum)
+        if extra:
             raise CodesSchemaError(_ctx(
                 path,
-                f"code {code!r} field {field_name!r} 'enum' must be a list "
-                f"when present,",
-                f"got {type(raw_enum).__name__}",
+                f"code {code!r} field {field_name!r} 'exact_values' contains "
+                f"members outside 'item_enum': {sorted(extra)!r}.",
             ))
-        if not raw_enum:
-            raise CodesSchemaError(_ctx(
-                path,
-                f"code {code!r} field {field_name!r} 'enum' must be non-empty "
-                f"when present.",
-            ))
-        for value in raw_enum:
-            if not isinstance(value, str):
-                raise CodesSchemaError(_ctx(
-                    path,
-                    f"code {code!r} field {field_name!r} 'enum' members must "
-                    f"be strings, got {type(value).__name__}: {value!r}",
-                ))
-        field_enum = tuple(raw_enum)
 
     return CodeFieldSpec(
         name=field_name,
@@ -390,6 +484,8 @@ def _validate_field(path: str, code: str, field_name: str, raw: Any) -> CodeFiel
         required=raw_required,
         description=description,
         enum=field_enum,
+        item_enum=item_enum,
+        exact_values=exact_values,
     )
 
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -2078,7 +2078,7 @@ W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     An integer literal that would be rendered into a C/C++ family template
     falls outside the default ``PYFCSTM_GENERATED_INT64`` signed range. This
@@ -2165,7 +2165,7 @@ W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     A ``/`` or ``%`` operation has a right-hand side that the lightweight
     literal-only constant folder can classify as zero. This is reported as a
@@ -2244,7 +2244,7 @@ W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     A shift count folds to a constant below zero or not less than the default
     C/C++ target integer width. This is a C/C++ 64-bit deployment-profile
@@ -2325,7 +2325,7 @@ W_NUMERIC_FLOAT_BITWISE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     A value known to be ``float`` participates in a bitwise or shift operator
     that belongs to the C/C++ integer operation profile. The warning is

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -23,9 +23,11 @@
 # is documentation; a test asserts the two stay aligned):
 #   str | str_or_null | int | int_or_null | float | number | bool | dict | Span | list[str] | list[Span]
 #
-# Adding a new code: append a new top-level entry here AND add a fixture
-# test that triggers it from a real DSL snippet. The loader in `codes.py`
-# verifies the schema at import time.
+# Adding a new emitted code: append a new top-level entry here AND add a
+# fixture test that triggers it from a real DSL snippet. Catalog-only
+# contract codes may instead provide a parseable DSL snippet that documents
+# the intended trigger shape before the emitting analyzer lands. The loader
+# in `codes.py` verifies the schema at import time.
 
 E_UNDEFINED_VAR:
   severity: error
@@ -2065,6 +2067,335 @@ W_LITERAL_TYPE_NARROWING:
   example_dsl: |
     def int truncated = 3.5;
     state Root { state A; [*] -> A; }
+
+# ---------------------------------------------------------------------------
+# C/C++ deployment-profile numeric diagnostics catalog contract.
+# ---------------------------------------------------------------------------
+
+W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
+  severity: warning
+  span_object: expression
+  capability: pure_static
+  emit_tier: catalog_only
+  description: >-
+    An integer literal that would be rendered into a C/C++ family template
+    falls outside the default ``PYFCSTM_GENERATED_INT64`` signed range. This
+    warning is target-profile-specific: Python generated runtimes may not have
+    the same fixed-width integer carrying risk.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ deployment-profile risk and
+        that Python generated runtimes may not have the same risk.
+    context:
+      type: str
+      required: true
+      description: Expression location where the literal appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the expression containing the literal.
+    literal_text:
+      type: str
+      required: true
+      description: Source text of the integer literal after applying a unary sign when present.
+    target_bits:
+      type: int
+      required: true
+      description: Target integer width in bits.
+    signed:
+      type: bool
+      required: true
+      description: Whether the target integer profile is signed.
+    min_value_text:
+      type: str
+      required: true
+      description: Decimal text of the minimum representable target value.
+    max_value_text:
+      type: str
+      required: true
+      description: Decimal text of the maximum representable target value.
+    var_name:
+      type: str
+      required: false
+      description: Variable receiving the literal when the location can be named.
+  for_llm:
+    summary: >-
+      A literal intended for C/C++ generated code exceeds the default 64-bit
+      signed integer profile. Treat this as a C/C++ deployment-profile warning,
+      not as proof that Python generated code is invalid.
+    recommended_actions:
+      - kind: reduce_literal
+        target: expression
+        rationale: Keep integer literals within the documented C/C++ target range when deploying to C-family templates.
+      - kind: choose_target_profile
+        target: deployment_plan
+        rationale: If the large value is intentional, document or verify a target profile that can carry it before generating C/C++ code.
+    do_not:
+      - "Do not describe this as a target-independent FCSTM model error; the risk is tied to the C/C++ default integer profile."
+      - "Do not flag the legal lower-bound spelling ``-9223372036854775808`` as out of range."
+  example_dsl: |
+    def int too_large = 9223372036854775808;
+    state Root { state A; [*] -> A; }
+
+W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
+  severity: warning
+  span_object: expression
+  capability: const_fold
+  emit_tier: catalog_only
+  description: >-
+    A ``/`` or ``%`` operation has a right-hand side that the lightweight
+    literal-only constant folder can classify as zero. This is reported as a
+    C/C++ deployment-profile risk because generated C/C++ code needs an
+    explicit definition or failure channel; Python runtime exception semantics
+    are different.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ deployment-profile risk and
+        that Python generated runtimes may not have the same failure contract.
+    context:
+      type: str
+      required: true
+      description: Expression location where the operator appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the expression containing the operation.
+    operator:
+      type: str
+      required: true
+      description: Operator whose right-hand side folded to zero.
+      enum: ['/', '%']
+    rhs_text:
+      type: str
+      required: true
+      description: Source text of the right-hand side that folded to zero.
+  for_llm:
+    summary: >-
+      A division or modulo RHS is statically zero under the lightweight
+      literal-only folder. For C/C++ generated code this needs a design fix or
+      explicit failure policy; do not conflate it with Python's exception model.
+    recommended_actions:
+      - kind: fix_denominator
+        target: expression
+        rationale: Replace the zero RHS with a non-zero expression or guard the operation before C/C++ deployment.
+      - kind: add_failure_policy
+        target: deployment_plan
+        rationale: If zero is possible by design, define the C/C++ failure channel instead of leaving generated code behavior implicit.
+    do_not:
+      - "Do not require the whole expression to be literal-only; only the RHS of ``/`` or ``%`` needs to fold to zero."
+      - "Do not drop ``refs.operator`` when division and modulo share this code."
+  example_dsl: |
+    def int result = 0;
+    def int input = 1;
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B effect { result = input / (1 - 1); };
+    }
+
+W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
+  severity: warning
+  span_object: expression
+  capability: const_fold
+  emit_tier: catalog_only
+  description: >-
+    A shift count folds to a constant below zero or not less than the default
+    C/C++ target integer width. This is a C/C++ 64-bit deployment-profile
+    portability risk; Python big-integer shifting is not the same target
+    contract.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ deployment-profile risk and
+        that Python generated runtimes may not have the same fixed-width shift risk.
+    context:
+      type: str
+      required: true
+      description: Expression location where the shift appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the shift expression.
+    operator:
+      type: str
+      required: true
+      description: Shift operator.
+      enum: ['<<', '>>']
+    target_bits:
+      type: int
+      required: true
+      description: Target integer width in bits.
+    shift_count_text:
+      type: str
+      required: true
+      description: Source text of the shift count after lightweight folding.
+  for_llm:
+    summary: >-
+      A shift count is statically outside the C/C++ default 64-bit profile.
+      Treat this as a target-profile portability warning, not as a Python
+      generated-runtime error.
+    recommended_actions:
+      - kind: bound_shift_count
+        target: expression
+        rationale: Keep constant shift counts within ``0 <= count < 64`` for the default C/C++ profile.
+      - kind: use_verify_for_dynamic_count
+        target: deployment_plan
+        rationale: If the shift count is not constant, use the verify line to prove the range before C/C++ deployment.
+    do_not:
+      - "Do not report dynamic shift counts as proven unsafe from this catalog-only rule."
+      - "Do not fold negative or oversized shift operations into a normal numeric result."
+  example_dsl: |
+    def int flags = 1;
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B : if [(flags << 64) != 0];
+    }
+
+W_NUMERIC_FLOAT_BITWISE:
+  severity: warning
+  span_object: expression
+  capability: pure_static
+  emit_tier: catalog_only
+  description: >-
+    A value known to be ``float`` participates in a bitwise or shift operator
+    that belongs to the C/C++ integer operation profile. The warning is
+    target-profile-specific even when other runtimes may also reject some
+    float-bitwise shapes for different reasons.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ integer-operation profile
+        risk and that other runtimes may fail for different reasons.
+    context:
+      type: str
+      required: true
+      description: Expression location where the bitwise operation appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the bitwise expression.
+    operator:
+      type: str
+      required: true
+      description: Bitwise or shift operator involving a float-shaped operand.
+      enum: ['&', '^', '|', '<<', '>>']
+    operand_types:
+      type: list[str]
+      required: true
+      description: >-
+        Operand type tags in expression order. Allowed members are ``int``,
+        ``float``, and ``unknown``.
+    operand_type_sources:
+      type: list[str]
+      required: true
+      description: >-
+        Evidence source for each operand type tag. Allowed members are
+        ``literal``, ``declared_var``, and ``local_expression``.
+  for_llm:
+    summary: >-
+      A float-shaped operand reaches a C/C++ integer bitwise operation. Keep
+      the diagnostic target-specific and use the operand type refs to explain
+      why the expression is considered risky.
+    recommended_actions:
+      - kind: use_integer_operand
+        target: expression
+        rationale: Replace the float operand with an integer flag/mask value when deploying to C/C++ templates.
+      - kind: change_variable_type
+        target: variable_definition
+        rationale: If the value is intended as a bit mask, declare and update it as an integer-shaped variable.
+    do_not:
+      - "Do not describe this only as a generic Python TypeError; the shared contract is about the C/C++ integer-operation profile."
+      - "Do not infer cross-statement temporary types for this first deterministic rule."
+  example_dsl: |
+    def float gain = 1.5;
+    def int flags = 1;
+    state Root {
+        state A {
+            during { flags = flags & gain; }
+        }
+        [*] -> A;
+    }
 
 W_ASPECT_NO_DESCENDANT_LEAF:
   severity: warning

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -11,7 +11,9 @@
 #                        but the source slice must still hit this object.
 #   - `refs`           — payload schema for `ModelDiagnostic.refs`. Each
 #                        field declares its type, whether it is required,
-#                        and a short description. Field names are part of
+#                        and a short description. String fields may declare
+#                        `enum`; `list[str]` fields may declare `item_enum`
+#                        and/or `exact_values`. Field names are part of
 #                        the public contract; downstream consumers should
 #                        rely on these names verbatim.
 #   - `example_dsl`    — minimal DSL snippet that triggers the code (used
@@ -2094,6 +2096,8 @@ W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2180,6 +2184,8 @@ W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2256,6 +2262,8 @@ W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2335,6 +2343,8 @@ W_NUMERIC_FLOAT_BITWISE:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2366,12 +2376,14 @@ W_NUMERIC_FLOAT_BITWISE:
       description: >-
         Operand type tags in expression order. Allowed members are ``int``,
         ``float``, and ``unknown``.
+      item_enum: ['int', 'float', 'unknown']
     operand_type_sources:
       type: list[str]
       required: true
       description: >-
         Evidence source for each operand type tag. Allowed members are
         ``literal``, ``declared_var``, and ``local_expression``.
+      item_enum: ['literal', 'declared_var', 'local_expression']
   for_llm:
     summary: >-
       A float-shaped operand reaches a C/C++ integer bitwise operation. Keep

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -2078,7 +2078,7 @@ W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     An integer literal that would be rendered into a C/C++ family template
     falls outside the default ``PYFCSTM_GENERATED_INT64`` signed range. This
@@ -2165,7 +2165,7 @@ W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     A ``/`` or ``%`` operation has a right-hand side that the lightweight
     literal-only constant folder can classify as zero. This is reported as a
@@ -2244,7 +2244,7 @@ W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     A shift count folds to a constant below zero or not less than the default
     C/C++ target integer width. This is a C/C++ 64-bit deployment-profile
@@ -2325,7 +2325,7 @@ W_NUMERIC_FLOAT_BITWISE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     A value known to be ``float`` participates in a bitwise or shift operator
     that belongs to the C/C++ integer operation profile. The warning is

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -54,7 +54,7 @@ from .analyzers import (
     collect_design_health_warnings,
     collect_expr_variables,
 )
-from .codes import CODE_REGISTRY, CodeFieldSpec
+from .codes import CODE_REGISTRY, CodeFieldSpec, CodeSpec
 from ..utils.validate import ModelDiagnostic, Span
 
 if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
@@ -2250,7 +2250,12 @@ def _type_matches_schema(value: Any, field_spec: CodeFieldSpec) -> bool:
     return True
 
 
-def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
+def _refs_match_code_schema(
+        code: str,
+        refs: Mapping[str, Any],
+        *,
+        _registry: Mapping[str, CodeSpec] = CODE_REGISTRY,
+) -> bool:
     """Return whether refs satisfy the declared verify-adapter schema.
 
     The conversion layer uses this as a fail-closed guard: raw verify findings
@@ -2264,6 +2269,10 @@ def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
     :type code: str
     :param refs: Candidate refs payload.
     :type refs: Mapping[str, Any]
+    :param _registry: Diagnostic code registry used for validation. Defaults
+        to :data:`CODE_REGISTRY`; tests may pass a synthetic registry to cover
+        schema predicates without mutating the global registry.
+    :type _registry: Mapping[str, CodeSpec], optional
     :return: ``True`` when the code may be emitted by the verify adapter and
         refs match its schema.
     :rtype: bool
@@ -2286,7 +2295,7 @@ def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
         ... })
         True
     """
-    spec = CODE_REGISTRY.get(code)
+    spec = _registry.get(code)
     if spec is None:
         return False
     if spec.emit_tier != 'verify_pipeline' and code not in VERIFY_SHARED_STATIC_CODES:
@@ -2304,6 +2313,12 @@ def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
         if field_spec.enum and value not in set(field_spec.enum):
             return False
         if not _type_matches_schema(value, field_spec):
+            return False
+        if field_spec.item_enum:
+            allowed_items = set(field_spec.item_enum)
+            if any(item not in allowed_items for item in value):
+                return False
+        if field_spec.exact_values and tuple(value) != field_spec.exact_values:
             return False
     return True
 
@@ -2427,6 +2442,39 @@ def _verify_diagnostics_from_results(
             continue
         diagnostics.extend(_structural_verify_diagnostics(result, states, events))
     return tuple(diagnostics)
+
+
+def _catalog_emittable_diagnostics(
+        diagnostics: Sequence[ModelDiagnostic],
+) -> Tuple[ModelDiagnostic, ...]:
+    """
+    Return diagnostics that are allowed to appear in inspect output.
+
+    Catalog-only codes freeze cross-end contracts before an analyzer is wired.
+    If a future analyzer accidentally emits such a code before the contract is
+    promoted to a real emit tier, the public inspect surface must fail closed
+    by dropping it.
+
+    :param diagnostics: Candidate diagnostics collected from inspect analyzers.
+    :type diagnostics: Sequence[ModelDiagnostic]
+    :return: Diagnostics whose code registry entry is not ``catalog_only``.
+    :rtype: Tuple[ModelDiagnostic, ...]
+
+    Example::
+
+        >>> _catalog_emittable_diagnostics((ModelDiagnostic(
+        ...     code='W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+        ...     severity='warning',
+        ...     message='catalog-only test',
+        ... ),))
+        ()
+    """
+    return tuple(
+        diagnostic
+        for diagnostic in diagnostics
+        if CODE_REGISTRY.get(diagnostic.code) is None
+        or CODE_REGISTRY[diagnostic.code].emit_tier != 'catalog_only'
+    )
 
 
 def _deduplicate_model_diagnostics(
@@ -2586,6 +2634,7 @@ def inspect_model(
             events,
             actions,
         ))
+    diagnostics = list(_catalog_emittable_diagnostics(diagnostics))
     diagnostics = list(_deduplicate_model_diagnostics(diagnostics))
     return ModelInspect(
         root_state_path=root_state_path,

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -2465,7 +2465,7 @@ def _catalog_emittable_diagnostics(
         >>> diagnostic = ModelDiagnostic(
         ...     code='W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
         ...     severity='warning',
-        ...     message='partial-static test',
+        ...     message='static-pipeline test',
         ... )
         >>> _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
         True

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -2462,12 +2462,13 @@ def _catalog_emittable_diagnostics(
 
     Example::
 
-        >>> _catalog_emittable_diagnostics((ModelDiagnostic(
+        >>> diagnostic = ModelDiagnostic(
         ...     code='W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
         ...     severity='warning',
-        ...     message='catalog-only test',
-        ... ),))
-        ()
+        ...     message='partial-static test',
+        ... )
+        >>> _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
+        True
     """
     return tuple(
         diagnostic

--- a/test/diagnostics/_schema_check.py
+++ b/test/diagnostics/_schema_check.py
@@ -105,6 +105,18 @@ def assert_refs_match_schema(diag: ModelDiagnostic, *, context: str = '') -> Non
             f'has runtime type {type(value).__name__}, expected schema '
             f'type {field_spec.type!r}'
         )
+        if field_spec.item_enum:
+            allowed_items = set(field_spec.item_enum)
+            invalid_items = [item for item in value if item not in allowed_items]
+            assert not invalid_items, (
+                f'{prefix}{diag.code} refs[{field_name!r}] has items '
+                f'{invalid_items!r} outside item_enum {sorted(allowed_items)}'
+            )
+        if field_spec.exact_values:
+            assert tuple(value) == field_spec.exact_values, (
+                f'{prefix}{diag.code} refs[{field_name!r}] = {value!r} '
+                f'does not match exact_values {field_spec.exact_values!r}'
+            )
         if field_name == 'suggested_fix' and value is not None:
             _assert_suggested_fix_payload(value, prefix=prefix, code=diag.code)
 

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -157,7 +157,10 @@ class TestLoaderValidation:
         """)
         reg = load_codes(path)
         assert 'E_FOO' in reg
-        assert reg['E_FOO'].refs_schema['bar'].type == 'str'
+        field = reg['E_FOO'].refs_schema['bar']
+        assert field.type == 'str'
+        assert field.item_enum is None
+        assert field.exact_values is None
 
     def test_rejects_unknown_severity(self, tmp_path):
         path = self._write_yaml(tmp_path, """

--- a/test/diagnostics/test_codes_yaml_layer2.py
+++ b/test/diagnostics/test_codes_yaml_layer2.py
@@ -259,6 +259,22 @@ class TestCodesLoaderNegativePaths:
         registry = load_codes(path)
         assert registry['W_DEMO'].emit_tier == 'verify_pipeline'
 
+    def test_loader_accepts_catalog_only_emit_tier(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: catalog-only demo
+              capability: pure_static
+              emit_tier: catalog_only
+              refs:
+                expr_text:
+                  type: str
+                  required: true
+                  description: expression
+            """)
+        registry = load_codes(path)
+        assert registry['W_DEMO'].emit_tier == 'catalog_only'
+
     def test_loader_rejects_for_llm_not_a_dict(self, tmp_path):
         # ``for_llm`` declared as a string — must be a mapping.
         path = _write_yaml(tmp_path, """

--- a/test/diagnostics/test_codes_yaml_layer2.py
+++ b/test/diagnostics/test_codes_yaml_layer2.py
@@ -208,6 +208,73 @@ class TestCapabilityField:
 
 
 @pytest.mark.unittest
+class TestEmitTierField:
+    def test_loader_accepts_catalog_only_emit_tier(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: catalog-only demo
+              capability: pure_static
+              emit_tier: catalog_only
+              refs:
+                expr_text:
+                  type: str
+                  required: true
+                  description: expression
+            """)
+        registry = load_codes(path)
+        assert registry['W_DEMO'].emit_tier == 'catalog_only'
+
+    def test_loader_accepts_list_string_item_contracts(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: list string schema demo
+              refs:
+                target_templates:
+                  type: list[str]
+                  required: true
+                  description: target template set
+                  item_enum: [c, c_poll]
+                  exact_values: [c, c_poll]
+            """)
+        spec = load_codes(path)['W_DEMO'].refs_schema['target_templates']
+        assert spec.item_enum == ('c', 'c_poll')
+        assert spec.exact_values == ('c', 'c_poll')
+
+    def test_loader_rejects_list_contracts_on_scalar_types(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: bad list schema demo
+              refs:
+                target_family:
+                  type: str
+                  required: true
+                  description: target family
+                  item_enum: [c_family]
+            """)
+        with pytest.raises(CodesSchemaError, match='item_enum'):
+            load_codes(path)
+
+    def test_loader_rejects_exact_values_outside_item_enum(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: bad exact list schema demo
+              refs:
+                target_templates:
+                  type: list[str]
+                  required: true
+                  description: target templates
+                  item_enum: [c, c_poll]
+                  exact_values: [c, python]
+            """)
+        with pytest.raises(CodesSchemaError, match='exact_values'):
+            load_codes(path)
+
+
+@pytest.mark.unittest
 class TestExistingErrorCodesStillLoad:
     """The 14 Layer 1 ``E_*`` codes must keep loading without ``for_llm``."""
 
@@ -258,22 +325,6 @@ class TestCodesLoaderNegativePaths:
             """)
         registry = load_codes(path)
         assert registry['W_DEMO'].emit_tier == 'verify_pipeline'
-
-    def test_loader_accepts_catalog_only_emit_tier(self, tmp_path):
-        path = _write_yaml(tmp_path, """
-            W_DEMO:
-              severity: warning
-              description: catalog-only demo
-              capability: pure_static
-              emit_tier: catalog_only
-              refs:
-                expr_text:
-                  type: str
-                  required: true
-                  description: expression
-            """)
-        registry = load_codes(path)
-        assert registry['W_DEMO'].emit_tier == 'catalog_only'
 
     def test_loader_rejects_for_llm_not_a_dict(self, tmp_path):
         # ``for_llm`` declared as a string — must be a mapping.

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -1686,13 +1686,20 @@ def test_lookup_api_codes_never_fire_in_static_pipeline():
 
 
 @pytest.mark.unittest
-def test_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
-    """I-b sibling: E_TYPE_MISMATCH is currently ``emit_tier:
-    partial_static_pipeline`` — jsfcstm has an analyzer that emits it
-    on type-confused expressions, pyfcstm has no such analyzer. This
-    test pins the "pyfcstm doesn't fire it" half so downstream
-    consumers know not to expect it from the Python side.
+def test_js_only_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
+    """Partial-static codes may be implemented on only one diagnostic end.
+
+    ``E_TYPE_MISMATCH`` is currently jsfcstm-only; numeric C/C++ profile
+    warnings are Python-only until the matching jsfcstm analyzer lands. This
+    test pins only the jsfcstm-only half so Python-emitted partial-static
+    diagnostics remain allowed.
     """
+    pyfcstm_partial_codes = {
+        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+        'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+        'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+        'W_NUMERIC_FLOAT_BITWISE',
+    }
     from pyfcstm.diagnostics import CODE_REGISTRY
 
     partial_codes = {
@@ -1700,13 +1707,14 @@ def test_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
         for code, spec in CODE_REGISTRY.items()
         if spec.emit_tier == 'partial_static_pipeline'
     }
-    if not partial_codes:
-        pytest.skip('no partial_static_pipeline codes declared')
+    js_only_partial_codes = partial_codes - pyfcstm_partial_codes
+    if not js_only_partial_codes:
+        pytest.skip('no js-only partial_static_pipeline codes declared')
 
     for name, dsl, _ in SINGLE_FILE_FIXTURES:
         codes, _, _ = _collect_codes_from_dsl(dsl)
-        leaked = [c for c in codes if c in partial_codes]
+        leaked = [c for c in codes if c in js_only_partial_codes]
         assert not leaked, (
-            f'fixture {name}: pyfcstm emitted partial_static_pipeline code(s) {leaked}; '
-            f'these are currently implemented only on jsfcstm.'
+            f'fixture {name}: pyfcstm emitted js-only partial_static_pipeline '
+            f'code(s) {leaked}.'
         )

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -1686,20 +1686,15 @@ def test_lookup_api_codes_never_fire_in_static_pipeline():
 
 
 @pytest.mark.unittest
-def test_js_only_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
-    """Partial-static codes may be implemented on only one diagnostic end.
+def test_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
+    """Partial-static codes are intentionally absent from pyfcstm output.
 
-    ``E_TYPE_MISMATCH`` is currently jsfcstm-only; numeric C/C++ profile
-    warnings are Python-only until the matching jsfcstm analyzer lands. This
-    test pins only the jsfcstm-only half so Python-emitted partial-static
-    diagnostics remain allowed.
+    Numeric C/C++ profile warnings have been promoted to
+    ``emit_tier: static_pipeline`` after both Python and jsfcstm analyzers
+    landed. Any remaining ``partial_static_pipeline`` code is therefore a
+    one-ended diagnostic such as jsfcstm-only type-shape analysis and must not
+    leak from pyfcstm's static inspect surface.
     """
-    pyfcstm_partial_codes = {
-        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
-        'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
-        'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
-        'W_NUMERIC_FLOAT_BITWISE',
-    }
     from pyfcstm.diagnostics import CODE_REGISTRY
 
     partial_codes = {
@@ -1707,14 +1702,13 @@ def test_js_only_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
         for code, spec in CODE_REGISTRY.items()
         if spec.emit_tier == 'partial_static_pipeline'
     }
-    js_only_partial_codes = partial_codes - pyfcstm_partial_codes
-    if not js_only_partial_codes:
-        pytest.skip('no js-only partial_static_pipeline codes declared')
+    if not partial_codes:
+        pytest.skip('no partial_static_pipeline codes declared')
 
     for name, dsl, _ in SINGLE_FILE_FIXTURES:
         codes, _, _ = _collect_codes_from_dsl(dsl)
-        leaked = [c for c in codes if c in js_only_partial_codes]
+        leaked = [c for c in codes if c in partial_codes]
         assert not leaked, (
-            f'fixture {name}: pyfcstm emitted js-only partial_static_pipeline '
+            f'fixture {name}: pyfcstm emitted partial_static_pipeline '
             f'code(s) {leaked}.'
         )

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -3266,6 +3266,47 @@ class TestInspectModelVerifyIntegration:
             )
             assert not inspect_module._type_matches_schema(value, field_spec)
 
+    def test_verify_refs_schema_honors_list_string_constraints(self):
+        registry = {
+            'W_TEST_NUMERIC_PROFILE': inspect_module.CodeSpec(
+                code='W_TEST_NUMERIC_PROFILE',
+                severity='warning',
+                description='test numeric profile',
+                emit_tier='verify_pipeline',
+                refs_schema={
+                    'target_family': inspect_module.CodeFieldSpec(
+                        name='target_family',
+                        type='str',
+                        required=True,
+                        description='target family',
+                        enum=('c_family',),
+                    ),
+                    'target_templates': inspect_module.CodeFieldSpec(
+                        name='target_templates',
+                        type='list[str]',
+                        required=True,
+                        description='target templates',
+                        item_enum=('c', 'c_poll'),
+                        exact_values=('c', 'c_poll'),
+                    ),
+                },
+            ),
+        }
+        valid_refs = {
+            'target_family': 'c_family',
+            'target_templates': ['c', 'c_poll'],
+        }
+        assert inspect_module._refs_match_code_schema(
+            'W_TEST_NUMERIC_PROFILE',
+            valid_refs,
+            _registry=registry,
+        )
+        assert not inspect_module._refs_match_code_schema(
+            'W_TEST_NUMERIC_PROFILE',
+            dict(valid_refs, target_templates=['python']),
+            _registry=registry,
+        )
+
     @pytest.mark.parametrize(
         'kind',
         ['unknown', 'timeout', 'undecidable_skip'],

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -1,4 +1,4 @@
-"""Catalog contract tests for C/C++ numeric inspect diagnostics."""
+"""Contract and emission tests for C/C++ numeric inspect diagnostics."""
 
 from __future__ import annotations
 
@@ -105,10 +105,10 @@ def test_numeric_contract_declares_exact_code_set():
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
-def test_numeric_codes_are_catalog_only_warning_contracts(code):
+def test_numeric_codes_are_partial_static_warning_contracts(code):
     spec = CODE_REGISTRY[code]
     assert spec.severity == "warning"
-    assert spec.emit_tier == "catalog_only"
+    assert spec.emit_tier == "partial_static_pipeline"
     assert spec.span_object == "expression"
     assert spec.for_llm is not None
     assert spec.example_dsl
@@ -116,22 +116,28 @@ def test_numeric_codes_are_catalog_only_warning_contracts(code):
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
-def test_numeric_codes_do_not_emit_before_analyzer_lands(code):
+def test_numeric_example_dsls_emit_after_python_analyzer_lands(code):
     spec = CODE_REGISTRY[code]
     report = inspect_model(_parse(spec.example_dsl))
-    assert code not in {diag.code for diag in report.diagnostics}
+    emitted = [diag for diag in report.diagnostics if diag.code == code]
+    assert emitted, [diag.code for diag in report.diagnostics]
+    for diag in emitted:
+        assert_refs_match_schema(diag, context=code)
+        assert diag.span is not None
+        assert "C/C++" in diag.message
+        assert "Python" in diag.message
 
 
-def test_catalog_only_diagnostics_are_filtered_from_inspect_output():
+def test_catalog_filter_allows_partial_static_numeric_diagnostics():
     diagnostic = ModelDiagnostic(
         code="W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
         severity="warning",
-        message="synthetic catalog-only diagnostic",
+        message="synthetic partial-static diagnostic",
         span=None,
         refs=SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"],
     )
 
-    assert _catalog_emittable_diagnostics((diagnostic,)) == ()
+    assert _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
@@ -184,10 +190,10 @@ def test_literal_range_code_locks_signed_int64_boundary_refs():
     assert any(MIN_SIGNED_INT64_TEXT in item for item in spec.for_llm.do_not)
     assert spec.example_dsl is not None
     assert TOO_LARGE_SIGNED_INT64_TEXT in spec.example_dsl
-    assert MIN_SIGNED_INT64_TEXT == str(-(2 ** 63))
-    assert MAX_SIGNED_INT64_TEXT == str(2 ** 63 - 1)
-    assert TOO_LARGE_SIGNED_INT64_TEXT == str(2 ** 63)
-    assert TOO_SMALL_SIGNED_INT64_TEXT == str(-(2 ** 63) - 1)
+    assert MIN_SIGNED_INT64_TEXT == str(-(2**63))
+    assert MAX_SIGNED_INT64_TEXT == str(2**63 - 1)
+    assert TOO_LARGE_SIGNED_INT64_TEXT == str(2**63)
+    assert TOO_SMALL_SIGNED_INT64_TEXT == str(-(2**63) - 1)
 
 
 def test_numeric_boundary_example_dsl_variants_parse():
@@ -265,6 +271,524 @@ def test_numeric_schema_rejects_float_bitwise_unknown_list_members():
             ),
             context="invalid operand vocab",
         )
+
+
+def _diagnostics_for(source: str, code: str):
+    report = inspect_model(_parse(source))
+    return [diag for diag in report.diagnostics if diag.code == code]
+
+
+def _single_diagnostic(source: str, code: str):
+    diagnostics = _diagnostics_for(source, code)
+    assert len(diagnostics) == 1, [diag.refs for diag in diagnostics]
+    diagnostic = diagnostics[0]
+    assert_refs_match_schema(diagnostic, context=code)
+    assert diagnostic.span is not None
+    return diagnostic
+
+
+@pytest.mark.parametrize(
+    ("literal_text", "expect_warning"),
+    [
+        (TOO_LARGE_SIGNED_INT64_TEXT, True),
+        (MIN_SIGNED_INT64_TEXT, False),
+        (TOO_SMALL_SIGNED_INT64_TEXT, True),
+    ],
+)
+def test_numeric_literal_range_int64_boundary_emission(
+    literal_text,
+    expect_warning,
+):
+    diagnostics = _diagnostics_for(
+        f"""
+        def int value = {literal_text};
+        state Root {{ state A; [*] -> A; }}
+        """,
+        "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+    )
+    if expect_warning:
+        assert len(diagnostics) == 1
+        refs = diagnostics[0].refs
+        assert refs["literal_text"] == literal_text
+        assert refs["context"] == "var_initializer"
+        assert refs["var_name"] == "value"
+        assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+        assert_refs_match_schema(diagnostics[0], context=literal_text)
+    else:
+        assert diagnostics == []
+
+
+@pytest.mark.parametrize(
+    ("name", "source", "code", "expected_refs"),
+    [
+        (
+            "var-literal-range",
+            f"""
+            def int value = {TOO_LARGE_SIGNED_INT64_TEXT};
+            state Root {{ state A; [*] -> A; }}
+            """,
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            {"context": "var_initializer", "var_name": "value"},
+        ),
+        (
+            "guard-division",
+            """
+            def int input = 1;
+            state Root {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [input / (1 - 1) > 0];
+            }
+            """,
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            {"context": "guard", "operator": "/", "rhs_text": "1 - 1"},
+        ),
+        (
+            "transition-effect-shift",
+            """
+            def int flags = 1;
+            state Root {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B effect { flags = flags << 64; };
+            }
+            """,
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            {
+                "context": "transition_effect",
+                "statement_kind": "operation_assignment",
+                "operator": "<<",
+                "shift_count_text": "64",
+            },
+        ),
+        (
+            "lifecycle-float-bitwise",
+            """
+            def int flags = 1;
+            def float gain = 1.5;
+            state Root {
+                state A { during { flags = flags & gain; } }
+                [*] -> A;
+            }
+            """,
+            "W_NUMERIC_FLOAT_BITWISE",
+            {
+                "context": "lifecycle_action",
+                "statement_kind": "operation_assignment",
+                "operator": "&",
+                "operand_types": ["int", "float"],
+                "operand_type_sources": ["declared_var", "declared_var"],
+            },
+        ),
+    ],
+)
+def test_numeric_analyzer_emits_context_specific_refs(
+    name,
+    source,
+    code,
+    expected_refs,
+):
+    diagnostic = _single_diagnostic(source, code)
+    for key, value in expected_refs.items():
+        assert diagnostic.refs[key] == value, name
+    assert diagnostic.refs["target_family"] == "c_family"
+    assert diagnostic.refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+    assert "C/C++" in diagnostic.message
+    assert "Python" in diagnostic.message
+
+
+def test_numeric_division_by_zero_folds_rhs_even_when_lhs_is_dynamic():
+    diagnostic = _single_diagnostic(
+        """
+        def int result = 0;
+        def int input = 1;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { result = input / (1 - 1); };
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostic.refs["operator"] == "/"
+    assert diagnostic.refs["rhs_text"] == "1 - 1"
+    assert diagnostic.refs["expr_text"] == "input / (1 - 1)"
+
+
+def test_numeric_modulo_by_zero_reports_operator_separately():
+    diagnostic = _single_diagnostic(
+        """
+        def int result = 0;
+        def int input = 1;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { result = input % (2 - 2); };
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostic.refs["operator"] == "%"
+    assert diagnostic.refs["rhs_text"] == "2 - 2"
+
+
+def test_numeric_division_dynamic_rhs_is_not_reported():
+    diagnostics = _diagnostics_for(
+        """
+        def int result = 0;
+        def int input = 1;
+        def int denom = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { result = input / denom; };
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostics == []
+
+
+@pytest.mark.parametrize("shift_expr", ["flags << -1", "flags >> 64"])
+def test_numeric_shift_constant_out_of_target_range_reports(shift_expr):
+    diagnostic = _single_diagnostic(
+        f"""
+        def int flags = 1;
+        state Root {{
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect {{ flags = {shift_expr}; }};
+        }}
+        """,
+        "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+    )
+    assert diagnostic.refs["operator"] in {"<<", ">>"}
+    assert diagnostic.refs["target_bits"] == 64
+
+
+def test_numeric_shift_dynamic_rhs_is_not_reported():
+    diagnostics = _diagnostics_for(
+        """
+        def int flags = 1;
+        def int amount = 64;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { flags = flags << amount; };
+        }
+        """,
+        "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+    )
+    assert diagnostics == []
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_types", "expected_sources"),
+    [
+        ("1.5 & flags", ["float", "int"], ["literal", "declared_var"]),
+        ("gain | flags", ["float", "int"], ["declared_var", "declared_var"]),
+        (
+            "(gain + 1.0) ^ flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+    ],
+)
+def test_numeric_float_bitwise_operand_evidence(
+    expr,
+    expected_types,
+    expected_sources,
+):
+    diagnostic = _single_diagnostic(
+        f"""
+        def int flags = 1;
+        def float gain = 1.5;
+        state Root {{
+            state A {{ during {{ flags = {expr}; }} }}
+            [*] -> A;
+        }}
+        """,
+        "W_NUMERIC_FLOAT_BITWISE",
+    )
+    assert diagnostic.refs["operand_types"] == expected_types
+    assert diagnostic.refs["operand_type_sources"] == expected_sources
+
+
+def test_numeric_float_shift_can_overlap_shift_count_warning():
+    source = """
+    def int flags = 1;
+    def float gain = 1.5;
+    state Root {
+        state A { during { flags = gain << 64; } }
+        [*] -> A;
+    }
+    """
+    report = inspect_model(_parse(source))
+    numeric_codes = [
+        diag.code for diag in report.diagnostics if diag.code in NUMERIC_CODES
+    ]
+    assert numeric_codes.count("W_NUMERIC_FLOAT_BITWISE") == 1
+    assert numeric_codes.count("W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE") == 1
+
+
+def test_numeric_scans_operation_if_branch_conditions_and_nested_assignments():
+    report = inspect_model(
+        _parse("""
+        def int flags = 1;
+        state Root {
+            state A {
+                during {
+                    if [flags > 0] {
+                        flags = flags << 64;
+                    }
+                }
+            }
+            [*] -> A;
+        }
+    """)
+    )
+    diagnostics = [
+        diag
+        for diag in report.diagnostics
+        if diag.code == "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"
+    ]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].refs["context"] == "lifecycle_action"
+    assert diagnostics[0].refs["statement_kind"] == "operation_assignment"
+
+
+@pytest.mark.parametrize(
+    ("context_name", "source"),
+    [
+        (
+            "var_initializer",
+            """
+            def int value = 1 / (1 - 1);
+            state Root { state A; [*] -> A; }
+            """,
+        ),
+        (
+            "guard",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B : if [value / 0 > 0]; }
+            """,
+        ),
+        (
+            "transition_effect",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B effect { value = value / 0; }; }
+            """,
+        ),
+        (
+            "lifecycle_action",
+            """
+            def int value = 1;
+            state Root { state A { exit { value = value / 0; } } [*] -> A; }
+            """,
+        ),
+    ],
+)
+def test_numeric_division_warning_covers_all_expression_contexts(
+    context_name,
+    source,
+):
+    diagnostic = _single_diagnostic(
+        source,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostic.refs["context"] == context_name
+    if context_name in {"transition_effect", "lifecycle_action"}:
+        assert diagnostic.refs["statement_kind"] == "operation_assignment"
+
+
+@pytest.mark.parametrize(
+    ("code", "context_name", "source", "statement_kind"),
+    [
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "var_initializer",
+            f"""
+            def int value = {TOO_LARGE_SIGNED_INT64_TEXT};
+            state Root {{ state A; [*] -> A; }}
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "guard",
+            f"""
+            state Root {{
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [{TOO_LARGE_SIGNED_INT64_TEXT} > 0];
+            }}
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "transition_effect",
+            f"""
+            def int value = 0;
+            state Root {{
+                state A;
+                state B;
+                [*] -> A;
+                A -> B effect {{ value = {TOO_LARGE_SIGNED_INT64_TEXT}; }};
+            }}
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "lifecycle_action",
+            f"""
+            def int value = 0;
+            state Root {{
+                state A {{ enter {{ value = {TOO_LARGE_SIGNED_INT64_TEXT}; }} }}
+                [*] -> A;
+            }}
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "var_initializer",
+            """
+            def int value = 1 / 0;
+            state Root { state A; [*] -> A; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "guard",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B : if [value / 0 > 0]; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "transition_effect",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B effect { value = value / 0; }; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "lifecycle_action",
+            """
+            def int value = 1;
+            state Root { state A { exit { value = value / 0; } } [*] -> A; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "var_initializer",
+            """
+            def int value = 1 << 64;
+            state Root { state A; [*] -> A; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "guard",
+            """
+            state Root { state A; state B; [*] -> A; A -> B : if [(1 << 64) != 0]; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "transition_effect",
+            """
+            def int flags = 1;
+            state Root { state A; state B; [*] -> A; A -> B effect { flags = flags << 64; }; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "lifecycle_action",
+            """
+            def int flags = 1;
+            state Root { state A { during { flags = flags << 64; } } [*] -> A; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "var_initializer",
+            """
+            def int flags = 1.5 & 1;
+            state Root { state A; [*] -> A; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "guard",
+            """
+            def float gain = 1.5;
+            state Root { state A; state B; [*] -> A; A -> B : if [(gain & 1) != 0]; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "transition_effect",
+            """
+            def int flags = 1;
+            def float gain = 1.5;
+            state Root { state A; state B; [*] -> A; A -> B effect { flags = gain & flags; }; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "lifecycle_action",
+            """
+            def int flags = 1;
+            def float gain = 1.5;
+            state Root { state A { during { flags = gain & flags; } } [*] -> A; }
+            """,
+            "operation_assignment",
+        ),
+    ],
+)
+def test_numeric_rules_cover_all_public_expression_contexts(
+    code,
+    context_name,
+    source,
+    statement_kind,
+):
+    diagnostics = _diagnostics_for(source, code)
+    assert diagnostics, code
+    assert any(
+        diag.refs["context"] == context_name
+        and (
+            statement_kind is None or diag.refs.get("statement_kind") == statement_kind
+        )
+        for diag in diagnostics
+    ), [diag.refs for diag in diagnostics]
+    for diag in diagnostics:
+        assert_refs_match_schema(diag, context=code)
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -7,11 +7,18 @@ from textwrap import dedent
 import pytest
 
 from pyfcstm.diagnostics import CODE_REGISTRY, inspect_model
+from pyfcstm.diagnostics.inspect import _catalog_emittable_diagnostics
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.utils import ModelDiagnostic
 
 from ._schema_check import assert_refs_match_schema
+
+
+MIN_SIGNED_INT64_TEXT = "-9223372036854775808"
+MAX_SIGNED_INT64_TEXT = "9223372036854775807"
+TOO_LARGE_SIGNED_INT64_TEXT = "9223372036854775808"
+TOO_SMALL_SIGNED_INT64_TEXT = "-9223372036854775809"
 
 
 pytestmark = pytest.mark.unittest
@@ -28,7 +35,14 @@ C_FAMILY_TARGET_TEMPLATES = ["c", "c_poll", "cpp", "cpp_poll"]
 CONTEXT_ENUM = ("var_initializer", "guard", "transition_effect", "lifecycle_action")
 OPERAND_TYPES = {"int", "float", "unknown"}
 OPERAND_TYPE_SOURCES = {"literal", "declared_var", "local_expression"}
+OPERAND_TYPE_ENUM = ("int", "float", "unknown")
+OPERAND_TYPE_SOURCE_ENUM = ("literal", "declared_var", "local_expression")
 RUNTIME_NOTE_REQUIRED_TEXT = ("C/C++", "Python")
+SIGNED_INT64_BOUNDARY_CASES = (
+    (TOO_LARGE_SIGNED_INT64_TEXT, "warning"),
+    (MIN_SIGNED_INT64_TEXT, "no_warning"),
+    (TOO_SMALL_SIGNED_INT64_TEXT, "warning"),
+)
 
 
 SYNTHETIC_REFS = {
@@ -37,12 +51,12 @@ SYNTHETIC_REFS = {
         "target_templates": C_FAMILY_TARGET_TEMPLATES,
         "runtime_note": "C/C++ deployment profile risk; Python generated runtime may not have the same risk.",
         "context": "var_initializer",
-        "expr_text": "9223372036854775808",
-        "literal_text": "9223372036854775808",
+        "expr_text": TOO_LARGE_SIGNED_INT64_TEXT,
+        "literal_text": TOO_LARGE_SIGNED_INT64_TEXT,
         "target_bits": 64,
         "signed": True,
-        "min_value_text": "-9223372036854775808",
-        "max_value_text": "9223372036854775807",
+        "min_value_text": MIN_SIGNED_INT64_TEXT,
+        "max_value_text": MAX_SIGNED_INT64_TEXT,
         "var_name": "too_large",
     },
     "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO": {
@@ -79,13 +93,6 @@ SYNTHETIC_REFS = {
 }
 
 
-SIGNED_INT64_BOUNDARY_CASES = [
-    ("9223372036854775808", "warning"),
-    ("-9223372036854775808", "no_warning"),
-    ("-9223372036854775809", "warning"),
-]
-
-
 def _parse(source: str):
     ast = parse_with_grammar_entry(dedent(source), "state_machine_dsl")
     return parse_dsl_node_to_state_machine(ast)
@@ -115,6 +122,18 @@ def test_numeric_codes_do_not_emit_before_analyzer_lands(code):
     assert code not in {diag.code for diag in report.diagnostics}
 
 
+def test_catalog_only_diagnostics_are_filtered_from_inspect_output():
+    diagnostic = ModelDiagnostic(
+        code="W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+        severity="warning",
+        message="synthetic catalog-only diagnostic",
+        span=None,
+        refs=SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"],
+    )
+
+    assert _catalog_emittable_diagnostics((diagnostic,)) == ()
+
+
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
 def test_numeric_refs_schema_accepts_representative_payloads(code):
     spec = CODE_REGISTRY[code]
@@ -142,10 +161,13 @@ def test_numeric_target_profile_fields_are_required_and_stable(code):
         "expr_text",
     } <= required
     assert spec.refs_schema["target_family"].enum == ("c_family",)
-    assert spec.refs_schema["target_templates"].type == "list[str]"
+    target_templates = spec.refs_schema["target_templates"]
+    assert target_templates.type == "list[str]"
+    assert target_templates.item_enum == tuple(C_FAMILY_TARGET_TEMPLATES)
+    assert target_templates.exact_values == tuple(C_FAMILY_TARGET_TEMPLATES)
     refs = SYNTHETIC_REFS[code]
-    assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
-    assert "python" not in refs["target_templates"]
+    assert refs["target_templates"] == list(target_templates.exact_values)
+    assert "python" not in target_templates.exact_values
     assert spec.refs_schema["context"].enum == CONTEXT_ENUM
     assert refs["context"] in CONTEXT_ENUM
     for snippet in RUNTIME_NOTE_REQUIRED_TEXT:
@@ -157,14 +179,15 @@ def test_literal_range_code_locks_signed_int64_boundary_refs():
     refs = SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
     assert refs["target_bits"] == 64
     assert refs["signed"] is True
-    assert refs["min_value_text"] == "-9223372036854775808"
-    assert refs["max_value_text"] == "9223372036854775807"
-    assert "-9223372036854775808" in spec.for_llm.do_not[1]
-    assert SIGNED_INT64_BOUNDARY_CASES == [
-        ("9223372036854775808", "warning"),
-        ("-9223372036854775808", "no_warning"),
-        ("-9223372036854775809", "warning"),
-    ]
+    assert refs["min_value_text"] == MIN_SIGNED_INT64_TEXT
+    assert refs["max_value_text"] == MAX_SIGNED_INT64_TEXT
+    assert any(MIN_SIGNED_INT64_TEXT in item for item in spec.for_llm.do_not)
+    assert spec.example_dsl is not None
+    assert TOO_LARGE_SIGNED_INT64_TEXT in spec.example_dsl
+    assert MIN_SIGNED_INT64_TEXT == str(-(2 ** 63))
+    assert MAX_SIGNED_INT64_TEXT == str(2 ** 63 - 1)
+    assert TOO_LARGE_SIGNED_INT64_TEXT == str(2 ** 63)
+    assert TOO_SMALL_SIGNED_INT64_TEXT == str(-(2 ** 63) - 1)
 
 
 def test_numeric_boundary_example_dsl_variants_parse():
@@ -194,6 +217,10 @@ def test_shift_code_locks_target_bits_and_operator_contract():
 def test_float_bitwise_locks_operand_type_vocabularies():
     spec = CODE_REGISTRY["W_NUMERIC_FLOAT_BITWISE"]
     assert spec.refs_schema["operator"].enum == ("&", "^", "|", "<<", ">>")
+    operand_types = spec.refs_schema["operand_types"]
+    operand_type_sources = spec.refs_schema["operand_type_sources"]
+    assert operand_types.item_enum == OPERAND_TYPE_ENUM
+    assert operand_type_sources.item_enum == OPERAND_TYPE_SOURCE_ENUM
     assert (
         set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_types"]) <= OPERAND_TYPES
     )
@@ -201,6 +228,43 @@ def test_float_bitwise_locks_operand_type_vocabularies():
         set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_type_sources"])
         <= OPERAND_TYPE_SOURCES
     )
+
+
+def test_numeric_schema_rejects_target_templates_outside_c_family():
+    spec = CODE_REGISTRY["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
+    refs = dict(SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"])
+    refs["target_templates"] = ["python"]
+
+    with pytest.raises(AssertionError, match="item_enum|exact_values"):
+        assert_refs_match_schema(
+            ModelDiagnostic(
+                code=spec.code,
+                severity=spec.severity,
+                message="synthetic invalid target templates",
+                span=None,
+                refs=refs,
+            ),
+            context="invalid target_templates",
+        )
+
+
+def test_numeric_schema_rejects_float_bitwise_unknown_list_members():
+    spec = CODE_REGISTRY["W_NUMERIC_FLOAT_BITWISE"]
+    refs = dict(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"])
+    refs["operand_types"] = ["number"]
+    refs["operand_type_sources"] = ["magic"]
+
+    with pytest.raises(AssertionError, match="item_enum"):
+        assert_refs_match_schema(
+            ModelDiagnostic(
+                code=spec.code,
+                severity=spec.severity,
+                message="synthetic invalid operand vocab",
+                span=None,
+                refs=refs,
+            ),
+            context="invalid operand vocab",
+        )
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -1,0 +1,217 @@
+"""Catalog contract tests for C/C++ numeric inspect diagnostics."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pyfcstm.diagnostics import CODE_REGISTRY, inspect_model
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.utils import ModelDiagnostic
+
+from ._schema_check import assert_refs_match_schema
+
+
+pytestmark = pytest.mark.unittest
+
+
+NUMERIC_CODES = {
+    "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+    "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+    "W_NUMERIC_FLOAT_BITWISE",
+}
+
+C_FAMILY_TARGET_TEMPLATES = ["c", "c_poll", "cpp", "cpp_poll"]
+CONTEXT_ENUM = ("var_initializer", "guard", "transition_effect", "lifecycle_action")
+OPERAND_TYPES = {"int", "float", "unknown"}
+OPERAND_TYPE_SOURCES = {"literal", "declared_var", "local_expression"}
+RUNTIME_NOTE_REQUIRED_TEXT = ("C/C++", "Python")
+
+
+SYNTHETIC_REFS = {
+    "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ deployment profile risk; Python generated runtime may not have the same risk.",
+        "context": "var_initializer",
+        "expr_text": "9223372036854775808",
+        "literal_text": "9223372036854775808",
+        "target_bits": 64,
+        "signed": True,
+        "min_value_text": "-9223372036854775808",
+        "max_value_text": "9223372036854775807",
+        "var_name": "too_large",
+    },
+    "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ deployment profile risk; Python generated runtime has different exception semantics.",
+        "context": "transition_effect",
+        "statement_kind": "operation_assignment",
+        "expr_text": "input / (1 - 1)",
+        "operator": "/",
+        "rhs_text": "(1 - 1)",
+    },
+    "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ deployment profile risk; Python generated runtime may not have the same fixed-width shift risk.",
+        "context": "guard",
+        "expr_text": "flags << 64",
+        "operator": "<<",
+        "target_bits": 64,
+        "shift_count_text": "64",
+    },
+    "W_NUMERIC_FLOAT_BITWISE": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ integer-operation profile risk; Python generated runtime may fail for a different reason.",
+        "context": "lifecycle_action",
+        "statement_kind": "operation_assignment",
+        "expr_text": "flags & gain",
+        "operator": "&",
+        "operand_types": ["int", "float"],
+        "operand_type_sources": ["declared_var", "declared_var"],
+    },
+}
+
+
+SIGNED_INT64_BOUNDARY_CASES = [
+    ("9223372036854775808", "warning"),
+    ("-9223372036854775808", "no_warning"),
+    ("-9223372036854775809", "warning"),
+]
+
+
+def _parse(source: str):
+    ast = parse_with_grammar_entry(dedent(source), "state_machine_dsl")
+    return parse_dsl_node_to_state_machine(ast)
+
+
+def test_numeric_contract_declares_exact_code_set():
+    assert NUMERIC_CODES <= set(CODE_REGISTRY)
+    assert "W_NUMERIC_SHIFT_REQUIRES_PROOF" not in CODE_REGISTRY
+    assert "I_NUMERIC_VERIFY_RECOMMENDED" not in CODE_REGISTRY
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_codes_are_catalog_only_warning_contracts(code):
+    spec = CODE_REGISTRY[code]
+    assert spec.severity == "warning"
+    assert spec.emit_tier == "catalog_only"
+    assert spec.span_object == "expression"
+    assert spec.for_llm is not None
+    assert spec.example_dsl
+    _parse(spec.example_dsl)
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_codes_do_not_emit_before_analyzer_lands(code):
+    spec = CODE_REGISTRY[code]
+    report = inspect_model(_parse(spec.example_dsl))
+    assert code not in {diag.code for diag in report.diagnostics}
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_refs_schema_accepts_representative_payloads(code):
+    spec = CODE_REGISTRY[code]
+    assert_refs_match_schema(
+        ModelDiagnostic(
+            code=code,
+            severity=spec.severity,
+            message=f"synthetic contract check for {code}",
+            span=None,
+            refs=SYNTHETIC_REFS[code],
+        ),
+        context=code,
+    )
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_target_profile_fields_are_required_and_stable(code):
+    spec = CODE_REGISTRY[code]
+    required = set(spec.required_fields())
+    assert {
+        "target_family",
+        "target_templates",
+        "runtime_note",
+        "context",
+        "expr_text",
+    } <= required
+    assert spec.refs_schema["target_family"].enum == ("c_family",)
+    assert spec.refs_schema["target_templates"].type == "list[str]"
+    refs = SYNTHETIC_REFS[code]
+    assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+    assert "python" not in refs["target_templates"]
+    assert spec.refs_schema["context"].enum == CONTEXT_ENUM
+    assert refs["context"] in CONTEXT_ENUM
+    for snippet in RUNTIME_NOTE_REQUIRED_TEXT:
+        assert snippet in refs["runtime_note"]
+
+
+def test_literal_range_code_locks_signed_int64_boundary_refs():
+    spec = CODE_REGISTRY["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
+    refs = SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
+    assert refs["target_bits"] == 64
+    assert refs["signed"] is True
+    assert refs["min_value_text"] == "-9223372036854775808"
+    assert refs["max_value_text"] == "9223372036854775807"
+    assert "-9223372036854775808" in spec.for_llm.do_not[1]
+    assert SIGNED_INT64_BOUNDARY_CASES == [
+        ("9223372036854775808", "warning"),
+        ("-9223372036854775808", "no_warning"),
+        ("-9223372036854775809", "warning"),
+    ]
+
+
+def test_numeric_boundary_example_dsl_variants_parse():
+    for literal_text, _classification in SIGNED_INT64_BOUNDARY_CASES:
+        _parse(f"""
+            def int value = {literal_text};
+            state Root {{ state A; [*] -> A; }}
+        """)
+
+
+def test_division_and_modulo_share_required_operator_contract():
+    spec = CODE_REGISTRY["W_NUMERIC_CONSTANT_DIVISION_BY_ZERO"]
+    assert "operator" in spec.required_fields()
+    assert spec.refs_schema["operator"].enum == ("/", "%")
+
+
+def test_shift_code_locks_target_bits_and_operator_contract():
+    spec = CODE_REGISTRY["W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"]
+    assert "operator" in spec.required_fields()
+    assert spec.refs_schema["operator"].enum == ("<<", ">>")
+    assert "target_bits" in spec.required_fields()
+    assert (
+        SYNTHETIC_REFS["W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"]["target_bits"] == 64
+    )
+
+
+def test_float_bitwise_locks_operand_type_vocabularies():
+    spec = CODE_REGISTRY["W_NUMERIC_FLOAT_BITWISE"]
+    assert spec.refs_schema["operator"].enum == ("&", "^", "|", "<<", ">>")
+    assert (
+        set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_types"]) <= OPERAND_TYPES
+    )
+    assert (
+        set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_type_sources"])
+        <= OPERAND_TYPE_SOURCES
+    )
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_descriptions_are_target_specific(code):
+    spec = CODE_REGISTRY[code]
+    text = " ".join(
+        [
+            spec.description,
+            spec.for_llm.summary if spec.for_llm is not None else "",
+            " ".join(spec.for_llm.do_not) if spec.for_llm is not None else "",
+        ]
+    )
+    assert "C/C++" in text
+    assert "Python" in text

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -291,6 +291,7 @@ def _single_diagnostic(source: str, code: str):
     ("literal_text", "expect_warning"),
     [
         (TOO_LARGE_SIGNED_INT64_TEXT, True),
+        ("+" + TOO_LARGE_SIGNED_INT64_TEXT, True),
         (MIN_SIGNED_INT64_TEXT, False),
         (TOO_SMALL_SIGNED_INT64_TEXT, True),
     ],
@@ -499,6 +500,26 @@ def test_numeric_shift_dynamic_rhs_is_not_reported():
             ["float", "int"],
             ["local_expression", "declared_var"],
         ),
+        (
+            "(1 / 2) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+        (
+            "sin(1) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+        (
+            "abs(gain) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+        (
+            "((flags > 0) ? 1.0 : 0) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
     ],
 )
 def test_numeric_float_bitwise_operand_evidence(
@@ -519,6 +540,20 @@ def test_numeric_float_bitwise_operand_evidence(
     )
     assert diagnostic.refs["operand_types"] == expected_types
     assert diagnostic.refs["operand_type_sources"] == expected_sources
+
+
+def test_numeric_float_bitwise_does_not_treat_int_local_expression_as_float():
+    diagnostics = _diagnostics_for(
+        """
+        def int flags = 1;
+        state Root {
+            state A { during { flags = (1 + 2) & flags; } }
+            [*] -> A;
+        }
+        """,
+        "W_NUMERIC_FLOAT_BITWISE",
+    )
+    assert diagnostics == []
 
 
 def test_numeric_float_shift_can_overlap_shift_count_warning():
@@ -559,6 +594,26 @@ def test_numeric_scans_operation_if_branch_conditions_and_nested_assignments():
         for diag in report.diagnostics
         if diag.code == "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"
     ]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].refs["context"] == "lifecycle_action"
+    assert diagnostics[0].refs["statement_kind"] == "operation_assignment"
+
+
+def test_numeric_lifecycle_refs_do_not_duplicate_inline_action_warnings():
+    diagnostics = _diagnostics_for(
+        """
+        def int value = 1;
+        state Root {
+            state A {
+                enter abstract HardwareInit;
+                enter Inline { value = value / 0; }
+                enter ref Inline;
+            }
+            [*] -> A;
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
     assert len(diagnostics) == 1
     assert diagnostics[0].refs["context"] == "lifecycle_action"
     assert diagnostics[0].refs["statement_kind"] == "operation_assignment"

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from textwrap import dedent
 
 import pytest
@@ -105,10 +106,10 @@ def test_numeric_contract_declares_exact_code_set():
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
-def test_numeric_codes_are_partial_static_warning_contracts(code):
+def test_numeric_codes_are_static_pipeline_warning_contracts(code):
     spec = CODE_REGISTRY[code]
     assert spec.severity == "warning"
-    assert spec.emit_tier == "partial_static_pipeline"
+    assert spec.emit_tier == "static_pipeline"
     assert spec.span_object == "expression"
     assert spec.for_llm is not None
     assert spec.example_dsl
@@ -128,16 +129,55 @@ def test_numeric_example_dsls_emit_after_python_analyzer_lands(code):
         assert "Python" in diag.message
 
 
-def test_catalog_filter_allows_partial_static_numeric_diagnostics():
+def test_catalog_filter_allows_static_pipeline_numeric_diagnostics():
     diagnostic = ModelDiagnostic(
         code="W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
         severity="warning",
-        message="synthetic partial-static diagnostic",
+        message="synthetic static-pipeline diagnostic",
         span=None,
         refs=SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"],
     )
 
     assert _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
+
+
+def test_numeric_diagnostics_surface_in_build_inspect_json(tmp_path):
+    source = dedent(f"""
+        def int too_large = {TOO_LARGE_SIGNED_INT64_TEXT};
+        def int result = 0;
+        def int input = 1;
+        def int flags = 1;
+        def float gain = 1.5;
+        state Root {{
+            state A {{ during {{ flags = gain & flags; }} }}
+            state B;
+            [*] -> A;
+            A -> B : if [(flags << 64) != 0];
+            B -> A effect {{ result = input / (1 - 1); }};
+        }}
+    """)
+    path = tmp_path / "numeric_cli.fcstm"
+    path.write_text(source, encoding="utf-8")
+
+    from pyfcstm.entry.inspect import build_inspect_json
+
+    payload = json.loads(build_inspect_json(str(path)))
+    diagnostics_by_code = {
+        diagnostic["code"]: diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic["code"] in NUMERIC_CODES
+    }
+
+    assert set(diagnostics_by_code) == NUMERIC_CODES
+    for code in NUMERIC_CODES:
+        diagnostic = diagnostics_by_code[code]
+        refs = diagnostic["refs"]
+        assert "C/C++" in diagnostic["message"]
+        assert "Python" in diagnostic["message"]
+        assert refs["target_family"] == "c_family"
+        assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+        assert "C/C++" in refs["runtime_note"]
+        assert "Python" in refs["runtime_note"]
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
@@ -455,7 +495,12 @@ def test_numeric_division_dynamic_rhs_is_not_reported():
     assert diagnostics == []
 
 
-@pytest.mark.parametrize("shift_expr", ["flags << -1", "flags >> 64"])
+@pytest.mark.parametrize("shift_expr", [
+    "flags << -1",
+    "flags >> 64",
+    "flags << -9223372036854775808",
+    "flags >> 9223372036854775808",
+])
 def test_numeric_shift_constant_out_of_target_range_reports(shift_expr):
     diagnostic = _single_diagnostic(
         f"""


### PR DESCRIPTION
## 目标

本 PR 是 [issue #253](https://github.com/HansBug/pyfcstm/issues/253) 的伞 PR，只负责把 **inspect 数值规则与基础诊断** 的落地路线拆成可执行、可验收的子 PR，并持续汇总子 PR 状态。伞 PR 初始创建时不直接引入运行时代码改动；随着子 PR 合入，本分支最终聚合 N1-N4 的实际 diagnostics / jsfcstm / docs / tests 改动。

本轮实现范围严格限定在 issue #253 已 ready 的第一阶段：面向 **C/C++ 默认部署剖面（C/C++ deployment profile）** 的 4 类确定性 inspect 诊断，不把这些 warning 表述成 Python 目标或所有目标的通用模型错误。

第一阶段默认剖面固定为：

- 目标族：`c_family`。
- 目标模板集合：`["c", "c_poll", "cpp", "cpp_poll"]`，顺序稳定且不包含 Python。
- DSL `int` 对齐 C/C++ 模板中的 `PYFCSTM_GENERATED_INT64`，即 64-bit signed，范围 `[-9223372036854775808, 9223372036854775807]`。
- DSL `float` 对齐 C/C++ 模板中的 `double`。
- Python 生成目标不是本阶段风险目标；message 与 refs 都必须明确这一点。

## 非目标

| 非目标 | 说明 |
|---|---|
| 不做动态溢出证明、BitVec、BMC、fixed-point 位宽证明 | 归入 [issue #254](https://github.com/HansBug/pyfcstm/issues/254)。 |
| 不对动态/变量移位量或可能无界 counter 给出“已证明不安全”的结论 | 这需要 SMT / BitVec / range / BMC 分析，属于 #254；若未来加入动态提示，必须通过 refs 指向 #254 的 verify check。 |
| 不做 codegen 数值策略选项、checked arithmetic 策略、目标 profile 配置系统 | 归入 [issue #255](https://github.com/HansBug/pyfcstm/issues/255)。 |
| 不修改 DSL `int` / `float` 当前语义 | 本线只增加目标相关 inspect 诊断。 |
| 不把 C/C++ 风险写成目标无关错误 | Python 目标可能没有同类风险或语义不同。 |
| 不共享 Python 与 jsfcstm 测试 fixture | Python 测试数据在 `test/`，jsfcstm 测试数据在 `editors/jsfcstm/test/`。 |

## 必做诊断范围

| 诊断 | 触发下限 | message / refs 硬要求 |
|---|---|---|
| 超出 C/C++ 默认 int64 signed 剖面的整数字面量 | 会进入 C/C++ 表达式渲染的整数字面量超出 `PYFCSTM_GENERATED_INT64` 范围；一元负号 + literal 按组合后的 signed 值判定，`-9223372036854775808` 合法，`9223372036854775808` 与 `-9223372036854775809` 告警 | 明确说这是 C/C++ 默认部署剖面承载风险；Python 目标不一定有同类风险；refs 必须给出 `min_value_text` / `max_value_text` 或等价上下界字段。 |
| 常量除零 / 常量取模零 | `/` 或 `%` 的 RHS 经轻量常量折叠可判 0；LHS 可以是动态表达式 | 明确说这是 C/C++ 生成代码定义性 / failure 通道风险；Python 异常语义不同；若 div 与 mod 合并为单一 code，`operator` 必须是 required refs 字段。 |
| 常量移位量越界 | shift count 常量小于 0 或不小于目标位宽 64；动态 shift 不在本阶段必做范围 | 明确说这是 C/C++ 默认 64-bit 剖面不可移植 / 不合法风险；Python 大整数移位不是同类风险。 |
| float 参与 bitwise | inspect 可确定的 float literal、声明为 `float` 的变量，或同一表达式内轻量可判定为 float 的子表达式参与 `&` / `^` / `|` / shift 等位运算 | 明确说这是 C/C++ 整数位运算剖面风险；不能泛化成所有目标错误；`operand_types` 取值必须跨端稳定。 |

## 公共契约

### 诊断 refs 必含语义

新增诊断进入默认 inspect/static pipeline 时，`message` 和 `refs` 都必须表达目标限定。`refs` 至少需要稳定表达以下语义，字段名以 `pyfcstm/diagnostics/codes.yaml` 最终契约为准：

- `target_family="c_family"` 或等价字段；
- `target_templates=["c", "c_poll", "cpp", "cpp_poll"]` 或等价字段，顺序稳定；
- C/C++ 与 Python 运行时差异说明，例如 `runtime_note`；
- `context`，固定枚举至少包含 `var_initializer`、`guard`、`transition_effect`、`lifecycle_action`；
- 对赋值 RHS，使用 `statement_kind="operation_assignment"` 或等价字段表达语句形状，不把它混入 `context` 枚举；
- `operand_types` 取值集合锁定为 `int`、`float`、`unknown`；若引入 `operand_type_sources` 或等价字段，取值集合锁定为 `literal`、`declared_var`、`local_expression`；
- 规则必要字段：例如 `expr_text`、`operator`、`rhs_text`、`literal_text`、`target_bits`、`signed`、`shift_count_text`、`min_value_text`、`max_value_text`、`operand_types` 等。

### 诊断 refs 细化清单

| 诊断 | 必含 / 条件必含 refs 语义 |
|---|---|
| 超范围 literal | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`literal_text`、`target_bits`、`signed`、`min_value_text`、`max_value_text`；若能定位变量则带 `var_name`；一元负号边界样例必须进测试。 |
| 常量除零 / 取模零 | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`operator`、`rhs_text`；若除零和取模零合并为一个 code，`operator` 必须 required。 |
| 常量移位越界 | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`operator`、`target_bits`、`shift_count_text`。 |
| float bitwise | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`operator`、`operand_types`；赋值 RHS 场景使用 `statement_kind="operation_assignment"` 或等价字段。 |

### 轻量常量折叠边界

只允许折叠同一个表达式 AST 内的 literal-only numeric 子表达式。允许字面量、一元 `+` / `-`、括号，以及由 literal-only 子表达式组成且两端可一致实现的基础二元运算：`+`、`-`、`*`、`/`、`%`、`<<`、`>>`、`&`、`^`、`|`。遇到除零、负移位、过大移位或无法稳定表示的结果时不折叠。

禁止变量、函数调用、跨语句常量传播、block-local temporary 推导、`a-a`、`0*x` 这类依赖变量语义的化简。Python 与 jsfcstm 必须用各自测试树里的独立样例锁定正反例。

### 扫描面下限

4 类必做规则都需要覆盖同一组最小表达式位置：

- 变量 initializer；
- guard condition；
- transition effect；
- lifecycle action；
- operation assignment RHS，其中 `context` 表达所在 block / action，`statement_kind` 表达赋值 RHS 形状。

若某个子 PR 暂不覆盖某个位置，必须在该子 PR body 中列为显式非目标，并说明后续补齐 PR。

## 执行计划

1. 先锁定诊断码、refs、schema、jsfcstm 同步资源与文档契约，避免 Python 与 jsfcstm 语义漂移。
2. Python 侧实现 analyzer，并接入 `inspect_model` / 默认 static pipeline，使用 `test/diagnostics/` 下内联 DSL 用例覆盖 4 类规则和目标限定 refs。
3. jsfcstm 侧同步实现同一诊断契约，测试数据独立维护，不调用 Python 代码、不读取 Python `test/` 树。
4. 收口跨端 parity、文档和入口验收，确认 CLI / jsfcstm editor / schema / docs 对同一批诊断有一致解释；VSCode 侧若只消费 jsfcstm 输出，本线只确认其不需要额外独立实现。
5. 每个子 PR 都需要先同步最新上游，若遇到冲突必须证明两边内容均保留且语义正确。


## 当前进展

- 🟩 PR-N1 已完成并合入：诊断码、schema、refs 与目标剖面契约已锁定。
- 🟩 PR-N2 已完成并合入：Python `inspect_model()` 数值 analyzer 已接入默认诊断路径。
- 🟩 PR-N3 已完成并合入：[PR #275](https://github.com/HansBug/pyfcstm/pull/275) 已将 jsfcstm `inspectModel()` 数值诊断与 Python N2 语义对齐；CI 全绿，三路最新 head 实现级 review 无 C/I。
- 🟩 PR-N4 已完成并合入：[PR #276](https://github.com/HansBug/pyfcstm/pull/276) 已统一 Python/jsfcstm numeric 诊断跨端契约、CLI/editor 用户可见输出与文档回归；CI 全绿，三路最新 head 实现级 review 无 C/I。

## 子 PR 划分

| 子 PR 名称 | 当前状态 | 目标 | 实施方案 | 验收标准 | 前置依赖 |
|---|---|---|---|---|---|
| PR-N1：诊断契约与目标剖面字段 | 🟩 已完成 | 先把 numeric diagnostic codes、refs、schema、文档口径和 jsfcstm 共享资源锁住 | 更新 `pyfcstm/diagnostics/codes.yaml`、`pyfcstm/diagnostics/schema.json`、`pyfcstm/diagnostics/README.md` 和生成/加载所需资源；定义 4 类必做诊断码或等价拆分；锁定 `target_family`、`target_templates`、`runtime_note`、`context`、`statement_kind`、`operand_types`、`min_value_text`、`max_value_text`、常量折叠算子集合；运行 `cd editors/jsfcstm && node ./scripts/sync-runtime-assets.js --phase=src` 或等价同步，更新/校验 `editors/jsfcstm/src/diagnostics/codes.json` 与 `schema.json`，但不实现 JS analyzer | `codes.yaml` schema 测试通过；jsfcstm `codes.json` / `schema.json` 与 Python 侧共享契约同步；`diagnostics-resources.test.ts` 或等价资源测试通过；refs 契约中目标限定字段是必含语义；文档明确 C/C++ 默认部署剖面风险与 Python 差异；不引入 analyzer 行为改动或仅保留空契约 | 无 |
| PR-N2：Python inspect 数值 analyzer | 🟩 已完成 | Python 侧落地 4 类确定性规则 | 新增或扩展 `pyfcstm/diagnostics/analyzers/` 下 numeric analyzer；在 `pyfcstm/diagnostics/inspect.py` 默认 pipeline 接入；复用/扩展现有常量折叠工具但不做跨语句推导；补 `test/diagnostics/` 内联 DSL 用例 | 4 类规则均可由 `inspect_model` 默认调用路径触发；message 与 refs 均含 C/C++ 目标限定；RHS-zero 不要求整条表达式 literal-only；扫描面覆盖最小集合；包含 int64 边界样例：`9223372036854775808` warning、`-9223372036854775808` no warning、`-9223372036854775809` warning；`make unittest RANGE_DIR=./diagnostics` 或等价局部测试通过 | PR-N1 |
| PR-N3：jsfcstm inspect 数值 parity | 🟩 已完成 | jsfcstm 侧同步诊断契约和 analyzer 行为 | 更新 `editors/jsfcstm/src/diagnostics/` 下 codes/schema/analyzer/inspect 接入；在 `editors/jsfcstm/test/` 添加独立 DSL / expected / snapshot 测试；不调用 Python 代码、不读取 `test/` fixture | jsfcstm 对 4 类规则输出与 Python 同等语义的 code/message/refs；测试数据完全位于 jsfcstm 测试树；`npm test` 或项目现有 jsfcstm 测试命令通过 | PR-N1；与 PR-N2 可并行，二者都以 PR-N1 契约为硬基线；若 PR-N2 先合入，N3 review 必须复核其实现语义但不把 N2 作为硬合并依赖 |
| PR-N4：跨端契约回归与文档收口 | 🟩 已完成 | 统一 Python/jsfcstm 契约，补齐用户可见文档与回归测试 | Python 侧只做内联 DSL / refs 契约检查，不调用 Node、不读取 jsfcstm 测试树；jsfcstm 侧用 `editors/jsfcstm/test/` 内独立 fixture / snapshot 检查，不调用 Python、不读取 `test/` fixture；补 CLI inspect 入口和 jsfcstm editor 入口的 message + refs 用户可见输出回归；更新 diagnostics README 和必要 API 文档；确认 `make rst_auto` 结果 | Python 与 jsfcstm 诊断码、refs 必含字段、context 枚举、`target_templates` 集合一致；Python CLI inspect 与 jsfcstm editor 都有 4 类规则的 fixture 级 message + refs 验证；文档不把 C/C++ 风险写成 Python 风险；Python/jsfcstm 测试树独立；`make rst_auto` 后无意外 diff；相关单元测试通过 | PR-N2、PR-N3 |


## 状态维护约定

后续维护本伞 PR 时，子 PR 表格与 Mermaid 图必须同步更新状态。状态统一使用 emoji + 短文本，并保持 Mermaid block color 与状态一致：

| 状态 | 含义 |
|---|---|
| 🟨 待开始 | 已规划但尚未开 PR / 尚未进入实现。 |
| 🟦 进行中 | PR 已打开或正在实现 / review / CI 迭代。 |
| 🟩 已完成 | 子 PR 已 merge，验收项已同步回本伞 PR。 |
| 🟥 阻塞 | 存在 C/I 级阻塞或外部依赖，不能继续推进。 |
| 🟪 后置 | 明确不属于当前伞 PR 闭环，转入后续 issue / PR。 |

## 依赖关系

```mermaid
flowchart TD
    I253["issue #253<br/>inspect 数值规则设计<br/>🟩 已完成"]
    N1["PR-N1<br/>诊断契约与目标剖面字段<br/>🟩 已完成"]
    N2["PR-N2<br/>Python inspect 数值 analyzer<br/>🟩 已完成"]
    N3["PR-N3<br/>jsfcstm inspect 数值 parity<br/>🟩 已完成"]
    N4["PR-N4<br/>跨端契约回归与文档收口<br/>🟩 已完成"]

    I253 --> N1
    N1 --> N2
    N1 --> N3
    N2 --> N4
    N3 --> N4

    classDef done fill:#dcfce7,stroke:#16a34a,color:#111827;
    classDef pending fill:#fef3c7,stroke:#d97706,color:#111827;
    classDef progress fill:#dbeafe,stroke:#2563eb,color:#111827;
    classDef blocked fill:#fee2e2,stroke:#dc2626,color:#111827;
    classDef deferred fill:#ede9fe,stroke:#7c3aed,color:#111827;

    class I253 done;
    class N1 done;
    class N2 done;
    class N3 done;
    class N4 done;
```

## 总体验收标准

- [x] 伞 PR body 与 issue #253 当前 ready 设计一致，没有把 #254 / #255 工作偷塞进本线。
- [x] 4 类必做诊断均已通过子 PR 落地，并进入默认 inspect/static pipeline；若某条规则未进入默认 pipeline，必须在对应子 PR 和本伞 PR 中显式说明能力边界。
- [x] 每条新增诊断的 message 和 refs 都明确表达 C/C++ / C-family 默认部署剖面限定，不能只靠 message 或只靠 refs。
- [x] `target_templates` 稳定表达 `c`、`c_poll`、`cpp`、`cpp_poll`，Python 不被误列为同类风险目标。
- [x] RHS-zero 按 `/`、`%` 右操作数可折叠为 0 触发，LHS 动态不影响触发；若 div/mod 合并为一个 code，`operator` 是 required refs 字段。
- [x] int64 signed 边界样例在 Python 与 jsfcstm 两侧锁定：`9223372036854775808` warning、`-9223372036854775808` no warning、`-9223372036854775809` warning。
- [x] 常量折叠算子集合、折叠禁区、`context` 枚举、`statement_kind`、`operand_types`、目标剖面字段在 Python 与 jsfcstm 双侧测试中锁定。
- [x] Python 测试只使用 `test/` 树内数据且不调用 Node / jsfcstm；jsfcstm 测试只使用 `editors/jsfcstm/test/` 树内数据且不调用 Python。
- [x] `codes.yaml`、schema、jsfcstm 同步资源、Python analyzer、jsfcstm analyzer、CLI / jsfcstm editor 用户可见输出保持一致。
- [x] 公共 Python API 或 pydoc 有变更时已运行 `make rst_auto` 并提交预期 RST 更新。
- [x] 相关 CI 全绿；Codecov 评论无新增 C/I 级覆盖缺口。

## Review 关注点

后续每个子 PR review 都必须重点检查：

1. 是否把 C/C++ 目标相关 warning 写成目标无关错误；
2. 是否只在 message 或只在 refs 写目标限定；
3. 是否漏掉 `lifecycle_action`、`transition_effect` 或 assignment RHS 等扫描位置；
4. 是否在 Python/jsfcstm 之间共享测试 fixture 或跨 runtime 调用；
5. 是否把动态证明、BitVec、BMC、fixed-point 或 codegen policy 偷带进本线；
6. 是否漏掉 jsfcstm `codes.json` / `schema.json` 共享资源同步；
7. 是否把合法的 `-9223372036854775808` 误报为超范围 literal。






