### PR TITLE
B1c 模板：收束模板测试入口

### DIFF
--- a/test/template/cpp/_utils.py
+++ b/test/template/cpp/_utils.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import subprocess
 import textwrap
-import zipfile
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 
@@ -11,26 +10,11 @@ import pytest
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.render import StateMachineCodeRenderer
-from tools.package_templates import package_templates
+from pyfcstm.template import extract_template
 
 
-def _repo_root():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-
-
-def _extract_packaged_template(name, work_dir):
-    package_dir = os.path.join(work_dir, "package")
-    extraction_dir = os.path.join(work_dir, "extract")
-    os.makedirs(package_dir, exist_ok=True)
-    os.makedirs(extraction_dir, exist_ok=True)
-    package_templates(
-        os.path.join(_repo_root(), "templates"),
-        package_dir,
-        verbose=False,
-    )
-    with zipfile.ZipFile(os.path.join(package_dir, name + ".zip"), "r") as zf:
-        zf.extractall(extraction_dir)
-    return os.path.join(extraction_dir, name)
+def _extract_cpp_template(work_dir):
+    return extract_template("cpp", os.path.join(work_dir, "template"))
 
 
 def _find_cmake():
@@ -80,7 +64,7 @@ def render_cpp_artifacts(dsl_code):
     model = parse_dsl_node_to_state_machine(ast_node)
 
     with TemporaryDirectory() as td:
