### PR TITLE
B1b 维护：迁出模板打包与源码安装检查

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,11 @@ jobs:
         shell: bash
         run: |
           make unittest IS_WIN=${{ env.IS_WIN }} IS_MAC=${{ env.IS_MAC }}
+      - name: Run template maintenance checks
+        shell: bash
+        run: |
+          make template_packaging_check
+          make template_source_install_check
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docs test unittest resource antlr antlr_build build package clean docs_auto todos_auto tests_auto rst_auto sha256 jsfcstm jsfcstm_clean vscode vscode_clean vscode_install vscode_uninstall logos logos_clean app_icons app_icons_clean help tpl tpl_clean templates_package
+.PHONY: docs test unittest resource antlr antlr_build build package clean docs_auto todos_auto tests_auto rst_auto sha256 jsfcstm jsfcstm_clean vscode vscode_clean vscode_install vscode_uninstall logos logos_clean app_icons app_icons_clean help tpl tpl_clean templates_package template_packaging_check template_source_install_check
 
 PYTHON := $(shell which python)
 
@@ -112,6 +112,8 @@ help:
 	@echo "  make tpl          - Package repository templates into pyfcstm/template zip assets"
 	@echo "  make tpl_clean    - Remove packaged template zip assets and index"
 	@echo "  make templates_package - Alias of 'make tpl'"
+	@echo "  make template_packaging_check - Validate repository template packaging contracts"
+	@echo "  make template_source_install_check - Validate source-install template extraction"
 	@echo ""
 	@echo "Sample Tests:"
 	@echo "  make sample       - Generate test files from sample DSL files"
