### PR TITLE
调研：落库数值渲染语义 R0 映射框架

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1251,3 +1251,6 @@ junit.xml
 
 # Local demo fixtures (mirrored in jsfcstm test fixtures, see editors/jsfcstm/test/diagnostics-showcase-demos.test.ts)
 /demo/
+
+# Research numeric render semantics — local heavy probe outputs
+/research/numeric-render-semantics/results/local/

--- a/research/numeric-render-semantics/README.md
+++ b/research/numeric-render-semantics/README.md
@@ -1,0 +1,37 @@
+# FCSTM 数值表达式渲染语义调研
+
+本目录保存 [issue #280](https://github.com/HansBug/pyfcstm/issues/280) 的可复跑调研资产。调研目标不是比较目标语言的全部数值体系，而是记录 **FCSTM 当前数值表达式经 pyfcstm renderer / template 实际渲染后的目标表达式**，再把这些表达式与目标语言、主流工具链和 Z3 的语义逐步对齐。
+
+## 当前 PR-1 范围
+
+PR-1 先落库轻量框架和 R0 映射工具；整个调研系列统一禁止修改 `test/` 路径：
+
+| 文件 | 作用 |
+|---|---|
+| `plan.md` | 子 PR 执行计划、验收命令和边界。 |
+| `mapping.md` | R0 render mapping 输出结构和人工阅读指南。 |
+| `probes.md` | 后续 probe runner 设计约束；PR-1 仅提供 `env` stub。 |
+| `schemas/` | 调研 JSON artifact 的轻量契约。 |
+| `results/snapshots/` | 可提交的小型 snapshot。 |
+| `results/local/` | gitignored heavy / local 输出目录。 |
+
+## 非目标
+
+- PR-1 不运行 C/C++、Java、Rust、Go、Node 或 TypeScript probe。
+- PR-1 不修改 solver、verify、fixed 或模板语义。
+- PR-1 不提交 exhaustive 原始输出。
+- 整个调研系列不修改 `test/` 路径；调研自检、native probe、exhaustive/shard harness 放在 `tools/` / `research/` 入口和 gitignored `results/local/` 中，避免污染常规 unittest。
+
+## 快速开始
+
+```bash
+python tools/numeric_render_mapping.py \
+  --output research/numeric-render-semantics/results/snapshots/render_mapping.json
+
+python tools/numeric_render_mapping.py --check
+
+python tools/numeric_render_probe.py env \
+  --output research/numeric-render-semantics/results/local/env.json
+```
+
+`--check` 是 PR-1 的调研自检入口；后续子 PR 也应继续使用 `tools/` / `research/` 下的自检和 probe 入口，而不是修改 `test/`。`results/local/` 被 `.gitignore` 忽略，适合放本机探测结果和后续 heavy probe 输出。

--- a/research/numeric-render-semantics/mapping.md
+++ b/research/numeric-render-semantics/mapping.md
@@ -1,0 +1,20 @@
+# R0 映射说明
+
+`tools/numeric_render_mapping.py` 生成 `render_mapping.json`，并通过 `python tools/numeric_render_mapping.py --check` 执行不依赖 `test/` 路径的轻量契约自检。该文件用于回答：当前 pyfcstm 把 FCSTM 数值表达式渲染成什么目标表达式，后续 probe 应该测试哪条真实路径。
+
+## 必须保留的层次
+
+| 层次 | JSON 字段 | 说明 |
+|---|---|---|
+| Builtin expression renderer | `builtin_expr_styles` | `pyfcstm.render.expr` 内置样式，如 `c`、`cpp`、`python`、`go`。 |
+| Builtin statement renderer | `builtin_stmt_styles` | `pyfcstm.render.statement` 内置 statement 样式。 |
+| Template expression override | `templates.*.expr_styles` | `templates/*/config.yaml` 中的 `expr_styles`。 |
+| Statement expression override | `templates.*.stmt_styles.*.expr_templates` | statement 渲染时的表达式 override，例如 Python runtime `_s(...)`。 |
+| Helper inventory | `renderer_helper_inventory` | 会改变最终表达式语义或 probe 入口的 helper。 |
+| Packaged template metadata | `packaged_templates` | `pyfcstm/template/index.json` 元数据、archive 声明和 source digest；不 hash gitignored zip payload。 |
+| C++ 双路径 | `cxx_paths` | 区分 `_CPP_STYLE` standalone 与 `templates/cpp*` 的 `base_lang: c` 生成路径。 |
+| 运行时语义备注 | `runtime_semantics_notes` | 记录不能由当前 mapping 自动推出、但后续不能猜测的语义点。 |
+
+## `~` 备注
+
+当前 parser 的数值一元规则只接收 `+` / `-`，因此 PR-1 不能假装已经有运行时 `~` 行为。R0 snapshot 仍显式记录 `~`，用于提醒后续 solver/template 工作不要直接按 Z3 或 C 的 bitwise not 语义猜测。

--- a/research/numeric-render-semantics/plan.md
+++ b/research/numeric-render-semantics/plan.md
@@ -1,0 +1,35 @@
+# 执行计划
+
+## 原则
+
+1. 以当前 renderer / template 的实际渲染结果为准。
+2. 只覆盖 FCSTM 数值表达式，不覆盖逻辑表达式本身。
+3. C/C++ 是默认定长语义设计的 P0 参考；Java/Rust 次之；Go/JS/TS 作为未来模板风险面。
+4. Z3 是 solver / verify 编码目标，不把 BitVec natural wrap 直接等同于 C/C++ signed semantics。
+5. Heavy exhaustive 输出只写入 `results/local/`，不得提交进 git。
+6. 整个调研系列不修改 `test/` 路径；调研校验、native probe、exhaustive/shard harness 通过 `tools/` / `research/` 自检入口和 gitignored `results/local/` 完成，避免把一次性研究实验放进常规 unittest。
+
+## PR-1 验收
+
+```bash
+python tools/numeric_render_mapping.py \
+  --output research/numeric-render-semantics/results/snapshots/render_mapping.json
+
+python tools/numeric_render_mapping.py --check
+
+git check-ignore research/numeric-render-semantics/results/local/dummy-output.jsonl
+
+make rst_auto
+```
+
+## 后续子 PR
+
+| 子 PR | 状态 | 内容 |
+|---|---|---|
+| PR-1 | 🟡 当前 | 落库框架、R0 mapping、env stub、轻量 schema；确立整个调研系列不修改 `test/` 路径。 |
+| PR-2 | 🟡 后续 | C/C++ smoke probe。 |
+| PR-3 | 🟡 后续 | Python + Z3 基线。 |
+| PR-4 | 🟡 后续 | Java / Rust smoke probe。 |
+| PR-5 | 🟡 后续 | Go / JS / TS smoke probe。 |
+| PR-6 | 🟡 后续 | 8-bit exhaustive 与 16-bit shard harness。 |
+| PR-7 | 🟡 后续 | 汇总报告与 solver / fixed / template 后续建议。 |

--- a/research/numeric-render-semantics/probes.md
+++ b/research/numeric-render-semantics/probes.md
@@ -1,0 +1,11 @@
+# Probe 设计说明
+
+PR-1 只提供 `tools/numeric_render_probe.py env`，用于输出本地 Python、平台和可用命令清单；PR-1 的契约校验由 `tools/numeric_render_mapping.py --check` 承担。整个调研系列都不新增 `test/` 路径；任何会调用 native compiler、Node.js、Java、Rust、Go 或 Z3 求解的 probe 都应在后续子 PR 中继续落在 `tools/` / `research/` 与 gitignored `results/local/` 下。
+
+## 后续 runner 约束
+
+- runner 必须读取 R0 `render_mapping.json`，不要手写与 renderer 脱节的表达式表。
+- 编译失败、链接失败、运行时异常、sanitizer trap 都是结果，不得静默替换为“更合理”的 helper。
+- 每次运行前探测 CPU、内存、磁盘、工具链版本和可承受并行度。
+- Heavy 输出写入 `results/local/`，小型 summary / digest 才能提交。
+- 8-bit exhaustive 可以作为调研阶段强验证；16-bit 必须支持 shard / resume / digest。

--- a/research/numeric-render-semantics/results/README.md
+++ b/research/numeric-render-semantics/results/README.md
@@ -1,0 +1,8 @@
+# 调研结果目录
+
+| 路径 | 是否提交 | 用途 |
+|---|---|---|
+| `snapshots/` | 是 | 小型、可审阅、可复跑的 mapping 或 summary snapshot。 |
+| `local/` | 否 | 本机环境报告、native 编译产物、heavy exhaustive JSONL、临时 shard 输出。 |
+
+`local/` 已由仓库 `.gitignore` 忽略。

--- a/research/numeric-render-semantics/results/snapshots/render_mapping.json
+++ b/research/numeric-render-semantics/results/snapshots/render_mapping.json
@@ -548,7 +548,7 @@
     "research_path": "research/numeric-render-semantics",
     "tool": "tools/numeric_render_mapping.py"
   },
