### PR TITLE
B1a 纪律：持久化 test 边界规则

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1044,6 +1044,31 @@ For built-in template work, the current design bar is defined by the `python` te
   migration indexes. If fixture inventories, test documentation, or other test-tree maintenance data need executable
   validation, put that check in a maintenance command outside the unit-test suite (for example under [tools/](tools/)) and run
   it explicitly.
+- Python unit tests must enter built-in template behavior through production package/runtime surfaces. Tests may use
+  packaged template assets through :mod:`pyfcstm.template`, `pyfcstm.template.extract_template(...)`,
+  `pyfcstm.template.list_templates()`, `pyfcstm.template.get_template_info(...)`,
+  `StateMachineCodeRenderer` pointed at an extracted packaged template, or CLI paths such as
+  `pyfcstm generate --template ...`. Tests may also create throwaway templates under their own temporary directories or
+  under [test/](test/) when the test target is the renderer itself.
+- Python unit tests must not directly read, render, compare, or assert against repository root `templates/` source
+  directories. Avoid source-layout shortcuts such as `_REPO_ROOT / "templates"`,
+  `Path(__file__).parents[...] / "templates"`, or `os.path.join(..., "templates")` in [test/](test/) when the behavior
+  under test can be reached through packaged template assets or public CLI/runtime entry points.
+- Python unit tests must not import `tools.*`, execute `tools.*`, or assert private helper behavior from maintenance
+  scripts. Packaging, release, source-template packaging, source-install smoke, symlink/stub resolution, and similar
+  maintenance checks should live as explicit commands under [tools/](tools/) or Makefile targets, not as default
+  `pytest -m unittest` cases. Do not delete that coverage when migrating it out of pytest; keep a reproducible
+  maintenance command.
+- Keep generated README executable documentation tests in pytest when they validate runnable quick starts,
+  compile/run commands, formatter-friendly code blocks, public API examples, or integration commands emitted by
+  generated artifacts. Do not use pytest primarily to assert repo-source maintainer README wording, prose inventories,
+  comment-only text, or documentation synchronization that is not production behavior.
+- Native template tests are part of the unit-test contract when they verify generated runtime behavior. C / C++ /
+  C++ wrapper native compile, native run, CMake, ctypes, formatter, and native alignment checks must be preserved when
+  their inputs are generated through packaged template or public API paths.
+- `make unittest` intentionally depends on `make tpl` so packaged built-in template assets are refreshed before the
+  Python unit-test suite runs. Do not remove that dependency merely to avoid packaging work in tests; instead, keep
+  pytest on packaged/public inputs and move source-template maintenance coverage to explicit tooling commands.
 - Shared test utilities and fixtures in [test/testings/](test/testings/)
 - Sample DSL files in [test/testfile/sample_codes/](test/testfile/sample_codes/) (auto-generate tests via `make sample`)
 - Negative cases in [test/testfile/sample_neg_codes/](test/testfile/sample_neg_codes/)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1045,7 +1045,7 @@ For built-in template work, the current design bar is defined by the `python` te
   validation, put that check in a maintenance command outside the unit-test suite (for example under [tools/](tools/)) and run
   it explicitly.
 - Python unit tests must enter built-in template behavior through production package/runtime surfaces. Tests may use
-  packaged template assets through :mod:`pyfcstm.template`, `pyfcstm.template.extract_template(...)`,
+  packaged template assets through `pyfcstm.template`, `pyfcstm.template.extract_template(...)`,
   `pyfcstm.template.list_templates()`, `pyfcstm.template.get_template_info(...)`,
   `StateMachineCodeRenderer` pointed at an extracted packaged template, or CLI paths such as
   `pyfcstm generate --template ...`. Tests may also create throwaway templates under their own temporary directories or


### PR DESCRIPTION
## 定位

