### PR TITLE
实现：同步 jsfcstm inspect 数值诊断

### DIFF
--- a/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/design-health.ts
@@ -13,6 +13,7 @@ import {refsWithSuggestedFix} from '../suggested-fix';
 import {collectConstFoldWarnings} from './const-fold';
 import {collectDataFlowWarnings} from './data-flow';
 import {collectNamingWarnings} from './naming';
+import {collectNumericWarnings} from './numeric';
 import {collectRedundancyWarnings} from './redundancy';
 import {collectStructuralWarnings} from './structural';
 import {collectThresholdWarnings, type ThresholdOptions} from './thresholds';
@@ -53,6 +54,7 @@ export function collectDesignHealthWarnings(
         ...collectNamingWarnings(actions),
         ...collectTypeWarnings(variables),
         ...collectDataFlowWarnings(variables, machine),
+        ...(machine ? collectNumericWarnings(machine) : []),
         ...collectRedundancyWarnings(transitions, events, states),
         ...collectTransitionInfos(states, transitions),
     ];

--- a/editors/jsfcstm/src/diagnostics/analyzers/index.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/index.ts
@@ -5,6 +5,7 @@ export {
 } from './const-fold';
 export {collectDesignHealthWarnings} from './design-health';
 export {collectNamingWarnings} from './naming';
+export {collectNumericWarnings} from './numeric';
 export {collectThresholdWarnings} from './thresholds';
 export {collectTransitionInfos} from './transition-info';
 export {collectTypeWarnings} from './type-shape';

