### PR TITLE
B1d 清理：移除 tools 与文案断言

### DIFF
--- a/test/diagnostics/test_codes_yaml.py
+++ b/test/diagnostics/test_codes_yaml.py
@@ -674,31 +674,8 @@ class TestResolveCodesYamlPath:
 
 
 @pytest.mark.unittest
-class TestYamlCommentBlockSync:
-    """
-    M6 from PR-107 review: the type-token comment block at the top of
-    codes.yaml must mirror ``_ALLOWED_REF_TYPES`` (single source of truth
-    in codes.py). Drift would silently let new tokens land in the comment
-    but not in the loader, or vice versa.
-    """
-
-    def test_comment_block_lists_all_allowed_types(self):
-        path = os.path.join(
-            os.path.dirname(__file__), '..', '..',
-            'pyfcstm', 'diagnostics', 'codes.yaml',
-        )
-        with open(path, 'r', encoding='utf-8') as f:
-            text = f.read()
-        # Comment block uses ` | `-separated list. Extract any tokens in
-        # backticks doesn't apply here (raw text). We assert each allowed
-        # type appears at least once in the comment area (before the first
-        # top-level YAML key, which is `E_UNDEFINED_VAR:` per the schema).
-        head = text.split('E_UNDEFINED_VAR:', 1)[0]
-        for ref_type in _ALLOWED_REF_TYPES:
-            assert ref_type in head, (
-                f"type token {ref_type!r} listed in _ALLOWED_REF_TYPES but "
-                f"not documented in the codes.yaml comment block"
-            )
+class TestRefTypePredicateCoverage:
+    """Verify runtime predicates cover every diagnostic refs type token."""
 
     def test_schema_check_type_predicates_cover_all_allowed_types(self):
         """M3 from PR #115 final review: ``_schema_check._TYPE_PREDICATES``

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -590,28 +590,6 @@ class TestSchemaJsonValidates:
         assert 'default inspect graph' in description
         assert 'composite initial edges' in description
 
-    def test_diagnostics_readme_documents_range_layers(self):
-        readme_path = os.path.join(
-            os.path.dirname(__file__), '..', '..',
-            'pyfcstm', 'diagnostics', 'README.md',
-        )
-        assert os.path.exists(readme_path)
-        with open(readme_path, 'r', encoding='utf-8') as f:
-            text = f.read()
-
-        for required in [
-            'problem range',
-            'fix-edit range',
-            'related range',
-            'Span',
-            '<object>_span',
-            '1-based',
-            'end-exclusive',
-            'LSP Range',
-            '0-based',
-        ]:
-            assert required in text
-
 
 @pytest.mark.unittest
 class TestInspectModelAdvancedFeatures:

--- a/test/llm/test_grammar_guide.py
+++ b/test/llm/test_grammar_guide.py
@@ -8,7 +8,6 @@ import pytest
 import pyfcstm.llm as llm
 from pyfcstm.dsl.error import GrammarParseError
 from pyfcstm.model import load_state_machine_from_text
-from tools.evaluate_llm_grammar_guide import _extract_fcstm_source
 
 
 _FCSTM_BLOCK_RE = re.compile(r"```fcstm\n(.*?)\n```", re.DOTALL)
@@ -267,22 +266,3 @@ def test_grammar_guide_invalid_examples_are_rejected():
     for example in examples:
         with pytest.raises((GrammarParseError, SyntaxError, ValueError)):
             load_state_machine_from_text(example, path=os.getcwd())
-
-
-@pytest.mark.unittest
-def test_eval_source_extraction_skips_prose_that_starts_with_state_word():
-    raw_output = """
-Here is the model.
-state transitions are important in this controller.
-
-def int x = 0;
-state Root {
-    [*] -> Idle;
-    state Idle;
-}
-"""
-
-    source = _extract_fcstm_source(raw_output)
-
-    assert source.startswith("def int x = 0;")
-    load_state_machine_from_text(source, path=os.getcwd())


### PR DESCRIPTION
## 定位

这是 [PR #285](https://github.com/HansBug/pyfcstm/pull/285) 的子 PR：**B1d 清理**。

本 PR 负责清理 `test/llm` 对 `tools.*` 私有 helper 的直接依赖，并删除 diagnostics 侧只验证 README / comment block / prose 文案同步的 pytest。它不处理 template 测试入口（B1c 已完成），也不做最终全局 guard（B1e 负责）。

## 与上游伞 PR 的一致性

对应伞 PR 表格中的 B1d：

- **目标**：`test/llm` 只测试 `pyfcstm.llm` packaged prompt、DSL parser、model loader 等生产入口；diagnostics pytest 聚焦 production behavior、structured data、public API contract；diagnostics README/comment/prose 文案同步不作为 unit test 主目标。
- **执行方案**：删除 `test/llm` 中 `from tools.evaluate_llm_grammar_guide import _extract_fcstm_source` 及其私有 helper 测试；删除 diagnostics 中直接读取 `pyfcstm/diagnostics/README.md` 并断言 prose 的测试；删除只验证 `codes.yaml` 顶部 comment block 文案与 `_ALLOWED_REF_TYPES` 同步的 pytest；保留 schema / codes.yaml / diagnostics payload / inspect behavior 的结构化测试。
- **验收标准**：`test/llm` 不再 import/call `tools.*`；B1d 范围 pytest 通过；删除的测试函数清单明确；不误删 structured `codes.yaml` / `schema.json` / inspect_model 行为测试。

## 精确实施计划

### 1. `test/llm` 清理 tools 私有 helper 直连

- 删除 `test/llm/test_grammar_guide.py` 中：
  - `from tools.evaluate_llm_grammar_guide import _extract_fcstm_source`
  - `test_eval_source_extraction_skips_prose_that_starts_with_state_word`
- 不把 `_extract_fcstm_source` 提升为 `pyfcstm.llm` public API。本 PR 的边界清理目标是让 pytest 不直接测试 eval tooling 私有实现。
- 保留所有 packaged grammar guide / integrity / metadata / positive examples / invalid examples 相关测试。

### 2. diagnostics README prose-only pytest 删除

- 删除 `test/diagnostics/test_inspect_model.py` 中 `TestSchemaJsonValidates.test_diagnostics_readme_documents_range_layers`。
- 保留同一类中的 schema contract 测试：
  - `test_schema_exists`
  - `test_schema_is_valid_json`
  - `test_schema_local_refs_resolve`
  - `test_schema_validates_simple_inspect`
  - `test_schema_documents_span_contract`
  - `test_schema_documents_default_inspect_reachability`
- 原因：schema JSON 的 description / required keys 是 structured public contract，仍可测；README 文案层同步不是 pytest unit 的主要断言目标。

### 3. diagnostics `codes.yaml` comment-only pytest 删除

- 删除 `test/diagnostics/test_codes_yaml.py` 中 `TestYamlCommentBlockSync.test_comment_block_lists_all_allowed_types`。
- 保留 `TestYamlCommentBlockSync.test_schema_check_type_predicates_cover_all_allowed_types`。
- 原因：`_ALLOWED_REF_TYPES` 与 runtime `_TYPE_PREDICATES` 的一致性是结构化行为约束；`codes.yaml` 顶部注释是否逐字覆盖所有 token 是 prose/comment 维护问题，不留在 pytest unit。

### 4. 保留项审计

必须确认以下测试能力仍在：

- `test/llm/test_grammar_guide.py` 仍覆盖 packaged guide API、checksum/integrity、路径、metadata、正例 parse、反例 reject。
- `test/diagnostics/test_codes_yaml.py` 仍覆盖 `CODE_REGISTRY` shape、`load_codes(...)` schema validation、PyInstaller path resolution、refs schema immutability。
- `test/diagnostics/test_codes_yaml_verify.py` 仍覆盖 verify diagnostics 的 structured payload 与 schema contract；`schema.json` description 中关于 `codes.yaml` 的 structured refs 描述可保留，因为它属于 JSON schema contract。
- `test/diagnostics/test_inspect_model.py` 仍覆盖 inspect_model behavior、schema JSON local refs、span contract、default inspect reachability contract。

## 删除清单

| 文件 | 删除对象 | 删除原因 | 替代/保留覆盖 |
|---|---|---|---|
| `test/llm/test_grammar_guide.py` | `from tools.evaluate_llm_grammar_guide import _extract_fcstm_source` | pytest 不应直接 import `tools.*` 私有 helper | 保留 `pyfcstm.llm` packaged prompt API 与 DSL parse/model validation 测试 |
| `test/llm/test_grammar_guide.py` | `test_eval_source_extraction_skips_prose_that_starts_with_state_word` | 该行为属于 eval tooling 私有逻辑，不是 `pyfcstm.llm` public contract | 若以后需要覆盖 eval script，应放到显式维护命令或工具自检，不放 pytest unit |
| `test/diagnostics/test_inspect_model.py` | `TestSchemaJsonValidates.test_diagnostics_readme_documents_range_layers` | 直接读取 diagnostics README 并断言 prose 文案 | 保留 `schema.json` 的 span/default reachability structured contract 测试 |
| `test/diagnostics/test_codes_yaml.py` | `TestYamlCommentBlockSync.test_comment_block_lists_all_allowed_types` | 只验证 `codes.yaml` comment block 文案同步 | 保留 `_ALLOWED_REF_TYPES` ↔ `_TYPE_PREDICATES` runtime validation 覆盖 |

## 本地验证计划

```bash
pytest test/llm test/diagnostics -m unittest -v

SKIP_SLOW_TESTS=1 make unittest

make rst_auto

rg -n '^\s*(from|import)\s+tools\b|\btools\.[A-Za-z_]' test/llm -g '*.py'

rg -n 'pyfcstm.+diagnostics.+README\.md|test_diagnostics_readme_documents_range_layers|test_comment_block_lists_all_allowed_types|evaluate_llm_grammar_guide|_extract_fcstm_source' \
  test/llm test/diagnostics -g '*.py'
```

## 非目标

- 不修改 `tools/evaluate_llm_grammar_guide.py` 行为。
- 不修改 `pyfcstm.llm` public API。
- 不修改 diagnostics runtime / schema / codes.yaml 生产语义。
- 不处理 `test/template`；B1c 已负责。
- 不做全 `test/` 最终边界审计；B1e 负责。

## 当前状态

- 🟢 实现已推送：删除 `test/llm` 对 `tools.evaluate_llm_grammar_guide._extract_fcstm_source` 的直接依赖；删除 eval helper 私有行为 pytest；删除 diagnostics README prose-only pytest；删除 `codes.yaml` comment-block 同步 pytest。
- 🟢 已吸收 review M 级建议：删除 comment-only 测试后，`TestYamlCommentBlockSync` 已改为 `TestRefTypePredicateCoverage`，避免类 docstring 继续声称验证 YAML 注释。
- 🟢 保留项已确认：`pyfcstm.llm` packaged guide API / integrity / parse/reject 测试仍在；diagnostics schema/codes/inspect behavior/verify refs contract 测试仍在。
- 🟡 等待 GitHub CI 完成；如 CI / Codecov / 后续 review 出现 C/I 级问题会继续修复。

## 已验证

```bash
pytest test/llm test/diagnostics -m unittest -v
# 803 passed

SKIP_SLOW_TESTS=1 make unittest
# 41327 passed, 640 skipped, 67 deselected

make rst_auto

git diff --check

# test/llm 不再 import/call tools.*
rg -n '^\s*(from|import)\s+tools\b|\btools\.[A-Za-z_]' test/llm -g '*.py'
# no matches

# 删除对象已清零
rg -n 'evaluate_llm_grammar_guide|_extract_fcstm_source' test/llm -g '*.py'
rg -n 'pyfcstm.+diagnostics.+README\.md|test_diagnostics_readme_documents_range_layers' test/diagnostics -g '*.py'
rg -n 'test_comment_block_lists_all_allowed_types|TestYamlCommentBlockSync' test/diagnostics -g '*.py'
# all no matches

# 关键保留项仍存在
rg -n 'def test_grammar_guide_(positive_examples_parse_and_validate|invalid_examples_are_rejected)|def test_schema_documents_span_contract|def test_schema_documents_default_inspect_reachability|class TestRefTypePredicateCoverage|def test_json_schema_keeps_verify_refs_extensible_via_codes_yaml_contract' test/llm test/diagnostics -g '*.py'
```