@@ -185,6 +187,13 @@ templates_package: tpl
 
 tpl_clean:
 	rm -f ${SRC_DIR}/template/*.zip ${SRC_DIR}/template/index.json
+
+template_packaging_check:
+	$(PYTHON) tools/check_template_packaging.py
+
+template_source_install_check:
+	$(PYTHON) tools/check_template_source_install.py
+
 
 # LLM-based documentation generation targets
 docs_auto:

--- a/test/template/test_template.py
+++ b/test/template/test_template.py
@@ -1,7 +1,4 @@
 import os.path
-import subprocess
-import sys
-
 import pytest
 from hbutils.system import TemporaryDirectory
 
@@ -135,50 +132,3 @@ class TestBuiltinTemplateModule:
         with TemporaryDirectory() as td:
             with pytest.raises(LookupError):
                 extract_template("not_exists", td)
-
-    def test_source_install_extracts_builtin_template_outside_checkout(self):
-        with TemporaryDirectory() as build_root:
-            install_dir = os.path.join(build_root, "install")
-            command = [
-                sys.executable,
-                "-m",
-                "pip",
-                "install",
-                "--quiet",
-                "--no-deps",
-                "--target",
-                install_dir,
-                ".",
-            ]
-            subprocess.run(
-                command,
-                cwd=os.path.abspath(
-                    os.path.join(os.path.dirname(__file__), "..", "..")
-                ),
-                check=True,
-            )
-
-            probe_code = (
-                "import os\n"
-                "from tempfile import TemporaryDirectory\n"
-                "from pyfcstm.template import extract_template\n"
-                "with TemporaryDirectory() as td:\n"
-                "    path = extract_template('python', td)\n"
-                "    assert os.path.basename(path) == 'python', path\n"
-                "    assert os.path.isfile(os.path.join(path, 'config.yaml')), path\n"
-                "    assert os.path.isfile(os.path.join(path, 'machine.py.j2')), path\n"
-                "    print('ok')\n"
-            )
-            probe = subprocess.run(
-                [sys.executable, "-c", probe_code],
-                cwd=build_root,
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                env={
-                    **os.environ,
-                    "PYTHONPATH": install_dir,
-                },
-            )
-            assert probe.stdout.strip() == "ok"

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -2,10 +2,7 @@
 
 import ast
 import json
-import os
 import re
-import stat
-import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -17,7 +14,6 @@ from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.render import StateMachineCodeRenderer
 from pyfcstm.template import extract_template, get_template_info, list_templates
-from tools.package_templates import package_templates, _resolve_archive_source
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -171,34 +167,8 @@ def representative_model():
     return parse_dsl_node_to_state_machine(ast_node)
 
 
-def _extract_archives(package_dir, output_root):
-    template_dirs = {}
-    for name in _CURRENT_TEMPLATE_NAMES:
-        archive_path = package_dir / "{name}.zip".format(name=name)
-        with zipfile.ZipFile(str(archive_path), "r") as zf:
-            zf.extractall(str(output_root / name))
-        template_dirs[name] = output_root / name / name
-    return template_dirs
-
-
 @pytest.fixture(scope="session")
 def rendered_templates(representative_model):
-    with TemporaryDirectory() as package_td:
-        with TemporaryDirectory() as extraction_td:
-            with TemporaryDirectory() as render_td:
-                package_root = Path(package_td)
-                extraction_root = Path(extraction_td)
-                output_root = Path(render_td)
-                package_templates(str(_TEMPLATES_DIR), str(package_root), verbose=False)
-                yield _render_template_directories(
-                    _extract_archives(package_root, extraction_root),
-                    representative_model,
-                    output_root,
-                )
-
-
-@pytest.fixture(scope="session")
-def extracted_rendered_templates(representative_model):
     with TemporaryDirectory() as extraction_td, TemporaryDirectory() as render_td:
         extraction_root = Path(extraction_td)
         output_root = Path(render_td)
@@ -518,13 +488,11 @@ def test_c_family_readmes_document_deployment_safety_boundaries(rendered_templat
         )
         assert (
             "本生成运行时不宣称已经满足 MISRA、AUTOSAR、DO-178C、IEC 61508 "
-            "或 ISO 26262 认证就绪要求。"
-            in generated_readme_zh_words
+            "或 ISO 26262 认证就绪要求。" in generated_readme_zh_words
         )
         assert (
             "它们本身不会让生成运行时达到 MISRA、AUTOSAR、DO-178C、IEC 61508、"
-            "ISO 26262 或其他认证 ready。"
-            in generated_readme_zh_words
+            "ISO 26262 或其他认证 ready。" in generated_readme_zh_words
         )
 
         assert "Integration Preflight Checklist" in generated_readme
@@ -605,10 +573,8 @@ def test_cpp_template_documentation_describes_early_first_class_status(
 @pytest.mark.unittest
 def test_generated_sources_preserve_banner_source_context_and_dependency_boundary(
     rendered_templates,
-    extracted_rendered_templates,
 ):
     _assert_rendered_template_contracts(rendered_templates)
-    _assert_rendered_template_contracts(extracted_rendered_templates)
 
 
 @pytest.mark.unittest
@@ -626,53 +592,6 @@ def test_generated_source_templates_keep_source_metadata_wording():
 
 
 @pytest.mark.unittest
-def test_packaging_output_preserves_metadata_and_archive_roots():
-    with TemporaryDirectory() as td:
-        output_dir = Path(td)
-        stale_zip = output_dir / "stale.zip"
-        stale_zip.write_bytes(b"stale")
-
-        package_templates(str(_TEMPLATES_DIR), str(output_dir), verbose=False)
-
-        assert not stale_zip.exists()
-        index = _read_json(output_dir / "index.json")
-        assert [item["name"] for item in index["templates"]] == list(
-            _repository_template_names()
-        )
-
-        for item in index["templates"]:
-            name = item["name"]
-            repo_metadata = _load_template_metadata(name)
-            assert item["archive"] == "{name}.zip".format(name=name)
-            assert item["root_dir"] == name
-            for key in ["title", "description", "language", "experimental"]:
-                assert item[key] == repo_metadata[key]
-
-            archive_path = output_dir / item["archive"]
-            assert archive_path.is_file()
-            with zipfile.ZipFile(str(archive_path), "r") as zf:
-                names = zf.namelist()
-            assert names
-            assert all(path.startswith(name + "/") for path in names)
-            archived_rel_paths = {path[len(name) + 1 :] for path in names}
-            assert _REQUIRED_TEMPLATE_FILES[name] <= archived_rel_paths
-            assert not any("__pycache__" in path for path in names)
-
-
-@pytest.mark.unittest
-def test_distribution_metadata_keeps_template_assets_declared():
-    setup_text = _read_text(_REPO_ROOT / "setup.py")
-    manifest_text = _read_text(_REPO_ROOT / "MANIFEST.in")
-
-    assert "from tools.package_templates import package_templates" in setup_text
-    assert "package_templates(" in setup_text
-    assert "package_data" in setup_text
-    assert "*.zip" in setup_text
-    assert "*.json" in setup_text
-    assert "recursive-include pyfcstm/template *.zip *.json" in manifest_text
-
-
-@pytest.mark.unittest
 def test_extracted_builtin_templates_preserve_source_structure_contract():
     with TemporaryDirectory() as td:
         for name in _repository_template_names():
@@ -686,119 +605,6 @@ def test_extracted_builtin_templates_preserve_source_structure_contract():
             spec = _ignore_spec(config)
             for maintainer_file in _MAINTAINER_ONLY_FILES:
                 assert spec.match_file(maintainer_file)
-
-
-def _zip_payload(output_dir, template_name, rel_path):
-    with zipfile.ZipFile(
-        str(output_dir / "{name}.zip".format(name=template_name)), "r"
-    ) as zf:
-        info = zf.getinfo("{name}/{rel}".format(name=template_name, rel=rel_path))
-        payload = zf.read(info)
-    return info, payload
-
-
-@pytest.mark.unittest
-def test_cpp_templates_reuse_c_core_as_packaged_file_payloads():
-    with TemporaryDirectory() as td:
-        output_dir = Path(td)
-        package_templates(str(_TEMPLATES_DIR), str(output_dir), verbose=False)
-
-        for template_name, source_template in [("cpp", "c"), ("cpp_poll", "c_poll")]:
-            for rel_path in ["machine.c.j2", "machine.h.j2"]:
-                info, payload = _zip_payload(output_dir, template_name, rel_path)
-                assert stat.S_IFMT(info.external_attr >> 16) != stat.S_IFLNK
-                assert (
-                    payload
-                    == (_TEMPLATES_DIR / source_template / rel_path).read_bytes()
-                )
-                assert payload.strip() != (
-                    "../{source}/{rel}".format(source=source_template, rel=rel_path)
-                ).encode("utf-8")
-
-
-@pytest.mark.unittest
-def test_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(
-    monkeypatch,
-):
-    src_file = _TEMPLATES_DIR / "cpp" / "machine.c.j2"
-    target_file = _TEMPLATES_DIR / "c" / "machine.c.j2"
-    realpath = os.path.realpath
-
-    def unresolved_realpath(path):
-        if os.path.abspath(path) == os.path.abspath(str(src_file)):
-            return os.path.abspath(path)
-        return realpath(path)
-
-    monkeypatch.setattr(os.path, "realpath", unresolved_realpath)
-
-    assert _resolve_archive_source(
-        str(_TEMPLATES_DIR / "cpp"),
-        str(src_file),
-        "cpp",
-        "machine.c.j2",
-    ) == str(target_file)
-
-
-@pytest.mark.unittest
-def test_cpp_template_packaging_resolves_windows_symlink_text_stubs():
-    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
-        source_root = Path(source_td) / "templates"
-        output_dir = Path(output_td)
-        for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-            src_dir = _TEMPLATES_DIR / name
-            dst_dir = source_root / name
-            dst_dir.mkdir(parents=True)
-            for item in src_dir.iterdir():
-                if item.is_file() or item.is_symlink():
-                    if item.is_symlink():
-                        target = Path(os.readlink(str(item))).as_posix()
-                        (dst_dir / item.name).write_text(
-                            target + "\n", encoding="utf-8"
-                        )
-                    else:
-                        (dst_dir / item.name).write_bytes(item.read_bytes())
-
-        package_templates(str(source_root), str(output_dir), verbose=False)
-
-        _, cpp_c_payload = _zip_payload(output_dir, "cpp", "machine.c.j2")
-        _, cpp_h_payload = _zip_payload(output_dir, "cpp", "machine.h.j2")
-        _, cpp_poll_c_payload = _zip_payload(output_dir, "cpp_poll", "machine.c.j2")
-        _, cpp_poll_h_payload = _zip_payload(output_dir, "cpp_poll", "machine.h.j2")
-        assert cpp_c_payload == (source_root / "c" / "machine.c.j2").read_bytes()
-        assert cpp_h_payload == (source_root / "c" / "machine.h.j2").read_bytes()
-        assert (
-            cpp_poll_c_payload == (source_root / "c_poll" / "machine.c.j2").read_bytes()
-        )
-        assert (
-            cpp_poll_h_payload == (source_root / "c_poll" / "machine.h.j2").read_bytes()
-        )
-
-
-@pytest.mark.unittest
-def test_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub():
-    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
-        source_root = Path(source_td) / "templates"
-        output_dir = Path(output_td)
-        for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-            src_dir = _TEMPLATES_DIR / name
-            dst_dir = source_root / name
-            dst_dir.mkdir(parents=True)
-            for item in src_dir.iterdir():
-                if item.is_file() or item.is_symlink():
-                    if item.is_symlink():
-                        target = Path(os.readlink(str(item))).as_posix()
-                        (dst_dir / item.name).write_text(
-                            target + "\n", encoding="utf-8"
-                        )
-                    else:
-                        (dst_dir / item.name).write_bytes(item.read_bytes())
-
-        (source_root / "cpp" / "machine.c.j2").write_text(
-            "../c_poll/machine.c.j2", encoding="utf-8"
-        )
-
-        with pytest.raises(ValueError, match="expected checkout stub"):
-            package_templates(str(source_root), str(output_dir), verbose=False)
 
 
 @pytest.mark.unittest

--- a/tools/check_template_packaging.py
+++ b/tools/check_template_packaging.py
@@ -1,0 +1,583 @@
+"""
+Validate repository-source built-in template packaging contracts.
+
+This maintenance command checks the packaging behavior that is intentionally
+outside the pytest unit-test boundary. It exercises :mod:`tools.package_templates`
+against repository-source template directories and verifies that the generated
+zip assets are self-contained, metadata-rich, and suitable for packaged runtime
+extraction.
+
+The command contains the following checks:
+* packaged index metadata and archive root layout
+* C++ template reuse payload resolution for symlinks and Windows text stubs
+* rejection of unexpected C++ reuse text stubs
+* package/distribution metadata declarations for packaged template assets
+
+Example::
+
+    $ python tools/check_template_packaging.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import stat
+import zipfile
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict, Iterable, List, Optional, Tuple
+
+
+def _bootstrap_repo_imports() -> Path:
+    """
+    Add the repository root to ``sys.path`` for direct script execution.
+
+    :return: Repository root path.
+    :rtype: pathlib.Path
+    """
+    import sys
+
+    root = Path(__file__).resolve().parents[1]
+    root_text = str(root)
+    if root_text not in sys.path:
+        sys.path.insert(0, root_text)
+    return root
+
+
+_REPO_ROOT = _bootstrap_repo_imports()
+
+from tools.package_templates import package_templates, _resolve_archive_source  # noqa: E402
+
+
+CURRENT_TEMPLATE_NAMES = ("c", "c_poll", "cpp", "cpp_poll", "python")
+REQUIRED_TEMPLATE_FILES = {
+    "c": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+    },
+    "c_poll": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+    },
+    "cpp": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+        "machine.hpp.j2",
+        "machine.cpp.j2",
+    },
+    "cpp_poll": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.h.j2",
+        "machine.c.j2",
+        "machine.hpp.j2",
+        "machine.cpp.j2",
+    },
+    "python": {
+        "README.md",
+        "README_zh.md",
+        "README.md.j2",
+        "README_zh.md.j2",
+        "config.yaml",
+        "template.json",
+        "machine.py.j2",
+    },
+}
+
+
+def repository_root() -> Path:
+    """
+    Return the repository root for this maintenance command.
+
+    :return: Repository root path.
+    :rtype: pathlib.Path
+
+    Example::
+
+        >>> repository_root().name  # doctest: +SKIP
+        'pyfcstm'
+    """
+    return _REPO_ROOT
+
+
+def read_json(path: Path) -> Dict[str, object]:
+    """
+    Load a UTF-8 JSON object from ``path``.
+
+    :param path: JSON file path.
+    :type path: pathlib.Path
+    :return: Decoded JSON object.
+    :rtype: Dict[str, object]
+    :raises json.JSONDecodeError: If the file is not valid JSON.
+    :raises OSError: If the file cannot be read.
+
+    Example::
+
+        >>> isinstance(read_json(repository_root() / 'pyfcstm' / 'template' / 'index.json'), dict)
+        True
+    """
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def read_text(path: Path) -> str:
+    """
+    Read a UTF-8 text file.
+
+    :param path: Text file path.
+    :type path: pathlib.Path
+    :return: File text.
+    :rtype: str
+    :raises OSError: If the file cannot be read.
+
+    Example::
+
+        >>> 'pyfcstm' in read_text(repository_root() / 'setup.py')
+        True
+    """
+    return path.read_text(encoding="utf-8")
+
+
+def repository_template_names(templates_dir: Path) -> Tuple[str, ...]:
+    """
+    Return sorted repository-source built-in template names.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: Template directory names.
+    :rtype: Tuple[str, ...]
+
+    Example::
+
+        >>> 'python' in repository_template_names(repository_root() / 'templates')
+        True
+    """
+    return tuple(
+        item.name
+        for item in sorted(templates_dir.iterdir())
+        if item.is_dir() and not item.name.startswith(".")
+    )
+
+
+def load_template_metadata(templates_dir: Path, name: str) -> Dict[str, object]:
+    """
+    Load one repository-source template metadata file.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :param name: Template name.
+    :type name: str
+    :return: Template metadata object.
+    :rtype: Dict[str, object]
+    :raises OSError: If the metadata file cannot be read.
+    :raises json.JSONDecodeError: If the metadata file is not valid JSON.
+
+    Example::
+
+        >>> load_template_metadata(repository_root() / 'templates', 'python')['name']
+        'python'
+    """
+    return read_json(templates_dir / name / "template.json")
+
+
+def zip_payload(
+    output_dir: Path, template_name: str, rel_path: str
+) -> Tuple[zipfile.ZipInfo, bytes]:
+    """
+    Return metadata and bytes for one packaged template member.
+
+    :param output_dir: Directory containing template zip archives.
+    :type output_dir: pathlib.Path
+    :param template_name: Packaged template name.
+    :type template_name: str
+    :param rel_path: Template-relative member path.
+    :type rel_path: str
+    :return: Zip member metadata and payload bytes.
+    :rtype: Tuple[zipfile.ZipInfo, bytes]
+    :raises KeyError: If the member does not exist in the archive.
+    :raises zipfile.BadZipFile: If the archive is invalid.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     zip_payload(Path(td), 'python', 'config.yaml')
+    """
+    with zipfile.ZipFile(
+        str(output_dir / "{name}.zip".format(name=template_name)), "r"
+    ) as zf:
+        info = zf.getinfo("{name}/{rel}".format(name=template_name, rel=rel_path))
+        payload = zf.read(info)
+    return info, payload
+
+
+def package_to_tempdir(templates_dir: Path) -> Tuple[TemporaryDirectory, Path]:
+    """
+    Package repository templates into a temporary output directory.
+
+    The returned :class:`tempfile.TemporaryDirectory` must be kept alive by the
+    caller while the output path is used.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: Temporary directory manager and output path.
+    :rtype: Tuple[tempfile.TemporaryDirectory, pathlib.Path]
+
+    Example::
+
+        >>> manager, output = package_to_tempdir(repository_root() / 'templates')  # doctest: +SKIP
+        >>> manager.cleanup()  # doctest: +SKIP
+    """
+    manager = TemporaryDirectory()
+    output_dir = Path(manager.name)
+    package_templates(str(templates_dir), str(output_dir), verbose=False)
+    return manager, output_dir
+
+
+def assert_packaging_output_preserves_metadata_and_archive_roots(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify packaged template metadata, roots, required files, and stale cleanup.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a packaging contract is violated.
+
+    Example::
+
+        >>> assert_packaging_output_preserves_metadata_and_archive_roots(repository_root() / 'templates')
+    """
+    with TemporaryDirectory() as td:
+        output_dir = Path(td)
+        stale_zip = output_dir / "stale.zip"
+        stale_zip.write_bytes(b"stale")
+
+        package_templates(str(templates_dir), str(output_dir), verbose=False)
+
+        assert not stale_zip.exists()
+        index = read_json(output_dir / "index.json")
+        assert [item["name"] for item in index["templates"]] == list(
+            repository_template_names(templates_dir)
+        )
+
+        for item in index["templates"]:
+            name = item["name"]
+            repo_metadata = load_template_metadata(templates_dir, name)
+            assert item["archive"] == "{name}.zip".format(name=name)
+            assert item["root_dir"] == name
+            for key in ["title", "description", "language", "experimental"]:
+                assert item[key] == repo_metadata[key]
+
+            archive_path = output_dir / item["archive"]
+            assert archive_path.is_file()
+            with zipfile.ZipFile(str(archive_path), "r") as zf:
+                names = zf.namelist()
+            assert names
+            assert all(path.startswith(name + "/") for path in names)
+            archived_rel_paths = {path[len(name) + 1 :] for path in names}
+            assert REQUIRED_TEMPLATE_FILES[name] <= archived_rel_paths
+            assert not any("__pycache__" in path for path in names)
+
+
+def assert_distribution_metadata_keeps_template_assets_declared(
+    repo_root: Path,
+) -> None:
+    """
+    Verify source distribution metadata declares packaged template assets.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If package metadata no longer declares assets.
+
+    Example::
+
+        >>> assert_distribution_metadata_keeps_template_assets_declared(repository_root())
+    """
+    setup_text = read_text(repo_root / "setup.py")
+    manifest_text = read_text(repo_root / "MANIFEST.in")
+
+    assert "from tools.package_templates import package_templates" in setup_text
+    assert "package_templates(" in setup_text
+    assert "package_data" in setup_text
+    assert "*.zip" in setup_text
+    assert "*.json" in setup_text
+    assert "recursive-include pyfcstm/template *.zip *.json" in manifest_text
+
+
+def assert_cpp_templates_reuse_c_core_as_packaged_file_payloads(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify C++ packaged core files contain C payload bytes, not symlinks/stubs.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a C++ package stores a symlink or stub payload.
+
+    Example::
+
+        >>> assert_cpp_templates_reuse_c_core_as_packaged_file_payloads(repository_root() / 'templates')
+    """
+    manager, output_dir = package_to_tempdir(templates_dir)
+    try:
+        for template_name, source_template in [("cpp", "c"), ("cpp_poll", "c_poll")]:
+            for rel_path in ["machine.c.j2", "machine.h.j2"]:
+                info, payload = zip_payload(output_dir, template_name, rel_path)
+                assert stat.S_IFMT(info.external_attr >> 16) != stat.S_IFLNK
+                assert (
+                    payload == (templates_dir / source_template / rel_path).read_bytes()
+                )
+                assert payload.strip() != (
+                    "../{source}/{rel}".format(source=source_template, rel=rel_path)
+                ).encode("utf-8")
+    finally:
+        manager.cleanup()
+
+
+def assert_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify explicit symlink text is accepted when ``realpath`` is unreliable.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If symlink target text does not resolve correctly.
+
+    Example::
+
+        >>> assert_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(repository_root() / 'templates')
+    """
+    src_file = templates_dir / "cpp" / "machine.c.j2"
+    target_file = templates_dir / "c" / "machine.c.j2"
+    realpath = os.path.realpath
+
+    def unresolved_realpath(path: str) -> str:
+        """
+        Simulate a checkout mode where ``realpath`` cannot resolve one symlink.
+
+        :param path: Path passed to :func:`os.path.realpath`.
+        :type path: str
+        :return: Simulated real path.
+        :rtype: str
+        """
+        if os.path.abspath(path) == os.path.abspath(str(src_file)):
+            return os.path.abspath(path)
+        return realpath(path)
+
+    try:
+        os.path.realpath = unresolved_realpath
+        assert _resolve_archive_source(
+            str(templates_dir / "cpp"),
+            str(src_file),
+            "cpp",
+            "machine.c.j2",
+        ) == str(target_file)
+    finally:
+        os.path.realpath = realpath
+
+
+def copy_templates_with_windows_symlink_text_stubs(
+    templates_dir: Path,
+    source_root: Path,
+    template_names: Iterable[str],
+) -> None:
+    """
+    Copy templates while replacing symlinks with Windows checkout text stubs.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :param source_root: Temporary template source root to create.
+    :type source_root: pathlib.Path
+    :param template_names: Template names to copy.
+    :type template_names: Iterable[str]
+    :return: ``None``.
+    :rtype: None
+    :raises OSError: If a file cannot be copied or written.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     copy_templates_with_windows_symlink_text_stubs(repository_root() / 'templates', Path(td), ['c'])
+    """
+    for name in template_names:
+        src_dir = templates_dir / name
+        dst_dir = source_root / name
+        dst_dir.mkdir(parents=True)
+        for item in src_dir.iterdir():
+            if item.is_file() or item.is_symlink():
+                if item.is_symlink():
+                    target = Path(os.readlink(str(item))).as_posix()
+                    (dst_dir / item.name).write_text(target + "\n", encoding="utf-8")
+                else:
+                    (dst_dir / item.name).write_bytes(item.read_bytes())
+
+
+def assert_cpp_template_packaging_resolves_windows_symlink_text_stubs(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify expected Windows text stubs are packaged as target payloads.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a text stub is not resolved to target bytes.
+
+    Example::
+
+        >>> assert_cpp_template_packaging_resolves_windows_symlink_text_stubs(repository_root() / 'templates')
+    """
+    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
+        source_root = Path(source_td) / "templates"
+        output_dir = Path(output_td)
+        copy_templates_with_windows_symlink_text_stubs(
+            templates_dir,
+            source_root,
+            ["c", "c_poll", "cpp", "cpp_poll"],
+        )
+
+        package_templates(str(source_root), str(output_dir), verbose=False)
+
+        _, cpp_c_payload = zip_payload(output_dir, "cpp", "machine.c.j2")
+        _, cpp_h_payload = zip_payload(output_dir, "cpp", "machine.h.j2")
+        _, cpp_poll_c_payload = zip_payload(output_dir, "cpp_poll", "machine.c.j2")
+        _, cpp_poll_h_payload = zip_payload(output_dir, "cpp_poll", "machine.h.j2")
+        assert cpp_c_payload == (source_root / "c" / "machine.c.j2").read_bytes()
+        assert cpp_h_payload == (source_root / "c" / "machine.h.j2").read_bytes()
+        assert (
+            cpp_poll_c_payload == (source_root / "c_poll" / "machine.c.j2").read_bytes()
+        )
+        assert (
+            cpp_poll_h_payload == (source_root / "c_poll" / "machine.h.j2").read_bytes()
+        )
+
+
+def assert_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub(
+    templates_dir: Path,
+) -> None:
+    """
+    Verify unexpected Windows text stubs fail packaging.
+
+    :param templates_dir: Repository-root ``templates`` directory.
+    :type templates_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If the unexpected text stub is not rejected.
+
+    Example::
+
+        >>> assert_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub(repository_root() / 'templates')
+    """
+    with TemporaryDirectory() as source_td, TemporaryDirectory() as output_td:
+        source_root = Path(source_td) / "templates"
+        output_dir = Path(output_td)
+        copy_templates_with_windows_symlink_text_stubs(
+            templates_dir,
+            source_root,
+            ["c", "c_poll", "cpp", "cpp_poll"],
+        )
+        (source_root / "cpp" / "machine.c.j2").write_text(
+            "../c_poll/machine.c.j2", encoding="utf-8"
+        )
+
+        try:
+            package_templates(str(source_root), str(output_dir), verbose=False)
+        except ValueError as err:
+            # ValueError: tools.package_templates rejects unexpected checkout stub text.
+            assert "expected checkout stub" in str(err)
+        else:
+            raise AssertionError("Unexpected C++ reuse text stub was accepted.")
+
+
+def run_checks(repo_root: Path) -> None:
+    """
+    Run all template packaging maintenance checks.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If any maintenance contract fails.
+    :raises OSError: If required repository files cannot be read.
+
+    Example::
+
+        >>> run_checks(repository_root())
+    """
+    templates_dir = repo_root / "templates"
+    assert set(CURRENT_TEMPLATE_NAMES) <= set(repository_template_names(templates_dir))
+    assert_packaging_output_preserves_metadata_and_archive_roots(templates_dir)
+    assert_distribution_metadata_keeps_template_assets_declared(repo_root)
+    assert_cpp_templates_reuse_c_core_as_packaged_file_payloads(templates_dir)
+    assert_cpp_template_packaging_accepts_symlink_when_realpath_does_not_resolve(
+        templates_dir
+    )
+    assert_cpp_template_packaging_resolves_windows_symlink_text_stubs(templates_dir)
+    assert_cpp_template_packaging_rejects_unexpected_windows_symlink_text_stub(
+        templates_dir
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """
+    Run the command-line template packaging maintenance check.
+
+    :param argv: Optional command-line argument list, defaults to ``None``.
+    :type argv: List[str], optional
+    :return: ``None``.
+    :rtype: None
+    :raises AssertionError: If a maintenance contract fails.
+
+    Example::
+
+        >>> main([])  # doctest: +SKIP
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate repository-source built-in template packaging contracts."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(repository_root()),
+        help="Repository root to check. Defaults to the parent of this tools directory.",
+    )
+    args = parser.parse_args(argv)
+    run_checks(Path(args.repo_root).resolve())
+    print("template packaging checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_template_source_install.py
+++ b/tools/check_template_source_install.py
@@ -1,0 +1,183 @@
+"""
+Validate source-install access to packaged built-in templates.
+
+This maintenance command checks the source-install smoke path that is
+intentionally outside the pytest unit-test boundary. It installs the current
+checkout into a temporary target directory without dependencies, runs a probe
+outside the checkout, and verifies that :func:`pyfcstm.template.extract_template`
+can still extract a packaged built-in template.
+
+Example::
+
+    $ python tools/check_template_source_install.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict, List, Optional
+
+
+def repository_root() -> Path:
+    """
+    Return the repository root for this maintenance command.
+
+    :return: Repository root path.
+    :rtype: pathlib.Path
+
+    Example::
+
+        >>> repository_root().name  # doctest: +SKIP
+        'pyfcstm'
+    """
+    return Path(__file__).resolve().parents[1]
+
+
+def install_checkout(repo_root: Path, install_dir: Path) -> None:
+    """
+    Install the checkout into ``install_dir`` without dependencies.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :param install_dir: Target directory for ``pip install --target``.
+    :type install_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If pip installation fails.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     install_checkout(repository_root(), Path(td) / 'install')
+    """
+    command = [
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "--quiet",
+        "--no-deps",
+        "--target",
+        str(install_dir),
+        ".",
+    ]
+    subprocess.run(command, cwd=str(repo_root), check=True)
+
+
+def probe_environment(install_dir: Path) -> Dict[str, str]:
+    """
+    Build the environment for the installed-template probe.
+
+    :param install_dir: Directory containing the installed checkout package.
+    :type install_dir: pathlib.Path
+    :return: Environment mapping for :func:`subprocess.run`.
+    :rtype: Dict[str, str]
+
+    Example::
+
+        >>> 'PYTHONPATH' in probe_environment(Path('/tmp/install'))
+        True
+    """
+    return {
+        **os.environ,
+        "PYTHONPATH": str(install_dir),
+    }
+
+
+def run_extract_probe(build_root: Path, install_dir: Path) -> None:
+    """
+    Run the installed-package built-in template extraction probe.
+
+    :param build_root: Temporary working directory outside the checkout.
+    :type build_root: pathlib.Path
+    :param install_dir: Directory containing the installed checkout package.
+    :type install_dir: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If the probe fails.
+    :raises AssertionError: If the probe output is not ``ok``.
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:  # doctest: +SKIP
+        ...     run_extract_probe(Path(td), Path(td) / 'install')
+    """
+    probe_code = (
+        "import os\n"
+        "from tempfile import TemporaryDirectory\n"
+        "from pyfcstm.template import extract_template\n"
+        "with TemporaryDirectory() as td:\n"
+        "    path = extract_template('python', td)\n"
+        "    assert os.path.basename(path) == 'python', path\n"
+        "    assert os.path.isfile(os.path.join(path, 'config.yaml')), path\n"
+        "    assert os.path.isfile(os.path.join(path, 'machine.py.j2')), path\n"
+        "    print('ok')\n"
+    )
+    probe = subprocess.run(
+        [sys.executable, "-c", probe_code],
+        cwd=str(build_root),
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=probe_environment(install_dir),
+    )
+    assert probe.stdout.strip() == "ok"
+
+
+def run_check(repo_root: Path) -> None:
+    """
+    Run the source-install built-in template extraction smoke check.
+
+    :param repo_root: Repository root path.
+    :type repo_root: pathlib.Path
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If installation or probing fails.
+    :raises AssertionError: If the probe output is unexpected.
+
+    Example::
+
+        >>> run_check(repository_root())  # doctest: +SKIP
+    """
+    with TemporaryDirectory() as build_td:
+        build_root = Path(build_td)
+        install_dir = build_root / "install"
+        install_checkout(repo_root, install_dir)
+        run_extract_probe(build_root, install_dir)
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    """
+    Run the command-line source-install template extraction check.
+
+    :param argv: Optional command-line argument list, defaults to ``None``.
+    :type argv: List[str], optional
+    :return: ``None``.
+    :rtype: None
+    :raises subprocess.CalledProcessError: If installation or probing fails.
+
+    Example::
+
+        >>> main([])  # doctest: +SKIP
+    """
+    parser = argparse.ArgumentParser(
+        description="Validate source-install built-in template extraction."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(repository_root()),
+        help="Repository root to install. Defaults to the parent of this tools directory.",
+    )
+    args = parser.parse_args(argv)
+    run_check(Path(args.repo_root).resolve())
+    print("template source-install check passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 定位

这是 [PR #285](https://github.com/HansBug/pyfcstm/pull/285) 的子 PR：**B1b 维护**。

本 PR 负责把模板打包机制（source-template packaging mechanics）和源码安装冒烟（source-install smoke）从 pytest unit 体系迁出到显式维护命令，同时保留等价回归覆盖。它不负责把所有模板测试改成 packaged/public API 入口；那是后续 B1c 的范围。

## 与上游伞 PR 的一致性

对应伞 PR 表格中的 B1b：

- **目标**：`tools.package_templates`、archive roots、metadata、C++ symlink realpath fallback、Windows text stub resolution、unexpected stub rejection、source-template bytes copied into packaged archive、distribution metadata 资产声明、checkout 外 source install 后提取内置模板，都由显式维护/打包命令覆盖。
- **执行方案**：新增 `tools/check_template_packaging.py` 与 `tools/check_template_source_install.py`；新增 Makefile target；从 pytest unit 删除对 `tools.package_templates` / `_resolve_archive_source` 的 import 和测试，以及 `pip install --target .` source-install 测试；禁止无替代删除覆盖。
- **验收标准**：两个 tools 命令通过；pytest 中不再 import `tools.package_templates`；`test/template/test_template.py` 不再残留 source-install pytest；维护脚本不进入 `pytest -m unittest` 默认执行；常规单元测试用 `SKIP_SLOW_TESTS=1 make unittest` 验证；CI workflow 显式执行迁出的维护检查，避免覆盖从自动化链路中消失。

## 已实施内容

1. **新增显式维护脚本**
   - 新增 `tools/check_template_packaging.py`：覆盖原 pytest 中针对 `tools.package_templates` 的打包契约，包括 stale zip 清理、`index.json` 元数据、zip root、required files、`__pycache__` 排除、C++/C++ poll 对 C/C poll core `.j2` 的 payload 消解、symlink realpath fallback、Windows text stub、unexpected stub rejection，以及 `setup.py` / `MANIFEST.in` 中 packaged template 资产声明。
   - 新增 `tools/check_template_source_install.py`：覆盖原 pytest 中 `pip install --target` 后在 checkout 外 `extract_template('python', ...)` 的源码安装冒烟。
   - 两个脚本使用 English module/function docstrings，避免 broad `except Exception`，失败时依赖普通 assertion/subprocess error 暴露。

2. **新增维护入口**
   - `Makefile` 新增 `template_packaging_check` 与 `template_source_install_check`。
   - 这些 target 不挂到 `unittest` 默认链路；它们是维护/发布回归入口。

3. **收束 pytest unit 边界**
   - 从 B1b 自有范围 `test/template/test_template_structure.py` 移除 `from tools.package_templates import ...`。
   - 删除/迁出该文件中直接调用 `package_templates(...)`、`_resolve_archive_source(...)` 的测试；其中 `setup.py` / `MANIFEST.in` 字符串断言迁到 `tools/check_template_packaging.py`，不是无替代删除。
   - 从 `test/template/test_template.py` 移除 `pip install --target .` source-install smoke。
   - 保留通过 `pyfcstm.template` packaged API 的模板列表、元数据、提取、生成物行为测试；不删除 native compile/run、generated README executable docs tests。

4. **接入 CI 自动化链路**
   - `.github/workflows/test.yml` 的 `Code test` job 在 `make unittest` 后新增 `Run template maintenance checks` step：
     - `make template_packaging_check`
     - `make template_source_install_check`
   - 这样迁出 pytest 的打包/安装覆盖仍会在 CI 中自动执行，不会变成纯手动检查。

## 非目标 / 范围边界

- 不把所有 `test/template` 的 repo-root `templates/` 读取一次性清掉；B1c 会负责模板测试入口生产化。
- 不处理 `test/template/cpp/_utils.py` 与 `test/template/cpp_poll/_utils.py` 中现有 `tools.package_templates` 引用；这两个 helper 已在上游伞 PR 的 B1c 行列为主要文件，由 B1c 改成 `extract_template('cpp', ...)` / `extract_template('cpp_poll', ...)`。
- 不处理 `test/llm/test_grammar_guide.py` 中现有 `tools.evaluate_llm_grammar_guide` 引用；它属于 B1d 范围。
- 不删除 C/C++/C++ wrapper native compile/run、CMake、ctypes、formatter、native alignment 测试。
- 不移除 `make unittest: tpl`。
- 不改 built-in template runtime 语义。
- 不把新增维护脚本挂进 pytest unit；需要显式命令运行，并已通过 CI workflow step 自动执行。

## 本地验证证据

已在本分支执行：

```bash
python -m py_compile tools/check_template_packaging.py tools/check_template_source_install.py
python -m ruff format tools/check_template_packaging.py tools/check_template_source_install.py test/template/test_template.py test/template/test_template_structure.py
python -m ruff check tools/check_template_packaging.py tools/check_template_source_install.py test/template/test_template.py test/template/test_template_structure.py
python tools/check_template_packaging.py
python tools/check_template_source_install.py
make template_packaging_check
make template_source_install_check
pytest test/template/test_template.py test/template/test_template_structure.py -m unittest -v
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
python - <<'PY'
import yaml
with open('.github/workflows/test.yml', 'r', encoding='utf-8') as f:
    yaml.safe_load(f)
print('workflow yaml parsed')
PY
```

结果摘要：

- `python tools/check_template_packaging.py`：通过，输出 `template packaging checks passed`。
- `python tools/check_template_source_install.py`：通过，输出 `template source-install check passed`。
- `make template_packaging_check` / `make template_source_install_check`：通过。
- B1b 范围 pytest：`16 passed, 88 warnings in 4.19s` / 修复 CI step 后复跑为 `16 passed, 88 warnings in 4.43s`。
- `SKIP_SLOW_TESTS=1 make unittest`：`41330 passed, 640 skipped, 67 deselected, 1757 warnings in 309.49s`。
- `make rst_auto`：通过，最终未保留无关 RST diff。
- workflow YAML 解析通过。

B1b 范围静态审计：

```bash
rg -n '^\s*(from|import)\s+tools\b|\btools\.package_templates\b|package_templates\(' test/template/test_template_structure.py test/template/test_template.py
rg -n 'pip install|--target|source install|install_dir' test/template/test_template.py
```

结果：两条命令均无命中。

## 当前状态

- 🔵 已按 reviewer I1 修复并推送：迁出的维护检查已接入 CI workflow。
- 等待最新 GitHub CI 与三路实现复核；若仍发现 C/I 级问题，本 PR 继续修复，M 级问题尽量处理但不阻塞 ready。