--- a/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
@@ -1,0 +1,486 @@
+import {
+    BinaryOp,
+    BooleanExpr,
+    ConditionalOp,
+    Float,
+    IfBlock,
+    Integer,
+    Operation,
+    OperationStatement,
+    StateMachine,
+    UFunc,
+    UnaryOp,
+    Variable,
+    type Expr,
+    type OnAspect,
+    type OnStage,
+} from '../../model/runtime';
+import {exprText, type ModelDiagnosticJson} from '../inspect';
+import {foldNumericExpression} from './const-fold';
+
+const TARGET_FAMILY = 'c_family';
+const TARGET_TEMPLATES = ['c', 'c_poll', 'cpp', 'cpp_poll'];
+const TARGET_BITS = 64;
+const MIN_SIGNED_INT64_TEXT = '-9223372036854775808';
+const MAX_SIGNED_INT64_TEXT = '9223372036854775807';
+const BITWISE_OPERATORS = new Set(['&', '^', '|', '<<', '>>']);
+const ZERO_OPERATORS = new Set(['/', '%']);
+const SHIFT_OPERATORS = new Set(['<<', '>>']);
+const C_FAMILY_INTEGER_UFUNCS = new Set(['ceil', 'floor', 'int', 'round', 'sign', 'trunc']);
+const C_FAMILY_CONDITION_OPERATORS = new Set([
+    '&&',
+    '||',
+    '=>',
+    'xor',
+    'iff',
+    '==',
+    '!=',
+    '<',
+    '<=',
+    '>',
+    '>=',
+]);
+
+const RUNTIME_NOTES: Record<string, string> = {
+    W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
+        'C/C++ deployment profile risk: the default C-family templates use '
+        + 'PYFCSTM_GENERATED_INT64, while Python generated runtimes may not have '
+        + 'the same fixed-width integer carrying risk.',
+    W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
+        'C/C++ deployment profile risk: generated C/C++ code needs an explicit '
+        + 'division-by-zero or modulo-by-zero policy, while Python generated '
+        + 'runtimes use different exception semantics.',
+    W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
+        'C/C++ deployment profile risk: the default C-family integer width is '
+        + '64 bits, while Python generated runtimes may not have the same '
+        + 'fixed-width shift risk.',
+    W_NUMERIC_FLOAT_BITWISE:
+        'C/C++ integer-operation profile risk: bitwise and shift operators are '
+        + 'integer operations in the generated C-family templates; Python '
+        + 'generated runtimes may fail for a different reason.',
+};
+
+interface ExpressionContext {
+    expr: Expr;
+    context: 'var_initializer' | 'guard' | 'transition_effect' | 'lifecycle_action';
+    statementKind?: 'operation_assignment';
+    varName?: string;
+}
+
+interface SignedIntegerLiteral {
+    text: string;
+    decimalText: string;
+}
+
+type NumericType = 'int' | 'float' | 'unknown';
+type NumericTypeSource = 'literal' | 'declared_var' | 'local_expression';
+
+/**
+ * Collect C/C++ deployment-profile numeric warnings for a model.
+ */
+export function collectNumericWarnings(machine: StateMachine | null | undefined): ModelDiagnosticJson[] {
+    if (!machine) return [];
+    const varTypes = variableTypes(machine);
+    const diagnostics: ModelDiagnosticJson[] = [];
+    for (const context of expressionContexts(machine)) {
+        diagnostics.push(...diagnosticsForExpression(context, varTypes));
+    }
+    return diagnostics;
+}
+
+function variableTypes(machine: StateMachine): Record<string, 'int' | 'float'> {
+    const out: Record<string, 'int' | 'float'> = {};
+    for (const [name, definition] of Object.entries(machine.defines)) {
+        out[name] = definition.type;
+    }
+    return out;
+}
+
+function diagnosticsForExpression(
+    context: ExpressionContext,
+    varTypes: Record<string, 'int' | 'float'>,
+): ModelDiagnosticJson[] {
+    const diagnostics: ModelDiagnosticJson[] = [];
+    const signedLiteralChildren = signedLiteralChildIds(context.expr);
+    for (const expr of walkExpressions(context.expr)) {
+        if (!signedLiteralChildren.has(expr)) {
+            diagnostics.push(...literalRangeDiagnostic(context, expr));
+        }
+        diagnostics.push(...constantZeroDivisionDiagnostic(context, expr));
+        diagnostics.push(...shiftCountDiagnostic(context, expr));
+        diagnostics.push(...floatBitwiseDiagnostic(context, expr, varTypes));
+    }
+    return diagnostics;
+}
+
+function* expressionContexts(machine: StateMachine): Generator<ExpressionContext, void, void> {
+    for (const [varName, definition] of Object.entries(machine.defines)) {
+        yield {
+            expr: definition.init,
+            context: 'var_initializer',
+            varName,
+        };
+    }
+
+    for (const state of machine.allStates) {
+        for (const transition of state.transitions) {
+            if (transition.guard) {
+                yield {
+                    expr: transition.guard,
+                    context: 'guard',
+                };
+            }
+            for (const statement of transition.effects) {
+                yield* statementExpressionContexts(statement, 'transition_effect');
+            }
+        }
+        for (const action of concreteActions([
+            ...state.onEnters,
+            ...state.onDurings,
+            ...state.onExits,
+            ...state.onDuringAspects,
+        ])) {
+            for (const statement of action.operations) {
+                yield* statementExpressionContexts(statement, 'lifecycle_action');
+            }
+        }
+    }
+}
+
+function* concreteActions(actions: Array<OnStage | OnAspect>): Generator<OnStage | OnAspect, void, void> {
+    for (const action of actions) {
+        if (action.isAbstract || action.isRef) continue;
+        yield action;
+    }
+}
+
+function* statementExpressionContexts(
+    statement: OperationStatement,
+    context: ExpressionContext['context'],
+): Generator<ExpressionContext, void, void> {
+    if (statement instanceof Operation) {
+        yield {
+            expr: statement.expr,
+            context,
+            statementKind: 'operation_assignment',
+            varName: statement.varName,
+        };
+        return;
+    }
+    if (statement instanceof IfBlock) {
+        for (const branch of statement.branches) {
+            if (branch.condition) {
+                yield {
+                    expr: branch.condition,
+                    context,
+                };
+            }
+            for (const inner of branch.statements) {
+                yield* statementExpressionContexts(inner, context);
+            }
+        }
+    }
+}
+
+function* walkExpressions(expr: Expr): Generator<Expr, void, void> {
+    yield expr;
+    if (expr instanceof UnaryOp) {
+        yield* walkExpressions(expr.x);
+    } else if (expr instanceof BinaryOp) {
+        yield* walkExpressions(expr.x);
+        yield* walkExpressions(expr.y);
+    } else if (expr instanceof ConditionalOp) {
+        yield* walkExpressions(expr.cond);
+        yield* walkExpressions(expr.ifTrue);
+        yield* walkExpressions(expr.ifFalse);
+    } else if (expr instanceof UFunc) {
+        yield* walkExpressions(expr.x);
+    }
+}
+
+function signedLiteralChildIds(expr: Expr): Set<Expr> {
+    const out = new Set<Expr>();
+    for (const item of walkExpressions(expr)) {
+        if (item instanceof UnaryOp && (item.op === '+' || item.op === '-') && item.x instanceof Integer) {
+            out.add(item.x);
+        }
+    }
+    return out;
+}
+
+function literalRangeDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
+    const literal = signedIntegerLiteral(expr);
+    if (!literal || isSignedInt64Literal(literal.decimalText)) return [];
+    const refs = baseRefs('W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE', context, exprText(expr));
+    refs.literal_text = literal.text;
+    refs.target_bits = TARGET_BITS;
+    refs.signed = true;
+    refs.min_value_text = MIN_SIGNED_INT64_TEXT;
+    refs.max_value_text = MAX_SIGNED_INT64_TEXT;
+    if (context.varName) {
+        refs.var_name = context.varName;
+    }
+    return [diagnostic(
+        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+        `C/C++ default deployment profile risk: integer literal ${literal.text} is outside the `
+            + `PYFCSTM_GENERATED_INT64 range [${MIN_SIGNED_INT64_TEXT}, ${MAX_SIGNED_INT64_TEXT}]; `
+            + 'Python generated runtimes may not have the same fixed-width risk.',
+        refs,
+    )];
+}
+
+function constantZeroDivisionDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
+    if (!(expr instanceof BinaryOp) || !ZERO_OPERATORS.has(expr.op)) return [];
+    const rhsValue = foldNumericExpression(expr.y);
+    if (rhsValue !== 0) return [];
+    const refs = baseRefs('W_NUMERIC_CONSTANT_DIVISION_BY_ZERO', context, exprText(expr));
+    refs.operator = expr.op;
+    refs.rhs_text = exprText(expr.y) ?? '';
+    return [diagnostic(
+        'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+        `C/C++ default deployment profile risk: the RHS of operator ${JSON.stringify(expr.op)} `
+            + 'folds to 0; generated C/C++ code needs an explicit failure policy, '
+            + 'while Python runtime exception semantics differ.',
+        refs,
+    )];
+}
+
+function shiftCountDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
+    if (!(expr instanceof BinaryOp) || !SHIFT_OPERATORS.has(expr.op)) return [];
+    const rhsValue = foldNumericExpression(expr.y);
+    if (
+        typeof rhsValue !== 'number'
+        || !Number.isFinite(rhsValue)
+        || !(rhsValue < 0 || rhsValue >= TARGET_BITS)
+    ) {
+        return [];
+    }
+    const refs = baseRefs('W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE', context, exprText(expr));
+    refs.operator = expr.op;
+    refs.target_bits = TARGET_BITS;
+    refs.shift_count_text = numberText(rhsValue);
+    return [diagnostic(
+        'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+        `C/C++ default deployment profile risk: the shift count of operator ${JSON.stringify(expr.op)} `
+            + `folds to ${numberText(rhsValue)}, outside 0 <= count < ${TARGET_BITS}; `
+            + 'Python generated runtimes do not represent the same fixed-width shift contract.',
+        refs,
+    )];
+}
+
+function floatBitwiseDiagnostic(
+    context: ExpressionContext,
+    expr: Expr,
+    varTypes: Record<string, 'int' | 'float'>,
+): ModelDiagnosticJson[] {
+    if (!(expr instanceof BinaryOp) || !BITWISE_OPERATORS.has(expr.op)) return [];
+    const left = inferNumericType(expr.x, varTypes);
+    const right = inferNumericType(expr.y, varTypes);
+    if (left[0] !== 'float' && right[0] !== 'float') return [];
+    const refs = baseRefs('W_NUMERIC_FLOAT_BITWISE', context, exprText(expr));
+    refs.operator = expr.op;
+    refs.operand_types = [left[0], right[0]];
+    refs.operand_type_sources = [left[1], right[1]];
+    return [diagnostic(
+        'W_NUMERIC_FLOAT_BITWISE',
+        `C/C++ default deployment profile risk: a float-shaped operand participates in integer `
+            + `bitwise or shift operator ${JSON.stringify(expr.op)}; C-family templates generate `
+            + 'integer operations, while Python runtime failures have different semantics.',
+        refs,
+    )];
+}
+
+function inferNumericType(
+    expr: Expr,
+    varTypes: Record<string, 'int' | 'float'>,
+): [NumericType, NumericTypeSource] {
+    if (expr instanceof BooleanExpr || expr instanceof Integer) {
+        return ['int', 'literal'];
+    }
+    if (expr instanceof Float) {
+        return ['float', 'literal'];
+    }
+    if (expr instanceof Variable) {
+        const declared = varTypes[expr.name];
+        if (declared === 'float') return ['float', 'declared_var'];
+        if (declared === 'int') return ['int', 'declared_var'];
+        return ['unknown', 'declared_var'];
+    }
+    if (expr instanceof UnaryOp) {
+        const inner = inferNumericType(expr.x, varTypes);
+        return inner[0] === 'int' || inner[0] === 'float' ? inner : ['unknown', 'local_expression'];
+    }
+    if (expr instanceof UFunc) {
+        if (C_FAMILY_INTEGER_UFUNCS.has(expr.func)) {
+            return ['int', 'local_expression'];
+        }
+        if (expr.func === 'abs') {
+            const inner = inferNumericType(expr.x, varTypes);
+            return inner[0] === 'int' || inner[0] === 'float'
+                ? [inner[0], 'local_expression']
+                : ['unknown', 'local_expression'];
+        }
+        return ['float', 'local_expression'];
+    }
+    if (expr instanceof BinaryOp) {
+        if (BITWISE_OPERATORS.has(expr.op) || C_FAMILY_CONDITION_OPERATORS.has(expr.op)) {
+            return ['int', 'local_expression'];
+        }
+        if (expr.op === '/') {
+            return ['float', 'local_expression'];
+        }
+        const left = inferNumericType(expr.x, varTypes);
+        const right = inferNumericType(expr.y, varTypes);
+        return [mergeNumericTypes(left[0], right[0]), 'local_expression'];
+    }
+    if (expr instanceof ConditionalOp) {
+        const ifTrue = inferNumericType(expr.ifTrue, varTypes);
+        const ifFalse = inferNumericType(expr.ifFalse, varTypes);
+        return [mergeNumericTypes(ifTrue[0], ifFalse[0]), 'local_expression'];
+    }
+    return ['unknown', 'local_expression'];
+}
+
+function mergeNumericTypes(typeA: NumericType, typeB: NumericType): NumericType {
+    if (typeA === 'float' || typeB === 'float') return 'float';
+    if (typeA === 'int' && typeB === 'int') return 'int';
+    return 'unknown';
+}
+
+function signedIntegerLiteral(expr: Expr): SignedIntegerLiteral | null {
+    if (expr instanceof Integer) {
+        const digits = unsignedIntegerDecimalText(expr.text);
+        return digits === null ? null : {text: expr.text.trim(), decimalText: digits};
+    }
+    if (expr instanceof UnaryOp && (expr.op === '+' || expr.op === '-') && expr.x instanceof Integer) {
+        const digits = unsignedIntegerDecimalText(expr.x.text);
+        if (digits === null) return null;
+        const sign = expr.op === '-' ? '-' : '+';
+        return {
+            text: `${sign}${expr.x.text.trim()}`,
+            decimalText: expr.op === '-' && digits !== '0' ? `-${digits}` : digits,
+        };
+    }
+    return null;
+}
+
+function unsignedIntegerDecimalText(rawText: string): string | null {
+    const raw = rawText.trim();
+    if (/^\d+$/.test(raw)) {
+        return normalizeDecimalDigits(raw);
+    }
+    if (/^0[xX][0-9a-fA-F]+$/.test(raw)) {
+        return convertRadixDigitsToDecimal(raw.slice(2), 16);
+    }
+    if (/^0[bB][01]+$/.test(raw)) {
+        return convertRadixDigitsToDecimal(raw.slice(2), 2);
+    }
+    return null;
+}
+
+function isSignedInt64Literal(signedDecimalText: string): boolean {
+    const normalized = normalizeSignedDecimal(signedDecimalText);
+    if (normalized.startsWith('-')) {
+        return compareUnsignedDecimal(normalized.slice(1), MIN_SIGNED_INT64_TEXT.slice(1)) <= 0;
+    }
+    return compareUnsignedDecimal(normalized, MAX_SIGNED_INT64_TEXT) <= 0;
+}
+
+function normalizeSignedDecimal(raw: string): string {
+    if (raw.startsWith('-')) {
+        const digits = normalizeDecimalDigits(raw.slice(1));
+        return digits === '0' ? '0' : `-${digits}`;
+    }
+    if (raw.startsWith('+')) {
+        return normalizeDecimalDigits(raw.slice(1));
+    }
+    return normalizeDecimalDigits(raw);
+}
+
+function normalizeDecimalDigits(raw: string): string {
+    const normalized = raw.replace(/^0+/, '');
+    return normalized.length > 0 ? normalized : '0';
+}
+
+function compareUnsignedDecimal(left: string, right: string): number {
+    const leftNormalized = normalizeDecimalDigits(left);
+    const rightNormalized = normalizeDecimalDigits(right);
+    if (leftNormalized.length !== rightNormalized.length) {
+        return leftNormalized.length < rightNormalized.length ? -1 : 1;
+    }
+    if (leftNormalized === rightNormalized) return 0;
+    return leftNormalized < rightNormalized ? -1 : 1;
+}
+
+function addSmallDecimal(raw: string, value: number): string {
+    if (value === 0) return raw;
+    let carry = value;
+    const out: string[] = [];
+    for (let index = raw.length - 1; index >= 0; index -= 1) {
+        const total = Number(raw[index]) + carry;
+        out.push(String(total % 10));
+        carry = Math.floor(total / 10);
+    }
+    while (carry > 0) {
+        out.push(String(carry % 10));
+        carry = Math.floor(carry / 10);
+    }
+    return out.reverse().join('');
+}
+
+function multiplySmallDecimal(raw: string, factor: number): string {
+    if (raw === '0' || factor === 0) return '0';
+    let carry = 0;
+    const out: string[] = [];
+    for (let index = raw.length - 1; index >= 0; index -= 1) {
+        const total = Number(raw[index]) * factor + carry;
+        out.push(String(total % 10));
+        carry = Math.floor(total / 10);
+    }
+    while (carry > 0) {
+        out.push(String(carry % 10));
+        carry = Math.floor(carry / 10);
+    }
+    return out.reverse().join('');
+}
+
+function convertRadixDigitsToDecimal(digits: string, radix: number): string {
+    let value = '0';
+    for (const char of digits.toLowerCase()) {
+        const digit = parseInt(char, radix);
+        value = addSmallDecimal(multiplySmallDecimal(value, radix), digit);
+    }
+    return normalizeDecimalDigits(value);
+}
+
+function baseRefs(
+    code: keyof typeof RUNTIME_NOTES,
+    context: ExpressionContext,
+    renderedExpr: string | null,
+): Record<string, unknown> {
+    const refs: Record<string, unknown> = {
+        target_family: TARGET_FAMILY,
+        target_templates: [...TARGET_TEMPLATES],
+        runtime_note: RUNTIME_NOTES[code],
+        context: context.context,
+        expr_text: renderedExpr ?? '',
+    };
+    if (context.statementKind) {
+        refs.statement_kind = context.statementKind;
+    }
+    return refs;
+}
+
+function diagnostic(code: string, message: string, refs: Record<string, unknown>): ModelDiagnosticJson {
+    return {
+        code,
+        severity: 'warning',
+        message,
+        span: null,
+        refs,
+    };
+}
+
+function numberText(value: number): string {
+    return Number.isInteger(value) ? String(Math.trunc(value)) : String(value);
+}

