### PR TITLE
实现：接入 Python inspect 数值诊断

### DIFF
--- a/docs/source/api_doc/diagnostics/analyzers/index.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/index.rst
@@ -13,6 +13,7 @@ pyfcstm.diagnostics.analyzers
     data_flow
     design_health
     naming
+    numeric
     redundancy
     structural
     thresholds

--- a/docs/source/api_doc/diagnostics/analyzers/numeric.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/numeric.rst
@@ -10,5 +10,3 @@ collect\_numeric\_warnings
 -----------------------------------------------------
 
 .. autofunction:: collect_numeric_warnings
-
-

--- a/docs/source/api_doc/diagnostics/analyzers/numeric.rst
+++ b/docs/source/api_doc/diagnostics/analyzers/numeric.rst
@@ -1,0 +1,14 @@
+pyfcstm.diagnostics.analyzers.numeric
+========================================================
+
+.. currentmodule:: pyfcstm.diagnostics.analyzers.numeric
+
+.. automodule:: pyfcstm.diagnostics.analyzers.numeric
+
+
+collect\_numeric\_warnings
+-----------------------------------------------------
+
+.. autofunction:: collect_numeric_warnings
+
+

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -90,13 +90,17 @@ describe('diagnostics resources (PR-A)', () => {
             }
         });
 