-  "mapping_sha256": "b3819a4df946d90c4c5aec56048b075cb7545f748847595dceb769680572c99e",
+  "mapping_sha256": "d79b2fc4eb981eb794def52fc8fa2589c87e836673106eabdc589081eb8ad2da",
   "packaged_templates": {
     "entries": [
       {
@@ -730,7 +730,7 @@
     "bitwise_not": {
       "current_dsl_numeric_unary_rule": "PLUS | MINUS",
       "operator": "~",
-      "reason": "Issue #280 requires the R0 inventory to record '~' explicitly so later solver/template work does not guess from Z3 or C semantics.",
+      "reason": "The mapping records '~' explicitly so solver and template work does not guess from Z3 or C semantics.",
       "status": "not inferred from runtime; current parser grammar does not accept numeric unary '~'"
     }
   },

--- a/research/numeric-render-semantics/results/snapshots/render_mapping.json
+++ b/research/numeric-render-semantics/results/snapshots/render_mapping.json
@@ -1,0 +1,1064 @@
+{
+  "builtin_expr_styles": {
+    "aliases": {
+      "c++": "cpp",
+      "cc": "cpp",
+      "cxx": "cpp",
+      "golang": "go",
+      "javascript": "js",
+      "node": "js",
+      "nodejs": "js",
+      "py": "python",
+      "python3": "python",
+      "rs": "rust",
+      "rustlang": "rust",
+      "typescript": "ts"
+    },
+    "styles": {
+      "c": {
+        "base_lang": "c",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(**)": "pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})",
+          "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "Boolean": "{{ (1 if node.value else 0) | hex }}",
+          "ConditionalOp": "({{ node.cond | expr_render }}) ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}",
+          "Constant": "{{ node.value | repr }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "{{ node.func }}({{ node.expr | expr_render }})",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      },
+      "cpp": {
+        "base_lang": "cpp",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(**)": "std::pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})",
+          "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "Boolean": "{{ \"true\" if node.value else \"false\" }}",
+          "ConditionalOp": "({{ node.cond | expr_render }}) ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}",
+          "Constant": "{{ node.value | repr }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "std::{{ node.func }}({{ node.expr | expr_render }})",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      },
+      "dsl": {
+        "base_lang": "dsl",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(=>)": "{{ node.expr1 | expr_render }} => {{ node.expr2 | expr_render }}",
+          "BinaryOp(iff)": "{{ node.expr1 | expr_render }} iff {{ node.expr2 | expr_render }}",
+          "BinaryOp(xor)": "{{ node.expr1 | expr_render }} xor {{ node.expr2 | expr_render }}",
+          "Boolean": "{{ node.value | repr }}",
+          "ConditionalOp": "({{ node.cond | expr_render }}) ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}",
+          "Constant": "{{ node.value | repr }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "{{ node.func }}({{ node.expr | expr_render }})",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      },
+      "go": {
+        "base_lang": "go",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(**)": "math.Pow(float64({{ node.expr1 | expr_render }}), float64({{ node.expr2 | expr_render }}))",
+          "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "Boolean": "{{ \"true\" if node.value else \"false\" }}",
+          "ConditionalOp": "func() {{ go_expr_type(node) }} { if {{ node.cond | expr_render }} { return {{ node.value_true | expr_render }} }; return {{ node.value_false | expr_render }} }()",
+          "Constant": "{{ \"math.Pi\" if node.value == \"pi\" else (\"math.E\" if node.value == \"e\" else (\"(2 * math.Pi)\" if node.value == \"tau\" else node.value | repr)) }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "math.{{ node.func | capitalize }}(float64({{ node.expr | expr_render }}))",
+          "UFunc(abs)": "{{ go_abs_expr(node.expr | expr_render, node.expr) }}",
+          "UFunc(ceil)": "int(math.Ceil(float64({{ node.expr | expr_render }})))",
+          "UFunc(floor)": "int(math.Floor(float64({{ node.expr | expr_render }})))",
+          "UFunc(round)": "int(math.Round(float64({{ node.expr | expr_render }})))",
+          "UFunc(trunc)": "int(math.Trunc(float64({{ node.expr | expr_render }})))",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      },
+      "java": {
+        "base_lang": "java",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(**)": "Math.pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})",
+          "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "Boolean": "{{ \"true\" if node.value else \"false\" }}",
+          "ConditionalOp": "{{ node.cond | expr_render }} ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}",
+          "Constant": "{{ \"Math.PI\" if node.value == \"pi\" else (\"Math.E\" if node.value == \"e\" else (\"(2.0 * Math.PI)\" if node.value == \"tau\" else node.value | repr)) }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "Math.{{ node.func }}({{ node.expr | expr_render }})",
+          "UFunc(trunc)": "({{ node.expr | expr_render }}) >= 0 ? Math.floor({{ node.expr | expr_render }}) : Math.ceil({{ node.expr | expr_render }})",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      },
+      "js": {
+        "base_lang": "js",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(**)": "Math.pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})",
+          "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "Boolean": "{{ \"true\" if node.value else \"false\" }}",
+          "ConditionalOp": "({{ node.cond | expr_render }}) ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}",
+          "Constant": "{{ \"Math.PI\" if node.value == \"pi\" else (\"Math.E\" if node.value == \"e\" else (\"(2 * Math.PI)\" if node.value == \"tau\" else node.value | repr)) }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "Math.{{ node.func }}({{ node.expr | expr_render }})",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      },
+      "python": {
+        "base_lang": "python",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(!=)": "{{ py_condition_operand(node.expr1 | expr_render, node.expr1) }} != {{ py_condition_operand(node.expr2 | expr_render, node.expr2) }}",
+          "BinaryOp(&&)": "{{ node.expr1 | expr_render }} and {{ node.expr2 | expr_render }}",
+          "BinaryOp(==)": "{{ py_condition_operand(node.expr1 | expr_render, node.expr1) }} == {{ py_condition_operand(node.expr2 | expr_render, node.expr2) }}",
+          "BinaryOp(=>)": "((not ({{ node.expr1 | expr_render }})) or ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(||)": "{{ node.expr1 | expr_render }} or {{ node.expr2 | expr_render }}",
+          "Boolean": "{{ node.value | repr }}",
+          "ConditionalOp": "{{ node.value_true | expr_render }} if {{ node.cond | expr_render }} else {{ node.value_false | expr_render }}",
+          "Constant": "{{ node.value | repr }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "{{ node.func }}({{ node.expr | expr_render }})",
+          "UFunc(abs)": "abs({{ node.expr | expr_render }})",
+          "UFunc(acos)": "math.acos({{ node.expr | expr_render }})",
+          "UFunc(acosh)": "math.acosh({{ node.expr | expr_render }})",
+          "UFunc(asin)": "math.asin({{ node.expr | expr_render }})",
+          "UFunc(asinh)": "math.asinh({{ node.expr | expr_render }})",
+          "UFunc(atan)": "math.atan({{ node.expr | expr_render }})",
+          "UFunc(atanh)": "math.atanh({{ node.expr | expr_render }})",
+          "UFunc(cbrt)": "math.copysign(abs({{ node.expr | expr_render }}) ** (1.0 / 3.0), {{ node.expr | expr_render }})",
+          "UFunc(ceil)": "math.ceil({{ node.expr | expr_render }})",
+          "UFunc(cos)": "math.cos({{ node.expr | expr_render }})",
+          "UFunc(cosh)": "math.cosh({{ node.expr | expr_render }})",
+          "UFunc(exp)": "math.exp({{ node.expr | expr_render }})",
+          "UFunc(floor)": "math.floor({{ node.expr | expr_render }})",
+          "UFunc(log)": "math.log({{ node.expr | expr_render }})",
+          "UFunc(log10)": "math.log10({{ node.expr | expr_render }})",
+          "UFunc(log1p)": "math.log1p({{ node.expr | expr_render }})",
+          "UFunc(log2)": "math.log2({{ node.expr | expr_render }})",
+          "UFunc(round)": "round({{ node.expr | expr_render }})",
+          "UFunc(sign)": "int((({{ node.expr | expr_render }}) > 0) - (({{ node.expr | expr_render }}) < 0))",
+          "UFunc(sin)": "math.sin({{ node.expr | expr_render }})",
+          "UFunc(sinh)": "math.sinh({{ node.expr | expr_render }})",
+          "UFunc(sqrt)": "math.sqrt({{ node.expr | expr_render }})",
+          "UFunc(tan)": "math.tan({{ node.expr | expr_render }})",
+          "UFunc(tanh)": "math.tanh({{ node.expr | expr_render }})",
+          "UFunc(trunc)": "math.trunc({{ node.expr | expr_render }})",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}",
+          "UnaryOp(!)": "not {{ node.expr | expr_render }}"
+        }
+      },
+      "rust": {
+        "base_lang": "rust",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(**)": "({{ node.expr1 | expr_render }} as f64).powf({{ node.expr2 | expr_render }} as f64)",
+          "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "Boolean": "{{ \"true\" if node.value else \"false\" }}",
+          "ConditionalOp": "(if {{ node.cond | expr_render }} { {{ node.value_true | expr_render }} } else { {{ node.value_false | expr_render }} })",
+          "Constant": "{{ \"std::f64::consts::PI\" if node.value == \"pi\" else (\"std::f64::consts::E\" if node.value == \"e\" else (\"std::f64::consts::TAU\" if node.value == \"tau\" else node.value | repr)) }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "({{ node.expr | expr_render }} as f64).{{ node.func }}()",
+          "UFunc(abs)": "({{ node.expr | expr_render }}).abs()",
+          "UFunc(ceil)": "({{ node.expr | expr_render }} as f64).ceil() as i64",
+          "UFunc(floor)": "({{ node.expr | expr_render }} as f64).floor() as i64",
+          "UFunc(log)": "({{ node.expr | expr_render }} as f64).ln()",
+          "UFunc(log10)": "({{ node.expr | expr_render }} as f64).log10()",
+          "UFunc(log1p)": "({{ node.expr | expr_render }} as f64).ln_1p()",
+          "UFunc(log2)": "({{ node.expr | expr_render }} as f64).log2()",
+          "UFunc(round)": "({{ node.expr | expr_render }} as f64).round() as i64",
+          "UFunc(trunc)": "({{ node.expr | expr_render }} as f64).trunc() as i64",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      },
+      "ts": {
+        "base_lang": "ts",
+        "templates": {
+          "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+          "BinaryOp(**)": "Math.pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})",
+          "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+          "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+          "Boolean": "{{ \"true\" if node.value else \"false\" }}",
+          "ConditionalOp": "({{ node.cond | expr_render }}) ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}",
+          "Constant": "{{ \"Math.PI\" if node.value == \"pi\" else (\"Math.E\" if node.value == \"e\" else (\"(2 * Math.PI)\" if node.value == \"tau\" else node.value | repr)) }}",
+          "Float": "{{ node.value | repr }}",
+          "HexInt": "{{ node.value | hex }}",
+          "Integer": "{{ node.value | repr }}",
+          "Name": "{{ node.name }}",
+          "Paren": "({{ node.expr | expr_render }})",
+          "UFunc": "Math.{{ node.func }}({{ node.expr | expr_render }})",
+          "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+        }
+      }
+    }
+  },
+  "builtin_stmt_styles": {
+    "aliases": {
+      "c++": "cpp",
+      "cc": "cpp",
+      "cxx": "cpp",
+      "golang": "go",
+      "javascript": "js",
+      "node": "js",
+      "nodejs": "js",
+      "py": "python",
+      "python3": "python",
+      "rs": "rust",
+      "rustlang": "rust",
+      "typescript": "ts"
+    },
+    "styles": {
+      "c": {
+        "assign": "{{ target }} = {{ expr }};",
+        "base_lang": "c",
+        "block_end": "}",
+        "declare_temp": "{{ temp_type }} {{ name }};",
+        "elif": "} else if ({{ condition }}) {",
+        "else": "} else {",
+        "expr_lang": "c",
+        "expr_templates": {},
+        "if": "if ({{ condition }}) {",
+        "pass": "/* no-op */",
+        "state_var_target": "scope->{{ name }}",
+        "temp_type_aliases": {
+          "float": "double",
+          "int": "int"
+        },
+        "temp_type_fallback": "double",
+        "temp_var_target": "{{ name }}"
+      },
+      "cpp": {
+        "assign": "{{ target }} = {{ expr }};",
+        "base_lang": "cpp",
+        "block_end": "}",
+        "declare_temp": "{{ temp_type }} {{ name }};",
+        "elif": "} else if ({{ condition }}) {",
+        "else": "} else {",
+        "expr_lang": "cpp",
+        "expr_templates": {},
+        "if": "if ({{ condition }}) {",
+        "pass": "/* no-op */",
+        "state_var_target": "scope->{{ name }}",
+        "temp_type_aliases": {
+          "float": "double",
+          "int": "int"
+        },
+        "temp_type_fallback": "double",
+        "temp_var_target": "{{ name }}"
+      },
+      "dsl": {
+        "assign": "{{ target }} = {{ expr }};",
+        "base_lang": "dsl",
+        "block_end": "}",
+        "declare_temp": null,
+        "elif": "} else if [{{ condition }}] {",
+        "else": "} else {",
+        "expr_lang": "dsl",
+        "expr_templates": {},
+        "if": "if [{{ condition }}] {",
+        "pass": "",
+        "state_var_target": "{{ name }}",
+        "temp_type_aliases": {},
+        "temp_type_fallback": null,
+        "temp_var_target": "{{ name }}"
+      },
+      "go": {
+        "assign": "{{ target }} = {{ expr }}",
+        "base_lang": "go",
+        "block_end": "}",
+        "declare_temp": "var {{ name }} {{ temp_type }}",
+        "elif": "} else if {{ condition }} {",
+        "else": "} else {",
+        "expr_lang": "go",
+        "expr_templates": {},
+        "if": "if {{ condition }} {",
+        "pass": "// no-op",
+        "state_var_target": "scope.{{ name }}",
+        "temp_type_aliases": {
+          "float": "float64",
+          "int": "int"
+        },
+        "temp_type_fallback": "float64",
+        "temp_var_target": "{{ name }}"
+      },
+      "java": {
+        "assign": "{{ target }} = {{ expr }};",
+        "base_lang": "java",
+        "block_end": "}",
+        "declare_temp": "{{ temp_type }} {{ name }};",
+        "elif": "} else if ({{ condition }}) {",
+        "else": "} else {",
+        "expr_lang": "java",
+        "expr_templates": {},
+        "if": "if ({{ condition }}) {",
+        "pass": "// no-op",
+        "state_var_target": "scope.{{ name }}",
+        "temp_type_aliases": {
+          "float": "double",
+          "int": "int"
+        },
+        "temp_type_fallback": "double",
+        "temp_var_target": "{{ name }}"
+      },
+      "js": {
+        "assign": "{{ target }} = {{ expr }};",
+        "base_lang": "js",
+        "block_end": "}",
+        "declare_temp": "let {{ name }};",
+        "elif": "} else if ({{ condition }}) {",
+        "else": "} else {",
+        "expr_lang": "js",
+        "expr_templates": {},
+        "if": "if ({{ condition }}) {",
+        "pass": "// no-op",
+        "state_var_target": "scope.{{ name }}",
+        "temp_type_aliases": {},
+        "temp_type_fallback": null,
+        "temp_var_target": "{{ name }}"
+      },
+      "python": {
+        "assign": "{{ target }} = {{ expr }}",
+        "base_lang": "python",
+        "block_end": null,
+        "declare_temp": null,
+        "elif": "elif {{ condition }}:",
+        "else": "else:",
+        "expr_lang": "python",
+        "expr_templates": {},
+        "if": "if {{ condition }}:",
+        "pass": "pass",
+        "state_var_target": "scope[{{ name | tojson }}]",
+        "temp_type_aliases": {},
+        "temp_type_fallback": null,
+        "temp_var_target": "{{ name }}"
+      },
+      "rust": {
+        "assign": "{{ target }} = {{ expr }};",
+        "base_lang": "rust",
+        "block_end": "}",
+        "declare_temp": "let mut {{ name }}: {{ temp_type }};",
+        "elif": "} else if {{ condition }} {",
+        "else": "} else {",
+        "expr_lang": "rust",
+        "expr_templates": {},
+        "if": "if {{ condition }} {",
+        "pass": "// no-op",
+        "state_var_target": "scope.{{ name }}",
+        "temp_type_aliases": {
+          "float": "f64",
+          "int": "i64"
+        },
+        "temp_type_fallback": "f64",
+        "temp_var_target": "{{ name }}"
+      },
+      "ts": {
+        "assign": "{{ target }} = {{ expr }};",
+        "base_lang": "ts",
+        "block_end": "}",
+        "declare_temp": "let {{ name }}: {{ temp_type }};",
+        "elif": "} else if ({{ condition }}) {",
+        "else": "} else {",
+        "expr_lang": "ts",
+        "expr_templates": {},
+        "if": "if ({{ condition }}) {",
+        "pass": "// no-op",
+        "state_var_target": "scope.{{ name }}",
+        "temp_type_aliases": {
+          "float": "number",
+          "int": "number"
+        },
+        "temp_type_fallback": "number",
+        "temp_var_target": "{{ name }}"
+      }
+    }
+  },
+  "cxx_paths": {
+    "builtin_cpp_style": {
+      "base_lang": "cpp",
+      "notes": [
+        "Standalone renderer path emits std::* expressions such as std::pow."
+      ],
+      "source": "pyfcstm.render.expr._CPP_STYLE",
+      "templates": {
+        "BinaryOp": "{{ node.expr1 | expr_render }} {{ node.op }} {{ node.expr2 | expr_render }}",
+        "BinaryOp(**)": "std::pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})",
+        "BinaryOp(=>)": "((!({{ node.expr1 | expr_render }})) || ({{ node.expr2 | expr_render }}))",
+        "BinaryOp(iff)": "(({{ node.expr1 | expr_render }}) == ({{ node.expr2 | expr_render }}))",
+        "BinaryOp(xor)": "(({{ node.expr1 | expr_render }}) != ({{ node.expr2 | expr_render }}))",
+        "Boolean": "{{ \"true\" if node.value else \"false\" }}",
+        "ConditionalOp": "({{ node.cond | expr_render }}) ? {{ node.value_true | expr_render }} : {{ node.value_false | expr_render }}",
+        "Constant": "{{ node.value | repr }}",
+        "Float": "{{ node.value | repr }}",
+        "HexInt": "{{ node.value | hex }}",
+        "Integer": "{{ node.value | repr }}",
+        "Name": "{{ node.name }}",
+        "Paren": "({{ node.expr | expr_render }})",
+        "UFunc": "std::{{ node.func }}({{ node.expr | expr_render }})",
+        "UnaryOp": "{{ node.op }}{{ node.expr | expr_render }}"
+      }
+    },
+    "template_generated_paths": [
+      {
+        "expr_styles": {
+          "c_scope_expr": {
+            "base_lang": "c",
+            "overrides": {
+              "Name": "scope->{{ node.name | to_c_identifier }}"
+            }
+          }
+        },
+        "generated_artifacts": [
+          "templates/c/machine.c.j2",
+          "templates/c/machine.h.j2",
+          "templates/cpp/machine.cpp.j2",
+          "templates/cpp/machine.hpp.j2"
+        ],
+        "notes": [
+          "Current C++ wrapper template path reuses C-style expression configuration via base_lang: c."
+        ],
+        "source": "templates/cpp/config.yaml",
+        "stmt_styles": {
+          "c_runtime": {
+            "base_lang": "c",
+            "expr_templates": {},
+            "overrides": {
+              "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+              "state_var_target": "scope->{{ name | to_c_identifier }}",
+              "temp_type_aliases": {
+                "float": "double",
+                "int": "PYFCSTM_GENERATED_INT64"
+              },
+              "temp_type_fallback": "double",
+              "temp_var_target": "{{ name | to_c_identifier }}"
+            },
+            "stmt_overrides": {
+              "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+              "state_var_target": "scope->{{ name | to_c_identifier }}",
+              "temp_type_aliases": {
+                "float": "double",
+                "int": "PYFCSTM_GENERATED_INT64"
+              },
+              "temp_type_fallback": "double",
+              "temp_var_target": "{{ name | to_c_identifier }}"
+            }
+          }
+        },
+        "template": "cpp"
+      },
+      {
+        "expr_styles": {
+          "c_scope_expr": {
+            "base_lang": "c",
+            "overrides": {
+              "Name": "scope->{{ node.name | to_c_identifier }}"
+            }
+          }
+        },
+        "generated_artifacts": [
+          "templates/c_poll/machine.c.j2",
+          "templates/c_poll/machine.h.j2",
+          "templates/cpp_poll/machine.cpp.j2",
+          "templates/cpp_poll/machine.hpp.j2"
+        ],
+        "notes": [
+          "Current C++ wrapper template path reuses C-style expression configuration via base_lang: c."
+        ],
+        "source": "templates/cpp_poll/config.yaml",
+        "stmt_styles": {
+          "c_runtime": {
+            "base_lang": "c",
+            "expr_templates": {},
+            "overrides": {
+              "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+              "state_var_target": "scope->{{ name | to_c_identifier }}",
+              "temp_type_aliases": {
+                "float": "double",
+                "int": "PYFCSTM_GENERATED_INT64"
+              },
+              "temp_type_fallback": "double",
+              "temp_var_target": "{{ name | to_c_identifier }}"
+            },
+            "stmt_overrides": {
+              "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+              "state_var_target": "scope->{{ name | to_c_identifier }}",
+              "temp_type_aliases": {
+                "float": "double",
+                "int": "PYFCSTM_GENERATED_INT64"
+              },
+              "temp_type_fallback": "double",
+              "temp_var_target": "{{ name | to_c_identifier }}"
+            }
+          }
+        },
+        "template": "cpp_poll"
+      }
+    ]
+  },
+  "generated_at_utc": null,
+  "generator": {
+    "provenance": "stable snapshot; repository identity is captured by source and packaged-template digests",
+    "research_path": "research/numeric-render-semantics",
+    "tool": "tools/numeric_render_mapping.py"
+  },
+  "mapping_sha256": "b3819a4df946d90c4c5aec56048b075cb7545f748847595dceb769680572c99e",
+  "packaged_templates": {
+    "entries": [
+      {
+        "archive": "c.zip",
+        "archive_declared": true,
+        "archive_path": "pyfcstm/template/c.zip",
+        "archive_snapshot_policy": "archive zip files are gitignored build outputs; the committed snapshot records index metadata and source digests instead of hashing local archive payloads",
+        "language": "c",
+        "metadata": {
+          "archive": "c.zip",
+          "description": "Native C99 built-in template with embedded runtime logic and abstract hook callbacks.",
+          "experimental": true,
+          "language": "c",
+          "name": "c",
+          "root_dir": "c",
+          "title": "C99"
+        },
+        "name": "c",
+        "root_dir": "c",
+        "source_archive_sync_status": "source-and-archive-declared",
+        "source_digest": {
+          "file_count": 8,
+          "sha256": "194e5d2bda778ee94f18f8e2d478ba9fd581822ee022d7c8592f35feff8dc29a"
+        }
+      },
+      {
+        "archive": "c_poll.zip",
+        "archive_declared": true,
+        "archive_path": "pyfcstm/template/c_poll.zip",
+        "archive_snapshot_policy": "archive zip files are gitignored build outputs; the committed snapshot records index metadata and source digests instead of hashing local archive payloads",
+        "language": "c",
+        "metadata": {
+          "archive": "c_poll.zip",
+          "description": "Native C99 / C++98 built-in template with hook-polled events and embedded runtime logic.",
+          "experimental": true,
+          "language": "c",
+          "name": "c_poll",
+          "root_dir": "c_poll",
+          "title": "C Poll"
+        },
+        "name": "c_poll",
+        "root_dir": "c_poll",
+        "source_archive_sync_status": "source-and-archive-declared",
+        "source_digest": {
+          "file_count": 8,
+          "sha256": "639824b90d9b0af371c77c889d49e055baf876f55ce95883dcafd80b6ae28e7e"
+        }
+      },
+      {
+        "archive": "cpp.zip",
+        "archive_declared": true,
+        "archive_path": "pyfcstm/template/cpp.zip",
+        "archive_snapshot_policy": "archive zip files are gitignored build outputs; the committed snapshot records index metadata and source digests instead of hashing local archive payloads",
+        "language": "cpp",
+        "metadata": {
+          "archive": "cpp.zip",
+          "description": "Early-stage first-class C++ template that reuses the C99 runtime core and emits C++ wrapper files.",
+          "experimental": true,
+          "language": "cpp",
+          "name": "cpp",
+          "root_dir": "cpp",
+          "title": "C++ Wrapper"
+        },
+        "name": "cpp",
+        "root_dir": "cpp",
+        "source_archive_sync_status": "source-and-archive-declared",
+        "source_digest": {
+          "file_count": 10,
+          "sha256": "6753886a3f13fd7a32aca502dfb23185cf7b86737fb95f39b0db546499707e06"
+        }
+      },
+      {
+        "archive": "cpp_poll.zip",
+        "archive_declared": true,
+        "archive_path": "pyfcstm/template/cpp_poll.zip",
+        "archive_snapshot_policy": "archive zip files are gitignored build outputs; the committed snapshot records index metadata and source digests instead of hashing local archive payloads",
+        "language": "cpp",
+        "metadata": {
+          "archive": "cpp_poll.zip",
+          "description": "Early-stage first-class C++ poll template that reuses the C poll runtime core and emits C++ wrapper files.",
+          "experimental": true,
+          "language": "cpp",
+          "name": "cpp_poll",
+          "root_dir": "cpp_poll",
+          "title": "C++ Poll Wrapper"
+        },
+        "name": "cpp_poll",
+        "root_dir": "cpp_poll",
+        "source_archive_sync_status": "source-and-archive-declared",
+        "source_digest": {
+          "file_count": 10,
+          "sha256": "f33c9bbab27baa8804f0e4a2d7b193d2c82ea832fb6dd986abffd2daaf553933"
+        }
+      },
+      {
+        "archive": "python.zip",
+        "archive_declared": true,
+        "archive_path": "pyfcstm/template/python.zip",
+        "archive_snapshot_policy": "archive zip files are gitignored build outputs; the committed snapshot records index metadata and source digests instead of hashing local archive payloads",
+        "language": "python",
+        "metadata": {
+          "archive": "python.zip",
+          "description": "Native Python built-in template with embedded runtime logic.",
+          "experimental": true,
+          "language": "python",
+          "name": "python",
+          "root_dir": "python",
+          "title": "Python"
+        },
+        "name": "python",
+        "root_dir": "python",
+        "source_archive_sync_status": "source-and-archive-declared",
+        "source_digest": {
+          "file_count": 7,
+          "sha256": "63fcd4154ebac3f6b3e3461d45a6b4785569a58b9d687fb5222245af37f051a0"
+        }
+      }
+    ],
+    "index_exists": true,
+    "index_path": "pyfcstm/template/index.json",
+    "index_sha256": "ccbe23659c02f1fbd5943115a56836c85728c5510944d6cf675b76b1e12278f0"
+  },
+  "renderer_helper_inventory": [
+    {
+      "layer": "builtin expression renderer",
+      "module": "pyfcstm.render.expr",
+      "name": "py_condition_operand",
+      "purpose": "Parenthesizes Python condition-valued comparison operands."
+    },
+    {
+      "layer": "builtin expression renderer",
+      "module": "pyfcstm.render.expr",
+      "name": "go_expr_type",
+      "purpose": "Chooses the Go conditional-expression closure return type."
+    },
+    {
+      "layer": "builtin expression renderer",
+      "module": "pyfcstm.render.expr",
+      "name": "go_abs_expr",
+      "purpose": "Chooses integer or floating Go abs rendering based on inferred DSL type."
+    },
+    {
+      "layer": "solver helper",
+      "module": "pyfcstm.solver.expr",
+      "name": "python_round_to_z3",
+      "purpose": "Encodes Python half-even single-argument round semantics for Z3."
+    },
+    {
+      "layer": "C runtime template helper",
+      "module": "pyfcstm.render.c_runtime",
+      "name": "render_c_action_body",
+      "purpose": "Renders fallible generated C action bodies with runtime diagnostics."
+    },
+    {
+      "layer": "C runtime template helper",
+      "module": "pyfcstm.render.c_runtime",
+      "name": "render_c_condition_body",
+      "purpose": "Renders fallible generated C transition-guard condition bodies."
+    },
+    {
+      "layer": "Python generated runtime helper",
+      "module": "templates/python/machine.py.j2",
+      "name": "_sign",
+      "purpose": "Implements sign for Python generated runtime expression paths."
+    },
+    {
+      "layer": "Python generated runtime helper alias",
+      "module": "templates/python/machine.py.j2",
+      "name": "_s",
+      "purpose": "Local alias used by python_runtime statement expr_templates for sign."
+    }
+  ],
+  "repository": {
+    "packaged_template_root": "pyfcstm/template",
+    "root": ".",
+    "template_source_root": "templates"
+  },
+  "runtime_semantics_notes": {
+    "bitwise_not": {
+      "current_dsl_numeric_unary_rule": "PLUS | MINUS",
+      "operator": "~",
+      "reason": "Issue #280 requires the R0 inventory to record '~' explicitly so later solver/template work does not guess from Z3 or C semantics.",
+      "status": "not inferred from runtime; current parser grammar does not accept numeric unary '~'"
+    }
+  },
+  "schema_version": 1,
+  "templates": {
+    "c": {
+      "config_path": "templates/c/config.yaml",
+      "expr_styles": {
+        "c_scope_expr": {
+          "base_lang": "c",
+          "overrides": {
+            "Name": "scope->{{ node.name | to_c_identifier }}"
+          }
+        }
+      },
+      "files": [
+        "README.md",
+        "README.md.j2",
+        "README_zh.md",
+        "README_zh.md.j2",
+        "config.yaml",
+        "machine.c.j2",
+        "machine.h.j2",
+        "template.json"
+      ],
+      "generated_artifacts": [
+        "templates/c/machine.c.j2",
+        "templates/c/machine.h.j2"
+      ],
+      "ignored_static_files": [
+        "README.md",
+        "README_zh.md",
+        "template.json"
+      ],
+      "name": "c",
+      "path": "templates/c",
+      "source_digest": {
+        "file_count": 8,
+        "sha256": "194e5d2bda778ee94f18f8e2d478ba9fd581822ee022d7c8592f35feff8dc29a"
+      },
+      "stmt_styles": {
+        "c_runtime": {
+          "base_lang": "c",
+          "expr_templates": {},
+          "overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          },
+          "stmt_overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          }
+        }
+      }
+    },
+    "c_poll": {
+      "config_path": "templates/c_poll/config.yaml",
+      "expr_styles": {
+        "c_scope_expr": {
+          "base_lang": "c",
+          "overrides": {
+            "Name": "scope->{{ node.name | to_c_identifier }}"
+          }
+        }
+      },
+      "files": [
+        "README.md",
+        "README.md.j2",
+        "README_zh.md",
+        "README_zh.md.j2",
+        "config.yaml",
+        "machine.c.j2",
+        "machine.h.j2",
+        "template.json"
+      ],
+      "generated_artifacts": [
+        "templates/c_poll/machine.c.j2",
+        "templates/c_poll/machine.h.j2"
+      ],
+      "ignored_static_files": [
+        "README.md",
+        "README_zh.md",
+        "template.json"
+      ],
+      "name": "c_poll",
+      "path": "templates/c_poll",
+      "source_digest": {
+        "file_count": 8,
+        "sha256": "639824b90d9b0af371c77c889d49e055baf876f55ce95883dcafd80b6ae28e7e"
+      },
+      "stmt_styles": {
+        "c_runtime": {
+          "base_lang": "c",
+          "expr_templates": {},
+          "overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          },
+          "stmt_overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          }
+        }
+      }
+    },
+    "cpp": {
+      "config_path": "templates/cpp/config.yaml",
+      "expr_styles": {
+        "c_scope_expr": {
+          "base_lang": "c",
+          "overrides": {
+            "Name": "scope->{{ node.name | to_c_identifier }}"
+          }
+        }
+      },
+      "files": [
+        "README.md",
+        "README.md.j2",
+        "README_zh.md",
+        "README_zh.md.j2",
+        "config.yaml",
+        "machine.c.j2",
+        "machine.cpp.j2",
+        "machine.h.j2",
+        "machine.hpp.j2",
+        "template.json"
+      ],
+      "generated_artifacts": [
+        "templates/c/machine.c.j2",
+        "templates/c/machine.h.j2",
+        "templates/cpp/machine.cpp.j2",
+        "templates/cpp/machine.hpp.j2"
+      ],
+      "ignored_static_files": [
+        "README.md",
+        "README_zh.md",
+        "config.yaml",
+        "template.json"
+      ],
+      "name": "cpp",
+      "path": "templates/cpp",
+      "source_digest": {
+        "file_count": 10,
+        "sha256": "6753886a3f13fd7a32aca502dfb23185cf7b86737fb95f39b0db546499707e06"
+      },
+      "stmt_styles": {
+        "c_runtime": {
+          "base_lang": "c",
+          "expr_templates": {},
+          "overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          },
+          "stmt_overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          }
+        }
+      }
+    },
+    "cpp_poll": {
+      "config_path": "templates/cpp_poll/config.yaml",
+      "expr_styles": {
+        "c_scope_expr": {
+          "base_lang": "c",
+          "overrides": {
+            "Name": "scope->{{ node.name | to_c_identifier }}"
+          }
+        }
+      },
+      "files": [
+        "README.md",
+        "README.md.j2",
+        "README_zh.md",
+        "README_zh.md.j2",
+        "config.yaml",
+        "machine.c.j2",
+        "machine.cpp.j2",
+        "machine.h.j2",
+        "machine.hpp.j2",
+        "template.json"
+      ],
+      "generated_artifacts": [
+        "templates/c_poll/machine.c.j2",
+        "templates/c_poll/machine.h.j2",
+        "templates/cpp_poll/machine.cpp.j2",
+        "templates/cpp_poll/machine.hpp.j2"
+      ],
+      "ignored_static_files": [
+        "README.md",
+        "README_zh.md",
+        "config.yaml",
+        "template.json"
+      ],
+      "name": "cpp_poll",
+      "path": "templates/cpp_poll",
+      "source_digest": {
+        "file_count": 10,
+        "sha256": "f33c9bbab27baa8804f0e4a2d7b193d2c82ea832fb6dd986abffd2daaf553933"
+      },
+      "stmt_styles": {
+        "c_runtime": {
+          "base_lang": "c",
+          "expr_templates": {},
+          "overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          },
+          "stmt_overrides": {
+            "declare_temp": "{{ temp_type }} {{ name | to_c_identifier }};",
+            "state_var_target": "scope->{{ name | to_c_identifier }}",
+            "temp_type_aliases": {
+              "float": "double",
+              "int": "PYFCSTM_GENERATED_INT64"
+            },
+            "temp_type_fallback": "double",
+            "temp_var_target": "{{ name | to_c_identifier }}"
+          }
+        }
+      }
+    },
+    "python": {
+      "config_path": "templates/python/config.yaml",
+      "expr_styles": {
+        "python_expr": {
+          "base_lang": "python",
+          "overrides": {
+            "Name": "self._vars[{{ node.name | tojson }}]",
+            "UFunc(sign)": "self._sign({{ node.expr | expr_render }})"
+          }
+        },
+        "python_scope_expr": {
+          "base_lang": "python",
+          "overrides": {
+            "Name": "scope[{{ node.name | tojson }}]",
+            "UFunc(sign)": "self._sign({{ node.expr | expr_render }})"
+          }
+        }
+      },
+      "files": [
+        "README.md",
+        "README.md.j2",
+        "README_zh.md",
+        "README_zh.md.j2",
+        "config.yaml",
+        "machine.py.j2",
+        "template.json"
+      ],
+      "generated_artifacts": [
+        "templates/python/machine.py.j2"
+      ],
+      "ignored_static_files": [
+        "README.md",
+        "README_zh.md",
+        "template.json"
+      ],
+      "name": "python",
+      "path": "templates/python",
+      "source_digest": {
+        "file_count": 7,
+        "sha256": "63fcd4154ebac3f6b3e3461d45a6b4785569a58b9d687fb5222245af37f051a0"
+      },
+      "stmt_styles": {
+        "python_runtime": {
+          "base_lang": "python",
+          "expr_templates": {
+            "UFunc(sign)": "_s({{ node.expr | expr_render }})"
+          },
+          "overrides": {
+            "assign": "{{ target }} = self._evaluate_runtime_expr(\n    lambda: {{ expr }},\n    {{ (\"operation assignment to '\" ~ name ~ \"'\") | tojson }},\n)",
+            "elif": "elif self._evaluate_runtime_expr(\n    lambda: {{ condition }},\n    \"if-block condition\",\n):",
+            "expr_lang": "python",
+            "if": "if self._evaluate_runtime_expr(\n    lambda: {{ condition }},\n    \"if-block condition\",\n):",
+            "state_var_target": "_v[{{ name | tojson }}]",
+            "temp_var_target": "{{ name }}"
+          },
+          "stmt_overrides": {
+            "assign": "{{ target }} = self._evaluate_runtime_expr(\n    lambda: {{ expr }},\n    {{ (\"operation assignment to '\" ~ name ~ \"'\") | tojson }},\n)",
+            "elif": "elif self._evaluate_runtime_expr(\n    lambda: {{ condition }},\n    \"if-block condition\",\n):",
+            "expr_lang": "python",
+            "if": "if self._evaluate_runtime_expr(\n    lambda: {{ condition }},\n    \"if-block condition\",\n):",
+            "state_var_target": "_v[{{ name | tojson }}]",
+            "temp_var_target": "{{ name }}"
+          }
+        }
+      }
+    }
+  }
+}

--- a/research/numeric-render-semantics/schemas/environment.schema.json
+++ b/research/numeric-render-semantics/schemas/environment.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HansBug/pyfcstm/research/numeric-render-semantics/schemas/environment.schema.json",
+  "title": "Numeric render probe environment report",
+  "type": "object",
+  "required": ["schema_version", "mode", "native_runner_enabled", "repository", "python", "platform", "resources", "available_commands"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "mode": {"const": "env"},
+    "native_runner_enabled": {"const": false},
+    "repository": {"type": "object", "required": ["root", "research_path"]},
+    "python": {"type": "object", "required": ["executable", "version", "implementation"]},
+    "platform": {"type": "object"},
+    "resources": {"type": "object"},
+    "available_commands": {"type": "array"}
+  }
+}

--- a/research/numeric-render-semantics/schemas/operator_matrix.schema.json
+++ b/research/numeric-render-semantics/schemas/operator_matrix.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HansBug/pyfcstm/research/numeric-render-semantics/schemas/operator_matrix.schema.json",
+  "title": "Numeric operator matrix summary",
+  "type": "object",
+  "required": ["schema_version", "source_mapping_sha256", "operators"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "source_mapping_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "operators": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["fcstm_operator", "render_paths", "risk_level"],
+        "properties": {
+          "fcstm_operator": {"type": "string"},
+          "render_paths": {"type": "array"},
+          "risk_level": {"enum": ["low", "medium", "high", "unknown"]}
+        }
+      }
+    }
+  }
+}

--- a/research/numeric-render-semantics/schemas/probe_summary.schema.json
+++ b/research/numeric-render-semantics/schemas/probe_summary.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HansBug/pyfcstm/research/numeric-render-semantics/schemas/probe_summary.schema.json",
+  "title": "Numeric render probe summary",
+  "type": "object",
+  "required": ["schema_version", "source_mapping_sha256", "language", "toolchain", "cases"],
+  "properties": {
+    "schema_version": {"const": 1},
+    "source_mapping_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "language": {"type": "string"},
+    "toolchain": {"type": "object"},
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["case_id", "render_expression", "status"],
+        "properties": {
+          "case_id": {"type": "string"},
+          "render_expression": {"type": "string"},
+          "status": {"enum": ["passed", "compile_failed", "link_failed", "runtime_failed", "skipped", "unknown"]}
+        }
+      }
+    }
+  }
+}