--- a/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/numeric.ts
@@ -75,6 +75,12 @@ interface SignedIntegerLiteral {
 type NumericType = 'int' | 'float' | 'unknown';
 type NumericTypeSource = 'literal' | 'declared_var' | 'local_expression';
 
+interface FoldedExactInteger {
+    kind: 'exactInteger';
+    sign: -1 | 1;
+    digits: string;
+}
+
 /**
  * Collect C/C++ deployment-profile numeric warnings for a model.
  */
@@ -247,22 +253,16 @@ function constantZeroDivisionDiagnostic(context: ExpressionContext, expr: Expr):
 
 function shiftCountDiagnostic(context: ExpressionContext, expr: Expr): ModelDiagnosticJson[] {
     if (!(expr instanceof BinaryOp) || !SHIFT_OPERATORS.has(expr.op)) return [];
-    const rhsValue = foldNumericExpression(expr.y);
-    if (
-        typeof rhsValue !== 'number'
-        || !Number.isFinite(rhsValue)
-        || !(rhsValue < 0 || rhsValue >= TARGET_BITS)
-    ) {
-        return [];
-    }
+    const shiftCountText = outOfRangeShiftCountText(foldNumericExpression(expr.y));
+    if (shiftCountText === null) return [];
     const refs = baseRefs('W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE', context, exprText(expr));
     refs.operator = expr.op;
     refs.target_bits = TARGET_BITS;
-    refs.shift_count_text = numberText(rhsValue);
+    refs.shift_count_text = shiftCountText;
     return [diagnostic(
         'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
         `C/C++ default deployment profile risk: the shift count of operator ${JSON.stringify(expr.op)} `
-            + `folds to ${numberText(rhsValue)}, outside 0 <= count < ${TARGET_BITS}; `
+            + `folds to ${shiftCountText}, outside 0 <= count < ${TARGET_BITS}; `
             + 'Python generated runtimes do not represent the same fixed-width shift contract.',
         refs,
     )];
@@ -342,8 +342,9 @@ function inferNumericType(
 }
 
 function mergeNumericTypes(typeA: NumericType, typeB: NumericType): NumericType {
-    if (typeA === 'float' || typeB === 'float') return 'float';
-    if (typeA === 'int' && typeB === 'int') return 'int';
+    const known = new Set([typeA, typeB].filter((type): type is Exclude<NumericType, 'unknown'> => type !== 'unknown'));
+    if (known.has('float')) return 'float';
+    if (known.size === 1 && known.has('int')) return 'int';
     return 'unknown';
 }
 
@@ -410,6 +411,35 @@ function compareUnsignedDecimal(left: string, right: string): number {
     }
     if (leftNormalized === rightNormalized) return 0;
     return leftNormalized < rightNormalized ? -1 : 1;
+}
+
+function outOfRangeShiftCountText(value: unknown): string | null {
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value) || !(value < 0 || value >= TARGET_BITS)) return null;
+        return numberText(value);
+    }
+
+    const exactInteger = foldedExactInteger(value);
+    if (exactInteger === null) return null;
+    if (exactInteger.sign < 0 && exactInteger.digits !== '0') {
+        return `-${exactInteger.digits}`;
+    }
+    return compareUnsignedDecimal(exactInteger.digits, String(TARGET_BITS)) >= 0
+        ? exactInteger.digits
+        : null;
+}
+
+function foldedExactInteger(value: unknown): FoldedExactInteger | null {
+    if (typeof value !== 'object' || value === null) return null;
+    const maybe = value as Record<string, unknown>;
+    if (maybe.kind !== 'exactInteger') return null;
+    if (maybe.sign !== -1 && maybe.sign !== 1) return null;
+    if (typeof maybe.digits !== 'string' || !/^\d+$/.test(maybe.digits)) return null;
+    return {
+        kind: 'exactInteger',
+        sign: maybe.sign,
+        digits: normalizeDecimalDigits(maybe.digits),
+    };
 }
 
 function addSmallDecimal(raw: string, value: number): string {

--- a/editors/jsfcstm/test/diagnostics-numeric.test.ts
+++ b/editors/jsfcstm/test/diagnostics-numeric.test.ts
@@ -1,0 +1,308 @@
+import assert from 'node:assert/strict';
+
+import {
+    collectNumericWarnings,
+} from '../src/diagnostics/analyzers/numeric';
+import {
+    inspectModel,
+    refsWithSuggestedFix,
+    type ModelDiagnosticJson,
+} from '../src/diagnostics';
+import {buildStateMachineModel} from '../src/model';
+import {parseAstDocument} from '../src/ast';
+import {createDocument, packageModule} from './support';
+
+const MIN_SIGNED_INT64_TEXT = '-9223372036854775808';
+const MAX_SIGNED_INT64_TEXT = '9223372036854775807';
+const TOO_LARGE_SIGNED_INT64_TEXT = '9223372036854775808';
+const TOO_SMALL_SIGNED_INT64_TEXT = '-9223372036854775809';
+
+const NUMERIC_CODES = new Set([
+    'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
+    'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
+    'W_NUMERIC_FLOAT_BITWISE',
+]);
+
+const C_FAMILY_TARGET_TEMPLATES = ['c', 'c_poll', 'cpp', 'cpp_poll'];
+
+async function buildMachine(src: string) {
+    const document = createDocument(src, '/tmp/diagnostics-numeric.fcstm');
+    const ast = await parseAstDocument(document);
+    const machine = buildStateMachineModel(ast);
+    if (!machine) {
+        throw new Error('buildStateMachineModel returned null');
+    }
+    return machine;
+}
+
+async function numericDiagnostics(source: string): Promise<ModelDiagnosticJson[]> {
+    const report = inspectModel(await buildMachine(source));
+    return report.diagnostics.filter(item => NUMERIC_CODES.has(item.code));
+}
+
+function diagnosticsFor(diagnostics: ModelDiagnosticJson[], code: string): ModelDiagnosticJson[] {
+    return diagnostics.filter(item => item.code === code);
+}
+
+function assertRegistryRefs(diagnostic: ModelDiagnosticJson): void {
+    const registry = packageModule.loadCodesRegistry();
+    const spec = registry[diagnostic.code];
+    assert.ok(spec, `${diagnostic.code} missing from bundled registry`);
+    assert.equal(diagnostic.severity, spec.severity);
+    const refsSpec = spec.refs ?? {};
+    for (const [fieldName, fieldSpec] of Object.entries(refsSpec)) {
+        if (fieldSpec.required) {
+            assert.ok(
+                Object.prototype.hasOwnProperty.call(diagnostic.refs, fieldName),
+                `${diagnostic.code} refs missing required ${fieldName}`,
+            );
+        }
+        const value = diagnostic.refs[fieldName];
+        if (value === undefined) continue;
+        if (fieldSpec.enum) {
+            assert.equal(typeof value, 'string', `${diagnostic.code}.${fieldName} must be a string enum`);
+            assert.ok(fieldSpec.enum.includes(value), `${diagnostic.code}.${fieldName} has invalid enum value ${value}`);
+        }
+        if (fieldSpec.item_enum || fieldSpec.exact_values) {
+            assert.ok(Array.isArray(value), `${diagnostic.code}.${fieldName} must be an array`);
+        }
+        if (fieldSpec.item_enum && Array.isArray(value)) {
+            for (const item of value) {
+                assert.equal(typeof item, 'string', `${diagnostic.code}.${fieldName} item must be a string`);
+                assert.ok(fieldSpec.item_enum.includes(item), `${diagnostic.code}.${fieldName} invalid item ${item}`);
+            }
+        }
+        if (fieldSpec.exact_values) {
+            assert.deepEqual(value, fieldSpec.exact_values, `${diagnostic.code}.${fieldName} exact values drifted`);
+        }
+    }
+
+    const refsWithoutSuggestedFix = {...diagnostic.refs};
+    delete refsWithoutSuggestedFix.suggested_fix;
+    assert.deepEqual(
+        diagnostic.refs,
+        refsWithSuggestedFix(diagnostic.code, refsWithoutSuggestedFix),
+        `${diagnostic.code} bypassed refsWithSuggestedFix() normalization`,
+    );
+}
+
+function assertTargetProfileRefs(diagnostic: ModelDiagnosticJson): void {
+    assertRegistryRefs(diagnostic);
+    assert.equal(diagnostic.refs.target_family, 'c_family');
+    assert.deepEqual(diagnostic.refs.target_templates, C_FAMILY_TARGET_TEMPLATES);
+    assert.equal(String(diagnostic.message).includes('C/C++'), true);
+    assert.equal(String(diagnostic.message).includes('Python'), true);
+    assert.equal(String(diagnostic.refs.runtime_note).includes('C/C++'), true);
+    assert.equal(String(diagnostic.refs.runtime_note).includes('Python'), true);
+}
+
+describe('diagnostics/numeric', () => {
+    it('keeps nullable analyzer entry as a no-op', () => {
+        assert.deepEqual(collectNumericWarnings(null), []);
+        assert.deepEqual(collectNumericWarnings(undefined), []);
+    });
+
+    it('reports signed int64 literal range boundaries for C-family templates', async () => {
+        for (const [literalText, shouldWarn] of [
+            [TOO_LARGE_SIGNED_INT64_TEXT, true],
+            [`+${TOO_LARGE_SIGNED_INT64_TEXT}`, true],
+            [MIN_SIGNED_INT64_TEXT, false],
+            [MAX_SIGNED_INT64_TEXT, false],
+            [TOO_SMALL_SIGNED_INT64_TEXT, true],
+        ] as const) {
+            const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int value = ${literalText};
+state Root { state A; [*] -> A; }
+`), 'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE');
+
+            if (!shouldWarn) {
+                assert.deepEqual(diagnostics, [], literalText);
+                continue;
+            }
+
+            assert.equal(diagnostics.length, 1, literalText);
+            const diagnostic = diagnostics[0];
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.context, 'var_initializer');
+            assert.equal(diagnostic.refs.var_name, 'value');
+            assert.equal(diagnostic.refs.literal_text, literalText);
+            assert.equal(diagnostic.refs.min_value_text, MIN_SIGNED_INT64_TEXT);
+            assert.equal(diagnostic.refs.max_value_text, MAX_SIGNED_INT64_TEXT);
+            assert.equal(diagnostic.refs.target_bits, 64);
+            assert.equal(diagnostic.refs.signed, true);
+        }
+    });
+
+    it('uses RHS-only constant folding for division and modulo by zero', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int result = 0;
+def int input = 1;
+def int denom = 0;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B effect {
+        result = input / (1 - 1);
+        result = input % (2 - 2);
+        result = input / denom;
+    };
+}
+`), 'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO');
+
+        assert.deepEqual(
+            diagnostics.map(item => [item.refs.operator, item.refs.rhs_text]),
+            [['/', '1 - 1'], ['%', '2 - 2']],
+        );
+        for (const diagnostic of diagnostics) {
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.context, 'transition_effect');
+            assert.equal(diagnostic.refs.statement_kind, 'operation_assignment');
+        }
+    });
+
+    it('reports only constant shift counts outside the 64-bit C-family profile', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+def int amount = 64;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B effect {
+        flags = flags << -1;
+        flags = flags >> 64;
+        flags = flags << 0;
+        flags = flags << 63;
+        flags = flags << amount;
+    };
+}
+`), 'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE');
+
+        assert.deepEqual(
+            diagnostics.map(item => [item.refs.operator, item.refs.shift_count_text]),
+            [['<<', '-1'], ['>>', '64']],
+        );
+        for (const diagnostic of diagnostics) {
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.target_bits, 64);
+            assert.equal(diagnostic.refs.context, 'transition_effect');
+            assert.equal(diagnostic.refs.statement_kind, 'operation_assignment');
+        }
+    });
+
+    it('reports float-shaped operands in C-family bitwise and shift expressions', async () => {
+        for (const [expr, expectedTypes, expectedSources] of [
+            ['1.5 & flags', ['float', 'int'], ['literal', 'declared_var']],
+            ['gain | flags', ['float', 'int'], ['declared_var', 'declared_var']],
+            ['(gain + 1.0) ^ flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['(1 / 2) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['sin(1) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['abs(gain) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+            ['((flags > 0) ? 1.0 : 0) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
+        ] as const) {
+            const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+def float gain = 1.5;
+state Root {
+    state A { during { flags = ${expr}; } }
+    [*] -> A;
+}
+`), 'W_NUMERIC_FLOAT_BITWISE');
+
+            assert.equal(diagnostics.length, 1, expr);
+            const diagnostic = diagnostics[0];
+            assertTargetProfileRefs(diagnostic);
+            assert.equal(diagnostic.refs.operator, expr.includes('<<') ? '<<' : expr.match(/[&^|]/)![0]);
+            assert.deepEqual(diagnostic.refs.operand_types, expectedTypes, expr);
+            assert.deepEqual(diagnostic.refs.operand_type_sources, expectedSources, expr);
+        }
+    });
+
+    it('does not report int-shaped local expressions as float bitwise risks', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+state Root {
+    state A {
+        during {
+            flags = (1 + 2) & flags;
+            flags = sign(1.5) & flags;
+            flags = ceil(1.5) & flags;
+        }
+    }
+    [*] -> A;
+}
+`), 'W_NUMERIC_FLOAT_BITWISE');
+
+        assert.deepEqual(diagnostics, []);
+    });
+
+    it('allows float shift expressions to overlap with shift-count warnings', async () => {
+        const diagnostics = await numericDiagnostics(`
+def int flags = 1;
+def float gain = 1.5;
+state Root {
+    state A { during { flags = gain << 64; } }
+    [*] -> A;
+}
+`);
+
+        assert.equal(diagnosticsFor(diagnostics, 'W_NUMERIC_FLOAT_BITWISE').length, 1);
+        assert.equal(diagnosticsFor(diagnostics, 'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE').length, 1);
+    });
+
+    it('scans public expression contexts, if conditions, and nested assignments', async () => {
+        const diagnostics = await numericDiagnostics(`
+def int initialized = 1 / 0;
+def int flags = 1;
+state Root {
+    state A {
+        during {
+            if [flags / 0 > 0] {
+                if [flags > 0] {
+                    flags = flags << 64;
+                }
+            }
+        }
+    }
+    state B;
+    [*] -> A;
+    A -> B : if [flags / 0 > 0];
+    B -> A effect { flags = flags / 0; };
+}
+`);
+
+        const divisionContexts = diagnosticsFor(diagnostics, 'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO')
+            .map(item => [item.refs.context, item.refs.statement_kind ?? null]);
+        assert.deepEqual(divisionContexts, [
+            ['var_initializer', null],
+            ['guard', null],
+            ['transition_effect', 'operation_assignment'],
+            ['lifecycle_action', null],
+        ]);
+
+        const shiftDiagnostics = diagnosticsFor(diagnostics, 'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE');
+        assert.equal(shiftDiagnostics.length, 1);
+        assert.equal(shiftDiagnostics[0].refs.context, 'lifecycle_action');
+        assert.equal(shiftDiagnostics[0].refs.statement_kind, 'operation_assignment');
+    });
+
+    it('does not duplicate diagnostics through abstract or ref lifecycle actions', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int value = 1;
+state Root {
+    state A {
+        enter abstract HardwareInit;
+        enter Inline { value = value / 0; }
+        enter ref Inline;
+    }
+    [*] -> A;
+}
+`), 'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO');
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(diagnostics[0].refs.context, 'lifecycle_action');
+        assert.equal(diagnostics[0].refs.statement_kind, 'operation_assignment');
+    });
+});

