### PR TITLE
契约：锁定 inspect 数值诊断公共字段

### DIFF
--- a/docs/source/api_doc/diagnostics/codes.rst
+++ b/docs/source/api_doc/diagnostics/codes.rst
@@ -22,7 +22,7 @@ CodeFieldSpec
 -----------------------------------------------------
 
 .. autoclass:: CodeFieldSpec
-    :members: name,type,required,description,enum
+    :members: name,type,required,description,enum,item_enum,exact_values
 
 
 ForLlmSpec

--- a/editors/jsfcstm/src/diagnostics/codes.ts
+++ b/editors/jsfcstm/src/diagnostics/codes.ts
@@ -65,6 +65,12 @@ export interface CodeSpec {
     description: string;
     refs?: Record<string, CodeFieldSpec>;
     capability?: 'pure_static' | 'const_fold' | 'requires_solver' | 'requires_simulation';
+    emit_tier?:
+        | 'static_pipeline'
+        | 'lookup_api'
+        | 'partial_static_pipeline'
+        | 'verify_pipeline'
+        | 'catalog_only';
     for_llm?: ForLlmSpec;
     suggested_fix?: SuggestedFixSpec;
     example_dsl?: string;

--- a/editors/jsfcstm/src/diagnostics/codes.ts
+++ b/editors/jsfcstm/src/diagnostics/codes.ts
@@ -22,6 +22,8 @@ export interface CodeFieldSpec {
     required?: boolean;
     description?: string;
     enum?: readonly string[];
+    item_enum?: readonly string[];
+    exact_values?: readonly string[];
 }
 
 /**

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -4,6 +4,16 @@ import {packageModule} from './support';
 
 const {loadCodesRegistry, loadInspectModelSchema} = packageModule;
 
+const numericCodes = [
+    'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+    'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_FLOAT_BITWISE',
+] as const;
+
+const cFamilyTargetTemplates = ['c', 'c_poll', 'cpp', 'cpp_poll'];
+const numericContexts = ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action'];
+
 describe('diagnostics resources (PR-A)', () => {
     describe('schema.json bundled', () => {
         it('loads as a valid JSON schema document', () => {
@@ -76,6 +86,67 @@ describe('diagnostics resources (PR-A)', () => {
             ]) {
                 assert.ok(registry[code], `${code} missing from bundled codes registry`);
             }
+        });
+
+        it('contains C/C++ numeric catalog-only diagnostics', () => {
+            const registry = loadCodesRegistry();
+            for (const code of numericCodes) {
+                const spec = registry[code];
+                assert.ok(spec, `${code} missing from bundled codes registry`);
+                assert.equal(spec.severity, 'warning', `${code} must stay warning-level`);
+                assert.equal(spec.emit_tier, 'catalog_only', `${code} must not emit before analyzers land`);
+                assert.equal(spec.span_object, 'expression', `${code} must identify an expression`);
+                assert.ok(spec.example_dsl, `${code} must keep a parseable example DSL contract`);
+                assert.ok(spec.for_llm, `${code} must keep LLM-facing guidance`);
+            }
+        });
+
+        it('locks numeric target-profile refs fields', () => {
+            const registry = loadCodesRegistry();
+            for (const code of numericCodes) {
+                const refs = registry[code].refs ?? {};
+                for (const field of ['target_family', 'target_templates', 'runtime_note', 'context', 'expr_text']) {
+                    assert.ok(refs[field], `${code} refs missing ${field}`);
+                    assert.equal(refs[field].required, true, `${code}.${field} must be required`);
+                }
+                assert.deepEqual(refs.target_family.enum, ['c_family']);
+                assert.equal(refs.target_templates.type, 'list[str]');
+                assert.deepEqual(refs.context.enum, numericContexts);
+            }
+        });
+
+        it('locks numeric rule-specific refs fields', () => {
+            const registry = loadCodesRegistry();
+
+            const literalRefs = registry.W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE.refs ?? {};
+            for (const field of ['literal_text', 'target_bits', 'signed', 'min_value_text', 'max_value_text']) {
+                assert.equal(literalRefs[field]?.required, true, `literal range refs missing required ${field}`);
+            }
+
+            const divRefs = registry.W_NUMERIC_CONSTANT_DIVISION_BY_ZERO.refs ?? {};
+            assert.equal(divRefs.operator?.required, true);
+            assert.deepEqual(divRefs.operator?.enum, ['/', '%']);
+            assert.equal(divRefs.rhs_text?.required, true);
+
+            const shiftRefs = registry.W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE.refs ?? {};
+            assert.equal(shiftRefs.operator?.required, true);
+            assert.deepEqual(shiftRefs.operator?.enum, ['<<', '>>']);
+            assert.equal(shiftRefs.target_bits?.required, true);
+            assert.equal(shiftRefs.shift_count_text?.required, true);
+
+            const bitwiseRefs = registry.W_NUMERIC_FLOAT_BITWISE.refs ?? {};
+            assert.equal(bitwiseRefs.operator?.required, true);
+            assert.deepEqual(bitwiseRefs.operator?.enum, ['&', '^', '|', '<<', '>>']);
+            assert.equal(bitwiseRefs.operand_types?.required, true);
+            assert.equal(bitwiseRefs.operand_type_sources?.required, true);
+            assert.deepEqual(bitwiseRefs.statement_kind?.enum, ['operation_assignment']);
+        });
+
+        it('does not predeclare deferred verify-guidance numeric codes', () => {
+            const registry = loadCodesRegistry();
+            assert.equal(registry.W_NUMERIC_SHIFT_REQUIRES_PROOF, undefined);
+            assert.equal(registry.I_NUMERIC_VERIFY_RECOMMENDED, undefined);
+            assert.deepEqual(cFamilyTargetTemplates, ['c', 'c_poll', 'cpp', 'cpp_poll']);
         });
     });
 });

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -13,6 +13,8 @@ const numericCodes = [
 
 const cFamilyTargetTemplates = ['c', 'c_poll', 'cpp', 'cpp_poll'];
 const numericContexts = ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action'];
+const operandTypes = ['int', 'float', 'unknown'];
+const operandTypeSources = ['literal', 'declared_var', 'local_expression'];
 
 describe('diagnostics resources (PR-A)', () => {
     describe('schema.json bundled', () => {
@@ -111,6 +113,9 @@ describe('diagnostics resources (PR-A)', () => {
                 }
                 assert.deepEqual(refs.target_family.enum, ['c_family']);
                 assert.equal(refs.target_templates.type, 'list[str]');
+                assert.deepEqual(refs.target_templates.item_enum, cFamilyTargetTemplates);
+                assert.deepEqual(refs.target_templates.exact_values, cFamilyTargetTemplates);
+                assert.ok(!refs.target_templates.exact_values?.includes('python'));
                 assert.deepEqual(refs.context.enum, numericContexts);
             }
         });
@@ -138,7 +143,9 @@ describe('diagnostics resources (PR-A)', () => {
             assert.equal(bitwiseRefs.operator?.required, true);
             assert.deepEqual(bitwiseRefs.operator?.enum, ['&', '^', '|', '<<', '>>']);
             assert.equal(bitwiseRefs.operand_types?.required, true);
+            assert.deepEqual(bitwiseRefs.operand_types?.item_enum, operandTypes);
             assert.equal(bitwiseRefs.operand_type_sources?.required, true);
+            assert.deepEqual(bitwiseRefs.operand_type_sources?.item_enum, operandTypeSources);
             assert.deepEqual(bitwiseRefs.statement_kind?.enum, ['operation_assignment']);
         });
 
@@ -146,7 +153,6 @@ describe('diagnostics resources (PR-A)', () => {
             const registry = loadCodesRegistry();
             assert.equal(registry.W_NUMERIC_SHIFT_REQUIRES_PROOF, undefined);
             assert.equal(registry.I_NUMERIC_VERIFY_RECOMMENDED, undefined);
-            assert.deepEqual(cFamilyTargetTemplates, ['c', 'c_poll', 'cpp', 'cpp_poll']);
         });
     });
 });

--- a/pyfcstm/diagnostics/README.md
+++ b/pyfcstm/diagnostics/README.md
@@ -66,3 +66,67 @@ object that the primary problem range is expected to identify. Some diagnostics
 allow reasonable precision differences across implementations: one side may
 cover an identifier while the other covers the containing declaration or
 transition, but both source slices must still hit the same problem object.
+
+## C/C++ deployment profile numeric contract
+
+The numeric diagnostics catalog also declares a target-specific contract for the
+current C/C++ family templates. This contract is intentionally separate from the
+core FCSTM model semantics: it describes risks that matter when a model is
+rendered into C/C++ generated code, not target-independent model errors.
+
+The default C/C++ deployment profile is:
+
+- `target_family`: `c_family`
+- `target_templates`: `c`, `c_poll`, `cpp`, `cpp_poll` in that order
+- DSL `int`: `PYFCSTM_GENERATED_INT64`, a 64-bit signed integer with range
+  `[-9223372036854775808, 9223372036854775807]`
+- DSL `float`: C/C++ `double`
+
+Python generated runtimes may not have the same risks. For example, Python
+integers are not bounded to this 64-bit C-family profile, and Python exception
+semantics for division by zero are not the same as a C/C++ deployment failure
+policy. Numeric diagnostic messages and `refs` payloads therefore must state the
+C/C++ target profile explicitly instead of reporting a generic FCSTM model
+error.
+
+### Numeric `refs` fields
+
+Every C/C++ numeric warning in the shared catalog carries these target fields:
+
+| Field | Contract |
+|---|---|
+| `target_family` | The string `c_family`. |
+| `target_templates` | The ordered list `c`, `c_poll`, `cpp`, `cpp_poll`; Python is not included. |
+| `runtime_note` | Human-readable note that distinguishes C/C++ deployment risk from Python generated runtime behavior. |
+| `context` | One of `var_initializer`, `guard`, `transition_effect`, `lifecycle_action`. |
+| `statement_kind` | Optional `operation_assignment` when the expression is an assignment right-hand side. |
+| `expr_text` | Source text for the expression shape being diagnosed. |
+
+Rule-specific fields are declared in `codes.yaml`. The first C/C++ numeric
+contract covers:
+
+- integer literals outside the default signed 64-bit range;
+- constant `/` or `%` with a right-hand side that folds to zero;
+- constant shift counts outside `0 <= count < 64`;
+- float-shaped operands in bitwise or shift operators.
+
+For the signed 64-bit boundary, a unary sign is interpreted together with the
+literal for contract classification: `9223372036854775808` is outside the upper
+bound, `-9223372036854775808` is the legal lower bound spelling, and
+`-9223372036854775809` is below the lower bound.
+
+### Lightweight constant folding boundary
+
+The numeric contract only assumes a lightweight, literal-only constant folder.
+It may fold numeric literals, unary `+` / `-`, parentheses, and literal-only
+uses of `+`, `-`, `*`, `/`, `%`, `<<`, `>>`, `&`, `^`, and `|` when both ends can
+represent the result consistently. It must not fold through division by zero,
+negative shifts, oversized shifts, variables, function calls, cross-statement
+constant propagation, block-local temporary inference, or algebraic rewrites such
+as `a - a` and `0 * x`.
+
+The shared catalog may contain `catalog_only` numeric codes. Those entries freeze
+code names and `refs` payloads before pyfcstm or jsfcstm emitters exist. They are
+not expected from `inspect_model()` or jsfcstm diagnostics until the corresponding
+analyzers land; tests for those entries should validate the catalog contract and
+parseable examples, not runtime emission.

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -98,11 +98,16 @@ _ALLOWED_CAPABILITIES = (
 #: * ``verify_pipeline`` — emitted only by the optional Python verify /
 #:   inspect adapter path. These codes are not part of the default static
 #:   inspect output and are not expected from jsfcstm.
+#: * ``catalog_only`` — declared in the shared catalog as a cross-end
+#:   contract but not emitted by any runtime pipeline yet. This is used when
+#:   a diagnostic contract must be frozen before the concrete pyfcstm /
+#:   jsfcstm analyzers land.
 _ALLOWED_EMIT_TIERS = (
     'static_pipeline',
     'lookup_api',
     'partial_static_pipeline',
     'verify_pipeline',
+    'catalog_only',
 )
 
 _ALLOWED_SUGGESTED_FIX_KINDS = ('insert', 'delete', 'replace')
@@ -288,8 +293,9 @@ class CodeSpec:
         end only (typically jsfcstm) — downstream LLM consumers should
         not block waiting for the missing end. ``'verify_pipeline'`` marks
         diagnostics emitted only by optional Python verify integration.
-        The field lets dispatchers register handlers based on the actual
-        emit channel.
+        ``'catalog_only'`` marks a shared catalog contract that no runtime
+        pipeline emits yet. The field lets dispatchers register handlers
+        based on the actual emit channel.
     :type emit_tier: str, optional
     :param span_object: Semantic source object identified by the primary
         diagnostic span. Repository entries declare this to make source-slice

--- a/pyfcstm/diagnostics/codes.py
+++ b/pyfcstm/diagnostics/codes.py
@@ -193,6 +193,26 @@ class CodeFieldSpec:
         runtime validator) checks that ``refs[field]`` is a member of the
         tuple. ``None`` means the field has no enumeration constraint.
     :type enum: Optional[Tuple[str, ...]]
+    :param item_enum: Optional tuple of allowed string values for items in a
+        ``list[str]`` field. ``None`` means list members are unconstrained
+        beyond being strings.
+    :type item_enum: Optional[Tuple[str, ...]]
+    :param exact_values: Optional exact ordered value contract for a
+        ``list[str]`` field. ``None`` means the list may contain any ordered
+        members allowed by ``item_enum`` and the base type token.
+    :type exact_values: Optional[Tuple[str, ...]]
+
+    Example::
+
+        >>> spec = CodeFieldSpec(
+        ...     name='target_templates',
+        ...     type='list[str]',
+        ...     required=True,
+        ...     description='Target templates.',
+        ...     exact_values=('c', 'c_poll'),
+        ... )
+        >>> spec.exact_values
+        ('c', 'c_poll')
     """
 
     name: str
@@ -200,6 +220,8 @@ class CodeFieldSpec:
     required: bool
     description: str
     enum: Optional[Tuple[str, ...]] = None
+    item_enum: Optional[Tuple[str, ...]] = None
+    exact_values: Optional[Tuple[str, ...]] = None
 
 
 @dataclass(frozen=True)
@@ -328,6 +350,67 @@ def _ctx(path: str, *bits: str) -> str:
     return f"codes.yaml at {path!r}: " + " ".join(bits)
 
 
+def _validate_string_list_field(
+        path: str,
+        code: str,
+        field_name: str,
+        raw: Mapping[str, Any],
+        key: str,
+) -> Optional[Tuple[str, ...]]:
+    """
+    Validate an optional string-list schema attribute.
+
+    :param path: Filesystem path for diagnostics in error messages.
+    :type path: str
+    :param code: Diagnostic code currently being loaded.
+    :type code: str
+    :param field_name: Refs field name currently being loaded.
+    :type field_name: str
+    :param raw: Raw YAML mapping for the refs field.
+    :type raw: Mapping[str, Any]
+    :param key: Attribute name to validate.
+    :type key: str
+    :return: Tuple of string values when present, otherwise ``None``.
+    :rtype: Optional[Tuple[str, ...]]
+    :raises CodesSchemaError: If ``key`` is present but is not a non-empty
+        YAML list of strings.
+
+    Example::
+
+        >>> _validate_string_list_field(
+        ...     'codes.yaml',
+        ...     'W_DEMO',
+        ...     'target_templates',
+        ...     {'exact_values': ['c', 'c_poll']},
+        ...     'exact_values',
+        ... )
+        ('c', 'c_poll')
+    """
+    raw_values = raw.get(key)
+    if raw_values is None:
+        return None
+    if not isinstance(raw_values, list):
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} {key!r} must be a list "
+            f"when present, got {type(raw_values).__name__}.",
+        ))
+    if not raw_values:
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} {key!r} must be non-empty "
+            f"when present.",
+        ))
+    for value in raw_values:
+        if not isinstance(value, str):
+            raise CodesSchemaError(_ctx(
+                path,
+                f"code {code!r} field {field_name!r} {key!r} members must "
+                f"be strings, got {type(value).__name__}: {value!r}.",
+            ))
+    return tuple(raw_values)
+
+
 def _validate_field(path: str, code: str, field_name: str, raw: Any) -> CodeFieldSpec:
     if not isinstance(raw, dict):
         raise CodesSchemaError(_ctx(
@@ -359,30 +442,41 @@ def _validate_field(path: str, code: str, field_name: str, raw: Any) -> CodeFiel
         ))
     description = str(raw.get('description', ''))
 
-    raw_enum = raw.get('enum')
-    field_enum: Optional[Tuple[str, ...]] = None
-    if raw_enum is not None:
-        if not isinstance(raw_enum, list):
+    field_enum = _validate_string_list_field(path, code, field_name, raw, 'enum')
+    item_enum = _validate_string_list_field(path, code, field_name, raw, 'item_enum')
+    exact_values = _validate_string_list_field(
+        path,
+        code,
+        field_name,
+        raw,
+        'exact_values',
+    )
+    if field_enum is not None and field_type != 'str':
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} 'enum' may only be used "
+            f"with type 'str', got {field_type!r}.",
+        ))
+    if item_enum is not None and field_type != 'list[str]':
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} 'item_enum' may only be "
+            f"used with type 'list[str]', got {field_type!r}.",
+        ))
+    if exact_values is not None and field_type != 'list[str]':
+        raise CodesSchemaError(_ctx(
+            path,
+            f"code {code!r} field {field_name!r} 'exact_values' may only be "
+            f"used with type 'list[str]', got {field_type!r}.",
+        ))
+    if item_enum is not None and exact_values is not None:
+        extra = set(exact_values) - set(item_enum)
+        if extra:
             raise CodesSchemaError(_ctx(
                 path,
-                f"code {code!r} field {field_name!r} 'enum' must be a list "
-                f"when present,",
-                f"got {type(raw_enum).__name__}",
+                f"code {code!r} field {field_name!r} 'exact_values' contains "
+                f"members outside 'item_enum': {sorted(extra)!r}.",
             ))
-        if not raw_enum:
-            raise CodesSchemaError(_ctx(
-                path,
-                f"code {code!r} field {field_name!r} 'enum' must be non-empty "
-                f"when present.",
-            ))
-        for value in raw_enum:
-            if not isinstance(value, str):
-                raise CodesSchemaError(_ctx(
-                    path,
-                    f"code {code!r} field {field_name!r} 'enum' members must "
-                    f"be strings, got {type(value).__name__}: {value!r}",
-                ))
-        field_enum = tuple(raw_enum)
 
     return CodeFieldSpec(
         name=field_name,
@@ -390,6 +484,8 @@ def _validate_field(path: str, code: str, field_name: str, raw: Any) -> CodeFiel
         required=raw_required,
         description=description,
         enum=field_enum,
+        item_enum=item_enum,
+        exact_values=exact_values,
     )
 
 

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -23,9 +23,11 @@
 # is documentation; a test asserts the two stay aligned):
 #   str | str_or_null | int | int_or_null | float | number | bool | dict | Span | list[str] | list[Span]
 #
-# Adding a new code: append a new top-level entry here AND add a fixture
-# test that triggers it from a real DSL snippet. The loader in `codes.py`
-# verifies the schema at import time.
+# Adding a new emitted code: append a new top-level entry here AND add a
+# fixture test that triggers it from a real DSL snippet. Catalog-only
+# contract codes may instead provide a parseable DSL snippet that documents
+# the intended trigger shape before the emitting analyzer lands. The loader
+# in `codes.py` verifies the schema at import time.
 
 E_UNDEFINED_VAR:
   severity: error
@@ -2065,6 +2067,335 @@ W_LITERAL_TYPE_NARROWING:
   example_dsl: |
     def int truncated = 3.5;
     state Root { state A; [*] -> A; }
+
+# ---------------------------------------------------------------------------
+# C/C++ deployment-profile numeric diagnostics catalog contract.
+# ---------------------------------------------------------------------------
+
+W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
+  severity: warning
+  span_object: expression
+  capability: pure_static
+  emit_tier: catalog_only
+  description: >-
+    An integer literal that would be rendered into a C/C++ family template
+    falls outside the default ``PYFCSTM_GENERATED_INT64`` signed range. This
+    warning is target-profile-specific: Python generated runtimes may not have
+    the same fixed-width integer carrying risk.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ deployment-profile risk and
+        that Python generated runtimes may not have the same risk.
+    context:
+      type: str
+      required: true
+      description: Expression location where the literal appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the expression containing the literal.
+    literal_text:
+      type: str
+      required: true
+      description: Source text of the integer literal after applying a unary sign when present.
+    target_bits:
+      type: int
+      required: true
+      description: Target integer width in bits.
+    signed:
+      type: bool
+      required: true
+      description: Whether the target integer profile is signed.
+    min_value_text:
+      type: str
+      required: true
+      description: Decimal text of the minimum representable target value.
+    max_value_text:
+      type: str
+      required: true
+      description: Decimal text of the maximum representable target value.
+    var_name:
+      type: str
+      required: false
+      description: Variable receiving the literal when the location can be named.
+  for_llm:
+    summary: >-
+      A literal intended for C/C++ generated code exceeds the default 64-bit
+      signed integer profile. Treat this as a C/C++ deployment-profile warning,
+      not as proof that Python generated code is invalid.
+    recommended_actions:
+      - kind: reduce_literal
+        target: expression
+        rationale: Keep integer literals within the documented C/C++ target range when deploying to C-family templates.
+      - kind: choose_target_profile
+        target: deployment_plan
+        rationale: If the large value is intentional, document or verify a target profile that can carry it before generating C/C++ code.
+    do_not:
+      - "Do not describe this as a target-independent FCSTM model error; the risk is tied to the C/C++ default integer profile."
+      - "Do not flag the legal lower-bound spelling ``-9223372036854775808`` as out of range."
+  example_dsl: |
+    def int too_large = 9223372036854775808;
+    state Root { state A; [*] -> A; }
+
+W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
+  severity: warning
+  span_object: expression
+  capability: const_fold
+  emit_tier: catalog_only
+  description: >-
+    A ``/`` or ``%`` operation has a right-hand side that the lightweight
+    literal-only constant folder can classify as zero. This is reported as a
+    C/C++ deployment-profile risk because generated C/C++ code needs an
+    explicit definition or failure channel; Python runtime exception semantics
+    are different.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ deployment-profile risk and
+        that Python generated runtimes may not have the same failure contract.
+    context:
+      type: str
+      required: true
+      description: Expression location where the operator appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the expression containing the operation.
+    operator:
+      type: str
+      required: true
+      description: Operator whose right-hand side folded to zero.
+      enum: ['/', '%']
+    rhs_text:
+      type: str
+      required: true
+      description: Source text of the right-hand side that folded to zero.
+  for_llm:
+    summary: >-
+      A division or modulo RHS is statically zero under the lightweight
+      literal-only folder. For C/C++ generated code this needs a design fix or
+      explicit failure policy; do not conflate it with Python's exception model.
+    recommended_actions:
+      - kind: fix_denominator
+        target: expression
+        rationale: Replace the zero RHS with a non-zero expression or guard the operation before C/C++ deployment.
+      - kind: add_failure_policy
+        target: deployment_plan
+        rationale: If zero is possible by design, define the C/C++ failure channel instead of leaving generated code behavior implicit.
+    do_not:
+      - "Do not require the whole expression to be literal-only; only the RHS of ``/`` or ``%`` needs to fold to zero."
+      - "Do not drop ``refs.operator`` when division and modulo share this code."
+  example_dsl: |
+    def int result = 0;
+    def int input = 1;
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B effect { result = input / (1 - 1); };
+    }
+
+W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
+  severity: warning
+  span_object: expression
+  capability: const_fold
+  emit_tier: catalog_only
+  description: >-
+    A shift count folds to a constant below zero or not less than the default
+    C/C++ target integer width. This is a C/C++ 64-bit deployment-profile
+    portability risk; Python big-integer shifting is not the same target
+    contract.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ deployment-profile risk and
+        that Python generated runtimes may not have the same fixed-width shift risk.
+    context:
+      type: str
+      required: true
+      description: Expression location where the shift appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the shift expression.
+    operator:
+      type: str
+      required: true
+      description: Shift operator.
+      enum: ['<<', '>>']
+    target_bits:
+      type: int
+      required: true
+      description: Target integer width in bits.
+    shift_count_text:
+      type: str
+      required: true
+      description: Source text of the shift count after lightweight folding.
+  for_llm:
+    summary: >-
+      A shift count is statically outside the C/C++ default 64-bit profile.
+      Treat this as a target-profile portability warning, not as a Python
+      generated-runtime error.
+    recommended_actions:
+      - kind: bound_shift_count
+        target: expression
+        rationale: Keep constant shift counts within ``0 <= count < 64`` for the default C/C++ profile.
+      - kind: use_verify_for_dynamic_count
+        target: deployment_plan
+        rationale: If the shift count is not constant, use the verify line to prove the range before C/C++ deployment.
+    do_not:
+      - "Do not report dynamic shift counts as proven unsafe from this catalog-only rule."
+      - "Do not fold negative or oversized shift operations into a normal numeric result."
+  example_dsl: |
+    def int flags = 1;
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B : if [(flags << 64) != 0];
+    }
+
+W_NUMERIC_FLOAT_BITWISE:
+  severity: warning
+  span_object: expression
+  capability: pure_static
+  emit_tier: catalog_only
+  description: >-
+    A value known to be ``float`` participates in a bitwise or shift operator
+    that belongs to the C/C++ integer operation profile. The warning is
+    target-profile-specific even when other runtimes may also reject some
+    float-bitwise shapes for different reasons.
+  refs:
+    target_family:
+      type: str
+      required: true
+      description: Target family whose default deployment profile owns this risk.
+      enum: ['c_family']
+    target_templates:
+      type: list[str]
+      required: true
+      description: >-
+        Ordered target templates covered by this default C/C++ profile:
+        ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+    runtime_note:
+      type: str
+      required: true
+      description: >-
+        Human-readable note that this is a C/C++ integer-operation profile
+        risk and that other runtimes may fail for different reasons.
+    context:
+      type: str
+      required: true
+      description: Expression location where the bitwise operation appears.
+      enum: ['var_initializer', 'guard', 'transition_effect', 'lifecycle_action']
+    statement_kind:
+      type: str
+      required: false
+      description: Statement shape when the expression is an operation assignment RHS.
+      enum: ['operation_assignment']
+    expr_text:
+      type: str
+      required: true
+      description: Source text of the bitwise expression.
+    operator:
+      type: str
+      required: true
+      description: Bitwise or shift operator involving a float-shaped operand.
+      enum: ['&', '^', '|', '<<', '>>']
+    operand_types:
+      type: list[str]
+      required: true
+      description: >-
+        Operand type tags in expression order. Allowed members are ``int``,
+        ``float``, and ``unknown``.
+    operand_type_sources:
+      type: list[str]
+      required: true
+      description: >-
+        Evidence source for each operand type tag. Allowed members are
+        ``literal``, ``declared_var``, and ``local_expression``.
+  for_llm:
+    summary: >-
+      A float-shaped operand reaches a C/C++ integer bitwise operation. Keep
+      the diagnostic target-specific and use the operand type refs to explain
+      why the expression is considered risky.
+    recommended_actions:
+      - kind: use_integer_operand
+        target: expression
+        rationale: Replace the float operand with an integer flag/mask value when deploying to C/C++ templates.
+      - kind: change_variable_type
+        target: variable_definition
+        rationale: If the value is intended as a bit mask, declare and update it as an integer-shaped variable.
+    do_not:
+      - "Do not describe this only as a generic Python TypeError; the shared contract is about the C/C++ integer-operation profile."
+      - "Do not infer cross-statement temporary types for this first deterministic rule."
+  example_dsl: |
+    def float gain = 1.5;
+    def int flags = 1;
+    state Root {
+        state A {
+            during { flags = flags & gain; }
+        }
+        [*] -> A;
+    }
 
 W_ASPECT_NO_DESCENDANT_LEAF:
   severity: warning

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -11,7 +11,9 @@
 #                        but the source slice must still hit this object.
 #   - `refs`           — payload schema for `ModelDiagnostic.refs`. Each
 #                        field declares its type, whether it is required,
-#                        and a short description. Field names are part of
+#                        and a short description. String fields may declare
+#                        `enum`; `list[str]` fields may declare `item_enum`
+#                        and/or `exact_values`. Field names are part of
 #                        the public contract; downstream consumers should
 #                        rely on these names verbatim.
 #   - `example_dsl`    — minimal DSL snippet that triggers the code (used
@@ -2094,6 +2096,8 @@ W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2180,6 +2184,8 @@ W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2256,6 +2262,8 @@ W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2335,6 +2343,8 @@ W_NUMERIC_FLOAT_BITWISE:
       description: >-
         Ordered target templates covered by this default C/C++ profile:
         ``c``, ``c_poll``, ``cpp``, ``cpp_poll``.
+      item_enum: ['c', 'c_poll', 'cpp', 'cpp_poll']
+      exact_values: ['c', 'c_poll', 'cpp', 'cpp_poll']
     runtime_note:
       type: str
       required: true
@@ -2366,12 +2376,14 @@ W_NUMERIC_FLOAT_BITWISE:
       description: >-
         Operand type tags in expression order. Allowed members are ``int``,
         ``float``, and ``unknown``.
+      item_enum: ['int', 'float', 'unknown']
     operand_type_sources:
       type: list[str]
       required: true
       description: >-
         Evidence source for each operand type tag. Allowed members are
         ``literal``, ``declared_var``, and ``local_expression``.
+      item_enum: ['literal', 'declared_var', 'local_expression']
   for_llm:
     summary: >-
       A float-shaped operand reaches a C/C++ integer bitwise operation. Keep

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -54,7 +54,7 @@ from .analyzers import (
     collect_design_health_warnings,
     collect_expr_variables,
 )
-from .codes import CODE_REGISTRY, CodeFieldSpec
+from .codes import CODE_REGISTRY, CodeFieldSpec, CodeSpec
 from ..utils.validate import ModelDiagnostic, Span
 
 if TYPE_CHECKING:  # pragma: no cover - import-time forward refs only
@@ -2250,7 +2250,12 @@ def _type_matches_schema(value: Any, field_spec: CodeFieldSpec) -> bool:
     return True
 
 
-def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
+def _refs_match_code_schema(
+        code: str,
+        refs: Mapping[str, Any],
+        *,
+        _registry: Mapping[str, CodeSpec] = CODE_REGISTRY,
+) -> bool:
     """Return whether refs satisfy the declared verify-adapter schema.
 
     The conversion layer uses this as a fail-closed guard: raw verify findings
@@ -2264,6 +2269,10 @@ def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
     :type code: str
     :param refs: Candidate refs payload.
     :type refs: Mapping[str, Any]
+    :param _registry: Diagnostic code registry used for validation. Defaults
+        to :data:`CODE_REGISTRY`; tests may pass a synthetic registry to cover
+        schema predicates without mutating the global registry.
+    :type _registry: Mapping[str, CodeSpec], optional
     :return: ``True`` when the code may be emitted by the verify adapter and
         refs match its schema.
     :rtype: bool
@@ -2286,7 +2295,7 @@ def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
         ... })
         True
     """
-    spec = CODE_REGISTRY.get(code)
+    spec = _registry.get(code)
     if spec is None:
         return False
     if spec.emit_tier != 'verify_pipeline' and code not in VERIFY_SHARED_STATIC_CODES:
@@ -2304,6 +2313,12 @@ def _refs_match_code_schema(code: str, refs: Mapping[str, Any]) -> bool:
         if field_spec.enum and value not in set(field_spec.enum):
             return False
         if not _type_matches_schema(value, field_spec):
+            return False
+        if field_spec.item_enum:
+            allowed_items = set(field_spec.item_enum)
+            if any(item not in allowed_items for item in value):
+                return False
+        if field_spec.exact_values and tuple(value) != field_spec.exact_values:
             return False
     return True
 
@@ -2427,6 +2442,39 @@ def _verify_diagnostics_from_results(
             continue
         diagnostics.extend(_structural_verify_diagnostics(result, states, events))
     return tuple(diagnostics)
+
+
+def _catalog_emittable_diagnostics(
+        diagnostics: Sequence[ModelDiagnostic],
+) -> Tuple[ModelDiagnostic, ...]:
+    """
+    Return diagnostics that are allowed to appear in inspect output.
+
+    Catalog-only codes freeze cross-end contracts before an analyzer is wired.
+    If a future analyzer accidentally emits such a code before the contract is
+    promoted to a real emit tier, the public inspect surface must fail closed
+    by dropping it.
+
+    :param diagnostics: Candidate diagnostics collected from inspect analyzers.
+    :type diagnostics: Sequence[ModelDiagnostic]
+    :return: Diagnostics whose code registry entry is not ``catalog_only``.
+    :rtype: Tuple[ModelDiagnostic, ...]
+
+    Example::
+
+        >>> _catalog_emittable_diagnostics((ModelDiagnostic(
+        ...     code='W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+        ...     severity='warning',
+        ...     message='catalog-only test',
+        ... ),))
+        ()
+    """
+    return tuple(
+        diagnostic
+        for diagnostic in diagnostics
+        if CODE_REGISTRY.get(diagnostic.code) is None
+        or CODE_REGISTRY[diagnostic.code].emit_tier != 'catalog_only'
+    )
 
 
 def _deduplicate_model_diagnostics(
@@ -2586,6 +2634,7 @@ def inspect_model(
             events,
             actions,
         ))
+    diagnostics = list(_catalog_emittable_diagnostics(diagnostics))
     diagnostics = list(_deduplicate_model_diagnostics(diagnostics))
     return ModelInspect(
         root_state_path=root_state_path,

--- a/test/diagnostics/_schema_check.py
+++ b/test/diagnostics/_schema_check.py
@@ -105,6 +105,18 @@ def assert_refs_match_schema(diag: ModelDiagnostic, *, context: str = '') -> Non
             f'has runtime type {type(value).__name__}, expected schema '
             f'type {field_spec.type!r}'
         )
+        if field_spec.item_enum:
+            allowed_items = set(field_spec.item_enum)
+            invalid_items = [item for item in value if item not in allowed_items]
+            assert not invalid_items, (
+                f'{prefix}{diag.code} refs[{field_name!r}] has items '
+                f'{invalid_items!r} outside item_enum {sorted(allowed_items)}'
+            )
+        if field_spec.exact_values:
+            assert tuple(value) == field_spec.exact_values, (
+                f'{prefix}{diag.code} refs[{field_name!r}] = {value!r} '
+                f'does not match exact_values {field_spec.exact_values!r}'
+            )
         if field_name == 'suggested_fix' and value is not None:
             _assert_suggested_fix_payload(value, prefix=prefix, code=diag.code)
 

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -157,7 +157,10 @@ class TestLoaderValidation:
         """)
         reg = load_codes(path)
         assert 'E_FOO' in reg
-        assert reg['E_FOO'].refs_schema['bar'].type == 'str'
+        field = reg['E_FOO'].refs_schema['bar']
+        assert field.type == 'str'
+        assert field.item_enum is None
+        assert field.exact_values is None
 
     def test_rejects_unknown_severity(self, tmp_path):
         path = self._write_yaml(tmp_path, """

--- a/test/diagnostics/test_codes_yaml_layer2.py
+++ b/test/diagnostics/test_codes_yaml_layer2.py
@@ -259,6 +259,22 @@ class TestCodesLoaderNegativePaths:
         registry = load_codes(path)
         assert registry['W_DEMO'].emit_tier == 'verify_pipeline'
 
+    def test_loader_accepts_catalog_only_emit_tier(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: catalog-only demo
+              capability: pure_static
+              emit_tier: catalog_only
+              refs:
+                expr_text:
+                  type: str
+                  required: true
+                  description: expression
+            """)
+        registry = load_codes(path)
+        assert registry['W_DEMO'].emit_tier == 'catalog_only'
+
     def test_loader_rejects_for_llm_not_a_dict(self, tmp_path):
         # ``for_llm`` declared as a string — must be a mapping.
         path = _write_yaml(tmp_path, """

--- a/test/diagnostics/test_codes_yaml_layer2.py
+++ b/test/diagnostics/test_codes_yaml_layer2.py
@@ -208,6 +208,73 @@ class TestCapabilityField:
 
 
 @pytest.mark.unittest
+class TestEmitTierField:
+    def test_loader_accepts_catalog_only_emit_tier(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: catalog-only demo
+              capability: pure_static
+              emit_tier: catalog_only
+              refs:
+                expr_text:
+                  type: str
+                  required: true
+                  description: expression
+            """)
+        registry = load_codes(path)
+        assert registry['W_DEMO'].emit_tier == 'catalog_only'
+
+    def test_loader_accepts_list_string_item_contracts(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: list string schema demo
+              refs:
+                target_templates:
+                  type: list[str]
+                  required: true
+                  description: target template set
+                  item_enum: [c, c_poll]
+                  exact_values: [c, c_poll]
+            """)
+        spec = load_codes(path)['W_DEMO'].refs_schema['target_templates']
+        assert spec.item_enum == ('c', 'c_poll')
+        assert spec.exact_values == ('c', 'c_poll')
+
+    def test_loader_rejects_list_contracts_on_scalar_types(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: bad list schema demo
+              refs:
+                target_family:
+                  type: str
+                  required: true
+                  description: target family
+                  item_enum: [c_family]
+            """)
+        with pytest.raises(CodesSchemaError, match='item_enum'):
+            load_codes(path)
+
+    def test_loader_rejects_exact_values_outside_item_enum(self, tmp_path):
+        path = _write_yaml(tmp_path, """
+            W_DEMO:
+              severity: warning
+              description: bad exact list schema demo
+              refs:
+                target_templates:
+                  type: list[str]
+                  required: true
+                  description: target templates
+                  item_enum: [c, c_poll]
+                  exact_values: [c, python]
+            """)
+        with pytest.raises(CodesSchemaError, match='exact_values'):
+            load_codes(path)
+
+
+@pytest.mark.unittest
 class TestExistingErrorCodesStillLoad:
     """The 14 Layer 1 ``E_*`` codes must keep loading without ``for_llm``."""
 
@@ -258,22 +325,6 @@ class TestCodesLoaderNegativePaths:
             """)
         registry = load_codes(path)
         assert registry['W_DEMO'].emit_tier == 'verify_pipeline'
-
-    def test_loader_accepts_catalog_only_emit_tier(self, tmp_path):
-        path = _write_yaml(tmp_path, """
-            W_DEMO:
-              severity: warning
-              description: catalog-only demo
-              capability: pure_static
-              emit_tier: catalog_only
-              refs:
-                expr_text:
-                  type: str
-                  required: true
-                  description: expression
-            """)
-        registry = load_codes(path)
-        assert registry['W_DEMO'].emit_tier == 'catalog_only'
 
     def test_loader_rejects_for_llm_not_a_dict(self, tmp_path):
         # ``for_llm`` declared as a string — must be a mapping.

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -3266,6 +3266,47 @@ class TestInspectModelVerifyIntegration:
             )
             assert not inspect_module._type_matches_schema(value, field_spec)
 
+    def test_verify_refs_schema_honors_list_string_constraints(self):
+        registry = {
+            'W_TEST_NUMERIC_PROFILE': inspect_module.CodeSpec(
+                code='W_TEST_NUMERIC_PROFILE',
+                severity='warning',
+                description='test numeric profile',
+                emit_tier='verify_pipeline',
+                refs_schema={
+                    'target_family': inspect_module.CodeFieldSpec(
+                        name='target_family',
+                        type='str',
+                        required=True,
+                        description='target family',
+                        enum=('c_family',),
+                    ),
+                    'target_templates': inspect_module.CodeFieldSpec(
+                        name='target_templates',
+                        type='list[str]',
+                        required=True,
+                        description='target templates',
+                        item_enum=('c', 'c_poll'),
+                        exact_values=('c', 'c_poll'),
+                    ),
+                },
+            ),
+        }
+        valid_refs = {
+            'target_family': 'c_family',
+            'target_templates': ['c', 'c_poll'],
+        }
+        assert inspect_module._refs_match_code_schema(
+            'W_TEST_NUMERIC_PROFILE',
+            valid_refs,
+            _registry=registry,
+        )
+        assert not inspect_module._refs_match_code_schema(
+            'W_TEST_NUMERIC_PROFILE',
+            dict(valid_refs, target_templates=['python']),
+            _registry=registry,
+        )
+
     @pytest.mark.parametrize(
         'kind',
         ['unknown', 'timeout', 'undecidable_skip'],

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -7,11 +7,18 @@ from textwrap import dedent
 import pytest
 
 from pyfcstm.diagnostics import CODE_REGISTRY, inspect_model
+from pyfcstm.diagnostics.inspect import _catalog_emittable_diagnostics
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.utils import ModelDiagnostic
 
 from ._schema_check import assert_refs_match_schema
+
+
+MIN_SIGNED_INT64_TEXT = "-9223372036854775808"
+MAX_SIGNED_INT64_TEXT = "9223372036854775807"
+TOO_LARGE_SIGNED_INT64_TEXT = "9223372036854775808"
+TOO_SMALL_SIGNED_INT64_TEXT = "-9223372036854775809"
 
 
 pytestmark = pytest.mark.unittest
@@ -28,7 +35,14 @@ C_FAMILY_TARGET_TEMPLATES = ["c", "c_poll", "cpp", "cpp_poll"]
 CONTEXT_ENUM = ("var_initializer", "guard", "transition_effect", "lifecycle_action")
 OPERAND_TYPES = {"int", "float", "unknown"}
 OPERAND_TYPE_SOURCES = {"literal", "declared_var", "local_expression"}
+OPERAND_TYPE_ENUM = ("int", "float", "unknown")
+OPERAND_TYPE_SOURCE_ENUM = ("literal", "declared_var", "local_expression")
 RUNTIME_NOTE_REQUIRED_TEXT = ("C/C++", "Python")
+SIGNED_INT64_BOUNDARY_CASES = (
+    (TOO_LARGE_SIGNED_INT64_TEXT, "warning"),
+    (MIN_SIGNED_INT64_TEXT, "no_warning"),
+    (TOO_SMALL_SIGNED_INT64_TEXT, "warning"),
+)
 
 
 SYNTHETIC_REFS = {
@@ -37,12 +51,12 @@ SYNTHETIC_REFS = {
         "target_templates": C_FAMILY_TARGET_TEMPLATES,
         "runtime_note": "C/C++ deployment profile risk; Python generated runtime may not have the same risk.",
         "context": "var_initializer",
-        "expr_text": "9223372036854775808",
-        "literal_text": "9223372036854775808",
+        "expr_text": TOO_LARGE_SIGNED_INT64_TEXT,
+        "literal_text": TOO_LARGE_SIGNED_INT64_TEXT,
         "target_bits": 64,
         "signed": True,
-        "min_value_text": "-9223372036854775808",
-        "max_value_text": "9223372036854775807",
+        "min_value_text": MIN_SIGNED_INT64_TEXT,
+        "max_value_text": MAX_SIGNED_INT64_TEXT,
         "var_name": "too_large",
     },
     "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO": {
@@ -79,13 +93,6 @@ SYNTHETIC_REFS = {
 }
 
 
-SIGNED_INT64_BOUNDARY_CASES = [
-    ("9223372036854775808", "warning"),
-    ("-9223372036854775808", "no_warning"),
-    ("-9223372036854775809", "warning"),
-]
-
-
 def _parse(source: str):
     ast = parse_with_grammar_entry(dedent(source), "state_machine_dsl")
     return parse_dsl_node_to_state_machine(ast)
@@ -115,6 +122,18 @@ def test_numeric_codes_do_not_emit_before_analyzer_lands(code):
     assert code not in {diag.code for diag in report.diagnostics}
 
 
+def test_catalog_only_diagnostics_are_filtered_from_inspect_output():
+    diagnostic = ModelDiagnostic(
+        code="W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+        severity="warning",
+        message="synthetic catalog-only diagnostic",
+        span=None,
+        refs=SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"],
+    )
+
+    assert _catalog_emittable_diagnostics((diagnostic,)) == ()
+
+
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
 def test_numeric_refs_schema_accepts_representative_payloads(code):
     spec = CODE_REGISTRY[code]
@@ -142,10 +161,13 @@ def test_numeric_target_profile_fields_are_required_and_stable(code):
         "expr_text",
     } <= required
     assert spec.refs_schema["target_family"].enum == ("c_family",)
-    assert spec.refs_schema["target_templates"].type == "list[str]"
+    target_templates = spec.refs_schema["target_templates"]
+    assert target_templates.type == "list[str]"
+    assert target_templates.item_enum == tuple(C_FAMILY_TARGET_TEMPLATES)
+    assert target_templates.exact_values == tuple(C_FAMILY_TARGET_TEMPLATES)
     refs = SYNTHETIC_REFS[code]
-    assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
-    assert "python" not in refs["target_templates"]
+    assert refs["target_templates"] == list(target_templates.exact_values)
+    assert "python" not in target_templates.exact_values
     assert spec.refs_schema["context"].enum == CONTEXT_ENUM
     assert refs["context"] in CONTEXT_ENUM
     for snippet in RUNTIME_NOTE_REQUIRED_TEXT:
@@ -157,14 +179,15 @@ def test_literal_range_code_locks_signed_int64_boundary_refs():
     refs = SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
     assert refs["target_bits"] == 64
     assert refs["signed"] is True
-    assert refs["min_value_text"] == "-9223372036854775808"
-    assert refs["max_value_text"] == "9223372036854775807"
-    assert "-9223372036854775808" in spec.for_llm.do_not[1]
-    assert SIGNED_INT64_BOUNDARY_CASES == [
-        ("9223372036854775808", "warning"),
-        ("-9223372036854775808", "no_warning"),
-        ("-9223372036854775809", "warning"),
-    ]
+    assert refs["min_value_text"] == MIN_SIGNED_INT64_TEXT
+    assert refs["max_value_text"] == MAX_SIGNED_INT64_TEXT
+    assert any(MIN_SIGNED_INT64_TEXT in item for item in spec.for_llm.do_not)
+    assert spec.example_dsl is not None
+    assert TOO_LARGE_SIGNED_INT64_TEXT in spec.example_dsl
+    assert MIN_SIGNED_INT64_TEXT == str(-(2 ** 63))
+    assert MAX_SIGNED_INT64_TEXT == str(2 ** 63 - 1)
+    assert TOO_LARGE_SIGNED_INT64_TEXT == str(2 ** 63)
+    assert TOO_SMALL_SIGNED_INT64_TEXT == str(-(2 ** 63) - 1)
 
 
 def test_numeric_boundary_example_dsl_variants_parse():
@@ -194,6 +217,10 @@ def test_shift_code_locks_target_bits_and_operator_contract():
 def test_float_bitwise_locks_operand_type_vocabularies():
     spec = CODE_REGISTRY["W_NUMERIC_FLOAT_BITWISE"]
     assert spec.refs_schema["operator"].enum == ("&", "^", "|", "<<", ">>")
+    operand_types = spec.refs_schema["operand_types"]
+    operand_type_sources = spec.refs_schema["operand_type_sources"]
+    assert operand_types.item_enum == OPERAND_TYPE_ENUM
+    assert operand_type_sources.item_enum == OPERAND_TYPE_SOURCE_ENUM
     assert (
         set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_types"]) <= OPERAND_TYPES
     )
@@ -201,6 +228,43 @@ def test_float_bitwise_locks_operand_type_vocabularies():
         set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_type_sources"])
         <= OPERAND_TYPE_SOURCES
     )
+
+
+def test_numeric_schema_rejects_target_templates_outside_c_family():
+    spec = CODE_REGISTRY["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
+    refs = dict(SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"])
+    refs["target_templates"] = ["python"]
+
+    with pytest.raises(AssertionError, match="item_enum|exact_values"):
+        assert_refs_match_schema(
+            ModelDiagnostic(
+                code=spec.code,
+                severity=spec.severity,
+                message="synthetic invalid target templates",
+                span=None,
+                refs=refs,
+            ),
+            context="invalid target_templates",
+        )
+
+
+def test_numeric_schema_rejects_float_bitwise_unknown_list_members():
+    spec = CODE_REGISTRY["W_NUMERIC_FLOAT_BITWISE"]
+    refs = dict(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"])
+    refs["operand_types"] = ["number"]
+    refs["operand_type_sources"] = ["magic"]
+
+    with pytest.raises(AssertionError, match="item_enum"):
+        assert_refs_match_schema(
+            ModelDiagnostic(
+                code=spec.code,
+                severity=spec.severity,
+                message="synthetic invalid operand vocab",
+                span=None,
+                refs=refs,
+            ),
+            context="invalid operand vocab",
+        )
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -1,0 +1,217 @@
+"""Catalog contract tests for C/C++ numeric inspect diagnostics."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+
+import pytest
+
+from pyfcstm.diagnostics import CODE_REGISTRY, inspect_model
+from pyfcstm.dsl import parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.utils import ModelDiagnostic
+
+from ._schema_check import assert_refs_match_schema
+
+
+pytestmark = pytest.mark.unittest
+
+
+NUMERIC_CODES = {
+    "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+    "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+    "W_NUMERIC_FLOAT_BITWISE",
+}
+
+C_FAMILY_TARGET_TEMPLATES = ["c", "c_poll", "cpp", "cpp_poll"]
+CONTEXT_ENUM = ("var_initializer", "guard", "transition_effect", "lifecycle_action")
+OPERAND_TYPES = {"int", "float", "unknown"}
+OPERAND_TYPE_SOURCES = {"literal", "declared_var", "local_expression"}
+RUNTIME_NOTE_REQUIRED_TEXT = ("C/C++", "Python")
+
+
+SYNTHETIC_REFS = {
+    "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ deployment profile risk; Python generated runtime may not have the same risk.",
+        "context": "var_initializer",
+        "expr_text": "9223372036854775808",
+        "literal_text": "9223372036854775808",
+        "target_bits": 64,
+        "signed": True,
+        "min_value_text": "-9223372036854775808",
+        "max_value_text": "9223372036854775807",
+        "var_name": "too_large",
+    },
+    "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ deployment profile risk; Python generated runtime has different exception semantics.",
+        "context": "transition_effect",
+        "statement_kind": "operation_assignment",
+        "expr_text": "input / (1 - 1)",
+        "operator": "/",
+        "rhs_text": "(1 - 1)",
+    },
+    "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ deployment profile risk; Python generated runtime may not have the same fixed-width shift risk.",
+        "context": "guard",
+        "expr_text": "flags << 64",
+        "operator": "<<",
+        "target_bits": 64,
+        "shift_count_text": "64",
+    },
+    "W_NUMERIC_FLOAT_BITWISE": {
+        "target_family": "c_family",
+        "target_templates": C_FAMILY_TARGET_TEMPLATES,
+        "runtime_note": "C/C++ integer-operation profile risk; Python generated runtime may fail for a different reason.",
+        "context": "lifecycle_action",
+        "statement_kind": "operation_assignment",
+        "expr_text": "flags & gain",
+        "operator": "&",
+        "operand_types": ["int", "float"],
+        "operand_type_sources": ["declared_var", "declared_var"],
+    },
+}
+
+
+SIGNED_INT64_BOUNDARY_CASES = [
+    ("9223372036854775808", "warning"),
+    ("-9223372036854775808", "no_warning"),
+    ("-9223372036854775809", "warning"),
+]
+
+
+def _parse(source: str):
+    ast = parse_with_grammar_entry(dedent(source), "state_machine_dsl")
+    return parse_dsl_node_to_state_machine(ast)
+
+
+def test_numeric_contract_declares_exact_code_set():
+    assert NUMERIC_CODES <= set(CODE_REGISTRY)
+    assert "W_NUMERIC_SHIFT_REQUIRES_PROOF" not in CODE_REGISTRY
+    assert "I_NUMERIC_VERIFY_RECOMMENDED" not in CODE_REGISTRY
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_codes_are_catalog_only_warning_contracts(code):
+    spec = CODE_REGISTRY[code]
+    assert spec.severity == "warning"
+    assert spec.emit_tier == "catalog_only"
+    assert spec.span_object == "expression"
+    assert spec.for_llm is not None
+    assert spec.example_dsl
+    _parse(spec.example_dsl)
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_codes_do_not_emit_before_analyzer_lands(code):
+    spec = CODE_REGISTRY[code]
+    report = inspect_model(_parse(spec.example_dsl))
+    assert code not in {diag.code for diag in report.diagnostics}
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_refs_schema_accepts_representative_payloads(code):
+    spec = CODE_REGISTRY[code]
+    assert_refs_match_schema(
+        ModelDiagnostic(
+            code=code,
+            severity=spec.severity,
+            message=f"synthetic contract check for {code}",
+            span=None,
+            refs=SYNTHETIC_REFS[code],
+        ),
+        context=code,
+    )
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_target_profile_fields_are_required_and_stable(code):
+    spec = CODE_REGISTRY[code]
+    required = set(spec.required_fields())
+    assert {
+        "target_family",
+        "target_templates",
+        "runtime_note",
+        "context",
+        "expr_text",
+    } <= required
+    assert spec.refs_schema["target_family"].enum == ("c_family",)
+    assert spec.refs_schema["target_templates"].type == "list[str]"
+    refs = SYNTHETIC_REFS[code]
+    assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+    assert "python" not in refs["target_templates"]
+    assert spec.refs_schema["context"].enum == CONTEXT_ENUM
+    assert refs["context"] in CONTEXT_ENUM
+    for snippet in RUNTIME_NOTE_REQUIRED_TEXT:
+        assert snippet in refs["runtime_note"]
+
+
+def test_literal_range_code_locks_signed_int64_boundary_refs():
+    spec = CODE_REGISTRY["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
+    refs = SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"]
+    assert refs["target_bits"] == 64
+    assert refs["signed"] is True
+    assert refs["min_value_text"] == "-9223372036854775808"
+    assert refs["max_value_text"] == "9223372036854775807"
+    assert "-9223372036854775808" in spec.for_llm.do_not[1]
+    assert SIGNED_INT64_BOUNDARY_CASES == [
+        ("9223372036854775808", "warning"),
+        ("-9223372036854775808", "no_warning"),
+        ("-9223372036854775809", "warning"),
+    ]
+
+
+def test_numeric_boundary_example_dsl_variants_parse():
+    for literal_text, _classification in SIGNED_INT64_BOUNDARY_CASES:
+        _parse(f"""
+            def int value = {literal_text};
+            state Root {{ state A; [*] -> A; }}
+        """)
+
+
+def test_division_and_modulo_share_required_operator_contract():
+    spec = CODE_REGISTRY["W_NUMERIC_CONSTANT_DIVISION_BY_ZERO"]
+    assert "operator" in spec.required_fields()
+    assert spec.refs_schema["operator"].enum == ("/", "%")
+
+
+def test_shift_code_locks_target_bits_and_operator_contract():
+    spec = CODE_REGISTRY["W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"]
+    assert "operator" in spec.required_fields()
+    assert spec.refs_schema["operator"].enum == ("<<", ">>")
+    assert "target_bits" in spec.required_fields()
+    assert (
+        SYNTHETIC_REFS["W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"]["target_bits"] == 64
+    )
+
+
+def test_float_bitwise_locks_operand_type_vocabularies():
+    spec = CODE_REGISTRY["W_NUMERIC_FLOAT_BITWISE"]
+    assert spec.refs_schema["operator"].enum == ("&", "^", "|", "<<", ">>")
+    assert (
+        set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_types"]) <= OPERAND_TYPES
+    )
+    assert (
+        set(SYNTHETIC_REFS["W_NUMERIC_FLOAT_BITWISE"]["operand_type_sources"])
+        <= OPERAND_TYPE_SOURCES
+    )
+
+
+@pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
+def test_numeric_descriptions_are_target_specific(code):
+    spec = CODE_REGISTRY[code]
+    text = " ".join(
+        [
+            spec.description,
+            spec.for_llm.summary if spec.for_llm is not None else "",
+            " ".join(spec.for_llm.do_not) if spec.for_llm is not None else "",
+        ]
+    )
+    assert "C/C++" in text
+    assert "Python" in text


### PR DESCRIPTION
## 目标

本 PR 是 [PR #272](https://github.com/HansBug/pyfcstm/pull/272) 的 PR-N1 子 PR，对应 [issue #253](https://github.com/HansBug/pyfcstm/issues/253) 的第一阶段契约准备工作：先把 inspect 数值诊断的 **code / refs / catalog tests / docs / jsfcstm 同步资源读取契约** 锁住，给后续 Python analyzer 与 jsfcstm analyzer 并行实现提供稳定公共契约。

本 PR 只做契约与资源准备，不实现 numeric analyzer 行为，不新增实际诊断触发逻辑。

## 上游对齐

| 来源 | 对齐内容 |
|---|---|
| issue #253 | 4 类确定性 C/C++ 默认部署剖面 numeric inspect 诊断；message 与 refs 都必须表达 `c_family` 目标限定。 |
| PR #272 | PR-N1 定义为“诊断契约与目标剖面字段”：锁定 `codes.yaml`、diagnostics README、jsfcstm 共享资源生成/读取测试；不实现 analyzer。 |

## 实施范围

| 文件 / 区域 | 计划 |
|---|---|
| `pyfcstm/diagnostics/codes.yaml` | 增加 4 类第一阶段 numeric diagnostic codes；每个 code 固定 `severity`、`capability`、`emit_tier`、`span_object`、`description`、`example_dsl`、`refs` schema 与 `for_llm`。字段名由本 PR 的 `codes.yaml` 直接 freeze，后续 PR 不再改名。 |
| `pyfcstm/diagnostics/codes.py` | 复核新增 code 仅使用现有 `capability` / `emit_tier` / refs type token；预期无需改枚举。若实现中发现必须新增枚举，本 PR 同步更新 loader 与 tests。 |
| `pyfcstm/diagnostics/schema.json` | 预期无需修改：当前 `ModelDiagnostic.refs.additionalProperties=true`，per-code refs 契约由 `codes.yaml` / `CODE_REGISTRY` 与 catalog tests 锁定。仅当需要新增通用顶层 inspect 结构或通用 `Span` 结构时才修改。 |
| `pyfcstm/diagnostics/README.md` | 新增独立章节说明 C/C++ 默认部署剖面、Python 目标差异、轻量常量折叠边界、`context` / `statement_kind` / `operand_types` 等契约；不重写既有 span/range contract。 |
| `editors/jsfcstm/src/diagnostics/codes.json` | ignored generated resource，由 `pyfcstm/diagnostics/codes.yaml` 同步生成；本 PR 不手写、不要求提交该 ignored artifact。验收通过 jsfcstm resource test 证明 `loadCodesRegistry()` 可读到新增 numeric code。 |
| `editors/jsfcstm/src/diagnostics/schema.json` | ignored generated resource，由 `pyfcstm/diagnostics/schema.json` 同步生成；本 PR 不手写、不要求提交该 ignored artifact。验收通过 jsfcstm resource test 证明 schema 可读。 |
| `editors/jsfcstm/dist/diagnostics/*.json` | `dist/` 是 ignored build output；通过 `npm test` / `npm run build` 自动运行 src + dist 同步，不提交 build artifact。 |
| `test/diagnostics/test_codes_yaml.py` / `test_codes_yaml_layer2.py` / `test_cross_end_parity.py` 等 | 增加或扩展 catalog/schema/resource tests，锁定 numeric code refs 必含字段、枚举、目标限定字段、示例 DSL、边界样例和 jsfcstm resource 可见性。 |
| `editors/jsfcstm/test/diagnostics-resources.test.ts` | 增加或扩展资源测试，确认 jsfcstm generated/bundled resources 通过 loader 可读新增 numeric code 与 schema；测试数据留在 jsfcstm 测试树。 |

## 必须锁定的公共契约

字段名以本 PR 合入后的 `pyfcstm/diagnostics/codes.yaml` 为准；下列 key 是本 PR 需要 freeze 的 exact refs key，不使用“等价字段”替代。

| 契约点 | 要求 |
|---|---|
| 目标族 | refs 必须包含 `target_family="c_family"`。 |
| 目标模板集合 | refs 必须包含 `target_templates=["c", "c_poll", "cpp", "cpp_poll"]`，顺序稳定且不包含 Python。 |
| 运行时差异 | refs 必须包含 `runtime_note`，说明 C/C++ deployment profile risk；Python generated runtime may not have the same risk。 |
| 表达式位置 | `context` enum 固定覆盖 `var_initializer`、`guard`、`transition_effect`、`lifecycle_action`。 |
| 赋值 RHS | 使用 `statement_kind="operation_assignment"` 表达赋值 RHS 形状，不把 `operation_assignment` 混入 `context` enum。 |
| float bitwise 类型 | `operand_types` 取值锁定为 `int`、`float`、`unknown`；`operand_type_sources` 取值锁定为 `literal`、`declared_var`、`local_expression`。 |
| 超范围 literal | 必含 `min_value_text`、`max_value_text`、`target_bits`、`signed`、`literal_text`、`expr_text`；`var_name` 可选。 |
| div/mod zero | 除零与取模零合并为单一 code，`operator` 必须 required，用于区分 `/` 与 `%`。 |
| 常量折叠边界 | 文档锁定算子集合：`+`、`-`、`*`、`/`、`%`、`<<`、`>>`、`&`、`^`、`|`；遇到除零、负移位、过大移位或无法稳定表示结果时不折叠。 |
| int64 signed 边界 | N1 只在 catalog/example contract 中锁定分类：一元负号 + literal 按组合后的 signed 值判定，`9223372036854775808` 属于 warning 样例，`-9223372036854775808` 属于 no-warning 合法边界样例，`-9223372036854775809` 属于 warning 样例。实际 analyzer emission tests 留给 PR-N2 / PR-N3。 |

## 第一阶段新增 code 范围

本 PR 只预声明 4 类第一阶段确定性 warning code：

| Code | 目的 | 必含 refs 摘要 |
|---|---|---|
| `W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE` | C/C++ 默认 `PYFCSTM_GENERATED_INT64` 剖面无法承载的整数字面量。 | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`literal_text`、`target_bits`、`signed`、`min_value_text`、`max_value_text`、可选 `var_name`。 |
| `W_NUMERIC_CONSTANT_DIVISION_BY_ZERO` | `/` 或 `%` 的 RHS 经轻量常量折叠可判 0。 | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`operator`、`rhs_text`。 |
| `W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE` | 常量 shift count 小于 0 或不小于目标位宽 64。 | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`operator`、`target_bits`、`shift_count_text`。 |
| `W_NUMERIC_FLOAT_BITWISE` | inspect 可确定的 float 参与 C/C++ 整数位运算剖面。 | `target_family`、`target_templates`、`runtime_note`、`context`、`expr_text`、`operator`、`operand_types`、`operand_type_sources`、可选 `statement_kind`。 |

`W_NUMERIC_SHIFT_REQUIRES_PROOF` / `I_NUMERIC_VERIFY_RECOMMENDED` 这类 verify 引导 code 不在 PR-N1 预占 schema 槽位；如未来需要，必须回到 #254 或新的契约 PR 明确 `verify_check` / `reason` 等字段。

## 非目标

- 不实现 `pyfcstm/diagnostics/analyzers/` numeric analyzer 行为；留给 PR-N2。
- 不实现 jsfcstm numeric analyzer 行为；留给 PR-N3。
- 不在 N1 里要求 `inspect_model` 或 jsfcstm analyzer 对新增 numeric code 发出 warning；N1 的边界样例是 catalog/example contract，不是 emission test。
- 不做 dynamic shift / counter / overflow 的证明；归入 issue #254。
- 不预声明 verify 引导 info / warning code；需要时走 #254 或新的契约 PR。
- 不做 codegen policy / checked arithmetic / target profile option；归入 issue #255。
- 不跨树共享 Python 与 jsfcstm 测试 fixture。

## 验收标准

- [ ] `codes.yaml` 中新增 4 个 numeric code 的 refs schema 全部含目标限定字段，并且 description / `example_dsl` / `for_llm` 明确 C/C++ 默认部署剖面风险，不写成 Python 或目标无关错误。
- [ ] 新增 numeric code 均声明 `span_object`，并只使用现有 `capability` / `emit_tier` / refs type token；如扩展 loader 枚举，已同步 `codes.py` 与 tests。
- [ ] `test/diagnostics/` 中有 catalog/schema 测试覆盖新增 code、refs required 字段、`context` / `operand_types` / `operand_type_sources` 枚举、div/mod `operator` required 规则、int64 signed 边界样例分类。
- [ ] `schema.json` 未改时，测试或 PR summary 明确说明 numeric refs 由 `codes.yaml` per-code contract 锁定，JSON Schema 的 refs bag 无需新增字段。
- [ ] 已运行 jsfcstm 同步/测试命令；推荐完整验收命令：`cd editors/jsfcstm && npm test`。快速局部验收至少运行：`cd editors/jsfcstm && node ./scripts/sync-runtime-assets.js --phase=src && npx mocha --require ts-node/register/transpile-only --extension ts "test/diagnostics-resources.test.ts" --reporter spec`。
- [ ] jsfcstm resource test 确认 generated/bundled codes/schema 可读取新增 numeric code；不要求提交 ignored `src/diagnostics/*.json` 或 `dist/diagnostics/*.json`。
- [ ] diagnostics README 新增独立章节，清楚说明本 PR只是 C/C++ 默认部署剖面的 inspect 契约准备，不改变 DSL `int` / `float` 语义。
- [ ] 本 PR 不新增 analyzer 行为；`inspect_model` 对新增 numeric code 不会在本 PR 中开始触发。
- [ ] Python/jsfcstm 测试树保持独立；Python 测试不调用 Node，jsfcstm 测试不调用 Python。
- [ ] 本地 Python 测试通过：`SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=./diagnostics`。
- [ ] N1 默认不改 Python public API；若实际改动 public API / pydoc，则运行 `make rst_auto` 并提交预期 RST 更新，否则在 PR summary 中说明无 RST diff 预期。

## 状态

🟦 进行中：已根据第一轮 body review 去掉“等价字段”模糊口径，明确 jsfcstm generated resource 验收、schema 策略、N1 不预留 verify code、以及 N1 边界样例仅为 catalog/example contract。