--- a/research/numeric-render-semantics/schemas/render_mapping.schema.json
+++ b/research/numeric-render-semantics/schemas/render_mapping.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/HansBug/pyfcstm/research/numeric-render-semantics/schemas/render_mapping.schema.json",
+  "title": "Numeric render mapping snapshot",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "generator",
+    "repository",
+    "builtin_expr_styles",
+    "builtin_stmt_styles",
+    "templates",
+    "packaged_templates",
+    "renderer_helper_inventory",
+    "cxx_paths",
+    "runtime_semantics_notes",
+    "mapping_sha256"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "generated_at_utc": {"type": ["string", "null"]},
+    "mapping_sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "generator": {"type": "object", "required": ["tool", "research_path"]},
+    "repository": {"type": "object", "required": ["template_source_root", "packaged_template_root"]},
+    "builtin_expr_styles": {"type": "object", "required": ["styles"]},
+    "builtin_stmt_styles": {"type": "object", "required": ["styles"]},
+    "templates": {"type": "object"},
+    "packaged_templates": {"type": "object", "required": ["entries"]},
+    "renderer_helper_inventory": {"type": "array"},
+    "cxx_paths": {"type": "object", "required": ["builtin_cpp_style", "template_generated_paths"]},
+    "runtime_semantics_notes": {"type": "object"}
+  }
+}

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,31 @@
+"""
+Roadmap for repository maintenance tools.
+
+The :mod:`tools` package contains scripts that support packaging,
+maintenance, research, and release workflows around pyfcstm. These modules are
+kept outside :mod:`pyfcstm` so they can inspect the repository layout directly
+without becoming part of the runtime library API.
+
+.. list-table:: Tool areas
+   :header-rows: 1
+
+   * - Area
+     - Representative modules
+     - Responsibility
+   * - Template packaging
+     - :mod:`tools.package_templates`
+     - Build distributable built-in template archives.
+   * - Runtime inventories
+     - :mod:`tools.inventory_simulate_semantics`
+     - Summarize simulator and generated-runtime fixture coverage.
+   * - Numeric render-semantics research
+     - :mod:`tools.numeric_render_mapping`, :mod:`tools.numeric_render_probe`
+     - Capture renderer/template mappings and provide probe entry points for
+       cross-language numeric semantics research.
+
+Example::
+
+    >>> import tools
+    >>> tools.__name__
+    'tools'
+"""