这是 [PR #285](https://github.com/HansBug/pyfcstm/pull/285) 的子 PR：**B1a 纪律**。

本 PR 先做最小纪律持久化：只更新 `CLAUDE.md`（`AGENTS.md` 是同一文件的 symlink，不单独编辑），把 `test/` 边界写进仓库长期协作规则。它不清理现有测试、不迁出工具脚本、不改模板 runtime。

## 与上游伞 PR 的一致性

对应伞 PR 表格中的 B1a：

- **目标**：让规则长期可见：保留 `make tpl` / native tests，禁止 `test/` 直连 repo-root `templates/` / `tools`。
- **执行方案**：在 Testing Strategy 增加明确条款；说明允许的 public API 路径、禁止的 source-template/tooling 路径、native tests 保留原则、generated README 行为测试保留原则、source packaging/source install 迁出原则。
- **验收标准**：验证 `AGENTS.md` 与 `CLAUDE.md` 的 symlink；review `git diff -- CLAUDE.md`；用精确短语确认关键边界；不得包含移除 `make unittest: tpl` 或移除 native compile tests 的表述。

## 实施计划

1. 确认 `AGENTS.md -> CLAUDE.md` 仍是 symlink。
2. 只编辑 `CLAUDE.md` 的 Testing Strategy 相关段落。
3. 新增/强化以下规则：
   - `make unittest` 继续依赖 `make tpl`，这是 intentional，不得移除。
   - Python unit tests 可以通过 `pyfcstm.template` 的 packaged asset / public API 使用内置模板。
   - `test/` 禁止直接读取 repo 根 `templates/`，例如 `_REPO_ROOT / "templates"`、`Path(__file__).parents[...] / "templates"`、`os.path.join(..., "templates")`。
   - `test/` 禁止直接 `import tools.*`、执行 `tools.*`、或 assert `tools.*` 私有 helper；维护/打包检查应迁到显式 `tools/` 命令或 Makefile target。
   - C/C++/C++ wrapper native compile/run、CMake、ctypes、formatter、native alignment 等模板行为测试必须保留。
   - generated README executable docs tests 必须保留；repo-source maintainer README/prose/comment-only assertions 不应作为 pytest unit 主断言。
   - source-template packaging mechanics、symlink/stub、source-install smoke 应迁出 pytest unit 但保留显式维护覆盖。
4. 不修改任何测试文件或生产代码。

## 验收命令

```bash
ls -l AGENTS.md CLAUDE.md
git diff -- CLAUDE.md
rg -n "make unittest.*make tpl" CLAUDE.md
rg -n "repository root.*templates|repo 根.*templates|_REPO_ROOT.*/.*templates" CLAUDE.md
rg -n "tools\.\*|import tools|tools.*私有" CLAUDE.md
rg -n "native.*compile|native.*运行|CMake|ctypes|formatter|native alignment" CLAUDE.md
rg -n "generated README|可执行.*README|README.*executable" CLAUDE.md
rg -n "source-install|source install|源码安装|source-template packaging|symlink/stub" CLAUDE.md
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
```

## 非目标

- 不清理 `test/` 中已有 direct `tools.*` / repo-root `templates` 用法；这些属于后续 B1b/B1c/B1d/B1e。
- 不删除 native template compile/run tests。
- 不移除 `make unittest: tpl`。
- 不改 `tools/`、`templates/`、`pyfcstm/` 或 CI workflow。

## 当前状态

- 🟢 ready to merge / 等待用户指示：`CLAUDE.md` 已更新，`AGENTS.md` 仍是 symlink，未修改测试文件、生产代码、`tools/`、`templates/` 或 CI workflow；三路实现后 review 均无 C/I 级问题。

## 已执行验证

```bash
ls -l AGENTS.md CLAUDE.md
git diff -- CLAUDE.md
rg -n "make unittest.*make tpl" CLAUDE.md
rg -n "repository root.*templates|repo 根.*templates|_REPO_ROOT.*/.*templates" CLAUDE.md
rg -n "tools\.\*|import tools|tools.*私有" CLAUDE.md
rg -n "native.*compile|native.*运行|CMake|ctypes|formatter|native alignment" CLAUDE.md
rg -n "generated README|可执行.*README|README.*executable" CLAUDE.md
rg -n "source-install|source install|源码安装|source-template packaging|symlink/stub" CLAUDE.md
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
```

- `SKIP_SLOW_TESTS=1 make unittest` 本地结果：`41337 passed, 640 skipped, 67 deselected`。
- GitHub Actions 状态：当前分支只改 `CLAUDE.md`，现有 workflow 的 `push`/`pull_request` path filters 未对该路径创建 checks；`gh pr checks 286` 报告 no checks。