--- a/editors/jsfcstm/test/diagnostics-numeric.test.ts
+++ b/editors/jsfcstm/test/diagnostics-numeric.test.ts
@@ -97,6 +97,13 @@ function assertTargetProfileRefs(diagnostic: ModelDiagnosticJson): void {
     assert.equal(String(diagnostic.refs.runtime_note).includes('Python'), true);
 }
 
+function expectedBitwiseOperator(expr: string): string {
+    for (const operator of ['<<', '>>', '&', '^', '|']) {
+        if (expr.includes(operator)) return operator;
+    }
+    throw new Error(`missing bitwise operator in ${expr}`);
+}
+
 describe('diagnostics/numeric', () => {
     it('keeps nullable analyzer entry as a no-op', () => {
         assert.deepEqual(collectNumericWarnings(null), []);
@@ -132,6 +139,16 @@ state Root { state A; [*] -> A; }
             assert.equal(diagnostic.refs.target_bits, 64);
             assert.equal(diagnostic.refs.signed, true);
         }
+    });
+
+    it('deduplicates signed integer child literals under unary operators', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int value = ${TOO_SMALL_SIGNED_INT64_TEXT};
+state Root { state A; [*] -> A; }
+`), 'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE');
+
+        assert.equal(diagnostics.length, 1);
+        assert.equal(diagnostics[0].refs.literal_text, TOO_SMALL_SIGNED_INT64_TEXT);
     });
 
     it('uses RHS-only constant folding for division and modulo by zero', async () => {
@@ -173,6 +190,8 @@ state Root {
     A -> B effect {
         flags = flags << -1;
         flags = flags >> 64;
+        flags = flags << -9223372036854775808;
+        flags = flags >> 9223372036854775808;
         flags = flags << 0;
         flags = flags << 63;
         flags = flags << amount;
@@ -182,7 +201,12 @@ state Root {
 
         assert.deepEqual(
             diagnostics.map(item => [item.refs.operator, item.refs.shift_count_text]),
-            [['<<', '-1'], ['>>', '64']],
+            [
+                ['<<', '-1'],
+                ['>>', '64'],
+                ['<<', '-9223372036854775808'],
+                ['>>', '9223372036854775808'],
+            ],
         );
         for (const diagnostic of diagnostics) {
             assertTargetProfileRefs(diagnostic);
@@ -196,6 +220,7 @@ state Root {
         for (const [expr, expectedTypes, expectedSources] of [
             ['1.5 & flags', ['float', 'int'], ['literal', 'declared_var']],
             ['gain | flags', ['float', 'int'], ['declared_var', 'declared_var']],
+            ['gain >> flags', ['float', 'int'], ['declared_var', 'declared_var']],
             ['(gain + 1.0) ^ flags', ['float', 'int'], ['local_expression', 'declared_var']],
             ['(1 / 2) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
             ['sin(1) & flags', ['float', 'int'], ['local_expression', 'declared_var']],
@@ -214,10 +239,25 @@ state Root {
             assert.equal(diagnostics.length, 1, expr);
             const diagnostic = diagnostics[0];
             assertTargetProfileRefs(diagnostic);
-            assert.equal(diagnostic.refs.operator, expr.includes('<<') ? '<<' : expr.match(/[&^|]/)![0]);
+            assert.equal(diagnostic.refs.operator, expectedBitwiseOperator(expr));
             assert.deepEqual(diagnostic.refs.operand_types, expectedTypes, expr);
             assert.deepEqual(diagnostic.refs.operand_type_sources, expectedSources, expr);
         }
+    });
+
+    it('keeps known int evidence when local expressions contain unknown variables', async () => {
+        const diagnostics = diagnosticsFor(await numericDiagnostics(`
+def int flags = 1;
+def float gain = 1.5;
+state Root {
+    state A { during { tmp = 1; flags = (tmp + 1) & gain; } }
+    [*] -> A;
+}
+`), 'W_NUMERIC_FLOAT_BITWISE');
+
+        assert.equal(diagnostics.length, 1);
+        assert.deepEqual(diagnostics[0].refs.operand_types, ['int', 'float']);
+        assert.deepEqual(diagnostics[0].refs.operand_type_sources, ['local_expression', 'declared_var']);
     });
 
     it('does not report int-shaped local expressions as float bitwise risks', async () => {


### PR DESCRIPTION
## 目标

本 PR 是 [伞 PR #272](https://github.com/HansBug/pyfcstm/pull/272) 的 PR-N3 子 PR，负责在 **jsfcstm** 侧落地 [issue #253](https://github.com/HansBug/pyfcstm/issues/253) 与 PR-N1 / PR-N2 已冻结并实现的 4 类 **C/C++ 默认部署剖面（C/C++ deployment profile）** 数值 inspect 诊断。

本 PR 的核心目标是让 jsfcstm 的 `inspectModel()` 默认诊断输出在 **语义等价的一批 jsfcstm 测试树内 DSL 场景** 下与 Python `inspect_model()` 具备同等语义：同一 code、同一目标剖面 refs、同一 C/C++ 风险限定文案，以及同一组轻量常量折叠 / 表达式类型推断边界。这里的“语义等价”不表示复用 Python fixture；jsfcstm 的 DSL 与 expected refs 必须独立放在 `editors/jsfcstm/test/` 内。

## 上游基线

| 来源 | 本 PR 必须继承的内容 |
|---|---|
| [issue #253](https://github.com/HansBug/pyfcstm/issues/253) | inspect 只做轻量、目标相关数值诊断；不做 BitVec / BMC / fixed-point / codegen 策略。 |
| [PR #273](https://github.com/HansBug/pyfcstm/pull/273) / PR-N1 | 4 个 numeric code、`codes.json` / `schema.json` 资源契约、`target_family` / `target_templates` / `runtime_note` / `context` / `statement_kind` / `operand_types` / `operand_type_sources` 等 refs 契约。 |
| [PR #274](https://github.com/HansBug/pyfcstm/pull/274) / PR-N2 | Python numeric analyzer 的实际触发语义、C-family 类型推断边界、RHS-only 常量判零、scan context、测试样例方向。 |

## 现有契约状态

- 4 个 numeric code 的 `emit_tier` 已由 PR-N1 / PR-N2 迁移并锁定为 `partial_static_pipeline`；本 PR 不再调整 emit tier。
- `pyfcstm/diagnostics/codes.yaml` 与 `pyfcstm/diagnostics/schema.json` 是 canonical source。
- `editors/jsfcstm/src/diagnostics/codes.json` 与 `editors/jsfcstm/src/diagnostics/schema.json` 是 `scripts/sync-runtime-assets.js --phase=src` 生成的 gitignored 资源，不是手改或提交对象。

## 必做诊断

| 诊断码 | jsfcstm 触发语义 |
|---|---|
| `W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE` | 会进入 C/C++ 表达式渲染的整数字面量超出 `PYFCSTM_GENERATED_INT64` 范围；一元 `+` / `-` 与 literal 按组合后的 signed 值判断，`+9223372036854775808` warning，`-9223372036854775808` no warning，`-9223372036854775809` warning。 |
| `W_NUMERIC_CONSTANT_DIVISION_BY_ZERO` | `/` 或 `%` 的 RHS 经同表达式 literal-only 轻量常量折叠可判为 0；LHS 可以是动态表达式；`operator` 必须区分 `/` 与 `%`；不可把“整条表达式 literal-only”作为触发条件。 |
| `W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE` | `<<` / `>>` 的 RHS 经轻量常量折叠为常量且 `< 0` 或 `>= 64`；动态或不可折叠 RHS 不报本 PR 的 numeric warning。 |
| `W_NUMERIC_FLOAT_BITWISE` | inspect 可确定的 float literal、声明为 `float` 的变量、同一表达式内可轻量判定为 float 的子表达式参与 `&` / `^` / `|` / `<<` / `>>`；`operand_types` 与 `operand_type_sources` 都必须出现且顺序对应操作数顺序。 |

## 实施方案

| 区域 | 计划 |
|---|---|
| analyzer 新增 | 新增 `editors/jsfcstm/src/diagnostics/analyzers/numeric.ts`，导出 `collectNumericWarnings(machine: StateMachine | null | undefined): ModelDiagnosticJson[]`。nullable / undefined no-op 入口与现有 `collectConstFoldWarnings(machine: StateMachine | null | undefined)` 对齐；调用侧仍应只在有 `machine` 时接入。保持职责独立，不把 4 类规则塞进 `const-fold.ts`。 |
| analyzer export | 更新 `editors/jsfcstm/src/diagnostics/analyzers/index.ts`，导出 `collectNumericWarnings`，便于 `design-health.ts` 统一接入，并为 PR-N4 的 import-level / contract 回归测试保留稳定入口。 |
| inspect pipeline 接入 | 在 `editors/jsfcstm/src/diagnostics/analyzers/design-health.ts` 的 `collectDesignHealthWarnings(..., machine?: StateMachine)` 中追加 `...(machine ? collectNumericWarnings(machine) : [])` 或等价 no-op 调用；保持 `refsWithSuggestedFix()` 的统一后处理路径，不绕过 existing diagnostics map。 |
| 常量折叠 | 复用 `editors/jsfcstm/src/diagnostics/analyzers/const-fold.ts` 的 `foldNumericExpression()`。除零/取模零和 shift count 必须遍历 `BinaryOp` 节点时直接提取 `binop.y` 单独调用 `foldNumericExpression(binop.y)`；不允许通过折叠整条 `binop` 推导 RHS。若需要新增辅助函数，只能服务这 4 类 numeric 规则的 RHS-only 判定。 |
| const-fold 最小修正 | 若发现现有 jsfcstm folding 与 Python N2 行为不一致，只修与 4 类 numeric 规则触发判定直接相关的折叠分支，并在 jsfcstm 自有测试中锁定；不修 const-fold 的其它现有行为，不触碰 `codes.yaml` / `schema.json` 中已冻结的折叠算子集合。 |
| 表达式扫描 | 遍历 jsfcstm runtime model：`machine.defines` 的 initializer、`state.transitions` 的 guard/effects、`state.onEnters` / `onDurings` / `onExits` / `onDuringAspects` 的 concrete lifecycle action operations；跳过 `isAbstract` 与 `isRef` action，避免 ref 重复计数。 |
| 语句扫描 | operation assignment RHS 使用 `context='transition_effect'` 或 `context='lifecycle_action'` 表达所在 block，使用 `statement_kind='operation_assignment'` 表达赋值 RHS 形状；`IfBlock` 分支 condition 与 nested assignment 都要扫描。IfBlock condition 的 `context` 沿用所在 block：transition effect 内为 `transition_effect`，lifecycle action 内为 `lifecycle_action`，不引入 `if_condition` 等新枚举值。 |
| 类型推断 | 与 Python N2 / C-family renderer 对齐：`Integer` / `BooleanExpr` → `int`；`Float` → `float`；声明为 `float` / `int` 的 `Variable` → `declared_var`；`UnaryOp` 继承子表达式；`UFunc floor/ceil/round/trunc/int/sign` → `int`，`abs` 继承子表达式，其它 math functions → `float`；`BinaryOp('/')` → `float`；bitwise 与 condition operator → `int`；其它二元 / `ConditionalOp` 用 float 优先合并。`operand_type_sources` 取值严格使用 `literal`、`declared_var`、`local_expression`，顺序与 `operand_types` 一一对应，不引入其它 source 取值。 |
| refs/message | 每条诊断都必须通过 PR-N1 的资源契约生成稳定 refs：`target_family='c_family'`、`target_templates=['c','c_poll','cpp','cpp_poll']`、`runtime_note`、`context`、`expr_text` 以及规则 required refs。message 必须明确 C/C++ 默认部署剖面风险，不能写成 Python 或目标无关错误。 |
| 测试 | 新增或扩展 `editors/jsfcstm/test/diagnostics-numeric.test.ts`（推荐新文件），全部 DSL 与 expected refs 放在 jsfcstm 测试树内；不得调用 Python，不得读取 `test/` 树。每条 emitted numeric diagnostic 都要按 bundled registry / `codes.json` 校验 required refs，并确认 `refsWithSuggestedFix()` 后处理路径未被绕过。 |
| 资源同步 | N3 不重新定义诊断码，不手改、不提交 `editors/jsfcstm/src/diagnostics/codes.json` / `schema.json` 或 `editors/jsfcstm/dist/diagnostics/*.json`。若本地构建发现 drift，只运行 `cd editors/jsfcstm && node ./scripts/sync-runtime-assets.js --phase=src` 或 `npm run build` 生成本地测试资源。若确实需要修改 canonical `pyfcstm/diagnostics/codes.yaml` / `schema.json`，必须明确扩大 PR 范围并说明为什么不违反 PR-N1/N2 冻结语义；否则转独立契约修正。 |

## 必测样例矩阵

至少覆盖以下场景；若具体 DSL 语法限制导致某个组合不可表达，必须在测试注释中说明原因。

| 规则 | 必测样例 |
|---|---|
| literal range | `9223372036854775808`、`+9223372036854775808`、`-9223372036854775808`、`-9223372036854775809`。 |
| zero RHS | `input / (1 - 1)`、`input % (2 - 2)`、动态 RHS 不触发。 |
| shift count | `flags << -1`、`flags >> 64`、`flags << 0` 不触发、`flags << 63` 不触发、动态 RHS 不触发。 |
| float bitwise | `1.5 & flags`、`gain | flags`、`(gain + 1.0) ^ flags`、`(1 / 2) & flags`、`sin(1) & flags`、`abs(gain) & flags`、`((flags > 0) ? 1.0 : 0) & flags`。 |
| negative case | `(1 + 2) & flags` 不触发 `W_NUMERIC_FLOAT_BITWISE`；`sign(1.5) & flags` 不触发，因为 `sign` 按 C-family 类型推断返回 `int`；`ceil(1.5) & flags` 不触发，因为 `ceil` 按 C-family 类型推断返回 `int`。 |
| overlap | `gain << 64` 同时发出 `W_NUMERIC_FLOAT_BITWISE` 与 `W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE`。 |
| scan contexts | `var_initializer`、`guard`、`transition_effect`、`lifecycle_action`、operation assignment RHS、IfBlock branch condition、nested assignment。 |
| action ref 去重 | `enter abstract X; enter Inline {...}; enter ref Inline;` 只扫描 concrete inline action 一次，不因 ref 重复。 |

## 非目标

| 非目标 | 原因 |
|---|---|
| 不修改 Python analyzer | Python 侧已由 PR-N2 完成；本 PR 只在必要时对照其语义。 |
| 不调用 Python 或读取 Python `test/` fixture | 遵守仓库 Python/jsfcstm 测试树独立性约束。 |
| 不实现 BitVec / BMC / 动态 shift proof / overflow proof | 属于 [issue #254](https://github.com/HansBug/pyfcstm/issues/254)。 |
| 不实现 codegen numeric policy / checked arithmetic / target profile 配置系统 | 属于 [issue #255](https://github.com/HansBug/pyfcstm/issues/255)。 |
| 不新增 deferred verify-guidance numeric code | 本线只落地 PR-N1 已冻结的 4 个 code。 |
| 不把 C/C++ warning 表述为 Python 风险 | Python 目标不是本阶段风险目标。 |
| 不引入跨语句 temporary 类型流或变量范围推断 | 第一阶段只做同一表达式内的轻量判定。 |
| 不提交 jsfcstm generated diagnostics JSON | `src/diagnostics/*.json` / `dist/diagnostics/*.json` 是 generated + gitignored，本 PR 不 force-add。 |

## 验收标准

- [ ] jsfcstm `inspectModel()` 默认诊断输出能触发 4 个 numeric code；`emit_tier=partial_static_pipeline` 已由 PR-N1 / PR-N2 确立，本 PR 不再调整 emit tier，只补 analyzer 行为与 refs。
- [ ] 4 个 code 的 `refs` 必含字段与 bundled registry / `codes.json` 契约一致；`target_templates` 顺序稳定为 `['c','c_poll','cpp','cpp_poll']` 且不包含 Python。
- [ ] 每条 message 与 `runtime_note` 都明确 C/C++ 默认部署剖面限定，不把风险写成目标无关错误。
- [ ] RHS-zero 按 RHS 可折叠为 0 触发，LHS 动态不影响；`operator` 正确区分 `/` 与 `%`；实现必须对 `BinaryOp.y` 单独调用 `foldNumericExpression()`。
- [ ] shift count 只对可折叠常量 RHS 越界发 warning，动态 RHS 不发本 PR warning；实现必须对 `BinaryOp.y` 单独调用 `foldNumericExpression()`。
- [ ] float bitwise 的 `operand_types` / `operand_type_sources` 都存在、顺序一致、取值合法；覆盖 C-family local float expression，例如 `(1 / 2) & flags` 与 `sin(1) & flags`。
- [ ] 扫描面覆盖变量 initializer、guard、transition effect、lifecycle action、operation assignment RHS、IfBlock branch condition、nested assignment；IfBlock condition context 沿用所在 block；abstract/ref lifecycle action 不重复扫描。
- [ ] 每条 emitted numeric diagnostic 都按 bundled registry required refs 做测试校验，且测试确认 `refsWithSuggestedFix()` 统一后处理路径未被绕过。
- [ ] jsfcstm 测试数据全部位于 `editors/jsfcstm/test/`，不调用 Python、不读取仓库 `test/` 树。
- [ ] 完整 jsfcstm 验收必须运行 `cd editors/jsfcstm && npm test`；如果开发迭代只运行局部 mocha / ts-node transpile-only 测试，则同轮还必须运行 `cd editors/jsfcstm && npm run build` 或等价 TypeScript 编译检查。
- [ ] Python 侧回归使用 slow skip：`SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=./diagnostics` 或说明为何本 PR 未触及 Python runtime 行为且局部诊断测试已足够。
- [ ] 提交前检查 commit message 包含 `[skip-slow]`；若 public Python API / pydoc 未变更，`make rst_auto` 不应产生额外 Python API 文档 diff。
- [ ] CI 全绿；如果 Codecov 评论指出 jsfcstm 不相关 coverage，无需为 Python patch coverage 返工，但新增 TypeScript analyzer 分支必须有 jsfcstm 单测覆盖。

## Review 重点

1. 是否严格复用 PR-N1 / PR-N2 语义，而不是在 jsfcstm 侧重新发明一套 numeric contract。
2. 是否漏掉 C/C++ target-profile refs，或只在 message / refs 单侧写目标限定。
3. 是否把动态 shift / overflow proof / verify guidance 偷带进本 PR。
4. 是否错误共享 Python/jsfcstm 测试 fixture 或调用另一端 runtime。
5. 是否漏扫 lifecycle / transition effect / IfBlock / nested assignment / assignment RHS。
6. 是否对 float bitwise 类型推断过宽导致 int-only 表达式误报，或过窄导致 C-family local float expression 漏报。
7. 是否仍保持 `partial_static_pipeline` 的 N2/N3 临时语义，不提前把 N4 的跨端最终收口混入本 PR。
8. 是否误提交 jsfcstm generated diagnostics JSON，破坏 canonical source / generated resource 边界。