--- a/tools/numeric_render_mapping.py
+++ b/tools/numeric_render_mapping.py
@@ -1,0 +1,1320 @@
+"""
+Build render-mapping snapshots for numeric semantics research.
+
+This module inspects the repository's production expression renderer,
+statement renderer, built-in template source directories, and packaged template
+metadata. The resulting JSON snapshot is the R0 input for the numeric
+render-semantics research line: later probe runners should consume this mapping
+instead of hand-copying assumptions about how FCSTM expressions are rendered.
+
+The module contains:
+
+* :func:`build_render_mapping` - Collect the in-memory mapping dictionary.
+* :func:`write_render_mapping` - Write a stable JSON snapshot to disk.
+* :func:`check_render_mapping` - Validate the research mapping contract.
+* :func:`main` - Command-line entry point used by maintainers and CI.
+
+Example::
+
+    >>> from tools.numeric_render_mapping import build_render_mapping
+    >>> mapping = build_render_mapping('.')
+    >>> mapping['schema_version']
+    1
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
+
+import yaml
+
+_REPO_ROOT_FOR_SCRIPT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT_FOR_SCRIPT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT_FOR_SCRIPT))
+
+_JSON_OBJECT = Dict[str, Any]
+_RESEARCH_PATH = "research/numeric-render-semantics"
+_TOOL_PATH = "tools/numeric_render_mapping.py"
+_SNAPSHOT_PATH = "%s/results/snapshots/render_mapping.json" % _RESEARCH_PATH
+
+
+def _builtin_expr_styles() -> Mapping[str, Mapping[str, Any]]:
+    """
+    Return built-in expression renderer styles.
+
+    The import is intentionally lazy so this script remains directly
+    executable from ``tools/`` while still allowing normal module imports.
+
+    :return: Built-in expression style mapping.
+    :rtype: Mapping[str, Mapping[str, Any]]
+
+    Example::
+
+        >>> 'python' in _builtin_expr_styles()
+        True
+    """
+    from pyfcstm.render.expr import _KNOWN_STYLES
+
+    return _KNOWN_STYLES
+
+
+def _builtin_expr_aliases() -> Mapping[str, str]:
+    """
+    Return built-in expression style aliases.
+
+    :return: Alias mapping.
+    :rtype: Mapping[str, str]
+
+    Example::
+
+        >>> _builtin_expr_aliases()['py']
+        'python'
+    """
+    from pyfcstm.render.expr import _STYLE_ALIASES
+
+    return _STYLE_ALIASES
+
+
+def _builtin_stmt_styles() -> Mapping[str, Mapping[str, Any]]:
+    """
+    Return built-in statement renderer styles.
+
+    :return: Built-in statement style mapping.
+    :rtype: Mapping[str, Mapping[str, Any]]
+
+    Example::
+
+        >>> _builtin_stmt_styles()['c']['base_lang']
+        'c'
+    """
+    from pyfcstm.render.statement import _KNOWN_STMT_STYLES
+
+    return _KNOWN_STMT_STYLES
+
+
+def _builtin_stmt_aliases() -> Mapping[str, str]:
+    """
+    Return built-in statement style aliases.
+
+    :return: Alias mapping.
+    :rtype: Mapping[str, str]
+
+    Example::
+
+        >>> _builtin_stmt_aliases()['c++']
+        'cpp'
+    """
+    from pyfcstm.render.statement import _STMT_STYLE_ALIASES
+
+    return _STMT_STYLE_ALIASES
+
+
+class MappingBuildError(RuntimeError):
+    """
+    Report an invalid repository layout during mapping construction.
+
+    :param message: Human-readable failure reason.
+    :type message: str
+
+    Example::
+
+        >>> raise MappingBuildError('missing templates directory')
+        Traceback (most recent call last):
+        ...
+        tools.numeric_render_mapping.MappingBuildError: missing templates directory
+    """
+
+
+def _as_repo_path(repo_root: Union[str, Path]) -> Path:
+    """
+    Normalize a repository root path.
+
+    :param repo_root: Repository root path supplied by a caller or CLI.
+    :type repo_root: Union[str, pathlib.Path]
+    :return: Absolute repository root path.
+    :rtype: pathlib.Path
+
+    Example::
+
+        >>> _as_repo_path('.').is_absolute()
+        True
+    """
+    return Path(repo_root).resolve()
+
+
+def _relpath(path: Path, repo_root: Path) -> str:
+    """
+    Return a POSIX-style path relative to the repository root.
+
+    :param path: File or directory path.
+    :type path: pathlib.Path
+    :param repo_root: Absolute repository root path.
+    :type repo_root: pathlib.Path
+    :return: POSIX relative path.
+    :rtype: str
+
+    Example::
+
+        >>> root = Path('/tmp/example')
+        >>> _relpath(root / 'a' / 'b.txt', root)
+        'a/b.txt'
+    """
+    return path.resolve().relative_to(repo_root).as_posix()
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    """
+    Return a SHA-256 digest for bytes.
+
+    :param payload: Bytes to hash.
+    :type payload: bytes
+    :return: Hex-encoded SHA-256 digest.
+    :rtype: str
+
+    Example::
+
+        >>> _sha256_bytes(b'fcstm')[:8]
+        '9d550fa8'
+    """
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    """
+    Return a SHA-256 digest for one file.
+
+    :param path: File path.
+    :type path: pathlib.Path
+    :return: Hex-encoded SHA-256 digest.
+    :rtype: str
+
+    Example::
+
+        >>> digest = _sha256_file(Path('pyfcstm/template/index.json'))
+        >>> len(digest)
+        64
+    """
+    return _sha256_bytes(path.read_bytes())
+
+
+def _iter_source_files(root: Path) -> Iterable[Path]:
+    """
+    Yield source files under a directory in deterministic order.
+
+    :param root: Directory to walk.
+    :type root: pathlib.Path
+    :return: Iterator of file paths.
+    :rtype: Iterable[pathlib.Path]
+
+    Example::
+
+        >>> any(path.name == 'config.yaml' for path in _iter_source_files(Path('templates/python')))
+        True
+    """
+    for current_root, dirs, files in os.walk(str(root)):
+        dirs[:] = sorted(item for item in dirs if item != "__pycache__")
+        for file_name in sorted(files):
+            yield Path(current_root) / file_name
+
+
+def _tree_digest(root: Path) -> _JSON_OBJECT:
+    """
+    Build a stable digest for a directory tree.
+
+    Symlink targets are included as metadata and the resolved file payload is
+    included when the symlink points to a regular file. This keeps C++ wrapper
+    templates honest: their checked-in symlinks and reused C template payloads
+    are both represented.
+
+    :param root: Directory to hash.
+    :type root: pathlib.Path
+    :return: Digest metadata with a file count and SHA-256 digest.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> digest = _tree_digest(Path('templates/python'))
+        >>> digest['file_count'] > 0
+        True
+    """
+    hasher = hashlib.sha256()
+    file_count = 0
+    for file_path in _iter_source_files(root):
+        rel_file = file_path.relative_to(root).as_posix()
+        hasher.update(rel_file.encode("utf-8"))
+        hasher.update(b"\0")
+        if file_path.is_symlink():
+            link_target = os.readlink(str(file_path)).replace(os.sep, "/")
+            hasher.update(b"symlink\0")
+            hasher.update(link_target.encode("utf-8"))
+            hasher.update(b"\0")
+        else:
+            hasher.update(b"file\0")
+        hasher.update(file_path.read_bytes())
+        hasher.update(b"\0")
+        file_count += 1
+    return {"sha256": hasher.hexdigest(), "file_count": file_count}
+
+
+def _canonical_json(data: _JSON_OBJECT) -> bytes:
+    """
+    Serialize JSON data for stable digesting.
+
+    :param data: JSON-compatible object.
+    :type data: Dict[str, Any]
+    :return: Canonical UTF-8 JSON bytes.
+    :rtype: bytes
+
+    Example::
+
+        >>> _canonical_json({'b': 1, 'a': 2}).decode('utf-8')
+        '{"a":2,"b":1}'
+    """
+    return json.dumps(
+        data, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+
+
+def _copy_mapping(mapping: Mapping[str, Any]) -> _JSON_OBJECT:
+    """
+    Deep-copy a renderer mapping into JSON-compatible data.
+
+    :param mapping: Renderer style mapping.
+    :type mapping: Mapping[str, Any]
+    :return: JSON-compatible copy.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> copied = _copy_mapping({'x': {'y': 1}})
+        >>> copied == {'x': {'y': 1}}
+        True
+    """
+    return copy.deepcopy(dict(mapping))
+
+
+def _load_yaml_mapping(config_path: Path) -> _JSON_OBJECT:
+    """
+    Load a YAML file whose root must be a mapping.
+
+    :param config_path: YAML file path.
+    :type config_path: pathlib.Path
+    :return: YAML root mapping.
+    :rtype: Dict[str, Any]
+    :raises MappingBuildError: If the YAML root is not a mapping.
+    :raises yaml.YAMLError: If the YAML parser rejects the file.
+
+    Example::
+
+        >>> config = _load_yaml_mapping(Path('templates/python/config.yaml'))
+        >>> 'expr_styles' in config
+        True
+    """
+    with config_path.open("r", encoding="utf-8") as f:
+        loaded = yaml.safe_load(f)
+    if not isinstance(loaded, dict):
+        raise MappingBuildError("YAML root in %s must be a mapping." % config_path)
+    return loaded
+
+
+def _split_style(style_config: Mapping[str, Any]) -> _JSON_OBJECT:
+    """
+    Split a renderer style into base language and overrides.
+
+    :param style_config: Style configuration from a template ``config.yaml``.
+    :type style_config: Mapping[str, Any]
+    :return: Split style representation.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> _split_style({'base_lang': 'python', 'Name': 'x'})
+        {'base_lang': 'python', 'overrides': {'Name': 'x'}}
+    """
+    base_lang = style_config.get("base_lang")
+    overrides = {
+        key: copy.deepcopy(value)
+        for key, value in sorted(style_config.items())
+        if key != "base_lang"
+    }
+    return {"base_lang": base_lang, "overrides": overrides}
+
+
+def _split_stmt_style(style_config: Mapping[str, Any]) -> _JSON_OBJECT:
+    """
+    Split a statement style into base fields and expression overrides.
+
+    :param style_config: Statement style configuration from ``config.yaml``.
+    :type style_config: Mapping[str, Any]
+    :return: Split statement style representation.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> style = _split_stmt_style({'base_lang': 'python', 'expr_templates': {'Name': 'x'}})
+        >>> style['expr_templates']
+        {'Name': 'x'}
+    """
+    result = _split_style(style_config)
+    overrides = result["overrides"]
+    expr_templates = copy.deepcopy(overrides.pop("expr_templates", {}) or {})
+    result["stmt_overrides"] = overrides
+    result["expr_templates"] = expr_templates
+    return result
+
+
+def _classify_template_files(
+    template_dir: Path, repo_root: Path
+) -> Tuple[List[str], List[str]]:
+    """
+    Return all template files and generated-artifact template files.
+
+    :param template_dir: One built-in template source directory.
+    :type template_dir: pathlib.Path
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: Tuple of all files and generated artifact templates.
+    :rtype: Tuple[List[str], List[str]]
+
+    Example::
+
+        >>> files, artifacts = _classify_template_files(Path('templates/python'), Path('.').resolve())
+        >>> 'config.yaml' in files and any(item.endswith('.j2') for item in artifacts)
+        True
+    """
+    files = []
+    generated_artifacts = []
+    for file_path in _iter_source_files(template_dir):
+        rel_from_template = file_path.relative_to(template_dir).as_posix()
+        files.append(rel_from_template)
+        if file_path.suffix == ".j2" and not rel_from_template.startswith("README"):
+            generated_artifacts.append(_relpath(file_path, repo_root))
+    return sorted(files), sorted(generated_artifacts)
+
+
+def _collect_template_config(template_dir: Path, repo_root: Path) -> _JSON_OBJECT:
+    """
+    Collect mapping metadata for one repository-source built-in template.
+
+    :param template_dir: Template source directory.
+    :type template_dir: pathlib.Path
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: Template mapping metadata.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> info = _collect_template_config(Path('templates/python'), Path('.').resolve())
+        >>> info['expr_styles']['python_expr']['base_lang']
+        'python'
+    """
+    config_path = template_dir / "config.yaml"
+    if not config_path.exists():
+        raise MappingBuildError("Missing template config: %s" % config_path)
+    config = _load_yaml_mapping(config_path)
+    files, generated_artifacts = _classify_template_files(template_dir, repo_root)
+    expr_styles = {
+        key: _split_style(value)
+        for key, value in sorted((config.get("expr_styles") or {}).items())
+    }
+    stmt_styles = {
+        key: _split_stmt_style(value)
+        for key, value in sorted((config.get("stmt_styles") or {}).items())
+    }
+    return {
+        "name": template_dir.name,
+        "path": _relpath(template_dir, repo_root),
+        "config_path": _relpath(config_path, repo_root),
+        "source_digest": _tree_digest(template_dir),
+        "files": files,
+        "expr_styles": expr_styles,
+        "stmt_styles": stmt_styles,
+        "generated_artifacts": generated_artifacts,
+        "ignored_static_files": sorted(config.get("ignores") or []),
+    }
+
+
+def _collect_templates(repo_root: Path) -> _JSON_OBJECT:
+    """
+    Collect repository-source built-in template metadata.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: Mapping keyed by template name.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> templates = _collect_templates(Path('.').resolve())
+        >>> 'python' in templates
+        True
+    """
+    templates_root = repo_root / "templates"
+    if not templates_root.is_dir():
+        raise MappingBuildError("Missing templates directory: %s" % templates_root)
+    templates = {}
+    for item in sorted(templates_root.iterdir()):
+        if item.is_dir() and not item.name.startswith("."):
+            templates[item.name] = _collect_template_config(item, repo_root)
+    return templates
+
+
+def _packaged_sync_status(
+    name: Optional[str], archive_declared: bool, source_exists: bool
+) -> str:
+    """
+    Classify packaged-template availability against repository source.
+
+    :param name: Template name from ``index.json``.
+    :type name: Optional[str]
+    :param archive_declared: Whether ``index.json`` declares an archive.
+    :type archive_declared: bool
+    :param source_exists: Whether the repository-source template exists.
+    :type source_exists: bool
+    :return: Human-readable sync status.
+    :rtype: str
+
+    Example::
+
+        >>> _packaged_sync_status('python', True, True)
+        'source-and-archive-declared'
+    """
+    if not name:
+        return "missing-template-name"
+    if source_exists and archive_declared:
+        return "source-and-archive-declared"
+    if source_exists and not archive_declared:
+        return "source-present-archive-undeclared"
+    if archive_declared and not source_exists:
+        return "archive-declared-source-missing"
+    return "index-entry-without-source-or-archive"
+
+
+def _collect_packaged_templates(
+    repo_root: Path, source_templates: Mapping[str, Any]
+) -> _JSON_OBJECT:
+    """
+    Collect packaged built-in template index and archive metadata.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :param source_templates: Repository-source template metadata keyed by name.
+    :type source_templates: Mapping[str, Any]
+    :return: Packaged template metadata.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> packaged = _collect_packaged_templates(Path('.').resolve(), _collect_templates(Path('.').resolve()))
+        >>> 'entries' in packaged
+        True
+    """
+    template_pkg = repo_root / "pyfcstm" / "template"
+    index_path = template_pkg / "index.json"
+    if not index_path.exists():
+        return {
+            "index_path": _relpath(index_path, repo_root),
+            "index_exists": False,
+            "entries": [],
+        }
+
+    index_data = json.loads(index_path.read_text(encoding="utf-8"))
+    entries = []
+    for entry in sorted(
+        index_data.get("templates", []), key=lambda item: item.get("name", "")
+    ):
+        archive = entry.get("archive")
+        archive_path = template_pkg / archive if archive else None
+        archive_declared = archive_path is not None
+        archive_relpath = (
+            _relpath(archive_path, repo_root) if archive_path is not None else None
+        )
+        name = entry.get("name")
+        source_digest = None
+        source_exists = name in source_templates
+        if source_exists:
+            source_digest = source_templates[name]["source_digest"]
+        entries.append(
+            {
+                "name": name,
+                "language": entry.get("language"),
+                "archive": archive,
+                "archive_path": archive_relpath,
+                "archive_declared": archive_declared,
+                "archive_snapshot_policy": (
+                    "archive zip files are gitignored build outputs; the "
+                    "committed snapshot records index metadata and source "
+                    "digests instead of hashing local archive payloads"
+                ),
+                "root_dir": entry.get("root_dir"),
+                "source_digest": source_digest,
+                "source_archive_sync_status": _packaged_sync_status(
+                    name,
+                    archive_declared,
+                    source_exists,
+                ),
+                "metadata": copy.deepcopy(entry),
+            }
+        )
+
+    return {
+        "index_path": _relpath(index_path, repo_root),
+        "index_exists": True,
+        "index_sha256": _sha256_file(index_path),
+        "entries": entries,
+    }
+
+
+def _collect_builtin_expr_styles() -> _JSON_OBJECT:
+    """
+    Collect built-in expression renderer styles.
+
+    :return: Built-in expression style metadata.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> styles = _collect_builtin_expr_styles()
+        >>> styles['styles']['python']['templates']['UFunc(round)']
+        'round({{ node.expr | expr_render }})'
+    """
+    return {
+        "aliases": dict(sorted(_builtin_expr_aliases().items())),
+        "styles": {
+            name: {"base_lang": name, "templates": _copy_mapping(style)}
+            for name, style in sorted(_builtin_expr_styles().items())
+        },
+    }
+
+
+def _collect_builtin_stmt_styles() -> _JSON_OBJECT:
+    """
+    Collect built-in statement renderer styles.
+
+    :return: Built-in statement style metadata.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> styles = _collect_builtin_stmt_styles()
+        >>> styles['styles']['c']['base_lang']
+        'c'
+    """
+    return {
+        "aliases": dict(sorted(_builtin_stmt_aliases().items())),
+        "styles": {
+            name: _copy_mapping(style)
+            for name, style in sorted(_builtin_stmt_styles().items())
+        },
+    }
+
+
+def _collect_renderer_helper_inventory() -> List[_JSON_OBJECT]:
+    """
+    Return helper functions that affect numeric render/probe semantics.
+
+    :return: Helper inventory entries.
+    :rtype: List[Dict[str, Any]]
+
+    Example::
+
+        >>> any(item['name'] == 'go_abs_expr' for item in _collect_renderer_helper_inventory())
+        True
+    """
+    return [
+        {
+            "name": "py_condition_operand",
+            "layer": "builtin expression renderer",
+            "module": "pyfcstm.render.expr",
+            "purpose": "Parenthesizes Python condition-valued comparison operands.",
+        },
+        {
+            "name": "go_expr_type",
+            "layer": "builtin expression renderer",
+            "module": "pyfcstm.render.expr",
+            "purpose": "Chooses the Go conditional-expression closure return type.",
+        },
+        {
+            "name": "go_abs_expr",
+            "layer": "builtin expression renderer",
+            "module": "pyfcstm.render.expr",
+            "purpose": "Chooses integer or floating Go abs rendering based on inferred DSL type.",
+        },
+        {
+            "name": "python_round_to_z3",
+            "layer": "solver helper",
+            "module": "pyfcstm.solver.expr",
+            "purpose": "Encodes Python half-even single-argument round semantics for Z3.",
+        },
+        {
+            "name": "render_c_action_body",
+            "layer": "C runtime template helper",
+            "module": "pyfcstm.render.c_runtime",
+            "purpose": "Renders fallible generated C action bodies with runtime diagnostics.",
+        },
+        {
+            "name": "render_c_condition_body",
+            "layer": "C runtime template helper",
+            "module": "pyfcstm.render.c_runtime",
+            "purpose": "Renders fallible generated C transition-guard condition bodies.",
+        },
+        {
+            "name": "_sign",
+            "layer": "Python generated runtime helper",
+            "module": "templates/python/machine.py.j2",
+            "purpose": "Implements sign for Python generated runtime expression paths.",
+        },
+        {
+            "name": "_s",
+            "layer": "Python generated runtime helper alias",
+            "module": "templates/python/machine.py.j2",
+            "purpose": "Local alias used by python_runtime statement expr_templates for sign.",
+        },
+    ]
+
+
+def _collect_cxx_paths(templates: Mapping[str, Any]) -> _JSON_OBJECT:
+    """
+    Collect the two distinct C++ render paths required by issue #280.
+
+    :param templates: Repository-source template metadata keyed by name.
+    :type templates: Mapping[str, Any]
+    :return: C++ path metadata.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> paths = _collect_cxx_paths(_collect_templates(Path('.').resolve()))
+        >>> paths['builtin_cpp_style']['base_lang']
+        'cpp'
+    """
+    return {
+        "builtin_cpp_style": {
+            "source": "pyfcstm.render.expr._CPP_STYLE",
+            "base_lang": "cpp",
+            "templates": _copy_mapping(_builtin_expr_styles()["cpp"]),
+            "notes": [
+                "Standalone renderer path emits std::* expressions such as std::pow.",
+            ],
+        },
+        "template_generated_paths": [
+            {
+                "template": name,
+                "source": info["config_path"],
+                "expr_styles": copy.deepcopy(info["expr_styles"]),
+                "stmt_styles": copy.deepcopy(info["stmt_styles"]),
+                "generated_artifacts": list(info["generated_artifacts"]),
+                "notes": [
+                    "Current C++ wrapper template path reuses C-style expression configuration via base_lang: c.",
+                ],
+            }
+            for name, info in sorted(templates.items())
+            if name in {"cpp", "cpp_poll"}
+        ],
+    }
+
+
+def _runtime_semantics_notes() -> _JSON_OBJECT:
+    """
+    Return hand-authored runtime semantic notes required by R0.
+
+    :return: Runtime semantic note mapping.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> _runtime_semantics_notes()['bitwise_not']['operator']
+        '~'
+    """
+    return {
+        "bitwise_not": {
+            "operator": "~",
+            "current_dsl_numeric_unary_rule": "PLUS | MINUS",
+            "status": "not inferred from runtime; current parser grammar does not accept numeric unary '~'",
+            "reason": (
+                "Issue #280 requires the R0 inventory to record '~' explicitly so later "
+                "solver/template work does not guess from Z3 or C semantics."
+            ),
+        }
+    }
+
+
+def _attach_mapping_digest(mapping: _JSON_OBJECT) -> _JSON_OBJECT:
+    """
+    Attach a stable digest to a mapping payload.
+
+    :param mapping: Mapping payload without ``mapping_sha256``.
+    :type mapping: Dict[str, Any]
+    :return: Mapping payload with ``mapping_sha256``.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> payload = _attach_mapping_digest({'schema_version': 1})
+        >>> len(payload['mapping_sha256'])
+        64
+    """
+    payload = copy.deepcopy(mapping)
+    payload.pop("mapping_sha256", None)
+    payload["mapping_sha256"] = _sha256_bytes(_canonical_json(payload))
+    return payload
+
+
+def _load_snapshot_mapping(repo_root: Path) -> _JSON_OBJECT:
+    """
+    Load the committed render-mapping snapshot.
+
+    The snapshot is intentionally version-controlled as a small research
+    artifact. Loading it during ``--check`` makes drift between the tool and the
+    submitted JSON visible without adding files under ``test/``.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: Committed snapshot mapping.
+    :rtype: Dict[str, Any]
+    :raises MappingBuildError: If the snapshot is missing or is not a JSON object.
+    :raises json.JSONDecodeError: If the snapshot is not valid JSON.
+
+    Example::
+
+        >>> snapshot = _load_snapshot_mapping(Path('.').resolve())
+        >>> snapshot['schema_version']
+        1
+    """
+    snapshot_path = repo_root / _SNAPSHOT_PATH
+    if not snapshot_path.exists():
+        raise MappingBuildError("Missing committed snapshot: %s" % snapshot_path)
+    snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    if not isinstance(snapshot, dict):
+        raise MappingBuildError(
+            "Committed snapshot must be a JSON object: %s" % snapshot_path
+        )
+    return snapshot
+
+
+def _format_json_path(path: Tuple[Union[str, int], ...]) -> str:
+    """
+    Format a nested JSON path for diagnostics.
+
+    :param path: Nested dictionary keys and list indexes.
+    :type path: Tuple[Union[str, int], ...]
+    :return: Human-readable JSON path.
+    :rtype: str
+
+    Example::
+
+        >>> _format_json_path(('templates', 'python', 'files', 0))
+        'templates.python.files[0]'
+    """
+    result = []
+    for item in path:
+        if isinstance(item, int):
+            if result:
+                result[-1] = "%s[%d]" % (result[-1], item)
+            else:
+                result.append("[%d]" % item)
+        else:
+            result.append(item)
+    return ".".join(result) if result else "<root>"
+
+
+def _first_json_differences(
+    expected: Any, actual: Any, path: Tuple[Union[str, int], ...] = (), limit: int = 5
+) -> List[str]:
+    """
+    Return the first nested differences between two JSON-compatible values.
+
+    :param expected: Expected value.
+    :type expected: Any
+    :param actual: Actual value.
+    :type actual: Any
+    :param path: Current nested JSON path, defaults to the root path.
+    :type path: Tuple[Union[str, int], ...], optional
+    :param limit: Maximum number of diagnostics to return, defaults to ``5``.
+    :type limit: int, optional
+    :return: Human-readable difference diagnostics.
+    :rtype: List[str]
+
+    Example::
+
+        >>> _first_json_differences({'a': [1]}, {'a': [2]})
+        ['snapshot mismatch at a[0]: expected 1, got 2']
+    """
+    if limit <= 0:
+        return []
+    if type(expected) is not type(actual):
+        return [
+            "snapshot mismatch at %s: expected %s, got %s"
+            % (_format_json_path(path), type(expected).__name__, type(actual).__name__)
+        ]
+    if isinstance(expected, dict):
+        diagnostics = []
+        expected_keys = set(expected)
+        actual_keys = set(actual)
+        for key in sorted(expected_keys - actual_keys):
+            diagnostics.append(
+                "snapshot missing key at %s" % _format_json_path(path + (key,))
+            )
+            if len(diagnostics) >= limit:
+                return diagnostics
+        for key in sorted(actual_keys - expected_keys):
+            diagnostics.append(
+                "snapshot extra key at %s" % _format_json_path(path + (key,))
+            )
+            if len(diagnostics) >= limit:
+                return diagnostics
+        for key in sorted(expected_keys & actual_keys):
+            diagnostics.extend(
+                _first_json_differences(
+                    expected[key], actual[key], path + (key,), limit - len(diagnostics)
+                )
+            )
+            if len(diagnostics) >= limit:
+                return diagnostics
+        return diagnostics
+    if isinstance(expected, list):
+        diagnostics = []
+        if len(expected) != len(actual):
+            diagnostics.append(
+                "snapshot mismatch at %s: expected list length %d, got %d"
+                % (_format_json_path(path), len(expected), len(actual))
+            )
+            if len(diagnostics) >= limit:
+                return diagnostics
+        for index, (expected_item, actual_item) in enumerate(zip(expected, actual)):
+            diagnostics.extend(
+                _first_json_differences(
+                    expected_item,
+                    actual_item,
+                    path + (index,),
+                    limit - len(diagnostics),
+                )
+            )
+            if len(diagnostics) >= limit:
+                return diagnostics
+        return diagnostics
+    if expected != actual:
+        return [
+            "snapshot mismatch at %s: expected %r, got %r"
+            % (_format_json_path(path), expected, actual)
+        ]
+    return []
+
+
+def _validate_snapshot_matches(
+    mapping: Mapping[str, Any], repo_root: Path
+) -> List[str]:
+    """
+    Validate that the committed snapshot matches the live mapping.
+
+    :param mapping: Fresh mapping payload built from repository sources.
+    :type mapping: Mapping[str, Any]
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: Snapshot drift diagnostics.
+    :rtype: List[str]
+
+    Example::
+
+        >>> result = _validate_snapshot_matches(build_render_mapping('.'), Path('.').resolve())
+        >>> result
+        []
+    """
+    snapshot = _load_snapshot_mapping(repo_root)
+    return _first_json_differences(dict(mapping), snapshot)
+
+
+def build_render_mapping(repo_root: Union[str, Path] = ".") -> _JSON_OBJECT:
+    """
+    Build the numeric render-semantics mapping snapshot.
+
+    :param repo_root: Repository root path, defaults to the current directory.
+    :type repo_root: Union[str, pathlib.Path], optional
+    :return: JSON-compatible mapping snapshot.
+    :rtype: Dict[str, Any]
+    :raises MappingBuildError: If required repository directories are missing.
+
+    Example::
+
+        >>> mapping = build_render_mapping('.')
+        >>> 'python' in mapping['templates']
+        True
+    """
+    root = _as_repo_path(repo_root)
+    templates = _collect_templates(root)
+    mapping = {
+        "schema_version": 1,
+        "generated_at_utc": None,
+        "generator": {
+            "tool": _TOOL_PATH,
+            "research_path": _RESEARCH_PATH,
+            "provenance": "stable snapshot; repository identity is captured by source and packaged-template digests",
+        },
+        "repository": {
+            "root": ".",
+            "template_source_root": "templates",
+            "packaged_template_root": "pyfcstm/template",
+        },
+        "builtin_expr_styles": _collect_builtin_expr_styles(),
+        "builtin_stmt_styles": _collect_builtin_stmt_styles(),
+        "templates": templates,
+        "packaged_templates": _collect_packaged_templates(root, templates),
+        "renderer_helper_inventory": _collect_renderer_helper_inventory(),
+        "cxx_paths": _collect_cxx_paths(templates),
+        "runtime_semantics_notes": _runtime_semantics_notes(),
+    }
+    return _attach_mapping_digest(mapping)
+
+
+def _require_mapping_path(
+    root: Mapping[str, Any], path: Iterable[Union[str, int]], expected: Any
+) -> Optional[str]:
+    """
+    Validate one nested mapping path.
+
+    :param root: Root mapping to inspect.
+    :type root: Mapping[str, Any]
+    :param path: Nested keys or indexes to traverse.
+    :type path: Iterable[Union[str, int]]
+    :param expected: Expected value at the nested path.
+    :type expected: Any
+    :return: ``None`` when the value matches, otherwise a diagnostic string.
+    :rtype: Optional[str]
+
+    Example::
+
+        >>> _require_mapping_path({'a': {'b': 1}}, ['a', 'b'], 1) is None
+        True
+    """
+    current: Any = root
+    visited = []
+    for item in path:
+        visited.append(str(item))
+        if isinstance(item, int):
+            if not isinstance(current, list) or item >= len(current):
+                return "missing mapping path: %s" % ".".join(visited)
+            current = current[item]
+        else:
+            if not isinstance(current, dict) or item not in current:
+                return "missing mapping path: %s" % ".".join(visited)
+            current = current[item]
+    if current != expected:
+        return "unexpected value at %s: expected %r, got %r" % (
+            ".".join(str(item) for item in path),
+            expected,
+            current,
+        )
+    return None
+
+
+def _validate_render_mapping(mapping: Mapping[str, Any]) -> List[str]:
+    """
+    Validate the R0 mapping contract without using repository unit tests.
+
+    The research PR keeps validation close to the tool instead of adding files
+    under ``test/``. The checks intentionally cover production renderer facts
+    that later probe PRs depend on: template overrides, C++ dual paths,
+    packaged-template digests, helper inventory, and semantic notes.
+
+    :param mapping: Mapping payload returned by :func:`build_render_mapping`.
+    :type mapping: Mapping[str, Any]
+    :return: Human-readable validation diagnostics.
+    :rtype: List[str]
+
+    Example::
+
+        >>> _validate_render_mapping({'schema_version': 1})
+        ['missing mapping path: generator.tool', 'missing mapping path: builtin_expr_styles.styles.cpp.templates.UFunc', 'missing mapping path: builtin_expr_styles.styles.c.templates.BinaryOp(**)', 'missing mapping path: builtin_stmt_styles.styles.go.base_lang', 'missing template: python', 'missing template: cpp', 'missing C++ template path: cpp', 'missing C++ template path: cpp_poll', 'packaged template index is missing', 'missing helper inventory entry: go_abs_expr', 'missing helper inventory entry: python_round_to_z3', 'missing helper inventory entry: render_c_action_body', 'missing helper inventory entry: _sign', 'missing mapping path: runtime_semantics_notes.bitwise_not.operator']
+    """
+    errors = []
+    expected_paths = [
+        (["generator", "tool"], _TOOL_PATH),
+        (
+            ["builtin_expr_styles", "styles", "cpp", "templates", "UFunc"],
+            "std::{{ node.func }}({{ node.expr | expr_render }})",
+        ),
+        (
+            ["builtin_expr_styles", "styles", "c", "templates", "BinaryOp(**)"],
+            "pow({{ node.expr1 | expr_render }}, {{ node.expr2 | expr_render }})",
+        ),
+        (["builtin_stmt_styles", "styles", "go", "base_lang"], "go"),
+    ]
+    for path, expected in expected_paths:
+        error = _require_mapping_path(mapping, path, expected)
+        if error:
+            errors.append(error)
+
+    templates = mapping.get("templates", {})
+    if not isinstance(templates, dict):
+        errors.append("templates must be a mapping")
+        templates = {}
+
+    python_template = templates.get("python")
+    if not isinstance(python_template, dict):
+        errors.append("missing template: python")
+    else:
+        python_checks = [
+            (
+                ["expr_styles", "python_expr", "base_lang"],
+                "python",
+            ),
+            (
+                ["expr_styles", "python_expr", "overrides", "UFunc(sign)"],
+                "self._sign({{ node.expr | expr_render }})",
+            ),
+            (
+                ["expr_styles", "python_scope_expr", "overrides", "Name"],
+                "scope[{{ node.name | tojson }}]",
+            ),
+            (
+                ["stmt_styles", "python_runtime", "expr_templates", "UFunc(sign)"],
+                "_s({{ node.expr | expr_render }})",
+            ),
+        ]
+        for path, expected in python_checks:
+            error = _require_mapping_path(python_template, path, expected)
+            if error:
+                errors.append("python template: %s" % error)
+
+    cpp_template = templates.get("cpp")
+    if not isinstance(cpp_template, dict):
+        errors.append("missing template: cpp")
+    else:
+        if not cpp_template.get("source_digest", {}).get("sha256"):
+            errors.append("cpp template source digest is missing")
+        if not cpp_template.get("generated_artifacts"):
+            errors.append("cpp template generated artifacts are missing")
+        if "config.yaml" not in cpp_template.get("files", []):
+            errors.append("cpp template config.yaml is missing from file inventory")
+
+    cxx_paths = mapping.get("cxx_paths", {})
+    if isinstance(cxx_paths, dict):
+        builtin_cpp = cxx_paths.get("builtin_cpp_style", {})
+        if builtin_cpp.get("base_lang") != "cpp":
+            errors.append("builtin C++ style base_lang must be cpp")
+        pow_template = builtin_cpp.get("templates", {}).get("BinaryOp(**)")
+        if not isinstance(pow_template, str) or not pow_template.startswith(
+            "std::pow("
+        ):
+            errors.append("builtin C++ power template must use std::pow")
+        template_paths = {
+            item.get("template"): item
+            for item in cxx_paths.get("template_generated_paths", [])
+            if isinstance(item, dict)
+        }
+        for template_name in ["cpp", "cpp_poll"]:
+            template_path = template_paths.get(template_name)
+            if not template_path:
+                errors.append("missing C++ template path: %s" % template_name)
+                continue
+            base_lang = (
+                template_path.get("expr_styles", {})
+                .get("c_scope_expr", {})
+                .get("base_lang")
+            )
+            if base_lang != "c":
+                errors.append(
+                    "C++ template %s c_scope_expr must inherit C base_lang"
+                    % template_name
+                )
+    else:
+        errors.append("cxx_paths must be a mapping")
+
+    packaged = mapping.get("packaged_templates", {})
+    packaged_entries = packaged.get("entries") if isinstance(packaged, dict) else None
+    allowed_statuses = {
+        "source-and-archive-declared",
+        "source-present-archive-undeclared",
+        "archive-declared-source-missing",
+        "index-entry-without-source-or-archive",
+        "missing-template-name",
+    }
+    if not isinstance(packaged_entries, list):
+        errors.append("packaged template index is missing")
+    else:
+        packaged_names = {
+            entry.get("name") for entry in packaged_entries if isinstance(entry, dict)
+        }
+        required_names = {"c", "cpp", "cpp_poll", "python"}
+        missing = sorted(required_names - packaged_names)
+        if missing:
+            errors.append("missing packaged template entries: %s" % ", ".join(missing))
+        for entry in packaged_entries:
+            if not isinstance(entry, dict):
+                errors.append("packaged template entry must be a mapping")
+                continue
+            if "archive_declared" not in entry:
+                errors.append(
+                    "packaged template %r missing archive_declared" % entry.get("name")
+                )
+            if "archive_snapshot_policy" not in entry:
+                errors.append(
+                    "packaged template %r missing archive_snapshot_policy"
+                    % entry.get("name")
+                )
+            if "source_digest" not in entry:
+                errors.append(
+                    "packaged template %r missing source_digest" % entry.get("name")
+                )
+            status = entry.get("source_archive_sync_status")
+            if status not in allowed_statuses:
+                errors.append(
+                    "packaged template %r has invalid sync status %r"
+                    % (entry.get("name"), status)
+                )
+
+    helpers = mapping.get("renderer_helper_inventory", [])
+    helper_names = {item.get("name") for item in helpers if isinstance(item, dict)}
+    for required in [
+        "go_abs_expr",
+        "python_round_to_z3",
+        "render_c_action_body",
+        "_sign",
+    ]:
+        if required not in helper_names:
+            errors.append("missing helper inventory entry: %s" % required)
+
+    error = _require_mapping_path(
+        mapping, ["runtime_semantics_notes", "bitwise_not", "operator"], "~"
+    )
+    if error:
+        errors.append(error)
+
+    return errors
+
+
+def check_render_mapping(repo_root: Union[str, Path] = ".") -> _JSON_OBJECT:
+    """
+    Build and validate the R0 mapping snapshot.
+
+    This is the PR-1 self-check entry point. It validates both the live
+    renderer/template contract and the committed snapshot without adding
+    anything under the repository ``test/`` tree.
+
+    :param repo_root: Repository root path, defaults to the current directory.
+    :type repo_root: Union[str, pathlib.Path], optional
+    :return: Check result with ``ok``, ``errors`` and ``mapping_sha256`` fields.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> result = check_render_mapping('.')
+        >>> result['ok']
+        True
+    """
+    root = _as_repo_path(repo_root)
+    mapping = build_render_mapping(root)
+    errors = _validate_render_mapping(mapping)
+    errors.extend(_validate_snapshot_matches(mapping, root))
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "mapping_sha256": mapping["mapping_sha256"],
+        "schema_version": mapping["schema_version"],
+    }
+
+
+def write_render_mapping(
+    output_path: Union[str, Path], repo_root: Union[str, Path] = "."
+) -> _JSON_OBJECT:
+    """
+    Write the render mapping snapshot as stable JSON.
+
+    :param output_path: Destination JSON file path.
+    :type output_path: Union[str, pathlib.Path]
+    :param repo_root: Repository root path, defaults to the current directory.
+    :type repo_root: Union[str, pathlib.Path], optional
+    :return: Mapping snapshot that was written.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> import tempfile
+        >>> with tempfile.TemporaryDirectory() as tmp:
+        ...     path = Path(tmp) / 'mapping.json'
+        ...     mapping = write_render_mapping(path, '.')
+        ...     path.exists() and mapping['schema_version'] == 1
+        True
+    """
+    output = Path(output_path)
+    mapping = build_render_mapping(repo_root)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(mapping, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return mapping
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """
+    Build the command-line argument parser.
+
+    :return: Configured argument parser.
+    :rtype: argparse.ArgumentParser
+
+    Example::
+
+        >>> parser = _build_arg_parser()
+        >>> parser.prog
+        'numeric_render_mapping.py'
+    """
+    parser = argparse.ArgumentParser(
+        prog="numeric_render_mapping.py",
+        description="Build a JSON mapping of FCSTM numeric expression render paths.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root to inspect, defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Destination JSON path. When omitted, JSON is printed to stdout.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate the R0 research mapping contract without using test/.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """
+    Run the render-mapping command-line interface.
+
+    :param argv: Optional argument vector excluding the executable name.
+    :type argv: Optional[List[str]], optional
+    :return: Process exit status.
+    :rtype: int
+
+    Example::
+
+        >>> main(['--repo-root', '.', '--output', '/tmp/pyfcstm-render-mapping-example.json'])
+        0
+    """
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.check:
+        result = check_render_mapping(args.repo_root)
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0 if result["ok"] else 1
+    if args.output:
+        write_render_mapping(args.output, repo_root=args.repo_root)
+    else:
+        mapping = build_render_mapping(args.repo_root)
+        print(json.dumps(mapping, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/numeric_render_mapping.py
+++ b/tools/numeric_render_mapping.py
@@ -3,8 +3,8 @@ Build render-mapping snapshots for numeric semantics research.
 
 This module inspects the repository's production expression renderer,
 statement renderer, built-in template source directories, and packaged template
-metadata. The resulting JSON snapshot is the R0 input for the numeric
-render-semantics research line: later probe runners should consume this mapping
+metadata. The resulting JSON snapshot is the baseline input for the numeric
+render-semantics research line: probe runners should consume this mapping
 instead of hand-copying assumptions about how FCSTM expressions are rendered.
 
 The module contains:
@@ -683,7 +683,7 @@ def _collect_renderer_helper_inventory() -> List[_JSON_OBJECT]:
 
 def _collect_cxx_paths(templates: Mapping[str, Any]) -> _JSON_OBJECT:
     """
