### PR TITLE
收口：统一 inspect 数值诊断跨端契约

### DIFF
--- a/editors/jsfcstm/test/diagnostics-numeric.test.ts
+++ b/editors/jsfcstm/test/diagnostics-numeric.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../src/diagnostics';
 import {buildStateMachineModel} from '../src/model';
 import {parseAstDocument} from '../src/ast';
-import {createDocument, packageModule} from './support';
+import {createDocument, packageModule, sliceByRange} from './support';
 
 const MIN_SIGNED_INT64_TEXT = '-9223372036854775808';
 const MAX_SIGNED_INT64_TEXT = '9223372036854775807';
@@ -139,6 +139,26 @@ state Root { state A; [*] -> A; }
             assert.equal(diagnostic.refs.target_bits, 64);
             assert.equal(diagnostic.refs.signed, true);
         }
+    });
+
+    it('surfaces numeric warnings through collectDocumentDiagnostics with refs and non-fallback source range', async () => {
+        const source = `
+def int value = ${TOO_LARGE_SIGNED_INT64_TEXT};
+state Root { state A; [*] -> A; }
+`;
+        const document = createDocument(source, '/tmp/diagnostics-numeric-editor-surface.fcstm');
+        const diagnostics = await packageModule.collectDocumentDiagnostics(document);
+        const diagnostic = diagnostics.find(item => item.code === 'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE');
+
+        assert.ok(diagnostic, 'expected collectDocumentDiagnostics to surface numeric warning');
+        assert.equal(diagnostic.message.includes('C/C++'), true);
+        assert.equal(diagnostic.message.includes('Python'), true);
+        assert.equal(diagnostic.data?.target_family, 'c_family');
+        assert.deepEqual(diagnostic.data?.target_templates, C_FAMILY_TARGET_TEMPLATES);
+        assert.equal(String(diagnostic.data?.runtime_note).includes('C/C++'), true);
+        assert.equal(String(diagnostic.data?.runtime_note).includes('Python'), true);
+        assert.equal(diagnostic.data?.__rangeFallback, undefined);
+        assert.equal(sliceByRange(source, diagnostic.range).includes(TOO_LARGE_SIGNED_INT64_TEXT), true);
     });
 
     it('deduplicates signed integer child literals under unary operators', async () => {

--- a/editors/jsfcstm/test/diagnostics-resources.test.ts
+++ b/editors/jsfcstm/test/diagnostics-resources.test.ts
@@ -90,7 +90,7 @@ describe('diagnostics resources (PR-A)', () => {
             }
         });
 
-        it('contains C/C++ numeric partial-static diagnostics', () => {
+        it('contains C/C++ numeric static-pipeline diagnostics', () => {
             const registry = loadCodesRegistry();
             for (const code of numericCodes) {
                 const spec = registry[code];
@@ -98,8 +98,8 @@ describe('diagnostics resources (PR-A)', () => {
                 assert.equal(spec.severity, 'warning', `${code} must stay warning-level`);
                 assert.equal(
                     spec.emit_tier,
-                    'partial_static_pipeline',
-                    `${code} is emitted by the Python inspect analyzer before jsfcstm parity lands`
+                    'static_pipeline',
+                    `${code} must stay in the complete static inspect pipeline`
                 );
                 assert.equal(spec.span_object, 'expression', `${code} must identify an expression`);
                 assert.ok(spec.example_dsl, `${code} must keep a parseable example DSL contract`);

--- a/pyfcstm/diagnostics/README.md
+++ b/pyfcstm/diagnostics/README.md
@@ -125,9 +125,10 @@ negative shifts, oversized shifts, variables, function calls, cross-statement
 constant propagation, block-local temporary inference, or algebraic rewrites such
 as `a - a` and `0 * x`.
 
-The first Python numeric analyzer emits these warnings from `inspect_model()`
-under `emit_tier: partial_static_pipeline`. In this tier, the Python static
-inspect pipeline has landed while jsfcstm parity is still a follow-up task. Tests
-for these entries must therefore validate both the shared catalog contract and
-Python runtime emission, while jsfcstm-side behavior stays out of scope until its
-matching analyzer lands.
+The numeric analyzer now emits these warnings under
+`emit_tier: static_pipeline` on both pyfcstm and jsfcstm. Tests for these entries
+must validate the shared catalog contract, Python `inspect_model()` /
+`build_inspect_json()` output, jsfcstm `inspectModel()` output, and the
+`collectDocumentDiagnostics()` editor surface. Numeric warnings are still
+C/C++ deployment-profile diagnostics: Python generated runtimes are documented as
+a different target semantics rather than part of the C/C++ target set.

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -2078,7 +2078,7 @@ W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     An integer literal that would be rendered into a C/C++ family template
     falls outside the default ``PYFCSTM_GENERATED_INT64`` signed range. This
@@ -2165,7 +2165,7 @@ W_NUMERIC_CONSTANT_DIVISION_BY_ZERO:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     A ``/`` or ``%`` operation has a right-hand side that the lightweight
     literal-only constant folder can classify as zero. This is reported as a
@@ -2244,7 +2244,7 @@ W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE:
   severity: warning
   span_object: expression
   capability: const_fold
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     A shift count folds to a constant below zero or not less than the default
     C/C++ target integer width. This is a C/C++ 64-bit deployment-profile
@@ -2325,7 +2325,7 @@ W_NUMERIC_FLOAT_BITWISE:
   severity: warning
   span_object: expression
   capability: pure_static
-  emit_tier: partial_static_pipeline
+  emit_tier: static_pipeline
   description: >-
     A value known to be ``float`` participates in a bitwise or shift operator
     that belongs to the C/C++ integer operation profile. The warning is

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -2465,7 +2465,7 @@ def _catalog_emittable_diagnostics(
         >>> diagnostic = ModelDiagnostic(
         ...     code='W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
         ...     severity='warning',
-        ...     message='partial-static test',
+        ...     message='static-pipeline test',
         ... )
         >>> _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
         True

--- a/test/diagnostics/test_cross_end_parity.py
+++ b/test/diagnostics/test_cross_end_parity.py
@@ -1686,20 +1686,15 @@ def test_lookup_api_codes_never_fire_in_static_pipeline():
 
 
 @pytest.mark.unittest
-def test_js_only_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
-    """Partial-static codes may be implemented on only one diagnostic end.
+def test_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
+    """Partial-static codes are intentionally absent from pyfcstm output.
 
-    ``E_TYPE_MISMATCH`` is currently jsfcstm-only; numeric C/C++ profile
-    warnings are Python-only until the matching jsfcstm analyzer lands. This
-    test pins only the jsfcstm-only half so Python-emitted partial-static
-    diagnostics remain allowed.
+    Numeric C/C++ profile warnings have been promoted to
+    ``emit_tier: static_pipeline`` after both Python and jsfcstm analyzers
+    landed. Any remaining ``partial_static_pipeline`` code is therefore a
+    one-ended diagnostic such as jsfcstm-only type-shape analysis and must not
+    leak from pyfcstm's static inspect surface.
     """
-    pyfcstm_partial_codes = {
-        'W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE',
-        'W_NUMERIC_CONSTANT_DIVISION_BY_ZERO',
-        'W_NUMERIC_SHIFT_COUNT_OUT_OF_TARGET_RANGE',
-        'W_NUMERIC_FLOAT_BITWISE',
-    }
     from pyfcstm.diagnostics import CODE_REGISTRY
 
     partial_codes = {
@@ -1707,14 +1702,13 @@ def test_js_only_partial_static_pipeline_codes_dont_fire_on_pyfcstm():
         for code, spec in CODE_REGISTRY.items()
         if spec.emit_tier == 'partial_static_pipeline'
     }
-    js_only_partial_codes = partial_codes - pyfcstm_partial_codes
-    if not js_only_partial_codes:
-        pytest.skip('no js-only partial_static_pipeline codes declared')
+    if not partial_codes:
+        pytest.skip('no partial_static_pipeline codes declared')
 
     for name, dsl, _ in SINGLE_FILE_FIXTURES:
         codes, _, _ = _collect_codes_from_dsl(dsl)
-        leaked = [c for c in codes if c in js_only_partial_codes]
+        leaked = [c for c in codes if c in partial_codes]
         assert not leaked, (
-            f'fixture {name}: pyfcstm emitted js-only partial_static_pipeline '
+            f'fixture {name}: pyfcstm emitted partial_static_pipeline '
             f'code(s) {leaked}.'
         )

--- a/test/diagnostics/test_numeric_contract.py
+++ b/test/diagnostics/test_numeric_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from textwrap import dedent
 
 import pytest
@@ -105,10 +106,10 @@ def test_numeric_contract_declares_exact_code_set():
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
-def test_numeric_codes_are_partial_static_warning_contracts(code):
+def test_numeric_codes_are_static_pipeline_warning_contracts(code):
     spec = CODE_REGISTRY[code]
     assert spec.severity == "warning"
-    assert spec.emit_tier == "partial_static_pipeline"
+    assert spec.emit_tier == "static_pipeline"
     assert spec.span_object == "expression"
     assert spec.for_llm is not None
     assert spec.example_dsl
@@ -128,16 +129,55 @@ def test_numeric_example_dsls_emit_after_python_analyzer_lands(code):
         assert "Python" in diag.message
 
 
-def test_catalog_filter_allows_partial_static_numeric_diagnostics():
+def test_catalog_filter_allows_static_pipeline_numeric_diagnostics():
     diagnostic = ModelDiagnostic(
         code="W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE",
         severity="warning",
-        message="synthetic partial-static diagnostic",
+        message="synthetic static-pipeline diagnostic",
         span=None,
         refs=SYNTHETIC_REFS["W_NUMERIC_LITERAL_OUT_OF_TARGET_RANGE"],
     )
 
     assert _catalog_emittable_diagnostics((diagnostic,)) == (diagnostic,)
+
+
+def test_numeric_diagnostics_surface_in_build_inspect_json(tmp_path):
+    source = dedent(f"""
+        def int too_large = {TOO_LARGE_SIGNED_INT64_TEXT};
+        def int result = 0;
+        def int input = 1;
+        def int flags = 1;
+        def float gain = 1.5;
+        state Root {{
+            state A {{ during {{ flags = gain & flags; }} }}
+            state B;
+            [*] -> A;
+            A -> B : if [(flags << 64) != 0];
+            B -> A effect {{ result = input / (1 - 1); }};
+        }}
+    """)
+    path = tmp_path / "numeric_cli.fcstm"
+    path.write_text(source, encoding="utf-8")
+
+    from pyfcstm.entry.inspect import build_inspect_json
+
+    payload = json.loads(build_inspect_json(str(path)))
+    diagnostics_by_code = {
+        diagnostic["code"]: diagnostic
+        for diagnostic in payload["diagnostics"]
+        if diagnostic["code"] in NUMERIC_CODES
+    }
+
+    assert set(diagnostics_by_code) == NUMERIC_CODES
+    for code in NUMERIC_CODES:
+        diagnostic = diagnostics_by_code[code]
+        refs = diagnostic["refs"]
+        assert "C/C++" in diagnostic["message"]
+        assert "Python" in diagnostic["message"]
+        assert refs["target_family"] == "c_family"
+        assert refs["target_templates"] == C_FAMILY_TARGET_TEMPLATES
+        assert "C/C++" in refs["runtime_note"]
+        assert "Python" in refs["runtime_note"]
 
 
 @pytest.mark.parametrize("code", sorted(NUMERIC_CODES))
@@ -455,7 +495,12 @@ def test_numeric_division_dynamic_rhs_is_not_reported():
     assert diagnostics == []
 
 
-@pytest.mark.parametrize("shift_expr", ["flags << -1", "flags >> 64"])
+@pytest.mark.parametrize("shift_expr", [
+    "flags << -1",
+    "flags >> 64",
+    "flags << -9223372036854775808",
+    "flags >> 9223372036854775808",
+])
 def test_numeric_shift_constant_out_of_target_range_reports(shift_expr):
     diagnostic = _single_diagnostic(
         f"""


### PR DESCRIPTION
## 目标

本 PR 是 [伞 PR #272](https://github.com/HansBug/pyfcstm/pull/272) 的 PR-N4 子 PR，负责在 PR-N1 / PR-N2 / PR-N3 已完成后，对 [issue #253](https://github.com/HansBug/pyfcstm/issues/253) 的 **C/C++ 默认部署剖面（C/C++ deployment profile）数值 inspect 诊断** 做最后收口。

N4 不重新设计 numeric analyzer，也不扩展 BitVec / BMC / codegen policy。它只把已经落地的 4 个 numeric warning 在 **Python inspect / Python CLI inspect / jsfcstm inspect / jsfcstm editor diagnostic surface / 文档说明** 之间的公共契约锁紧，确保后续维护不会把 C/C++ 目标限定、`emit_tier`、refs 字段、用户可见 JSON / editor diagnostic 输出或 Python/jsfcstm 测试独立性打散。

## 上游基线

| 来源 | 本 PR 必须继承的内容 |
|---|---|
| [issue #253](https://github.com/HansBug/pyfcstm/issues/253) | inspect 只做轻量、目标相关数值诊断；动态证明 / BitVec / BMC / codegen 策略转入 #254 / #255。 |
| [PR #273](https://github.com/HansBug/pyfcstm/pull/273) / PR-N1 | 4 个 numeric code、`target_family` / `target_templates` / `runtime_note` / `context` / `statement_kind` / rule-specific refs 契约。 |
| [PR #274](https://github.com/HansBug/pyfcstm/pull/274) / PR-N2 | Python `inspect_model()` numeric analyzer 已接入默认 pipeline；N2 为了分阶段落地临时保留 `emit_tier: partial_static_pipeline`。 |
| [PR #275](https://github.com/HansBug/pyfcstm/pull/275) / PR-N3 | jsfcstm `inspectModel()` numeric analyzer 已接入默认 pipeline，并与 Python N2 语义对齐；N3 不负责最终调整 `emit_tier`。 |
| [伞 PR #272](https://github.com/HansBug/pyfcstm/pull/272) | N4 的职责是“跨端契约回归与文档收口”，不是新增第五类数值诊断。 |

## 实施计划

| 区域 | 具体动作 | 验收点 |
|---|---|---|
| `emit_tier` 最终收口 | 将 `pyfcstm/diagnostics/codes.yaml` 中 4 个 `W_NUMERIC_*` code 从临时 `partial_static_pipeline` 迁移到最终 `static_pipeline`；同步更新 Python / jsfcstm bundled registry 与资源测试。 | 4 个 numeric code 的 canonical registry、Python 测试、jsfcstm `codes.json` 资源测试均断言 `emit_tier === 'static_pipeline'`；不再把本线 numeric warning 视作 js-only / partial-only code。 |
| Python CLI inspect 回归 | 在 `test/diagnostics/` 增加或扩展测试，使用内联 DSL 和 `pyfcstm.entry.inspect.build_inspect_json()` 验证 numeric diagnostics 会出现在 CLI JSON payload 中。 | JSON payload 中 4 个 numeric code 至少各有代表样例；`message`、`refs.runtime_note` 都包含 `C/C++` 与 `Python`；`target_templates` 精确为 `['c','c_poll','cpp','cpp_poll']`，顺序稳定且不包含 Python；测试不调用 Node / jsfcstm。 |
| Python contract 回归 | 补强 Python 侧 numeric contract / inspect tests，使 canonical `codes.yaml` / schema 与 emitted diagnostics 的 required refs、`suggested_fix` normalization、`context` / `statement_kind` / rule-specific refs 全部被锁住。 | 每条 emitted numeric diagnostic 都通过 schema 检查；`refs_with_suggested_fix()` 未被绕过；int64 signed 边界、RHS-only div/mod zero、constant shift、float bitwise 均至少有用户可见输出级断言。 |
| jsfcstm inspect 回归 | 在 `editors/jsfcstm/test/` 内扩展 numeric / resources 测试，验证 jsfcstm `inspectModel()` 的 numeric diagnostics 与 bundled `codes.json` required refs 契约一致。 | jsfcstm 测试数据全部内联或位于 `editors/jsfcstm/test/`；不调用 Python、不读取 repo-level `test/`；4 个 numeric code 的 target refs、runtime note、message、rule-specific refs 被测试锁定。 |
| jsfcstm editor surface 回归 | 增加至少一个真实 `collectDocumentDiagnostics(document)` 端到端测试，验证 numeric inspect diagnostics 会进入 editor diagnostic surface；`collectInspectDiagnosticsFromItems()` 只能作为精确 range / fallback 的补充单测。 | editor diagnostic 的 `code`、`message`、`data` 保留 numeric refs；至少一个真实 document 入口能看到 numeric warning；`data.__rangeFallback` 只在无法定位时出现；至少验证一个可定位表达式范围（例如 literal / RHS / bitwise expr）不会退化成 full-document fallback。 |
| 文档收口 | 更新 `pyfcstm/diagnostics/README.md` 以及必要的 jsfcstm / diagnostics 文档说明，明确 numeric warnings 是 C/C++ 默认部署剖面风险，不是 Python 目标通用错误，并说明 #254 / #255 的边界。 | 文档用中文/英文现有风格保持一致；不把 Python 写成风险目标；列出 4 类 code、公共 refs、`emit_tier: static_pipeline`、测试独立性和后续 issue 边界；移除旧的“jsfcstm 仍在后续/不在范围内”阶段性表述。 |
| API 文档同步 | 若修改 Python public pydoc / docstring / `__init__.py` module map，运行 `make rst_auto` 并提交预期 RST diff。 | 没有 public Python pydoc 改动则 `make rst_auto` 不应产生意外 diff；若有改动，docstring 符合 reST + params + Examples:: 规则。 |

## 非目标

| 非目标 | 原因 |
|---|---|
| 不新增 numeric diagnostic code | N1 已冻结本线 4 个 code；新增 code 需要新设计。 |
| 不修改 Python / jsfcstm numeric analyzer 的核心触发语义 | N2 / N3 已完成 analyzer 行为；N4 只做契约收口。若发现真实 C/I bug，可最小修复并补回归。 |
| 不实现 BitVec、BMC、range proof、fixed-width signed/unsigned 形式化验证 | 属于 [issue #254](https://github.com/HansBug/pyfcstm/issues/254)。 |
| 不实现 codegen numeric policy、checked arithmetic、target profile 配置 | 属于 [issue #255](https://github.com/HansBug/pyfcstm/issues/255)。 |
| 不共享 Python 与 jsfcstm 测试 fixture | 仓库规则要求两侧测试树独立。Python 测试只使用 `test/`，jsfcstm 测试只使用 `editors/jsfcstm/test/`。 |
| 不跑 slow native-template 单测作为本地默认验收 | 本 PR 不触碰 C/C++ runtime templates；本地 Python 回归使用 `SKIP_SLOW_TESTS=1`，CI 仍按仓库规则运行。 |

## 必测矩阵

| 层级 | 必测内容 |
|---|---|
| canonical registry | `pyfcstm/diagnostics/codes.yaml` 与 jsfcstm bundled `codes.json` 中 4 个 numeric code 均为 `emit_tier: static_pipeline`。 |
| Python inspect API | `inspect_model()` 对 4 个 numeric code 的 emitted diagnostics schema / refs / C++ target wording。 |
| Python CLI | `build_inspect_json()` 输出 JSON 中 numeric diagnostics 的 code/message/refs。 |
| jsfcstm inspect API | `inspectModel()` 对 4 个 numeric code 的 required refs、target refs、runtime note、suggested-fix normalization。 |
| jsfcstm editor | `collectDocumentDiagnostics(document)` 能携带 numeric diagnostic `data`，并能解析到表达式相关范围；mapper 层测试只用于更细的 range/fallback 断言。 |
| docs | `pyfcstm/diagnostics/README.md` 明确 4 类 code、`static_pipeline`、C/C++ target profile、Python 非风险目标、#254/#255 边界。 |
| independence | Python 测试不调用 Node / jsfcstm；jsfcstm 测试不调用 Python / repo-level `test/`。 |

## 验收标准

- [ ] N4 只在契约、入口回归、editor surface 回归和文档范围内收口；没有偷带 #254 / #255。
- [ ] 4 个 numeric code 的 `emit_tier` 已从 N2/N3 临时 `partial_static_pipeline` 收口为最终 `static_pipeline`，并由 Python/jsfcstm registry 测试锁定。
- [ ] Python CLI JSON payload 覆盖 4 个 numeric code 的代表样例，并锁定 target refs 与 C/C++ vs Python 文案。
- [ ] jsfcstm editor diagnostic surface 通过真实 `collectDocumentDiagnostics(document)` 暴露 numeric warnings，且 diagnostic `data` 保留 refs 字段。
- [ ] Python 与 jsfcstm numeric contract 测试各自在自己的测试树内独立完成，不跨 runtime 调用、不共享 fixture。
- [ ] `target_templates` 稳定为 `['c','c_poll','cpp','cpp_poll']`，且不包含 Python。
- [ ] 每条 numeric warning 的 `message` 与 `runtime_note` 均明确 C/C++ 默认部署剖面限定，并说明 Python 目标语义不同。
- [ ] 每条 emitted numeric diagnostic 都通过 schema / required refs 校验，并确认 `refs_with_suggested_fix()` / `refsWithSuggestedFix()` 后处理未被绕过。
- [ ] 文档说明当前 inspect 能力边界：轻量静态诊断已落地；动态证明与 codegen 策略分别转入 #254 / #255。
- [ ] 本地 Python 回归使用 `SKIP_SLOW_TESTS=1`；提交信息包含 `[skip-slow]`；本 PR 不要求本地跑 native-template slow tests。
- [ ] 运行 `cd editors/jsfcstm && npm test` 或至少 `npm run build` + 相关 mocha 测试；运行 `SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=./diagnostics` 或等价 diagnostics 局部 Python 测试。
- [ ] CI 全绿；如果 Codecov 评论出现与本 PR 相关的覆盖缺口，需要处理或说明。

## Review 重点

1. 是否把 C/C++ 风险误写成 Python 或目标无关风险；
2. 是否只测试 analyzer 内部而漏掉 CLI/editor 用户可见入口；
3. 是否漏掉 `emit_tier: static_pipeline`、`refs` required fields、`target_templates` 精确顺序或 suggested-fix normalization；
4. 是否违反 Python/jsfcstm 测试独立性；
5. 是否新增了 analyzer 行为但没有明确必要性和回归；
6. 是否遗漏文档中 #254 / #255 的边界说明；
7. 是否忘记本地 slow-skip 纪律。