-        template_dir = _extract_packaged_template("cpp", td)
+        template_dir = _extract_cpp_template(td)
         output_dir = os.path.join(td, "out")
         StateMachineCodeRenderer(template_dir).render(
             model=model, output_dir=output_dir

--- a/test/template/cpp_poll/_utils.py
+++ b/test/template/cpp_poll/_utils.py
@@ -2,7 +2,6 @@ import os
 import shutil
 import subprocess
 import textwrap
-import zipfile
 from contextlib import contextmanager
 from tempfile import TemporaryDirectory
 
@@ -11,26 +10,11 @@ import pytest
 from pyfcstm.dsl import parse_with_grammar_entry
 from pyfcstm.model import parse_dsl_node_to_state_machine
 from pyfcstm.render import StateMachineCodeRenderer
-from tools.package_templates import package_templates
+from pyfcstm.template import extract_template
 
 
-def _repo_root():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
-
-
-def _extract_packaged_template(name, work_dir):
-    package_dir = os.path.join(work_dir, "package")
-    extraction_dir = os.path.join(work_dir, "extract")
-    os.makedirs(package_dir, exist_ok=True)
-    os.makedirs(extraction_dir, exist_ok=True)
-    package_templates(
-        os.path.join(_repo_root(), "templates"),
-        package_dir,
-        verbose=False,
-    )
-    with zipfile.ZipFile(os.path.join(package_dir, name + ".zip"), "r") as zf:
-        zf.extractall(extraction_dir)
-    return os.path.join(extraction_dir, name)
+def _extract_cpp_poll_template(work_dir):
+    return extract_template("cpp_poll", os.path.join(work_dir, "template"))
 
 
 def _find_cmake():
@@ -80,7 +64,7 @@ def render_cpp_poll_artifacts(dsl_code):
     model = parse_dsl_node_to_state_machine(ast_node)
 
     with TemporaryDirectory() as td:
-        template_dir = _extract_packaged_template("cpp_poll", td)
+        template_dir = _extract_cpp_poll_template(td)
         output_dir = os.path.join(td, "out")
         StateMachineCodeRenderer(template_dir).render(
             model=model, output_dir=output_dir

--- a/test/template/test_c_family_helper_scope.py
+++ b/test/template/test_c_family_helper_scope.py
@@ -6,16 +6,19 @@ built-in template structure tests so target-language template structure changes
 can advance independently from renderer-boundary cleanup.
 """
 
+import inspect
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 import yaml
 
+import pyfcstm.render.render as render_module
 from pyfcstm.render import StateMachineCodeRenderer
+from pyfcstm.template import extract_template
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_TEMPLATES_DIR = _REPO_ROOT / "templates"
+_TEMPLATE_NAMES = ("c", "c_poll", "cpp", "cpp_poll")
 
 _C_HELPER_NAMES = {
     "to_c_identifier",
@@ -29,80 +32,87 @@ _C_HELPER_NAMES = {
 }
 
 
-def _read_text(path: Path) -> str:
+def _load_config(template_dir: Path) -> dict:
     """
-    Read UTF-8 text from a repository file.
+    Load an extracted built-in template configuration file.
 
-    :param path: Path to the text file.
-    :type path: pathlib.Path
-    :return: File contents decoded as UTF-8.
-    :rtype: str
-
-    Example::
-
-        >>> text = _read_text(_TEMPLATES_DIR / 'python' / 'config.yaml')
-        >>> 'expr_styles' in text
-        True
-    """
-    return path.read_text(encoding="utf-8")
-
-
-def _load_config(name: str) -> dict:
-    """
-    Load a built-in template configuration file.
-
-    :param name: Built-in template directory name.
-    :type name: str
+    :param template_dir: Extracted built-in template directory.
+    :type template_dir: pathlib.Path
     :return: Parsed YAML configuration mapping.
     :rtype: dict
 
     Example::
 
-        >>> config = _load_config('c')
+        >>> with TemporaryDirectory() as td:
+        ...     path = Path(extract_template('c', td))
+        ...     config = _load_config(path)
         >>> 'globals' in config
         True
     """
-    with (_TEMPLATES_DIR / name / "config.yaml").open("r", encoding="utf-8") as f:
+    with (template_dir / "config.yaml").open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _extract_templates(root: Path) -> dict:
+    """
+    Extract C-family and Python built-in templates for boundary checks.
+
+    :param root: Temporary directory used as extraction root.
+    :type root: pathlib.Path
+    :return: Mapping from template names to extracted template directories.
+    :rtype: dict
+
+    Example::
+
+        >>> with TemporaryDirectory() as td:
+        ...     paths = _extract_templates(Path(td))
+        >>> 'python' in paths
+        True
+    """
+    names = ("python",) + _TEMPLATE_NAMES
+    return {name: Path(extract_template(name, str(root / name))) for name in names}
 
 
 @pytest.mark.unittest
 def test_c_family_helpers_are_template_scoped():
-    render_source = _read_text(_REPO_ROOT / "pyfcstm" / "render" / "render.py")
+    render_source = inspect.getsource(render_module)
     for helper_name in _C_HELPER_NAMES:
         assert helper_name not in render_source
 
-    python_renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / "python"))
-    assert not (_C_HELPER_NAMES & set(python_renderer.env.filters))
-    assert not (_C_HELPER_NAMES & set(python_renderer.env.globals))
-    assert "c_public_identifier_reserved" not in python_renderer.env.tests
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
 
-    for name in ["c", "c_poll"]:
-        renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / name))
-        assert _C_HELPER_NAMES <= (
-            set(renderer.env.filters) | set(renderer.env.globals)
-        )
-        assert "c_public_identifier_reserved" in renderer.env.tests
+        python_renderer = StateMachineCodeRenderer(str(template_dirs["python"]))
+        assert not (_C_HELPER_NAMES & set(python_renderer.env.filters))
+        assert not (_C_HELPER_NAMES & set(python_renderer.env.globals))
+        assert "c_public_identifier_reserved" not in python_renderer.env.tests
 
-        config = _load_config(name)
-        globals_config = config["globals"]
-        assert globals_config["render_c_action_body"] == {
-            "type": "import",
-            "from": "pyfcstm.render.c_runtime.render_c_action_body",
-        }
-        assert globals_config["render_c_condition_body"] == {
-            "type": "import",
-            "from": "pyfcstm.render.c_runtime.render_c_condition_body",
-        }
-        assert globals_config["render_c_reset_vars_body"] == {
-            "type": "import",
-            "from": "pyfcstm.render.c_runtime.render_c_reset_vars_body",
-        }
-        assert config["filters"]["to_c_identifier"] == {
-            "type": "import",
-            "from": "pyfcstm.utils.to_c_identifier",
-        }
-        assert config["tests"]["c_public_identifier_reserved"] == {
-            "type": "import",
-            "from": "pyfcstm.utils.is_c_public_identifier_reserved",
-        }
+        for name in _TEMPLATE_NAMES:
+            renderer = StateMachineCodeRenderer(str(template_dirs[name]))
+            assert _C_HELPER_NAMES <= (
+                set(renderer.env.filters) | set(renderer.env.globals)
+            )
+            assert "c_public_identifier_reserved" in renderer.env.tests
+
+            config = _load_config(template_dirs[name])
+            globals_config = config["globals"]
+            assert globals_config["render_c_action_body"] == {
+                "type": "import",
+                "from": "pyfcstm.render.c_runtime.render_c_action_body",
+            }
+            assert globals_config["render_c_condition_body"] == {
+                "type": "import",
+                "from": "pyfcstm.render.c_runtime.render_c_condition_body",
+            }
+            assert globals_config["render_c_reset_vars_body"] == {
+                "type": "import",
+                "from": "pyfcstm.render.c_runtime.render_c_reset_vars_body",
+            }
+            assert config["filters"]["to_c_identifier"] == {
+                "type": "import",
+                "from": "pyfcstm.utils.to_c_identifier",
+            }
+            assert config["tests"]["c_public_identifier_reserved"] == {
+                "type": "import",
+                "from": "pyfcstm.utils.is_c_public_identifier_reserved",
+            }

--- a/test/template/test_template_structure.py
+++ b/test/template/test_template_structure.py
@@ -16,10 +16,7 @@ from pyfcstm.render import StateMachineCodeRenderer
 from pyfcstm.template import extract_template, get_template_info, list_templates
 
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_TEMPLATES_DIR = _REPO_ROOT / "templates"
-_PACKAGED_TEMPLATE_DIR = _REPO_ROOT / "pyfcstm" / "template"
-_CURRENT_TEMPLATE_NAMES = ("c", "c_poll", "cpp", "cpp_poll", "python")
+_CURRENT_TEMPLATE_NAMES = tuple(list_templates())
 _TEMPLATE_LANGUAGE_VOCABULARY = {
     "c",
     "cpp",
@@ -38,7 +35,6 @@ _CONFIG_TOP_LEVEL_KEYS = {
     "tests",
     "ignores",
 }
-_MAINTAINER_ONLY_FILES = {"README.md", "README_zh.md", "template.json"}
 _REQUIRED_TEMPLATE_FILES = {
     "c": {
         "README.md",
@@ -172,10 +168,7 @@ def rendered_templates(representative_model):
     with TemporaryDirectory() as extraction_td, TemporaryDirectory() as render_td:
         extraction_root = Path(extraction_td)
         output_root = Path(render_td)
-        template_dirs = {
-            name: Path(extract_template(name, str(extraction_root / name)))
-            for name in _CURRENT_TEMPLATE_NAMES
-        }
+        template_dirs = _extract_templates(extraction_root)
         yield _render_template_directories(
             template_dirs,
             representative_model,
@@ -183,30 +176,25 @@ def rendered_templates(representative_model):
         )
 
 
-def _repository_template_names():
-    return tuple(
-        item.name
-        for item in sorted(_TEMPLATES_DIR.iterdir())
-        if item.is_dir() and not item.name.startswith(".")
-    )
-
-
-def _read_json(path):
-    with path.open("r", encoding="utf-8") as f:
-        return json.load(f)
-
-
 def _read_text(path):
     return path.read_text(encoding="utf-8")
 
 
-def _load_template_metadata(name):
-    return _read_json(_TEMPLATES_DIR / name / "template.json")
+def _extract_templates(root):
+    return {
+        name: Path(extract_template(name, str(root / name)))
+        for name in _CURRENT_TEMPLATE_NAMES
+    }
 
 
-def _load_config(name):
-    with (_TEMPLATES_DIR / name / "config.yaml").open("r", encoding="utf-8") as f:
+def _load_config(template_dir):
+    with (template_dir / "config.yaml").open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def _load_template_metadata(template_dir):
+    with (template_dir / "template.json").open("r", encoding="utf-8") as f:
+        return json.load(f)
 
 
 def _ignore_spec(config):
@@ -337,96 +325,62 @@ def _assert_rendered_template_contracts(rendered_templates):
 
 
 @pytest.mark.unittest
-def test_repository_templates_expose_required_file_contract():
-    template_names = _repository_template_names()
-    assert set(_CURRENT_TEMPLATE_NAMES) <= set(template_names)
+def test_extracted_templates_expose_required_file_contract():
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
+        assert set(_CURRENT_TEMPLATE_NAMES) <= set(template_dirs)
 
-    for name in template_names:
-        metadata = _load_template_metadata(name)
-        assert metadata["name"] == name
-        assert metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
-        if name not in _REQUIRED_TEMPLATE_FILES:
-            pytest.fail(
-                "Add a required-file contract for built-in template {name!r}.".format(
-                    name=name,
+        for name, template_dir in template_dirs.items():
+            metadata = _load_template_metadata(template_dir)
+            assert metadata["name"] == name
+            assert metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
+            if name not in _REQUIRED_TEMPLATE_FILES:
+                pytest.fail(
+                    "Add a required-file contract for built-in template {name!r}.".format(
+                        name=name,
+                    )
                 )
-            )
 
-        files = {
-            item.name for item in (_TEMPLATES_DIR / name).iterdir() if item.is_file()
-        }
-        assert _REQUIRED_TEMPLATE_FILES[name] <= files
+            files = {item.name for item in template_dir.iterdir() if item.is_file()}
+            assert _REQUIRED_TEMPLATE_FILES[name] <= files
 
 
 @pytest.mark.unittest
-def test_template_metadata_matches_packaged_index_contract():
-    index = _read_json(_PACKAGED_TEMPLATE_DIR / "index.json")
-    index_items = {item["name"]: item for item in index["templates"]}
-    repository_names = set(_repository_template_names())
+def test_template_metadata_matches_packaged_asset_contract():
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
+        assert set(_CURRENT_TEMPLATE_NAMES) == set(template_dirs)
 
-    assert set(list_templates()) == repository_names
-    assert set(index_items) == repository_names
+        for name, template_dir in template_dirs.items():
+            template_metadata = _load_template_metadata(template_dir)
+            api_metadata = get_template_info(name)
 
-    for name in repository_names:
-        repo_metadata = _load_template_metadata(name)
-        indexed_metadata = index_items[name]
-        api_metadata = get_template_info(name)
-
-        assert api_metadata == indexed_metadata
-        assert indexed_metadata["name"] == name
-        assert indexed_metadata["archive"] == "{name}.zip".format(name=name)
-        assert indexed_metadata["root_dir"] == name
-        for key in ["title", "description", "language", "experimental"]:
-            assert indexed_metadata[key] == repo_metadata[key]
-        assert indexed_metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
+            assert api_metadata["name"] == name
+            assert api_metadata["archive"] == "{name}.zip".format(name=name)
+            assert api_metadata["root_dir"] == name
+            for key in ["name", "title", "description", "language", "experimental"]:
+                assert api_metadata[key] == template_metadata[key]
+            assert api_metadata["language"] in _TEMPLATE_LANGUAGE_VOCABULARY
 
 
 @pytest.mark.unittest
 def test_template_configs_keep_renderer_contract_and_ignores():
-    for name in _repository_template_names():
-        config = _load_config(name)
-        unknown_keys = set(config) - _CONFIG_TOP_LEVEL_KEYS
-        assert not unknown_keys
+    with TemporaryDirectory() as td:
+        for name, template_dir in _extract_templates(Path(td)).items():
+            config = _load_config(template_dir)
+            unknown_keys = set(config) - _CONFIG_TOP_LEVEL_KEYS
+            assert not unknown_keys
 
-        spec = _ignore_spec(config)
-        for maintainer_file in _MAINTAINER_ONLY_FILES:
-            assert spec.match_file(maintainer_file)
-        assert not spec.match_file("README.md.j2")
-        assert not spec.match_file("README_zh.md.j2")
-        for runtime_template in _RUNTIME_TEMPLATES[name]:
-            assert not spec.match_file(runtime_template)
+            spec = _ignore_spec(config)
+            assert not spec.match_file("README.md.j2")
+            assert not spec.match_file("README_zh.md.j2")
+            for runtime_template in _RUNTIME_TEMPLATES[name]:
+                assert not spec.match_file(runtime_template)
 
 
 @pytest.mark.unittest
-def test_template_readmes_keep_maintainer_and_generated_guidance_separate(
-    rendered_templates,
-):
-    root_readme = _read_text(_TEMPLATES_DIR / "README.md")
-    root_readme_zh = _read_text(_TEMPLATES_DIR / "README_zh.md")
-    for expected in [
-        "python",
-        "c",
-        "c_poll",
-        "cpp",
-        "cpp_poll",
-        "java",
-        "js",
-        "rust",
-        "ruby",
-        "go",
-    ]:
-        assert expected in root_readme
-        assert expected in root_readme_zh
-
-    for name in _repository_template_names():
-        template_dir = _TEMPLATES_DIR / name
-        maintainer_readme = _read_text(template_dir / "README.md").lower()
-        maintainer_readme_zh = _read_text(template_dir / "README_zh.md").lower()
-        assert "maintainer" in maintainer_readme
-        assert "template" in maintainer_readme
-        assert "not copied" in maintainer_readme or "ignored" in maintainer_readme
-        assert "template" in maintainer_readme_zh or "模板" in maintainer_readme_zh
-
+def test_generated_readmes_keep_generated_guidance(rendered_templates):
+    for name in _CURRENT_TEMPLATE_NAMES:
         generated_readme = _read_text(rendered_templates[name] / "README.md")
         generated_readme_zh = _read_text(rendered_templates[name] / "README_zh.md")
         for generated_text in [generated_readme, generated_readme_zh]:
@@ -439,29 +393,7 @@ def test_template_readmes_keep_maintainer_and_generated_guidance_separate(
 
 @pytest.mark.unittest
 def test_c_family_readmes_document_deployment_safety_boundaries(rendered_templates):
-    root_readme = _read_text(_TEMPLATES_DIR / "README.md")
-    root_readme_zh = _read_text(_TEMPLATES_DIR / "README_zh.md")
-
-    assert "C/C++ deployment safety wording" in root_readme
-    assert "C/C++ 部署安全表述" in root_readme_zh
-
     for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-        maintainer_readme = _read_text(_TEMPLATES_DIR / name / "README.md")
-        maintainer_readme_zh = _read_text(_TEMPLATES_DIR / name / "README_zh.md")
-        maintainer_readme_words = " ".join(maintainer_readme.split())
-        maintainer_readme_zh_words = " ".join(maintainer_readme_zh.split())
-        assert "engineering baseline" in maintainer_readme_words
-        assert "not a certification package" in maintainer_readme_words
-        assert "不是认证包" in maintainer_readme_zh_words
-        assert (
-            "Numeric inspect warning" in maintainer_readme
-            or "Numeric-risk wording" in maintainer_readme
-        )
-        assert (
-            "Numeric inspect warning" in maintainer_readme_zh
-            or "数值风险表述" in maintainer_readme_zh
-        )
-
         generated_readme = _read_text(rendered_templates[name] / "README.md")
         generated_readme_zh = _read_text(rendered_templates[name] / "README_zh.md")
         for text in [generated_readme, generated_readme_zh]:
@@ -521,41 +453,14 @@ def test_c_family_readmes_document_deployment_safety_boundaries(rendered_templat
 def test_cpp_template_documentation_describes_early_first_class_status(
     rendered_templates,
 ):
-    root_readme = _read_text(_TEMPLATES_DIR / "README.md")
-    root_readme_zh = _read_text(_TEMPLATES_DIR / "README_zh.md")
-    for text in [root_readme, root_readme_zh]:
-        lowered = text.lower()
-        assert "cpp" in lowered
-        assert "cpp_poll" in lowered
-        assert "early" in lowered or "早期" in text
-        assert "first-class" in lowered or "一等" in text
-        assert "experimental: true" in text
-        assert "skeleton" not in lowered
-        assert "prototype" not in lowered
-        assert "原型" not in text
-
     expected_metadata_descriptions = {
         "cpp": "Early-stage first-class C++ template",
         "cpp_poll": "Early-stage first-class C++ poll template",
     }
     for name, expected_description in expected_metadata_descriptions.items():
-        metadata = _load_template_metadata(name)
+        metadata = get_template_info(name)
         assert metadata["experimental"] is True
         assert expected_description in metadata["description"]
-
-        maintainer_readme = _read_text(_TEMPLATES_DIR / name / "README.md")
-        maintainer_readme_zh = _read_text(_TEMPLATES_DIR / name / "README_zh.md")
-        for text in [maintainer_readme, maintainer_readme_zh]:
-            lowered = text.lower()
-            assert "experimental: true" in text
-            assert "early" in lowered or "早期" in text
-            assert "first-class" in lowered or "一等" in text
-            assert "unimplemented" in lowered or "未实现" in text
-            assert "wrapper" in lowered
-            assert "native toolchain" in lowered or "原生工具链" in text
-            assert "skeleton" not in lowered
-            assert "prototype" not in lowered
-            assert "原型" not in text
 
         generated_readme = _read_text(rendered_templates[name] / "README.md")
         generated_readme_zh = _read_text(rendered_templates[name] / "README_zh.md")
@@ -579,23 +484,23 @@ def test_generated_sources_preserve_banner_source_context_and_dependency_boundar
 
 @pytest.mark.unittest
 def test_generated_source_templates_keep_source_metadata_wording():
-    for name in _repository_template_names():
-        for rel_path in ["README.md.j2", "README_zh.md.j2"] + list(
-            _RUNTIME_TEMPLATES[name]
-        ):
-            source = _read_text(_TEMPLATES_DIR / name / rel_path)
-            normalized = " ".join(source.lower().split())
-            compact = "".join(source.lower().split())
-            for banned in _BANNED_SOURCE_WORDING:
-                assert banned not in normalized
-                assert "".join(banned.split()) not in compact
+    with TemporaryDirectory() as td:
+        for name, template_dir in _extract_templates(Path(td)).items():
+            for rel_path in ["README.md.j2", "README_zh.md.j2"] + list(
+                _RUNTIME_TEMPLATES[name]
+            ):
+                source = _read_text(template_dir / rel_path)
+                normalized = " ".join(source.lower().split())
+                compact = "".join(source.lower().split())
+                for banned in _BANNED_SOURCE_WORDING:
+                    assert banned not in normalized
+                    assert "".join(banned.split()) not in compact
 
 
 @pytest.mark.unittest
 def test_extracted_builtin_templates_preserve_source_structure_contract():
     with TemporaryDirectory() as td:
-        for name in _repository_template_names():
-            extracted_dir = Path(extract_template(name, td))
+        for name, extracted_dir in _extract_templates(Path(td)).items():
             assert extracted_dir.name == get_template_info(name)["root_dir"]
             files = {item.name for item in extracted_dir.iterdir() if item.is_file()}
             assert _REQUIRED_TEMPLATE_FILES[name] <= files
@@ -603,8 +508,8 @@ def test_extracted_builtin_templates_preserve_source_structure_contract():
             config = yaml.safe_load(_read_text(extracted_dir / "config.yaml"))
             assert not (set(config) - _CONFIG_TOP_LEVEL_KEYS)
             spec = _ignore_spec(config)
-            for maintainer_file in _MAINTAINER_ONLY_FILES:
-                assert spec.match_file(maintainer_file)
+            assert not spec.match_file("README.md.j2")
+            assert not spec.match_file("README_zh.md.j2")
 
 
 @pytest.mark.unittest
@@ -620,22 +525,26 @@ def test_cpp_c_core_generated_outputs_match_c_templates(rendered_templates):
 
 @pytest.mark.unittest
 def test_c_family_helpers_are_template_scoped():
-    python_renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / "python"))
-    c_helper_names = {
-        "to_c_identifier",
-        "to_c_path_identifier",
-        "to_c_public_identifier",
-        "to_c_public_macro_identifier",
-        "is_c_public_identifier_reserved",
-        "render_c_action_body",
-        "render_c_condition_body",
-        "render_c_reset_vars_body",
-    }
-    assert not (c_helper_names & set(python_renderer.env.filters))
-    assert not (c_helper_names & set(python_renderer.env.globals))
-    assert "c_public_identifier_reserved" not in python_renderer.env.tests
+    with TemporaryDirectory() as td:
+        template_dirs = _extract_templates(Path(td))
+        python_renderer = StateMachineCodeRenderer(str(template_dirs["python"]))
+        c_helper_names = {
+            "to_c_identifier",
+            "to_c_path_identifier",
+            "to_c_public_identifier",
+            "to_c_public_macro_identifier",
+            "is_c_public_identifier_reserved",
+            "render_c_action_body",
+            "render_c_condition_body",
+            "render_c_reset_vars_body",
+        }
+        assert not (c_helper_names & set(python_renderer.env.filters))
+        assert not (c_helper_names & set(python_renderer.env.globals))
+        assert "c_public_identifier_reserved" not in python_renderer.env.tests
 
-    for name in ["c", "c_poll", "cpp", "cpp_poll"]:
-        renderer = StateMachineCodeRenderer(str(_TEMPLATES_DIR / name))
-        assert c_helper_names <= (set(renderer.env.filters) | set(renderer.env.globals))
-        assert "c_public_identifier_reserved" in renderer.env.tests
+        for name in ["c", "c_poll", "cpp", "cpp_poll"]:
+            renderer = StateMachineCodeRenderer(str(template_dirs[name]))
+            assert c_helper_names <= (
+                set(renderer.env.filters) | set(renderer.env.globals)
+            )
+            assert "c_public_identifier_reserved" in renderer.env.tests


### PR DESCRIPTION
## 定位

这是 [PR #285](https://github.com/HansBug/pyfcstm/pull/285) 的子 PR：**B1c 模板**。

本 PR 负责把 template 相关 pytest 的模板来源收束到 packaged built-in template / public API 路径，并清理 template 侧只断言 repo-source README/prose/inventory 的 pytest。它不负责 `test/llm` / `test/diagnostics` 的 tools/prose 清理（B1d），也不做最终全局审计（B1e）。

## 与上游伞 PR 的一致性

对应伞 PR 表格中的 B1c：

- **目标**：模板结构、渲染、helper scope、C++ / C++ poll wrapper/native tests 继续存在，但模板来源必须是 packaged built-in template / public API；generated README 行为测试保留；source/maintainer README 文案同步不留在 pytest。
- **执行方案**：删除 `_TEMPLATES_DIR`、`_REPO_ROOT / "templates"`、`_repo_root()` source-template packaging、手动 zip extract；用 `list_templates` / `get_template_info` / `extract_template` 替代；C++ / C++ poll helper 改为 `extract_template('cpp', ...)` / `extract_template('cpp_poll', ...)`；删除或迁出 template source/maintainer README wording/inventory 断言。
- **验收标准**：B1c 范围 pytest 通过；涉及 C++ helper/native 时运行 wrapper unittest smoke 与显式 native profile smoke 或说明等价 CI 证据；静态审计确认 B1c 范围不再直连 repo-root `templates/` 或 `tools.package_templates`；generated README compile/run / formatter-friendly tests 不被删除。

## 精确实施计划

### 1. 替换 template source 读取入口

- `test/template/test_template_structure.py` 改为通过 `pyfcstm.template` public API 获取模板清单、元数据、提取目录和 packaged 文件内容。
- `test/template/test_c_family_helper_scope.py` 改为从 `extract_template(...)` 后的临时目录构造 `StateMachineCodeRenderer`，并从同一个 extracted template dir 读取 `config.yaml`。
- `_CURRENT_TEMPLATE_NAMES` 不再作为硬编码事实源；模板枚举改用 `tuple(list_templates())`。若仍需要固定语言 vocabulary 或 runtime template 文件名，只作为**当前模板契约的断言期望**存在，不再用于发现 repo-source 目录。
- `_load_config(name)` / `_load_template_metadata(name)` 的来源改为 packaged API / extracted dir：
  - metadata 走 `get_template_info(name)`；
  - config 走 `yaml.safe_load(extracted_dir / "config.yaml")`；
  - 不再读取 `_TEMPLATES_DIR / name / ...`。
- `test_c_family_helper_scope.py` 的 C-family helper scope 覆盖从 `c` / `c_poll` 扩展到 `c` / `c_poll` / `cpp` / `cpp_poll`，同时保留 config YAML 中 template-local import 的结构断言。

### 2. 替换 C++ / C++ poll helper 的模板来源

- `test/template/cpp/_utils.py` 删除 `from tools.package_templates import package_templates`、`zipfile`、`_repo_root()`、手动打包/解压逻辑，改为：
  - `from pyfcstm.template import extract_template`
  - `template_dir = extract_template("cpp", os.path.join(td, "template"))`
- `test/template/cpp_poll/_utils.py` 同理改为 `extract_template("cpp_poll", ...)`。
- 保持 wrapper/native compile/run 测试入口不直接调用 C/H 底层入口，现有 C++/HPP public wrapper 入口测试语义不降级。

### 3. 逐测试函数删除/保留决策

| 测试函数 | 删除/迁出的 source/maintainer 断言 | 必须保留的 generated/packaged 行为断言 | 处理方式 |
|---|---|---|---|
| `test_template_readmes_keep_maintainer_and_generated_guidance_separate` | 删除读取 `templates/README*.md` 与 `templates/<name>/README*.md` 的 maintainer handbook / inventory / not-copied wording 断言 | 保留对 `rendered_templates[name] / README*.md` 的 generated files / model text / cycle / 不包含 maintainer handbook 的断言 | 就地拆分：函数改成只验证 generated README 行为；不再读取 repo-source maintainer README |
| `test_c_family_readmes_document_deployment_safety_boundaries` | 删除读取 root maintainer README 和 `templates/<name>/README*.md` 的 engineering baseline / certification-package / numeric-risk maintainer wording 断言 | 保留 generated README 中 `pyfcstm inspect`、C/C++ deployment profile、Python 对比、issue 链接、non-reentrant / volatile / DMA、MISRA/AUTOSAR/DO-178C/IEC 61508/ISO 26262 安全边界、Integration Preflight Checklist 等行为性集成指导断言 | 就地拆分：只删除 `_TEMPLATES_DIR` maintainer 段；保留 `rendered_templates` 段 |
| `test_cpp_template_documentation_describes_early_first_class_status` | 删除读取 root maintainer README 和 `templates/cpp*/README*.md` 的 roadmap/prose 断言 | 保留 generated README 中 `c` / `c_poll` / `cpp` / `cpp_poll` 说明、`gcc -std=c99`、`g++ -std=c++98`、`clang -std=c99`、`clang++ -std=c++98`、`cmake_minimum_required` 等可执行编译指引断言 | 就地拆分：只删除 maintainer/prose 段；保留 compile-command 行为断言 |
| `test_generated_source_templates_keep_source_metadata_wording` | 不删除。它不是 maintainer README prose-only 测试，而是检查生成源模板 `.j2` 的 banned wording | packaged template zip 已核实包含 `.j2`（`c.zip`/`c_poll.zip` 4 个、`cpp.zip`/`cpp_poll.zip` 6 个、`python.zip` 3 个），因此保留该测试语义 | 改为从 `extract_template()` 后的 packaged template dir 读取 `README*.md.j2` 和 runtime `.j2`，不再读取 `_TEMPLATES_DIR` |
| `test_extracted_builtin_templates_preserve_source_structure_contract` | 删除对 maintainer-only ignore behavior 的 source-layout 断言若它只服务 source inventory；不删除 packaged extraction 结构契约 | 保留 extracted packaged template 的 root dir、required `.j2`/config 文件、config top-level key、ignore spec 对 generated template files 的可渲染性检查 | 保留并改用 packaged file list；required file 期望可继续作为当前 packaged template contract |
| 两个同名 `test_c_family_helpers_are_template_scoped` | 不因重名而直接删除任一行为覆盖 | 保留“全局 renderer 不注入 C helper”和“C-family template-local config import/render env 含 helper”的覆盖 | 可合并或分别迁移，但最终不得丢失 render.py 不含 C helper、python renderer 不含 C helper、c/c_poll/cpp/cpp_poll renderer 含 C helper、config YAML import contract 这四类断言 |

### 4. 验证与审计

常规本地验证：

```bash
SKIP_SLOW_TESTS=1 make unittest
```

B1c 范围功能验证：

```bash
pytest test/template/test_template_structure.py test/template/test_c_family_helper_scope.py -m unittest -v
pytest test/template/cpp test/template/cpp_poll -m unittest -v
```

显式 native profile smoke（如果本机有对应工具链；若没有，需要在 PR body 中说明缺失工具并提供等价 CI / 已有 native workflow 证据）：

```bash
PYFCSTM_RUN_NATIVE_TOOLCHAIN=1 PYFCSTM_NATIVE_TOOLCHAIN_PROFILE=linux-gcc-o2 \
  pytest test/template/cpp/test_native_toolchain_alignment.py \
         test/template/cpp_poll/test_native_toolchain_alignment.py \
         --run-native-toolchain -v
```

B1c 范围静态审计（应无命中；如果出现 test-local/generated 文本例外，必须在 PR body 中逐条解释）：

```bash
rg -n "_TEMPLATES_DIR|parents\[[0-9]+\].*templates|_REPO_ROOT / \"templates\"|tools\.package_templates|package_templates\(|_repo_root|os\.path\.join\([^\n]*[\"']templates[\"']" \
  test/template/test_template_structure.py \
  test/template/test_c_family_helper_scope.py \
  test/template/cpp \
  test/template/cpp_poll
```

行为保留审计：

```bash
rg -n "pyfcstm inspect|non-reentrant|volatile|DMA|MISRA|AUTOSAR|DO-178C|IEC 61508|ISO 26262|Integration Preflight Checklist|gcc -std=c99|g\+\+ -std=c\+\+98|clang -std=c99|clang\+\+ -std=c\+\+98|cmake_minimum_required|generated files|model text|cycle" \
  test/template/test_template_structure.py
```

## 非目标

- 不修改内置模板运行时语义。
- 不移除 `make unittest: tpl`。
- 不删除 C/C++/C++ wrapper native compile/run、CMake、ctypes、formatter、alignment 等行为测试。
- 不处理 `test/llm` / `test/diagnostics` 的 `tools.*` 或 diagnostics prose 清理；这些属于 B1d。
- 不做最终全局 guard；最终审计属于 B1e。

## 当前状态

- 🟢 已完成实现并推送：`test/template/test_template_structure.py`、`test/template/test_c_family_helper_scope.py`、`test/template/cpp/_utils.py`、`test/template/cpp_poll/_utils.py` 已改为 packaged built-in template / public API 路径。
- 🟢 C++ / C++ poll helper 已移除 `tools.package_templates`、手动 zip 解包、`_repo_root()`，改用 `pyfcstm.template.extract_template(...)`。
- 🟢 generated README 行为断言保留；repo-source / maintainer README prose-only 断言已从 pytest 中删除。
- 🟢 三路实现后 review 已完成，未发现 C/I 阻塞问题；codex reviewer 提出的 M 级 `template.json` JSON 契约放宽问题已修复为 `json.load(...)`。

## 已验证

```bash
pytest test/template/test_template_structure.py test/template/test_c_family_helper_scope.py -m unittest -v
pytest test/template/cpp test/template/cpp_poll -m unittest -v
ruff format --check test/template/cpp/_utils.py test/template/cpp_poll/_utils.py test/template/test_c_family_helper_scope.py test/template/test_template_structure.py
ruff check test/template/cpp/_utils.py test/template/cpp_poll/_utils.py test/template/test_c_family_helper_scope.py test/template/test_template_structure.py
git diff --check
make rst_auto
SKIP_SLOW_TESTS=1 make unittest
```

B1c 范围静态审计零命中：

```bash
rg -n "_TEMPLATES_DIR|parents\[[0-9]+\].*templates|_REPO_ROOT / \"templates\"|tools\.package_templates|package_templates\(|_repo_root|os\.path\.join\([^\n]*[\"']templates[\"']" \
  test/template/test_template_structure.py \
  test/template/test_c_family_helper_scope.py \
  test/template/cpp \
  test/template/cpp_poll
```