-    Collect the two distinct C++ render paths required by issue #280.
+    Collect the two distinct C++ render paths used by the mapping snapshot.
 
     :param templates: Repository-source template metadata keyed by name.
     :type templates: Mapping[str, Any]
@@ -724,7 +724,7 @@ def _collect_cxx_paths(templates: Mapping[str, Any]) -> _JSON_OBJECT:
 
 def _runtime_semantics_notes() -> _JSON_OBJECT:
     """
-    Return hand-authored runtime semantic notes required by R0.
+    Return hand-authored runtime semantic notes for mapping consumers.
 
     :return: Runtime semantic note mapping.
     :rtype: Dict[str, Any]
@@ -740,8 +740,8 @@ def _runtime_semantics_notes() -> _JSON_OBJECT:
             "current_dsl_numeric_unary_rule": "PLUS | MINUS",
             "status": "not inferred from runtime; current parser grammar does not accept numeric unary '~'",
             "reason": (
-                "Issue #280 requires the R0 inventory to record '~' explicitly so later "
-                "solver/template work does not guess from Z3 or C semantics."
+                "The mapping records '~' explicitly so solver and template work "
+                "does not guess from Z3 or C semantics."
             ),
         }
     }
@@ -1017,11 +1017,11 @@ def _require_mapping_path(
 
 def _validate_render_mapping(mapping: Mapping[str, Any]) -> List[str]:
     """
