### PR TITLE
规划：收束 test 测试边界

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,6 +152,10 @@ jobs:
           else
             echo "SKIP_SLOW_TESTS=" >> "$GITHUB_ENV"
           fi
+      - name: Run test boundary check
+        shell: bash
+        run: |
+          make test_boundary_check
       - name: Run unittest
         env:
           CI: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,11 @@ jobs:
         shell: bash
         run: |
           make unittest IS_WIN=${{ env.IS_WIN }} IS_MAC=${{ env.IS_MAC }}
+      - name: Run template maintenance checks
+        shell: bash
+        run: |
+          make template_packaging_check
+          make template_source_install_check
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1044,6 +1044,31 @@ For built-in template work, the current design bar is defined by the `python` te
   migration indexes. If fixture inventories, test documentation, or other test-tree maintenance data need executable
   validation, put that check in a maintenance command outside the unit-test suite (for example under [tools/](tools/)) and run
   it explicitly.
+- Python unit tests must enter built-in template behavior through production package/runtime surfaces. Tests may use
+  packaged template assets through :mod:`pyfcstm.template`, `pyfcstm.template.extract_template(...)`,
+  `pyfcstm.template.list_templates()`, `pyfcstm.template.get_template_info(...)`,
+  `StateMachineCodeRenderer` pointed at an extracted packaged template, or CLI paths such as
+  `pyfcstm generate --template ...`. Tests may also create throwaway templates under their own temporary directories or
+  under [test/](test/) when the test target is the renderer itself.
+- Python unit tests must not directly read, render, compare, or assert against repository root `templates/` source
+  directories. Avoid source-layout shortcuts such as `_REPO_ROOT / "templates"`,
+  `Path(__file__).parents[...] / "templates"`, or `os.path.join(..., "templates")` in [test/](test/) when the behavior
+  under test can be reached through packaged template assets or public CLI/runtime entry points.
+- Python unit tests must not import `tools.*`, execute `tools.*`, or assert private helper behavior from maintenance
+  scripts. Packaging, release, source-template packaging, source-install smoke, symlink/stub resolution, and similar
+  maintenance checks should live as explicit commands under [tools/](tools/) or Makefile targets, not as default
+  `pytest -m unittest` cases. Do not delete that coverage when migrating it out of pytest; keep a reproducible
+  maintenance command.
+- Keep generated README executable documentation tests in pytest when they validate runnable quick starts,
+  compile/run commands, formatter-friendly code blocks, public API examples, or integration commands emitted by
+  generated artifacts. Do not use pytest primarily to assert repo-source maintainer README wording, prose inventories,
+  comment-only text, or documentation synchronization that is not production behavior.
+- Native template tests are part of the unit-test contract when they verify generated runtime behavior. C / C++ /
+  C++ wrapper native compile, native run, CMake, ctypes, formatter, and native alignment checks must be preserved when
+  their inputs are generated through packaged template or public API paths.
+- `make unittest` intentionally depends on `make tpl` so packaged built-in template assets are refreshed before the
+  Python unit-test suite runs. Do not remove that dependency merely to avoid packaging work in tests; instead, keep
+  pytest on packaged/public inputs and move source-template maintenance coverage to explicit tooling commands.
 - Shared test utilities and fixtures in [test/testings/](test/testings/)
 - Sample DSL files in [test/testfile/sample_codes/](test/testfile/sample_codes/) (auto-generate tests via `make sample`)
 - Negative cases in [test/testfile/sample_neg_codes/](test/testfile/sample_neg_codes/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ make unittest RANGE_DIR=./config                     # Specific directory
 make unittest COV_TYPES="xml term-missing"           # With coverage types
 make unittest MIN_COVERAGE=80                        # With minimum coverage
 make unittest WORKERS=4                              # With parallel workers
+make test_boundary_check                              # Validate pytest boundary rules
 
 # Run a single test file or function directly:
 pytest test/simulate/test_semantic_fixtures.py -v
@@ -1069,6 +1070,9 @@ For built-in template work, the current design bar is defined by the `python` te
 - `make unittest` intentionally depends on `make tpl` so packaged built-in template assets are refreshed before the
   Python unit-test suite runs. Do not remove that dependency merely to avoid packaging work in tests; instead, keep
   pytest on packaged/public inputs and move source-template maintenance coverage to explicit tooling commands.
+- Run `make test_boundary_check` when changing test infrastructure, template tests, maintenance tooling, or
+  repository guidance that affects the pytest boundary. This command is a pytest-external guard for direct `tools.*`
+  imports/execution, repo-root `templates/` access, and source-install smoke markers under [test/](test/).
 - Shared test utilities and fixtures in [test/testings/](test/testings/)
 - Sample DSL files in [test/testfile/sample_codes/](test/testfile/sample_codes/) (auto-generate tests via `make sample`)
 - Negative cases in [test/testfile/sample_neg_codes/](test/testfile/sample_neg_codes/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1045,7 +1045,7 @@ For built-in template work, the current design bar is defined by the `python` te
   validation, put that check in a maintenance command outside the unit-test suite (for example under [tools/](tools/)) and run
   it explicitly.
 - Python unit tests must enter built-in template behavior through production package/runtime surfaces. Tests may use
-  packaged template assets through :mod:`pyfcstm.template`, `pyfcstm.template.extract_template(...)`,
+  packaged template assets through `pyfcstm.template`, `pyfcstm.template.extract_template(...)`,
   `pyfcstm.template.list_templates()`, `pyfcstm.template.get_template_info(...)`,
   `StateMachineCodeRenderer` pointed at an extracted packaged template, or CLI paths such as
   `pyfcstm generate --template ...`. Tests may also create throwaway templates under their own temporary directories or

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs test unittest resource antlr antlr_build build package clean docs_auto todos_auto tests_auto rst_auto sha256 jsfcstm jsfcstm_clean vscode vscode_clean vscode_install vscode_uninstall logos logos_clean app_icons app_icons_clean help tpl tpl_clean templates_package template_packaging_check template_source_install_check
+.PHONY: docs test unittest resource antlr antlr_build build package clean docs_auto todos_auto tests_auto rst_auto sha256 jsfcstm jsfcstm_clean vscode vscode_clean vscode_install vscode_uninstall logos logos_clean app_icons app_icons_clean help tpl tpl_clean templates_package template_packaging_check template_source_install_check test_boundary_check
 
 PYTHON := $(shell which python)
 
@@ -114,6 +114,7 @@ help:
 	@echo "  make templates_package - Alias of 'make tpl'"
 	@echo "  make template_packaging_check - Validate repository template packaging contracts"
 	@echo "  make template_source_install_check - Validate source-install template extraction"
+	@echo "  make test_boundary_check - Validate pytest test-boundary rules"
 	@echo ""
 	@echo "Sample Tests:"
 	@echo "  make sample       - Generate test files from sample DSL files"
@@ -193,6 +194,9 @@ template_packaging_check:
 
 template_source_install_check:
 	$(PYTHON) tools/check_template_source_install.py
+
+test_boundary_check:
+	$(PYTHON) tools/check_test_boundary.py
 
 
 # LLM-based documentation generation targets

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs test unittest resource antlr antlr_build build package clean docs_auto todos_auto tests_auto rst_auto sha256 jsfcstm jsfcstm_clean vscode vscode_clean vscode_install vscode_uninstall logos logos_clean app_icons app_icons_clean help tpl tpl_clean templates_package
+.PHONY: docs test unittest resource antlr antlr_build build package clean docs_auto todos_auto tests_auto rst_auto sha256 jsfcstm jsfcstm_clean vscode vscode_clean vscode_install vscode_uninstall logos logos_clean app_icons app_icons_clean help tpl tpl_clean templates_package template_packaging_check template_source_install_check
 
 PYTHON := $(shell which python)
 
@@ -112,6 +112,8 @@ help:
 	@echo "  make tpl          - Package repository templates into pyfcstm/template zip assets"
 	@echo "  make tpl_clean    - Remove packaged template zip assets and index"
 	@echo "  make templates_package - Alias of 'make tpl'"
+	@echo "  make template_packaging_check - Validate repository template packaging contracts"
+	@echo "  make template_source_install_check - Validate source-install template extraction"
 	@echo ""
 	@echo "Sample Tests:"
 	@echo "  make sample       - Generate test files from sample DSL files"
@@ -185,6 +187,13 @@ templates_package: tpl
 
 tpl_clean:
 	rm -f ${SRC_DIR}/template/*.zip ${SRC_DIR}/template/index.json
+
+template_packaging_check:
+	$(PYTHON) tools/check_template_packaging.py
+
+template_source_install_check:
+	$(PYTHON) tools/check_template_source_install.py
+
 
 # LLM-based documentation generation targets
 docs_auto:

--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -674,31 +674,8 @@ class TestResolveCodesYamlPath:
 
 
 @pytest.mark.unittest
-class TestYamlCommentBlockSync:
-    """
-    M6 from PR-107 review: the type-token comment block at the top of
-    codes.yaml must mirror ``_ALLOWED_REF_TYPES`` (single source of truth
-    in codes.py). Drift would silently let new tokens land in the comment
-    but not in the loader, or vice versa.
-    """
-
-    def test_comment_block_lists_all_allowed_types(self):
-        path = os.path.join(
-            os.path.dirname(__file__), '..', '..',
-            'pyfcstm', 'diagnostics', 'codes.yaml',
-        )
-        with open(path, 'r', encoding='utf-8') as f:
-            text = f.read()
-        # Comment block uses ` | `-separated list. Extract any tokens in
-        # backticks doesn't apply here (raw text). We assert each allowed
-        # type appears at least once in the comment area (before the first
-        # top-level YAML key, which is `E_UNDEFINED_VAR:` per the schema).
-        head = text.split('E_UNDEFINED_VAR:', 1)[0]
-        for ref_type in _ALLOWED_REF_TYPES:
-            assert ref_type in head, (
-                f"type token {ref_type!r} listed in _ALLOWED_REF_TYPES but "
-                f"not documented in the codes.yaml comment block"
-            )
+class TestRefTypePredicateCoverage:
+    """Verify runtime predicates cover every diagnostic refs type token."""
 
     def test_schema_check_type_predicates_cover_all_allowed_types(self):
         """M3 from PR #115 final review: ``_schema_check._TYPE_PREDICATES``

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -590,28 +590,6 @@ class TestSchemaJsonValidates:
         assert 'default inspect graph' in description
         assert 'composite initial edges' in description
 
-    def test_diagnostics_readme_documents_range_layers(self):
-        readme_path = os.path.join(
-            os.path.dirname(__file__), '..', '..',
-            'pyfcstm', 'diagnostics', 'README.md',
-        )
-        assert os.path.exists(readme_path)
-        with open(readme_path, 'r', encoding='utf-8') as f:
-            text = f.read()
-
-        for required in [
-            'problem range',
-            'fix-edit range',
-            'related range',
-            'Span',
-            '<object>_span',
-            '1-based',
-            'end-exclusive',
-            'LSP Range',
-            '0-based',
-        ]:
-            assert required in text
-
 
 @pytest.mark.unittest
 class TestInspectModelAdvancedFeatures:

--- a/test/llm/test_grammar_guide.py
+++ b/test/llm/test_grammar_guide.py
@@ -8,7 +8,6 @@ import pytest
 import pyfcstm.llm as llm
 from pyfcstm.dsl.error import GrammarParseError
 from pyfcstm.model import load_state_machine_from_text
-from tools.evaluate_llm_grammar_guide import _extract_fcstm_source
 
 
 _FCSTM_BLOCK_RE = re.compile(r"```fcstm\n(.*?)\n```", re.DOTALL)
@@ -267,22 +266,3 @@ def test_grammar_guide_invalid_examples_are_rejected():
     for example in examples:
         with pytest.raises((GrammarParseError, SyntaxError, ValueError)):
             load_state_machine_from_text(example, path=os.getcwd())
-
-
-@pytest.mark.unittest
-def test_eval_source_extraction_skips_prose_that_starts_with_state_word():
-    raw_output = """
-Here is the model.
-state transitions are important in this controller.
-
-def int x = 0;
-state Root {
-    [*] -> Idle;
-    state Idle;
-}
-"""
-
-    source = _extract_fcstm_source(raw_output)
-
-    assert source.startswith("def int x = 0;")
-    load_state_machine_from_text(source, path=os.getcwd())

--- a/test/template/cpp/_utils.py
+++ b/test/template/cpp/_utils.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import subprocess
 import textwrap
-import zipfile
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 
@@ -11,26 +10,11 @@ import pytest
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.render import StateMachineCodeRenderer
-from tools.package_templates import package_templates
+from pyfcstm.template import extract_template
 
 
-def _repo_root():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-
-
-def _extract_packaged_template(name, work_dir):
-    package_dir = os.path.join(work_dir, "package")
-    extraction_dir = os.path.join(work_dir, "extract")
-    os.makedirs(package_dir, exist_ok=True)
-    os.makedirs(extraction_dir, exist_ok=True)
-    package_templates(
-        os.path.join(_repo_root(), "templates"),
-        package_dir,
-        verbose=False,
-    )
-    with zipfile.ZipFile(os.path.join(package_dir, name + ".zip"), "r") as zf:
-        zf.extractall(extraction_dir)
-    return os.path.join(extraction_dir, name)
+def _extract_cpp_template(work_dir):
+    return extract_template("cpp", os.path.join(work_dir, "template"))
 
 
 def _find_cmake():
@@ -80,7 +64,7 @@ def render_cpp_artifacts(dsl_code):
     model = parse_dsl_node_to_state_machine(ast_node)
 
     with TemporaryDirectory() as td:
-        template_dir = _extract_packaged_template("cpp", td)
+        template_dir = _extract_cpp_template(td)
         output_dir = os.path.join(td, "out")
         StateMachineCodeRenderer(template_dir).render(
             model=model, output_dir=output_dir

--- a/test/template/cpp_poll/_utils.py
+++ b/test/template/cpp_poll/_utils.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import subprocess
 import textwrap
-import zipfile
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 
@@ -11,26 +10,11 @@ import pytest
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.render import StateMachineCodeRenderer
-from tools.package_templates import package_templates
+from pyfcstm.template import extract_template
 
 
-def _repo_root():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-
-
-def _extract_packaged_template(name, work_dir):
-    package_dir = os.path.join(work_dir, "package")
-    extraction_dir = os.path.join(work_dir, "extract")
-    os.makedirs(package_dir, exist_ok=True)
-    os.makedirs(extraction_dir, exist_ok=True)
-    package_templates(
-        os.path.join(_repo_root(), "templates"),
-        package_dir,
-        verbose=False,
-    )
-    with zipfile.ZipFile(os.path.join(package_dir, name + ".zip"), "r") as zf:
-        zf.extractall(extraction_dir)
-    return os.path.join(extraction_dir, name)
+def _extract_cpp_poll_template(work_dir):
+    return extract_template("cpp_poll", os.path.join(work_dir, "template"))
 
 
 def _find_cmake():
@@ -80,7 +64,7 @@ def render_cpp_poll_artifacts(dsl_code):
     model = parse_dsl_node_to_state_machine(ast_node)
 
     with TemporaryDirectory() as td:
-        template_dir = _extract_packaged_template("cpp_poll", td)
+        template_dir = _extract_cpp_poll_template(td)
         output_dir = os.path.join(td, "out")
         StateMachineCodeRenderer(template_dir).render(
             model=model, output_dir=output_dir

--- a/test/template/test_c_family_helper_scope.py
+++ b/test/template/test_c_family_helper_scope.py
@@ -6,16 +6,19 @@ built-in template structure tests so target-language template structure changes
 can advance independently from renderer-boundary cleanup.
 """
 
+import inspect
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 import yaml
 
+import pyfcstm.render.render as render_module
 from pyfcstm.render import StateMachineCodeRenderer
+from pyfcstm.template import extract_template
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_TEMPLATES_DIR = _REPO_ROOT / "templates"
+_TEMPLATE_NAMES = ("c", "c_poll", "cpp", "cpp_poll")
 
 _C_HELPER_NAMES = {
     "to_c_identifier",
@@ -29,80 +32,87 @@ _C_HELPER_NAMES = {
 }
 
 
-def _read_text(path: Path) -> str:
+def _load_config(template_dir: Path) -> dict:
     """
-    Read UTF-8 text from a repository file.
+    Load an extracted built-in template configuration file.
 
-    :param path: Path to the text file.
-    :type path: pathlib.Path
-    :return: File contents decoded as UTF-8.
-    :rtype: str
-
-    Example::
-
-        >>> text = _read_text(_TEMPLATES_DIR / 'python' / 'config.yaml')
-        >>> 'expr_styles' in text
-        True
-    """
-    return path.read_text(encoding="utf-8")
-
-
-def _load_config(name: str) -> dict:
-    """
-    Load a built-in template configuration file.
-
-    :param name: Built-in template directory name.
-    :type name: str
+    :param template_dir: Extracted built-in template directory.
+    :type template_dir: pathlib.Path
     :return: Parsed YAML configuration mapping.
     :rtype: dict
 
     Example::
 
-        >>> config = _load_config('c')
+        >>> with TemporaryDirectory() as td:
+        ...     path = Path(extract_template('c', td))
+        ...     config = _load_config(path)
         >>> 'globals' in config
         True
     """
-    with (_TEMPLATES_DIR / name / "config.yaml").open("r", encoding="utf-8") as f:
+    with (template_dir / "config.yaml").open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _extract_templates(root: Path) -> dict:
+    """
+    Extract C-family and Python built-in templates for boundary checks.
+
+    :param root: Temporary directory used as extraction root.
+    :type root: pathlib.Path
+    :return: Mapping from template names to extracted template directories.
+    :rtype: dict
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:
+        ...     paths = _extract_templates(Path(td))
+        >>> 'python' in paths
+        True
+    """
+    names = ("python",) + _TEMPLATE_NAMES
+    return {name: Path(extract_template(name, str(root / name))) for name in names}
 
 
 @pytest.mark.unittest
 def test_c_family_helpers_are_template_scoped():
-    render_source = _read_text(_REPO_ROOT / "pyfcstm" / "render" / "render.py")
+    render_source = inspect.getsource(render_module)
     for helper_name in _C_HELPER_NAMES:
         assert helper_name not in render_source
 
-    python_renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / "python"))
-    assert not (_C_HELPER_NAMES & set(python_renderer.env.filters))
-    assert not (_C_HELPER_NAMES & set(python_renderer.env.globals))
-    assert "c_public_identifier_reserved" not in python_renderer.env.tests
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
 
-    for name in ["c", "c_poll"]:
-        renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / name))
-        assert _C_HELPER_NAMES <= (
-            set(renderer.env.filters) | set(renderer.env.globals)
-        )
-        assert "c_public_identifier_reserved" in renderer.env.tests
+        python_renderer = StateMachineCodeRenderer(str(template_dirs["python"]))
+        assert not (_C_HELPER_NAMES & set(python_renderer.env.filters))
+        assert not (_C_HELPER_NAMES & set(python_renderer.env.globals))
+        assert "c_public_identifier_reserved" not in python_renderer.env.tests
 
-        config = _load_config(name)
-        globals_config = config["globals"]
-        assert globals_config["render_c_action_body"] == {
-            "type": "import",
-            "from": "pyfcstm.render.c_runtime.render_c_action_body",
-        }
-        assert globals_config["render_c_condition_body"] == {
-            "type": "import",
-            "from": "pyfcstm.render.c_runtime.render_c_condition_body",
-        }
-        assert globals_config["render_c_reset_vars_body"] == {
-            "type": "import",
-            "from": "pyfcstm.render.c_runtime.render_c_reset_vars_body",
-        }
-        assert config["filters"]["to_c_identifier"] == {
-            "type": "import",
-            "from": "pyfcstm.utils.to_c_identifier",
-        }
-        assert config["tests"]["c_public_identifier_reserved"] == {
-            "type": "import",
-            "from": "pyfcstm.utils.is_c_public_identifier_reserved",
-        }
+        for name in _TEMPLATE_NAMES:
+            renderer = StateMachineCodeRenderer(str(template_dirs[name]))
+            assert _C_HELPER_NAMES <= (
+                set(renderer.env.filters) | set(renderer.env.globals)
+            )
+            assert "c_public_identifier_reserved" in renderer.env.tests
+
+            config = _load_config(template_dirs[name])
+            globals_config = config["globals"]
+            assert globals_config["render_c_action_body"] == {
+                "type": "import",
+                "from": "pyfcstm.render.c_runtime.render_c_action_body",
+            }
+            assert globals_config["render_c_condition_body"] == {
+                "type": "import",
+                "from": "pyfcstm.render.c_runtime.render_c_condition_body",
+            }
+            assert globals_config["render_c_reset_vars_body"] == {
+                "type": "import",
+                "from": "pyfcstm.render.c_runtime.render_c_reset_vars_body",
+            }
+            assert config["filters"]["to_c_identifier"] == {
+                "type": "import",
+                "from": "pyfcstm.utils.to_c_identifier",
+            }
+            assert config["tests"]["c_public_identifier_reserved"] == {
+                "type": "import",
+                "from": "pyfcstm.utils.is_c_public_identifier_reserved",
+            }

--- a/test/template/test_template.py
+++ b/test/template/test_template.py
@@ -1,7 +1,4 @@
 import os.path
-import subprocess
-import sys
-
 import pytest
 from hbutils.system import TemporaryDirectory
 
@@ -135,50 +132,3 @@ class TestBuiltinTemplateModule:
         with TemporaryDirectory() as td:
             with pytest.raises(LookupError):
                 extract_template("not_exists", td)
-
-    def test_source_install_extracts_builtin_template_outside_checkout(self):
-        with TemporaryDirectory() as build_root:
-            install_dir = os.path.join(build_root, "install")
-            command = [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "--quiet",
-                "--no-deps",
-                "--target",
-                install_dir,
-                ".",
-            ]
-            subprocess.run(
-                command,
-                cwd=os.path.abspath(
-                    os.path.join(os.path.dirname(__file__), "..", "..")
-                ),
-                check=True,
-            )
-
-            probe_code = (
-                "import os\n"
-                "from tempfile import TemporaryDirectory\n"
-                "from pyfcstm.template import extract_template\n"
-                "with TemporaryDirectory() as td:\n"
-                "    path = extract_template('python', td)\n"
-                "    assert os.path.basename(path) == 'python', path\n"
-                "    assert os.path.isfile(os.path.join(path, 'config.yaml')), path\n"
-                "    assert os.path.isfile(os.path.join(path, 'machine.py.j2')), path\n"
-                "    print('ok')\n"
-            )
-            probe = subprocess.run(
-                [sys.executable, "-c", probe_code],
-                cwd=build_root,
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                env={
-                    **os.environ,
-                    "PYTHONPATH": install_dir,
-                },
-            )
-            assert probe.stdout.strip() == "ok"

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -2,10 +2,7 @@
 
 import ast
 import json
-import os
 import re
-import stat
-import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -17,7 +14,6 @@ from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.render import StateMachineCodeRenderer
 from pyfcstm.template import extract_template, get_template_info, list_templates
-from tools.package_templates import package_templates, _resolve_archive_source
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -171,34 +167,8 @@ def representative_model():
     return parse_dsl_node_to_state_machine(ast_node)
 
 
-def _extract_archives(package_dir, output_root):
-    template_dirs = {}
-    for name in _CURRENT_TEMPLATE_NAMES:
-        archive_path = package_dir / "{name}.zip".format(name=name)
-        with zipfile.ZipFile(str(archive_path), "r") as zf:
-            zf.extractall(str(output_root / name))
-        template_dirs[name] = output_root / name / name
-    return template_dirs
-
-
 @pytest.fixture(scope="session")
 def rendered_templates(representative_model):
-    with TemporaryDirectory() as package_td:
-        with TemporaryDirectory() as extraction_td:
-            with TemporaryDirectory() as render_td:
-                package_root = Path(package_td)
-                extraction_root = Path(extraction_td)
-                output_root = Path(render_td)
-                package_templates(str(_TEMPLATES_DIR), str(package_root), verbose=False)
-                yield _render_template_directories(
-                    _extract_archives(package_root, extraction_root),
-                    representative_model,
-                    output_root,
-                )
-
-
-@pytest.fixture(scope="session")
-def extracted_rendered_templates(representative_model):
     with TemporaryDirectory() as extraction_td, TemporaryDirectory() as render_td:
         extraction_root = Path(extraction_td)
         output_root = Path(render_td)
@@ -518,13 +488,11 @@ def test_c_family_readmes_document_deployment_safety_boundaries(rendered_templat
         )
         assert (
             "本生成运行时不宣称已经满足 MISRA、AUTOSAR、DO-178C、IEC 61508 "
-            "或 ISO 26262 认证就绪要求。"
-            in generated_readme_zh_words
+            "或 ISO 26262 认证就绪要求。" in generated_readme_zh_words
         )
         assert (
             "它们本身不会让生成运行时达到 MISRA、AUTOSAR、DO-178C、IEC 61508、"
-            "ISO 26262 或其他认证 ready。"
-            in generated_readme_zh_words
+            "ISO 26262 或其他认证 ready。" in generated_readme_zh_words
         )
 
         assert "Integration Preflight Checklist" in generated_readme
@@ -605,10 +573,8 @@ def test_cpp_template_documentation_describes_early_first_class_status(
 @pytest.mark.unittest
 def test_generated_sources_preserve_banner_source_context_and_dependency_boundary(
     rendered_templates,
-    extracted_rendered_templates,
 ):
     _assert_rendered_template_contracts(rendered_templates)
-    _assert_rendered_template_contracts(extracted_rendered_templates)
 
 
 @pytest.mark.unittest
@@ -626,53 +592,6 @@ def test_generated_source_templates_keep_source_metadata_wording():
 
 
 @pytest.mark.unittest
-def test_packaging_output_preserves_metadata_and_archive_roots():
-    with TemporaryDirectory() as td:
-        output_dir = Path(td)
-        stale_zip = output_dir / "stale.zip"
-        stale_zip.write_bytes(b"stale")
-
-        package_templates(str(_TEMPLATES_DIR), str(output_dir), verbose=False)
-
-        assert not stale_zip.exists()
-        index = _read_json(output_dir / "index.json")
-        assert [item["name"] for item in index["templates"]] == list(
-            _repository_template_names()
-        )
-
-        for item in index["templates"]:
-            name = item["name"]
-            repo_metadata = _load_template_metadata(name)
-            assert item["archive"] == "{name}.zip".format(name=name)
-            assert item["root_dir"] == name
-            for key in ["title", "description", "language", "experimental"]:
-                assert item[key] == repo_metadata[key]
-
-            archive_path = output_dir / item["archive"]
-            assert archive_path.is_file()
-            with zipfile.ZipFile(str(archive_path), "r") as zf:
-                names = zf.namelist()
-            assert names
-            assert all(path.startswith(name + "/") for path in names)
-            archived_rel_paths = {path[len(name) + 1 :] for path in names}
-            assert _REQUIRED_TEMPLATE_FILES[name] <= archived_rel_paths
-            assert not any("__pycache__" in path for path in names)
-
-
-@pytest.mark.unittest
-def test_distribution_metadata_keeps_template_assets_declared():
-    setup_text = _read_text(_REPO_ROOT / "setup.py")
-    manifest_text = _read_text(_REPO_ROOT / "MANIFEST.in")
-
-    assert "from tools.package_templates import package_templates" in setup_text
-    assert "package_templates(" in setup_text
-    assert "package_data" in setup_text
-    assert "*.zip" in setup_text
-    assert "*.json" in setup_text
-    assert "recursive-include pyfcstm/template *.zip *.json" in manifest_text
-
-
-@pytest.mark.unittest
 def test_extracted_builtin_templates_preserve_source_structure_contract():
     with TemporaryDirectory() as td:
         for name in _repository_template_names():
@@ -686,119 +605,6 @@ def test_extracted_builtin_templates_preserve_source_structure_contract():
             spec = _ignore_spec(config)
             for maintainer_file in _MAINTAINER_ONLY_FILES:
                 assert spec.match_file(maintainer_file)
-
-
-def _zip_payload(output_dir, template_name, rel_path):
-    with zipfile.ZipFile(
-        str(output_dir / "{name}.zip".format(name=template_name)), "r"
-    ) as zf:
-        info = zf.getinfo("{name}/{rel}".format(name=template_name, rel=rel_path))
-        payload = zf.read(info)
-    return info, payload
-
-
-@pytest.mark.unittest
-def test_cpp_templates_reuse_c_core_as_packaged_file_payloads():
-    with TemporaryDirectory() as td:
-        output_dir = Path(td)
-        package_templates(str(_TEMPLATES_DIR), str(output_dir), verbose=False)
-
-        for template_name, source_template in [("cpp", "c"), ("cpp_poll", "c_poll")]:
-            for rel_path in ["machine.c.j2", "machine.h.j2"]:
-                info, payload = _zip_payload(output_dir, template_name, rel_path)
-                assert stat.S_IFMT(info.external_attr >> 16) != stat.S_IFLNK
-                assert (
-                    payload
-                    == (_TEMPLATES_DIR / source_template / rel_path).read_bytes()
-                )
-                assert payload.strip() != (
-                    "../{source}/{rel}".format(source=source_template, rel=rel_path)
-                ).encode("utf-8")
-
-
-@pytest.mark.unittest
-def test_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(
-    monkeypatch,
-):
-    src_file = _TEMPLATES_DIR / "cpp" / "machine.c.j2"
-    target_file = _TEMPLATES_DIR / "c" / "machine.c.j2"
-    realpath = os.path.realpath
-
-    def unresolved_realpath(path):
-        if os.path.abspath(path) == os.path.abspath(str(src_file)):
-            return os.path.abspath(path)
-        return realpath(path)
-
-    monkeypatch.setattr(os.path, "realpath", unresolved_realpath)
-
-    assert _resolve_archive_source(
-        str(_TEMPLATES_DIR / "cpp"),
-        str(src_file),
-        "cpp",
-        "machine.c.j2",
-    ) == str(target_file)
-
-
-@pytest.mark.unittest
-def test_cpp_template_packaging_resolves_windows_symlink_text_stubs():
-    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
-        source_root = Path(source_td) / "templates"
-        output_dir = Path(output_td)
-        for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-            src_dir = _TEMPLATES_DIR / name
-            dst_dir = source_root / name
-            dst_dir.mkdir(parents=True)
-            for item in src_dir.iterdir():
-                if item.is_file() or item.is_symlink():
-                    if item.is_symlink():
-                        target = Path(os.readlink(str(item))).as_posix()
-                        (dst_dir / item.name).write_text(
-                            target + "\n", encoding="utf-8"
-                        )
-                    else:
-                        (dst_dir / item.name).write_bytes(item.read_bytes())
-
-        package_templates(str(source_root), str(output_dir), verbose=False)
-
-        _, cpp_c_payload = _zip_payload(output_dir, "cpp", "machine.c.j2")
-        _, cpp_h_payload = _zip_payload(output_dir, "cpp", "machine.h.j2")
-        _, cpp_poll_c_payload = _zip_payload(output_dir, "cpp_poll", "machine.c.j2")
-        _, cpp_poll_h_payload = _zip_payload(output_dir, "cpp_poll", "machine.h.j2")
-        assert cpp_c_payload == (source_root / "c" / "machine.c.j2").read_bytes()
-        assert cpp_h_payload == (source_root / "c" / "machine.h.j2").read_bytes()
-        assert (
-            cpp_poll_c_payload == (source_root / "c_poll" / "machine.c.j2").read_bytes()
-        )
-        assert (
-            cpp_poll_h_payload == (source_root / "c_poll" / "machine.h.j2").read_bytes()
-        )
-
-
-@pytest.mark.unittest
-def test_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub():
-    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
-        source_root = Path(source_td) / "templates"
-        output_dir = Path(output_td)
-        for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-            src_dir = _TEMPLATES_DIR / name
-            dst_dir = source_root / name
-            dst_dir.mkdir(parents=True)
-            for item in src_dir.iterdir():
-                if item.is_file() or item.is_symlink():
-                    if item.is_symlink():
-                        target = Path(os.readlink(str(item))).as_posix()
-                        (dst_dir / item.name).write_text(
-                            target + "\n", encoding="utf-8"
-                        )
-                    else:
-                        (dst_dir / item.name).write_bytes(item.read_bytes())
-
-        (source_root / "cpp" / "machine.c.j2").write_text(
-            "../c_poll/machine.c.j2", encoding="utf-8"
-        )
-
-        with pytest.raises(ValueError, match="expected checkout stub"):
-            package_templates(str(source_root), str(output_dir), verbose=False)
 
 
 @pytest.mark.unittest

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -16,10 +16,7 @@ from pyfcstm.render import StateMachineCodeRenderer
 from pyfcstm.template import extract_template, get_template_info, list_templates
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_TEMPLATES_DIR = _REPO_ROOT / "templates"
-_PACKAGED_TEMPLATE_DIR = _REPO_ROOT / "pyfcstm" / "template"
-_CURRENT_TEMPLATE_NAMES = ("c", "c_poll", "cpp", "cpp_poll", "python")
+_CURRENT_TEMPLATE_NAMES = tuple(list_templates())
 _TEMPLATE_LANGUAGE_VOCABULARY = {
     "c",
     "cpp",
@@ -38,7 +35,6 @@ _CONFIG_TOP_LEVEL_KEYS = {
     "tests",
     "ignores",
 }
-_MAINTAINER_ONLY_FILES = {"README.md", "README_zh.md", "template.json"}
 _REQUIRED_TEMPLATE_FILES = {
     "c": {
         "README.md",
@@ -172,10 +168,7 @@ def rendered_templates(representative_model):
     with TemporaryDirectory() as extraction_td, TemporaryDirectory() as render_td:
         extraction_root = Path(extraction_td)
         output_root = Path(render_td)
-        template_dirs = {
-            name: Path(extract_template(name, str(extraction_root / name)))
-            for name in _CURRENT_TEMPLATE_NAMES
-        }
+        template_dirs = _extract_templates(extraction_root)
         yield _render_template_directories(
             template_dirs,
             representative_model,
@@ -183,30 +176,25 @@ def rendered_templates(representative_model):
         )
 
 
-def _repository_template_names():
-    return tuple(
-        item.name
-        for item in sorted(_TEMPLATES_DIR.iterdir())
-        if item.is_dir() and not item.name.startswith(".")
-    )
-
-
-def _read_json(path):
-    with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
-
-
 def _read_text(path):
     return path.read_text(encoding="utf-8")
 
 
-def _load_template_metadata(name):
-    return _read_json(_TEMPLATES_DIR / name / "template.json")
+def _extract_templates(root):
+    return {
+        name: Path(extract_template(name, str(root / name)))
+        for name in _CURRENT_TEMPLATE_NAMES
+    }
 
 
-def _load_config(name):
-    with (_TEMPLATES_DIR / name / "config.yaml").open("r", encoding="utf-8") as f:
+def _load_config(template_dir):
+    with (template_dir / "config.yaml").open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _load_template_metadata(template_dir):
+    with (template_dir / "template.json").open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def _ignore_spec(config):
@@ -337,96 +325,62 @@ def _assert_rendered_template_contracts(rendered_templates):
 
 
 @pytest.mark.unittest
-def test_repository_templates_expose_required_file_contract():
-    template_names = _repository_template_names()
-    assert set(_CURRENT_TEMPLATE_NAMES) <= set(template_names)
+def test_extracted_templates_expose_required_file_contract():
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
+        assert set(_CURRENT_TEMPLATE_NAMES) <= set(template_dirs)
 
-    for name in template_names:
-        metadata = _load_template_metadata(name)
-        assert metadata["name"] == name
-        assert metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
-        if name not in _REQUIRED_TEMPLATE_FILES:
-            pytest.fail(
-                "Add a required-file contract for built-in template {name!r}.".format(
-                    name=name,
+        for name, template_dir in template_dirs.items():
+            metadata = _load_template_metadata(template_dir)
+            assert metadata["name"] == name
+            assert metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
+            if name not in _REQUIRED_TEMPLATE_FILES:
+                pytest.fail(
+                    "Add a required-file contract for built-in template {name!r}.".format(
+                        name=name,
+                    )
                 )
-            )
 
-        files = {
-            item.name for item in (_TEMPLATES_DIR / name).iterdir() if item.is_file()
-        }
-        assert _REQUIRED_TEMPLATE_FILES[name] <= files
+            files = {item.name for item in template_dir.iterdir() if item.is_file()}
+            assert _REQUIRED_TEMPLATE_FILES[name] <= files
 
 
 @pytest.mark.unittest
-def test_template_metadata_matches_packaged_index_contract():
-    index = _read_json(_PACKAGED_TEMPLATE_DIR / "index.json")
-    index_items = {item["name"]: item for item in index["templates"]}
-    repository_names = set(_repository_template_names())
+def test_template_metadata_matches_packaged_asset_contract():
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
+        assert set(_CURRENT_TEMPLATE_NAMES) == set(template_dirs)
 
-    assert set(list_templates()) == repository_names
-    assert set(index_items) == repository_names
+        for name, template_dir in template_dirs.items():
+            template_metadata = _load_template_metadata(template_dir)
+            api_metadata = get_template_info(name)
 
-    for name in repository_names:
-        repo_metadata = _load_template_metadata(name)
-        indexed_metadata = index_items[name]
-        api_metadata = get_template_info(name)
-
-        assert api_metadata == indexed_metadata
-        assert indexed_metadata["name"] == name
-        assert indexed_metadata["archive"] == "{name}.zip".format(name=name)
-        assert indexed_metadata["root_dir"] == name
-        for key in ["title", "description", "language", "experimental"]:
-            assert indexed_metadata[key] == repo_metadata[key]
-        assert indexed_metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
+            assert api_metadata["name"] == name
+            assert api_metadata["archive"] == "{name}.zip".format(name=name)
+            assert api_metadata["root_dir"] == name
+            for key in ["name", "title", "description", "language", "experimental"]:
+                assert api_metadata[key] == template_metadata[key]
+            assert api_metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
 
 
 @pytest.mark.unittest
 def test_template_configs_keep_renderer_contract_and_ignores():
-    for name in _repository_template_names():
-        config = _load_config(name)
-        unknown_keys = set(config) - _CONFIG_TOP_LEVEL_KEYS
-        assert not unknown_keys
+    with TemporaryDirectory() as td:
+        for name, template_dir in _extract_templates(Path(td)).items():
+            config = _load_config(template_dir)
+            unknown_keys = set(config) - _CONFIG_TOP_LEVEL_KEYS
+            assert not unknown_keys
 
-        spec = _ignore_spec(config)
-        for maintainer_file in _MAINTAINER_ONLY_FILES:
-            assert spec.match_file(maintainer_file)
-        assert not spec.match_file("README.md.j2")
-        assert not spec.match_file("README_zh.md.j2")
-        for runtime_template in _RUNTIME_TEMPLATES[name]:
-            assert not spec.match_file(runtime_template)
+            spec = _ignore_spec(config)
+            assert not spec.match_file("README.md.j2")
+            assert not spec.match_file("README_zh.md.j2")
+            for runtime_template in _RUNTIME_TEMPLATES[name]:
+                assert not spec.match_file(runtime_template)
 
 
 @pytest.mark.unittest
-def test_template_readmes_keep_maintainer_and_generated_guidance_separate(
-    rendered_templates,
-):
-    root_readme = _read_text(_TEMPLATES_DIR / "README.md")
-    root_readme_zh = _read_text(_TEMPLATES_DIR / "README_zh.md")
-    for expected in [
-        "python",
-        "c",
-        "c_poll",
-        "cpp",
-        "cpp_poll",
-        "java",
-        "js",
-        "rust",
-        "ruby",
-        "go",
-    ]:
-        assert expected in root_readme
-        assert expected in root_readme_zh
-
-    for name in _repository_template_names():
-        template_dir = _TEMPLATES_DIR / name
-        maintainer_readme = _read_text(template_dir / "README.md").lower()
-        maintainer_readme_zh = _read_text(template_dir / "README_zh.md").lower()
-        assert "maintainer" in maintainer_readme
-        assert "template" in maintainer_readme
-        assert "not copied" in maintainer_readme or "ignored" in maintainer_readme
-        assert "template" in maintainer_readme_zh or "模板" in maintainer_readme_zh
-
+def test_generated_readmes_keep_generated_guidance(rendered_templates):
+    for name in _CURRENT_TEMPLATE_NAMES:
         generated_readme = _read_text(rendered_templates[name] / "README.md")
         generated_readme_zh = _read_text(rendered_templates[name] / "README_zh.md")
         for generated_text in [generated_readme, generated_readme_zh]:
@@ -439,29 +393,7 @@ def test_template_readmes_keep_maintainer_and_generated_guidance_separate(
 
 @pytest.mark.unittest
 def test_c_family_readmes_document_deployment_safety_boundaries(rendered_templates):
-    root_readme = _read_text(_TEMPLATES_DIR / "README.md")
-    root_readme_zh = _read_text(_TEMPLATES_DIR / "README_zh.md")
-
-    assert "C/C++ deployment safety wording" in root_readme
-    assert "C/C++ 部署安全表述" in root_readme_zh
-
     for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-        maintainer_readme = _read_text(_TEMPLATES_DIR / name / "README.md")
-        maintainer_readme_zh = _read_text(_TEMPLATES_DIR / name / "README_zh.md")
-        maintainer_readme_words = " ".join(maintainer_readme.split())
-        maintainer_readme_zh_words = " ".join(maintainer_readme_zh.split())
-        assert "engineering baseline" in maintainer_readme_words
-        assert "not a certification package" in maintainer_readme_words
-        assert "不是认证包" in maintainer_readme_zh_words
-        assert (
-            "Numeric inspect warning" in maintainer_readme
-            or "Numeric-risk wording" in maintainer_readme
-        )
-        assert (
-            "Numeric inspect warning" in maintainer_readme_zh
-            or "数值风险表述" in maintainer_readme_zh
-        )
-
         generated_readme = _read_text(rendered_templates[name] / "README.md")
         generated_readme_zh = _read_text(rendered_templates[name] / "README_zh.md")
         for text in [generated_readme, generated_readme_zh]:
@@ -521,41 +453,14 @@ def test_c_family_readmes_document_deployment_safety_boundaries(rendered_templat
 def test_cpp_template_documentation_describes_early_first_class_status(
     rendered_templates,
 ):
-    root_readme = _read_text(_TEMPLATES_DIR / "README.md")
-    root_readme_zh = _read_text(_TEMPLATES_DIR / "README_zh.md")
-    for text in [root_readme, root_readme_zh]:
-        lowered = text.lower()
-        assert "cpp" in lowered
-        assert "cpp_poll" in lowered
-        assert "early" in lowered or "早期" in text
-        assert "first-class" in lowered or "一等" in text
-        assert "experimental: true" in text
-        assert "skeleton" not in lowered
-        assert "prototype" not in lowered
-        assert "原型" not in text
-
     expected_metadata_descriptions = {
         "cpp": "Early-stage first-class C++ template",
         "cpp_poll": "Early-stage first-class C++ poll template",
     }
     for name, expected_description in expected_metadata_descriptions.items():
-        metadata = _load_template_metadata(name)
+        metadata = get_template_info(name)
         assert metadata["experimental"] is True
         assert expected_description in metadata["description"]
-
-        maintainer_readme = _read_text(_TEMPLATES_DIR / name / "README.md")
-        maintainer_readme_zh = _read_text(_TEMPLATES_DIR / name / "README_zh.md")
-        for text in [maintainer_readme, maintainer_readme_zh]:
-            lowered = text.lower()
-            assert "experimental: true" in text
-            assert "early" in lowered or "早期" in text
-            assert "first-class" in lowered or "一等" in text
-            assert "unimplemented" in lowered or "未实现" in text
-            assert "wrapper" in lowered
-            assert "native toolchain" in lowered or "原生工具链" in text
-            assert "skeleton" not in lowered
-            assert "prototype" not in lowered
-            assert "原型" not in text
 
         generated_readme = _read_text(rendered_templates[name] / "README.md")
         generated_readme_zh = _read_text(rendered_templates[name] / "README_zh.md")
@@ -579,23 +484,23 @@ def test_generated_sources_preserve_banner_source_context_and_dependency_boundar
 
 @pytest.mark.unittest
 def test_generated_source_templates_keep_source_metadata_wording():
-    for name in _repository_template_names():
-        for rel_path in ["README.md.j2", "README_zh.md.j2"] + list(
-            _RUNTIME_TEMPLATES[name]
-        ):
-            source = _read_text(_TEMPLATES_DIR / name / rel_path)
-            normalized = " ".join(source.lower().split())
-            compact = "".join(source.lower().split())
-            for banned in _BANNED_SOURCE_WORDING:
-                assert banned not in normalized
-                assert "".join(banned.split()) not in compact
+    with TemporaryDirectory() as td:
+        for name, template_dir in _extract_templates(Path(td)).items():
+            for rel_path in ["README.md.j2", "README_zh.md.j2"] + list(
+                _RUNTIME_TEMPLATES[name]
+            ):
+                source = _read_text(template_dir / rel_path)
+                normalized = " ".join(source.lower().split())
+                compact = "".join(source.lower().split())
+                for banned in _BANNED_SOURCE_WORDING:
+                    assert banned not in normalized
+                    assert "".join(banned.split()) not in compact
 
 
 @pytest.mark.unittest
 def test_extracted_builtin_templates_preserve_source_structure_contract():
     with TemporaryDirectory() as td:
-        for name in _repository_template_names():
-            extracted_dir = Path(extract_template(name, td))
+        for name, extracted_dir in _extract_templates(Path(td)).items():
             assert extracted_dir.name == get_template_info(name)["root_dir"]
             files = {item.name for item in extracted_dir.iterdir() if item.is_file()}
             assert _REQUIRED_TEMPLATE_FILES[name] <= files
@@ -603,8 +508,8 @@ def test_extracted_builtin_templates_preserve_source_structure_contract():
             config = yaml.safe_load(_read_text(extracted_dir / "config.yaml"))
             assert not (set(config) - _CONFIG_TOP_LEVEL_KEYS)
             spec = _ignore_spec(config)
-            for maintainer_file in _MAINTAINER_ONLY_FILES:
-                assert spec.match_file(maintainer_file)
+            assert not spec.match_file("README.md.j2")
+            assert not spec.match_file("README_zh.md.j2")
 
 
 @pytest.mark.unittest
@@ -620,22 +525,26 @@ def test_cpp_c_core_generated_outputs_match_c_templates(rendered_templates):
 
 @pytest.mark.unittest
 def test_c_family_helpers_are_template_scoped():
-    python_renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / "python"))
-    c_helper_names = {
-        "to_c_identifier",
-        "to_c_path_identifier",
-        "to_c_public_identifier",
-        "to_c_public_macro_identifier",
-        "is_c_public_identifier_reserved",
-        "render_c_action_body",
-        "render_c_condition_body",
-        "render_c_reset_vars_body",
-    }
-    assert not (c_helper_names & set(python_renderer.env.filters))
-    assert not (c_helper_names & set(python_renderer.env.globals))
-    assert "c_public_identifier_reserved" not in python_renderer.env.tests
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
+        python_renderer = StateMachineCodeRenderer(str(template_dirs["python"]))
+        c_helper_names = {
+            "to_c_identifier",
+            "to_c_path_identifier",
+            "to_c_public_identifier",
+            "to_c_public_macro_identifier",
+            "is_c_public_identifier_reserved",
+            "render_c_action_body",
+            "render_c_condition_body",
+            "render_c_reset_vars_body",
+        }
+        assert not (c_helper_names & set(python_renderer.env.filters))
+        assert not (c_helper_names & set(python_renderer.env.globals))
+        assert "c_public_identifier_reserved" not in python_renderer.env.tests
 
-    for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-        renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / name))
-        assert c_helper_names <= (set(renderer.env.filters) | set(renderer.env.globals))
-        assert "c_public_identifier_reserved" in renderer.env.tests
+        for name in ["c", "c_poll", "cpp", "cpp_poll"]:
+            renderer = StateMachineCodeRenderer(str(template_dirs[name]))
+            assert c_helper_names <= (
+                set(renderer.env.filters) | set(renderer.env.globals)
+            )
+            assert "c_public_identifier_reserved" in renderer.env.tests

--- a/tools/check_template_packaging.py
+++ b/tools/check_template_packaging.py
@@ -1,0 +1,583 @@
+"""
+Validate repository-source built-in template packaging contracts.
+
+This maintenance command checks the packaging behavior that is intentionally
+outside the pytest unit-test boundary. It exercises :mod:`tools.package_templates`
+against repository-source template directories and verifies that the generated
+zip assets are self-contained, metadata-rich, and suitable for packaged runtime
+extraction.
+
+The command contains the following checks:
+* packaged index metadata and archive root layout
+* C++ template reuse payload resolution for symlinks and Windows text stubs
+* rejection of unexpected C++ reuse text stubs
+* package/distribution metadata declarations for packaged template assets
+
+Example::
+
+    $ python tools/check_template_packaging.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+def _bootstrap_repo_imports() -> Path:
+    """
+    Add the repository root to ``sys.path`` for direct script execution.
+
+    :return: Repository root path.
+    :rtype: pathlib.Path
+    """
+    import sys
+
+    root = Path(__file__).resolve().parents[1]
+    root_text = str(root)
+    if root_text not in sys.path:
+        sys.path.insert(0, root_text)
+    return root
+
+
+_REPO_ROOT = _bootstrap_repo_imports()
+
+from tools.package_templates import package_templates, _resolve_archive_source  # noqa: E402
+
+
+CURRENT_TEMPLATE_NAMES = ("c", "c_poll", "cpp", "cpp_poll", "python")
+REQUIRED_TEMPLATE_FILES = {
+    "c": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+    },
+    "c_poll": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+    },
+    "cpp": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+        "machine.hpp.j2",
+        "machine.cpp.j2",
+    },
+    "cpp_poll": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+        "machine.hpp.j2",
+        "machine.cpp.j2",
+    },
+    "python": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.py.j2",
+    },
+}
+
+
+def repository_root() -> Path:
+    """
+    Return the repository root for this maintenance command.
+
+    :return: Repository root path.
+    :rtype: pathlib.Path
+
+    Example::
+
+        >>> repository_root().name  # doctest: +SKIP
+        'pyfcstm'
+    """
+    return _REPO_ROOT
+
+
+def read_json(path: Path) -> Dict[str, object]:
+    """
+    Load a UTF-8 JSON object from ``path``.
+
+    :param path: JSON file path.
+    :type path: pathlib.Path
+    :return: Decoded JSON object.
+    :rtype: Dict[str, object]
+    :raises json.JSONDecodeError: If the file is not valid JSON.
+    :raises OSError: If the file cannot be read.
+
+    Example::
+
+        >>> isinstance(read_json(repository_root() / 'pyfcstm' / 'template' / 'index.json'), dict)
+        True
+    """
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def read_text(path: Path) -> str:
+    """
+    Read a UTF-8 text file.
+
+    :param path: Text file path.
+    :type path: pathlib.Path
+    :return: File text.
+    :rtype: str
+    :raises OSError: If the file cannot be read.
+
+    Example::
+
+        >>> 'pyfcstm' in read_text(repository_root() / 'setup.py')
+        True
+    """
+    return path.read_text(encoding="utf-8")
+
+
+def repository_template_names(templates_dir: Path) -> Tuple[str, ...]:
+    """
+    Return sorted repository-source built-in template names.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: Template directory names.
+    :rtype: Tuple[str, ...]
+
+    Example::
+
+        >>> 'python' in repository_template_names(repository_root() / 'templates')
+        True
+    """
+    return tuple(
+        item.name
+        for item in sorted(templates_dir.iterdir())
+        if item.is_dir() and not item.name.startswith(".")
+    )
+
+
+def load_template_metadata(templates_dir: Path, name: str) -> Dict[str, object]:
+    """
+    Load one repository-source template metadata file.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :param name: Template name.
+    :type name: str
+    :return: Template metadata object.
+    :rtype: Dict[str, object]
+    :raises OSError: If the metadata file cannot be read.
+    :raises json.JSONDecodeError: If the metadata file is not valid JSON.
+
+    Example::
+
+        >>> load_template_metadata(repository_root() / 'templates', 'python')['name']
+        'python'
+    """
+    return read_json(templates_dir / name / "template.json")
+
+
+def zip_payload(
+    output_dir: Path, template_name: str, rel_path: str
+) -> Tuple[zipfile.ZipInfo, bytes]:
+    """
+    Return metadata and bytes for one packaged template member.
+
+    :param output_dir: Directory containing template zip archives.
+    :type output_dir: pathlib.Path
+    :param template_name: Packaged template name.
+    :type template_name: str
+    :param rel_path: Template-relative member path.
+    :type rel_path: str
+    :return: Zip member metadata and payload bytes.
+    :rtype: Tuple[zipfile.ZipInfo, bytes]
+    :raises KeyError: If the member does not exist in the archive.
+    :raises zipfile.BadZipFile: If the archive is invalid.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     zip_payload(Path(td), 'python', 'config.yaml')
+    """
+    with zipfile.ZipFile(
+        str(output_dir / "{name}.zip".format(name=template_name)), "r"
+    ) as zf:
+        info = zf.getinfo("{name}/{rel}".format(name=template_name, rel=rel_path))
+        payload = zf.read(info)
+    return info, payload
+
+
+def package_to_tempdir(templates_dir: Path) -> Tuple[TemporaryDirectory, Path]:
+    """
+    Package repository templates into a temporary output directory.
+
+    The returned :class:`tempfile.TemporaryDirectory` must be kept alive by the
+    caller while the output path is used.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: Temporary directory manager and output path.
+    :rtype: Tuple[tempfile.TemporaryDirectory, pathlib.Path]
+
+    Example::
+
+        >>> manager, output = package_to_tempdir(repository_root() / 'templates')  # doctest: +SKIP
+        >>> manager.cleanup()  # doctest: +SKIP
+    """
+    manager = TemporaryDirectory()
+    output_dir = Path(manager.name)
+    package_templates(str(templates_dir), str(output_dir), verbose=False)
+    return manager, output_dir
+
+
+def assert_packaging_output_preserves_metadata_and_archive_roots(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify packaged template metadata, roots, required files, and stale cleanup.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a packaging contract is violated.
+
+    Example::
+
+        >>> assert_packaging_output_preserves_metadata_and_archive_roots(repository_root() / 'templates')
+    """
+    with TemporaryDirectory() as td:
+        output_dir = Path(td)
+        stale_zip = output_dir / "stale.zip"
+        stale_zip.write_bytes(b"stale")
+
+        package_templates(str(templates_dir), str(output_dir), verbose=False)
+
+        assert not stale_zip.exists()
+        index = read_json(output_dir / "index.json")
+        assert [item["name"] for item in index["templates"]] == list(
+            repository_template_names(templates_dir)
+        )
+
+        for item in index["templates"]:
+            name = item["name"]
+            repo_metadata = load_template_metadata(templates_dir, name)
+            assert item["archive"] == "{name}.zip".format(name=name)
+            assert item["root_dir"] == name
+            for key in ["title", "description", "language", "experimental"]:
+                assert item[key] == repo_metadata[key]
+
+            archive_path = output_dir / item["archive"]
+            assert archive_path.is_file()
+            with zipfile.ZipFile(str(archive_path), "r") as zf:
+                names = zf.namelist()
+            assert names
+            assert all(path.startswith(name + "/") for path in names)
+            archived_rel_paths = {path[len(name) + 1 :] for path in names}
+            assert REQUIRED_TEMPLATE_FILES[name] <= archived_rel_paths
+            assert not any("__pycache__" in path for path in names)
+
+
+def assert_distribution_metadata_keeps_template_assets_declared(
+    repo_root: Path,
+) -> None:
+    """
+    Verify source distribution metadata declares packaged template assets.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If package metadata no longer declares assets.
+
+    Example::
+
+        >>> assert_distribution_metadata_keeps_template_assets_declared(repository_root())
+    """
+    setup_text = read_text(repo_root / "setup.py")
+    manifest_text = read_text(repo_root / "MANIFEST.in")
+
+    assert "from tools.package_templates import package_templates" in setup_text
+    assert "package_templates(" in setup_text
+    assert "package_data" in setup_text
+    assert "*.zip" in setup_text
+    assert "*.json" in setup_text
+    assert "recursive-include pyfcstm/template *.zip *.json" in manifest_text
+
+
+def assert_cpp_templates_reuse_c_core_as_packaged_file_payloads(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify C++ packaged core files contain C payload bytes, not symlinks/stubs.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a C++ package stores a symlink or stub payload.
+
+    Example::
+
+        >>> assert_cpp_templates_reuse_c_core_as_packaged_file_payloads(repository_root() / 'templates')
+    """
+    manager, output_dir = package_to_tempdir(templates_dir)
+    try:
+        for template_name, source_template in [("cpp", "c"), ("cpp_poll", "c_poll")]:
+            for rel_path in ["machine.c.j2", "machine.h.j2"]:
+                info, payload = zip_payload(output_dir, template_name, rel_path)
+                assert stat.S_IFMT(info.external_attr >> 16) != stat.S_IFLNK
+                assert (
+                    payload == (templates_dir / source_template / rel_path).read_bytes()
+                )
+                assert payload.strip() != (
+                    "../{source}/{rel}".format(source=source_template, rel=rel_path)
+                ).encode("utf-8")
+    finally:
+        manager.cleanup()
+
+
+def assert_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify explicit symlink text is accepted when ``realpath`` is unreliable.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If symlink target text does not resolve correctly.
+
+    Example::
+
+        >>> assert_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(repository_root() / 'templates')
+    """
+    src_file = templates_dir / "cpp" / "machine.c.j2"
+    target_file = templates_dir / "c" / "machine.c.j2"
+    realpath = os.path.realpath
+
+    def unresolved_realpath(path: str) -> str:
+        """
+        Simulate a checkout mode where ``realpath`` cannot resolve one symlink.
+
+        :param path: Path passed to :func:`os.path.realpath`.
+        :type path: str
+        :return: Simulated real path.
+        :rtype: str
+        """
+        if os.path.abspath(path) == os.path.abspath(str(src_file)):
+            return os.path.abspath(path)
+        return realpath(path)
+
+    try:
+        os.path.realpath = unresolved_realpath
+        assert _resolve_archive_source(
+            str(templates_dir / "cpp"),
+            str(src_file),
+            "cpp",
+            "machine.c.j2",
+        ) == str(target_file)
+    finally:
+        os.path.realpath = realpath
+
+
+def copy_templates_with_windows_symlink_text_stubs(
+    templates_dir: Path,
+    source_root: Path,
+    template_names: Iterable[str],
+) -> None:
+    """
+    Copy templates while replacing symlinks with Windows checkout text stubs.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :param source_root: Temporary template source root to create.
+    :type source_root: pathlib.Path
+    :param template_names: Template names to copy.
+    :type template_names: Iterable[str]
+    :return: ``None``.
+    :rtype: None
+    :raises OSError: If a file cannot be copied or written.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     copy_templates_with_windows_symlink_text_stubs(repository_root() / 'templates', Path(td), ['c'])
+    """
+    for name in template_names:
+        src_dir = templates_dir / name
+        dst_dir = source_root / name
+        dst_dir.mkdir(parents=True)
+        for item in src_dir.iterdir():
+            if item.is_file() or item.is_symlink():
+                if item.is_symlink():
+                    target = Path(os.readlink(str(item))).as_posix()
+                    (dst_dir / item.name).write_text(target + "\n", encoding="utf-8")
+                else:
+                    (dst_dir / item.name).write_bytes(item.read_bytes())
+
+
+def assert_cpp_template_packaging_resolves_windows_symlink_text_stubs(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify expected Windows text stubs are packaged as target payloads.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a text stub is not resolved to target bytes.
+
+    Example::
+
+        >>> assert_cpp_template_packaging_resolves_windows_symlink_text_stubs(repository_root() / 'templates')
+    """
+    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
+        source_root = Path(source_td) / "templates"
+        output_dir = Path(output_td)
+        copy_templates_with_windows_symlink_text_stubs(
+            templates_dir,
+            source_root,
+            ["c", "c_poll", "cpp", "cpp_poll"],
+        )
+
+        package_templates(str(source_root), str(output_dir), verbose=False)
+
+        _, cpp_c_payload = zip_payload(output_dir, "cpp", "machine.c.j2")
+        _, cpp_h_payload = zip_payload(output_dir, "cpp", "machine.h.j2")
+        _, cpp_poll_c_payload = zip_payload(output_dir, "cpp_poll", "machine.c.j2")
+        _, cpp_poll_h_payload = zip_payload(output_dir, "cpp_poll", "machine.h.j2")
+        assert cpp_c_payload == (source_root / "c" / "machine.c.j2").read_bytes()
+        assert cpp_h_payload == (source_root / "c" / "machine.h.j2").read_bytes()
+        assert (
+            cpp_poll_c_payload == (source_root / "c_poll" / "machine.c.j2").read_bytes()
+        )
+        assert (
+            cpp_poll_h_payload == (source_root / "c_poll" / "machine.h.j2").read_bytes()
+        )
+
+
+def assert_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify unexpected Windows text stubs fail packaging.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If the unexpected text stub is not rejected.
+
+    Example::
+
+        >>> assert_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub(repository_root() / 'templates')
+    """
+    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
+        source_root = Path(source_td) / "templates"
+        output_dir = Path(output_td)
+        copy_templates_with_windows_symlink_text_stubs(
+            templates_dir,
+            source_root,
+            ["c", "c_poll", "cpp", "cpp_poll"],
+        )
+        (source_root / "cpp" / "machine.c.j2").write_text(
+            "../c_poll/machine.c.j2", encoding="utf-8"
+        )
+
+        try:
+            package_templates(str(source_root), str(output_dir), verbose=False)
+        except ValueError as err:
+            # ValueError: tools.package_templates rejects unexpected checkout stub text.
+            assert "expected checkout stub" in str(err)
+        else:
+            raise AssertionError("Unexpected C++ reuse text stub was accepted.")
+
+
+def run_checks(repo_root: Path) -> None:
+    """
+    Run all template packaging maintenance checks.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If any maintenance contract fails.
+    :raises OSError: If required repository files cannot be read.
+
+    Example::
+
+        >>> run_checks(repository_root())
+    """
+    templates_dir = repo_root / "templates"
+    assert set(CURRENT_TEMPLATE_NAMES) <= set(repository_template_names(templates_dir))
+    assert_packaging_output_preserves_metadata_and_archive_roots(templates_dir)
+    assert_distribution_metadata_keeps_template_assets_declared(repo_root)
+    assert_cpp_templates_reuse_c_core_as_packaged_file_payloads(templates_dir)
+    assert_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(
+        templates_dir
+    )
+    assert_cpp_template_packaging_resolves_windows_symlink_text_stubs(templates_dir)
+    assert_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub(
+        templates_dir
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """
+    Run the command-line template packaging maintenance check.
+
+    :param argv: Optional command-line argument list, defaults to ``None``.
+    :type argv: List[str], optional
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a maintenance contract fails.
+
+    Example::
+
+        >>> main([])  # doctest: +SKIP
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate repository-source built-in template packaging contracts."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(repository_root()),
+        help="Repository root to check. Defaults to the parent of this tools directory.",
+    )
+    args = parser.parse_args(argv)
+    run_checks(Path(args.repo_root).resolve())
+    print("template packaging checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_template_source_install.py
+++ b/tools/check_template_source_install.py
@@ -1,0 +1,183 @@
+"""
+Validate source-install access to packaged built-in templates.
+
+This maintenance command checks the source-install smoke path that is
+intentionally outside the pytest unit-test boundary. It installs the current
+checkout into a temporary target directory without dependencies, runs a probe
+outside the checkout, and verifies that :func:`pyfcstm.template.extract_template`
+can still extract a packaged built-in template.
+
+Example::
+
+    $ python tools/check_template_source_install.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict, List, Optional
+
+
+def repository_root() -> Path:
+    """
+    Return the repository root for this maintenance command.
+
+    :return: Repository root path.
+    :rtype: pathlib.Path
+
+    Example::
+
+        >>> repository_root().name  # doctest: +SKIP
+        'pyfcstm'
+    """
+    return Path(__file__).resolve().parents[1]
+
+
+def install_checkout(repo_root: Path, install_dir: Path) -> None:
+    """
+    Install the checkout into ``install_dir`` without dependencies.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :param install_dir: Target directory for ``pip install --target``.
+    :type install_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If pip installation fails.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     install_checkout(repository_root(), Path(td) / 'install')
+    """
+    command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--quiet",
+        "--no-deps",
+        "--target",
+        str(install_dir),
+        ".",
+    ]
+    subprocess.run(command, cwd=str(repo_root), check=True)
+
+
+def probe_environment(install_dir: Path) -> Dict[str, str]:
+    """
+    Build the environment for the installed-template probe.
+
+    :param install_dir: Directory containing the installed checkout package.
+    :type install_dir: pathlib.Path
+    :return: Environment mapping for :func:`subprocess.run`.
+    :rtype: Dict[str, str]
+
+    Example::
+
+        >>> 'PYTHONPATH' in probe_environment(Path('/tmp/install'))
+        True
+    """
+    return {
+        **os.environ,
+        "PYTHONPATH": str(install_dir),
+    }
+
+
+def run_extract_probe(build_root: Path, install_dir: Path) -> None:
+    """
+    Run the installed-package built-in template extraction probe.
+
+    :param build_root: Temporary working directory outside the checkout.
+    :type build_root: pathlib.Path
+    :param install_dir: Directory containing the installed checkout package.
+    :type install_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If the probe fails.
+    :raises AssertionError: If the probe output is not ``ok``.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     run_extract_probe(Path(td), Path(td) / 'install')
+    """
+    probe_code = (
+        "import os\n"
+        "from tempfile import TemporaryDirectory\n"
+        "from pyfcstm.template import extract_template\n"
+        "with TemporaryDirectory() as td:\n"
+        "    path = extract_template('python', td)\n"
+        "    assert os.path.basename(path) == 'python', path\n"
+        "    assert os.path.isfile(os.path.join(path, 'config.yaml')), path\n"
+        "    assert os.path.isfile(os.path.join(path, 'machine.py.j2')), path\n"
+        "    print('ok')\n"
+    )
+    probe = subprocess.run(
+        [sys.executable, "-c", probe_code],
+        cwd=str(build_root),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=probe_environment(install_dir),
+    )
+    assert probe.stdout.strip() == "ok"
+
+
+def run_check(repo_root: Path) -> None:
+    """
+    Run the source-install built-in template extraction smoke check.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If installation or probing fails.
+    :raises AssertionError: If the probe output is unexpected.
+
+    Example::
+
+        >>> run_check(repository_root())  # doctest: +SKIP
+    """
+    with TemporaryDirectory() as build_td:
+        build_root = Path(build_td)
+        install_dir = build_root / "install"
+        install_checkout(repo_root, install_dir)
+        run_extract_probe(build_root, install_dir)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """
+    Run the command-line source-install template extraction check.
+
+    :param argv: Optional command-line argument list, defaults to ``None``.
+    :type argv: List[str], optional
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If installation or probing fails.
+
+    Example::
+
+        >>> main([])  # doctest: +SKIP
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate source-install built-in template extraction."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(repository_root()),
+        help="Repository root to install. Defaults to the parent of this tools directory.",
+    )
+    args = parser.parse_args(argv)
+    run_check(Path(args.repo_root).resolve())
+    print("template source-install check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_test_boundary.py
+++ b/tools/check_test_boundary.py
@@ -1,0 +1,5780 @@
+"""
+Validate pytest boundary rules for repository tests.
+
+This maintenance command scans Python files under :mod:`test` and reports
+patterns that would make pytest depend on repository maintenance tooling or
+repository-source built-in templates. The command is intentionally outside the
+pytest unit-test suite so the guard can protect the test boundary without
+becoming another unit test that imports the private tooling it audits.
+
+The command contains the following checks:
+* direct imports or dynamic imports of ``tools.*`` from pytest files
+* subprocess or shell command strings that execute repository ``tools`` scripts
+* repo-root-tainted paths that access the source ``templates`` directory
+* source-install smoke-test markers that belong in maintenance commands
+
+Example::
+
+    $ python tools/check_test_boundary.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Set
+
+
+AST_CONSTANT_TYPE = getattr(ast, "Constant", None)
+AST_INDEX_TYPE = getattr(ast, "Index", None)
+AST_NUM_TYPE = getattr(ast, "Num", None)
+AST_STR_TYPE = getattr(ast, "Str", None) if sys.version_info < (3, 8) else None
+
+
+_STATIC_STRING_METHODS = {
+    "casefold",
+    "lower",
+    "upper",
+}
+_PATH_CONSTRUCTOR_NAMES = {
+    "Path",
+    "PurePath",
+    "PurePosixPath",
+    "PureWindowsPath",
+    "PosixPath",
+    "WindowsPath",
+}
+_OS_PATH_PASSTHROUGH_HELPERS = {
+    "abspath",
+    "normpath",
+    "realpath",
+}
+_OS_PATH_HELPERS = {
+    "abspath",
+    "dirname",
+    "join",
+    "normpath",
+    "realpath",
+    "split",
+}
+TOOLS_IMPORT_RULE = "tools-import"
+TOOLS_DYNAMIC_RULE = "tools-dynamic-import"
+TOOLS_CALL_RULE = "tools-call"
+TOOLS_EXEC_RULE = "tools-exec"
+SOURCE_TEMPLATE_RULE = "repo-source-templates"
+SOURCE_INSTALL_RULE = "source-install-smoke"
+PACKAGE_TEMPLATES_RULE = "package-templates-call"
+
+_SUBPROCESS_METHODS = {
+    "run",
+    "call",
+    "check_call",
+    "check_output",
+    "Popen",
+}
+_OS_COMMAND_METHODS = {
+    "execl",
+    "execle",
+    "execlp",
+    "execlpe",
+    "execv",
+    "execve",
+    "execvp",
+    "execvpe",
+    "system",
+    "popen",
+    "spawnl",
+    "spawnle",
+    "spawnlp",
+    "spawnlpe",
+    "spawnv",
+    "spawnve",
+    "spawnvp",
+    "spawnvpe",
+}
+_REPO_ROOT_NAME_FRAGMENTS = (
+    "repo_root",
+    "repository_root",
+)
+
+
+@dataclass
+class NameScope:
+    """
+    Track bindings and tainted aliases visible inside one lexical scope.
+
+    :param defined_names: Names bound by ordinary statements in the scope.
+    :type defined_names: Set[str]
+    :param shadowing_names: Non-import bindings that shadow same-scope import
+        aliases and outer-scope names.
+    :type shadowing_names: Set[str]
+    :param tools_aliases: Names known to refer to repository ``tools`` modules.
+    :type tools_aliases: Set[str]
+    :param dynamic_tools_aliases: Names assigned from dynamic ``tools`` imports.
+    :type dynamic_tools_aliases: Set[str]
+    :param importlib_aliases: Names that expose ``importlib.import_module``.
+    :type importlib_aliases: Set[str]
+    :param importlib_util_aliases: Names that expose the :mod:`importlib.util`
+        module.
+    :type importlib_util_aliases: Set[str]
+    :param importlib_util_spec_aliases: Names imported from
+        :func:`importlib.util.spec_from_file_location`.
+    :type importlib_util_spec_aliases: Set[str]
+    :param builtins_aliases: Names that expose the :mod:`builtins` module.
+    :type builtins_aliases: Set[str]
+    :param pathlib_aliases: Names that expose the :mod:`pathlib` module.
+    :type pathlib_aliases: Set[str]
+    :param path_class_aliases: Names that expose :class:`pathlib.Path` or
+        compatible :mod:`pathlib` path constructors.
+    :type path_class_aliases: Set[str]
+    :param pytest_aliases: Names that expose the :mod:`pytest` module.
+    :type pytest_aliases: Set[str]
+    :param pytest_importorskip_aliases: Names imported from
+        :func:`pytest.importorskip`.
+    :type pytest_importorskip_aliases: Set[str]
+    :param runpy_aliases: Names that expose the :mod:`runpy` module.
+    :type runpy_aliases: Set[str]
+    :param runpy_run_module_aliases: Names imported from
+        :func:`runpy.run_module`.
+    :type runpy_run_module_aliases: Set[str]
+    :param runpy_run_path_aliases: Names imported from :func:`runpy.run_path`.
+    :type runpy_run_path_aliases: Set[str]
+    :param sys_aliases: Names that expose the :mod:`sys` module.
+    :type sys_aliases: Set[str]
+    :param sys_modules_aliases: Names imported from :data:`sys.modules`.
+    :type sys_modules_aliases: Set[str]
+    :param sys_modules_getitem_aliases: Names that expose
+        ``sys.modules.__getitem__``.
+    :type sys_modules_getitem_aliases: Set[str]
+    :param sys_modules_get_aliases: Names that expose ``sys.modules.get``.
+    :type sys_modules_get_aliases: Set[str]
+    :param subprocess_aliases: Names that expose the :mod:`subprocess` module.
+    :type subprocess_aliases: Set[str]
+    :param subprocess_function_aliases: Names imported from subprocess command helpers.
+    :type subprocess_function_aliases: Set[str]
+    :param os_aliases: Names that expose the :mod:`os` module.
+    :type os_aliases: Set[str]
+    :param os_function_aliases: Names imported from OS command helpers.
+    :type os_function_aliases: Set[str]
+    :param os_function_alias_methods: Original OS command helper names by local
+        alias.
+    :type os_function_alias_methods: Dict[str, str]
+    :param os_path_aliases: Names that expose the :mod:`os.path` module.
+    :type os_path_aliases: Set[str]
+    :param os_path_join_aliases: Names imported from ``os.path.join``.
+    :type os_path_join_aliases: Set[str]
+    :param os_path_dirname_aliases: Names imported from ``os.path.dirname``.
+    :type os_path_dirname_aliases: Set[str]
+    :param os_path_abspath_aliases: Names imported from path-preserving
+        :mod:`os.path` helpers such as ``abspath``, ``normpath``, or
+        ``realpath``.
+    :type os_path_abspath_aliases: Set[str]
+    :param os_path_split_aliases: Names imported from ``os.path.split``.
+    :type os_path_split_aliases: Set[str]
+    :param os_getcwd_aliases: Names imported from ``os.getcwd``.
+    :type os_getcwd_aliases: Set[str]
+    :param repo_root_aliases: Names assigned from repository-root expressions.
+    :type repo_root_aliases: Set[str]
+    :param path_parent_hop_aliases: Parent-hop counts for path expressions rooted at
+        ``__file__`` but not necessarily at repo root yet.
+    :type path_parent_hop_aliases: Dict[str, int]
+    :param file_parents_aliases: Names assigned from ``Path(__file__).parents``
+        sequence expressions.
+    :type file_parents_aliases: Set[str]
+    :param string_aliases: Statically known string values by local name.
+    :type string_aliases: Dict[str, str]
+    :param dynamic_code_alias_rules: Boundary rules found in compiled dynamic
+        code by local name.
+    :type dynamic_code_alias_rules: Dict[str, str]
+    :param template_segment_aliases: Names assigned from the exact path segment
+        ``"templates"``.
+    :type template_segment_aliases: Set[str]
+    :param tools_module_name_aliases: Names assigned from ``tools`` module-name
+        strings.
+    :type tools_module_name_aliases: Set[str]
+    :param tools_command_aliases: Names assigned from commands that execute tools scripts.
+    :type tools_command_aliases: Set[str]
+    :param source_install_command_aliases: Names assigned from source-install commands.
+    :type source_install_command_aliases: Set[str]
+    :param package_templates_aliases: Names imported from ``tools.package_templates``.
+    :type package_templates_aliases: Set[str]
+    :param is_class_body: Whether this scope models a class namespace.
+    :type is_class_body: bool
+
+    Example::
+
+        >>> scope = NameScope.create(defined_names={'tools'})
+        >>> 'tools' in scope.defined_names
+        True
+    """
+
+    defined_names: Set[str]
+    shadowing_names: Set[str]
+    tools_aliases: Set[str]
+    dynamic_tools_aliases: Set[str]
+    importlib_aliases: Set[str]
+    importlib_util_aliases: Set[str]
+    importlib_util_spec_aliases: Set[str]
+    builtins_aliases: Set[str]
+    pathlib_aliases: Set[str]
+    path_class_aliases: Set[str]
+    pytest_aliases: Set[str]
+    pytest_importorskip_aliases: Set[str]
+    runpy_aliases: Set[str]
+    runpy_run_module_aliases: Set[str]
+    runpy_run_path_aliases: Set[str]
+    sys_aliases: Set[str]
+    sys_modules_aliases: Set[str]
+    sys_modules_getitem_aliases: Set[str]
+    sys_modules_get_aliases: Set[str]
+    subprocess_aliases: Set[str]
+    subprocess_function_aliases: Set[str]
+    os_aliases: Set[str]
+    os_function_aliases: Set[str]
+    os_function_alias_methods: Dict[str, str]
+    os_path_aliases: Set[str]
+    os_path_join_aliases: Set[str]
+    os_path_dirname_aliases: Set[str]
+    os_path_abspath_aliases: Set[str]
+    os_path_split_aliases: Set[str]
+    os_getcwd_aliases: Set[str]
+    repo_root_aliases: Set[str]
+    path_parent_hop_aliases: Dict[str, int]
+    file_parents_aliases: Set[str]
+    string_aliases: Dict[str, str]
+    dynamic_code_alias_rules: Dict[str, str]
+    template_segment_aliases: Set[str]
+    tools_module_name_aliases: Set[str]
+    tools_command_aliases: Set[str]
+    source_install_command_aliases: Set[str]
+    package_templates_aliases: Set[str]
+    is_class_body: bool = False
+
+    @classmethod
+    def create(
+        cls,
+        defined_names: Optional[Set[str]] = None,
+        shadowing_names: Optional[Set[str]] = None,
+        importlib_aliases: Optional[Set[str]] = None,
+        builtins_aliases: Optional[Set[str]] = None,
+        pathlib_aliases: Optional[Set[str]] = None,
+        path_class_aliases: Optional[Set[str]] = None,
+        pytest_aliases: Optional[Set[str]] = None,
+        runpy_aliases: Optional[Set[str]] = None,
+        sys_aliases: Optional[Set[str]] = None,
+        subprocess_aliases: Optional[Set[str]] = None,
+        os_aliases: Optional[Set[str]] = None,
+        is_class_body: bool = False,
+    ) -> "NameScope":
+        """
+        Create a scope with optional predefined bindings.
+
+        :param defined_names: Ordinary names bound in this scope, defaults to ``None``.
+        :type defined_names: Set[str], optional
+        :param shadowing_names: Non-import bindings that shadow aliases, defaults
+            to ``None``.
+        :type shadowing_names: Set[str], optional
+        :param importlib_aliases: Predefined importlib aliases, defaults to ``None``.
+        :type importlib_aliases: Set[str], optional
+        :param builtins_aliases: Predefined builtins aliases, defaults to ``None``.
+        :type builtins_aliases: Set[str], optional
+        :param pathlib_aliases: Predefined pathlib aliases, defaults to ``None``.
+        :type pathlib_aliases: Set[str], optional
+        :param path_class_aliases: Predefined Path class aliases, defaults to
+            ``None``.
+        :type path_class_aliases: Set[str], optional
+        :param pytest_aliases: Predefined pytest aliases, defaults to ``None``.
+        :type pytest_aliases: Set[str], optional
+        :param runpy_aliases: Predefined runpy aliases, defaults to ``None``.
+        :type runpy_aliases: Set[str], optional
+        :param sys_aliases: Predefined sys aliases, defaults to ``None``.
+        :type sys_aliases: Set[str], optional
+        :param subprocess_aliases: Predefined subprocess aliases, defaults to ``None``.
+        :type subprocess_aliases: Set[str], optional
+        :param os_aliases: Predefined os aliases, defaults to ``None``.
+        :type os_aliases: Set[str], optional
+        :param is_class_body: Whether the scope is a class namespace, defaults to ``False``.
+        :type is_class_body: bool, optional
+        :return: New lexical scope state.
+        :rtype: NameScope
+
+        Example::
+
+            >>> scope = NameScope.create(importlib_aliases={'importlib'})
+            >>> 'importlib' in scope.importlib_aliases
+            True
+        """
+        return cls(
+            defined_names=set(defined_names or set()),
+            shadowing_names=set(shadowing_names or set()),
+            tools_aliases=set(),
+            dynamic_tools_aliases=set(),
+            importlib_aliases=set(importlib_aliases or set()),
+            importlib_util_aliases=set(),
+            importlib_util_spec_aliases=set(),
+            builtins_aliases=set(builtins_aliases or set()),
+            pathlib_aliases=set(pathlib_aliases or set()),
+            path_class_aliases=set(path_class_aliases or set()),
+            pytest_aliases=set(pytest_aliases or set()),
+            pytest_importorskip_aliases=set(),
+            runpy_aliases=set(runpy_aliases or set()),
+            runpy_run_module_aliases=set(),
+            runpy_run_path_aliases=set(),
+            sys_aliases=set(sys_aliases or set()),
+            sys_modules_aliases=set(),
+            sys_modules_getitem_aliases=set(),
+            sys_modules_get_aliases=set(),
+            subprocess_aliases=set(subprocess_aliases or set()),
+            subprocess_function_aliases=set(),
+            os_aliases=set(os_aliases or set()),
+            os_function_aliases=set(),
+            os_function_alias_methods={},
+            os_path_aliases=set(),
+            os_path_join_aliases=set(),
+            os_path_dirname_aliases=set(),
+            os_path_abspath_aliases=set(),
+            os_path_split_aliases=set(),
+            os_getcwd_aliases=set(),
+            repo_root_aliases=set(),
+            path_parent_hop_aliases={},
+            file_parents_aliases=set(),
+            string_aliases={},
+            dynamic_code_alias_rules={},
+            template_segment_aliases=set(),
+            tools_module_name_aliases=set(),
+            tools_command_aliases=set(),
+            source_install_command_aliases=set(),
+            package_templates_aliases=set(),
+            is_class_body=is_class_body,
+        )
+
+
+@dataclass(frozen=True)
+class BoundaryFinding:
+    """
+    Describe one test-boundary violation.
+
+    :param path: Python file containing the finding.
+    :type path: pathlib.Path
+    :param line: One-based source line number.
+    :type line: int
+    :param column: One-based source column number.
+    :type column: int
+    :param rule: Stable rule identifier.
+    :type rule: str
+    :param message: Human-readable diagnostic message.
+    :type message: str
+    :param source: Source line text, if available.
+    :type source: str
+
+    Example::
+
+        >>> finding = BoundaryFinding(Path('test/example.py'), 1, 1, 'rule', 'message', 'text')
+        >>> finding.location
+        'test/example.py:1:1'
+    """
+
+    path: Path
+    line: int
+    column: int
+    rule: str
+    message: str
+    source: str
+
+    @property
+    def location(self) -> str:
+        """
+        Return the compact source location for this finding.
+
+        :return: Location formatted as ``path:line:column``.
+        :rtype: str
+
+        Example::
+
+            >>> BoundaryFinding(Path('x.py'), 2, 3, 'r', 'm', '').location
+            'x.py:2:3'
+        """
+        return "{path}:{line}:{column}".format(
+            path=self.path.as_posix(),
+            line=self.line,
+            column=self.column,
+        )
+
+
+def repository_root() -> Path:
+    """
+    Return the repository root for direct script execution.
+
+    :return: Repository root path.
+    :rtype: pathlib.Path
+
+    Example::
+
+        >>> repository_root().name  # doctest: +SKIP
+        'pyfcstm'
+    """
+    return Path(__file__).resolve().parents[1]
+
+
+def iter_python_files(test_root: Path) -> Iterable[Path]:
+    """
+    Yield Python test files in deterministic order.
+
+    :param test_root: Root directory to scan.
+    :type test_root: pathlib.Path
+    :return: Iterator over Python source paths.
+    :rtype: typing.Iterable[pathlib.Path]
+
+    Example::
+
+        >>> next(iter_python_files(repository_root() / 'test')).suffix
+        '.py'
+    """
+    for path in sorted(test_root.rglob("*.py")):
+        parts = set(path.parts)
+        if "__pycache__" not in parts:
+            yield path
+
+
+def read_source(path: Path) -> str:
+    """
+    Read a UTF-8 Python source file.
+
+    :param path: Python file path.
+    :type path: pathlib.Path
+    :return: Source text.
+    :rtype: str
+    :raises OSError: If the source file cannot be read.
+
+    Example::
+
+        >>> 'Validate pytest boundary' in read_source(repository_root() / 'tools' / 'check_test_boundary.py')
+        True
+    """
+    return path.read_text(encoding="utf-8")
+
+
+def dotted_name(node: ast.AST) -> Optional[str]:
+    """
+    Return a dotted expression name when ``node`` is name-like.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :return: Dotted name, or ``None`` when the node is not name-like.
+    :rtype: str, optional
+
+    Example::
+
+        >>> dotted_name(ast.parse('subprocess.run()').body[0].value.func)
+        'subprocess.run'
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = dotted_name(node.value)
+        if parent is not None:
+            return "{parent}.{attr}".format(parent=parent, attr=node.attr)
+    return None
+
+
+def literal_string(node: ast.AST) -> Optional[str]:
+    """
+    Return a statically known string value from an AST node.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :return: String literal value, or ``None`` when the node is not a string.
+    :rtype: str, optional
+
+    Example::
+
+        >>> literal_string(ast.parse('"x"').body[0].value)
+        'x'
+        >>> literal_string(ast.parse('"tem" + "plates"').body[0].value)
+        'templates'
+        >>> literal_string(ast.parse('f"tools.package_templates"').body[0].value)
+        'tools.package_templates'
+        >>> literal_string(ast.parse('chr(116) + "ools"').body[0].value)
+        'tools'
+        >>> literal_string(ast.parse('"TEMPLATES".lower()').body[0].value)
+        'templates'
+        >>> literal_string(ast.parse('b"templates".decode()').body[0].value)
+        'templates'
+    """
+    if AST_STR_TYPE is not None and isinstance(node, AST_STR_TYPE):
+        return getattr(node, "s")
+    if AST_CONSTANT_TYPE is not None and isinstance(node, AST_CONSTANT_TYPE):
+        if isinstance(node.value, str):
+            return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts = []
+        for value in node.values:
+            if isinstance(value, ast.FormattedValue):
+                if value.format_spec is not None:
+                    return None
+                part = literal_string(value.value)
+            else:
+                part = literal_string(value)
+            if part is None:
+                return None
+            parts.append(part)
+        return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = literal_string(node.left)
+        right = literal_string(node.right)
+        if left is not None and right is not None:
+            return left + right
+    if isinstance(node, ast.Call):
+        if (
+            dotted_name(node.func) == "chr"
+            and len(node.args) == 1
+            and not node.keywords
+        ):
+            codepoint = literal_integer(node.args[0])
+            if codepoint is not None and 0 <= codepoint <= 0x10FFFF:
+                return chr(codepoint)
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr in _STATIC_STRING_METHODS:
+                if node.args or node.keywords:
+                    return None
+                value = literal_string(node.func.value)
+                if value is None:
+                    return None
+                if node.func.attr == "lower":
+                    return value.lower()
+                if node.func.attr == "upper":
+                    return value.upper()
+                return value.casefold()
+            if node.func.attr == "decode":
+                return literal_decode_call_string(node)
+    return None
+
+
+def literal_decode_call_string(node: ast.Call) -> Optional[str]:
+    """
+    Return the static string produced by a bytes ``decode`` call.
+
+    :param node: Call expression to inspect.
+    :type node: ast.Call
+    :return: Decoded string, or ``None`` when the call is not static.
+    :rtype: str, optional
+
+    Example::
+
+        >>> literal_decode_call_string(ast.parse('b"tools".decode("ascii")').body[0].value)
+        'tools'
+    """
+    if not isinstance(node.func, ast.Attribute) or node.func.attr != "decode":
+        return None
+    if len(node.args) > 1 or node.keywords:
+        return None
+    value = literal_bytes(node.func.value)
+    if value is None:
+        return None
+    encoding = "utf-8"
+    if node.args:
+        static_encoding = literal_string(node.args[0])
+        if static_encoding is None:
+            return None
+        encoding = static_encoding
+    try:
+        return value.decode(encoding)
+    except (LookupError, UnicodeDecodeError):
+        # LookupError: static encoding literal is not a known codec.
+        # UnicodeDecodeError: static bytes cannot be decoded with that codec.
+        return None
+
+
+def literal_bytes(node: ast.AST) -> Optional[bytes]:
+    """
+    Return a static bytes literal value.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :return: Bytes value, or ``None`` when the node is not a bytes literal.
+    :rtype: bytes, optional
+
+    Example::
+
+        >>> literal_bytes(ast.parse('b"x"').body[0].value)
+        b'x'
+    """
+    if AST_CONSTANT_TYPE is not None and isinstance(node, AST_CONSTANT_TYPE):
+        if isinstance(node.value, bytes):
+            return node.value
+    return None
+
+
+def literal_integer(node: ast.AST) -> Optional[int]:
+    """
+    Return a static integer literal value.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :return: Integer value, or ``None`` when the node is not an integer literal.
+    :rtype: int, optional
+
+    Example::
+
+        >>> literal_integer(ast.parse('116').body[0].value)
+        116
+    """
+    if isinstance(node, int):
+        return node
+    if AST_CONSTANT_TYPE is not None and isinstance(node, AST_CONSTANT_TYPE):
+        if isinstance(node.value, int) and not isinstance(node.value, bool):
+            return node.value
+    if AST_NUM_TYPE is not None and isinstance(node, AST_NUM_TYPE):
+        number = getattr(node, "n", None)
+        if isinstance(number, int) and not isinstance(number, bool):
+            return number
+    return None
+
+
+def collect_string_literals(node: ast.AST) -> List[str]:
+    """
+    Collect string literals inside ``node``.
+
+    :param node: AST node to scan.
+    :type node: ast.AST
+    :return: String literal values in traversal order.
+    :rtype: List[str]
+
+    Example::
+
+        >>> collect_string_literals(ast.parse('["a", "b"]').body[0].value)
+        ['a', 'b']
+    """
+    values = []
+    for child in ast.walk(node):
+        value = literal_string(child)
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def collect_defined_names(tree: ast.AST) -> Set[str]:
+    """
+    Collect module-scope names that make bare names look locally defined.
+
+    :param tree: Parsed Python AST.
+    :type tree: ast.AST
+    :return: Module-scope defined names.
+    :rtype: Set[str]
+
+    Example::
+
+        >>> tree = ast.parse('def f(): pass')
+        >>> collect_defined_names(tree)
+        {'f'}
+        >>> tree = ast.parse('package_templates = lambda: None')
+        >>> 'package_templates' in collect_defined_names(tree)
+        True
+        >>> tree = ast.parse('def f():\\n    tools = object()')
+        >>> 'tools' in collect_defined_names(tree)
+        False
+    """
+    return collect_scope_defined_names(getattr(tree, "body", []), include_imports=True)
+
+
+def collect_scope_defined_names(
+    statements: Sequence[ast.AST], include_imports: bool = True
+) -> Set[str]:
+    """
+    Collect names bound directly in a lexical statement scope.
+
+    Nested function and class bodies are intentionally not traversed because
+    their local bindings must not shadow sibling functions in the containing
+    module.
+
+    :param statements: Statements that make up one lexical scope body.
+    :type statements: Sequence[ast.AST]
+    :param include_imports: Whether import statements count as ordinary
+        definitions, defaults to ``True``.
+    :type include_imports: bool, optional
+    :return: Names bound in that scope.
+    :rtype: Set[str]
+
+    Example::
+
+        >>> tree = ast.parse('def f():\\n    tools = object()\\ndef g(): pass')
+        >>> sorted(collect_scope_defined_names(tree.body))
+        ['f', 'g']
+        >>> func = tree.body[0]
+        >>> 'tools' in collect_scope_defined_names(func.body)
+        True
+    """
+    names = set()
+    for statement in statements:
+        names.update(
+            statement_defined_names(statement, include_imports=include_imports)
+        )
+    return names
+
+
+def statement_defined_names(
+    statement: ast.AST, include_imports: bool = True
+) -> Set[str]:
+    """
+    Collect names bound by one statement in its current lexical scope.
+
+    :param statement: Statement node to inspect.
+    :type statement: ast.AST
+    :param include_imports: Whether import statements count as definitions,
+        defaults to ``True``.
+    :type include_imports: bool, optional
+    :return: Names bound by the statement or nested same-scope branches.
+    :rtype: Set[str]
+
+    Example::
+
+        >>> statement_defined_names(ast.parse('for tools in items:\\n    pass').body[0])
+        {'tools'}
+    """
+    names = set()
+    if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        return {statement.name}
+    if isinstance(statement, ast.Import) and include_imports:
+        for alias in statement.names:
+            names.add(alias.asname or alias.name.split(".")[0])
+    elif isinstance(statement, ast.ImportFrom) and include_imports:
+        for alias in statement.names:
+            names.add(alias.asname or alias.name)
+    elif isinstance(statement, ast.Assign):
+        for target in statement.targets:
+            names.update(assigned_target_names(target))
+    elif isinstance(statement, ast.AnnAssign):
+        names.update(assigned_target_names(statement.target))
+    elif isinstance(statement, ast.AugAssign):
+        names.update(assigned_target_names(statement.target))
+    elif isinstance(statement, (ast.For, ast.AsyncFor)):
+        names.update(assigned_target_names(statement.target))
+        names.update(
+            collect_scope_defined_names(statement.body, include_imports=include_imports)
+        )
+        names.update(
+            collect_scope_defined_names(
+                statement.orelse, include_imports=include_imports
+            )
+        )
+    elif isinstance(statement, (ast.With, ast.AsyncWith)):
+        for item in statement.items:
+            if item.optional_vars is not None:
+                names.update(assigned_target_names(item.optional_vars))
+        names.update(
+            collect_scope_defined_names(statement.body, include_imports=include_imports)
+        )
+    elif isinstance(statement, ast.If):
+        names.update(
+            collect_scope_defined_names(statement.body, include_imports=include_imports)
+        )
+        names.update(
+            collect_scope_defined_names(
+                statement.orelse, include_imports=include_imports
+            )
+        )
+    elif isinstance(statement, ast.While):
+        names.update(
+            collect_scope_defined_names(statement.body, include_imports=include_imports)
+        )
+        names.update(
+            collect_scope_defined_names(
+                statement.orelse, include_imports=include_imports
+            )
+        )
+    elif isinstance(statement, ast.Try):
+        names.update(
+            collect_scope_defined_names(statement.body, include_imports=include_imports)
+        )
+        names.update(
+            collect_scope_defined_names(
+                statement.orelse, include_imports=include_imports
+            )
+        )
+        names.update(
+            collect_scope_defined_names(
+                statement.finalbody, include_imports=include_imports
+            )
+        )
+        for handler in statement.handlers:
+            if handler.name:
+                names.add(handler.name)
+            names.update(
+                collect_scope_defined_names(
+                    handler.body, include_imports=include_imports
+                )
+            )
+    return names
+
+
+def collect_shadowing_names(statements: Sequence[ast.AST]) -> Set[str]:
+    """
+    Collect non-import names that shadow aliases in one scope.
+
+    :param statements: Statements that make up one lexical scope body.
+    :type statements: Sequence[ast.AST]
+    :return: Names introduced by non-import bindings.
+    :rtype: Set[str]
+
+    Example::
+
+        >>> tree = ast.parse('import tools\\ndef tools(): pass')
+        >>> collect_shadowing_names(tree.body)
+        {'tools'}
+    """
+    return collect_scope_defined_names(statements, include_imports=False)
+
+
+def function_argument_names(arguments: ast.arguments) -> Set[str]:
+    """
+    Collect names bound by a function or lambda argument list.
+
+    :param arguments: Function argument node.
+    :type arguments: ast.arguments
+    :return: Argument names bound in the function scope.
+    :rtype: Set[str]
+
+    Example::
+
+        >>> func = ast.parse('def f(pos, /, x, *args, y, **kwargs): pass').body[0]
+        >>> sorted(function_argument_names(func.args))
+        ['args', 'kwargs', 'pos', 'x', 'y']
+    """
+    names = set()
+    for argument in list(getattr(arguments, "posonlyargs", [])) + list(arguments.args):
+        names.add(argument.arg)
+    for argument in arguments.kwonlyargs:
+        names.add(argument.arg)
+    if arguments.vararg is not None:
+        names.add(arguments.vararg.arg)
+    if arguments.kwarg is not None:
+        names.add(arguments.kwarg.arg)
+    return names
+
+
+def assigned_target_names(node: ast.AST) -> Set[str]:
+    """
+    Return simple names assigned by an assignment target.
+
+    :param node: Assignment target node.
+    :type node: ast.AST
+    :return: Assigned identifier names.
+    :rtype: Set[str]
+
+    Example::
+
+        >>> assigned_target_names(ast.parse('a = 1').body[0].targets[0])
+        {'a'}
+    """
+    if isinstance(node, ast.Name):
+        return {node.id}
+    names = set()
+    if isinstance(node, (ast.Tuple, ast.List)):
+        for item in node.elts:
+            names.update(assigned_target_names(item))
+    return names
+
+
+def is_tools_module_name(name: str) -> bool:
+    """
+    Return whether ``name`` denotes the repository ``tools`` package.
+
+    :param name: Dotted import or module name.
+    :type name: str
+    :return: ``True`` when the name is ``tools`` or a ``tools.*`` module.
+    :rtype: bool
+
+    Example::
+
+        >>> is_tools_module_name('tools.package_templates')
+        True
+    """
+    return name == "tools" or name.startswith("tools.")
+
+
+def is_pip_command_token(token: str) -> bool:
+    """
+    Return whether ``token`` is a direct pip executable name.
+
+    :param token: Command token to inspect.
+    :type token: str
+    :return: ``True`` for ``pip`` and versioned ``pip`` executable names.
+    :rtype: bool
+
+    Example::
+
+        >>> is_pip_command_token('pip')
+        True
+        >>> is_pip_command_token('pip3.10')
+        True
+        >>> is_pip_command_token('pip-tools')
+        False
+    """
+    if token == "pip":
+        return True
+    if not token.startswith("pip"):
+        return False
+    suffix = token[3:]
+    if not suffix:
+        return True
+    parts = suffix.split(".")
+    return all(part.isdigit() for part in parts)
+
+
+def is_repo_root_name(name: str) -> bool:
+    """
+    Return whether an identifier conventionally denotes the repository root.
+
+    :param name: Identifier to inspect.
+    :type name: str
+    :return: ``True`` when the name is a repo-root-style identifier.
+    :rtype: bool
+
+    Example::
+
+        >>> is_repo_root_name('_REPO_ROOT')
+        True
+    """
+    lower = name.lower()
+    return any(fragment in lower for fragment in _REPO_ROOT_NAME_FRAGMENTS)
+
+
+def node_contains_name(node: ast.AST, name: str) -> bool:
+    """
+    Return whether ``node`` contains a :class:`ast.Name` with ``name``.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :param name: Identifier to search for.
+    :type name: str
+    :return: ``True`` when the identifier appears in ``node``.
+    :rtype: bool
+
+    Example::
+
+        >>> node_contains_name(ast.parse('Path(__file__)').body[0].value, '__file__')
+        True
+    """
+    return any(
+        isinstance(child, ast.Name) and child.id == name for child in ast.walk(node)
+    )
+
+
+def is_file_parents_expr(node: ast.AST) -> bool:
+    """
+    Return whether ``node`` climbs from ``__file__`` toward parent paths.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :return: ``True`` for path expressions rooted at ``__file__`` parents.
+    :rtype: bool
+
+    Example::
+
+        >>> expr = ast.parse('Path(__file__).resolve().parents[2]').body[0].value
+        >>> is_file_parents_expr(expr)
+        True
+        >>> expr = ast.parse('Path(__file__).resolve().parent.parent').body[0].value
+        >>> is_file_parents_expr(expr)
+        True
+        >>> expr = ast.parse('Path(__file__).resolve().parent').body[0].value
+        >>> is_file_parents_expr(expr)
+        False
+    """
+    for child in ast.walk(node):
+        if isinstance(child, ast.Subscript):
+            value = child.value
+            if isinstance(value, ast.Attribute) and value.attr == "parents":
+                if node_contains_name(value.value, "__file__"):
+                    return True
+        if parent_chain_depth(child) >= 2:
+            return True
+    return False
+
+
+def parent_chain_depth(node: ast.AST) -> int:
+    """
+    Return the number of consecutive ``.parent`` hops from a ``__file__`` path.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :return: Number of consecutive ``.parent`` attributes rooted at ``__file__``.
+    :rtype: int
+
+    Example::
+
+        >>> expr = ast.parse('Path(__file__).resolve().parent.parent').body[0].value
+        >>> parent_chain_depth(expr)
+        2
+    """
+    depth = 0
+    current = node
+    while isinstance(current, ast.Attribute) and current.attr == "parent":
+        depth += 1
+        current = current.value
+    if depth and node_contains_name(current, "__file__"):
+        return depth
+    return 0
+
+
+def subscript_integer(node: ast.Subscript) -> Optional[int]:
+    """
+    Return an integer literal subscript index when available.
+
+    Python 3.7 parses ``x[2]`` as ``ast.Index(ast.Num(2))``, while newer
+    versions expose the literal directly as :class:`ast.Constant`. This helper
+    normalizes both layouts before reading the integer.
+
+    :param node: Subscript node to inspect.
+    :type node: ast.Subscript
+    :return: Integer index, or ``None`` when not statically literal.
+    :rtype: int, optional
+
+    Example::
+
+        >>> subscript_integer(ast.parse('x[2]').body[0].value)
+        2
+    """
+    value = node.slice
+    if AST_INDEX_TYPE is not None and isinstance(value, AST_INDEX_TYPE):
+        value = value.value
+    if isinstance(value, int):
+        return value
+    if AST_CONSTANT_TYPE is not None and isinstance(value, AST_CONSTANT_TYPE):
+        if isinstance(value.value, int):
+            return value.value
+    if AST_NUM_TYPE is not None and isinstance(value, AST_NUM_TYPE):
+        number = getattr(value, "n", None)
+        if isinstance(number, int):
+            return number
+    return None
+
+
+def is_exact_segment(node: ast.AST, segment: str) -> bool:
+    """
+    Return whether ``node`` contains an exact path segment.
+
+    :param node: AST node to inspect.
+    :type node: ast.AST
+    :param segment: Expected path segment.
+    :type segment: str
+    :return: ``True`` when ``node`` contains that exact path segment.
+    :rtype: bool
+
+    Example::
+
+        >>> is_exact_segment(ast.parse('"templates"').body[0].value, 'templates')
+        True
+        >>> is_exact_segment(ast.parse('"/repo/templates"').body[0].value, 'templates')
+        True
+        >>> is_exact_segment(ast.parse('"harness_templates"').body[0].value, 'templates')
+        False
+    """
+    value = literal_string(node)
+    if value is None:
+        return False
+    return segment in path_segments(value)
+
+
+def path_segments(value: str) -> List[str]:
+    """
+    Split a path-like literal into non-empty slash-delimited segments.
+
+    Both POSIX and Windows separators are normalized so exact segment checks can
+    recognize ``templates`` without treating ``harness_templates`` as a match.
+
+    :param value: String literal value to split.
+    :type value: str
+    :return: Non-empty path segments.
+    :rtype: List[str]
+
+    Example::
+
+        >>> path_segments('/repo/templates')
+        ['repo', 'templates']
+        >>> path_segments('harness_templates')
+        ['harness_templates']
+    """
+    return [segment for segment in value.replace("\\", "/").split("/") if segment]
+
+
+def command_text_runs_tools_script(text: str) -> bool:
+    """
+    Return whether a command string executes repository tools.
+
+    :param text: Command string or command argument.
+    :type text: str
+    :return: ``True`` for ``tools/*.py`` or ``python -m tools.*`` patterns.
+    :rtype: bool
+
+    Example::
+
+        >>> command_text_runs_tools_script('python -m tools.package_templates')
+        True
+        >>> command_text_runs_tools_script('python -m tools x.py')
+        True
+    """
+    normalized = text.replace("\\", "/")
+    if "tools/" in normalized and ".py" in normalized:
+        return True
+    tokens = normalized.strip().split()
+    for index, token in enumerate(tokens[:-1]):
+        if token == "-m" and (
+            tokens[index + 1] == "tools" or tokens[index + 1].startswith("tools.")
+        ):
+            return True
+    return "-m tools." in normalized or normalized.strip().startswith("tools.")
+
+
+def command_sequence_runs_tools_script(values: Sequence[str]) -> bool:
+    """
+    Return whether a command argument sequence executes repository tools.
+
+    :param values: Command argument literals.
+    :type values: Sequence[str]
+    :return: ``True`` when the sequence targets a repository tools module/script.
+    :rtype: bool
+
+    Example::
+
+        >>> command_sequence_runs_tools_script(['python', '-m', 'tools.package_templates'])
+        True
+    """
+    for index, value in enumerate(values):
+        if command_text_runs_tools_script(value):
+            return True
+        if value == "-m" and index + 1 < len(values):
+            if values[index + 1] == "tools" or values[index + 1].startswith("tools."):
+                return True
+    return False
+
+
+def expression_runs_tools_script(node: ast.AST) -> bool:
+    """
+    Return whether a command expression executes repository tools.
+
+    :param node: AST node for a subprocess or shell command argument.
+    :type node: ast.AST
+    :return: ``True`` when the command contains a tools script/module target.
+    :rtype: bool
+
+    Example::
+
+        >>> expression_runs_tools_script(ast.parse('["python", "-m", "tools.x"]').body[0].value)
+        True
+        >>> expression_runs_tools_script(ast.parse('Path("tools") / "x.py"').body[0].value)
+        True
+    """
+    if isinstance(node, ast.Name):
+        return False
+    values = collect_string_literals(node)
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return command_sequence_runs_tools_script(
+            values
+        ) or command_literals_form_tools_script_path(values)
+    if command_sequence_runs_tools_script(values):
+        return True
+    if command_literals_form_tools_script_path(values):
+        return True
+    return any(command_text_runs_tools_script(value) for value in values)
+
+
+def expression_runs_source_install_command(node: ast.AST) -> bool:
+    """
+    Return whether a command expression performs a source install.
+
+    :param node: AST node for a subprocess or shell command argument.
+    :type node: ast.AST
+    :return: ``True`` when string literals form ``pip install`` of local source.
+    :rtype: bool
+
+    Example::
+
+        >>> expression_runs_source_install_command(ast.parse('["python", "-m", "pip", "install", "."]').body[0].value)
+        True
+        >>> expression_runs_source_install_command(ast.parse('["pip", "install", "pytest"]').body[0].value)
+        False
+    """
+    if isinstance(node, ast.Name):
+        return False
+    values = collect_string_literals(node)
+    return any(
+        string_contains_source_install_marker(value) for value in values
+    ) or string_contains_source_install_marker(" ".join(values))
+
+
+def command_literals_form_tools_script_path(values: Sequence[str]) -> bool:
+    """
+    Return whether string literals combine into a ``tools/*.py`` path.
+
+    :param values: String literal values from a command expression.
+    :type values: Sequence[str]
+    :return: ``True`` when literals contain a ``tools`` segment and a Python file.
+    :rtype: bool
+
+    Example::
+
+        >>> command_literals_form_tools_script_path(['tools', 'x.py'])
+        True
+    """
+    normalized_values = [value.replace("\\", "/") for value in values]
+    has_tools_segment = any(
+        value == "tools" or "/tools/" in "/{value}/".format(value=value.strip("/"))
+        for value in normalized_values
+    )
+    has_python_file = any(value.endswith(".py") for value in normalized_values)
+    return has_tools_segment and has_python_file
+
+
+def string_contains_source_install_marker(value: str) -> bool:
+    """
+    Return whether a string literal describes a source-install smoke path.
+
+    The check intentionally requires a ``pip install`` command shape before
+    treating local paths or ``--target`` as source-install smoke evidence. This
+    avoids blocking ordinary test configuration keys such as ``install_dir`` or
+    native compiler flags such as ``--target``.
+
+    :param value: String literal value to inspect.
+    :type value: str
+    :return: ``True`` when the literal looks like a source-install smoke command.
+    :rtype: bool
+
+    Example::
+
+        >>> string_contains_source_install_marker('pip install pytest')
+        False
+        >>> string_contains_source_install_marker('python -m pip install .')
+        True
+        >>> string_contains_source_install_marker('pip3 install .')
+        True
+        >>> string_contains_source_install_marker('pip3.10 install --target /tmp/x .')
+        True
+        >>> string_contains_source_install_marker('python setup.py install')
+        True
+        >>> string_contains_source_install_marker('python setup.py develop')
+        True
+        >>> string_contains_source_install_marker('pip-tools install .')
+        False
+        >>> string_contains_source_install_marker('clang --target x86_64-linux-gnu')
+        False
+    """
+    normalized = value.lower().replace("\\", "/")
+    tokens = normalized.split()
+    for index in range(len(tokens) - 1):
+        if tokens[index].endswith("setup.py") and tokens[index + 1] in {
+            "install",
+            "develop",
+        }:
+            return True
+    for index in range(len(tokens) - 1):
+        if not is_pip_command_token(tokens[index]) or tokens[index + 1] != "install":
+            continue
+        install_args = tokens[index + 2 :]
+        for arg in install_args:
+            if arg in {"-e", "--editable", ".", "./", "..", "../", "--target"}:
+                return True
+            if arg.startswith("--target="):
+                return True
+            if arg.startswith("./") or arg.startswith("../"):
+                return True
+    return False
+
+
+class TestBoundaryVisitor(ast.NodeVisitor):
+    """
+    Visit a test module AST and collect boundary violations.
+
+    :param path: Source path relative to the repository root.
+    :type path: pathlib.Path
+    :param source: Source text for diagnostics.
+    :type source: str
+    :param defined_names: Names defined by functions and classes in the module.
+    :type defined_names: Set[str]
+    :param docstring_node_ids: String literal nodes that are docstrings,
+        defaults to ``None``.
+    :type docstring_node_ids: Set[int], optional
+
+    Example::
+
+        >>> source = 'import tools.package_templates'
+        >>> tree = ast.parse(source)
+        >>> visitor = TestBoundaryVisitor(Path('test/example.py'), source, set())
+        >>> visitor.visit(tree)
+        >>> visitor.findings[0].rule
+        'tools-import'
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        source: str,
+        defined_names: Set[str],
+        docstring_node_ids: Optional[Set[int]] = None,
+        shadowing_names: Optional[Set[str]] = None,
+    ) -> None:
+        self.path = path
+        self.source_lines = source.splitlines()
+        self.docstring_node_ids = docstring_node_ids or set()
+        self.findings = []  # type: List[BoundaryFinding]
+        self.scope_stack = [
+            NameScope.create(
+                defined_names=defined_names,
+                shadowing_names=shadowing_names,
+                importlib_aliases={"importlib"},
+                builtins_aliases={"builtins"},
+                pathlib_aliases={"pathlib"},
+                path_class_aliases=set(_PATH_CONSTRUCTOR_NAMES),
+                pytest_aliases={"pytest"},
+                runpy_aliases={"runpy"},
+                sys_aliases={"sys"},
+                subprocess_aliases={"subprocess"},
+                os_aliases={"os"},
+            )
+        ]  # type: List[NameScope]
+
+    @property
+    def current_scope(self) -> NameScope:
+        """
+        Return the innermost lexical scope currently being visited.
+
+        :return: Current lexical scope state.
+        :rtype: NameScope
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.defined_names
+            set()
+        """
+        return self.scope_stack[-1]
+
+    def visible_names(self, attribute: str) -> Set[str]:
+        """
+        Return one scope attribute with lexical shadowing applied.
+
+        Ordinary ``defined_names`` are returned as the visible union because
+        they model names that are already declared in the reachable lexical
+        scopes and suppress unresolved bare ``tools`` call diagnostics. Tainted
+        aliases use Python's lexical shadowing rule, so a local variable named
+        ``subprocess`` or ``importlib`` blocks the module-level alias of the
+        same name.
+
+        :param attribute: :class:`NameScope` set attribute name.
+        :type attribute: str
+        :return: Names visible from outer scopes through the current scope.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', {'tools'})
+            >>> 'tools' in visitor.visible_names('defined_names')
+            True
+            >>> visitor.current_scope.importlib_aliases.add('importlib')
+            >>> visitor.push_scope({'importlib'})
+            >>> 'importlib' in visitor.visible_names('importlib_aliases')
+            False
+        """
+        if attribute == "defined_names":
+            names = set()
+            for scope in self.scope_stack:
+                names.update(scope.defined_names)
+            return names
+        names = set()
+        shadowed = set()
+        for scope in reversed(self.scope_stack):
+            names.update(
+                name for name in getattr(scope, attribute) if name not in shadowed
+            )
+            shadowed.update(scope.shadowing_names)
+            shadowed.update(scope.defined_names)
+        return names
+
+    @property
+    def defined_names(self) -> Set[str]:
+        """
+        Return ordinary names visible in the current lexical scope.
+
+        :return: Visible ordinary bindings.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', {'tools'})
+            >>> visitor.defined_names
+            {'tools'}
+        """
+        return self.visible_names("defined_names")
+
+    @property
+    def tools_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for repository ``tools`` modules.
+
+        :return: Visible tools aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.tools_aliases
+            set()
+        """
+        return self.visible_names("tools_aliases")
+
+    @property
+    def dynamic_tools_aliases(self) -> Set[str]:
+        """
+        Return visible aliases produced by dynamic ``tools`` imports.
+
+        :return: Visible dynamic tools aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.dynamic_tools_aliases.add('mod')
+            >>> 'mod' in visitor.dynamic_tools_aliases
+            True
+        """
+        return self.visible_names("dynamic_tools_aliases")
+
+    @property
+    def importlib_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :mod:`importlib` helpers.
+
+        :return: Visible importlib aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'importlib' in TestBoundaryVisitor(Path('x.py'), '', set()).importlib_aliases
+            True
+        """
+        return self.visible_names("importlib_aliases")
+
+    @property
+    def importlib_util_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :mod:`importlib.util`.
+
+        :return: Visible importlib utility aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).importlib_util_aliases
+            set()
+        """
+        return self.visible_names("importlib_util_aliases")
+
+    @property
+    def importlib_util_spec_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for ``spec_from_file_location``.
+
+        :return: Visible importlib spec helper aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).importlib_util_spec_aliases
+            set()
+        """
+        return self.visible_names("importlib_util_spec_aliases")
+
+    @property
+    def builtins_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`builtins` module.
+
+        :return: Visible builtins aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'builtins' in TestBoundaryVisitor(Path('x.py'), '', set()).builtins_aliases
+            True
+        """
+        return self.visible_names("builtins_aliases")
+
+    @property
+    def pathlib_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`pathlib` module.
+
+        :return: Visible pathlib aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'pathlib' in TestBoundaryVisitor(Path('x.py'), '', set()).pathlib_aliases
+            True
+        """
+        return self.visible_names("pathlib_aliases")
+
+    @property
+    def path_class_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :mod:`pathlib` path constructors.
+
+        :return: Visible path-constructor aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'Path' in TestBoundaryVisitor(Path('x.py'), '', set()).path_class_aliases
+            True
+        """
+        return self.visible_names("path_class_aliases")
+
+    @property
+    def pytest_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`pytest` module.
+
+        :return: Visible pytest aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'pytest' in TestBoundaryVisitor(Path('x.py'), '', set()).pytest_aliases
+            True
+        """
+        return self.visible_names("pytest_aliases")
+
+    @property
+    def pytest_importorskip_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :func:`pytest.importorskip`.
+
+        :return: Visible ``importorskip`` aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).pytest_importorskip_aliases
+            set()
+        """
+        return self.visible_names("pytest_importorskip_aliases")
+
+    @property
+    def runpy_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`runpy` module.
+
+        :return: Visible runpy aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'runpy' in TestBoundaryVisitor(Path('x.py'), '', set()).runpy_aliases
+            True
+        """
+        return self.visible_names("runpy_aliases")
+
+    @property
+    def runpy_run_module_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :func:`runpy.run_module`.
+
+        :return: Visible ``run_module`` aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).runpy_run_module_aliases
+            set()
+        """
+        return self.visible_names("runpy_run_module_aliases")
+
+    @property
+    def runpy_run_path_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :func:`runpy.run_path`.
+
+        :return: Visible ``run_path`` aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).runpy_run_path_aliases
+            set()
+        """
+        return self.visible_names("runpy_run_path_aliases")
+
+    @property
+    def sys_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`sys` module.
+
+        :return: Visible sys aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'sys' in TestBoundaryVisitor(Path('x.py'), '', set()).sys_aliases
+            True
+        """
+        return self.visible_names("sys_aliases")
+
+    @property
+    def sys_modules_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :data:`sys.modules`.
+
+        :return: Visible ``sys.modules`` aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).sys_modules_aliases
+            set()
+        """
+        return self.visible_names("sys_modules_aliases")
+
+    @property
+    def sys_modules_getitem_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for ``sys.modules.__getitem__``.
+
+        :return: Visible ``sys.modules`` getitem aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).sys_modules_getitem_aliases
+            set()
+        """
+        return self.visible_names("sys_modules_getitem_aliases")
+
+    @property
+    def sys_modules_get_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for ``sys.modules.get``.
+
+        :return: Visible ``sys.modules.get`` aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).sys_modules_get_aliases
+            set()
+        """
+        return self.visible_names("sys_modules_get_aliases")
+
+    @property
+    def subprocess_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`subprocess` module.
+
+        :return: Visible subprocess aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'subprocess' in TestBoundaryVisitor(Path('x.py'), '', set()).subprocess_aliases
+            True
+        """
+        return self.visible_names("subprocess_aliases")
+
+    @property
+    def subprocess_function_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for subprocess command functions.
+
+        :return: Visible subprocess function aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.subprocess_function_aliases.add('run')
+            >>> 'run' in visitor.subprocess_function_aliases
+            True
+        """
+        return self.visible_names("subprocess_function_aliases")
+
+    @property
+    def os_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`os` module.
+
+        :return: Visible OS aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> 'os' in TestBoundaryVisitor(Path('x.py'), '', set()).os_aliases
+            True
+        """
+        return self.visible_names("os_aliases")
+
+    @property
+    def os_function_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for OS command helpers.
+
+        :return: Visible OS command aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).os_function_aliases
+            set()
+        """
+        return self.visible_names("os_function_aliases")
+
+    @property
+    def os_function_alias_methods(self) -> Dict[str, str]:
+        """
+        Return visible original helper names for OS command aliases.
+
+        :return: Mapping from local alias to original :mod:`os` helper name.
+        :rtype: Dict[str, str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.os_function_alias_methods['run_exec'] = 'execvp'
+            >>> visitor.os_function_alias_methods['run_exec']
+            'execvp'
+        """
+        visible = {}
+        shadowed = set()
+        for scope in reversed(self.scope_stack):
+            for name, method_name in scope.os_function_alias_methods.items():
+                if name not in shadowed:
+                    visible[name] = method_name
+            shadowed.update(scope.shadowing_names)
+            shadowed.update(scope.defined_names)
+        return visible
+
+    @property
+    def os_path_join_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for ``os.path.join``.
+
+        :return: Visible join aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).os_path_join_aliases
+            set()
+        """
+        return self.visible_names("os_path_join_aliases")
+
+    @property
+    def os_path_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for the :mod:`os.path` module.
+
+        :return: Visible ``os.path`` aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).os_path_aliases
+            set()
+        """
+        return self.visible_names("os_path_aliases")
+
+    @property
+    def os_path_dirname_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for ``os.path.dirname``.
+
+        :return: Visible dirname aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).os_path_dirname_aliases
+            set()
+        """
+        return self.visible_names("os_path_dirname_aliases")
+
+    @property
+    def os_path_abspath_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for path-preserving :mod:`os.path` wrappers.
+
+        :return: Visible path-preserving wrapper aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).os_path_abspath_aliases
+            set()
+        """
+        return self.visible_names("os_path_abspath_aliases")
+
+    @property
+    def os_path_split_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for ``os.path.split``.
+
+        :return: Visible split aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).os_path_split_aliases
+            set()
+        """
+        return self.visible_names("os_path_split_aliases")
+
+    @property
+    def os_getcwd_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for :func:`os.getcwd`.
+
+        :return: Visible ``getcwd`` aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).os_getcwd_aliases
+            set()
+        """
+        return self.visible_names("os_getcwd_aliases")
+
+    @property
+    def repo_root_aliases(self) -> Set[str]:
+        """
+        Return visible repository-root aliases.
+
+        :return: Visible repository-root aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.repo_root_aliases.add('repo_root')
+            >>> 'repo_root' in visitor.repo_root_aliases
+            True
+        """
+        return self.visible_names("repo_root_aliases")
+
+    @property
+    def path_parent_hop_aliases(self) -> Dict[str, int]:
+        """
+        Return visible parent-hop aliases rooted at ``__file__``.
+
+        :return: Mapping from visible local names to parent-hop counts.
+        :rtype: Dict[str, int]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> visitor.current_scope.path_parent_hop_aliases['base'] = 1
+            >>> visitor.path_parent_hop_aliases['base']
+            1
+        """
+        visible = {}
+        shadowed = set()
+        for scope in reversed(self.scope_stack):
+            for name, hops in scope.path_parent_hop_aliases.items():
+                if name not in shadowed:
+                    visible[name] = hops
+            shadowed.update(scope.shadowing_names)
+            shadowed.update(scope.defined_names)
+        return visible
+
+    @property
+    def file_parents_aliases(self) -> Set[str]:
+        """
+        Return aliases for ``Path(__file__).parents`` sequence expressions.
+
+        :return: Visible ``parents`` sequence aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.file_parents_aliases.add('parents')
+            >>> 'parents' in visitor.file_parents_aliases
+            True
+        """
+        return self.visible_names("file_parents_aliases")
+
+    @property
+    def string_aliases(self) -> Dict[str, str]:
+        """
+        Return visible statically known string aliases.
+
+        :return: Mapping from visible local names to string values.
+        :rtype: Dict[str, str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.string_aliases['name'] = 'tools'
+            >>> visitor.string_aliases['name']
+            'tools'
+        """
+        visible = {}
+        shadowed = set()
+        for scope in reversed(self.scope_stack):
+            for name, value in scope.string_aliases.items():
+                if name not in shadowed:
+                    visible[name] = value
+            shadowed.update(scope.shadowing_names)
+            shadowed.update(scope.defined_names)
+        return visible
+
+    @property
+    def dynamic_code_alias_rules(self) -> Dict[str, str]:
+        """
+        Return visible compiled dynamic-code findings by alias name.
+
+        :return: Mapping from aliases to nested boundary rule names.
+        :rtype: Dict[str, str]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.dynamic_code_alias_rules['code'] = 'tools-import'
+            >>> visitor.dynamic_code_alias_rules['code']
+            'tools-import'
+        """
+        visible = {}
+        shadowed = set()
+        for scope in reversed(self.scope_stack):
+            for name, rule in scope.dynamic_code_alias_rules.items():
+                if name not in shadowed:
+                    visible[name] = rule
+            shadowed.update(scope.shadowing_names)
+            shadowed.update(scope.defined_names)
+        return visible
+
+    @property
+    def template_segment_aliases(self) -> Set[str]:
+        """
+        Return aliases for the exact ``templates`` path segment.
+
+        :return: Visible template-segment aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).template_segment_aliases
+            set()
+        """
+        return self.visible_names("template_segment_aliases")
+
+    @property
+    def tools_module_name_aliases(self) -> Set[str]:
+        """
+        Return aliases for ``tools`` module-name strings.
+
+        :return: Visible tools-module-name aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).tools_module_name_aliases
+            set()
+        """
+        return self.visible_names("tools_module_name_aliases")
+
+    @property
+    def tools_command_aliases(self) -> Set[str]:
+        """
+        Return visible command aliases that execute repository tools scripts.
+
+        :return: Visible tools command aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).tools_command_aliases
+            set()
+        """
+        return self.visible_names("tools_command_aliases")
+
+    @property
+    def source_install_command_aliases(self) -> Set[str]:
+        """
+        Return visible command aliases that perform source installs.
+
+        :return: Visible source-install command aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).source_install_command_aliases
+            set()
+        """
+        return self.visible_names("source_install_command_aliases")
+
+    @property
+    def package_templates_aliases(self) -> Set[str]:
+        """
+        Return visible aliases for ``tools.package_templates`` helpers.
+
+        :return: Visible package-template helper aliases.
+        :rtype: Set[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).package_templates_aliases
+            set()
+        """
+        return self.visible_names("package_templates_aliases")
+
+    def add_finding(self, node: ast.AST, rule: str, message: str) -> None:
+        """
+        Append one finding for ``node``.
+
+        :param node: AST node that triggered the finding.
+        :type node: ast.AST
+        :param rule: Stable rule identifier.
+        :type rule: str
+        :param message: Human-readable diagnostic message.
+        :type message: str
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), 'bad', set())
+            >>> visitor.add_finding(ast.parse('bad').body[0], 'r', 'm')
+            >>> visitor.findings[0].line
+            1
+        """
+        line = getattr(node, "lineno", 1)
+        column = getattr(node, "col_offset", 0) + 1
+        if 1 <= line <= len(self.source_lines):
+            source = self.source_lines[line - 1].strip()
+        else:
+            source = ""
+        self.findings.append(
+            BoundaryFinding(
+                path=self.path,
+                line=line,
+                column=column,
+                rule=rule,
+                message=message,
+                source=source,
+            )
+        )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:  # noqa: N802
+        """
+        Visit a function body with its own lexical bindings.
+
+        :param node: Function definition node.
+        :type node: ast.FunctionDef
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'def f():' + chr(10) + '    tools = object()' + chr(10) + '    tools.x()'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings
+            []
+        """
+        self.visit_function_like(node, node.args, node.body)
+        self.clear_scope_aliases(node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:  # noqa: N802
+        """
+        Visit an async function body with its own lexical bindings.
+
+        :param node: Async function definition node.
+        :type node: ast.AsyncFunctionDef
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'async def f():' + chr(10) + '    tools = object()' + chr(10) + '    tools.x()'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings
+            []
+        """
+        self.visit_function_like(node, node.args, node.body)
+        self.clear_scope_aliases(node.name)
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:  # noqa: N802
+        """
+        Visit a lambda expression with argument bindings in scope.
+
+        :param node: Lambda node.
+        :type node: ast.Lambda
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'fn = lambda tools: tools.x()'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings
+            []
+        """
+        self.visit_argument_expressions(node.args)
+        self.visit_callable_body(function_argument_names(node.args), [node.body])
+
+    def visit_function_like(
+        self, node: ast.AST, arguments: ast.arguments, body: Sequence[ast.AST]
+    ) -> None:
+        """
+        Visit decorators, defaults, and a function body with proper scope.
+
+        :param node: Function-like node.
+        :type node: ast.AST
+        :param arguments: Function argument list.
+        :type arguments: ast.arguments
+        :param body: Function body statements.
+        :type body: Sequence[ast.AST]
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'def f(tools):' + chr(10) + '    tools.x()'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings
+            []
+        """
+        for decorator in getattr(node, "decorator_list", []):
+            self.visit(decorator)
+        returns = getattr(node, "returns", None)
+        if returns is not None:
+            self.visit(returns)
+        self.visit_argument_expressions(arguments)
+        argument_names = function_argument_names(arguments)
+        bound_names = argument_names | collect_scope_defined_names(body)
+        shadowing_names = argument_names | collect_shadowing_names(body)
+        self.visit_callable_body(bound_names, body, shadowing_names=shadowing_names)
+
+    def visit_argument_expressions(self, arguments: ast.arguments) -> None:
+        """
+        Visit default values and annotations outside the callee local scope.
+
+        :param arguments: Function or lambda argument list.
+        :type arguments: ast.arguments
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'fn = lambda x=__import__("tools.x"): x'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> [finding.rule for finding in visitor.findings]
+            ['tools-dynamic-import']
+        """
+        all_arguments = (
+            list(getattr(arguments, "posonlyargs", []))
+            + list(arguments.args)
+            + list(arguments.kwonlyargs)
+        )
+        for argument in all_arguments:
+            annotation = getattr(argument, "annotation", None)
+            if annotation is not None:
+                self.visit(annotation)
+        for argument in (arguments.vararg, arguments.kwarg):
+            if argument is not None and argument.annotation is not None:
+                self.visit(argument.annotation)
+        for default in list(arguments.defaults) + list(arguments.kw_defaults):
+            if default is not None:
+                self.visit(default)
+
+    def visit_callable_body(
+        self,
+        defined_names: Set[str],
+        body: Sequence[ast.AST],
+        shadowing_names: Optional[Set[str]] = None,
+    ) -> None:
+        """
+        Visit a function-like body while excluding class namespaces.
+
+        Python function and lambda bodies close over surrounding function scopes,
+        but class-body names are not lexical locals for methods. Excluding class
+        scopes here prevents class attributes such as ``tools`` or
+        ``subprocess`` from hiding forbidden module-level calls inside methods.
+
+        :param defined_names: Names bound by arguments and local statements.
+        :type defined_names: Set[str]
+        :param body: Function or lambda body nodes to visit.
+        :type body: Sequence[ast.AST]
+        :param shadowing_names: Non-import names that shadow aliases, defaults
+            to ``None``.
+        :type shadowing_names: Set[str], optional
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'class C:' + chr(10) + '    tools = object()' + chr(10) + '    def m(self):' + chr(10) + '        tools.x()'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> [finding.rule for finding in visitor.findings]
+            ['tools-call']
+            >>> source = 'def f():' + chr(10) + '    import subprocess' + chr(10) + '    subprocess.run(["python", "tools/x.py"])'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> [finding.rule for finding in visitor.findings]
+            ['tools-exec']
+        """
+        parent_stack = self.scope_stack
+        callable_scope = NameScope.create(
+            defined_names=defined_names,
+            shadowing_names=shadowing_names,
+        )
+        # Class namespaces are intentionally filtered here because Python
+        # method bodies do not close over class-body assignments.
+        self.scope_stack = [
+            scope for scope in parent_stack if not scope.is_class_body
+        ] + [callable_scope]
+        try:
+            for node in body:
+                self.visit(node)
+        finally:
+            self.scope_stack = parent_stack
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:  # noqa: N802
+        """
+        Visit a class body with class-local bindings.
+
+        :param node: Class definition node.
+        :type node: ast.ClassDef
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'class C:' + chr(10) + '    tools = object()' + chr(10) + '    tools.x()'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings
+            []
+        """
+        for decorator in node.decorator_list:
+            self.visit(decorator)
+        for base in node.bases:
+            self.visit(base)
+        for keyword in node.keywords:
+            self.visit(keyword.value)
+        self.push_scope(
+            collect_scope_defined_names(node.body),
+            shadowing_names=collect_shadowing_names(node.body),
+            is_class_body=True,
+        )
+        try:
+            for statement in node.body:
+                self.visit(statement)
+        finally:
+            self.scope_stack.pop()
+        self.clear_scope_aliases(node.name)
+
+    def push_scope(
+        self,
+        defined_names: Set[str],
+        shadowing_names: Optional[Set[str]] = None,
+        is_class_body: bool = False,
+    ) -> None:
+        """
+        Push a lexical scope with ordinary bindings but no inherited taint.
+
+        :param defined_names: Names bound by the new scope.
+        :type defined_names: Set[str]
+        :param shadowing_names: Non-import names that shadow aliases, defaults
+            to ``None``.
+        :type shadowing_names: Set[str], optional
+        :param is_class_body: Whether the scope models a class namespace, defaults to ``False``.
+        :type is_class_body: bool, optional
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.push_scope({'tools'})
+            >>> 'tools' in visitor.defined_names
+            True
+        """
+        self.scope_stack.append(
+            NameScope.create(
+                defined_names=defined_names,
+                shadowing_names=shadowing_names,
+                is_class_body=is_class_body,
+            )
+        )
+
+    def visit_Import(self, node: ast.Import) -> None:  # noqa: N802
+        """
+        Visit an ``import`` statement.
+
+        :param node: Import statement node.
+        :type node: ast.Import
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> tree = ast.parse('import importlib as imp')
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), 'import importlib as imp', set())
+            >>> visitor.visit(tree)
+            >>> 'imp' in visitor.importlib_aliases
+            True
+        """
+        for alias in node.names:
+            local_name = alias.asname or alias.name.split(".")[0]
+            if is_tools_module_name(alias.name):
+                self.current_scope.tools_aliases.add(local_name)
+                self.add_finding(
+                    node,
+                    TOOLS_IMPORT_RULE,
+                    "pytest files must not import repository tools modules directly",
+                )
+            elif alias.name == "importlib":
+                self.current_scope.importlib_aliases.add(local_name)
+            elif alias.name == "importlib.util":
+                if alias.asname is None:
+                    self.current_scope.importlib_aliases.add(local_name)
+                else:
+                    self.current_scope.importlib_util_aliases.add(local_name)
+            elif alias.name == "builtins":
+                self.current_scope.builtins_aliases.add(local_name)
+            elif alias.name == "pathlib":
+                self.current_scope.pathlib_aliases.add(local_name)
+            elif alias.name == "pytest":
+                self.current_scope.pytest_aliases.add(local_name)
+            elif alias.name == "runpy":
+                self.current_scope.runpy_aliases.add(local_name)
+            elif alias.name == "sys":
+                self.current_scope.sys_aliases.add(local_name)
+            elif alias.name == "subprocess":
+                self.current_scope.subprocess_aliases.add(local_name)
+            elif alias.name == "os":
+                self.current_scope.os_aliases.add(local_name)
+            elif alias.name == "os.path" and alias.asname is not None:
+                self.current_scope.os_path_aliases.add(local_name)
+        self.generic_visit(node)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:  # noqa: N802
+        """
+        Visit a ``from ... import ...`` statement.
+
+        :param node: Import-from statement node.
+        :type node: ast.ImportFrom
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> tree = ast.parse('from subprocess import run as sprun')
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), 'from subprocess import run as sprun', set())
+            >>> visitor.visit(tree)
+            >>> 'sprun' in visitor.subprocess_function_aliases
+            True
+        """
+        module = node.module or ""
+        if is_tools_module_name(module):
+            for alias in node.names:
+                local_name = alias.asname or alias.name
+                if (
+                    alias.name == "package_templates"
+                    or module == "tools.package_templates"
+                ):
+                    self.current_scope.package_templates_aliases.add(local_name)
+            self.add_finding(
+                node,
+                TOOLS_IMPORT_RULE,
+                "pytest files must not import repository tools modules directly",
+            )
+        elif module == "importlib":
+            for alias in node.names:
+                if alias.name == "import_module":
+                    self.current_scope.importlib_aliases.add(alias.asname or alias.name)
+                elif alias.name == "util":
+                    self.current_scope.importlib_util_aliases.add(
+                        alias.asname or alias.name
+                    )
+        elif module == "importlib.util":
+            for alias in node.names:
+                if alias.name == "spec_from_file_location":
+                    self.current_scope.importlib_util_spec_aliases.add(
+                        alias.asname or alias.name
+                    )
+        elif module == "builtins":
+            for alias in node.names:
+                if alias.name == "__import__":
+                    self.current_scope.importlib_aliases.add(alias.asname or alias.name)
+        elif module == "pathlib":
+            for alias in node.names:
+                if alias.name == "*":
+                    self.current_scope.path_class_aliases.update(
+                        _PATH_CONSTRUCTOR_NAMES
+                    )
+                elif alias.name in _PATH_CONSTRUCTOR_NAMES:
+                    self.current_scope.path_class_aliases.add(
+                        alias.asname or alias.name
+                    )
+        elif module == "pytest":
+            for alias in node.names:
+                if alias.name == "importorskip":
+                    self.current_scope.pytest_importorskip_aliases.add(
+                        alias.asname or alias.name
+                    )
+        elif module == "runpy":
+            for alias in node.names:
+                if alias.name == "run_module":
+                    self.current_scope.runpy_run_module_aliases.add(
+                        alias.asname or alias.name
+                    )
+                elif alias.name == "run_path":
+                    self.current_scope.runpy_run_path_aliases.add(
+                        alias.asname or alias.name
+                    )
+        elif module == "sys":
+            for alias in node.names:
+                if alias.name == "modules":
+                    self.current_scope.sys_modules_aliases.add(
+                        alias.asname or alias.name
+                    )
+        elif module == "subprocess":
+            for alias in node.names:
+                if alias.name in _SUBPROCESS_METHODS:
+                    self.current_scope.subprocess_function_aliases.add(
+                        alias.asname or alias.name
+                    )
+        elif module == "os":
+            for alias in node.names:
+                if alias.name in _OS_COMMAND_METHODS:
+                    local_name = alias.asname or alias.name
+                    self.current_scope.os_function_aliases.add(local_name)
+                    self.current_scope.os_function_alias_methods[local_name] = (
+                        alias.name
+                    )
+                elif alias.name == "getcwd":
+                    self.current_scope.os_getcwd_aliases.add(alias.asname or alias.name)
+                elif alias.name == "path":
+                    self.current_scope.os_path_aliases.add(alias.asname or alias.name)
+                elif alias.name == "pardir":
+                    self.current_scope.string_aliases[alias.asname or alias.name] = ".."
+        elif module == "os.path":
+            for alias in node.names:
+                if alias.name == "*":
+                    self.current_scope.os_path_join_aliases.add("join")
+                    self.current_scope.os_path_dirname_aliases.add("dirname")
+                    self.current_scope.os_path_abspath_aliases.update(
+                        _OS_PATH_PASSTHROUGH_HELPERS
+                    )
+                    self.current_scope.os_path_split_aliases.add("split")
+                    self.current_scope.string_aliases["pardir"] = ".."
+                elif alias.name == "join":
+                    self.current_scope.os_path_join_aliases.add(
+                        alias.asname or alias.name
+                    )
+                elif alias.name == "dirname":
+                    self.current_scope.os_path_dirname_aliases.add(
+                        alias.asname or alias.name
+                    )
+                elif alias.name == "abspath":
+                    self.current_scope.os_path_abspath_aliases.add(
+                        alias.asname or alias.name
+                    )
+                elif alias.name in {"normpath", "realpath"}:
+                    self.current_scope.os_path_abspath_aliases.add(
+                        alias.asname or alias.name
+                    )
+                elif alias.name == "split":
+                    self.current_scope.os_path_split_aliases.add(
+                        alias.asname or alias.name
+                    )
+                elif alias.name == "pardir":
+                    self.current_scope.string_aliases[alias.asname or alias.name] = ".."
+        self.generic_visit(node)
+
+    def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802
+        """
+        Visit an assignment and track tainted aliases.
+
+        :param node: Assignment node.
+        :type node: ast.Assign
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> tree = ast.parse('x = __import__("tools.x")')
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), 'x = __import__("tools.x")', set())
+            >>> visitor.visit(tree)
+            >>> 'x' in visitor.dynamic_tools_aliases
+            True
+        """
+        self._visit_assignment_targets(node.targets, node.value)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:  # noqa: N802
+        """
+        Visit an annotated assignment and track tainted aliases.
+
+        :param node: Annotated assignment node.
+        :type node: ast.AnnAssign
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> tree = ast.parse('x: object = __import__("tools.x")')
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), 'x: object = __import__("tools.x")', set())
+            >>> visitor.visit(tree)
+            >>> 'x' in visitor.dynamic_tools_aliases
+            True
+        """
+        if node.value is not None:
+            self._visit_assignment_targets([node.target], node.value)
+        self.generic_visit(node)
+
+    def visit_AugAssign(self, node: ast.AugAssign) -> None:  # noqa: N802
+        """
+        Visit an augmented assignment and refresh static alias taint.
+
+        String-building updates such as ``cmd += "tools/x.py"`` can turn a
+        previously harmless command alias into a boundary violation. The visitor
+        models ``+=`` as a static binary addition before rebinding the target so
+        command, module-name, and path-segment aliases stay conservative.
+
+        :param node: Augmented assignment node.
+        :type node: ast.AugAssign
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'import subprocess' + chr(10) + 'cmd = "python "' + chr(10) + 'cmd += "tools/x.py"' + chr(10) + 'subprocess.run(cmd, shell=True)'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> [finding.rule for finding in visitor.findings]
+            ['tools-exec']
+        """
+        if isinstance(node.op, ast.Add):
+            value = ast.BinOp(left=node.target, op=ast.Add(), right=node.value)
+            ast.copy_location(value, node)
+            self._visit_assignment_targets([node.target], value)
+        else:
+            for name in self._target_names(node.target):
+                self.clear_scope_aliases(name)
+        self.generic_visit(node)
+
+    def visit_For(self, node: ast.For) -> None:  # noqa: N802
+        """
+        Visit a ``for`` loop and conservatively propagate static iterable aliases.
+
+        :param node: For-loop node.
+        :type node: ast.For
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'import subprocess' + chr(10) + 'for cmd in [["python", "tools/x.py"]]:' + chr(10) + '    subprocess.run(cmd)'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> [finding.rule for finding in visitor.findings]
+            ['tools-exec']
+        """
+        if self.iterable_has_tools_command(node.iter):
+            self.mark_target_names(node.target, "tools_command_aliases")
+        if self.iterable_has_source_install_command(node.iter):
+            self.mark_target_names(node.target, "source_install_command_aliases")
+        self.generic_visit(node)
+
+    def mark_target_names(self, target: ast.AST, attribute: str) -> None:
+        """
+        Mark every simple name in an assignment target with an alias set.
+
+        :param target: Assignment target node.
+        :type target: ast.AST
+        :param attribute: Alias set attribute on the current scope.
+        :type attribute: str
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.mark_target_names(ast.Name(id='cmd'), 'tools_command_aliases')
+            >>> 'cmd' in visitor.tools_command_aliases
+            True
+        """
+        for name in self._target_names(target):
+            self.clear_scope_aliases(name)
+            getattr(self.current_scope, attribute).add(name)
+
+    def iterable_has_tools_command(self, node: ast.AST) -> bool:
+        """
+        Return whether a static iterable can yield a tools command.
+
+        :param node: Iterable expression node.
+        :type node: ast.AST
+        :return: ``True`` when any yielded element executes repository tools.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('[["python", "tools/x.py"]]').body[0].value
+            >>> visitor.iterable_has_tools_command(expr)
+            True
+        """
+        return any(
+            self.expression_or_alias_runs_tools_script(element)
+            for element in self.static_iterable_elements(node)
+        )
+
+    def iterable_has_tools_module_name(self, node: ast.AST) -> bool:
+        """
+        Return whether a static iterable contains a ``tools`` module name.
+
+        :param node: Iterable expression node.
+        :type node: ast.AST
+        :return: ``True`` when any yielded element names a ``tools`` module.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('("tools.package_templates",)').body[0].value
+            >>> visitor.iterable_has_tools_module_name(expr)
+            True
+        """
+        return any(
+            self.expression_denotes_tools_module(element)
+            for element in self.static_iterable_elements(node)
+        )
+
+    def iterable_has_source_install_command(self, node: ast.AST) -> bool:
+        """
+        Return whether a static iterable can yield a source-install command.
+
+        :param node: Iterable expression node.
+        :type node: ast.AST
+        :return: ``True`` when any yielded element performs a source install.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('[["python", "-m", "pip", "install", "."]]').body[0].value
+            >>> visitor.iterable_has_source_install_command(expr)
+            True
+        """
+        return any(
+            self.expression_or_alias_runs_source_install_command(element)
+            for element in self.static_iterable_elements(node)
+        )
+
+    def static_iterable_elements(self, node: ast.AST) -> List[ast.AST]:
+        """
+        Return statically visible elements yielded by a simple iterable.
+
+        :param node: Iterable expression node.
+        :type node: ast.AST
+        :return: Element expressions, or an empty list for dynamic iterables.
+        :rtype: List[ast.AST]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> len(visitor.static_iterable_elements(ast.parse('(["x"],)').body[0].value))
+            1
+        """
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            return list(node.elts)
+        return []
+
+    def _visit_assignment_targets(
+        self, targets: Sequence[ast.AST], value: ast.AST
+    ) -> None:
+        """
+        Track aliases introduced by assignment targets.
+
+        :param targets: Assignment targets.
+        :type targets: Sequence[ast.AST]
+        :param value: Assigned value expression.
+        :type value: ast.AST
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor._visit_assignment_targets([ast.Name(id='repo_root')], ast.parse('Path(__file__).parents[1]').body[0].value)
+            >>> 'repo_root' in visitor.repo_root_aliases
+            True
+        """
+        if self._visit_static_unpack(targets, value):
+            return
+        if self._visit_path_split_unpack(targets, value):
+            return
+        repo_root_tainted = self.is_repo_root_tainted(value)
+        path_parent_hops = self.path_argument_parent_hops(value)
+        file_parents_sequence = self.expression_denotes_file_parents_sequence(value)
+        dynamic_tools_import = self.is_dynamic_tools_import_call(value)
+        tools_command = self.expression_or_alias_runs_tools_script(value)
+        source_install_command = self.expression_or_alias_runs_source_install_command(
+            value
+        )
+        template_segment = self.expression_has_exact_segment(value, "templates")
+        tools_module_name = self.expression_denotes_tools_module(value)
+        tools_module_sequence = self.iterable_has_tools_module_name(value)
+        static_string = self.static_string(value)
+        dynamic_code_rule = self.compiled_dynamic_code_boundary_rule(value)
+        for target in targets:
+            for name in self._target_names(target):
+                self.clear_scope_aliases(name)
+                if static_string is not None:
+                    self.current_scope.string_aliases[name] = static_string
+                if repo_root_tainted:
+                    self.current_scope.repo_root_aliases.add(name)
+                if path_parent_hops is not None:
+                    self.current_scope.path_parent_hop_aliases[name] = path_parent_hops
+                if file_parents_sequence:
+                    self.current_scope.file_parents_aliases.add(name)
+                if dynamic_tools_import:
+                    self.current_scope.dynamic_tools_aliases.add(name)
+                if dynamic_code_rule is not None:
+                    self.current_scope.dynamic_code_alias_rules[name] = (
+                        dynamic_code_rule
+                    )
+                if template_segment:
+                    self.current_scope.template_segment_aliases.add(name)
+                if tools_module_name or tools_module_sequence:
+                    self.current_scope.tools_module_name_aliases.add(name)
+                if self.expression_denotes_importlib_module(value):
+                    self.current_scope.importlib_aliases.add(name)
+                if self.expression_denotes_importlib_import_module(value):
+                    self.current_scope.importlib_aliases.add(name)
+                if self.expression_denotes_importlib_util_module(value):
+                    self.current_scope.importlib_util_aliases.add(name)
+                if self.expression_denotes_importlib_util_spec_helper(value):
+                    self.current_scope.importlib_util_spec_aliases.add(name)
+                if self.expression_denotes_subprocess_command_helper(value):
+                    self.current_scope.subprocess_function_aliases.add(name)
+                os_helper = self.expression_denotes_os_command_helper(value)
+                if os_helper is not None:
+                    self.current_scope.os_function_aliases.add(name)
+                    self.current_scope.os_function_alias_methods[name] = os_helper
+                os_path_helper = self.expression_denotes_os_path_helper(value)
+                if os_path_helper == "join":
+                    self.current_scope.os_path_join_aliases.add(name)
+                elif os_path_helper == "dirname":
+                    self.current_scope.os_path_dirname_aliases.add(name)
+                elif os_path_helper == "abspath":
+                    self.current_scope.os_path_abspath_aliases.add(name)
+                elif os_path_helper == "split":
+                    self.current_scope.os_path_split_aliases.add(name)
+                sys_modules_method = self.sys_modules_method_name(value)
+                if sys_modules_method == "__getitem__":
+                    self.current_scope.sys_modules_getitem_aliases.add(name)
+                elif sys_modules_method == "get":
+                    self.current_scope.sys_modules_get_aliases.add(name)
+                if tools_command:
+                    self.current_scope.tools_command_aliases.add(name)
+                if source_install_command:
+                    self.current_scope.source_install_command_aliases.add(name)
+
+    def _visit_static_unpack(self, targets: Sequence[ast.AST], value: ast.AST) -> bool:
+        """
+        Track aliases introduced by static tuple or list unpacking.
+
+        :param targets: Assignment targets.
+        :type targets: Sequence[ast.AST]
+        :param value: Assigned iterable expression.
+        :type value: ast.AST
+        :return: ``True`` when static unpacking was handled.
+        :rtype: bool
+
+        Example::
+
+            >>> source = 'import importlib' + chr(10) + 'importer, _ = (importlib.import_module, None)' + chr(10) + 'importer("tools.package_templates")'
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings[0].rule
+            'tools-dynamic-import'
+        """
+        if len(targets) != 1 or not isinstance(targets[0], (ast.Tuple, ast.List)):
+            return False
+        elements = self.static_iterable_elements(value)
+        unpack_target = targets[0]
+        if not elements or len(elements) != len(unpack_target.elts):
+            return False
+        for target, element in zip(unpack_target.elts, elements):
+            self._visit_assignment_targets([target], element)
+        return True
+
+    def _visit_path_split_unpack(
+        self, targets: Sequence[ast.AST], value: ast.AST
+    ) -> bool:
+        """
+        Track parent hops from ``os.path.split`` tuple unpacking.
+
+        :param targets: Assignment targets.
+        :type targets: Sequence[ast.AST]
+        :param value: Assigned value expression.
+        :type value: ast.AST
+        :return: ``True`` when the assignment was handled as path splitting.
+        :rtype: bool
+
+        Example::
+
+            >>> source = 'import os' + chr(10) + 'base, _ = os.path.split(__file__)' + chr(10) + 'os.path.join(base, "..", "templates")'
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings[0].rule
+            'repo-source-templates'
+        """
+        if len(targets) != 1 or not isinstance(targets[0], (ast.Tuple, ast.List)):
+            return False
+        if not isinstance(value, ast.Call) or not value.args:
+            return False
+        if not self.is_os_path_split_call(value):
+            return False
+        base_hops = self.path_argument_parent_hops(value.args[0])
+        if base_hops is None:
+            return False
+        unpack_target = targets[0]
+        for name in self._target_names(unpack_target):
+            self.clear_scope_aliases(name)
+        if unpack_target.elts:
+            for name in self._target_names(unpack_target.elts[0]):
+                self.current_scope.path_parent_hop_aliases[name] = base_hops + 1
+        return True
+
+    def clear_scope_aliases(self, name: str) -> None:
+        """
+        Clear tainted aliases overwritten by an ordinary binding.
+
+        :param name: Name rebound in the current scope.
+        :type name: str
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'def f():' + chr(10) + '    import subprocess' + chr(10) + '    subprocess.run(["python", "tools/x.py"])' + chr(10) + '    subprocess = object()' + chr(10) + '    subprocess.run(["python", "tools/y.py"])'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> [(finding.rule, finding.line) for finding in visitor.findings]
+            [('tools-exec', 3)]
+        """
+        self.current_scope.tools_aliases.discard(name)
+        self.current_scope.dynamic_tools_aliases.discard(name)
+        self.current_scope.importlib_aliases.discard(name)
+        self.current_scope.importlib_util_aliases.discard(name)
+        self.current_scope.importlib_util_spec_aliases.discard(name)
+        self.current_scope.builtins_aliases.discard(name)
+        self.current_scope.pathlib_aliases.discard(name)
+        self.current_scope.path_class_aliases.discard(name)
+        self.current_scope.pytest_aliases.discard(name)
+        self.current_scope.pytest_importorskip_aliases.discard(name)
+        self.current_scope.runpy_aliases.discard(name)
+        self.current_scope.runpy_run_module_aliases.discard(name)
+        self.current_scope.runpy_run_path_aliases.discard(name)
+        self.current_scope.sys_aliases.discard(name)
+        self.current_scope.sys_modules_aliases.discard(name)
+        self.current_scope.sys_modules_getitem_aliases.discard(name)
+        self.current_scope.sys_modules_get_aliases.discard(name)
+        self.current_scope.subprocess_aliases.discard(name)
+        self.current_scope.subprocess_function_aliases.discard(name)
+        self.current_scope.os_aliases.discard(name)
+        self.current_scope.os_function_aliases.discard(name)
+        self.current_scope.os_function_alias_methods.pop(name, None)
+        self.current_scope.os_path_aliases.discard(name)
+        self.current_scope.os_path_join_aliases.discard(name)
+        self.current_scope.os_path_dirname_aliases.discard(name)
+        self.current_scope.os_path_abspath_aliases.discard(name)
+        self.current_scope.os_path_split_aliases.discard(name)
+        self.current_scope.os_getcwd_aliases.discard(name)
+        self.current_scope.repo_root_aliases.discard(name)
+        self.current_scope.path_parent_hop_aliases.pop(name, None)
+        self.current_scope.file_parents_aliases.discard(name)
+        self.current_scope.string_aliases.pop(name, None)
+        self.current_scope.dynamic_code_alias_rules.pop(name, None)
+        self.current_scope.template_segment_aliases.discard(name)
+        self.current_scope.tools_module_name_aliases.discard(name)
+        self.current_scope.tools_command_aliases.discard(name)
+        self.current_scope.source_install_command_aliases.discard(name)
+        self.current_scope.package_templates_aliases.discard(name)
+
+    def _target_names(self, node: ast.AST) -> List[str]:
+        """
+        Return names assigned by a target node.
+
+        :param node: Assignment target node.
+        :type node: ast.AST
+        :return: Assigned identifier names.
+        :rtype: List[str]
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set())._target_names(ast.Name(id='x'))
+            ['x']
+        """
+        if isinstance(node, ast.Name):
+            return [node.id]
+        names = []
+        if isinstance(node, (ast.Tuple, ast.List)):
+            for item in node.elts:
+                names.extend(self._target_names(item))
+        return names
+
+    def static_string(self, node: ast.AST) -> Optional[str]:
+        """
+        Return a statically known string value with local aliases expanded.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: String value, or ``None`` when it is not statically known.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.string_aliases['suffix'] = 'package_templates'
+            >>> visitor.static_string(ast.parse('f"tools.{suffix}"').body[0].value)
+            'tools.package_templates'
+        """
+        value = literal_string(node)
+        if value is not None:
+            return value
+        if isinstance(node, ast.Name):
+            return self.string_aliases.get(node.id)
+        if isinstance(node, ast.Attribute) and node.attr == "pardir":
+            if isinstance(node.value, ast.Name) and node.value.id in self.os_aliases:
+                return ".."
+            if self.expression_denotes_os_path_module(node.value):
+                return ".."
+            if dotted_name(node) in {"os.pardir", "os.path.pardir"}:
+                return ".."
+        if isinstance(node, ast.JoinedStr):
+            parts = []
+            for value_node in node.values:
+                if isinstance(value_node, ast.FormattedValue):
+                    if value_node.format_spec is not None:
+                        return None
+                    part = self.static_string(value_node.value)
+                else:
+                    part = self.static_string(value_node)
+                if part is None:
+                    return None
+                parts.append(part)
+            return "".join(parts)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            left = self.static_string(node.left)
+            right = self.static_string(node.right)
+            if left is not None and right is not None:
+                return left + right
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in _STATIC_STRING_METHODS:
+                if node.args or node.keywords:
+                    return None
+                value = self.static_string(node.func.value)
+                if value is None:
+                    return None
+                if node.func.attr == "lower":
+                    return value.lower()
+                if node.func.attr == "upper":
+                    return value.upper()
+                return value.casefold()
+        return None
+
+    def expression_denotes_importlib_module(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes the :mod:`importlib` module.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for visible importlib module aliases.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_denotes_importlib_module(ast.Name(id='importlib'))
+            True
+            >>> expr = ast.parse('__import__("importlib")').body[0].value
+            >>> visitor.expression_denotes_importlib_module(expr)
+            True
+        """
+        if isinstance(node, ast.Name):
+            return node.id in self.importlib_aliases
+        if isinstance(node, ast.Call) and self.is_module_import_call(node):
+            name = self.dynamic_import_target_module_name(node)
+            return name is not None and (
+                name == "importlib" or name.startswith("importlib.")
+            )
+        return False
+
+    def expression_denotes_importlib_import_module(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes :func:`importlib.import_module`.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for visible ``import_module`` helpers.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('importlib.import_module').body[0].value
+            >>> visitor.expression_denotes_importlib_import_module(expr)
+            True
+            >>> expr = ast.parse('getattr(importlib, "import_module")').body[0].value
+            >>> visitor.expression_denotes_importlib_import_module(expr)
+            True
+        """
+        if isinstance(node, ast.Attribute) and node.attr == "import_module":
+            return self.expression_denotes_importlib_module(node.value)
+        if isinstance(node, ast.Call) and dotted_name(node.func) == "getattr":
+            if len(node.args) < 2:
+                return False
+            return (
+                self.expression_denotes_importlib_module(node.args[0])
+                and self.static_string(node.args[1]) == "import_module"
+            )
+        return False
+
+    def expression_denotes_importlib_util_module(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes :mod:`importlib.util`.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for visible importlib utility module aliases.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_denotes_importlib_util_module(ast.parse('importlib.util').body[0].value)
+            True
+        """
+        if isinstance(node, ast.Name):
+            return node.id in self.importlib_util_aliases
+        if isinstance(node, ast.Attribute) and node.attr == "util":
+            return (
+                isinstance(node.value, ast.Name)
+                and node.value.id in self.importlib_aliases
+            )
+        return False
+
+    def expression_denotes_importlib_util_spec_helper(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes ``spec_from_file_location``.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for visible importlib utility spec helpers.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('importlib.util.spec_from_file_location').body[0].value
+            >>> visitor.expression_denotes_importlib_util_spec_helper(expr)
+            True
+        """
+        if isinstance(node, ast.Name):
+            return node.id in self.importlib_util_spec_aliases
+        if isinstance(node, ast.Attribute) and node.attr == "spec_from_file_location":
+            return self.expression_denotes_importlib_util_module(node.value)
+        if isinstance(node, ast.Call) and dotted_name(node.func) == "getattr":
+            if len(node.args) < 2:
+                return False
+            return (
+                self.expression_denotes_importlib_util_module(node.args[0])
+                and self.static_string(node.args[1]) == "spec_from_file_location"
+            )
+        return False
+
+    def expression_denotes_subprocess_command_helper(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes a subprocess command helper.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for visible subprocess helper attributes.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('getattr(subprocess, "run")').body[0].value
+            >>> visitor.expression_denotes_subprocess_command_helper(expr)
+            True
+        """
+        if isinstance(node, ast.Attribute) and node.attr in _SUBPROCESS_METHODS:
+            return (
+                isinstance(node.value, ast.Name)
+                and node.value.id in self.subprocess_aliases
+            )
+        if isinstance(node, ast.Call) and dotted_name(node.func) == "getattr":
+            if len(node.args) < 2:
+                return False
+            method = self.static_string(node.args[1])
+            return (
+                method in _SUBPROCESS_METHODS
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id in self.subprocess_aliases
+            )
+        return False
+
+    def expression_denotes_os_command_helper(self, node: ast.AST) -> Optional[str]:
+        """
+        Return the original :mod:`os` command helper denoted by ``node``.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: OS helper name, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('getattr(os, "system")').body[0].value
+            >>> visitor.expression_denotes_os_command_helper(expr)
+            'system'
+        """
+        if isinstance(node, ast.Name):
+            return self.os_function_alias_methods.get(node.id)
+        if isinstance(node, ast.Attribute) and node.attr in _OS_COMMAND_METHODS:
+            if isinstance(node.value, ast.Name) and node.value.id in self.os_aliases:
+                return node.attr
+        if isinstance(node, ast.Call) and dotted_name(node.func) == "getattr":
+            if len(node.args) < 2:
+                return None
+            method = self.static_string(node.args[1])
+            if method in _OS_COMMAND_METHODS:
+                if (
+                    isinstance(node.args[0], ast.Name)
+                    and node.args[0].id in self.os_aliases
+                ):
+                    return method
+        return None
+
+    def expression_denotes_os_path_helper(self, node: ast.AST) -> Optional[str]:
+        """
+        Return the :mod:`os.path` helper denoted by ``node``.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: Helper name such as ``"join"``, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_denotes_os_path_helper(ast.parse('getattr(os.path, "join")').body[0].value)
+            'join'
+        """
+        if isinstance(node, ast.Name):
+            if node.id in self.os_path_join_aliases:
+                return "join"
+            if node.id in self.os_path_dirname_aliases:
+                return "dirname"
+            if node.id in self.os_path_abspath_aliases:
+                return "abspath"
+            if node.id in self.os_path_split_aliases:
+                return "split"
+        if isinstance(node, ast.Attribute) and node.attr in _OS_PATH_HELPERS:
+            if self.expression_denotes_os_path_module(node.value):
+                return node.attr
+        if isinstance(node, ast.Call) and dotted_name(node.func) == "getattr":
+            if len(node.args) < 2:
+                return None
+            helper = self.static_string(node.args[1])
+            if helper in _OS_PATH_HELPERS:
+                if self.expression_denotes_os_path_module(node.args[0]):
+                    return helper
+        return None
+
+    def expression_denotes_os_path_module(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes the :mod:`os.path` module.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for visible ``os.path`` module aliases.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_denotes_os_path_module(ast.parse('os.path').body[0].value)
+            True
+        """
+        if isinstance(node, ast.Name):
+            return node.id in self.os_path_aliases
+        if isinstance(node, ast.Attribute) and node.attr == "path":
+            return isinstance(node.value, ast.Name) and node.value.id in self.os_aliases
+        return False
+
+    def sys_modules_method_name(self, node: ast.AST) -> Optional[str]:
+        """
+        Return the ``sys.modules`` method denoted by ``node``.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``"__getitem__"`` or ``"get"``, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('getattr(sys.modules, "__getitem__")').body[0].value
+            >>> visitor.sys_modules_method_name(expr)
+            '__getitem__'
+        """
+        if isinstance(node, ast.Attribute) and node.attr in {"__getitem__", "get"}:
+            if self.is_sys_modules_expr(node.value):
+                return node.attr
+        if isinstance(node, ast.Call) and dotted_name(node.func) == "getattr":
+            if len(node.args) < 2:
+                return None
+            if self.is_sys_modules_expr(node.args[0]):
+                method = self.static_string(node.args[1])
+                if method in {"__getitem__", "get"}:
+                    return method
+        return None
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        """
+        Visit a call expression and report forbidden tool/template patterns.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> tree = ast.parse('__import__("tools.x")')
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '__import__("tools.x")', set())
+            >>> visitor.visit(tree)
+            >>> visitor.findings[0].rule
+            'tools-dynamic-import'
+        """
+        if self.is_dynamic_tools_import_call(node):
+            self.add_finding(
+                node,
+                TOOLS_DYNAMIC_RULE,
+                "pytest files must not dynamically import repository tools modules",
+            )
+        dynamic_code_rule = self.dynamic_code_boundary_rule(node)
+        if dynamic_code_rule is not None:
+            self.add_finding(
+                node,
+                dynamic_code_rule,
+                "pytest files must not execute dynamic code that violates test-boundary rules",
+            )
+        if self.is_tools_attribute_call(node):
+            self.add_finding(
+                node,
+                TOOLS_CALL_RULE,
+                "pytest files must not call repository tools module attributes directly",
+            )
+        if self.is_getattr_tools_call(node):
+            self.add_finding(
+                node,
+                TOOLS_CALL_RULE,
+                "pytest files must not use getattr to call repository tools modules",
+            )
+        if self.is_package_templates_call(node):
+            self.add_finding(
+                node,
+                PACKAGE_TEMPLATES_RULE,
+                "pytest files must not call tools.package_templates from unit tests",
+            )
+        if self.is_sys_modules_tools_get_call(node):
+            self.add_finding(
+                node,
+                TOOLS_DYNAMIC_RULE,
+                "pytest files must not load repository tools modules from sys.modules",
+            )
+        if self.is_sys_modules_tools_getitem_call(node):
+            self.add_finding(
+                node,
+                TOOLS_DYNAMIC_RULE,
+                "pytest files must not load repository tools modules from sys.modules",
+            )
+        if self.is_command_call_running_tools(node):
+            self.add_finding(
+                node,
+                TOOLS_EXEC_RULE,
+                "pytest files must not execute repository tools scripts from subprocess or shell commands",
+            )
+        if self.is_command_call_running_source_install(node):
+            self.add_finding(
+                node,
+                SOURCE_INSTALL_RULE,
+                "pytest files must not run source-install smoke commands",
+            )
+        if self.is_repo_source_template_access(node):
+            self.add_finding(
+                node,
+                SOURCE_TEMPLATE_RULE,
+                "pytest files must not access the repository-source templates directory directly",
+            )
+        self.update_mutated_static_collection_aliases(node)
+        self.generic_visit(node)
+
+    def update_mutated_static_collection_aliases(self, node: ast.Call) -> None:
+        """
+        Propagate static taint through simple list mutation calls.
+
+        The boundary guard treats starred path arguments as a compact way to
+        hide repo-root and ``templates`` segments. Static list mutations such
+        as ``segments.append("templates")`` or ``segments.extend([...])`` need
+        the same conservative alias propagation as ``segments += [...]``.
+
+        :param node: Call expression node to inspect.
+        :type node: ast.Call
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'segments = []' + chr(10) + 'segments.append("templates")'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> 'segments' in visitor.template_segment_aliases
+            True
+        """
+        if not isinstance(node.func, ast.Attribute):
+            return
+        if not isinstance(node.func.value, ast.Name):
+            return
+        name = node.func.value.id
+        elements = self.static_collection_mutation_elements(node)
+        if not elements:
+            return
+        if any(self.is_repo_root_tainted(element) for element in elements):
+            self.current_scope.repo_root_aliases.add(name)
+        if any(
+            self.expression_has_exact_segment(element, "templates")
+            for element in elements
+        ):
+            self.current_scope.template_segment_aliases.add(name)
+        if any(
+            self.expression_or_alias_runs_tools_script(element) for element in elements
+        ):
+            self.current_scope.tools_command_aliases.add(name)
+        if any(
+            self.expression_or_alias_runs_source_install_command(element)
+            for element in elements
+        ):
+            self.current_scope.source_install_command_aliases.add(name)
+
+    def static_collection_mutation_elements(self, node: ast.Call) -> List[ast.AST]:
+        """
+        Return static elements added by a list-like mutation call.
+
+        :param node: Mutation call expression.
+        :type node: ast.Call
+        :return: Added element expressions, or an empty list for unsupported
+            calls.
+        :rtype: List[ast.AST]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('segments.extend(["templates"])').body[0].value
+            >>> [literal_string(item) for item in visitor.static_collection_mutation_elements(call)]
+            ['templates']
+        """
+        if not isinstance(node.func, ast.Attribute):
+            return []
+        if node.func.attr == "append" and len(node.args) == 1:
+            return [node.args[0]]
+        if node.func.attr == "extend" and len(node.args) == 1:
+            elements = self.static_iterable_elements(node.args[0])
+            return elements or [node.args[0]]
+        if node.func.attr == "insert" and len(node.args) >= 2:
+            return [node.args[1]]
+        return []
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:  # noqa: N802
+        """
+        Visit subscript expressions and report ``sys.modules`` tool lookups.
+
+        :param node: Subscript expression node.
+        :type node: ast.Subscript
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'sys.modules["tools.package_templates"]'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings[0].rule
+            'tools-dynamic-import'
+        """
+        if self.is_sys_modules_tools_subscript(node):
+            self.add_finding(
+                node,
+                TOOLS_DYNAMIC_RULE,
+                "pytest files must not load repository tools modules from sys.modules",
+            )
+        self.generic_visit(node)
+
+    def visit_BinOp(self, node: ast.BinOp) -> None:  # noqa: N802
+        """
+        Visit binary path joins and report repo-source template access.
+
+        :param node: Binary operation node.
+        :type node: ast.BinOp
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = '_REPO_ROOT = Path(__file__).resolve().parents[1]' + chr(10) + '_REPO_ROOT / "templates"'
+            >>> tree = ast.parse(source)
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), source, set())
+            >>> visitor.visit(tree)
+            >>> visitor.findings[0].rule
+            'repo-source-templates'
+        """
+        if self.is_repo_source_template_access(node):
+            self.add_finding(
+                node,
+                SOURCE_TEMPLATE_RULE,
+                "pytest files must not access the repository-source templates directory directly",
+            )
+        self.generic_visit(node)
+
+    def visit_JoinedStr(self, node: ast.JoinedStr) -> None:  # noqa: N802
+        """
+        Visit f-strings and report repo-source template access.
+
+        :param node: Joined string node.
+        :type node: ast.JoinedStr
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = 'repo_root = Path(__file__).resolve().parents[1]' + chr(10) + 'f"{repo_root}/templates"'
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), source, set())
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.findings[0].rule
+            'repo-source-templates'
+        """
+        if self.is_repo_source_template_access(node):
+            self.add_finding(
+                node,
+                SOURCE_TEMPLATE_RULE,
+                "pytest files must not access the repository-source templates directory directly",
+            )
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:  # noqa: N802
+        """
+        Visit Python 3.8+ literal constants for source-install markers.
+
+        :param node: Constant node.
+        :type node: ast.Constant
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> tree = ast.parse('"pip install ."')
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '"pip install ."', set())
+            >>> visitor.visit(tree)
+            >>> visitor.findings[0].rule
+            'source-install-smoke'
+        """
+        self._visit_string_marker(node)
+        self.generic_visit(node)
+
+    def visit_Str(self, node: ast.AST) -> None:  # noqa: N802
+        """
+        Visit Python 3.7 string literals for source-install markers.
+
+        :param node: String node.
+        :type node: ast.AST
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> tree = ast.parse('"python -m pip install --target ./vendor ."')
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '"python -m pip install --target ./vendor ."', set())
+            >>> visitor.visit(tree)
+            >>> visitor.findings[0].rule
+            'source-install-smoke'
+        """
+        self._visit_string_marker(node)
+        self.generic_visit(node)
+
+    def _visit_string_marker(self, node: ast.AST) -> None:
+        """
+        Report source-install smoke markers in runtime string literals.
+
+        :param node: Literal node.
+        :type node: ast.AST
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> source = '"python -m pip install --target ./vendor ."'
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), source, set())
+            >>> visitor._visit_string_marker(ast.parse(source).body[0].value)
+            >>> visitor.findings[0].rule
+            'source-install-smoke'
+        """
+        if id(node) in self.docstring_node_ids:
+            return
+        value = self.static_string(node)
+        if value is None:
+            return
+        if string_contains_source_install_marker(value):
+            self.add_finding(
+                node,
+                SOURCE_INSTALL_RULE,
+                "pytest files must not contain source-install smoke-test markers",
+            )
+            return
+
+    def dynamic_code_boundary_rule(self, node: ast.Call) -> Optional[str]:
+        """
+        Return the first boundary rule found inside literal ``exec``/``eval`` code.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: First nested boundary rule, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.dynamic_code_boundary_rule(ast.parse('exec("import tools")').body[0].value)
+            'tools-import'
+            >>> visitor.dynamic_code_boundary_rule(ast.parse('eval("tools.x()")').body[0].value)
+            'tools-call'
+        """
+        if dotted_name(node.func) not in {"exec", "eval"} or not node.args:
+            return None
+        if isinstance(node.args[0], ast.Name):
+            alias_rule = self.dynamic_code_alias_rules.get(node.args[0].id)
+            if alias_rule is not None:
+                return alias_rule
+        compiled_rule = self.compiled_dynamic_code_boundary_rule(node.args[0])
+        if compiled_rule is not None:
+            return compiled_rule
+        source = self.static_string(node.args[0])
+        if source is None:
+            return None
+        return self.boundary_rule_in_dynamic_source(source)
+
+    def compiled_dynamic_code_boundary_rule(self, node: ast.AST) -> Optional[str]:
+        """
+        Return the boundary rule found in a ``compile(...)`` source argument.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: Nested boundary rule, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('compile("import tools.x", "<string>", "exec")').body[0].value
+            >>> visitor.compiled_dynamic_code_boundary_rule(call)
+            'tools-import'
+        """
+        if not isinstance(node, ast.Call):
+            return None
+        if dotted_name(node.func) != "compile" or not node.args:
+            return None
+        source = self.static_string(node.args[0])
+        if source is None:
+            return None
+        return self.boundary_rule_in_dynamic_source(source)
+
+    def boundary_rule_in_dynamic_source(self, source: str) -> Optional[str]:
+        """
+        Return the first boundary rule found in nested Python source.
+
+        :param source: Python source string.
+        :type source: str
+        :return: First nested boundary rule, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set()).boundary_rule_in_dynamic_source('import tools.x')
+            'tools-import'
+        """
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            # SyntaxError: exec/eval literal is not parseable Python source, so the
+            # static boundary guard cannot inspect it as nested code.
+            return None
+        visitor = TestBoundaryVisitor(
+            self.path,
+            source,
+            collect_defined_names(tree),
+            collect_docstring_node_ids(tree),
+        )
+        visitor.visit(tree)
+        if visitor.findings:
+            return visitor.findings[0].rule
+        return None
+
+    def is_dynamic_tools_import_call(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` dynamically imports ``tools``.
+
+        :param node: AST node to inspect.
+        :type node: ast.AST
+        :return: ``True`` for ``importlib.import_module('tools...')`` or ``__import__``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('__import__("tools.x")').body[0].value)
+            True
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('__import__(name="tools.x")').body[0].value)
+            True
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('builtins.__import__("tools.x")').body[0].value)
+            True
+            >>> visitor.current_scope.builtins_aliases.add('bi')
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('bi.__import__("tools.x")').body[0].value)
+            True
+            >>> visitor.current_scope.importlib_aliases.add('import_module')
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('import_module(".x", package="tools")').body[0].value)
+            True
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('import_module(".x", "tools")').body[0].value)
+            True
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('pytest.importorskip("tools.package_templates")').body[0].value)
+            True
+            >>> visitor.is_dynamic_tools_import_call(ast.parse('runpy.run_module("tools.package_templates")').body[0].value)
+            True
+        """
+        if not isinstance(node, ast.Call):
+            return False
+        func_name = dotted_name(node.func)
+        if func_name == "__import__" or self.expression_denotes_builtin_import(
+            node.func
+        ):
+            return self.dynamic_import_target_is_tools(node)
+        if self.is_pytest_importorskip_call(node):
+            return self.dynamic_import_target_is_tools(node)
+        if self.is_runpy_run_module_call(node):
+            return self.dynamic_import_target_is_tools(node)
+        if self.is_runpy_run_path_call(node) and node.args:
+            return self.expression_or_alias_runs_tools_script(node.args[0])
+        if self.is_importlib_util_spec_from_file_location_call(node):
+            return self.importlib_util_spec_location_runs_tools_script(node)
+        if self.expression_denotes_importlib_import_module(node.func):
+            return self.dynamic_import_target_is_tools(node)
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr == "__import__" and isinstance(node.func.value, ast.Name):
+                if node.func.value.id in self.builtins_aliases:
+                    return self.dynamic_import_target_is_tools(node)
+            if node.func.attr == "import_module" and isinstance(
+                node.func.value, ast.Name
+            ):
+                if node.func.value.id in self.importlib_aliases:
+                    return self.dynamic_import_target_is_tools(node)
+        if isinstance(node.func, ast.Name) and node.func.id in self.importlib_aliases:
+            return self.dynamic_import_target_is_tools(node)
+        return False
+
+    def is_module_import_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls a visible module import helper.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for ``__import__`` and ``importlib.import_module`` forms.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_module_import_call(ast.parse('__import__("x")').body[0].value)
+            True
+            >>> visitor.is_module_import_call(ast.parse('importlib.import_module("x")').body[0].value)
+            True
+        """
+        func_name = dotted_name(node.func)
+        if func_name == "__import__" or self.expression_denotes_builtin_import(
+            node.func
+        ):
+            return True
+        if self.expression_denotes_importlib_import_module(node.func):
+            return True
+        return (
+            isinstance(node.func, ast.Name) and node.func.id in self.importlib_aliases
+        )
+
+    def dynamic_import_target_module_name(self, node: ast.Call) -> Optional[str]:
+        """
+        Return the statically visible target name of a dynamic import call.
+
+        :param node: Dynamic import call expression.
+        :type node: ast.Call
+        :return: Imported module name, or ``None`` when dynamic.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.dynamic_import_target_module_name(ast.parse('__import__("importlib")').body[0].value)
+            'importlib'
+        """
+        args = self.static_call_arguments(node)
+        name = self.static_module_name(args[0]) if args else None
+        for keyword in node.keywords:
+            if keyword.arg == "name":
+                name = self.static_module_name(keyword.value)
+        return name
+
+    def expression_denotes_builtin_import(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes the built-in ``__import__`` helper.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` when the expression resolves to ``__import__``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('getattr(builtins, "__import__")').body[0].value
+            >>> visitor.expression_denotes_builtin_import(expr)
+            True
+            >>> expr = ast.parse('getattr(__builtins__, "__import__")').body[0].value
+            >>> visitor.expression_denotes_builtin_import(expr)
+            True
+        """
+        if isinstance(node, ast.Attribute) and node.attr == "__import__":
+            if isinstance(node.value, ast.Name):
+                return node.value.id in self.builtins_aliases or node.value.id == (
+                    "__builtins__"
+                )
+        if isinstance(node, ast.Call) and dotted_name(node.func) == "getattr":
+            if len(node.args) < 2:
+                return False
+            if self.static_string(node.args[1]) != "__import__":
+                return False
+            target = node.args[0]
+            return isinstance(target, ast.Name) and (
+                target.id in self.builtins_aliases or target.id == "__builtins__"
+            )
+        return False
+
+    def is_importlib_util_spec_from_file_location_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls ``spec_from_file_location``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for visible importlib utility spec helpers.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('importlib.util.spec_from_file_location("x", "tools/x.py")').body[0].value
+            >>> visitor.is_importlib_util_spec_from_file_location_call(call)
+            True
+        """
+        return self.expression_denotes_importlib_util_spec_helper(node.func)
+
+    def importlib_util_spec_location_runs_tools_script(self, node: ast.Call) -> bool:
+        """
+        Return whether a spec helper location points at repository tools.
+
+        :param node: ``spec_from_file_location`` call expression.
+        :type node: ast.Call
+        :return: ``True`` when the location argument targets ``tools/*.py``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('importlib.util.spec_from_file_location("x", "tools/x.py")').body[0].value
+            >>> visitor.importlib_util_spec_location_runs_tools_script(call)
+            True
+        """
+        if len(node.args) > 1:
+            return self.expression_or_alias_runs_tools_script(node.args[1])
+        for keyword in node.keywords:
+            if keyword.arg == "location":
+                return self.expression_or_alias_runs_tools_script(keyword.value)
+        return False
+
+    def is_pytest_importorskip_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls :func:`pytest.importorskip`.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is a visible ``importorskip`` helper.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_pytest_importorskip_call(ast.parse('pytest.importorskip("x")').body[0].value)
+            True
+        """
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr == "importorskip" and isinstance(
+                node.func.value, ast.Name
+            ):
+                return node.func.value.id in self.pytest_aliases
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.pytest_importorskip_aliases
+        )
+
+    def is_runpy_run_module_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls :func:`runpy.run_module`.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is a visible ``run_module`` helper.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_runpy_run_module_call(ast.parse('runpy.run_module("x")').body[0].value)
+            True
+        """
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr == "run_module" and isinstance(node.func.value, ast.Name):
+                return node.func.value.id in self.runpy_aliases
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.runpy_run_module_aliases
+        )
+
+    def is_runpy_run_path_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls :func:`runpy.run_path`.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is a visible ``run_path`` helper.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_runpy_run_path_call(ast.parse('runpy.run_path("x.py")').body[0].value)
+            True
+        """
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr == "run_path" and isinstance(node.func.value, ast.Name):
+                return node.func.value.id in self.runpy_aliases
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.runpy_run_path_aliases
+        )
+
+    def dynamic_import_target_is_tools(self, node: ast.Call) -> bool:
+        """
+        Return whether a dynamic import call targets ``tools``.
+
+        :param node: Dynamic import call expression.
+        :type node: ast.Call
+        :return: ``True`` when positional or keyword import arguments resolve to ``tools``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('import_module(name="tools.x")').body[0].value
+            >>> visitor.dynamic_import_target_is_tools(call)
+            True
+            >>> visitor.current_scope.tools_module_name_aliases.add('module_name')
+            >>> call = ast.parse('import_module(module_name)').body[0].value
+            >>> visitor.dynamic_import_target_is_tools(call)
+            True
+            >>> call = ast.parse('import_module(*("tools.x",))').body[0].value
+            >>> visitor.dynamic_import_target_is_tools(call)
+            True
+            >>> call = ast.parse('import_module(*(".x", "tools"))').body[0].value
+            >>> visitor.dynamic_import_target_is_tools(call)
+            True
+        """
+        args = self.static_call_arguments(node)
+        name = None
+        package = None
+        if args:
+            name = self.static_module_name(args[0])
+        if len(args) > 1:
+            package = self.static_module_name(args[1])
+        for keyword in node.keywords:
+            if keyword.arg == "name":
+                name = self.static_module_name(keyword.value)
+            elif keyword.arg == "package":
+                package = self.static_module_name(keyword.value)
+        if name is None:
+            return False
+        if is_tools_module_name(name):
+            return True
+        if name.startswith(".") and package is not None:
+            return is_tools_module_name(package)
+        return False
+
+    def static_module_name(self, node: ast.AST) -> Optional[str]:
+        """
+        Return a statically known module-name string.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: Module name, ``"tools"`` for tools-name aliases, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.tools_module_name_aliases.add('name')
+            >>> visitor.static_module_name(ast.Name(id='name'))
+            'tools'
+        """
+        if isinstance(node, ast.Starred):
+            elements = self.static_iterable_elements(node.value)
+            if elements:
+                return self.static_module_name(elements[0])
+            return self.static_module_name(node.value)
+        value = self.static_string(node)
+        if value is not None:
+            return value
+        if isinstance(node, ast.Name) and node.id in self.tools_module_name_aliases:
+            return "tools"
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            left = self.static_module_name(node.left)
+            right = self.static_module_name(node.right)
+            if left is not None and right is not None:
+                return left + right
+        return None
+
+    def static_call_arguments(self, node: ast.Call) -> List[ast.AST]:
+        """
+        Return positional call arguments with static star-unpacking expanded.
+
+        :param node: Call expression to inspect.
+        :type node: ast.Call
+        :return: Positional argument expressions.
+        :rtype: List[ast.AST]
+
+        Example::
+
+            >>> call = ast.parse('f(*("tools.x",))').body[0].value
+            >>> len(TestBoundaryVisitor(Path('x.py'), '', set()).static_call_arguments(call))
+            1
+        """
+        arguments = []
+        for argument in node.args:
+            if isinstance(argument, ast.Starred):
+                elements = self.static_iterable_elements(argument.value)
+                if elements:
+                    arguments.extend(elements)
+                else:
+                    arguments.append(argument)
+            else:
+                arguments.append(argument)
+        return arguments
+
+    def expression_denotes_tools_module(self, node: ast.AST) -> bool:
+        """
+        Return whether an expression denotes a ``tools`` module-name string.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for tools-module literals or known aliases.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_denotes_tools_module(ast.parse('"tools" + ".x"').body[0].value)
+            True
+        """
+        value = self.static_module_name(node)
+        return value is not None and is_tools_module_name(value)
+
+    def is_tools_attribute_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call targets a known tools module alias.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is under a tools alias.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_tools_attribute_call(ast.parse('tools.x()').body[0].value)
+            True
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', {'tools'})
+            >>> visitor.is_tools_attribute_call(ast.parse('tools.x()').body[0].value)
+            False
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.tools_aliases.add('tools')
+            >>> visitor.is_tools_attribute_call(ast.parse('tools.x()').body[0].value)
+            True
+        """
+        if not isinstance(node.func, ast.Attribute):
+            return False
+        root = self._attribute_root_name(node.func)
+        if root == "tools" and root not in self.defined_names:
+            return True
+        return root in self.tools_aliases or root in self.dynamic_tools_aliases
+
+    def is_getattr_tools_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call uses ``getattr`` on a tools-like object.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when ``getattr`` targets a tools alias or tools-like name.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.dynamic_tools_aliases.add('tools_module')
+            >>> visitor.is_getattr_tools_call(ast.parse('getattr(tools_module, "x")').body[0].value)
+            True
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_getattr_tools_call(ast.parse('getattr(tools, "x")').body[0].value)
+            False
+        """
+        if dotted_name(node.func) != "getattr" or not node.args:
+            return False
+        target = node.args[0]
+        if isinstance(target, ast.Name):
+            name = target.id
+            return name in self.tools_aliases or name in self.dynamic_tools_aliases
+        return False
+
+    def _attribute_root_name(self, node: ast.AST) -> Optional[str]:
+        """
+        Return the root name of an attribute chain.
+
+        :param node: Attribute or name node.
+        :type node: ast.AST
+        :return: Root identifier, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('x.py'), '', set())._attribute_root_name(ast.parse('a.b.c').body[0].value)
+            'a'
+        """
+        current = node
+        while isinstance(current, ast.Attribute):
+            current = current.value
+        if isinstance(current, ast.Name):
+            return current.id
+        return None
+
+    def is_package_templates_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call invokes template-packaging helper code.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for direct or unresolved ``package_templates`` calls.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_package_templates_call(ast.parse('package_templates()').body[0].value)
+            True
+        """
+        name = dotted_name(node.func)
+        if name is None:
+            return False
+        if name in self.package_templates_aliases:
+            return True
+        if name.endswith(".package_templates"):
+            root = name.split(".", 1)[0]
+            if root in self.tools_aliases or root in self.dynamic_tools_aliases:
+                return True
+        return name == "package_templates" and name not in self.defined_names
+
+    def is_sys_modules_expr(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes :data:`sys.modules`.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for ``sys.modules`` or imported ``modules`` aliases.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_sys_modules_expr(ast.parse('sys.modules').body[0].value)
+            True
+        """
+        if isinstance(node, ast.Name):
+            return node.id in self.sys_modules_aliases
+        if isinstance(node, ast.Attribute) and node.attr == "modules":
+            return (
+                isinstance(node.value, ast.Name) and node.value.id in self.sys_aliases
+            )
+        return False
+
+    def is_sys_modules_tools_subscript(self, node: ast.Subscript) -> bool:
+        """
+        Return whether ``node`` reads a ``tools`` module from ``sys.modules``.
+
+        :param node: Subscript expression node.
+        :type node: ast.Subscript
+        :return: ``True`` when the lookup key names a ``tools`` module.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('sys.modules["tools.package_templates"]').body[0].value
+            >>> visitor.is_sys_modules_tools_subscript(expr)
+            True
+        """
+        if not self.is_sys_modules_expr(node.value):
+            return False
+        key = node.slice
+        if AST_INDEX_TYPE is not None and isinstance(key, AST_INDEX_TYPE):
+            key = key.value
+        return self.expression_denotes_tools_module(key)
+
+    def is_sys_modules_tools_get_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls ``sys.modules.get`` for ``tools``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when ``get`` receives a ``tools`` module name.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('sys.modules.get("tools.package_templates")').body[0].value
+            >>> visitor.is_sys_modules_tools_get_call(call)
+            True
+        """
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "get":
+            return False
+        if not self.is_sys_modules_expr(node.func.value):
+            return False
+        return bool(node.args) and self.expression_denotes_tools_module(node.args[0])
+
+    def is_sys_modules_tools_getitem_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls a ``sys.modules`` getitem alias.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the call reads a ``tools`` module.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> source = 'getattr(sys.modules, "__getitem__")("tools.x")'
+            >>> visitor.is_sys_modules_tools_getitem_call(ast.parse(source).body[0].value)
+            True
+        """
+        if isinstance(node.func, ast.Name):
+            if node.func.id in self.sys_modules_getitem_aliases:
+                return bool(node.args) and self.expression_denotes_tools_module(
+                    node.args[0]
+                )
+            if node.func.id in self.sys_modules_get_aliases:
+                return bool(node.args) and self.expression_denotes_tools_module(
+                    node.args[0]
+                )
+        method = self.sys_modules_method_name(node.func)
+        if method in {"__getitem__", "get"}:
+            return bool(node.args) and self.expression_denotes_tools_module(
+                node.args[0]
+            )
+        return False
+
+    def is_command_call_running_tools(self, node: ast.Call) -> bool:
+        """
+        Return whether a subprocess or shell call executes repository tools.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for command calls that target ``tools`` scripts/modules.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_command_call_running_tools(ast.parse('subprocess.run(["python", "-m", "tools.x"])').body[0].value)
+            True
+            >>> visitor.is_command_call_running_tools(ast.parse('subprocess.run(args=["python", "tools/x.py"])').body[0].value)
+            True
+            >>> visitor.is_command_call_running_tools(ast.parse('os.spawnl(os.P_WAIT, "python", "python", "tools/x.py")').body[0].value)
+            True
+            >>> visitor.is_command_call_running_tools(ast.parse('os.execlp("python", "python", "tools/x.py")').body[0].value)
+            True
+            >>> visitor.is_command_call_running_tools(ast.parse('os.execvp("python", ["python", "tools/x.py"])').body[0].value)
+            True
+        """
+        if self.expression_denotes_subprocess_command_helper(node.func):
+            return any(
+                self.expression_or_alias_runs_tools_script(command)
+                for command in self.subprocess_command_arguments(node)
+            )
+        os_helper = self.expression_denotes_os_command_helper(node.func)
+        if os_helper is not None:
+            return any(
+                self.expression_or_alias_runs_tools_script(command)
+                for command in self.os_command_arguments(node, os_helper)
+            )
+        if self.is_subprocess_command_call(node):
+            return any(
+                self.expression_or_alias_runs_tools_script(command)
+                for command in self.subprocess_command_arguments(node)
+            )
+        os_method = self.os_command_method_name(node)
+        if os_method is not None:
+            return any(
+                self.expression_or_alias_runs_tools_script(command)
+                for command in self.os_command_arguments(node, os_method)
+            )
+        return False
+
+    def is_command_call_running_source_install(self, node: ast.Call) -> bool:
+        """
+        Return whether a subprocess or shell call performs a source install.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for command calls such as ``pip install .``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_command_call_running_source_install(ast.parse('subprocess.run(["python", "-m", "pip", "install", "."])').body[0].value)
+            True
+        """
+        if self.expression_denotes_subprocess_command_helper(node.func):
+            return any(
+                self.expression_or_alias_runs_source_install_command(command)
+                for command in self.subprocess_command_arguments(node)
+            )
+        os_helper = self.expression_denotes_os_command_helper(node.func)
+        if os_helper is not None:
+            return any(
+                self.expression_or_alias_runs_source_install_command(command)
+                for command in self.os_command_arguments(node, os_helper)
+            )
+        if self.is_subprocess_command_call(node):
+            return any(
+                self.expression_or_alias_runs_source_install_command(command)
+                for command in self.subprocess_command_arguments(node)
+            )
+        os_method = self.os_command_method_name(node)
+        if os_method is not None:
+            return any(
+                self.expression_or_alias_runs_source_install_command(command)
+                for command in self.os_command_arguments(node, os_method)
+            )
+        return False
+
+    def os_command_arguments(self, node: ast.Call, method_name: str) -> List[ast.AST]:
+        """
+        Return command-bearing arguments for an :mod:`os` command helper call.
+
+        :param node: OS command call expression.
+        :type node: ast.Call
+        :param method_name: OS command helper name.
+        :type method_name: str
+        :return: Candidate command argument expressions.
+        :rtype: List[ast.AST]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('os.system("python tools/x.py")').body[0].value
+            >>> len(visitor.os_command_arguments(call, 'system'))
+            1
+            >>> call = ast.parse('os.execv("python", ["python", "tools/x.py"])').body[0].value
+            >>> len(visitor.os_command_arguments(call, 'execv'))
+            2
+            >>> call = ast.parse('os.spawnve(os.P_WAIT, "python", ["python"], {"PYTHONPATH": "tools/x.py"})').body[0].value
+            >>> len(visitor.os_command_arguments(call, 'spawnve'))
+            2
+        """
+        if method_name.startswith("spawn"):
+            if method_name in {"spawnle", "spawnlpe"} and len(node.args) > 3:
+                return node.args[1:-1]
+            if method_name in {"spawnve", "spawnvpe"}:
+                return node.args[1:3]
+            return node.args[1:]
+        if method_name.startswith("exec"):
+            if method_name in {"execle", "execlpe"} and len(node.args) > 2:
+                return node.args[:-1]
+            if method_name in {"execve", "execvpe"}:
+                return node.args[:2]
+            return node.args
+        return node.args[:1]
+
+    def subprocess_command_arguments(self, node: ast.Call) -> List[ast.AST]:
+        """
+        Return command argument expressions for a subprocess call.
+
+        :param node: Subprocess call expression.
+        :type node: ast.Call
+        :return: Candidate command argument expressions.
+        :rtype: List[ast.AST]
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('subprocess.run(args=["python"])').body[0].value
+            >>> len(visitor.subprocess_command_arguments(call))
+            2
+            >>> call = ast.parse('subprocess.run(["python", cmd + "/tools/x.py"])').body[0].value
+            >>> len(visitor.subprocess_command_arguments(call))
+            3
+            >>> call = ast.parse('subprocess.run(cmd=["python"])').body[0].value
+            >>> len(visitor.subprocess_command_arguments(call))
+            2
+        """
+        if node.args:
+            first_arg = node.args[0]
+            if isinstance(first_arg, (ast.List, ast.Tuple)):
+                return [first_arg] + list(first_arg.elts)
+            return [first_arg]
+        for keyword in node.keywords:
+            if keyword.arg in {"args", "argv", "cmd"}:
+                if isinstance(keyword.value, (ast.List, ast.Tuple)):
+                    return [keyword.value] + list(keyword.value.elts)
+                return [keyword.value]
+        return []
+
+    def expression_or_alias_runs_tools_script(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` is a tools command literal or known alias.
+
+        :param node: Command expression node.
+        :type node: ast.AST
+        :return: ``True`` when the expression targets repository tools.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.tools_command_aliases.add('cmd')
+            >>> visitor.expression_or_alias_runs_tools_script(ast.Name(id='cmd'))
+            True
+            >>> expr = ast.parse('str(cmd)').body[0].value
+            >>> visitor.expression_or_alias_runs_tools_script(expr)
+            True
+        """
+        if any(
+            isinstance(child, ast.Name) and child.id in self.tools_command_aliases
+            for child in ast.walk(node)
+        ):
+            return True
+        value = self.static_string(node)
+        if value is not None and command_text_runs_tools_script(value):
+            return True
+        return expression_runs_tools_script(node)
+
+    def expression_or_alias_runs_source_install_command(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` is a source-install command or known alias.
+
+        :param node: Command expression node.
+        :type node: ast.AST
+        :return: ``True`` when the expression performs a source install.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.source_install_command_aliases.add('cmd')
+            >>> visitor.expression_or_alias_runs_source_install_command(ast.Name(id='cmd'))
+            True
+        """
+        if any(
+            isinstance(child, ast.Name)
+            and child.id in self.source_install_command_aliases
+            for child in ast.walk(node)
+        ):
+            return True
+        value = self.static_string(node)
+        if value is not None and string_contains_source_install_marker(value):
+            return True
+        return expression_runs_source_install_command(node)
+
+    def is_subprocess_command_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call is a subprocess command invocation.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is subprocess-like.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_subprocess_command_call(ast.parse('subprocess.run([])').body[0].value)
+            True
+        """
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr in _SUBPROCESS_METHODS and isinstance(
+                node.func.value, ast.Name
+            ):
+                return node.func.value.id in self.subprocess_aliases
+        if isinstance(node.func, ast.Name):
+            return node.func.id in self.subprocess_function_aliases
+        return False
+
+    def is_os_command_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call is an OS shell command invocation.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is OS-command-like.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_command_call(ast.parse('os.system("true")').body[0].value)
+            True
+        """
+        return self.os_command_method_name(node) is not None
+
+    def os_command_method_name(self, node: ast.Call) -> Optional[str]:
+        """
+        Return the :mod:`os` command helper name called by ``node``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: OS command helper name, or ``None``.
+        :rtype: str, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.os_command_method_name(ast.parse('os.system("true")').body[0].value)
+            'system'
+            >>> source = 'from os import execvp as run_exec'
+            >>> visitor.visit(ast.parse(source))
+            >>> visitor.os_command_method_name(ast.parse('run_exec("python", ["python"])').body[0].value)
+            'execvp'
+        """
+        if isinstance(node.func, ast.Attribute):
+            if node.func.attr in _OS_COMMAND_METHODS and isinstance(
+                node.func.value, ast.Name
+            ):
+                if node.func.value.id in self.os_aliases:
+                    return node.func.attr
+        if isinstance(node.func, ast.Name):
+            if node.func.id in self.os_function_aliases:
+                return self.os_function_alias_methods.get(node.func.id, node.func.id)
+        return None
+
+    @property
+    def repo_root_parent_index(self) -> int:
+        """
+        Return the ``Path(__file__).parents`` index that reaches repo root.
+
+        :return: Parent index for this file's repository root.
+        :rtype: int
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('test/x.py'), '', set()).repo_root_parent_index
+            1
+        """
+        return len(self.path.parent.parts)
+
+    @property
+    def repo_root_dirname_depth(self) -> int:
+        """
+        Return nested ``dirname`` depth needed to reach repo root.
+
+        :return: Number of ``dirname`` hops from ``__file__`` to repo root.
+        :rtype: int
+
+        Example::
+
+            >>> TestBoundaryVisitor(Path('test/x.py'), '', set()).repo_root_dirname_depth
+            2
+        """
+        return self.repo_root_parent_index + 1
+
+    def expression_denotes_file_parents_sequence(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes ``Path(__file__).parents``.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for a visible ``parents`` sequence rooted at ``__file__``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_denotes_file_parents_sequence(ast.parse('Path(__file__).resolve().parents').body[0].value)
+            True
+        """
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "parents"
+            and node_contains_name(node.value, "__file__")
+        )
+
+    def file_parents_expr_reaches_repo_root(self, node: ast.AST) -> bool:
+        """
+        Return whether a ``__file__`` parent expression reaches repo root.
+
+        :param node: AST node to inspect.
+        :type node: ast.AST
+        :return: ``True`` when the parent expression reaches this file's repo root.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> visitor.file_parents_expr_reaches_repo_root(ast.parse('Path(__file__).parents[1]').body[0].value)
+            True
+            >>> visitor.file_parents_expr_reaches_repo_root(ast.parse('Path(__file__).resolve().parent / ".."').body[0].value)
+            True
+            >>> visitor = TestBoundaryVisitor(Path('test/sub/x.py'), '', set())
+            >>> visitor.file_parents_expr_reaches_repo_root(ast.parse('Path(__file__).parents[0]').body[0].value)
+            False
+            >>> visitor.file_parents_expr_reaches_repo_root(ast.parse('Path(__file__).parents[1]').body[0].value)
+            False
+            >>> visitor.file_parents_expr_reaches_repo_root(ast.parse('Path(__file__).parents[2]').body[0].value)
+            True
+        """
+        for child in ast.walk(node):
+            if isinstance(child, ast.Subscript):
+                value = child.value
+                if isinstance(value, ast.Attribute) and value.attr == "parents":
+                    if node_contains_name(value.value, "__file__"):
+                        index = subscript_integer(child)
+                        if index is not None and index >= self.repo_root_parent_index:
+                            return True
+            if parent_chain_depth(child) >= self.repo_root_dirname_depth:
+                return True
+        if self.file_path_hops_reach_repo_root(node):
+            return True
+        return False
+
+    def file_path_hops_reach_repo_root(self, node: ast.AST) -> bool:
+        """
+        Return whether a simple ``__file__`` path expression climbs to repo root.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` when ``.parent`` and ``".."`` hops reach repo root.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> visitor.file_path_hops_reach_repo_root(ast.parse('Path(__file__).resolve().parent / ".."').body[0].value)
+            True
+        """
+        hops = self.file_path_parent_hops(node)
+        return hops is not None and hops >= self.repo_root_dirname_depth
+
+    def file_path_parent_hops(self, node: ast.AST) -> Optional[int]:
+        """
+        Return parent-hop count for a simple ``__file__`` path expression.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: Parent-hop count, or ``None`` when the expression is dynamic.
+        :rtype: int, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> visitor.file_path_parent_hops(ast.parse('Path(__file__).resolve().parent / ".."').body[0].value)
+            2
+            >>> visitor.file_path_parent_hops(ast.parse('Path(__file__).resolve().parents[0] / ".."').body[0].value)
+            2
+        """
+        if isinstance(node, ast.Name):
+            return self.path_parent_hop_aliases.get(node.id)
+        if node_contains_name(node, "__file__") and not isinstance(
+            node, (ast.BinOp, ast.Call, ast.Attribute, ast.Subscript)
+        ):
+            return 0
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            left = self.file_path_parent_hops(node.left)
+            if left is None:
+                return None
+            segment = self.static_string(node.right)
+            if segment == "..":
+                return left + 1
+            if segment is not None:
+                return left
+            return None
+        if isinstance(node, ast.Attribute) and node.attr == "parent":
+            base = self.file_path_parent_hops(node.value)
+            if base is not None:
+                return base + 1
+        if isinstance(node, ast.Subscript):
+            value = node.value
+            if isinstance(value, ast.Name) and value.id in self.file_parents_aliases:
+                index = subscript_integer(node)
+                if index is not None:
+                    return index + 1
+            if isinstance(value, ast.Attribute) and value.attr == "parents":
+                if node_contains_name(value.value, "__file__"):
+                    index = subscript_integer(node)
+                    if index is not None:
+                        return index + 1
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                if node.func.attr in {"resolve", "absolute"}:
+                    return self.file_path_parent_hops(node.func.value)
+            if self.is_path_constructor_call(node) and node.args:
+                if node_contains_name(node.args[0], "__file__"):
+                    return 0
+        return None
+
+    def is_repo_root_tainted(self, node: ast.AST) -> bool:
+        """
+        Return whether an expression is rooted at the repository directory.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for repo-root-like expressions or aliases.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_repo_root_tainted(ast.parse('Path(__file__).parents[2]').body[0].value)
+            True
+            >>> visitor.current_scope.repo_root_aliases.add('repo_root')
+            >>> visitor.is_repo_root_tainted(ast.parse('str(repo_root)').body[0].value)
+            True
+            >>> visitor.current_scope.template_segment_aliases.add('segments')
+            >>> visitor.current_scope.repo_root_aliases.add('segments')
+            >>> visitor.is_repo_root_tainted(ast.parse('*segments').body[0].value)
+            True
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> visitor.current_scope.path_parent_hop_aliases['head'] = 2
+            >>> visitor.is_repo_root_tainted(ast.parse('head').body[0].value)
+            True
+        """
+        if isinstance(node, ast.Name):
+            parent_hops = self.path_parent_hop_aliases.get(node.id)
+            return node.id in self.repo_root_aliases or (
+                parent_hops is not None and parent_hops >= self.repo_root_dirname_depth
+            )
+        if isinstance(node, ast.Starred):
+            return self.is_repo_root_tainted(node.value)
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            if any(self.is_repo_root_tainted(element) for element in node.elts):
+                return True
+            hops = self.path_argument_sequence_parent_hops(node.elts)
+            return hops is not None and hops >= self.repo_root_dirname_depth
+        if isinstance(node, ast.JoinedStr):
+            return any(self.is_repo_root_tainted(value) for value in node.values)
+        if isinstance(node, ast.FormattedValue):
+            return self.is_repo_root_tainted(node.value)
+        if self.file_parents_expr_reaches_repo_root(node):
+            return True
+        if isinstance(node, ast.Call):
+            if self.os_path_dirname_depth(node) >= self.repo_root_dirname_depth:
+                return True
+            if self.is_path_cwd_call(node) or self.is_os_getcwd_call(node):
+                return True
+            if self.is_workspace_environment_call(node):
+                return True
+        if self.is_workspace_environment_subscript(node):
+            return True
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            return self.is_repo_root_tainted(node.left) or self.is_repo_root_tainted(
+                node.right
+            )
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            return self.is_repo_root_tainted(node.left) or self.is_repo_root_tainted(
+                node.right
+            )
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                if node.func.attr in {"resolve", "absolute", "joinpath"}:
+                    return self.is_repo_root_tainted(node.func.value)
+                if node.func.attr == "format":
+                    return self.is_repo_root_tainted_format_call(node)
+            if dotted_name(node.func) in {"str", "repr", "bytes", "os.fspath"}:
+                return any(self.is_repo_root_tainted(arg) for arg in node.args)
+            if dotted_name(node.func) in {"format", "builtins.format"}:
+                return any(self.is_repo_root_tainted(arg) for arg in node.args)
+            if self.is_path_constructor_call(node) and node.args:
+                if self.is_repo_root_tainted(node.args[0]):
+                    return True
+                return any(is_exact_segment(arg, "templates") for arg in node.args[1:])
+            if self.is_os_path_passthrough_call(node) and node.args:
+                return node_contains_name(
+                    node.args[0], "__file__"
+                ) or self.is_repo_root_tainted(node.args[0])
+            if self.is_os_path_join_call(node) and node.args:
+                if self.os_path_join_reaches_repo_root(node):
+                    return True
+                return self.is_repo_root_tainted(node.args[0])
+        return False
+
+    def path_argument_sequence_parent_hops(
+        self, arguments: Sequence[ast.AST]
+    ) -> Optional[int]:
+        """
+        Return parent-hop count for path helper argument sequences.
+
+        This helper models simple path-building calls such as
+        ``os.path.join(os.path.dirname(__file__), "..")`` where a base path and
+        static ``".."`` segments collectively climb to the repository root.
+
+        :param arguments: Path-building argument expressions.
+        :type arguments: Sequence[ast.AST]
+        :return: Parent-hop count, or ``None`` when the sequence is dynamic.
+        :rtype: int, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> expr = ast.parse('os.path.dirname(__file__)').body[0].value
+            >>> visitor.path_argument_sequence_parent_hops([expr, ast.Constant(value='..')])
+            2
+            >>> visitor.path_argument_sequence_parent_hops([expr, ast.Constant(value='../templates')])
+            2
+        """
+        if not arguments:
+            return None
+        hops = self.path_argument_parent_hops(arguments[0])
+        if hops is None:
+            return None
+        for argument in arguments[1:]:
+            segment = self.static_string(argument)
+            if segment == "..":
+                hops += 1
+            elif segment is not None:
+                hops += sum(
+                    1 for path_segment in path_segments(segment) if path_segment == ".."
+                )
+                continue
+            else:
+                return None
+        return hops
+
+    def path_argument_parent_hops(self, node: ast.AST) -> Optional[int]:
+        """
+        Return parent-hop count for one path-building argument.
+
+        :param node: Path argument expression.
+        :type node: ast.AST
+        :return: Parent-hop count, or ``None`` when unknown.
+        :rtype: int, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> visitor.path_argument_parent_hops(ast.parse('os.path.dirname(__file__)').body[0].value)
+            1
+            >>> visitor.path_argument_parent_hops(ast.parse('__file__').body[0].value)
+            0
+        """
+        if isinstance(node, ast.Name) and node.id == "__file__":
+            return 0
+        if isinstance(node, ast.Name):
+            parent_hops = self.path_parent_hop_aliases.get(node.id)
+            if parent_hops is not None:
+                return parent_hops
+            if node.id in self.repo_root_aliases:
+                return self.repo_root_dirname_depth
+        if isinstance(node, ast.Starred):
+            if self.is_repo_root_tainted(node.value):
+                return self.repo_root_dirname_depth
+            return None
+        dirname_depth = self.os_path_dirname_depth(node)
+        if dirname_depth:
+            return dirname_depth
+        file_hops = self.file_path_parent_hops(node)
+        if file_hops is not None:
+            return file_hops
+        if isinstance(node, ast.Call):
+            if self.is_os_path_passthrough_call(node) and node.args:
+                return self.path_argument_parent_hops(node.args[0])
+            if self.is_os_path_join_call(node):
+                return self.path_argument_sequence_parent_hops(node.args)
+        return None
+
+    def os_path_join_reaches_repo_root(self, node: ast.Call) -> bool:
+        """
+        Return whether ``os.path.join`` arguments climb to repo root.
+
+        :param node: ``os.path.join`` call expression.
+        :type node: ast.Call
+        :return: ``True`` when the static path sequence reaches repo root.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> call = ast.parse('os.path.join(os.path.dirname(__file__), "..", "templates")').body[0].value
+            >>> visitor.os_path_join_reaches_repo_root(call)
+            True
+        """
+        if not self.is_os_path_join_call(node):
+            return False
+        hops = self.path_argument_sequence_parent_hops(node.args)
+        return hops is not None and hops >= self.repo_root_dirname_depth
+
+    def is_path_constructor_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` constructs a :class:`pathlib.Path`.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is a visible ``Path`` constructor.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_path_constructor_call(ast.parse('Path("x")').body[0].value)
+            True
+        """
+        if isinstance(node.func, ast.Name):
+            return node.func.id in self.path_class_aliases
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr in _PATH_CONSTRUCTOR_NAMES
+        ):
+            return (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in self.pathlib_aliases
+            )
+        return False
+
+    def is_path_cwd_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls ``Path.cwd``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for visible ``Path.cwd`` helpers.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_path_cwd_call(ast.parse('Path.cwd()').body[0].value)
+            True
+        """
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "cwd":
+            return False
+        value = node.func.value
+        if isinstance(value, ast.Name):
+            return value.id in self.path_class_aliases
+        if isinstance(value, ast.Attribute) and value.attr == "Path":
+            return (
+                isinstance(value.value, ast.Name)
+                and value.value.id in self.pathlib_aliases
+            )
+        return False
+
+    def is_os_getcwd_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls :func:`os.getcwd`.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for visible ``getcwd`` helpers.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_getcwd_call(ast.parse('os.getcwd()').body[0].value)
+            True
+        """
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "getcwd":
+            return (
+                isinstance(node.func.value, ast.Name)
+                and node.func.value.id in self.os_aliases
+            )
+        return (
+            isinstance(node.func, ast.Name) and node.func.id in self.os_getcwd_aliases
+        )
+
+    def is_os_environ_expr(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes :data:`os.environ`.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for visible ``os.environ`` aliases.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_environ_expr(ast.parse('os.environ').body[0].value)
+            True
+        """
+        return (
+            isinstance(node, ast.Attribute)
+            and node.attr == "environ"
+            and isinstance(node.value, ast.Name)
+            and node.value.id in self.os_aliases
+        )
+
+    def is_workspace_environment_subscript(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` reads a workspace-root environment variable.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for ``os.environ["GITHUB_WORKSPACE"]``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('os.environ["GITHUB_WORKSPACE"]').body[0].value
+            >>> visitor.is_workspace_environment_subscript(expr)
+            True
+        """
+        if not isinstance(node, ast.Subscript):
+            return False
+        if not self.is_os_environ_expr(node.value):
+            return False
+        key = node.slice
+        if AST_INDEX_TYPE is not None and isinstance(key, AST_INDEX_TYPE):
+            key = key.value
+        return literal_string(key) == "GITHUB_WORKSPACE"
+
+    def is_workspace_environment_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``node`` calls ``os.environ.get`` for workspace root.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for ``os.environ.get("GITHUB_WORKSPACE")``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> call = ast.parse('os.environ.get("GITHUB_WORKSPACE")').body[0].value
+            >>> visitor.is_workspace_environment_call(call)
+            True
+        """
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "get":
+            return False
+        if not self.is_os_environ_expr(node.func.value):
+            return False
+        return bool(node.args) and literal_string(node.args[0]) == "GITHUB_WORKSPACE"
+
+    def is_repo_root_tainted_format_call(self, node: ast.Call) -> bool:
+        """
+        Return whether ``str.format`` interpolates a repo-root value.
+
+        :param node: Call expression for a ``format`` method.
+        :type node: ast.Call
+        :return: ``True`` when any format argument is repo-root tainted.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.repo_root_aliases.add('repo_root')
+            >>> visitor.is_repo_root_tainted_format_call(ast.parse('"{}".format(repo_root)').body[0].value)
+            True
+        """
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "format":
+            return False
+        values = list(node.args) + [keyword.value for keyword in node.keywords]
+        return any(self.is_repo_root_tainted(value) for value in values)
+
+    def format_call_has_exact_segment(self, node: ast.Call, segment: str) -> bool:
+        """
+        Return whether a ``str.format`` call can insert ``segment``.
+
+        :param node: Call expression for a ``format`` method.
+        :type node: ast.Call
+        :param segment: String segment to search for.
+        :type segment: str
+        :return: ``True`` when the format string or replacement values contain
+            the exact segment.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.template_segment_aliases.add('seg')
+            >>> call = ast.parse('"{root}/{seg}".format(root=repo_root, seg=seg)').body[0].value
+            >>> visitor.format_call_has_exact_segment(call, 'templates')
+            True
+        """
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "format":
+            return False
+        values = [node.func.value] + list(node.args)
+        values.extend(keyword.value for keyword in node.keywords)
+        return any(
+            self.expression_has_exact_segment(value, segment) for value in values
+        )
+
+    def mod_format_value_is_repo_root_tainted(self, node: ast.AST) -> bool:
+        """
+        Return whether a ``%`` format value carries repo-root taint.
+
+        :param node: Format value expression.
+        :type node: ast.AST
+        :return: ``True`` when any replacement value is repo-root tainted.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.repo_root_aliases.add('repo_root')
+            >>> visitor.mod_format_value_is_repo_root_tainted(ast.parse('repo_root').body[0].value)
+            True
+            >>> visitor.mod_format_value_is_repo_root_tainted(ast.parse('(1, repo_root)').body[0].value)
+            True
+        """
+        if isinstance(node, (ast.Tuple, ast.List)):
+            return any(self.is_repo_root_tainted(item) for item in node.elts)
+        if isinstance(node, ast.Dict):
+            return any(self.is_repo_root_tainted(value) for value in node.values)
+        return self.is_repo_root_tainted(node)
+
+    def is_os_path_join_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call targets ``os.path.join``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is ``os.path.join`` or an alias.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_path_join_call(ast.parse('os.path.join("a", "b")').body[0].value)
+            True
+        """
+        if self.is_os_path_function_call(node, "join"):
+            return True
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.os_path_join_aliases
+        )
+
+    def is_os_path_dirname_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call targets ``os.path.dirname``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is ``os.path.dirname`` or an alias.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_path_dirname_call(ast.parse('os.path.dirname(__file__)').body[0].value)
+            True
+        """
+        if self.is_os_path_function_call(node, "dirname"):
+            return True
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.os_path_dirname_aliases
+        )
+
+    def is_os_path_passthrough_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call preserves path parent-hop semantics.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` for wrappers such as ``abspath`` and ``normpath``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_path_passthrough_call(ast.parse('os.path.normpath(__file__)').body[0].value)
+            True
+        """
+        if self.is_os_path_abspath_call(node):
+            return True
+        return any(
+            self.is_os_path_function_call(node, helper)
+            for helper in _OS_PATH_PASSTHROUGH_HELPERS
+            if helper != "abspath"
+        )
+
+    def is_os_path_abspath_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call targets ``os.path.abspath``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is ``os.path.abspath`` or an alias.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_path_abspath_call(ast.parse('os.path.abspath(__file__)').body[0].value)
+            True
+        """
+        if self.is_os_path_function_call(node, "abspath"):
+            return True
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.os_path_abspath_aliases
+        )
+
+    def is_os_path_split_call(self, node: ast.Call) -> bool:
+        """
+        Return whether a call targets ``os.path.split``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when the callee is ``os.path.split`` or an alias.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.is_os_path_split_call(ast.parse('os.path.split(__file__)').body[0].value)
+            True
+        """
+        if self.is_os_path_function_call(node, "split"):
+            return True
+        return (
+            isinstance(node.func, ast.Name)
+            and node.func.id in self.os_path_split_aliases
+        )
+
+    def is_os_path_function_call(self, node: ast.Call, function_name: str) -> bool:
+        """
+        Return whether ``node`` calls an ``os.path`` module helper.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :param function_name: Helper name such as ``"join"``.
+        :type function_name: str
+        :return: ``True`` when the callee is ``os.path.<function_name>`` or an
+            ``os.path`` module alias.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.os_path_aliases.add('osp')
+            >>> visitor.is_os_path_function_call(ast.parse('osp.join("a", "b")').body[0].value, 'join')
+            True
+        """
+        if dotted_name(node.func) == "os.path.{name}".format(name=function_name):
+            return True
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != function_name:
+            return False
+        return self.expression_denotes_os_path_module(node.func.value)
+
+    def os_path_dirname_depth(self, node: ast.AST) -> int:
+        """
+        Return nested ``os.path.dirname`` depth from a ``__file__`` path.
+
+        :param node: AST node to inspect.
+        :type node: ast.AST
+        :return: Number of nested dirname calls rooted at ``__file__``.
+        :rtype: int
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('os.path.dirname(os.path.dirname(os.path.abspath(__file__)))').body[0].value
+            >>> visitor.os_path_dirname_depth(expr)
+            2
+            >>> expr = ast.parse('os.path.split(os.path.abspath(__file__))[0]').body[0].value
+            >>> visitor.os_path_dirname_depth(expr)
+            1
+        """
+        depth = 0
+        current = node
+        while isinstance(current, (ast.Call, ast.Subscript)):
+            split_arg = self.os_path_split_subscript_zero_arg(current)
+            if split_arg is not None:
+                depth += 1
+                current = split_arg
+                continue
+            if not isinstance(current, ast.Call):
+                break
+            if self.is_os_path_passthrough_call(current) and current.args:
+                current = current.args[0]
+                continue
+            if self.is_os_path_dirname_call(current) and current.args:
+                depth += 1
+                current = current.args[0]
+                continue
+            break
+        if depth and node_contains_name(current, "__file__"):
+            return depth
+        return 0
+
+    def os_path_split_subscript_zero_arg(self, node: ast.AST) -> Optional[ast.AST]:
+        """
+        Return the argument from ``os.path.split(path)[0]`` expressions.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: Split path argument, or ``None`` for other expressions.
+        :rtype: ast.AST, optional
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> expr = ast.parse('os.path.split(__file__)[0]').body[0].value
+            >>> visitor.os_path_split_subscript_zero_arg(expr) is not None
+            True
+        """
+        if not isinstance(node, ast.Subscript):
+            return None
+        if subscript_integer(node) != 0:
+            return None
+        if not isinstance(node.value, ast.Call) or not node.value.args:
+            return None
+        if not self.is_os_path_split_call(node.value):
+            return None
+        return node.value.args[0]
+
+    def is_repo_source_template_access(self, node: ast.AST) -> bool:
+        """
+        Return whether an expression accesses repo-root ``templates``.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` when repo-root taint combines with exact ``templates``.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.repo_root_aliases.add('_REPO_ROOT')
+            >>> visitor.is_repo_source_template_access(ast.parse('_REPO_ROOT / "templates"').body[0].value)
+            True
+            >>> source = 'os.path.join(str(_REPO_ROOT), "templates")'
+            >>> visitor.is_repo_source_template_access(ast.parse(source).body[0].value)
+            True
+            >>> source = 'f"{_REPO_ROOT}/templates"'
+            >>> visitor.is_repo_source_template_access(ast.parse(source).body[0].value)
+            True
+            >>> source = 'Path(*segments)'
+            >>> visitor.current_scope.repo_root_aliases.add('segments')
+            >>> visitor.current_scope.template_segment_aliases.add('segments')
+            >>> visitor.is_repo_source_template_access(ast.parse(source).body[0].value)
+            True
+        """
+        if isinstance(node, ast.JoinedStr):
+            return self.is_repo_root_tainted(
+                node
+            ) and self.expression_has_exact_segment(node, "templates")
+        if isinstance(node, ast.FormattedValue):
+            return self.is_repo_source_template_access(node.value)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            return (
+                self.is_repo_root_tainted(node.left)
+                and self.expression_has_exact_segment(node.right, "templates")
+            ) or (
+                self.is_repo_root_tainted(node.right)
+                and self.expression_has_exact_segment(node.left, "templates")
+            )
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            return (
+                self.is_repo_root_tainted(node.left)
+                and self.expression_has_exact_segment(node.right, "templates")
+            ) or (
+                self.is_repo_root_tainted(node.right)
+                and self.expression_has_exact_segment(node.left, "templates")
+            )
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+            return self.expression_has_exact_segment(
+                node.left, "templates"
+            ) and self.mod_format_value_is_repo_root_tainted(node.right)
+        if isinstance(node, ast.Call):
+            if self.path_separator_join_combines_repo_root_and_templates(node):
+                return True
+            if self.is_repo_root_tainted_format_call(node):
+                return self.format_call_has_exact_segment(node, "templates")
+            if self.is_path_constructor_call(node) and node.args:
+                if self.expressions_combine_repo_root_and_template_segment(node.args):
+                    return True
+                if self.is_repo_root_tainted(node.args[0]):
+                    return any(
+                        self.expression_has_exact_segment(arg, "templates")
+                        for arg in node.args[1:]
+                    )
+            if isinstance(node.func, ast.Attribute) and node.func.attr == "joinpath":
+                joinpath_parts = [node.func.value] + list(node.args)
+                if self.path_argument_sequence_reaches_repo_templates(joinpath_parts):
+                    return True
+                if self.expressions_combine_repo_root_and_template_segment(
+                    joinpath_parts
+                ):
+                    return True
+                if self.is_repo_root_tainted(node.func.value):
+                    return any(
+                        self.expression_has_exact_segment(arg, "templates")
+                        for arg in node.args
+                    )
+            if self.is_os_path_join_call(node) and node.args:
+                if self.os_path_join_reaches_repo_root(node) and any(
+                    self.expression_has_exact_segment(arg, "templates")
+                    for arg in node.args
+                ):
+                    return True
+                if self.expressions_combine_repo_root_and_template_segment(node.args):
+                    return True
+                if self.is_repo_root_tainted(node.args[0]):
+                    return any(
+                        self.expression_has_exact_segment(arg, "templates")
+                        for arg in node.args[1:]
+                    )
+                if any(self.is_repo_root_tainted(arg) for arg in node.args):
+                    return any(
+                        self.expression_has_exact_segment(arg, "templates")
+                        for arg in node.args
+                    )
+        return False
+
+    def path_separator_join_combines_repo_root_and_templates(
+        self, node: ast.Call
+    ) -> bool:
+        """
+        Return whether a string separator join builds repo-root ``templates``.
+
+        :param node: Call expression node.
+        :type node: ast.Call
+        :return: ``True`` when ``os.sep.join`` or literal-separator ``join``
+            combines repository-root taint with the ``templates`` segment.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> source = 'import os' + chr(10) + 'repo = Path(__file__).resolve().parents[1]' + chr(10) + 'os.sep.join([str(repo), "templates"])'
+            >>> tree = ast.parse(source)
+            >>> visitor.visit(tree)
+            >>> visitor.findings[-1].rule
+            'repo-source-templates'
+        """
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "join":
+            return False
+        if len(node.args) != 1:
+            return False
+        if not self.expression_denotes_path_separator(node.func.value):
+            return False
+        elements = self.static_iterable_elements(node.args[0])
+        return bool(
+            elements
+        ) and self.expressions_combine_repo_root_and_template_segment(elements)
+
+    def expression_denotes_path_separator(self, node: ast.AST) -> bool:
+        """
+        Return whether ``node`` denotes a filesystem path separator string.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :return: ``True`` for ``os.sep`` or literal slash separators.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_denotes_path_separator(ast.parse('os.sep').body[0].value)
+            True
+            >>> visitor.expression_denotes_path_separator(ast.parse('":"').body[0].value)
+            False
+        """
+        value = self.static_string(node)
+        if value in {"/", "\\"}:
+            return True
+        return dotted_name(node) in {"os.sep", "os.path.sep"}
+
+    def path_argument_sequence_reaches_repo_templates(
+        self, arguments: Sequence[ast.AST]
+    ) -> bool:
+        """
+        Return whether path arguments climb to repo root then ``templates``.
+
+        :param arguments: Path-building expressions in call order.
+        :type arguments: Sequence[ast.AST]
+        :return: ``True`` when static parent hops reach the repository root and
+            the sequence contains an exact ``templates`` segment.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('test/x.py'), '', set())
+            >>> expr = ast.parse('Path(__file__).resolve().parents[0].joinpath("..", "templates")').body[0].value
+            >>> visitor.path_argument_sequence_reaches_repo_templates([expr.func.value] + list(expr.args))
+            True
+        """
+        hops = self.path_argument_sequence_parent_hops(arguments)
+        return (
+            hops is not None
+            and hops >= self.repo_root_dirname_depth
+            and any(
+                self.expression_has_exact_segment(argument, "templates")
+                for argument in arguments
+            )
+        )
+
+    def expressions_combine_repo_root_and_template_segment(
+        self, expressions: Sequence[ast.AST]
+    ) -> bool:
+        """
+        Return whether expressions jointly contain repo-root and ``templates``.
+
+        :param expressions: Path-building expressions to inspect.
+        :type expressions: Sequence[ast.AST]
+        :return: ``True`` when the expressions combine repository root taint
+            with an exact ``templates`` segment.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.current_scope.repo_root_aliases.add('segments')
+            >>> visitor.current_scope.template_segment_aliases.add('segments')
+            >>> visitor.expressions_combine_repo_root_and_template_segment([ast.parse('*segments').body[0].value])
+            True
+        """
+        return any(self.is_repo_root_tainted(expr) for expr in expressions) and any(
+            self.expression_has_exact_segment(expr, "templates") for expr in expressions
+        )
+
+    def expression_has_exact_segment(self, node: ast.AST, segment: str) -> bool:
+        """
+        Return whether an expression contains an exact string segment.
+
+        :param node: AST expression node.
+        :type node: ast.AST
+        :param segment: String segment to search for.
+        :type segment: str
+        :return: ``True`` when the exact segment appears.
+        :rtype: bool
+
+        Example::
+
+            >>> visitor = TestBoundaryVisitor(Path('x.py'), '', set())
+            >>> visitor.expression_has_exact_segment(ast.parse('"templates"').body[0].value, 'templates')
+            True
+            >>> visitor.current_scope.template_segment_aliases.add('segments')
+            >>> visitor.expression_has_exact_segment(ast.parse('*segments').body[0].value, 'templates')
+            True
+            >>> expr = ast.parse('("templates", "python")').body[0].value
+            >>> visitor.expression_has_exact_segment(expr, 'templates')
+            True
+        """
+        value = self.static_string(node)
+        if value is not None and segment in path_segments(value):
+            return True
+        if is_exact_segment(node, segment):
+            return True
+        if isinstance(node, ast.Name):
+            if segment == "templates" and node.id in self.template_segment_aliases:
+                return True
+        if isinstance(node, ast.Starred):
+            return self.expression_has_exact_segment(node.value, segment)
+        if isinstance(node, ast.FormattedValue):
+            return self.expression_has_exact_segment(node.value, segment)
+        if isinstance(node, ast.IfExp):
+            return self.expression_has_exact_segment(
+                node.body, segment
+            ) or self.expression_has_exact_segment(node.orelse, segment)
+        if isinstance(node, ast.JoinedStr):
+            return any(
+                self.expression_has_exact_segment(value_node, segment)
+                for value_node in node.values
+            )
+        if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+            return any(
+                self.expression_has_exact_segment(element, segment)
+                for element in node.elts
+            )
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+            return self.expression_has_exact_segment(
+                node.left, segment
+            ) or self.expression_has_exact_segment(node.right, segment)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            return self.expression_has_exact_segment(
+                node.left, segment
+            ) or self.expression_has_exact_segment(node.right, segment)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mod):
+            return self.expression_has_exact_segment(node.left, segment) or (
+                self.expression_has_exact_segment(node.right, segment)
+            )
+        if isinstance(node, ast.Call):
+            return any(
+                self.expression_has_exact_segment(arg, segment) for arg in node.args
+            )
+        return False
+
+
+def collect_docstring_node_ids(tree: ast.AST) -> Set[int]:
+    """
+    Collect AST node identifiers for module, class, and function docstrings.
+
+    :param tree: Parsed Python AST.
+    :type tree: ast.AST
+    :return: ``id()`` values for string literal nodes used as docstrings.
+    :rtype: Set[int]
+
+    Example::
+
+        >>> source = "'''source install note'''" + chr(10) + "x = 'source install'"
+        >>> tree = ast.parse(source)
+        >>> len(collect_docstring_node_ids(tree))
+        1
+    """
+    docstring_node_ids = set()
+    for node in ast.walk(tree):
+        body = getattr(node, "body", None)
+        if not isinstance(body, list) or not body:
+            continue
+        first = body[0]
+        if isinstance(first, ast.Expr) and literal_string(first.value) is not None:
+            docstring_node_ids.add(id(first.value))
+    return docstring_node_ids
+
+
+def scan_source(path: Path, relative_path: Path, source: str) -> List[BoundaryFinding]:
+    """
+    Scan one Python test source file.
+
+    :param path: Absolute source path, used for parser diagnostics.
+    :type path: pathlib.Path
+    :param relative_path: Path to report in findings.
+    :type relative_path: pathlib.Path
+    :param source: Python source text.
+    :type source: str
+    :return: Boundary findings for the file.
+    :rtype: List[BoundaryFinding]
+    :raises SyntaxError: If the source cannot be parsed as Python.
+
+    Example::
+
+        >>> scan_source(Path('x.py'), Path('x.py'), 'import os')
+        []
+        >>> scan_source(Path('x.py'), Path('x.py'), "'''source install note'''")
+        []
+        >>> source = 'import subprocess' + chr(10) + 'cmd = "python "' + chr(10) + 'cmd += "tools/check.py"' + chr(10) + 'subprocess.run(cmd, shell=True)'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('x.py'), source)]
+        ['tools-exec']
+        >>> source = 'repo_root = Path(__file__).resolve().parents[1]' + chr(10) + 'segments = ("templates", "python")' + chr(10) + 'repo_root.joinpath(*segments)'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'from pathlib import Path' + chr(10) + 'repo_root = Path(__file__).resolve().parents[1]' + chr(10) + 'segments = (repo_root, "templates", "python")' + chr(10) + 'Path(*segments)'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'import os' + chr(10) + 'os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "templates"))'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'from pathlib import Path' + chr(10) + 'base = Path(__file__).resolve().parents[0]' + chr(10) + 'base.joinpath("..", "templates")'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'import os' + chr(10) + 'base = os.path.dirname(__file__)' + chr(10) + 'os.path.join(base, "..", "templates")'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'import os' + chr(10) + 'base = os.path.dirname(__file__)' + chr(10) + 'os.path.join(base, "../templates")'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'import subprocess' + chr(10) + 'cmd = "tools"' + chr(10) + 'subprocess.run(["python", cmd + "/check_test_boundary.py"])'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['tools-exec']
+        >>> source = 'import os' + chr(10) + 'head, tail = os.path.split(os.path.dirname(__file__))' + chr(10) + 'os.path.join(head, "templates", tail)'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'import pathlib' + chr(10) + 'from pathlib import Path' + chr(10) + 'repo = Path(__file__).resolve().parents[1]' + chr(10) + 'pathlib.PurePath(repo, "templates")'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'from pathlib import Path' + chr(10) + 'parents = Path(__file__).resolve().parents' + chr(10) + 'parents[1] / "templates"'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'from os.path import dirname, join, normpath' + chr(10) + 'join(normpath(join(dirname(__file__), "..")), "templates")'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'from os.path import *' + chr(10) + 'join(dirname(__file__), "..", "templates")'
+        >>> [finding.rule for finding in scan_source(Path('x.py'), Path('test/x.py'), source)]
+        ['repo-source-templates']
+        >>> source = 'repo_root = tmp_path' + chr(10) + 'repo_root / "templates"'
+        >>> scan_source(Path('x.py'), Path('test/x.py'), source)
+        []
+    """
+    tree = ast.parse(source, filename=str(path))
+    visitor = TestBoundaryVisitor(
+        relative_path,
+        source,
+        collect_defined_names(tree),
+        collect_docstring_node_ids(tree),
+        collect_shadowing_names(getattr(tree, "body", [])),
+    )
+    visitor.visit(tree)
+    return visitor.findings
+
+
+def scan_tests(repo_root: Path) -> List[BoundaryFinding]:
+    """
+    Scan all Python files under ``test``.
+
+    :param repo_root: Repository root directory.
+    :type repo_root: pathlib.Path
+    :return: Sorted boundary findings.
+    :rtype: List[BoundaryFinding]
+    :raises OSError: If a test file cannot be read.
+    :raises SyntaxError: If a test file cannot be parsed.
+
+    Example::
+
+        >>> isinstance(scan_tests(repository_root()), list)
+        True
+    """
+    test_root = repo_root / "test"
+    findings = []
+    for path in iter_python_files(test_root):
+        relative_path = path.relative_to(repo_root)
+        findings.extend(scan_source(path, relative_path, read_source(path)))
+    return sorted(
+        findings,
+        key=lambda item: (item.path.as_posix(), item.line, item.column, item.rule),
+    )
+
+
+def format_findings(findings: Sequence[BoundaryFinding]) -> str:
+    """
+    Format findings for command-line output.
+
+    :param findings: Boundary findings to format.
+    :type findings: Sequence[BoundaryFinding]
+    :return: Multi-line diagnostic text.
+    :rtype: str
+
+    Example::
+
+        >>> format_findings([])
+        'test boundary check passed: no violations found'
+    """
+    if not findings:
+        return "test boundary check passed: no violations found"
+    lines = [
+        "test boundary check failed: {count} violation(s) found".format(
+            count=len(findings)
+        )
+    ]
+    for finding in findings:
+        lines.append(
+            "{location}: {rule}: {message}".format(
+                location=finding.location,
+                rule=finding.rule,
+                message=finding.message,
+            )
+        )
+        if finding.source:
+            lines.append("    {source}".format(source=finding.source))
+    return os.linesep.join(lines)
+
+
+def run_check(repo_root: Path) -> int:
+    """
+    Run the test-boundary check.
+
+    :param repo_root: Repository root directory.
+    :type repo_root: pathlib.Path
+    :return: Process-style exit code, ``0`` when no findings exist.
+    :rtype: int
+
+    Example::
+
+        >>> run_check(repository_root()) in (0, 1)  # doctest: +ELLIPSIS
+        test boundary check ...
+        True
+    """
+    findings = scan_tests(repo_root)
+    print(format_findings(findings))
+    return 1 if findings else 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    """
+    Run the command-line test-boundary check.
+
+    :param argv: Optional command-line arguments, defaults to ``None``.
+    :type argv: List[str], optional
+    :return: Process exit code.
+    :rtype: int
+
+    Example::
+
+        >>> main(['--repo-root', str(repository_root())]) in (0, 1)  # doctest: +ELLIPSIS
+        test boundary check ...
+        True
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate pytest boundary rules for repository tests."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(repository_root()),
+        help="Repository root to scan. Defaults to the parent of this tools directory.",
+    )
+    args = parser.parse_args(argv)
+    return run_check(Path(args.repo_root).resolve())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 定位

这是一个**伞 PR / 集成收口 PR**。本 PR 先作为执行计划建立，随后通过子 PR 逐个合入实际清理代码；当前 body 作为整条 B1 线的计划、依赖、状态和验收证据总账。

这条线要解决的问题不是“把集成测试赶出 `test/`”，而是把 `test/` 的入口边界收束清楚：

- `make unittest` 依赖 `make tpl` 是正确且必须保留的。内置模板测试就应该覆盖打包后的 `pyfcstm.template` 资产。
- `test/` 可以继续承担必要的 pyfcstm 集成式行为验证；C/C++/C++ wrapper 的 CMake、compiler、ctypes、formatter、native alignment 属于模板测试刚需，不因为调用原生工具链就删除。
- 但 `test/` 不允许绕过 `pyfcstm` 生产入口直接读取仓库根目录的 `templates/`，也不允许直接 import / execute / assert `tools.*` 维护脚本。
- README 测试需要分层：
  - **保留在 pytest**：生成 README（generated README）里的可执行 quick start、compile/run command、formatter-friendly code block、公开 API 示例契约。
  - **迁出或删除**：repo source / maintainer README 的 inventory、文案同步、comment-only / prose-only 断言。
- 源模板打包机制、symlink/stub 处理、源码安装冒烟（source-install smoke）是有价值的维护/发布回归检查；它们要**迁出 pytest unit 并保留为显式维护/打包命令**，不得无替代删除。

## 目标

1. 所有 template 相关 pytest 都通过生产入口取得模板：
   - `pyfcstm.template.extract_template(...)`
   - `pyfcstm.template.list_templates()` / `get_template_info(...)`
   - 对提取后的 packaged template 使用 `StateMachineCodeRenderer`
   - `pyfcstm generate --template ...`
2. 清除 `test/` 中对仓库根目录 `templates/` 的直接读取、渲染、字节比较和源码结构断言。
3. 清除 `test/` 中对 `tools.*` 的直接 import / execution / private helper 测试。
4. 保留模板 native 编译/运行测试，并确保模板输入来自 packaged-template/public-API 路径。
5. 把 source-template packaging / source-install 相关回归检查迁移到明确的 `tools/` 维护脚本或 Makefile target，而不是留在 pytest unit。
6. 把这条纪律写入 `CLAUDE.md` / `AGENTS.md`（同一 symlink 文件），后续新增测试按此执行。

## 非目标

- 不移除 `make unittest: tpl`。
- 不删除 C/C++/C++ wrapper 编译、运行、CMake、ctypes、formatter、native alignment 等模板行为测试。
- 不拆掉 `test/testings/native_toolchain_alignment/` 现有能力。
- 不要求 `test/` 只能做狭义 unit；本仓库 `test/` 可以包含必要的 pyfcstm 集成式行为验证，但入口必须是生产 API / packaged asset。
- 不删除生成 README 中的可执行文档测试，例如 C++ quick start 编译运行、README direct compiler commands、formatter-friendly code block 检查。
- 不把 repo-source maintainer README、文档 prose、YAML/Markdown 注释文本同步作为 pytest unit 的主要断言目标。

## 允许 / 禁止规则

### 允许

- `make unittest` 继续依赖 `make tpl`。
- pytest 通过 `extract_template(...)` 获取 packaged built-in template 后进行 render、导入生成物、编译运行、formatter convergence、semantic alignment。
- pytest 使用 `tmp_path` / `TemporaryDirectory` 构造 test-local throwaway template 来测试 renderer 行为。
- pytest 使用 `test/` 内 fixture / literal / golden data。
- pytest 检查 generated README 的可执行示例、代码块、公开 API 示例和集成命令能运行或保持 formatter-friendly。
- 维护/打包脚本位于 `tools/`，由显式命令运行，不由 pytest unit import。

### 禁止

- `test/` 中 `from tools...`、`import tools...`、直接调用 `tools.*` 私有函数或脚本。
- `test/` 中通过 `_REPO_ROOT / "templates"`、`Path(__file__).parents[...] / "templates"`、`os.path.join(_repo_root(), "templates")` 等方式读取 repo 根 source templates。
- `test/` 中直接调用 `tools.package_templates` 来为测试准备模板。
- pytest unit 中执行 `pip install .` source-install smoke。
- pytest unit 中把 repo-source maintainer README / prose / comment 文案同步作为主要 assertion。

## 状态协议

| 状态 | Mermaid class | 含义 |
|---|---|---|
| 🟡 待开工 | `planned` | 尚未开始实现 |
| 🔵 进行中 | `inprogress` | 子 PR 已开或正在实现/review |
| 🟢 已完成 | `done` | 子 PR 已 merge，表格需填写 PR 链接和验证摘要 |
| 🔴 阻塞 | `blocked` | 阻塞，需要在表格中写明阻塞原因 |

每个子 PR merge 后，本伞 PR body 必须同步：状态 emoji + 短文本、子 PR 链接、实际验证命令摘要、是否改变模板来源、是否保留 native compile/run 行为、是否迁出打包/安装覆盖。

## 子 PR 划分

本版把执行切片收束为 5 个子 PR，避免过度碎片化；每个子 PR 仍保持可独立验收。

| 短名 | 主要文件 / 搜索入口 | 内容 | 目标 | 执行方案 | 验收标准 | 状态 | 前置依赖 |
|---|---|---|---|---|---|---|---|
| B1a 纪律 | `CLAUDE.md` / `AGENTS.md` | 持久化测试边界纪律 | 让规则长期可见：保留 `make tpl` / native tests，禁止 `test/` 直连 `templates/` / `tools` | 在 Testing Strategy 增加明确条款；说明允许的 public API 路径、禁止的 source-template/tooling 路径、native tests 保留原则、generated README 行为测试保留原则、source packaging/source install 迁出原则 | [PR #286](https://github.com/HansBug/pyfcstm/pull/286) 已 merge；`CLAUDE.md` 新增 Testing Strategy 边界纪律；`AGENTS.md -> CLAUDE.md` symlink 保持；已验证 `make rst_auto`、`SKIP_SLOW_TESTS=1 make unittest`（`41337 passed, 640 skipped, 67 deselected`）；只改 `CLAUDE.md`，未移除 `make unittest: tpl`、native compile/run tests 或 generated README executable tests | 🟢 已完成 | 无 |
| B1b 维护 | `test/template/test_template_structure.py` 中 `package_templates(...)`、`_resolve_archive_source`、symlink/stub、distribution metadata 相关测试；`test/template/test_template.py:139-184`；新增固定命令 `python tools/check_template_packaging.py`、`python tools/check_template_source_install.py`，Makefile target `template_packaging_check` / `template_source_install_check` | 把模板打包机制和源码安装冒烟从 pytest unit 迁出，但保留回归覆盖 | `tools.package_templates`、archive roots、metadata、C++ symlink realpath fallback、Windows text stub resolution、unexpected stub rejection、source-template bytes copied into packaged archive、distribution metadata 资产声明、checkout 外 source install 后提取内置模板，已迁入显式维护/打包命令并接入 CI | [PR #287](https://github.com/HansBug/pyfcstm/pull/287) 已 merge；新增 `tools/check_template_packaging.py`、`tools/check_template_source_install.py`、`make template_packaging_check`、`make template_source_install_check`；从 pytest unit 删除 `tools.package_templates` / `_resolve_archive_source` / `pip install --target .` source-install 检查；`.github/workflows/test.yml` 在 Code test job 中运行迁出的维护检查 | [PR #287](https://github.com/HansBug/pyfcstm/pull/287) 已 merge；本地验证 `python -m py_compile ...`、`ruff format/check ...`、两个 tools 命令、两个 Makefile target、`pytest test/template/test_template.py test/template/test_template_structure.py -m unittest -v`、`make rst_auto`、`SKIP_SLOW_TESTS=1 make unittest`；GitHub Code Test matrix 全部通过；`test/template/test_template_structure.py` / `test/template/test_template.py` 对 `tools.package_templates`、`package_templates(`、source-install smoke 静态搜索无命中 | 🟢 已完成 | B1a 纪律 |
| B1c 模板 | `test/template/test_template_structure.py`、`test/template/test_c_family_helper_scope.py`、`test/template/cpp/_utils.py`、`test/template/cpp_poll/_utils.py`、wrapper tests；重点函数：`test_template_readmes_keep_maintainer_and_generated_guidance_separate`、`test_c_family_readmes_document_deployment_safety_boundaries`、`test_cpp_template_documentation_describes_early_first_class_status`、`test_generated_source_templates_keep_source_metadata_wording` | 清理 template 测试对 repo-root `templates/` 的直接访问，并让 C++/C++ poll helper 走 packaged asset；模板侧 README/prose-only 清理由本 PR 一并负责 | 模板结构、渲染、helper scope、C++/C++ poll wrapper/native tests 继续存在，但模板来源必须是 packaged built-in template / public API；generated README 行为测试保留，source/maintainer README 文案同步不留在 pytest | [PR #288](https://github.com/HansBug/pyfcstm/pull/288) 已 merge；删除 `_TEMPLATES_DIR`、`_REPO_ROOT / "templates"`、`_repo_root()` source-template packaging、手动 zip extract；改用 `list_templates/get_template_info/extract_template`；C++/C++ poll helper 改用 `extract_template('cpp', td)` / `extract_template('cpp_poll', td)`；template source/maintainer README prose-only 断言已从 pytest 删除，generated README 行为断言保留 | [PR #288](https://github.com/HansBug/pyfcstm/pull/288) 已 merge；本地验证 `pytest test/template/test_template_structure.py test/template/test_c_family_helper_scope.py -m unittest -v`（12 passed）、`pytest test/template/cpp test/template/cpp_poll -m unittest -v`（303 passed, 10 skipped, 2 deselected）、`ruff format --check` / `ruff check`、`git diff --check`、`make rst_auto`、`SKIP_SLOW_TESTS=1 make unittest`（41330 passed, 640 skipped, 67 deselected）；B1c 范围静态审计无 repo-root `templates/` / `tools.package_templates` 命中；GitHub Code Test matrix 全部通过；generated README compile/run / formatter-friendly tests 未删除 | 🟢 已完成 | B1a 纪律、B1b 维护 |
| B1d 清理 | `test/llm/test_grammar_guide.py`、`tools/evaluate_llm_grammar_guide.py`、`test/diagnostics/test_inspect_model.py`、`test/diagnostics/test_codes_yaml.py`、`test/diagnostics/test_codes_yaml_verify.py` | 清理 `test/llm` 对 tools 私有 helper 的依赖，并删除/迁出 diagnostics README/prose/comment-only pytest assertions | `test/llm` 只测 `pyfcstm.llm` / DSL parser / model loader；diagnostics pytest 聚焦 production behavior、structured data、public API contract；diagnostics 文案同步不作为 unit 断言 | [PR #289](https://github.com/HansBug/pyfcstm/pull/289) 已 merge；删除 `test/llm` 对 `tools.evaluate_llm_grammar_guide._extract_fcstm_source` 的直接 import 与私有 helper 行为测试；删除 diagnostics README prose-only pytest 与 `codes.yaml` comment-block 同步 pytest；吸收 review 建议，将剩余 runtime predicate 覆盖类改为 `TestRefTypePredicateCoverage`，避免旧 comment-sync 类名误导 | [PR #289](https://github.com/HansBug/pyfcstm/pull/289) 已 merge；本地验证 `pytest test/llm test/diagnostics -m unittest -v`（803 passed）、`SKIP_SLOW_TESTS=1 make unittest`（41327 passed, 640 skipped, 67 deselected）、`make rst_auto`、`git diff --check`；B1d 静态审计确认 `test/llm` 无 `tools.*` 命中，删除对象符号无命中，关键 structured contract 保留；GitHub Code Test matrix 全部通过；三路实现 review 均无 C/I 阻塞并判定 ready to merge | 🟢 已完成 | B1a 纪律、B1b 维护 |
| B1e 收口 | 全 `test/` 静态搜索；`tools/check_test_boundary.py`；Makefile / CI / `CLAUDE.md` guard 入口；本伞 PR body | 汇总修正后边界审计与轻量 guard | 确认没有 direct `tools` / repo-root `templates` 漏网，同时不误伤 native compile tests、generated README behavior tests、test-local templates | [PR #290](https://github.com/HansBug/pyfcstm/pull/290) 已 merge；新增 `tools/check_test_boundary.py`、`make test_boundary_check`、CI 前置步骤与 `CLAUDE.md` 纪律入口；guard 用 AST/别名追踪覆盖 `tools.*` import/dynamic import/execute、repo-root `templates/`、source-install smoke；没有新增 pytest 对 `tools`/source templates 的依赖 | [PR #290](https://github.com/HansBug/pyfcstm/pull/290) 已 merge；本地验证 `python -m doctest -v tools/check_test_boundary.py`（572 passed）、`make test_boundary_check`、`ruff format --check`、`ruff check`、`python -m py_compile`、`git diff --check`、`SKIP_SLOW_TESTS=1 make unittest`（41327 passed, 640 skipped, 67 deselected）；PR #290 的 GitHub Code Test / Release Test 全部通过；三路最新复审均无 C/I 阻塞 | 🟢 已完成 | B1b 维护、B1c 模板、B1d 清理 |

## 依赖关系图

```mermaid
flowchart TD
    B1a["🟢 B1a 纪律\n持久化测试边界"]
    B1b["🟢 B1b 维护\n迁出打包与安装检查"]
    B1c["🟢 B1c 模板\n模板测试走生产入口"]
    B1d["🟢 B1d 清理\n移除 tools 与文案断言"]
    B1e["🟢 B1e 收口\n最终审计与证据"]

    B1a --> B1b
    B1a --> B1c
    B1a --> B1d
    B1b --> B1c
    B1b --> B1d
    B1b --> B1e
    B1c --> B1e
    B1d --> B1e

    classDef planned fill:#fff3bf,stroke:#f08c00,color:#5f3dc4,stroke-width:2px;
    classDef inprogress fill:#d0ebff,stroke:#1971c2,color:#0b7285,stroke-width:2px;
    classDef done fill:#d3f9d8,stroke:#2b8a3e,color:#1b4332,stroke-width:2px;
    classDef blocked fill:#ffe3e3,stroke:#c92a2a,color:#7f1d1d,stroke-width:2px;

    class B1a,B1b,B1c,B1d,B1e done;
```

## 最终边界审计命令

子 PR 可按范围裁剪；B1e 必须执行并解释剩余命中。

```bash
# 0. 权威 guard：pytest 边界规则由维护命令判定。
make test_boundary_check

# 1. test/ 不得 import 或直接调用 tools.*。
rg -n '^\s*(from|import)\s+tools\b|\btools\.[A-Za-z_]' test -g '*.py' -g '!**/__pycache__/**'

# 2. test/ 不得直接定位 repo 根 templates/，不得在 pytest 中调用 package_templates(...）。
rg -n "_TEMPLATES_DIR|_REPO_ROOT / \"templates\"|parents\[[0-9]+\].*templates|os\.path\.join\([^\n]*[\"']templates[\"']|package_templates\(" test -g '*.py' -g '!**/__pycache__/**'

# 3. pytest unit 不得执行 source-install smoke。
rg -n 'pip install|--target|source install|install_dir' test -g '*.py' -g '!**/__pycache__/**'
```

允许说明：

- `test/testings/native_toolchain_alignment/harness_templates/` 是 test-local harness templates，不是 repo 根 `templates/`。
- 自然语言里的 “tools” 或 native profile 的 “required tools” 不等于 `tools.*` import。
- generated README 行为测试允许读取生成输出中的 `README.md` / `README_zh.md`，只要断言目标是可执行示例、formatter-friendly code block、公开 API 示例或集成命令，而不是 repo-source maintainer README 文案同步。
- `make unittest` 继续依赖 `make tpl`，最终审计不得把这一点作为违规。
- 审计命令是当前已知模式的可复制检查；B1e 还需要人工 review 新增的 template-source / tooling 相关引用，避免变体写法漏网。

## 验收标准

### 边界验收

- `test/` 不再直接 import `tools.*`。例外：没有例外；维护脚本相关测试迁出 pytest unit。
- `test/` 不再直接读取、遍历、渲染 repo 根 `templates/`。允许读取的是：
  - `pyfcstm/template` packaged assets 通过 production API 提取后的临时目录；
  - `test/` 内 test-local throwaway templates；
  - CLI `pyfcstm generate --template ...` 的公开路径。
- C/C++/C++ wrapper 的 native 编译/运行测试仍存在，且模板输入来自 packaged template/public API。
- generated README executable docs tests 仍存在，不因 README 字样被误删。
- `make unittest` 仍然依赖 `make tpl`。
- source-template packaging mechanics、symlink/stub、source-install smoke 不再作为 pytest unit，但必须有显式维护/打包命令保留覆盖。
- repo-source maintainer README/prose/comment-only assertions 不再作为 pytest unit 的主要断言。

### 测试验收

- 常规子 PR 至少运行：`SKIP_SLOW_TESTS=1 make unittest`。
- 触及 C/C++/C++ wrapper helper 或 native template 测试的子 PR，需要额外运行对应不跳 slow 的 template 子集或 full `make unittest`，不能只用 slow-skip 证明完成。
- 触及 `tools/check_template_packaging.py` 或 `tools/check_template_source_install.py` 的子 PR 必须运行对应显式命令。
- 触及 docs/pydoc/API 的子 PR 按仓库规则运行 `make rst_auto` 并 review 生成 RST diff。
- 每个子 PR 的 PR body / review 必须明确说明是否改变模板来源、是否保留 native compile/run 行为、是否迁出 packaging/source-install coverage、是否删除 prose-only asserts。

## 当前状态

- 🟢 B1a 已完成：[PR #286](https://github.com/HansBug/pyfcstm/pull/286) 已 merge，测试边界纪律已持久化到 `CLAUDE.md`，`AGENTS.md` symlink 未破坏。
- 🟢 B1b 已完成：[PR #287](https://github.com/HansBug/pyfcstm/pull/287) 已 merge，模板打包与源码安装冒烟已迁出 pytest unit，保留为显式维护命令并接入 CI。
- 🟢 B1c 已完成：[PR #288](https://github.com/HansBug/pyfcstm/pull/288) 已 merge，模板测试入口已收束到 packaged/public API，C++/C++ poll helper 不再直连 repo-root templates 或 tools.package_templates，generated README 行为断言保留。
- 🟢 B1d 已完成：[PR #289](https://github.com/HansBug/pyfcstm/pull/289) 已 merge，`test/llm` tools 私有 helper 直连与 diagnostics prose/comment-only pytest 已清理，structured contract 覆盖保留。
- 🟢 B1e 已完成：[PR #290](https://github.com/HansBug/pyfcstm/pull/290) 已 merge，最终边界审计 guard 已落地为 `make test_boundary_check` 并接入 CI；PR #290 本地与 GitHub CI 均通过，三路最新复审无 C/I 阻塞。
- 子 PR 已全部完成；本伞 PR 最终 multiagent review 已完成，codex / claude / deepseek 三路均给出 ready 且无 C/I 阻塞。伞 PR head `f7ab59ff` 的 GitHub checks 已全部通过（33/33 pass），`mergeStateStatus=CLEAN`；已于 2026-06-28 合入 `main`，merge commit 为 `394301f6c85749ab58b267f04ed19c855e56e29d`，merge commit message 已包含 `[skip-slow]`。