-        it('contains C/C++ numeric catalog-only diagnostics', () => {
+        it('contains C/C++ numeric partial-static diagnostics', () => {
             const registry = loadCodesRegistry();
             for (const code of numericCodes) {
                 const spec = registry[code];
                 assert.ok(spec, `${code} missing from bundled codes registry`);
                 assert.equal(spec.severity, 'warning', `${code} must stay warning-level`);
-                assert.equal(spec.emit_tier, 'catalog_only', `${code} must not emit before analyzers land`);
+                assert.equal(
+                    spec.emit_tier,
+                    'partial_static_pipeline',
+                    `${code} is emitted by the Python inspect analyzer before jsfcstm parity lands`
+                );
                 assert.equal(spec.span_object, 'expression', `${code} must identify an expression`);
                 assert.ok(spec.example_dsl, `${code} must keep a parseable example DSL contract`);
                 assert.ok(spec.for_llm, `${code} must keep LLM-facing guidance`);

--- a/pyfcstm/diagnostics/README.md
+++ b/pyfcstm/diagnostics/README.md
@@ -125,8 +125,9 @@ negative shifts, oversized shifts, variables, function calls, cross-statement
 constant propagation, block-local temporary inference, or algebraic rewrites such
 as `a - a` and `0 * x`.
 
-The shared catalog may contain `catalog_only` numeric codes. Those entries freeze
-code names and `refs` payloads before pyfcstm or jsfcstm emitters exist. They are
-not expected from `inspect_model()` or jsfcstm diagnostics until the corresponding
-analyzers land; tests for those entries should validate the catalog contract and
-parseable examples, not runtime emission.
+The first Python numeric analyzer emits these warnings from `inspect_model()`
+under `emit_tier: partial_static_pipeline`. In this tier, the Python static
+inspect pipeline has landed while jsfcstm parity is still a follow-up task. Tests
+for these entries must therefore validate both the shared catalog contract and
+Python runtime emission, while jsfcstm-side behavior stays out of scope until its
+matching analyzer lands.

--- a/pyfcstm/diagnostics/analyzers/__init__.py
+++ b/pyfcstm/diagnostics/analyzers/__init__.py
@@ -1,4 +1,34 @@
-"""Analyzer helpers for :mod:`pyfcstm.diagnostics.inspect`."""
+"""
+Inspect analyzer package map.
+
+This package groups the small, composable analyzers used by
+:func:`pyfcstm.diagnostics.inspect.inspect_model`. Each analyzer owns one
+well-bounded diagnostic concern and returns structured
+:class:`pyfcstm.utils.validate.ModelDiagnostic` objects for the design-health
+pipeline.
+
+.. list-table:: Analyzer modules
+   :header-rows: 1
+
+   * - Module
+     - Responsibility
+   * - :mod:`pyfcstm.diagnostics.analyzers.const_fold`
+     - Literal-only constant-folding diagnostics.
+   * - :mod:`pyfcstm.diagnostics.analyzers.numeric`
+     - C/C++ deployment-profile numeric diagnostics.
+   * - :mod:`pyfcstm.diagnostics.analyzers.design_health`
+     - Aggregates analyzer outputs into the default inspect warning set.
+   * - :mod:`pyfcstm.diagnostics.analyzers.data_flow`
+     - Variable read/write and guard-affect data-flow diagnostics.
+   * - :mod:`pyfcstm.diagnostics.analyzers.structural`
+     - State and transition topology diagnostics.
+
+Example::
+
+    >>> from pyfcstm.diagnostics.analyzers import collect_numeric_warnings
+    >>> collect_numeric_warnings(None)
+    []
+"""
 
 from .const_fold import (
     collect_const_fold_warnings,
@@ -7,6 +37,7 @@ from .const_fold import (
 )
 from .design_health import collect_design_health_warnings
 from .naming import collect_naming_warnings
+from .numeric import collect_numeric_warnings
 from .thresholds import collect_threshold_warnings
 from .transition_info import collect_transition_infos
 from .type_shape import collect_type_warnings
@@ -18,6 +49,7 @@ __all__ = [
     'fold_condition_expression',
     'fold_numeric_expression',
     'collect_naming_warnings',
+    'collect_numeric_warnings',
     'collect_threshold_warnings',
     'collect_transition_infos',
     'collect_type_warnings',

--- a/pyfcstm/diagnostics/analyzers/design_health.py
+++ b/pyfcstm/diagnostics/analyzers/design_health.py
@@ -9,6 +9,7 @@ from ...utils.validate import ModelDiagnostic
 from .const_fold import collect_const_fold_warnings
 from .data_flow import collect_data_flow_warnings
 from .naming import collect_naming_warnings
+from .numeric import collect_numeric_warnings
 from .redundancy import collect_redundancy_warnings
 from .structural import collect_structural_warnings
 from .thresholds import collect_threshold_warnings
@@ -83,6 +84,7 @@ def collect_design_health_warnings(
     diagnostics.extend(collect_data_flow_warnings(variables, machine))
     diagnostics.extend(collect_redundancy_warnings(transitions, events, states))
     diagnostics.extend(collect_transition_infos(states, transitions))
+    diagnostics.extend(collect_numeric_warnings(machine))
     return _with_suggested_fixes(diagnostics)
 
 

--- a/pyfcstm/diagnostics/analyzers/numeric.py
+++ b/pyfcstm/diagnostics/analyzers/numeric.py
@@ -1,0 +1,476 @@
+"""
+C/C++ deployment-profile numeric diagnostics.
+
+This module implements the lightweight numeric analyzer used by
+:func:`pyfcstm.diagnostics.inspect.inspect_model`. The analyzer is target
+profile aware: each warning describes a risk for the default C/C++ generated
+runtime profile rather than a target-independent FCSTM model error.
+
+The module contains:
+
+* :func:`collect_numeric_warnings` - Collect deterministic numeric warnings
+  from a state-machine model.
+
+.. note::
+   The analyzer deliberately avoids variable range solving, cross-statement
+   propagation, SMT checks, and generated-code policy changes. Those belong
+   to the verify and code-generation tracks.
+"""
+
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
+
+from ...utils.validate import ModelDiagnostic, Span
+from .const_fold import fold_numeric_expression
+
+if TYPE_CHECKING:  # pragma: no cover - type-checking imports only.
+    from ...model.expr import Expr
+    from ...model.model import OperationStatement, StateMachine
+
+
+_TARGET_FAMILY = "c_family"
+_TARGET_TEMPLATES = ["c", "c_poll", "cpp", "cpp_poll"]
+_TARGET_BITS = 64
+_MIN_SIGNED_INT64 = -(2**63)
+_MAX_SIGNED_INT64 = 2**63 - 1
+_MIN_SIGNED_INT64_TEXT = str(_MIN_SIGNED_INT64)
+_MAX_SIGNED_INT64_TEXT = str(_MAX_SIGNED_INT64)
+_BITWISE_OPERATORS = {"&", "^", "|", "<<", ">>"}
+_NUMERIC_RESULT_OPERATORS = {"+", "-", "*", "/", "%", "**", "&", "^", "|", "<<", ">>"}
+_ZERO_OPERATORS = {"/", "%"}
+_SHIFT_OPERATORS = {"<<", ">>"}
+_RUNTIME_NOTES = {
+    "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE": (
+        "C/C++ deployment profile risk: the default C-family templates use "
+        "PYFCSTM_GENERATED_INT64, while Python generated runtimes may not have "
+        "the same fixed-width integer carrying risk."
+    ),
+    "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO": (
+        "C/C++ deployment profile risk: generated C/C++ code needs an explicit "
+        "division-by-zero or modulo-by-zero policy, while Python generated "
+        "runtimes use different exception semantics."
+    ),
+    "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE": (
+        "C/C++ deployment profile risk: the default C-family integer width is "
+        "64 bits, while Python generated runtimes may not have the same "
+        "fixed-width shift risk."
+    ),
+    "W_NUMERIC_FLOAT_BITWISE": (
+        "C/C++ integer-operation profile risk: bitwise and shift operators are "
+        "integer operations in the generated C-family templates; Python "
+        "generated runtimes may fail for a different reason."
+    ),
+}
+
+
+class _Context:
+    """One expression location scanned by the numeric analyzer."""
+
+    def __init__(
+        self,
+        expr: "Expr",
+        context: str,
+        span: Optional[Span],
+        statement_kind: Optional[str] = None,
+        var_name: Optional[str] = None,
+    ) -> None:
+        self.expr = expr
+        self.context = context
+        self.span = span
+        self.statement_kind = statement_kind
+        self.var_name = var_name
+
+
+def collect_numeric_warnings(
+    machine: Optional["StateMachine"],
+) -> List[ModelDiagnostic]:
+    """
+    Collect C/C++ deployment-profile numeric warnings for a model.
+
+    :param machine: State-machine model to inspect. ``None`` is accepted so
+        callers can mirror other analyzer entry points during defensive
+        composition.
+    :type machine: Optional[pyfcstm.model.StateMachine]
+    :return: Numeric warnings in model traversal order.
+    :rtype: List[pyfcstm.utils.validate.ModelDiagnostic]
+
+    Examples::
+
+        >>> from pyfcstm.dsl import parse_with_grammar_entry
+        >>> from pyfcstm.model import parse_dsl_node_to_state_machine
+        >>> source = '''
+        ... def int too_large = 9223372036854775808;
+        ... state Root { state A; [*] -> A; }
+        ... '''
+        >>> ast = parse_with_grammar_entry(source, 'state_machine_dsl')
+        >>> machine = parse_dsl_node_to_state_machine(ast)
+        >>> collect_numeric_warnings(machine)[0].code
+        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE'
+    """
+    if machine is None:
+        return []
+    var_types = {name: var_define.type for name, var_define in machine.defines.items()}
+    diagnostics: List[ModelDiagnostic] = []
+    for context in _iter_expression_contexts(machine):
+        diagnostics.extend(_diagnostics_for_expr(context, var_types))
+    return diagnostics
+
+
+def _diagnostics_for_expr(
+    context: _Context,
+    var_types: Dict[str, str],
+) -> List[ModelDiagnostic]:
+    diagnostics: List[ModelDiagnostic] = []
+    signed_literal_children = _signed_literal_child_ids(context.expr)
+    for expr in _walk_expressions(context.expr):
+        if id(expr) not in signed_literal_children:
+            diagnostics.extend(_literal_range_diagnostic(context, expr))
+        diagnostics.extend(_constant_zero_division_diagnostic(context, expr))
+        diagnostics.extend(_shift_count_diagnostic(context, expr))
+        diagnostics.extend(_float_bitwise_diagnostic(context, expr, var_types))
+    return diagnostics
+
+
+def _iter_expression_contexts(machine: "StateMachine") -> Iterable[_Context]:
+    for var_name, var_define in machine.defines.items():
+        yield _Context(
+            var_define.init,
+            "var_initializer",
+            getattr(var_define, "_span", None),
+            var_name=var_name,
+        )
+
+    for state in machine.walk_states():
+        for transition in state.transitions:
+            if transition.guard is not None:
+                yield _Context(
+                    transition.guard,
+                    "guard",
+                    getattr(transition, "_span", None),
+                )
+            for stmt in transition.effects:
+                yield from _iter_statement_expression_contexts(
+                    stmt,
+                    "transition_effect",
+                )
+        for action in _iter_concrete_actions(state):
+            for stmt in action.operations:
+                yield from _iter_statement_expression_contexts(
+                    stmt,
+                    "lifecycle_action",
+                )
+
+
+def _iter_concrete_actions(state):
+    for collection in (
+        state.on_enters,
+        state.on_durings,
+        state.on_exits,
+        state.on_during_aspects,
+    ):
+        for action in collection:
+            if action.is_abstract or action.is_ref:
+                continue
+            yield action
+
+
+def _iter_statement_expression_contexts(
+    stmt: "OperationStatement",
+    context: str,
+) -> Iterable[_Context]:
+    from ...model.model import IfBlock, Operation
+
+    if isinstance(stmt, Operation):
+        yield _Context(
+            stmt.expr,
+            context,
+            getattr(stmt, "_span", None),
+            statement_kind="operation_assignment",
+            var_name=stmt.var_name,
+        )
+        return
+    if isinstance(stmt, IfBlock):
+        for branch in stmt.branches:
+            if branch.condition is not None:
+                yield _Context(
+                    branch.condition,
+                    context,
+                    getattr(branch, "_span", None),
+                )
+            for inner in branch.statements:
+                yield from _iter_statement_expression_contexts(inner, context)
+
+
+def _walk_expressions(expr: "Expr") -> Iterable["Expr"]:
+    yield expr
+    for child in expr._iter_subs():
+        yield from _walk_expressions(child)
+
+
+def _signed_literal_child_ids(expr: "Expr") -> set:
+    from ...model.expr import Integer, UnaryOp
+
+    out = set()
+    for item in _walk_expressions(expr):
+        if (
+            isinstance(item, UnaryOp)
+            and item.op in {"+", "-"}
+            and isinstance(item.x, Integer)
+        ):
+            out.add(id(item.x))
+    return out
+
+
+def _literal_range_diagnostic(
+    context: _Context,
+    expr: "Expr",
+) -> List[ModelDiagnostic]:
+    literal = _signed_integer_literal(expr)
+    if literal is None:
+        return []
+    literal_text, literal_value = literal
+    if _MIN_SIGNED_INT64 <= literal_value <= _MAX_SIGNED_INT64:
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "literal_text": literal_text,
+            "target_bits": _TARGET_BITS,
+            "signed": True,
+            "min_value_text": _MIN_SIGNED_INT64_TEXT,
+            "max_value_text": _MAX_SIGNED_INT64_TEXT,
+        }
+    )
+    if context.var_name is not None:
+        refs["var_name"] = context.var_name
+    return [
+        _diagnostic(
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            (
+                "C/C++ default deployment profile risk: integer literal "
+                f"{literal_text} is outside the PYFCSTM_GENERATED_INT64 range "
+                f"[{_MIN_SIGNED_INT64_TEXT}, {_MAX_SIGNED_INT64_TEXT}]; "
+                "Python generated runtimes may not have the same fixed-width risk."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _constant_zero_division_diagnostic(
+    context: _Context,
+    expr: "Expr",
+) -> List[ModelDiagnostic]:
+    from ...model.expr import BinaryOp
+
+    if not isinstance(expr, BinaryOp) or expr.op not in _ZERO_OPERATORS:
+        return []
+    rhs_value = fold_numeric_expression(expr.y)
+    if rhs_value is None or rhs_value != 0:
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "operator": expr.op,
+            "rhs_text": _expr_text(expr.y),
+        }
+    )
+    return [
+        _diagnostic(
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            (
+                "C/C++ default deployment profile risk: the RHS of operator "
+                f"{expr.op!r} folds to 0; generated C/C++ code needs an explicit "
+                "failure policy, while Python runtime exception semantics differ."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _shift_count_diagnostic(
+    context: _Context,
+    expr: "Expr",
+) -> List[ModelDiagnostic]:
+    from ...model.expr import BinaryOp
+
+    if not isinstance(expr, BinaryOp) or expr.op not in _SHIFT_OPERATORS:
+        return []
+    rhs_value = fold_numeric_expression(expr.y)
+    if (
+        rhs_value is None
+        or not _plain_number(rhs_value)
+        or not (rhs_value < 0 or rhs_value >= _TARGET_BITS)
+    ):
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "operator": expr.op,
+            "target_bits": _TARGET_BITS,
+            "shift_count_text": _number_text(rhs_value),
+        }
+    )
+    return [
+        _diagnostic(
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            (
+                "C/C++ default deployment profile risk: the shift count of "
+                f"operator {expr.op!r} folds to {_number_text(rhs_value)}, "
+                f"outside 0 <= count < {_TARGET_BITS}; Python generated runtimes "
+                "do not represent the same fixed-width shift contract."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _float_bitwise_diagnostic(
+    context: _Context,
+    expr: "Expr",
+    var_types: Dict[str, str],
+) -> List[ModelDiagnostic]:
+    from ...model.expr import BinaryOp
+
+    if not isinstance(expr, BinaryOp) or expr.op not in _BITWISE_OPERATORS:
+        return []
+    left = _infer_numeric_type(expr.x, var_types)
+    right = _infer_numeric_type(expr.y, var_types)
+    if left[0] != "float" and right[0] != "float":
+        return []
+    refs = _base_refs(
+        "W_NUMERIC_FLOAT_BITWISE",
+        context,
+        _expr_text(expr),
+    )
+    refs.update(
+        {
+            "operator": expr.op,
+            "operand_types": [left[0], right[0]],
+            "operand_type_sources": [left[1], right[1]],
+        }
+    )
+    return [
+        _diagnostic(
+            "W_NUMERIC_FLOAT_BITWISE",
+            (
+                "C/C++ default deployment profile risk: a float-shaped operand "
+                f"participates in integer bitwise or shift operator {expr.op!r}; "
+                "C-family templates generate integer operations, while Python "
+                "runtime failures have different semantics."
+            ),
+            context.span,
+            refs,
+        )
+    ]
+
+
+def _infer_numeric_type(
+    expr: "Expr",
+    var_types: Dict[str, str],
+) -> Tuple[str, str]:
+    from ...model.expr import BinaryOp, Float, Integer, UnaryOp, Variable
+
+    if isinstance(expr, Float):
+        return "float", "literal"
+    if isinstance(expr, Integer):
+        return "int", "literal"
+    if isinstance(expr, Variable):
+        declared = var_types.get(expr.name)
+        if declared == "float":
+            return "float", "declared_var"
+        if declared == "int":
+            return "int", "declared_var"
+        return "unknown", "declared_var"
+    if isinstance(expr, UnaryOp) and expr.op in {"+", "-"}:
+        inner_type, inner_source = _infer_numeric_type(expr.x, var_types)
+        if inner_type in {"int", "float"}:
+            return inner_type, inner_source
+        return "unknown", "local_expression"
+    if isinstance(expr, BinaryOp):
+        if expr.op not in _NUMERIC_RESULT_OPERATORS:
+            return "unknown", "local_expression"
+        left_type, _ = _infer_numeric_type(expr.x, var_types)
+        right_type, _ = _infer_numeric_type(expr.y, var_types)
+        if left_type == "float" or right_type == "float":
+            return "float", "local_expression"
+        if left_type == "int" and right_type == "int":
+            if expr.op in {"/", "**"}:
+                return "unknown", "local_expression"
+            return "int", "local_expression"
+    return "unknown", "local_expression"
+
+
+def _signed_integer_literal(expr: "Expr") -> Optional[Tuple[str, int]]:
+    from ...model.expr import Integer, UnaryOp
+
+    if isinstance(expr, Integer):
+        return str(expr.value), expr.value
+    if isinstance(expr, UnaryOp) and isinstance(expr.x, Integer):
+        if expr.op == "-":
+            return "-" + str(expr.x.value), -expr.x.value
+        if expr.op == "+":
+            return "+" + str(expr.x.value), expr.x.value
+    return None
+
+
+def _base_refs(
+    code: str,
+    context: _Context,
+    expr_text: Optional[str],
+) -> Dict[str, object]:
+    refs: Dict[str, object] = {
+        "target_family": _TARGET_FAMILY,
+        "target_templates": list(_TARGET_TEMPLATES),
+        "runtime_note": _RUNTIME_NOTES[code],
+        "context": context.context,
+        "expr_text": expr_text or "",
+    }
+    if context.statement_kind is not None:
+        refs["statement_kind"] = context.statement_kind
+    return refs
+
+
+def _diagnostic(
+    code: str,
+    message: str,
+    span: Optional[Span],
+    refs: Dict[str, object],
+) -> ModelDiagnostic:
+    return ModelDiagnostic(
+        code=code,
+        severity="warning",
+        message=message,
+        span=span,
+        refs=refs,
+    )
+
+
+def _expr_text(expr: Optional["Expr"]) -> Optional[str]:
+    from ..inspect import _expr_text as render_expr_text
+
+    return render_expr_text(expr)
+
+
+def _plain_number(value) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _number_text(value) -> str:
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)

--- a/pyfcstm/diagnostics/analyzers/numeric.py
+++ b/pyfcstm/diagnostics/analyzers/numeric.py
@@ -35,8 +35,21 @@ _MAX_SIGNED_INT64 = 2**63 - 1
 _MIN_SIGNED_INT64_TEXT = str(_MIN_SIGNED_INT64)
 _MAX_SIGNED_INT64_TEXT = str(_MAX_SIGNED_INT64)
 _BITWISE_OPERATORS = {"&", "^", "|", "<<", ">>"}
-_NUMERIC_RESULT_OPERATORS = {"+", "-", "*", "/", "%", "**", "&", "^", "|", "<<", ">>"}
 _ZERO_OPERATORS = {"/", "%"}
+_C_FAMILY_INTEGER_UFUNCS = {"ceil", "floor", "int", "round", "sign", "trunc"}
+_C_FAMILY_CONDITION_OPERATORS = {
+    "&&",
+    "||",
+    "=>",
+    "xor",
+    "iff",
+    "==",
+    "!=",
+    "<",
+    "<=",
+    ">",
+    ">=",
+}
 _SHIFT_OPERATORS = {"<<", ">>"}
 _RUNTIME_NOTES = {
     "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE": (
@@ -383,12 +396,13 @@ def _infer_numeric_type(
     expr: "Expr",
     var_types: Dict[str, str],
 ) -> Tuple[str, str]:
-    from ...model.expr import BinaryOp, Float, Integer, UnaryOp, Variable
+    from ...model.expr import BinaryOp, Boolean, ConditionalOp, Float, Integer
+    from ...model.expr import UnaryOp, UFunc, Variable
 
+    if isinstance(expr, (Boolean, Integer)):
+        return "int", "literal"
     if isinstance(expr, Float):
         return "float", "literal"
-    if isinstance(expr, Integer):
-        return "int", "literal"
     if isinstance(expr, Variable):
         declared = var_types.get(expr.name)
         if declared == "float":
@@ -396,23 +410,42 @@ def _infer_numeric_type(
         if declared == "int":
             return "int", "declared_var"
         return "unknown", "declared_var"
-    if isinstance(expr, UnaryOp) and expr.op in {"+", "-"}:
+    if isinstance(expr, UnaryOp):
         inner_type, inner_source = _infer_numeric_type(expr.x, var_types)
         if inner_type in {"int", "float"}:
             return inner_type, inner_source
         return "unknown", "local_expression"
-    if isinstance(expr, BinaryOp):
-        if expr.op not in _NUMERIC_RESULT_OPERATORS:
-            return "unknown", "local_expression"
-        left_type, _ = _infer_numeric_type(expr.x, var_types)
-        right_type, _ = _infer_numeric_type(expr.y, var_types)
-        if left_type == "float" or right_type == "float":
-            return "float", "local_expression"
-        if left_type == "int" and right_type == "int":
-            if expr.op in {"/", "**"}:
-                return "unknown", "local_expression"
+    if isinstance(expr, UFunc):
+        if expr.func in _C_FAMILY_INTEGER_UFUNCS:
             return "int", "local_expression"
+        if expr.func == "abs":
+            inner_type, _inner_source = _infer_numeric_type(expr.x, var_types)
+            if inner_type in {"int", "float"}:
+                return inner_type, "local_expression"
+            return "unknown", "local_expression"
+        return "float", "local_expression"
+    if isinstance(expr, BinaryOp):
+        if expr.op in _BITWISE_OPERATORS or expr.op in _C_FAMILY_CONDITION_OPERATORS:
+            return "int", "local_expression"
+        if expr.op == "/":
+            return "float", "local_expression"
+        left_type, _left_source = _infer_numeric_type(expr.x, var_types)
+        right_type, _right_source = _infer_numeric_type(expr.y, var_types)
+        return _merge_numeric_types(left_type, right_type), "local_expression"
+    if isinstance(expr, ConditionalOp):
+        true_type, _true_source = _infer_numeric_type(expr.if_true, var_types)
+        false_type, _false_source = _infer_numeric_type(expr.if_false, var_types)
+        return _merge_numeric_types(true_type, false_type), "local_expression"
     return "unknown", "local_expression"
+
+
+def _merge_numeric_types(type_a: str, type_b: str) -> str:
+    known = {type_a, type_b} - {"unknown"}
+    if "float" in known:
+        return "float"
+    if known == {"int"}:
+        return "int"
+    return "unknown"
 
 
 def _signed_integer_literal(expr: "Expr") -> Optional[Tuple[str, int]]:

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -2078,7 +2078,7 @@ W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     An integer literal that would be rendered into a C/C++ family template
     falls outside the default ``PYFCSTM_GENERATED_INT64`` signed range. This
@@ -2165,7 +2165,7 @@ W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     A ``/`` or ``%`` operation has a right-hand side that the lightweight
     literal-only constant folder can classify as zero. This is reported as a
@@ -2244,7 +2244,7 @@ W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     A shift count folds to a constant below zero or not less than the default
     C/C++ target integer width. This is a C/C++ 64-bit deployment-profile
@@ -2325,7 +2325,7 @@ W_NUMERIC_FLOAT_BITWISE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: catalog_only
+  emit_tier: partial_static_pipeline
   description: >-
     A value known to be ``float`` participates in a bitwise or shift operator
     that belongs to the C/C++ integer operation profile. The warning is

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -2462,12 +2462,13 @@ def _catalog_emittable_diagnostics(
 
     Example::
 
-        >>> _catalog_emittable_diagnostics((ModelDiagnostic(
+        >>> diagnostic = ModelDiagnostic(
         ...     code='W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
         ...     severity='warning',
-        ...     message='catalog-only test',
-        ... ),))
-        ()
+        ...     message='partial-static test',
+        ... )
+        >>> _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
+        True
     """
     return tuple(
         diagnostic

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -1686,13 +1686,20 @@ def test_lookup_api_codes_never_fire_in_static_pipeline():
 
 
 @pytest.mark.unittest
-def test_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
-    """I-b sibling: E_TYPE_MISMATCH is currently ``emit_tier:
-    partial_static_pipeline`` — jsfcstm has an analyzer that emits it
-    on type-confused expressions, pyfcstm has no such analyzer. This
-    test pins the "pyfcstm doesn't fire it" half so downstream
-    consumers know not to expect it from the Python side.
+def test_js_only_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
+    """Partial-static codes may be implemented on only one diagnostic end.
+
+    ``E_TYPE_MISMATCH`` is currently jsfcstm-only; numeric C/C++ profile
+    warnings are Python-only until the matching jsfcstm analyzer lands. This
+    test pins only the jsfcstm-only half so Python-emitted partial-static
+    diagnostics remain allowed.
     """
+    pyfcstm_partial_codes = {
+        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+        'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+        'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+        'W_NUMERIC_FLOAT_BITWISE',
+    }
     from pyfcstm.diagnostics import CODE_REGISTRY
 
     partial_codes = {
@@ -1700,13 +1707,14 @@ def test_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
         for code, spec in CODE_REGISTRY.items()
         if spec.emit_tier == 'partial_static_pipeline'
     }
-    if not partial_codes:
-        pytest.skip('no partial_static_pipeline codes declared')
+    js_only_partial_codes = partial_codes - pyfcstm_partial_codes
+    if not js_only_partial_codes:
+        pytest.skip('no js-only partial_static_pipeline codes declared')
 
     for name, dsl, _ in SINGLE_FILE_FIXTURES:
         codes, _, _ = _collect_codes_from_dsl(dsl)
-        leaked = [c for c in codes if c in partial_codes]
+        leaked = [c for c in codes if c in js_only_partial_codes]
         assert not leaked, (
-            f'fixture {name}: pyfcstm emitted partial_static_pipeline code(s) {leaked}; '
-            f'these are currently implemented only on jsfcstm.'
+            f'fixture {name}: pyfcstm emitted js-only partial_static_pipeline '
+            f'code(s) {leaked}.'
         )

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -1,4 +1,4 @@
-"""Catalog contract tests for C/C++ numeric inspect diagnostics."""
+"""Contract and emission tests for C/C++ numeric inspect diagnostics."""
 
 from __future__ import annotations
 
@@ -105,10 +105,10 @@ def test_numeric_contract_declares_exact_code_set():
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
-def test_numeric_codes_are_catalog_only_warning_contracts(code):
+def test_numeric_codes_are_partial_static_warning_contracts(code):
     spec = CODE_REGISTRY[code]
     assert spec.severity == "warning"
-    assert spec.emit_tier == "catalog_only"
+    assert spec.emit_tier == "partial_static_pipeline"
     assert spec.span_object == "expression"
     assert spec.for_llm is not None
     assert spec.example_dsl
@@ -116,22 +116,28 @@ def test_numeric_codes_are_catalog_only_warning_contracts(code):
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
-def test_numeric_codes_do_not_emit_before_analyzer_lands(code):
+def test_numeric_example_dsls_emit_after_python_analyzer_lands(code):
     spec = CODE_REGISTRY[code]
     report = inspect_model(_parse(spec.example_dsl))
-    assert code not in {diag.code for diag in report.diagnostics}
+    emitted = [diag for diag in report.diagnostics if diag.code == code]
+    assert emitted, [diag.code for diag in report.diagnostics]
+    for diag in emitted:
+        assert_refs_match_schema(diag, context=code)
+        assert diag.span is not None
+        assert "C/C++" in diag.message
+        assert "Python" in diag.message
 
 
-def test_catalog_only_diagnostics_are_filtered_from_inspect_output():
+def test_catalog_filter_allows_partial_static_numeric_diagnostics():
     diagnostic = ModelDiagnostic(
         code="W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
         severity="warning",
-        message="synthetic catalog-only diagnostic",
+        message="synthetic partial-static diagnostic",
         span=None,
         refs=SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"],
     )
 
-    assert _catalog_emittable_diagnostics((diagnostic,)) == ()
+    assert _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
@@ -184,10 +190,10 @@ def test_literal_range_code_locks_signed_int64_boundary_refs():
     assert any(MIN_SIGNED_INT64_TEXT in item for item in spec.for_llm.do_not)
     assert spec.example_dsl is not None
     assert TOO_LARGE_SIGNED_INT64_TEXT in spec.example_dsl
-    assert MIN_SIGNED_INT64_TEXT == str(-(2 ** 63))
-    assert MAX_SIGNED_INT64_TEXT == str(2 ** 63 - 1)
-    assert TOO_LARGE_SIGNED_INT64_TEXT == str(2 ** 63)
-    assert TOO_SMALL_SIGNED_INT64_TEXT == str(-(2 ** 63) - 1)
+    assert MIN_SIGNED_INT64_TEXT == str(-(2**63))
+    assert MAX_SIGNED_INT64_TEXT == str(2**63 - 1)
+    assert TOO_LARGE_SIGNED_INT64_TEXT == str(2**63)
+    assert TOO_SMALL_SIGNED_INT64_TEXT == str(-(2**63) - 1)
 
 
 def test_numeric_boundary_example_dsl_variants_parse():
@@ -265,6 +271,524 @@ def test_numeric_schema_rejects_float_bitwise_unknown_list_members():
             ),
             context="invalid operand vocab",
         )
+
+
+def _diagnostics_for(source: str, code: str):
+    report = inspect_model(_parse(source))
+    return [diag for diag in report.diagnostics if diag.code == code]
+
+
+def _single_diagnostic(source: str, code: str):
+    diagnostics = _diagnostics_for(source, code)
+    assert len(diagnostics) == 1, [diag.refs for diag in diagnostics]
+    diagnostic = diagnostics[0]
+    assert_refs_match_schema(diagnostic, context=code)
+    assert diagnostic.span is not None
+    return diagnostic
+
+
+@pytest.mark.parametrize(
+    ("literal_text", "expect_warning"),
+    [
+        (TOO_LARGE_SIGNED_INT64_TEXT, True),
+        (MIN_SIGNED_INT64_TEXT, False),
+        (TOO_SMALL_SIGNED_INT64_TEXT, True),
+    ],
+)
+def test_numeric_literal_range_int64_boundary_emission(
+    literal_text,
+    expect_warning,
+):
+    diagnostics = _diagnostics_for(
+        f"""
+        def int value = {literal_text};
+        state Root {{ state A; [*] -> A; }}
+        """,
+        "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+    )
+    if expect_warning:
+        assert len(diagnostics) == 1
+        refs = diagnostics[0].refs
+        assert refs["literal_text"] == literal_text
+        assert refs["context"] == "var_initializer"
+        assert refs["var_name"] == "value"
+        assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+        assert_refs_match_schema(diagnostics[0], context=literal_text)
+    else:
+        assert diagnostics == []
+
+
+@pytest.mark.parametrize(
+    ("name", "source", "code", "expected_refs"),
+    [
+        (
+            "var-literal-range",
+            f"""
+            def int value = {TOO_LARGE_SIGNED_INT64_TEXT};
+            state Root {{ state A; [*] -> A; }}
+            """,
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            {"context": "var_initializer", "var_name": "value"},
+        ),
+        (
+            "guard-division",
+            """
+            def int input = 1;
+            state Root {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [input / (1 - 1) > 0];
+            }
+            """,
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            {"context": "guard", "operator": "/", "rhs_text": "1 - 1"},
+        ),
+        (
+            "transition-effect-shift",
+            """
+            def int flags = 1;
+            state Root {
+                state A;
+                state B;
+                [*] -> A;
+                A -> B effect { flags = flags << 64; };
+            }
+            """,
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            {
+                "context": "transition_effect",
+                "statement_kind": "operation_assignment",
+                "operator": "<<",
+                "shift_count_text": "64",
+            },
+        ),
+        (
+            "lifecycle-float-bitwise",
+            """
+            def int flags = 1;
+            def float gain = 1.5;
+            state Root {
+                state A { during { flags = flags & gain; } }
+                [*] -> A;
+            }
+            """,
+            "W_NUMERIC_FLOAT_BITWISE",
+            {
+                "context": "lifecycle_action",
+                "statement_kind": "operation_assignment",
+                "operator": "&",
+                "operand_types": ["int", "float"],
+                "operand_type_sources": ["declared_var", "declared_var"],
+            },
+        ),
+    ],
+)
+def test_numeric_analyzer_emits_context_specific_refs(
+    name,
+    source,
+    code,
+    expected_refs,
+):
+    diagnostic = _single_diagnostic(source, code)
+    for key, value in expected_refs.items():
+        assert diagnostic.refs[key] == value, name
+    assert diagnostic.refs["target_family"] == "c_family"
+    assert diagnostic.refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+    assert "C/C++" in diagnostic.message
+    assert "Python" in diagnostic.message
+
+
+def test_numeric_division_by_zero_folds_rhs_even_when_lhs_is_dynamic():
+    diagnostic = _single_diagnostic(
+        """
+        def int result = 0;
+        def int input = 1;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { result = input / (1 - 1); };
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostic.refs["operator"] == "/"
+    assert diagnostic.refs["rhs_text"] == "1 - 1"
+    assert diagnostic.refs["expr_text"] == "input / (1 - 1)"
+
+
+def test_numeric_modulo_by_zero_reports_operator_separately():
+    diagnostic = _single_diagnostic(
+        """
+        def int result = 0;
+        def int input = 1;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { result = input % (2 - 2); };
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostic.refs["operator"] == "%"
+    assert diagnostic.refs["rhs_text"] == "2 - 2"
+
+
+def test_numeric_division_dynamic_rhs_is_not_reported():
+    diagnostics = _diagnostics_for(
+        """
+        def int result = 0;
+        def int input = 1;
+        def int denom = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { result = input / denom; };
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostics == []
+
+
+@pytest.mark.parametrize("shift_expr", ["flags << -1", "flags >> 64"])
+def test_numeric_shift_constant_out_of_target_range_reports(shift_expr):
+    diagnostic = _single_diagnostic(
+        f"""
+        def int flags = 1;
+        state Root {{
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect {{ flags = {shift_expr}; }};
+        }}
+        """,
+        "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+    )
+    assert diagnostic.refs["operator"] in {"<<", ">>"}
+    assert diagnostic.refs["target_bits"] == 64
+
+
+def test_numeric_shift_dynamic_rhs_is_not_reported():
+    diagnostics = _diagnostics_for(
+        """
+        def int flags = 1;
+        def int amount = 64;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B effect { flags = flags << amount; };
+        }
+        """,
+        "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+    )
+    assert diagnostics == []
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_types", "expected_sources"),
+    [
+        ("1.5 & flags", ["float", "int"], ["literal", "declared_var"]),
+        ("gain | flags", ["float", "int"], ["declared_var", "declared_var"]),
+        (
+            "(gain + 1.0) ^ flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+    ],
+)
+def test_numeric_float_bitwise_operand_evidence(
+    expr,
+    expected_types,
+    expected_sources,
+):
+    diagnostic = _single_diagnostic(
+        f"""
+        def int flags = 1;
+        def float gain = 1.5;
+        state Root {{
+            state A {{ during {{ flags = {expr}; }} }}
+            [*] -> A;
+        }}
+        """,
+        "W_NUMERIC_FLOAT_BITWISE",
+    )
+    assert diagnostic.refs["operand_types"] == expected_types
+    assert diagnostic.refs["operand_type_sources"] == expected_sources
+
+
+def test_numeric_float_shift_can_overlap_shift_count_warning():
+    source = """
+    def int flags = 1;
+    def float gain = 1.5;
+    state Root {
+        state A { during { flags = gain << 64; } }
+        [*] -> A;
+    }
+    """
+    report = inspect_model(_parse(source))
+    numeric_codes = [
+        diag.code for diag in report.diagnostics if diag.code in NUMERIC_CODES
+    ]
+    assert numeric_codes.count("W_NUMERIC_FLOAT_BITWISE") == 1
+    assert numeric_codes.count("W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE") == 1
+
+
+def test_numeric_scans_operation_if_branch_conditions_and_nested_assignments():
+    report = inspect_model(
+        _parse("""
+        def int flags = 1;
+        state Root {
+            state A {
+                during {
+                    if [flags > 0] {
+                        flags = flags << 64;
+                    }
+                }
+            }
+            [*] -> A;
+        }
+    """)
+    )
+    diagnostics = [
+        diag
+        for diag in report.diagnostics
+        if diag.code == "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"
+    ]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].refs["context"] == "lifecycle_action"
+    assert diagnostics[0].refs["statement_kind"] == "operation_assignment"
+
+
+@pytest.mark.parametrize(
+    ("context_name", "source"),
+    [
+        (
+            "var_initializer",
+            """
+            def int value = 1 / (1 - 1);
+            state Root { state A; [*] -> A; }
+            """,
+        ),
+        (
+            "guard",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B : if [value / 0 > 0]; }
+            """,
+        ),
+        (
+            "transition_effect",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B effect { value = value / 0; }; }
+            """,
+        ),
+        (
+            "lifecycle_action",
+            """
+            def int value = 1;
+            state Root { state A { exit { value = value / 0; } } [*] -> A; }
+            """,
+        ),
+    ],
+)
+def test_numeric_division_warning_covers_all_expression_contexts(
+    context_name,
+    source,
+):
+    diagnostic = _single_diagnostic(
+        source,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
+    assert diagnostic.refs["context"] == context_name
+    if context_name in {"transition_effect", "lifecycle_action"}:
+        assert diagnostic.refs["statement_kind"] == "operation_assignment"
+
+
+@pytest.mark.parametrize(
+    ("code", "context_name", "source", "statement_kind"),
+    [
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "var_initializer",
+            f"""
+            def int value = {TOO_LARGE_SIGNED_INT64_TEXT};
+            state Root {{ state A; [*] -> A; }}
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "guard",
+            f"""
+            state Root {{
+                state A;
+                state B;
+                [*] -> A;
+                A -> B : if [{TOO_LARGE_SIGNED_INT64_TEXT} > 0];
+            }}
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "transition_effect",
+            f"""
+            def int value = 0;
+            state Root {{
+                state A;
+                state B;
+                [*] -> A;
+                A -> B effect {{ value = {TOO_LARGE_SIGNED_INT64_TEXT}; }};
+            }}
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
+            "lifecycle_action",
+            f"""
+            def int value = 0;
+            state Root {{
+                state A {{ enter {{ value = {TOO_LARGE_SIGNED_INT64_TEXT}; }} }}
+                [*] -> A;
+            }}
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "var_initializer",
+            """
+            def int value = 1 / 0;
+            state Root { state A; [*] -> A; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "guard",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B : if [value / 0 > 0]; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "transition_effect",
+            """
+            def int value = 1;
+            state Root { state A; state B; [*] -> A; A -> B effect { value = value / 0; }; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+            "lifecycle_action",
+            """
+            def int value = 1;
+            state Root { state A { exit { value = value / 0; } } [*] -> A; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "var_initializer",
+            """
+            def int value = 1 << 64;
+            state Root { state A; [*] -> A; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "guard",
+            """
+            state Root { state A; state B; [*] -> A; A -> B : if [(1 << 64) != 0]; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "transition_effect",
+            """
+            def int flags = 1;
+            state Root { state A; state B; [*] -> A; A -> B effect { flags = flags << 64; }; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE",
+            "lifecycle_action",
+            """
+            def int flags = 1;
+            state Root { state A { during { flags = flags << 64; } } [*] -> A; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "var_initializer",
+            """
+            def int flags = 1.5 & 1;
+            state Root { state A; [*] -> A; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "guard",
+            """
+            def float gain = 1.5;
+            state Root { state A; state B; [*] -> A; A -> B : if [(gain & 1) != 0]; }
+            """,
+            None,
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "transition_effect",
+            """
+            def int flags = 1;
+            def float gain = 1.5;
+            state Root { state A; state B; [*] -> A; A -> B effect { flags = gain & flags; }; }
+            """,
+            "operation_assignment",
+        ),
+        (
+            "W_NUMERIC_FLOAT_BITWISE",
+            "lifecycle_action",
+            """
+            def int flags = 1;
+            def float gain = 1.5;
+            state Root { state A { during { flags = gain & flags; } } [*] -> A; }
+            """,
+            "operation_assignment",
+        ),
+    ],
+)
+def test_numeric_rules_cover_all_public_expression_contexts(
+    code,
+    context_name,
+    source,
+    statement_kind,
+):
+    diagnostics = _diagnostics_for(source, code)
+    assert diagnostics, code
+    assert any(
+        diag.refs["context"] == context_name
+        and (
+            statement_kind is None or diag.refs.get("statement_kind") == statement_kind
+        )
+        for diag in diagnostics
+    ), [diag.refs for diag in diagnostics]
+    for diag in diagnostics:
+        assert_refs_match_schema(diag, context=code)
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -291,6 +291,7 @@ def _single_diagnostic(source: str, code: str):
     ("literal_text", "expect_warning"),
     [
         (TOO_LARGE_SIGNED_INT64_TEXT, True),
+        ("+" + TOO_LARGE_SIGNED_INT64_TEXT, True),
         (MIN_SIGNED_INT64_TEXT, False),
         (TOO_SMALL_SIGNED_INT64_TEXT, True),
     ],
@@ -499,6 +500,26 @@ def test_numeric_shift_dynamic_rhs_is_not_reported():
             ["float", "int"],
             ["local_expression", "declared_var"],
         ),
+        (
+            "(1 / 2) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+        (
+            "sin(1) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+        (
+            "abs(gain) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
+        (
+            "((flags > 0) ? 1.0 : 0) & flags",
+            ["float", "int"],
+            ["local_expression", "declared_var"],
+        ),
     ],
 )
 def test_numeric_float_bitwise_operand_evidence(
@@ -519,6 +540,20 @@ def test_numeric_float_bitwise_operand_evidence(
     )
     assert diagnostic.refs["operand_types"] == expected_types
     assert diagnostic.refs["operand_type_sources"] == expected_sources
+
+
+def test_numeric_float_bitwise_does_not_treat_int_local_expression_as_float():
+    diagnostics = _diagnostics_for(
+        """
+        def int flags = 1;
+        state Root {
+            state A { during { flags = (1 + 2) & flags; } }
+            [*] -> A;
+        }
+        """,
+        "W_NUMERIC_FLOAT_BITWISE",
+    )
+    assert diagnostics == []
 
 
 def test_numeric_float_shift_can_overlap_shift_count_warning():
@@ -559,6 +594,26 @@ def test_numeric_scans_operation_if_branch_conditions_and_nested_assignments():
         for diag in report.diagnostics
         if diag.code == "W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE"
     ]
+    assert len(diagnostics) == 1
+    assert diagnostics[0].refs["context"] == "lifecycle_action"
+    assert diagnostics[0].refs["statement_kind"] == "operation_assignment"
+
+
+def test_numeric_lifecycle_refs_do_not_duplicate_inline_action_warnings():
+    diagnostics = _diagnostics_for(
+        """
+        def int value = 1;
+        state Root {
+            state A {
+                enter abstract HardwareInit;
+                enter Inline { value = value / 0; }
+                enter ref Inline;
+            }
+            [*] -> A;
+        }
+        """,
+        "W_NUMERIC_CONSTANT_DIVISION_BY_ZERO",
+    )
     assert len(diagnostics) == 1
     assert diagnostics[0].refs["context"] == "lifecycle_action"
     assert diagnostics[0].refs["statement_kind"] == "operation_assignment"


### PR DESCRIPTION
## 目标

本 PR 是 [伞 PR #272](https://github.com/HansBug/pyfcstm/pull/272) 的 PR-N2 子 PR，负责在 Python 侧落地 [issue #253](https://github.com/HansBug/pyfcstm/issues/253) 已定义的 **inspect 数值 analyzer**。

本 PR 的边界严格继承 PR-N1（[#273](https://github.com/HansBug/pyfcstm/pull/273)）已经冻结的诊断契约：只把 4 类面向 **C/C++ 默认部署剖面（C/C++ deployment profile）** 的确定性 warning 接入 Python `inspect_model()` 默认静态诊断输出，不实现 jsfcstm analyzer、不实现 BitVec / BMC / 动态溢出证明，也不修改 codegen 数值策略。

## 本 PR 必须实现的 4 类 Python inspect 诊断

| 诊断码 | 触发范围 | 必须确认的语义 |
|---|---|---|
| `W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE` | 会进入 C/C++ 表达式渲染的整数字面量超出 `PYFCSTM_GENERATED_INT64` 范围 | 一元负号与 literal 按组合后的 signed 值判断；`9223372036854775808` warning，`-9223372036854775808` no warning，`-9223372036854775809` warning。 |
| `W_NUMERIC_CONSTANT_DIVISION_BY_ZERO` | `/` 或 `%` 的 RHS 经同表达式 literal-only 轻量常量折叠可判定为 0 | LHS 可以是动态表达式；numeric analyzer 必须先单独 fold RHS：`None` 表示不可静态判定，不触发；`0` / `0.0` 触发；`refs.operator` 必须区分 `/` 与 `%`。 |
| `W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE` | `<<` / `>>` 的 RHS 经轻量常量折叠为常量且 `< 0` 或 `>= 64` | 动态或不可常量折叠的 shift 不在本 PR 报 warning；不得为这类形状引入任何新增 verify 引导 code，相关能力归 issue #254。 |
| `W_NUMERIC_FLOAT_BITWISE` | inspect 可确定的 float literal、声明为 `float` 的变量，或同一表达式内可轻量判定为 float 的子表达式参与 `&` / `^` / `|` / `<<` / `>>` | 第一阶段不做跨语句临时变量类型流；`refs.operand_types` 与 `refs.operand_type_sources` 都必须出现，顺序对应操作数顺序，取值遵守 PR-N1 的枚举契约。 |

## PR-N2 的 `emit_tier` 策略

PR-N1 中 4 个 code 均为 `catalog_only`，表示只冻结契约、不允许公共 inspect 输出。本 PR 是 **Python-only analyzer** 阶段，jsfcstm analyzer 仍留给 PR-N3，因此本 PR 必须把 4 个 numeric code 从 `catalog_only` 迁移为 `partial_static_pipeline`：

- Python `inspect_model()` 默认 static pipeline 可以发出这些 code；
- jsfcstm 仍不需要在本 PR 发出这些 code；
- PR-N3 在 jsfcstm analyzer 落地后再把跨端状态收口到两端一致的 static pipeline 契约。

验收测试必须锁定该临时 emit tier，避免 analyzer 已接入但 `_catalog_emittable_diagnostics()` 仍把 numeric diagnostics 过滤掉。

## 实施方案

| 区域 | 计划 |
|---|---|
| Python analyzer | 新增 `pyfcstm/diagnostics/analyzers/numeric.py` 或等价 numeric analyzer 模块，提供 `collect_numeric_warnings(machine)`。推荐保持职责独立，不把 4 类规则塞进既有 `const_fold.py`。 |
| inspect 接入 | 推荐在 `collect_design_health_warnings(..., machine=machine)` 内追加 `collect_numeric_warnings(machine)`，从现有调用链进入 `inspect_model()` 默认诊断；仅在现有调用链不足时才修改 `pyfcstm/diagnostics/inspect.py`。 |
| 常量折叠 | 只让 `const_fold` capability 的规则消费 `fold_numeric_expression()`：除零/取模零和 shift 越界都先 fold RHS 子表达式。`pure_static` capability 的超范围 literal 与 float bitwise 直接遍历表达式 AST，不依赖 const-fold pipeline。不得做变量、函数调用、跨语句传播、代数化简。 |
| refs/message | 所有新增诊断必须从 PR-N1 `codes.yaml` 契约生成稳定 refs，包含 `target_family='c_family'`、`target_templates=['c','c_poll','cpp','cpp_poll']`、`runtime_note`、`context`、`expr_text` 和各规则 required refs；message 必须明确“C/C++ 默认部署剖面风险”，不能写成 Python 或目标无关错误。 |
| 扫描面 | 至少覆盖变量 initializer、guard、transition effect、lifecycle action，以及 operation assignment RHS；assignment RHS 使用 `statement_kind='operation_assignment'` 表达语句形状。 |
| 测试 | 在 `test/diagnostics/` 增加/扩展 Python 内联 DSL 单元测试，不调用 Node/jsfcstm，不读取 `editors/jsfcstm/test/`。测试需要覆盖 4 类规则 × 5 个表达式位置的最小矩阵，或显式说明某个组合不适用。 |
| 文档 / pydoc | 若新增 Python module，module docstring 使用 reST 并提供清晰模块地图；新增 public 函数/类 pydoc 必须包含 params/returns/Examples::。提交前运行 `make rst_auto`；若无 RST diff，在 PR summary 中说明。 |

## 非目标

| 非目标 | 原因 |
|---|---|
| 不实现 jsfcstm analyzer | 留给 PR-N3；本 PR 只做 Python inspect。 |
| 不做跨端 parity 收口、CLI/editor 用户可见输出总验收 | 留给 PR-N4。 |
| 不实现动态 shift / 动态 counter / overflow 证明 / BitVec / BMC | 属于 [issue #254](https://github.com/HansBug/pyfcstm/issues/254)。 |
| 不修改 codegen numeric policy 或模板运行时保护 | 属于 [issue #255](https://github.com/HansBug/pyfcstm/issues/255)。 |
| 不把 C/C++ warning 表述为 Python 风险 | Python 目标不是本阶段风险目标。 |
| 不共享 Python/jsfcstm 测试 fixture | 遵守仓库测试树独立性约束。 |

## 验收标准

- [ ] `codes.yaml` 中 4 个 numeric code 的 `emit_tier` 从 `catalog_only` 改为 `partial_static_pipeline`，catalog / schema / refs 测试同步锁定；`inspect_model()` 默认输出可触发 4 类 numeric warning，且不会被 `_catalog_emittable_diagnostics()` 过滤。
- [ ] 所有新增 warning 的 message 与 refs 都明确表达 C/C++ 默认部署剖面限定；message 至少包含 “C/C++ 默认部署剖面 / C-family / `PYFCSTM_GENERATED_INT64` / `double`” 中适用的语义，refs 同时包含 `target_family`、稳定 `target_templates`、`runtime_note`。
- [ ] `target_templates` 稳定为 `['c', 'c_poll', 'cpp', 'cpp_poll']` 且不包含 Python。
- [ ] int64 signed 边界测试锁定：`9223372036854775808` warning、`-9223372036854775808` no warning、`-9223372036854775809` warning。
- [ ] 常量除零 / 取模零按 RHS 可折叠为 0 触发；即使 LHS 是动态表达式，只要 RHS 可折叠为 0 即触发；`operator` 能区分 `/` 与 `%`。
- [ ] 常量 shift 越界只对可折叠常量 RHS 报 warning，动态 RHS 不报本 PR 的 numeric warning。
- [ ] float bitwise 覆盖 float literal、声明为 `float` 的变量、同表达式内可判定 float 子表达式；`operand_types` 与 `operand_type_sources` 都存在、顺序一致、枚举合法；不要求跨语句临时变量类型推断。若同一 shift 表达式同时满足 float bitwise 与 shift count 越界，允许同时发射两个 warning，并用测试锁定。
- [ ] 扫描面覆盖变量 initializer、guard、transition effect、lifecycle action、operation assignment RHS；各位置 refs.context / statement_kind 正确。
- [ ] 测试文件至少更新 `test/diagnostics/test_numeric_contract.py`（emit_tier / refs contract）、新增或扩展 numeric analyzer emission tests（真实 DSL 触发 4 类规则）、必要时更新 `test/diagnostics/test_codes_yaml*.py` / `test_cross_end_parity.py` 以保持 catalog 与 jsfcstm resource contract 不漂移；`test_cross_end_parity.py` 的调整仅服务 emit_tier 从 `catalog_only` 到 `partial_static_pipeline` 的 Python 先行状态，不要求 N2 验证 jsfcstm analyzer 行为。
- [ ] Python 测试位于 `test/diagnostics/`，不调用 Node/jsfcstm，不读取 jsfcstm 测试树。
- [ ] 本地测试使用 slow skip：`SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=./diagnostics`；提交前运行 `make rst_auto`。
- [ ] CI 全绿；Codecov 不触发 patch/project failure，且新增 analyzer / inspect 接入分支有对应单元测试覆盖。

## Review 重点

1. 是否严格复用 PR-N1 诊断契约，尤其 `refs` required fields / enums / exact list values。
2. 是否把 C/C++ deployment profile warning 误写成 Python 或目标无关错误。
3. 是否错误地把动态 shift / overflow proof 混入本 PR。
4. 是否扫描遗漏 lifecycle / transition effect / assignment RHS 等位置。
5. 是否出现 Python/jsfcstm 测试树耦合。
6. 是否引入 broad catch 或不符合 CLAUDE.md pydoc/reST 规范的 public API。
7. 是否误引入动态 shift / verify 引导类新增 code，尤其是不应在本 PR 中新增 `W_NUMERIC_SHIFT_REQUIRES_PROOF` / `I_NUMERIC_VERIFY_RECOMMENDED`。