-    Validate the R0 mapping contract without using repository unit tests.
+    Validate the numeric render mapping contract without repository unit tests.
 
-    The research PR keeps validation close to the tool instead of adding files
-    under ``test/``. The checks intentionally cover production renderer facts
-    that later probe PRs depend on: template overrides, C++ dual paths,
+    The research tooling keeps validation close to the tool instead of adding
+    files under ``test/``. The checks intentionally cover production renderer
+    facts that probe runners depend on: template overrides, C++ dual paths,
     packaged-template digests, helper inventory, and semantic notes.
 
     :param mapping: Mapping payload returned by :func:`build_render_mapping`.
@@ -1193,11 +1193,11 @@ def _validate_render_mapping(mapping: Mapping[str, Any]) -> List[str]:
 
 def check_render_mapping(repo_root: Union[str, Path] = ".") -> _JSON_OBJECT:
     """
-    Build and validate the R0 mapping snapshot.
+    Build and validate the numeric render mapping snapshot.
 
-    This is the PR-1 self-check entry point. It validates both the live
-    renderer/template contract and the committed snapshot without adding
-    anything under the repository ``test/`` tree.
+    This self-check entry point validates both the live renderer/template
+    contract and the committed snapshot without adding anything under the
+    repository ``test/`` tree.
 
     :param repo_root: Repository root path, defaults to the current directory.
     :type repo_root: Union[str, pathlib.Path], optional
@@ -1283,7 +1283,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Validate the R0 research mapping contract without using test/.",
+        help="Validate the numeric render mapping contract without using test/.",
     )
     return parser
 

--- a/tools/numeric_render_probe.py
+++ b/tools/numeric_render_probe.py
@@ -1,10 +1,10 @@
 """
 Provide probe-entry stubs for numeric render-semantics research.
 
-PR-1 deliberately does not run native compilers or language runtimes. This
-module therefore exposes only an environment-report mode and a documented CLI
-surface that later PRs can extend with C/C++, Python/Z3, Java/Rust, Go, and
-JavaScript probe runners.
+The lightweight environment mode deliberately does not run native compilers or
+language runtimes. This module therefore exposes only an environment-report mode
+and a documented CLI surface that later work can extend with C/C++, Python/Z3,
+Java/Rust, Go, and JavaScript probe runners.
 
 The module contains:
 
@@ -89,7 +89,7 @@ def _command_version(path: str) -> Optional[str]:
         return None
     except subprocess.TimeoutExpired:
         # TimeoutExpired: version probes are best-effort and must not hang the
-        # PR-1 environment stub.
+        # lightweight environment stub.
         return None
     output = result.stdout.strip().splitlines()
     return output[0] if output else None
@@ -159,8 +159,8 @@ def build_environment_report(repo_root: Union[str, Path] = ".") -> _JSON_OBJECT:
         },
         "available_commands": [_probe_command(name) for name in _COMMANDS],
         "notes": [
-            "PR-1 env mode is inventory-only and does not compile or execute target-language probes.",
-            "Native runners are intentionally deferred to later sub PRs.",
+            "Environment mode is inventory-only and does not compile or execute target-language probes.",
+            "Native runners are intentionally deferred to dedicated probe work.",
         ],
     }
 
@@ -187,7 +187,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         nargs="?",
         default="env",
         choices=["env"],
-        help="Probe mode. PR-1 supports only 'env'.",
+        help="Probe mode. The current lightweight entry point supports only 'env'.",
     )
     parser.add_argument(
         "--repo-root",

--- a/tools/numeric_render_probe.py
+++ b/tools/numeric_render_probe.py
@@ -1,0 +1,232 @@
+"""
+Provide probe-entry stubs for numeric render-semantics research.
+
+PR-1 deliberately does not run native compilers or language runtimes. This
+module therefore exposes only an environment-report mode and a documented CLI
+surface that later PRs can extend with C/C++, Python/Z3, Java/Rust, Go, and
+JavaScript probe runners.
+
+The module contains:
+
+* :func:`build_environment_report` - Collect lightweight local environment data.
+* :func:`main` - Command-line entry point with an ``env`` subcommand.
+
+Example::
+
+    >>> from tools.numeric_render_probe import build_environment_report
+    >>> report = build_environment_report('.')
+    >>> report['native_runner_enabled']
+    False
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+
+_REPO_ROOT_FOR_SCRIPT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT_FOR_SCRIPT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT_FOR_SCRIPT))
+
+_JSON_OBJECT = Dict[str, Any]
+_COMMANDS = [
+    "python",
+    "git",
+    "cc",
+    "gcc",
+    "g++",
+    "clang",
+    "clang++",
+    "java",
+    "javac",
+    "rustc",
+    "cargo",
+    "go",
+    "node",
+    "npm",
+    "tsc",
+    "z3",
+]
+
+
+def _command_version(path: str) -> Optional[str]:
+    """
+    Return a short version string for an executable when available.
+
+    :param path: Executable path.
+    :type path: str
+    :return: First version-output line or ``None``.
+    :rtype: Optional[str]
+
+    Example::
+
+        >>> version = _command_version(sys.executable)
+        >>> version is None or isinstance(version, str)
+        True
+    """
+    args = [path, "--version"]
+    if os.path.basename(path).startswith("python"):
+        args = [path, "--version"]
+    try:
+        result = subprocess.run(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            timeout=5,
+            check=False,
+        )
+    except OSError:
+        # OSError: the executable disappeared or cannot be started after
+        # shutil.which located it; record absence instead of failing env mode.
+        return None
+    except subprocess.TimeoutExpired:
+        # TimeoutExpired: version probes are best-effort and must not hang the
+        # PR-1 environment stub.
+        return None
+    output = result.stdout.strip().splitlines()
+    return output[0] if output else None
+
+
+def _probe_command(name: str) -> _JSON_OBJECT:
+    """
+    Probe one optional command without invoking any workload.
+
+    :param name: Command name to locate.
+    :type name: str
+    :return: Command availability metadata.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> info = _probe_command('python')
+        >>> info['name']
+        'python'
+    """
+    path = shutil.which(name)
+    return {
+        "name": name,
+        "path": path,
+        "available": path is not None,
+        "version": _command_version(path) if path else None,
+    }
+
+
+def build_environment_report(repo_root: Union[str, Path] = ".") -> _JSON_OBJECT:
+    """
+    Build a lightweight environment report for future probe planning.
+
+    :param repo_root: Repository root path, defaults to the current directory.
+    :type repo_root: Union[str, pathlib.Path], optional
+    :return: JSON-compatible environment report.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> report = build_environment_report('.')
+        >>> report['mode']
+        'env'
+    """
+    root = Path(repo_root).resolve()
+    return {
+        "schema_version": 1,
+        "mode": "env",
+        "native_runner_enabled": False,
+        "repository": {
+            "root": str(root),
+            "research_path": "research/numeric-render-semantics",
+        },
+        "python": {
+            "executable": sys.executable,
+            "version": sys.version.split()[0],
+            "implementation": platform.python_implementation(),
+        },
+        "platform": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+        },
+        "resources": {
+            "cpu_count": os.cpu_count(),
+        },
+        "available_commands": [_probe_command(name) for name in _COMMANDS],
+        "notes": [
+            "PR-1 env mode is inventory-only and does not compile or execute target-language probes.",
+            "Native runners are intentionally deferred to later sub PRs.",
+        ],
+    }
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """
+    Build the probe command-line argument parser.
+
+    :return: Configured argument parser.
+    :rtype: argparse.ArgumentParser
+
+    Example::
+
+        >>> parser = _build_arg_parser()
+        >>> parser.prog
+        'numeric_render_probe.py'
+    """
+    parser = argparse.ArgumentParser(
+        prog="numeric_render_probe.py",
+        description="Numeric render-semantics probe entry point.",
+    )
+    parser.add_argument(
+        "mode",
+        nargs="?",
+        default="env",
+        choices=["env"],
+        help="Probe mode. PR-1 supports only 'env'.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root to describe, defaults to the current directory.",
+    )
+    parser.add_argument(
+        "--output",
+        help="Destination JSON path. When omitted, JSON is printed to stdout.",
+    )
+    return parser
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """
+    Run the probe command-line interface.
+
+    :param argv: Optional argument vector excluding the executable name.
+    :type argv: Optional[List[str]], optional
+    :return: Process exit status.
+    :rtype: int
+
+    Example::
+
+        >>> main(['env', '--output', '/tmp/pyfcstm-probe-env-example.json'])
+        0
+    """
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    report = build_environment_report(args.repo_root)
+    payload = json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## 🟢 当前状态：PR-1 已 ready to merge，等待维护者指示

本 PR 是 [issue #280](https://github.com/HansBug/pyfcstm/issues/280) / [伞 PR #281](https://github.com/HansBug/pyfcstm/pull/281) 下的 **子 PR-1：落库调研框架与 R0 映射工具**。

本轮已按最新要求修正范围：**整个 issue #280 / 伞 PR #281 调研系列都禁止修改 `test/` 路径**。这类数值渲染语义工作是调研实验基础设施，不应污染常规 unittest；如需校验，统一通过 `tools/` / `research/` 下的轻量自检入口或后续 `results/local/` 本地实验输出完成。

## 目标

把 FCSTM 数值表达式渲染语义调研的第一层基础设施落进仓库，形成后续 PR-2 到 PR-7 可以复用的稳定底座：

- 建立 `research/numeric-render-semantics/` 调研目录，保存计划、映射说明、probe 说明、schema、小型 snapshot 与 gitignored 本地输出约定。
- 新增 `tools/numeric_render_mapping.py`，抽取 renderer / template / statement override / helper inventory 的 R0 映射信息，并提供 `--check` 自检入口。
- 新增 `tools/numeric_render_probe.py` 的 `env` / help stub，为后续语言 runner 预留入口，但本 PR 不接 native toolchain。
- 更新 `.gitignore`，确保 heavy / local 调研输出不会进入 git。
- 明确整个调研伞 PR 范围 **不新增、不修改 `test/` 路径**；调研校验不进入 unittest 树。

## 非目标

- 不直接修改 solver / verify / fixed / template 的数值语义。
- 不接入 C/C++、Java、Rust、Go、JS/TS 等 native runner；这些属于后续子 PR。
- 不提交 heavy exhaustive 输出或本地机器相关的大型 artifact。
- 不把 Z3 BitVec natural wrap、C/C++ signed overflow、Python 无限精度等任何一端直接声明为默认实现语义。
- 不调研 FCSTM 逻辑表达式；本系列仅覆盖数值表达式。
- 整个调研伞 PR 范围不修改 `test/` 路径，不把一次性调研实验纳入常规单元测试。

## 新增路径

```text
research/
└── numeric-render-semantics/
    ├── README.md
    ├── plan.md
    ├── mapping.md
    ├── probes.md
    ├── results/
    │   ├── README.md
    │   ├── snapshots/
    │   │   ├── .gitkeep
    │   │   └── render_mapping.json
    │   └── local/              # gitignored heavy outputs
    └── schemas/
        ├── environment.schema.json
        ├── render_mapping.schema.json
        ├── operator_matrix.schema.json
        └── probe_summary.schema.json

tools/
├── numeric_render_mapping.py
└── numeric_render_probe.py
```

## R0 映射抽取要求

`numeric_render_mapping.py` 不能只读 `pyfcstm/render/expr.py` 的 builtin style。它至少要抽取并在输出中保留来源信息：

- builtin renderer style，例如 C / C++ / Python / Java / JS / TS / Rust / Go / DSL；
- 内置模板 `config.yaml` 中的 `expr_styles` override；
- `stmt_styles.*.expr_templates` override；
- generated artifact 路径 / 占位说明；
- renderer helper inventory，例如 Go / Python / C runtime 相关 helper；
- repository-source `templates/` digest，以及 packaged template `index.json` 元数据 / archive 声明；为保持 fresh clone 稳定，R0 snapshot 不 hash gitignored zip payload；
- C++ 双路径差异：`_CPP_STYLE` standalone expression path 与 `templates/cpp*` 基于 `base_lang: c` 的 generated artifact path；
- `~` 在 simulation/runtime 或 renderer 层的记录方式，避免后续只按 Z3 / C 推断 bitwise not 语义。

## 实现与自检计划

1. 使用 `research/numeric-render-semantics/` 文档、schema 和 snapshot 固化 R0 调研契约。
2. 实现 `tools/numeric_render_mapping.py`，保证跨平台、标准库优先、Python 3.7+ 兼容。
3. 通过 `python tools/numeric_render_mapping.py --check` 锁定核心输出契约；该入口替代 `test/` 下的单元测试改动。
4. 实现 `tools/numeric_render_probe.py env`，只做环境信息输出和后续入口说明。
5. 运行本地 skip-slow 相关验证、`make rst_auto`，再 commit / push。
6. 等待 CI；若出现与本 PR 无关的临时环境错误，保留观察，但其余相关 check 必须通过。
7. CI 完成后启动三路强 review；若 CodeCov comment 到位则纳入 review，若缺失则如实记录，修复 C/I 问题直到 ready to merge。

## 本 PR 验收命令

```bash
python tools/numeric_render_mapping.py \
  --output research/numeric-render-semantics/results/snapshots/render_mapping.json

python tools/numeric_render_mapping.py --check

python tools/numeric_render_probe.py env \
  --output research/numeric-render-semantics/results/local/env.json

git check-ignore research/numeric-render-semantics/results/local/dummy-output.jsonl

make rst_auto
```

说明：

- `--check` 是 PR-1 的轻量契约自检入口；它不依赖 `test/` 路径，并会比较 live mapping 与已提交 snapshot，防止 snapshot 漂移。
- `results/local/` 是 gitignored，本地环境报告和后续 heavy 输出可以放这里。
- `make rst_auto` 已按本轮执行约定在提交前运行；本 PR 不改 `pyfcstm/` 公开 API，预期不会产生 API RST diff。
- 若工具脚本新增 public module / function / class pydoc，需遵守仓库 reST docstring 规范：module docstring 清晰说明路线图；function / class docstring 包含参数、返回值与 `Example::`。

## Ready to merge 标准

- 本 PR title/body 与 issue #280、伞 PR #281 的 PR-1 切分一致，且三者都明确 **整个调研伞 PR 范围不修改 `test/` 路径**。
- 三路一致性 review 无 C/I 阻塞。
- 调研自检入口覆盖核心输出契约，会校验已提交 snapshot 与 live mapping 一致，并且不污染 unittest 树。
- 本地验收命令通过。
- CI 相关 check 通过；CodeCov comment 已纳入 review 视野。
- 三路强 code review 无 C/I 阻塞；M 级问题尽量处理，但不因非阻塞项无限返工。
- 本 PR ready 后不自行 merge，等待维护者下一步指示。


