### PR TITLE
调研：建立 C/C++ 与 Z3 数值语义对齐试点

### DIFF
--- a/research/numeric-render-semantics/README.md
+++ b/research/numeric-render-semantics/README.md
@@ -4,13 +4,13 @@
 
 ## 当前调研工具范围
 
-当前调研工具提供轻量框架、R0 映射工具、C-family smoke 入口和 Python/Z3 baseline 入口；后续 Java/Rust、Go/JS/TS 与 exhaustive/shard runner 应继续追加到同一 probe CLI 和 artifact 约定中，而不是替换已有入口。整个调研系列统一禁止修改 `test/` 路径。
+当前调研工具提供轻量框架、R0 映射工具、C-family smoke 入口、Python/Z3 baseline 入口和 C/C++ ↔ Z3 alignment contract 入口；后续 Java/Rust、Go/JS/TS 与 exhaustive/shard runner 应继续追加到同一 probe CLI 和 artifact 约定中，而不是替换已有入口。整个调研系列统一禁止修改 `test/` 路径。
 
 | 文件 | 作用 |
 |---|---|
 | `plan.md` | 子 PR 执行计划、验收命令和边界。 |
 | `mapping.md` | R0 render mapping 输出结构和人工阅读指南。 |
-| `probes.md` | Probe runner 设计约束；当前累计提供 `env`、`c-smoke`、`cpp-smoke` 和 `python-z3-baseline` 入口，并说明后续 runner 的共享字段约定。 |
+| `probes.md` | Probe runner 设计约束；当前累计提供 `env`、`c-smoke`、`cpp-smoke`、`python-z3-baseline` 和 `c-cpp-z3-alignment` 入口，并说明后续 runner 的共享字段约定。 |
 | `schemas/` | 调研 JSON artifact 的轻量契约。 |
 | `results/snapshots/` | 可提交的小型 snapshot。 |
 | `results/local/` | gitignored heavy / local 输出目录。 |
@@ -46,6 +46,12 @@ python tools/numeric_render_probe.py python-z3-baseline \
   --output research/numeric-render-semantics/results/snapshots/python_z3_baseline.json
 
 python tools/numeric_render_probe.py python-z3-baseline --check
+
+python tools/numeric_render_probe.py c-cpp-z3-alignment \
+  --mapping research/numeric-render-semantics/results/snapshots/render_mapping.json \
+  --output research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json
+
+python tools/numeric_render_probe.py c-cpp-z3-alignment --check
 ```
 
-`--check` 是 R0 mapping 与 Python/Z3 baseline 的调研自检入口；`c-smoke` / `cpp-smoke` 是 C-family smoke probe 入口，summary 会引用 R0 `mapping_sha256`，并把 compile / link / runtime / sanitizer findings 记录成结果而不是命令失败。`python-z3-baseline` 默认读取同一份 R0 snapshot，并在 `--check` 中额外与 live mapping 做 drift 校验。后续语言 smoke 和 exhaustive/shard runner 也应继续使用 `tools/` / `research/` 下的同一 probe CLI、自检和 artifact 约定，而不是修改 `test/` 或重建独立 harness。`results/local/` 被 `.gitignore` 忽略，适合放本机探测结果和后续 heavy probe 输出。
+`--check` 是 R0 mapping、Python/Z3 baseline 和 C/C++ ↔ Z3 alignment contract 的调研自检入口；`c-smoke` / `cpp-smoke` 是 C-family smoke probe 入口，summary 会引用 R0 `mapping_sha256`，并把 compile / link / runtime / sanitizer findings 记录成结果而不是命令失败。`python-z3-baseline` 默认读取同一份 R0 snapshot，并在 `--check` 中额外与 live mapping 做 drift 校验。`c-cpp-z3-alignment` 生成 committed alignment snapshot，按 `value_expr + obligations + outcome` 三元组记录 C/C++ render path 到 Z3 profile 的候选值、definedness obligation 和 outcome；其 `--check` 校验 schema、required 字段、outcome 枚举、render path / operator 覆盖，以及 mapping、Python/Z3 baseline 和 C-family smoke fact digest。后续语言 smoke 和 exhaustive/shard runner 也应继续使用 `tools/` / `research/` 下的同一 probe CLI、自检和 artifact 约定，而不是修改 `test/` 或重建独立 harness。`results/local/` 被 `.gitignore` 忽略，适合放本机探测结果和后续 heavy probe 输出。

--- a/research/numeric-render-semantics/plan.md
+++ b/research/numeric-render-semantics/plan.md
@@ -42,14 +42,37 @@ SKIP_SLOW_TESTS=1 make unittest
 
 `python_z3_baseline.json` 只保存小型可审阅 snapshot：Python render/runtime 样例、Z3 `Int` / `Real` / `BitVec` / `FP` capability matrix、mapping digest、generator commit 和工具链版本。它不保存 heavy exhaustive 原始输出，也不把 Python 无限精度行为提升为默认定长 profile。
 
+## PR-6A 验收
+
+```bash
+python tools/numeric_render_mapping.py --check
+
+python tools/numeric_render_probe.py python-z3-baseline --check
+
+python tools/numeric_render_probe.py c-cpp-z3-alignment \
+  --output research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json
+
+python tools/numeric_render_probe.py c-cpp-z3-alignment --check
+
+git check-ignore research/numeric-render-semantics/results/local/dummy-output.jsonl
+
+SKIP_SLOW_TESTS=1 make unittest
+```
+
+`c_cpp_z3_alignment.json` 是 C/C++ ↔ Z3 对齐试点 snapshot。它按 C-family render path 展开每个 FCSTM numeric semantic case，并为每行记录 `value_expr + obligations + outcome`，同时保留 `render_path`、`target_semantics`、`definedness`、`z3_sort`、`z3_profile`、`evidence` 和 `counterexamples`。该 snapshot 不把 BitVec wrap 当作 C/C++ signed semantics；signed overflow、除零、`MIN/-1`、signed shift、math function 可用性和 writeback narrowing 都必须作为 obligation、profile-dependent、unsupported、compile_failed 或 counterexample 表达。
+
+`c-cpp-z3-alignment --check` 是 D6a 的稳定 validator 命令。它不依赖本机 native toolchain；live compile / sanitizer 输出仍应写入 `results/local/`，而 committed snapshot 只保存 deterministic render facts、schema fields 和 digest。
+
 ## 后续子 PR
 
 | 子 PR | 状态 | 内容 |
 |---|---|---|
 | PR-1 | 🟢 已完成 | 落库框架、R0 mapping、env stub、轻量 schema；确立整个调研系列不修改 `test/` 路径。 |
-| PR-2 | 🟡 后续 | C/C++ smoke probe。 |
-| PR-3 | 🟡 当前 | Python + Z3 基线、`python-z3-baseline` probe、small snapshot 与 schema。 |
+| PR-2 | 🟢 已完成 | C/C++ smoke probe。 |
+| PR-3 | 🟢 已完成 | Python + Z3 基线、`python-z3-baseline` probe、small snapshot 与 schema。 |
 | PR-4 | 🟡 后续 | Java / Rust smoke probe。 |
 | PR-5 | 🟡 后续 | Go / JS / TS smoke probe。 |
-| PR-6 | 🟡 后续 | 8-bit exhaustive 与 16-bit shard harness。 |
-| PR-7 | 🟡 后续 | 汇总报告与 solver / fixed / template 后续建议。 |
+| PR-6A | 🟡 当前 | C/C++ ↔ Z3 对齐试点、alignment schema、snapshot 与 validator。 |
+| PR-6B~6D | 🟡 后续 | 按 6A schema 套用 Python/DSL、Java/Rust、Go/JS/TS。 |
+| PR-6E | 🟡 后续 | 8-bit exhaustive、16-bit shard / sampled、跨语言 mismatch 与 counterexample 汇总。 |
+| PR-7 | 🟡 后续 | 最终 Z3 数值语义对齐规范与 solver / fixed / template 产品化方案。 |

--- a/research/numeric-render-semantics/probes.md
+++ b/research/numeric-render-semantics/probes.md
@@ -1,6 +1,6 @@
 # Probe 设计说明
 
-`tools/numeric_render_probe.py env` 用于输出本地 Python、平台和可用命令清单；`c-smoke` / `cpp-smoke` 用于从 R0 `render_mapping.json` 读取 C-family 渲染路径并编译运行小型 smoke 程序；`python-z3-baseline` 用于从同一 R0 snapshot 记录 Python renderer / Python template / statement override 事实和 Z3 capability matrix。R0 mapping 的契约校验由 `tools/numeric_render_mapping.py --check` 承担。后续语言 smoke 和 exhaustive/shard runner 应继续追加到同一 probe CLI、同一 mapping digest 约定和同一 artifact 目录结构中，而不是重建独立 harness。整个调研系列都不新增 `test/` 路径；任何会调用 native compiler、Node.js、Java、Rust、Go 或 Z3 求解的 probe 都应继续落在 `tools/` / `research/` 与 gitignored `results/local/` 下。
+`tools/numeric_render_probe.py env` 用于输出本地 Python、平台和可用命令清单；`c-smoke` / `cpp-smoke` 用于从 R0 `render_mapping.json` 读取 C-family 渲染路径并编译运行小型 smoke 程序；`python-z3-baseline` 用于从同一 R0 snapshot 记录 Python renderer / Python template / statement override 事实和 Z3 capability matrix；`c-cpp-z3-alignment` 用于生成和校验 C/C++ ↔ Z3 alignment contract。R0 mapping 的契约校验由 `tools/numeric_render_mapping.py --check` 承担。后续语言 smoke 和 exhaustive/shard runner 应继续追加到同一 probe CLI、同一 mapping digest 约定和同一 artifact 目录结构中，而不是重建独立 harness。整个调研系列都不新增 `test/` 路径；任何会调用 native compiler、Node.js、Java、Rust、Go 或 Z3 求解的 probe 都应继续落在 `tools/` / `research/` 与 gitignored `results/local/` 下。
 
 ## 当前累计入口
 
@@ -17,6 +17,10 @@ python tools/numeric_render_probe.py python-z3-baseline \
   --mapping research/numeric-render-semantics/results/snapshots/render_mapping.json \
   --output research/numeric-render-semantics/results/snapshots/python_z3_baseline.json
 python tools/numeric_render_probe.py python-z3-baseline --check
+python tools/numeric_render_probe.py c-cpp-z3-alignment \
+  --mapping research/numeric-render-semantics/results/snapshots/render_mapping.json \
+  --output research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json
+python tools/numeric_render_probe.py c-cpp-z3-alignment --check
 ```
 
 ## C/C++ smoke runner
@@ -28,6 +32,29 @@ Smoke summary 必须写入 `source_mapping_sha256`，并与所读取 mapping 的
 `python-z3-baseline` 默认读取 `research/numeric-render-semantics/results/snapshots/render_mapping.json`，避免手写与 renderer 脱节的表达式表；`--check` 会同时校验 committed `python_z3_baseline.json`、专用 schema、semantic invariants、snapshot-vs-live payload，以及 committed R0 mapping 与 live render mapping 的 drift。baseline 的 `alignment_cases[]` 使用与 smoke runner 相同的 join 字段：`case_id`、`operator`、`fcstm_expression`、`render_path` 和 `render_expression`，并额外提供 `semantic_case_id` 方便 PR-6 先按语义表达式聚合，再按 render path 展开。
 
 Python 输出作为 P3 / 无限精度 / 仿真兼容基线使用，不作为后续 solver / verify 的定长默认语义。Z3 capability matrix 记录 `Int` / `Real` / `BitVec` / `FP` 的 `exact`、`approximate`、`uninterpreted` 或 `unsupported` 等级；当前 baseline 避免记录不稳定 solver model 值，只记录可复跑的 capability、render path 和代表性 counterexample。
+
+## C/C++ ↔ Z3 alignment runner
+
+`c-cpp-z3-alignment` 是 PR-6A 的试点入口。它默认读取 committed R0 `render_mapping.json` 和 `python_z3_baseline.json`，再从 C-family render paths 构造小型 deterministic alignment snapshot。该 snapshot 不运行 native compiler，不保存 sanitizer 输出，也不提交 exhaustive 原始数据；live C/C++ 编译事实仍由 `c-smoke` / `cpp-smoke` 写入 gitignored `results/local/`。
+
+每条 contract 至少包含：
+
+- `render_path`：例如 builtin `_C_STYLE`、builtin `_CPP_STYLE` standalone、C template generated path、`templates/cpp*` 中 `base_lang: c` 的 generated path；
+- `operator` / `operator_family` / `fcstm_expression` / `render_expression`；
+- `target_semantics` 和 `definedness`；
+- `z3_sort` / `z3_profile`；
+- `value_expr + obligations + outcome`；
+- `evidence` 与必要 `counterexamples`。
+
+`outcome` 是闭集枚举：`exact`、`exact_with_obligations`、`profile_dependent`、`unsupported`、`compile_failed`、`runtime_trap`、`ub`。BitVec expression 只能作为候选 `value_expr`，不能单独代表 C/C++ signed defined behavior。signed overflow、division by zero、`MIN/-1`、signed shift、math function availability 和 narrowing/writeback 必须进入 obligation、profile-dependent / unsupported / compile_failed outcome 或 counterexample。
+
+稳定 validator 命令：
+
+```bash
+python tools/numeric_render_probe.py c-cpp-z3-alignment --check
+```
+
+该命令校验 committed snapshot、专用 schema、required 字段、outcome enum、C/C++ render path 覆盖、operator 覆盖、shift obligation 粒度，以及 R0 mapping、Python/Z3 baseline、C smoke facts、C++ smoke facts digest 漂移。
 
 ## 后续 runner 约束
 

--- a/research/numeric-render-semantics/results/README.md
+++ b/research/numeric-render-semantics/results/README.md
@@ -2,7 +2,7 @@
 
 | 路径 | 是否提交 | 用途 |
 |---|---|---|
-| `snapshots/` | 是 | 小型、可审阅、可复跑的 mapping 或 summary snapshot，例如 `render_mapping.json` 与 `python_z3_baseline.json`。 |
+| `snapshots/` | 是 | 小型、可审阅、可复跑的 mapping、baseline 或 alignment snapshot，例如 `render_mapping.json`、`python_z3_baseline.json` 与 `c_cpp_z3_alignment.json`。 |
 | `local/` | 否 | 本机环境报告、native 编译产物、heavy exhaustive JSONL、临时 shard 输出。 |
 
 `local/` 已由仓库 `.gitignore` 忽略。

--- a/research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json
+++ b/research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json
@@ -1,0 +1,9658 @@
+{
+  "c_smoke_facts_sha256": "d43ac706918c26ec500ae525fdcc2191590c6115d4662a7bf9ddd573bfb83657",
+  "contract_fields": {
+    "core_triple": [
+      "value_expr",
+      "obligations",
+      "outcome"
+    ],
+    "outcome_enum": [
+      "compile_failed",
+      "exact",
+      "exact_with_obligations",
+      "profile_dependent",
+      "runtime_trap",
+      "ub",
+      "unsupported"
+    ],
+    "required_fields": [
+      "render_path",
+      "operator",
+      "operator_family",
+      "fcstm_expression",
+      "target_semantics",
+      "definedness",
+      "z3_sort",
+      "z3_profile",
+      "value_expr",
+      "obligations",
+      "outcome",
+      "evidence"
+    ],
+    "shift_obligation_kinds": [
+      "no_signed_left_shift_ub",
+      "non_negative_shift_count",
+      "signed_right_shift_profile",
+      "valid_shift_count"
+    ]
+  },
+  "contracts": [
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:add",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:add:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A + B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "add",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A + B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A + B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "+",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A + B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "add",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_add(A + B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:subtract",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:subtract:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A - B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "subtract",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A - B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A - B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "-",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A - B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "subtract",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_subtract(A - B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:multiply",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:multiply:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A * B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "multiply",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A * B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A * B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "*",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A * B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "multiply",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_multiply(A * B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:divide",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:divide:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A / B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "builtin_c_style:divide:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A / B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "divide",
+          "summary": "C signed integer division over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A / B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "/",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A / B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "divide",
+      "target_semantics": "C signed integer division over promoted operands.",
+      "value_expr": "bvsdiv(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:modulo",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:modulo:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A % B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "builtin_c_style:modulo:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A % B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "modulo",
+          "summary": "C signed integer remainder over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A % B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "%",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A % B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "modulo",
+      "target_semantics": "C signed integer remainder over promoted operands.",
+      "value_expr": "bvsrem(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:unary_minus",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:unary_minus:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "-A",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "unary_minus",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "-A",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "unary-",
+      "operator_family": "unary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "-A",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "unary_minus",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_unary_minus(-A)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:bitwise_not",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:bitwise_not:parse",
+          "expected_issue": "GrammarParseError",
+          "reproduction": "~A",
+          "values": {
+            "expression": "~A"
+          }
+        }
+      ],
+      "definedness": "unsupported_by_current_fcstm_grammar_or_renderer",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is parse_failed."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_not",
+          "summary": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply."
+        }
+      ],
+      "fcstm_expression": "~A",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "~",
+      "operator_family": "bitwise",
+      "outcome": "unsupported",
+      "render_expression": "",
+      "render_path": "builtin_c_style",
+      "render_status": "parse_failed",
+      "semantic_case_id": "bitwise_not",
+      "target_semantics": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply.",
+      "value_expr": "unsupported",
+      "z3_profile": "unsupported",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:bitwise_and",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:bitwise_and:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A & B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_and",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A & B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "&",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "A & B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_and",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvand(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:bitwise_or",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:bitwise_or:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A | B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_or",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A | B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "|",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "A | B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_or",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:bitwise_xor",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:bitwise_xor:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A ^ B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_xor",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A ^ B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "^",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "A ^ B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_xor",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvxor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:shift_left",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:shift-left:negative",
+          "expected_issue": "signed left shift of a negative value is not a portable defined operation",
+          "reproduction": "A << B",
+          "values": {
+            "A": -1,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_left",
+          "summary": "C signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A << B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Signed left shift has additional definedness constraints beyond BitVec shift.",
+          "kind": "no_signed_left_shift_ub",
+          "predicate": "A >= 0 and left_shift_result_representable(A, B, width)",
+          "trigger": "signed left shift"
+        }
+      ],
+      "operator": "<<",
+      "operator_family": "shift",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A << B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_left",
+      "target_semantics": "C signed integer shift.",
+      "value_expr": "bvshl(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:shift_right",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:shift-right:negative",
+          "expected_issue": "negative signed right shift depends on implementation profile",
+          "reproduction": "A >> B",
+          "values": {
+            "A": -8,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_right",
+          "summary": "C signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A >> B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Right shift of a negative signed value is implementation-defined/profile-dependent.",
+          "kind": "signed_right_shift_profile",
+          "predicate": "profile selects arithmetic or logical right shift for negative lhs",
+          "trigger": "signed right shift"
+        }
+      ],
+      "operator": ">>",
+      "operator_family": "shift",
+      "outcome": "profile_dependent",
+      "render_expression": "A >> B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_right",
+      "target_semantics": "C signed integer shift.",
+      "value_expr": "bvashr(A, B) under arithmetic-shift profile",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:less_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_than",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A < B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "<",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A < B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "less_than",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:less_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A <= B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "<=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A <= B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "less_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:greater_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_than",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A > B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": ">",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A > B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_than",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:greater_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A >= B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": ">=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A >= B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A == B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "==",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A == B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(==, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:not_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "not_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A != B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "!=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A != B",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "not_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(!=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:pow",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "pow",
+          "summary": "C math-library pow evaluation."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "pow is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "pow",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(A, B)",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "pow",
+      "target_semantics": "C math-library pow evaluation.",
+      "value_expr": "pow_fp64(A ** B)",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:round",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "round",
+          "summary": "C math-library round evaluation."
+        }
+      ],
+      "fcstm_expression": "round(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "round is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "round",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "round(A)",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "round",
+      "target_semantics": "C math-library round evaluation.",
+      "value_expr": "round_fp64(round(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:abs",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:abs:min",
+          "expected_issue": "abs(INT_MIN) is not representable in the same signed width",
+          "reproduction": "abs(A)",
+          "values": {
+            "A": -128,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "profile_dependent_overload_and_min_value",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "abs",
+          "summary": "C absolute-value call selected by the render path."
+        }
+      ],
+      "fcstm_expression": "abs(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "C render paths may emit abs(A), which is not width-neutral for int64 operands.",
+          "kind": "abs_overload_matches_operand_width",
+          "predicate": "selected abs overload preserves the operand width",
+          "trigger": "math overload resolution"
+        },
+        {
+          "evidence": "The negated signed minimum is not representable in the same signed width.",
+          "kind": "no_abs_min",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "absolute value of signed minimum"
+        }
+      ],
+      "operator": "abs",
+      "operator_family": "math",
+      "outcome": "profile_dependent",
+      "render_expression": "abs(A)",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "abs",
+      "target_semantics": "C absolute-value call selected by the render path.",
+      "value_expr": "if signed(A) < 0 then -A else A",
+      "z3_profile": "math-overload-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:sign",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:sign:compile",
+          "expected_issue": "portable C/C++ sign function is unavailable",
+          "reproduction": "sign(A)",
+          "values": {
+            "A": -9
+          }
+        }
+      ],
+      "definedness": "not_defined_by_portable_c_family_library",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "sign",
+          "summary": "C render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function."
+        }
+      ],
+      "fcstm_expression": "sign(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "sign",
+      "operator_family": "math",
+      "outcome": "compile_failed",
+      "render_expression": "sign(A)",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "sign",
+      "target_semantics": "C render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function.",
+      "value_expr": "unsupported",
+      "z3_profile": "math-library-availability",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:cbrt",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "cbrt",
+          "summary": "C math-library cbrt evaluation."
+        }
+      ],
+      "fcstm_expression": "cbrt(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "cbrt is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "cbrt",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "cbrt(A)",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "cbrt",
+      "target_semantics": "C math-library cbrt evaluation.",
+      "value_expr": "cbrt_fp64(cbrt(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:integer_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "integer_constant",
+          "summary": "C literal rendering for integer_constant."
+        }
+      ],
+      "fcstm_expression": "42",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "integer_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "42",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "integer_constant",
+      "target_semantics": "C literal rendering for integer_constant.",
+      "value_expr": "literal(42)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:float_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "float_constant",
+          "summary": "C literal rendering for float_constant."
+        }
+      ],
+      "fcstm_expression": "3.5",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [],
+      "operator": "float_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "3.5",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "float_constant",
+      "target_semantics": "C literal rendering for float_constant.",
+      "value_expr": "literal(3.5)",
+      "z3_profile": "float-double",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "builtin_c_style:narrowing_writeback",
+      "counterexamples": [
+        {
+          "case_id": "builtin_c_style:writeback:pow-overflow",
+          "expected_issue": "mathematical result is outside signed 64-bit writeback range",
+          "reproduction": "A ** B",
+          "values": {
+            "A": 2,
+            "B": 63,
+            "target": "int64"
+          }
+        }
+      ],
+      "definedness": "defined_if_source_expression_and_conversion_are_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_c_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "narrowing_writeback",
+          "summary": "C assignment of an expression result back into a generated signed integer storage slot."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "obligations": [
+        {
+          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "kind": "source_expression_defined",
+          "predicate": "all source expression obligations hold",
+          "trigger": "writeback source evaluation"
+        },
+        {
+          "evidence": "C/C++ conversion to a signed integer target must not rely on out-of-range behavior.",
+          "kind": "representable_in_target_width",
+          "predicate": "INT64_MIN <= mathematical_result <= INT64_MAX",
+          "trigger": "integer writeback"
+        }
+      ],
+      "operator": "writeback",
+      "operator_family": "writeback",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(A, B)",
+      "render_path": "builtin_c_style",
+      "render_status": "rendered",
+      "semantic_case_id": "narrowing_writeback",
+      "target_semantics": "C assignment of an expression result back into a generated signed integer storage slot.",
+      "value_expr": "writeback_int64(value_expr(A ** B))",
+      "z3_profile": "promotion-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:add",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:add:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A + B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "add",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A + B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A + B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "+",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A + scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "add",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_add(A + B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:subtract",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:subtract:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A - B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "subtract",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A - B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A - B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "-",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A - scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "subtract",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_subtract(A - B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:multiply",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:multiply:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A * B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "multiply",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A * B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A * B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "*",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A * scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "multiply",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_multiply(A * B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:divide",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:divide:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A / B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_c_core:divide:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A / B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "divide",
+          "summary": "C signed integer division over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A / B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "/",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A / scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "divide",
+      "target_semantics": "C signed integer division over promoted operands.",
+      "value_expr": "bvsdiv(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:modulo",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:modulo:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A % B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_c_core:modulo:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A % B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "modulo",
+          "summary": "C signed integer remainder over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A % B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "%",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A % scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "modulo",
+      "target_semantics": "C signed integer remainder over promoted operands.",
+      "value_expr": "bvsrem(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:unary_minus",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:unary_minus:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "-A",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "unary_minus",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "-A",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "unary-",
+      "operator_family": "unary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "-scope->A",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "unary_minus",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_unary_minus(-A)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:bitwise_not",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:bitwise_not:parse",
+          "expected_issue": "GrammarParseError",
+          "reproduction": "~A",
+          "values": {
+            "expression": "~A"
+          }
+        }
+      ],
+      "definedness": "unsupported_by_current_fcstm_grammar_or_renderer",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is parse_failed."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_not",
+          "summary": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply."
+        }
+      ],
+      "fcstm_expression": "~A",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "~",
+      "operator_family": "bitwise",
+      "outcome": "unsupported",
+      "render_expression": "",
+      "render_path": "template_c_core",
+      "render_status": "parse_failed",
+      "semantic_case_id": "bitwise_not",
+      "target_semantics": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply.",
+      "value_expr": "unsupported",
+      "z3_profile": "unsupported",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:bitwise_and",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:bitwise_and:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A & B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_and",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A & B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "&",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A & scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_and",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvand(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:bitwise_or",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:bitwise_or:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A | B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_or",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A | B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "|",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A | scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_or",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:bitwise_xor",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:bitwise_xor:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A ^ B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_xor",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A ^ B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "^",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A ^ scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_xor",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvxor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:shift_left",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:shift-left:negative",
+          "expected_issue": "signed left shift of a negative value is not a portable defined operation",
+          "reproduction": "A << B",
+          "values": {
+            "A": -1,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_left",
+          "summary": "C signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A << B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Signed left shift has additional definedness constraints beyond BitVec shift.",
+          "kind": "no_signed_left_shift_ub",
+          "predicate": "A >= 0 and left_shift_result_representable(A, B, width)",
+          "trigger": "signed left shift"
+        }
+      ],
+      "operator": "<<",
+      "operator_family": "shift",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A << scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_left",
+      "target_semantics": "C signed integer shift.",
+      "value_expr": "bvshl(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:shift_right",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:shift-right:negative",
+          "expected_issue": "negative signed right shift depends on implementation profile",
+          "reproduction": "A >> B",
+          "values": {
+            "A": -8,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_right",
+          "summary": "C signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A >> B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Right shift of a negative signed value is implementation-defined/profile-dependent.",
+          "kind": "signed_right_shift_profile",
+          "predicate": "profile selects arithmetic or logical right shift for negative lhs",
+          "trigger": "signed right shift"
+        }
+      ],
+      "operator": ">>",
+      "operator_family": "shift",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A >> scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_right",
+      "target_semantics": "C signed integer shift.",
+      "value_expr": "bvashr(A, B) under arithmetic-shift profile",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:less_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_than",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A < B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A < scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_than",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:less_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A <= B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A <= scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:greater_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_than",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A > B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A > scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_than",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:greater_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A >= B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A >= scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A == B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "==",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A == scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(==, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:not_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "not_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A != B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "!=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A != scope->B",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "not_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(!=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:pow",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "pow",
+          "summary": "C math-library pow evaluation."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "pow is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "pow",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "pow",
+      "target_semantics": "C math-library pow evaluation.",
+      "value_expr": "pow_fp64(A ** B)",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:round",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "round",
+          "summary": "C math-library round evaluation."
+        }
+      ],
+      "fcstm_expression": "round(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "round is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "round",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "round(scope->A)",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "round",
+      "target_semantics": "C math-library round evaluation.",
+      "value_expr": "round_fp64(round(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:abs",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:abs:min",
+          "expected_issue": "abs(INT_MIN) is not representable in the same signed width",
+          "reproduction": "abs(scope->A)",
+          "values": {
+            "A": -128,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "profile_dependent_overload_and_min_value",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "abs",
+          "summary": "C absolute-value call selected by the render path."
+        }
+      ],
+      "fcstm_expression": "abs(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C render paths may emit abs(A), which is not width-neutral for int64 operands.",
+          "kind": "abs_overload_matches_operand_width",
+          "predicate": "selected abs overload preserves the operand width",
+          "trigger": "math overload resolution"
+        },
+        {
+          "evidence": "The negated signed minimum is not representable in the same signed width.",
+          "kind": "no_abs_min",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "absolute value of signed minimum"
+        }
+      ],
+      "operator": "abs",
+      "operator_family": "math",
+      "outcome": "profile_dependent",
+      "render_expression": "abs(scope->A)",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "abs",
+      "target_semantics": "C absolute-value call selected by the render path.",
+      "value_expr": "if signed(A) < 0 then -A else A",
+      "z3_profile": "math-overload-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:sign",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:sign:compile",
+          "expected_issue": "portable C/C++ sign function is unavailable",
+          "reproduction": "sign(scope->A)",
+          "values": {
+            "A": -9
+          }
+        }
+      ],
+      "definedness": "not_defined_by_portable_c_family_library",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "sign",
+          "summary": "C render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function."
+        }
+      ],
+      "fcstm_expression": "sign(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "sign",
+      "operator_family": "math",
+      "outcome": "compile_failed",
+      "render_expression": "sign(scope->A)",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "sign",
+      "target_semantics": "C render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function.",
+      "value_expr": "unsupported",
+      "z3_profile": "math-library-availability",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:cbrt",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "cbrt",
+          "summary": "C math-library cbrt evaluation."
+        }
+      ],
+      "fcstm_expression": "cbrt(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "cbrt is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "cbrt",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "cbrt(scope->A)",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "cbrt",
+      "target_semantics": "C math-library cbrt evaluation.",
+      "value_expr": "cbrt_fp64(cbrt(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:integer_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "integer_constant",
+          "summary": "C literal rendering for integer_constant."
+        }
+      ],
+      "fcstm_expression": "42",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "integer_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "42",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "integer_constant",
+      "target_semantics": "C literal rendering for integer_constant.",
+      "value_expr": "literal(42)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:float_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "float_constant",
+          "summary": "C literal rendering for float_constant."
+        }
+      ],
+      "fcstm_expression": "3.5",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "float_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "3.5",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "float_constant",
+      "target_semantics": "C literal rendering for float_constant.",
+      "value_expr": "literal(3.5)",
+      "z3_profile": "float-double",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_core:narrowing_writeback",
+      "counterexamples": [
+        {
+          "case_id": "template_c_core:writeback:pow-overflow",
+          "expected_issue": "mathematical result is outside signed 64-bit writeback range",
+          "reproduction": "A ** B",
+          "values": {
+            "A": 2,
+            "B": 63,
+            "target": "int64"
+          }
+        }
+      ],
+      "definedness": "defined_if_source_expression_and_conversion_are_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "narrowing_writeback",
+          "summary": "C assignment of an expression result back into a generated signed integer storage slot."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "kind": "source_expression_defined",
+          "predicate": "all source expression obligations hold",
+          "trigger": "writeback source evaluation"
+        },
+        {
+          "evidence": "C/C++ conversion to a signed integer target must not rely on out-of-range behavior.",
+          "kind": "representable_in_target_width",
+          "predicate": "INT64_MIN <= mathematical_result <= INT64_MAX",
+          "trigger": "integer writeback"
+        }
+      ],
+      "operator": "writeback",
+      "operator_family": "writeback",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "narrowing_writeback",
+      "target_semantics": "C assignment of an expression result back into a generated signed integer storage slot.",
+      "value_expr": "writeback_int64(value_expr(A ** B))",
+      "z3_profile": "promotion-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:add",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:add:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A + B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "add",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A + B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A + B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "+",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A + scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "add",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_add(A + B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:subtract",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:subtract:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A - B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "subtract",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A - B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A - B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "-",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A - scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "subtract",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_subtract(A - B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:multiply",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:multiply:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A * B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "multiply",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A * B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A * B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "*",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A * scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "multiply",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_multiply(A * B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:divide",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:divide:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A / B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_c_poll_core:divide:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A / B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "divide",
+          "summary": "C signed integer division over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A / B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "/",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A / scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "divide",
+      "target_semantics": "C signed integer division over promoted operands.",
+      "value_expr": "bvsdiv(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:modulo",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:modulo:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A % B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_c_poll_core:modulo:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A % B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "modulo",
+          "summary": "C signed integer remainder over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A % B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "%",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A % scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "modulo",
+      "target_semantics": "C signed integer remainder over promoted operands.",
+      "value_expr": "bvsrem(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:unary_minus",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:unary_minus:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "-A",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "unary_minus",
+          "summary": "C signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "-A",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "unary-",
+      "operator_family": "unary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "-scope->A",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "unary_minus",
+      "target_semantics": "C signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_unary_minus(-A)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:bitwise_not",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:bitwise_not:parse",
+          "expected_issue": "GrammarParseError",
+          "reproduction": "~A",
+          "values": {
+            "expression": "~A"
+          }
+        }
+      ],
+      "definedness": "unsupported_by_current_fcstm_grammar_or_renderer",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is parse_failed."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_not",
+          "summary": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply."
+        }
+      ],
+      "fcstm_expression": "~A",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "~",
+      "operator_family": "bitwise",
+      "outcome": "unsupported",
+      "render_expression": "",
+      "render_path": "template_c_poll_core",
+      "render_status": "parse_failed",
+      "semantic_case_id": "bitwise_not",
+      "target_semantics": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply.",
+      "value_expr": "unsupported",
+      "z3_profile": "unsupported",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:bitwise_and",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:bitwise_and:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A & B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_and",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A & B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "&",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A & scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_and",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvand(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:bitwise_or",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:bitwise_or:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A | B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_or",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A | B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "|",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A | scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_or",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:bitwise_xor",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:bitwise_xor:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A ^ B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_xor",
+          "summary": "C signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A ^ B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "^",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A ^ scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_xor",
+      "target_semantics": "C signed integer bitwise operation.",
+      "value_expr": "bvxor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:shift_left",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:shift-left:negative",
+          "expected_issue": "signed left shift of a negative value is not a portable defined operation",
+          "reproduction": "A << B",
+          "values": {
+            "A": -1,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_left",
+          "summary": "C signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A << B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Signed left shift has additional definedness constraints beyond BitVec shift.",
+          "kind": "no_signed_left_shift_ub",
+          "predicate": "A >= 0 and left_shift_result_representable(A, B, width)",
+          "trigger": "signed left shift"
+        }
+      ],
+      "operator": "<<",
+      "operator_family": "shift",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A << scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_left",
+      "target_semantics": "C signed integer shift.",
+      "value_expr": "bvshl(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:shift_right",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:shift-right:negative",
+          "expected_issue": "negative signed right shift depends on implementation profile",
+          "reproduction": "A >> B",
+          "values": {
+            "A": -8,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_right",
+          "summary": "C signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A >> B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Right shift of a negative signed value is implementation-defined/profile-dependent.",
+          "kind": "signed_right_shift_profile",
+          "predicate": "profile selects arithmetic or logical right shift for negative lhs",
+          "trigger": "signed right shift"
+        }
+      ],
+      "operator": ">>",
+      "operator_family": "shift",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A >> scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_right",
+      "target_semantics": "C signed integer shift.",
+      "value_expr": "bvashr(A, B) under arithmetic-shift profile",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:less_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_than",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A < B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A < scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_than",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:less_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A <= B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A <= scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:greater_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_than",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A > B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A > scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_than",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:greater_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A >= B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A >= scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A == B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "==",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A == scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(==, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:not_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "not_equal",
+          "summary": "C relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A != B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "!=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A != scope->B",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "not_equal",
+      "target_semantics": "C relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(!=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:pow",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "pow",
+          "summary": "C math-library pow evaluation."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "pow is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "pow",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "pow",
+      "target_semantics": "C math-library pow evaluation.",
+      "value_expr": "pow_fp64(A ** B)",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:round",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "round",
+          "summary": "C math-library round evaluation."
+        }
+      ],
+      "fcstm_expression": "round(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "round is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "round",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "round(scope->A)",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "round",
+      "target_semantics": "C math-library round evaluation.",
+      "value_expr": "round_fp64(round(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:abs",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:abs:min",
+          "expected_issue": "abs(INT_MIN) is not representable in the same signed width",
+          "reproduction": "abs(scope->A)",
+          "values": {
+            "A": -128,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "profile_dependent_overload_and_min_value",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "abs",
+          "summary": "C absolute-value call selected by the render path."
+        }
+      ],
+      "fcstm_expression": "abs(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C render paths may emit abs(A), which is not width-neutral for int64 operands.",
+          "kind": "abs_overload_matches_operand_width",
+          "predicate": "selected abs overload preserves the operand width",
+          "trigger": "math overload resolution"
+        },
+        {
+          "evidence": "The negated signed minimum is not representable in the same signed width.",
+          "kind": "no_abs_min",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "absolute value of signed minimum"
+        }
+      ],
+      "operator": "abs",
+      "operator_family": "math",
+      "outcome": "profile_dependent",
+      "render_expression": "abs(scope->A)",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "abs",
+      "target_semantics": "C absolute-value call selected by the render path.",
+      "value_expr": "if signed(A) < 0 then -A else A",
+      "z3_profile": "math-overload-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:sign",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:sign:compile",
+          "expected_issue": "portable C/C++ sign function is unavailable",
+          "reproduction": "sign(scope->A)",
+          "values": {
+            "A": -9
+          }
+        }
+      ],
+      "definedness": "not_defined_by_portable_c_family_library",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "sign",
+          "summary": "C render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function."
+        }
+      ],
+      "fcstm_expression": "sign(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "sign",
+      "operator_family": "math",
+      "outcome": "compile_failed",
+      "render_expression": "sign(scope->A)",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "sign",
+      "target_semantics": "C render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function.",
+      "value_expr": "unsupported",
+      "z3_profile": "math-library-availability",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:cbrt",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "cbrt",
+          "summary": "C math-library cbrt evaluation."
+        }
+      ],
+      "fcstm_expression": "cbrt(A)",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "cbrt is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "cbrt",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "cbrt(scope->A)",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "cbrt",
+      "target_semantics": "C math-library cbrt evaluation.",
+      "value_expr": "cbrt_fp64(cbrt(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:integer_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "integer_constant",
+          "summary": "C literal rendering for integer_constant."
+        }
+      ],
+      "fcstm_expression": "42",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "integer_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "42",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "integer_constant",
+      "target_semantics": "C literal rendering for integer_constant.",
+      "value_expr": "literal(42)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:float_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "float_constant",
+          "summary": "C literal rendering for float_constant."
+        }
+      ],
+      "fcstm_expression": "3.5",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "float_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "3.5",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "float_constant",
+      "target_semantics": "C literal rendering for float_constant.",
+      "value_expr": "literal(3.5)",
+      "z3_profile": "float-double",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "c",
+      "contract_id": "template_c_poll_core:narrowing_writeback",
+      "counterexamples": [
+        {
+          "case_id": "template_c_poll_core:writeback:pow-overflow",
+          "expected_issue": "mathematical result is outside signed 64-bit writeback range",
+          "reproduction": "A ** B",
+          "values": {
+            "A": 2,
+            "B": 63,
+            "target": "int64"
+          }
+        }
+      ],
+      "definedness": "defined_if_source_expression_and_conversion_are_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.c_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_c_poll_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "narrowing_writeback",
+          "summary": "C assignment of an expression result back into a generated signed integer storage slot."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "kind": "source_expression_defined",
+          "predicate": "all source expression obligations hold",
+          "trigger": "writeback source evaluation"
+        },
+        {
+          "evidence": "C/C++ conversion to a signed integer target must not rely on out-of-range behavior.",
+          "kind": "representable_in_target_width",
+          "predicate": "INT64_MIN <= mathematical_result <= INT64_MAX",
+          "trigger": "integer writeback"
+        }
+      ],
+      "operator": "writeback",
+      "operator_family": "writeback",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_c_poll_core",
+      "render_status": "rendered",
+      "semantic_case_id": "narrowing_writeback",
+      "target_semantics": "C assignment of an expression result back into a generated signed integer storage slot.",
+      "value_expr": "writeback_int64(value_expr(A ** B))",
+      "z3_profile": "promotion-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:add",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:add:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A + B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "add",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A + B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A + B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "+",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A + B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "add",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_add(A + B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:subtract",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:subtract:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A - B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "subtract",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A - B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A - B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "-",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A - B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "subtract",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_subtract(A - B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:multiply",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:multiply:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A * B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "multiply",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A * B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A * B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "*",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A * B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "multiply",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_multiply(A * B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:divide",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:divide:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A / B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "builtin_cpp_style:divide:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A / B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "divide",
+          "summary": "C++ signed integer division over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A / B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "/",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A / B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "divide",
+      "target_semantics": "C++ signed integer division over promoted operands.",
+      "value_expr": "bvsdiv(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:modulo",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:modulo:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A % B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "builtin_cpp_style:modulo:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A % B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "modulo",
+          "summary": "C++ signed integer remainder over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A % B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "%",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A % B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "modulo",
+      "target_semantics": "C++ signed integer remainder over promoted operands.",
+      "value_expr": "bvsrem(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:unary_minus",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:unary_minus:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "-A",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "unary_minus",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "-A",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "unary-",
+      "operator_family": "unary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "-A",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "unary_minus",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_unary_minus(-A)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:bitwise_not",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:bitwise_not:parse",
+          "expected_issue": "GrammarParseError",
+          "reproduction": "~A",
+          "values": {
+            "expression": "~A"
+          }
+        }
+      ],
+      "definedness": "unsupported_by_current_fcstm_grammar_or_renderer",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is parse_failed."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_not",
+          "summary": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply."
+        }
+      ],
+      "fcstm_expression": "~A",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "~",
+      "operator_family": "bitwise",
+      "outcome": "unsupported",
+      "render_expression": "",
+      "render_path": "builtin_cpp_style",
+      "render_status": "parse_failed",
+      "semantic_case_id": "bitwise_not",
+      "target_semantics": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply.",
+      "value_expr": "unsupported",
+      "z3_profile": "unsupported",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:bitwise_and",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:bitwise_and:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A & B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_and",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A & B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "&",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "A & B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_and",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvand(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:bitwise_or",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:bitwise_or:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A | B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_or",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A | B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "|",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "A | B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_or",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:bitwise_xor",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:bitwise_xor:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A ^ B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_xor",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A ^ B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "^",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "A ^ B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_xor",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvxor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:shift_left",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:shift-left:negative",
+          "expected_issue": "signed left shift of a negative value is not a portable defined operation",
+          "reproduction": "A << B",
+          "values": {
+            "A": -1,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_left",
+          "summary": "C++ signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A << B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Signed left shift has additional definedness constraints beyond BitVec shift.",
+          "kind": "no_signed_left_shift_ub",
+          "predicate": "A >= 0 and left_shift_result_representable(A, B, width)",
+          "trigger": "signed left shift"
+        }
+      ],
+      "operator": "<<",
+      "operator_family": "shift",
+      "outcome": "exact_with_obligations",
+      "render_expression": "A << B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_left",
+      "target_semantics": "C++ signed integer shift.",
+      "value_expr": "bvshl(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:shift_right",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:shift-right:negative",
+          "expected_issue": "negative signed right shift depends on implementation profile",
+          "reproduction": "A >> B",
+          "values": {
+            "A": -8,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_right",
+          "summary": "C++ signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A >> B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Right shift of a negative signed value is implementation-defined/profile-dependent.",
+          "kind": "signed_right_shift_profile",
+          "predicate": "profile selects arithmetic or logical right shift for negative lhs",
+          "trigger": "signed right shift"
+        }
+      ],
+      "operator": ">>",
+      "operator_family": "shift",
+      "outcome": "profile_dependent",
+      "render_expression": "A >> B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_right",
+      "target_semantics": "C++ signed integer shift.",
+      "value_expr": "bvashr(A, B) under arithmetic-shift profile",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:less_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_than",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A < B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "<",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A < B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "less_than",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:less_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A <= B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "<=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A <= B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "less_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:greater_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_than",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A > B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": ">",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A > B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_than",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:greater_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A >= B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": ">=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A >= B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A == B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "==",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A == B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(==, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:not_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "not_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A != B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "!=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "A != B",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "not_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(!=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:pow",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "pow",
+          "summary": "C++ math-library pow evaluation."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "pow is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "pow",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "std::pow(A, B)",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "pow",
+      "target_semantics": "C++ math-library pow evaluation.",
+      "value_expr": "pow_fp64(A ** B)",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:round",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "round",
+          "summary": "C++ math-library round evaluation."
+        }
+      ],
+      "fcstm_expression": "round(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "round is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "round",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "std::round(A)",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "round",
+      "target_semantics": "C++ math-library round evaluation.",
+      "value_expr": "round_fp64(round(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:abs",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:abs:min",
+          "expected_issue": "abs(INT_MIN) is not representable in the same signed width",
+          "reproduction": "std::abs(A)",
+          "values": {
+            "A": -128,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "profile_dependent_overload_and_min_value",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "abs",
+          "summary": "C++ absolute-value call selected by the render path."
+        }
+      ],
+      "fcstm_expression": "abs(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "C render paths may emit abs(A), which is not width-neutral for int64 operands.",
+          "kind": "abs_overload_matches_operand_width",
+          "predicate": "selected abs overload preserves the operand width",
+          "trigger": "math overload resolution"
+        },
+        {
+          "evidence": "The negated signed minimum is not representable in the same signed width.",
+          "kind": "no_abs_min",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "absolute value of signed minimum"
+        }
+      ],
+      "operator": "abs",
+      "operator_family": "math",
+      "outcome": "profile_dependent",
+      "render_expression": "std::abs(A)",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "abs",
+      "target_semantics": "C++ absolute-value call selected by the render path.",
+      "value_expr": "if signed(A) < 0 then -A else A",
+      "z3_profile": "math-overload-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:sign",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:sign:compile",
+          "expected_issue": "portable C/C++ sign function is unavailable",
+          "reproduction": "std::sign(A)",
+          "values": {
+            "A": -9
+          }
+        }
+      ],
+      "definedness": "not_defined_by_portable_c_family_library",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "sign",
+          "summary": "C++ render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function."
+        }
+      ],
+      "fcstm_expression": "sign(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "sign",
+      "operator_family": "math",
+      "outcome": "compile_failed",
+      "render_expression": "std::sign(A)",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "sign",
+      "target_semantics": "C++ render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function.",
+      "value_expr": "unsupported",
+      "z3_profile": "math-library-availability",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:cbrt",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "cbrt",
+          "summary": "C++ math-library cbrt evaluation."
+        }
+      ],
+      "fcstm_expression": "cbrt(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "cbrt is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "cbrt",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "std::cbrt(A)",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "cbrt",
+      "target_semantics": "C++ math-library cbrt evaluation.",
+      "value_expr": "cbrt_fp64(cbrt(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:integer_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "integer_constant",
+          "summary": "C++ literal rendering for integer_constant."
+        }
+      ],
+      "fcstm_expression": "42",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "integer_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "42",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "integer_constant",
+      "target_semantics": "C++ literal rendering for integer_constant.",
+      "value_expr": "literal(42)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:float_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "float_constant",
+          "summary": "C++ literal rendering for float_constant."
+        }
+      ],
+      "fcstm_expression": "3.5",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [],
+      "operator": "float_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "3.5",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "float_constant",
+      "target_semantics": "C++ literal rendering for float_constant.",
+      "value_expr": "literal(3.5)",
+      "z3_profile": "float-double",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "builtin_cpp_style:narrowing_writeback",
+      "counterexamples": [
+        {
+          "case_id": "builtin_cpp_style:writeback:pow-overflow",
+          "expected_issue": "mathematical result is outside signed 64-bit writeback range",
+          "reproduction": "A ** B",
+          "values": {
+            "A": 2,
+            "B": 63,
+            "target": "int64"
+          }
+        }
+      ],
+      "definedness": "defined_if_source_expression_and_conversion_are_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.builtin_cpp_style",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.cpp",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "builtin_cpp_style",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "narrowing_writeback",
+          "summary": "C++ assignment of an expression result back into a generated signed integer storage slot."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "obligations": [
+        {
+          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "kind": "source_expression_defined",
+          "predicate": "all source expression obligations hold",
+          "trigger": "writeback source evaluation"
+        },
+        {
+          "evidence": "C/C++ conversion to a signed integer target must not rely on out-of-range behavior.",
+          "kind": "representable_in_target_width",
+          "predicate": "INT64_MIN <= mathematical_result <= INT64_MAX",
+          "trigger": "integer writeback"
+        }
+      ],
+      "operator": "writeback",
+      "operator_family": "writeback",
+      "outcome": "exact_with_obligations",
+      "render_expression": "std::pow(A, B)",
+      "render_path": "builtin_cpp_style",
+      "render_status": "rendered",
+      "semantic_case_id": "narrowing_writeback",
+      "target_semantics": "C++ assignment of an expression result back into a generated signed integer storage slot.",
+      "value_expr": "writeback_int64(value_expr(A ** B))",
+      "z3_profile": "promotion-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:add",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:add:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A + B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "add",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A + B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A + B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "+",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A + scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "add",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_add(A + B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:subtract",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:subtract:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A - B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "subtract",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A - B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A - B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "-",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A - scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "subtract",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_subtract(A - B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:multiply",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:multiply:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A * B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "multiply",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A * B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A * B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "*",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A * scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "multiply",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_multiply(A * B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:divide",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:divide:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A / B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_cpp_c_core:divide:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A / B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "divide",
+          "summary": "C++ signed integer division over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A / B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "/",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A / scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "divide",
+      "target_semantics": "C++ signed integer division over promoted operands.",
+      "value_expr": "bvsdiv(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:modulo",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:modulo:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A % B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_cpp_c_core:modulo:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A % B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "modulo",
+          "summary": "C++ signed integer remainder over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A % B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "%",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A % scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "modulo",
+      "target_semantics": "C++ signed integer remainder over promoted operands.",
+      "value_expr": "bvsrem(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:unary_minus",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:unary_minus:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "-A",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "unary_minus",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "-A",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "unary-",
+      "operator_family": "unary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "-scope->A",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "unary_minus",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_unary_minus(-A)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:bitwise_not",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:bitwise_not:parse",
+          "expected_issue": "GrammarParseError",
+          "reproduction": "~A",
+          "values": {
+            "expression": "~A"
+          }
+        }
+      ],
+      "definedness": "unsupported_by_current_fcstm_grammar_or_renderer",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is parse_failed."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_not",
+          "summary": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply."
+        }
+      ],
+      "fcstm_expression": "~A",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "~",
+      "operator_family": "bitwise",
+      "outcome": "unsupported",
+      "render_expression": "",
+      "render_path": "template_cpp_c_core",
+      "render_status": "parse_failed",
+      "semantic_case_id": "bitwise_not",
+      "target_semantics": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply.",
+      "value_expr": "unsupported",
+      "z3_profile": "unsupported",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:bitwise_and",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:bitwise_and:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A & B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_and",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A & B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "&",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A & scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_and",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvand(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:bitwise_or",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:bitwise_or:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A | B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_or",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A | B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "|",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A | scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_or",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:bitwise_xor",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:bitwise_xor:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A ^ B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_xor",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A ^ B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "^",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A ^ scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_xor",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvxor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:shift_left",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:shift-left:negative",
+          "expected_issue": "signed left shift of a negative value is not a portable defined operation",
+          "reproduction": "A << B",
+          "values": {
+            "A": -1,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_left",
+          "summary": "C++ signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A << B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Signed left shift has additional definedness constraints beyond BitVec shift.",
+          "kind": "no_signed_left_shift_ub",
+          "predicate": "A >= 0 and left_shift_result_representable(A, B, width)",
+          "trigger": "signed left shift"
+        }
+      ],
+      "operator": "<<",
+      "operator_family": "shift",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A << scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_left",
+      "target_semantics": "C++ signed integer shift.",
+      "value_expr": "bvshl(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:shift_right",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:shift-right:negative",
+          "expected_issue": "negative signed right shift depends on implementation profile",
+          "reproduction": "A >> B",
+          "values": {
+            "A": -8,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_right",
+          "summary": "C++ signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A >> B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Right shift of a negative signed value is implementation-defined/profile-dependent.",
+          "kind": "signed_right_shift_profile",
+          "predicate": "profile selects arithmetic or logical right shift for negative lhs",
+          "trigger": "signed right shift"
+        }
+      ],
+      "operator": ">>",
+      "operator_family": "shift",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A >> scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_right",
+      "target_semantics": "C++ signed integer shift.",
+      "value_expr": "bvashr(A, B) under arithmetic-shift profile",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:less_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_than",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A < B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A < scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_than",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:less_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A <= B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A <= scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:greater_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_than",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A > B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A > scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_than",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:greater_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A >= B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A >= scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A == B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "==",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A == scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(==, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:not_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "not_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A != B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "!=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A != scope->B",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "not_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(!=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:pow",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "pow",
+          "summary": "C++ math-library pow evaluation."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "pow is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "pow",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "pow",
+      "target_semantics": "C++ math-library pow evaluation.",
+      "value_expr": "pow_fp64(A ** B)",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:round",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "round",
+          "summary": "C++ math-library round evaluation."
+        }
+      ],
+      "fcstm_expression": "round(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "round is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "round",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "round(scope->A)",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "round",
+      "target_semantics": "C++ math-library round evaluation.",
+      "value_expr": "round_fp64(round(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:abs",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:abs:min",
+          "expected_issue": "abs(INT_MIN) is not representable in the same signed width",
+          "reproduction": "abs(scope->A)",
+          "values": {
+            "A": -128,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "profile_dependent_overload_and_min_value",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "abs",
+          "summary": "C++ absolute-value call selected by the render path."
+        }
+      ],
+      "fcstm_expression": "abs(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C render paths may emit abs(A), which is not width-neutral for int64 operands.",
+          "kind": "abs_overload_matches_operand_width",
+          "predicate": "selected abs overload preserves the operand width",
+          "trigger": "math overload resolution"
+        },
+        {
+          "evidence": "The negated signed minimum is not representable in the same signed width.",
+          "kind": "no_abs_min",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "absolute value of signed minimum"
+        }
+      ],
+      "operator": "abs",
+      "operator_family": "math",
+      "outcome": "profile_dependent",
+      "render_expression": "abs(scope->A)",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "abs",
+      "target_semantics": "C++ absolute-value call selected by the render path.",
+      "value_expr": "if signed(A) < 0 then -A else A",
+      "z3_profile": "math-overload-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:sign",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:sign:compile",
+          "expected_issue": "portable C/C++ sign function is unavailable",
+          "reproduction": "sign(scope->A)",
+          "values": {
+            "A": -9
+          }
+        }
+      ],
+      "definedness": "not_defined_by_portable_c_family_library",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "sign",
+          "summary": "C++ render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function."
+        }
+      ],
+      "fcstm_expression": "sign(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "sign",
+      "operator_family": "math",
+      "outcome": "compile_failed",
+      "render_expression": "sign(scope->A)",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "sign",
+      "target_semantics": "C++ render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function.",
+      "value_expr": "unsupported",
+      "z3_profile": "math-library-availability",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:cbrt",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "cbrt",
+          "summary": "C++ math-library cbrt evaluation."
+        }
+      ],
+      "fcstm_expression": "cbrt(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "cbrt is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "cbrt",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "cbrt(scope->A)",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "cbrt",
+      "target_semantics": "C++ math-library cbrt evaluation.",
+      "value_expr": "cbrt_fp64(cbrt(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:integer_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "integer_constant",
+          "summary": "C++ literal rendering for integer_constant."
+        }
+      ],
+      "fcstm_expression": "42",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "integer_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "42",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "integer_constant",
+      "target_semantics": "C++ literal rendering for integer_constant.",
+      "value_expr": "literal(42)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:float_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "float_constant",
+          "summary": "C++ literal rendering for float_constant."
+        }
+      ],
+      "fcstm_expression": "3.5",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "float_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "3.5",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "float_constant",
+      "target_semantics": "C++ literal rendering for float_constant.",
+      "value_expr": "literal(3.5)",
+      "z3_profile": "float-double",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_c_core:narrowing_writeback",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_c_core:writeback:pow-overflow",
+          "expected_issue": "mathematical result is outside signed 64-bit writeback range",
+          "reproduction": "A ** B",
+          "values": {
+            "A": 2,
+            "B": 63,
+            "target": "int64"
+          }
+        }
+      ],
+      "definedness": "defined_if_source_expression_and_conversion_are_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "narrowing_writeback",
+          "summary": "C++ assignment of an expression result back into a generated signed integer storage slot."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "kind": "source_expression_defined",
+          "predicate": "all source expression obligations hold",
+          "trigger": "writeback source evaluation"
+        },
+        {
+          "evidence": "C/C++ conversion to a signed integer target must not rely on out-of-range behavior.",
+          "kind": "representable_in_target_width",
+          "predicate": "INT64_MIN <= mathematical_result <= INT64_MAX",
+          "trigger": "integer writeback"
+        }
+      ],
+      "operator": "writeback",
+      "operator_family": "writeback",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_cpp_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "narrowing_writeback",
+      "target_semantics": "C++ assignment of an expression result back into a generated signed integer storage slot.",
+      "value_expr": "writeback_int64(value_expr(A ** B))",
+      "z3_profile": "promotion-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:add",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:add:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A + B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "add",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A + B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A + B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "+",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A + scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "add",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_add(A + B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:subtract",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:subtract:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A - B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "subtract",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A - B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A - B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "-",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A - scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "subtract",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_subtract(A - B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:multiply",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:multiply:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "A * B",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "multiply",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A * B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "no_signed_overflow(A * B)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "*",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A * scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "multiply",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_multiply(A * B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:divide",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:divide:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A / B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_cpp_poll_c_core:divide:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A / B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "divide",
+          "summary": "C++ signed integer division over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A / B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "/",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A / scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "divide",
+      "target_semantics": "C++ signed integer division over promoted operands.",
+      "value_expr": "bvsdiv(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:modulo",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:modulo:div-zero",
+          "expected_issue": "division by zero",
+          "reproduction": "A % B",
+          "values": {
+            "A": 7,
+            "B": 0
+          }
+        },
+        {
+          "case_id": "template_cpp_poll_c_core:modulo:min-div-minus-one",
+          "expected_issue": "signed minimum divided by -1",
+          "reproduction": "A % B",
+          "values": {
+            "A": -128,
+            "B": -1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "modulo",
+          "summary": "C++ signed integer remainder over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A % B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "Division by zero is not a defined C/C++ integer operation.",
+          "kind": "divisor_nonzero",
+          "predicate": "B != 0",
+          "trigger": "division or remainder"
+        },
+        {
+          "evidence": "The signed minimum divided by -1 is not representable.",
+          "kind": "no_min_div_minus_one",
+          "predicate": "not (A == INT_MIN(width) and B == -1)",
+          "trigger": "signed division or remainder"
+        }
+      ],
+      "operator": "%",
+      "operator_family": "binary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A % scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "modulo",
+      "target_semantics": "C++ signed integer remainder over promoted operands.",
+      "value_expr": "bvsrem(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:unary_minus",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:unary_minus:overflow",
+          "expected_issue": "signed overflow would be required to match BitVec wrap",
+          "reproduction": "-A",
+          "values": {
+            "A": 127,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_no_signed_overflow",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "unary_minus",
+          "summary": "C++ signed integer arithmetic over promoted operands."
+        }
+      ],
+      "fcstm_expression": "-A",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+          "kind": "no_signed_overflow",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "signed arithmetic"
+        }
+      ],
+      "operator": "unary-",
+      "operator_family": "unary_arithmetic",
+      "outcome": "exact_with_obligations",
+      "render_expression": "-scope->A",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "unary_minus",
+      "target_semantics": "C++ signed integer arithmetic over promoted operands.",
+      "value_expr": "signed_bv_unary_minus(-A)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:bitwise_not",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:bitwise_not:parse",
+          "expected_issue": "GrammarParseError",
+          "reproduction": "~A",
+          "values": {
+            "expression": "~A"
+          }
+        }
+      ],
+      "definedness": "unsupported_by_current_fcstm_grammar_or_renderer",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is parse_failed."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_not",
+          "summary": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply."
+        }
+      ],
+      "fcstm_expression": "~A",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "~",
+      "operator_family": "bitwise",
+      "outcome": "unsupported",
+      "render_expression": "",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "parse_failed",
+      "semantic_case_id": "bitwise_not",
+      "target_semantics": "Current FCSTM parser or renderer rejects this expression before target-language semantics apply.",
+      "value_expr": "unsupported",
+      "z3_profile": "unsupported",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:bitwise_and",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:bitwise_and:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A & B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_and",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A & B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "&",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A & scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_and",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvand(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:bitwise_or",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:bitwise_or:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A | B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_or",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A | B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "|",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A | scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_or",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:bitwise_xor",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:bitwise_xor:negative-representation",
+          "expected_issue": "negative signed operand requires an explicit representation profile",
+          "reproduction": "A ^ B",
+          "values": {
+            "A": -1,
+            "B": 1
+          }
+        }
+      ],
+      "definedness": "profile_dependent_for_negative_signed_representation",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "bitwise_xor",
+          "summary": "C++ signed integer bitwise operation."
+        }
+      ],
+      "fcstm_expression": "A ^ B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+          "kind": "two_complement_representation_profile",
+          "predicate": "profile fixes signed representation as two's complement",
+          "trigger": "signed bitwise operation"
+        }
+      ],
+      "operator": "^",
+      "operator_family": "bitwise",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A ^ scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "bitwise_xor",
+      "target_semantics": "C++ signed integer bitwise operation.",
+      "value_expr": "bvxor(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:shift_left",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:shift-left:negative",
+          "expected_issue": "signed left shift of a negative value is not a portable defined operation",
+          "reproduction": "A << B",
+          "values": {
+            "A": -1,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_left",
+          "summary": "C++ signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A << B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Signed left shift has additional definedness constraints beyond BitVec shift.",
+          "kind": "no_signed_left_shift_ub",
+          "predicate": "A >= 0 and left_shift_result_representable(A, B, width)",
+          "trigger": "signed left shift"
+        }
+      ],
+      "operator": "<<",
+      "operator_family": "shift",
+      "outcome": "exact_with_obligations",
+      "render_expression": "scope->A << scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_left",
+      "target_semantics": "C++ signed integer shift.",
+      "value_expr": "bvshl(A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:shift_right",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:shift-right:negative",
+          "expected_issue": "negative signed right shift depends on implementation profile",
+          "reproduction": "A >> B",
+          "values": {
+            "A": -8,
+            "B": 1,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "defined_if_shift_obligations_hold",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "shift_right",
+          "summary": "C++ signed integer shift."
+        }
+      ],
+      "fcstm_expression": "A >> B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C/C++ shifts require a count smaller than the promoted operand width.",
+          "kind": "valid_shift_count",
+          "predicate": "B < width",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "C/C++ shifts do not define negative shift counts.",
+          "kind": "non_negative_shift_count",
+          "predicate": "B >= 0",
+          "trigger": "shift count"
+        },
+        {
+          "evidence": "Right shift of a negative signed value is implementation-defined/profile-dependent.",
+          "kind": "signed_right_shift_profile",
+          "predicate": "profile selects arithmetic or logical right shift for negative lhs",
+          "trigger": "signed right shift"
+        }
+      ],
+      "operator": ">>",
+      "operator_family": "shift",
+      "outcome": "profile_dependent",
+      "render_expression": "scope->A >> scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "shift_right",
+      "target_semantics": "C++ signed integer shift.",
+      "value_expr": "bvashr(A, B) under arithmetic-shift profile",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:less_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_than",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A < B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A < scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_than",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:less_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "less_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A <= B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "<=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A <= scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "less_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(<=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:greater_than",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_than",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A > B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A > scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_than",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:greater_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "greater_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A >= B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": ">=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A >= scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "greater_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(>=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A == B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "==",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A == scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(==, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:not_equal",
+      "counterexamples": [],
+      "definedness": "defined_if_operand_evaluation_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "not_equal",
+          "summary": "C++ relational comparison over promoted operands."
+        }
+      ],
+      "fcstm_expression": "A != B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "!=",
+      "operator_family": "comparison",
+      "outcome": "exact",
+      "render_expression": "scope->A != scope->B",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "not_equal",
+      "target_semantics": "C++ relational comparison over promoted operands.",
+      "value_expr": "signed_bv_compare(!=, A, B)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "Bool"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:pow",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "pow",
+          "summary": "C++ math-library pow evaluation."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "pow is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "pow",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "pow",
+      "target_semantics": "C++ math-library pow evaluation.",
+      "value_expr": "pow_fp64(A ** B)",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:round",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "round",
+          "summary": "C++ math-library round evaluation."
+        }
+      ],
+      "fcstm_expression": "round(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "round is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "round",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "round(scope->A)",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "round",
+      "target_semantics": "C++ math-library round evaluation.",
+      "value_expr": "round_fp64(round(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:abs",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:abs:min",
+          "expected_issue": "abs(INT_MIN) is not representable in the same signed width",
+          "reproduction": "abs(scope->A)",
+          "values": {
+            "A": -128,
+            "width": 8
+          }
+        }
+      ],
+      "definedness": "profile_dependent_overload_and_min_value",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "abs",
+          "summary": "C++ absolute-value call selected by the render path."
+        }
+      ],
+      "fcstm_expression": "abs(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C render paths may emit abs(A), which is not width-neutral for int64 operands.",
+          "kind": "abs_overload_matches_operand_width",
+          "predicate": "selected abs overload preserves the operand width",
+          "trigger": "math overload resolution"
+        },
+        {
+          "evidence": "The negated signed minimum is not representable in the same signed width.",
+          "kind": "no_abs_min",
+          "predicate": "A != INT_MIN(width)",
+          "trigger": "absolute value of signed minimum"
+        }
+      ],
+      "operator": "abs",
+      "operator_family": "math",
+      "outcome": "profile_dependent",
+      "render_expression": "abs(scope->A)",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "abs",
+      "target_semantics": "C++ absolute-value call selected by the render path.",
+      "value_expr": "if signed(A) < 0 then -A else A",
+      "z3_profile": "math-overload-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:sign",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:sign:compile",
+          "expected_issue": "portable C/C++ sign function is unavailable",
+          "reproduction": "sign(scope->A)",
+          "values": {
+            "A": -9
+          }
+        }
+      ],
+      "definedness": "not_defined_by_portable_c_family_library",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "sign",
+          "summary": "C++ render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function."
+        }
+      ],
+      "fcstm_expression": "sign(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "sign",
+      "operator_family": "math",
+      "outcome": "compile_failed",
+      "render_expression": "sign(scope->A)",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "sign",
+      "target_semantics": "C++ render path currently emits a sign function call but C and standard C++ do not provide a portable unary sign math function.",
+      "value_expr": "unsupported",
+      "z3_profile": "math-library-availability",
+      "z3_sort": "unsupported"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:cbrt",
+      "counterexamples": [],
+      "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "cbrt",
+          "summary": "C++ math-library cbrt evaluation."
+        }
+      ],
+      "fcstm_expression": "cbrt(A)",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "C-family smoke probes record compile/link facts for math functions.",
+          "kind": "math_function_available",
+          "predicate": "cbrt is available in the selected language standard/library",
+          "trigger": "math function call"
+        },
+        {
+          "evidence": "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+          "kind": "finite_float_result",
+          "predicate": "isFinite(result)",
+          "trigger": "floating-point math result"
+        }
+      ],
+      "operator": "cbrt",
+      "operator_family": "math",
+      "outcome": "exact_with_obligations",
+      "render_expression": "cbrt(scope->A)",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "cbrt",
+      "target_semantics": "C++ math-library cbrt evaluation.",
+      "value_expr": "cbrt_fp64(cbrt(A))",
+      "z3_profile": "float-double-math",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:integer_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "integer_constant",
+          "summary": "C++ literal rendering for integer_constant."
+        }
+      ],
+      "fcstm_expression": "42",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "integer_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "42",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "integer_constant",
+      "target_semantics": "C++ literal rendering for integer_constant.",
+      "value_expr": "literal(42)",
+      "z3_profile": "signed-fixed-width-candidate:int64",
+      "z3_sort": "BitVec(64)"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:float_constant",
+      "counterexamples": [],
+      "definedness": "defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "float_constant",
+          "summary": "C++ literal rendering for float_constant."
+        }
+      ],
+      "fcstm_expression": "3.5",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [],
+      "operator": "float_constant",
+      "operator_family": "constant",
+      "outcome": "exact",
+      "render_expression": "3.5",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "float_constant",
+      "target_semantics": "C++ literal rendering for float_constant.",
+      "value_expr": "literal(3.5)",
+      "z3_profile": "float-double",
+      "z3_sort": "FP64"
+    },
+    {
+      "compile_language": "cpp",
+      "contract_id": "template_cpp_poll_c_core:narrowing_writeback",
+      "counterexamples": [
+        {
+          "case_id": "template_cpp_poll_c_core:writeback:pow-overflow",
+          "expected_issue": "mathematical result is outside signed 64-bit writeback range",
+          "reproduction": "A ** B",
+          "values": {
+            "A": 2,
+            "B": 63,
+            "target": "int64"
+          }
+        }
+      ],
+      "definedness": "defined_if_source_expression_and_conversion_are_defined",
+      "evidence": [
+        {
+          "kind": "render_mapping",
+          "source": "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "builtin_expr_styles.styles.c",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_mapping",
+          "source": "templates.cpp_poll.expr_styles.c_scope_expr",
+          "summary": "Render path source recorded in render_mapping.json."
+        },
+        {
+          "kind": "render_result",
+          "source": "template_cpp_poll_c_core",
+          "summary": "Expression render status is rendered."
+        },
+        {
+          "kind": "contract_semantics",
+          "source": "narrowing_writeback",
+          "summary": "C++ assignment of an expression result back into a generated signed integer storage slot."
+        }
+      ],
+      "fcstm_expression": "A ** B",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "obligations": [
+        {
+          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "kind": "source_expression_defined",
+          "predicate": "all source expression obligations hold",
+          "trigger": "writeback source evaluation"
+        },
+        {
+          "evidence": "C/C++ conversion to a signed integer target must not rely on out-of-range behavior.",
+          "kind": "representable_in_target_width",
+          "predicate": "INT64_MIN <= mathematical_result <= INT64_MAX",
+          "trigger": "integer writeback"
+        }
+      ],
+      "operator": "writeback",
+      "operator_family": "writeback",
+      "outcome": "exact_with_obligations",
+      "render_expression": "pow(scope->A, scope->B)",
+      "render_path": "template_cpp_poll_c_core",
+      "render_status": "rendered",
+      "semantic_case_id": "narrowing_writeback",
+      "target_semantics": "C++ assignment of an expression result back into a generated signed integer storage slot.",
+      "value_expr": "writeback_int64(value_expr(A ** B))",
+      "z3_profile": "promotion-and-writeback:int64",
+      "z3_sort": "BitVec(64)"
+    }
+  ],
+  "coverage": {
+    "note": "Each semantic case is expanded across all C-family render paths; unsupported parser/render cases remain explicit contract rows.",
+    "operator_families": [
+      "binary_arithmetic",
+      "bitwise",
+      "comparison",
+      "constant",
+      "math",
+      "shift",
+      "unary_arithmetic",
+      "writeback"
+    ],
+    "operators": [
+      "!=",
+      "%",
+      "&",
+      "*",
+      "+",
+      "-",
+      "/",
+      "<",
+      "<<",
+      "<=",
+      "==",
+      ">",
+      ">=",
+      ">>",
+      "^",
+      "abs",
+      "cbrt",
+      "float_constant",
+      "integer_constant",
+      "pow",
+      "round",
+      "sign",
+      "unary-",
+      "writeback",
+      "|",
+      "~"
+    ],
+    "render_paths": [
+      "builtin_c_style",
+      "builtin_cpp_style",
+      "template_c_core",
+      "template_c_poll_core",
+      "template_cpp_c_core",
+      "template_cpp_poll_c_core"
+    ]
+  },
+  "cpp_smoke_facts_sha256": "19b54f6065510b005f817dcecce0190999eee1abac144b0b5b3120cc430e9f6b",
+  "generator": {
+    "determinism": "No native compiler output, wall-clock timestamp or solver model value is stored in the committed alignment snapshot.",
+    "research_path": "research/numeric-render-semantics",
+    "source_commit": "570228e90692aa1e5a9bff4e4ba125442bd07d83",
+    "source_commit_policy": "Best-effort commit at generation time; mapping, baseline and smoke fact digests are the stable comparison keys.",
+    "tool": "tools/numeric_render_probe.py"
+  },
+  "languages": [
+    "c",
+    "cpp"
+  ],
+  "mode": "c-cpp-z3-alignment",
+  "python_z3_baseline_sha256": "123f1a1e4f06b1aff323c01d26ca8cb76ff61dee8db44007ba750c0cd63be3e1",
+  "render_mapping_sha256": "d79b2fc4eb981eb794def52fc8fa2589c87e836673106eabdc589081eb8ad2da",
+  "render_paths": [
+    {
+      "compile_language": "c",
+      "expression_core_language": "c",
+      "lang_style": "c",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c"
+      ],
+      "path_id": "builtin_c_style",
+      "template_name": null,
+      "wrapper_language": null
+    },
+    {
+      "compile_language": "c",
+      "expression_core_language": "c",
+      "lang_style": "c",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c.expr_styles.c_scope_expr"
+      ],
+      "path_id": "template_c_core",
+      "template_name": "c",
+      "wrapper_language": null
+    },
+    {
+      "compile_language": "c",
+      "expression_core_language": "c",
+      "lang_style": "c",
+      "language": "c",
+      "mapping_sources": [
+        "builtin_expr_styles.styles.c",
+        "templates.c_poll.expr_styles.c_scope_expr"
+      ],
+      "path_id": "template_c_poll_core",
+      "template_name": "c_poll",
+      "wrapper_language": null
+    },
+    {
+      "compile_language": "cpp",
+      "expression_core_language": "cpp",
+      "lang_style": "cpp",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.builtin_cpp_style",
+        "builtin_expr_styles.styles.cpp"
+      ],
+      "path_id": "builtin_cpp_style",
+      "template_name": null,
+      "wrapper_language": null
+    },
+    {
+      "compile_language": "cpp",
+      "expression_core_language": "c",
+      "lang_style": "c",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[0].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp.expr_styles.c_scope_expr"
+      ],
+      "path_id": "template_cpp_c_core",
+      "template_name": "cpp",
+      "wrapper_language": "cpp"
+    },
+    {
+      "compile_language": "cpp",
+      "expression_core_language": "c",
+      "lang_style": "c",
+      "language": "cpp",
+      "mapping_sources": [
+        "cxx_paths.template_generated_paths[1].expr_styles.c_scope_expr",
+        "builtin_expr_styles.styles.c",
+        "templates.cpp_poll.expr_styles.c_scope_expr"
+      ],
+      "path_id": "template_cpp_poll_c_core",
+      "template_name": "cpp_poll",
+      "wrapper_language": "cpp"
+    }
+  ],
+  "repository": {
+    "python_z3_baseline_snapshot": "research/numeric-render-semantics/results/snapshots/python_z3_baseline.json",
+    "render_mapping_snapshot": "research/numeric-render-semantics/results/snapshots/render_mapping.json",
+    "root": ".",
+    "schema_path": "research/numeric-render-semantics/schemas/c_cpp_z3_alignment.schema.json"
+  },
+  "representative_notes": [
+    {
+      "summary": "BitVec expressions describe candidate values only; C/C++ signed overflow, invalid shifts and division traps stay in obligations or non-exact outcomes.",
+      "topic": "bitvec-is-candidate-not-definedness"
+    },
+    {
+      "summary": "The snapshot keeps builtin _CPP_STYLE separate from C++ templates that reuse C expression templates via base_lang: c.",
+      "topic": "cxx-render-path-split"
+    },
+    {
+      "summary": "The committed snapshot uses deterministic render and smoke facts; live native smoke output belongs in results/local/.",
+      "topic": "toolchain-independent-check"
+    }
+  ],
+  "schema_version": 1,
+  "source_mapping_sha256": "d79b2fc4eb981eb794def52fc8fa2589c87e836673106eabdc589081eb8ad2da"
+}

--- a/research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json
+++ b/research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json
@@ -1406,7 +1406,7 @@
       ],
       "obligations": [
         {
-          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "evidence": "The alignment contract composes source expression obligations before writeback.",
           "kind": "source_expression_defined",
           "predicate": "all source expression obligations hold",
           "trigger": "writeback source evaluation"
@@ -2955,7 +2955,7 @@
       ],
       "obligations": [
         {
-          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "evidence": "The alignment contract composes source expression obligations before writeback.",
           "kind": "source_expression_defined",
           "predicate": "all source expression obligations hold",
           "trigger": "writeback source evaluation"
@@ -4504,7 +4504,7 @@
       ],
       "obligations": [
         {
-          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "evidence": "The alignment contract composes source expression obligations before writeback.",
           "kind": "source_expression_defined",
           "predicate": "all source expression obligations hold",
           "trigger": "writeback source evaluation"
@@ -6053,7 +6053,7 @@
       ],
       "obligations": [
         {
-          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "evidence": "The alignment contract composes source expression obligations before writeback.",
           "kind": "source_expression_defined",
           "predicate": "all source expression obligations hold",
           "trigger": "writeback source evaluation"
@@ -7758,7 +7758,7 @@
       ],
       "obligations": [
         {
-          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "evidence": "The alignment contract composes source expression obligations before writeback.",
           "kind": "source_expression_defined",
           "predicate": "all source expression obligations hold",
           "trigger": "writeback source evaluation"
@@ -9463,7 +9463,7 @@
       ],
       "obligations": [
         {
-          "evidence": "PR-6A alignment contract composes source expression obligations before writeback.",
+          "evidence": "The alignment contract composes source expression obligations before writeback.",
           "kind": "source_expression_defined",
           "predicate": "all source expression obligations hold",
           "trigger": "writeback source evaluation"
@@ -9541,7 +9541,7 @@
   "generator": {
     "determinism": "No native compiler output, wall-clock timestamp or solver model value is stored in the committed alignment snapshot.",
     "research_path": "research/numeric-render-semantics",
-    "source_commit": "570228e90692aa1e5a9bff4e4ba125442bd07d83",
+    "source_commit": "5b0d79537660cc6b11abbb60e921e23373c09c6d",
     "source_commit_policy": "Best-effort commit at generation time; mapping, baseline and smoke fact digests are the stable comparison keys.",
     "tool": "tools/numeric_render_probe.py"
   },

--- a/research/numeric-render-semantics/schemas/c_cpp_z3_alignment.schema.json
+++ b/research/numeric-render-semantics/schemas/c_cpp_z3_alignment.schema.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "C/C++ to Z3 numeric alignment contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "mode",
+    "languages",
+    "source_mapping_sha256",
+    "render_mapping_sha256",
+    "python_z3_baseline_sha256",
+    "c_smoke_facts_sha256",
+    "cpp_smoke_facts_sha256",
+    "generator",
+    "repository",
+    "contract_fields",
+    "render_paths",
+    "coverage",
+    "contracts",
+    "representative_notes"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "mode": {"const": "c-cpp-z3-alignment"},
+    "languages": {
+      "type": "array",
+      "minItems": 2,
+      "items": {"type": "string", "enum": ["c", "cpp"]}
+    },
+    "source_mapping_sha256": {"$ref": "#/$defs/sha256"},
+    "render_mapping_sha256": {"$ref": "#/$defs/sha256"},
+    "python_z3_baseline_sha256": {"$ref": "#/$defs/sha256"},
+    "c_smoke_facts_sha256": {"$ref": "#/$defs/sha256"},
+    "cpp_smoke_facts_sha256": {"$ref": "#/$defs/sha256"},
+    "generator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "tool",
+        "research_path",
+        "source_commit",
+        "source_commit_policy",
+        "determinism"
+      ],
+      "properties": {
+        "tool": {"type": "string"},
+        "research_path": {"type": "string"},
+        "source_commit": {"type": ["string", "null"]},
+        "source_commit_policy": {"type": "string"},
+        "determinism": {"type": "string"}
+      }
+    },
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "root",
+        "render_mapping_snapshot",
+        "python_z3_baseline_snapshot",
+        "schema_path"
+      ],
+      "properties": {
+        "root": {"type": "string"},
+        "render_mapping_snapshot": {"type": "string"},
+        "python_z3_baseline_snapshot": {"type": "string"},
+        "schema_path": {"type": "string"}
+      }
+    },
+    "contract_fields": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["core_triple", "required_fields", "outcome_enum", "shift_obligation_kinds"],
+      "properties": {
+        "core_triple": {"type": "array", "minItems": 3, "items": {"type": "string"}},
+        "required_fields": {"type": "array", "minItems": 10, "items": {"type": "string"}},
+        "outcome_enum": {"type": "array", "minItems": 7, "items": {"$ref": "#/$defs/outcome"}},
+        "shift_obligation_kinds": {"type": "array", "minItems": 4, "items": {"type": "string"}}
+      }
+    },
+    "render_paths": {
+      "type": "array",
+      "minItems": 6,
+      "items": {"$ref": "#/$defs/render_path"}
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operators", "operator_families", "render_paths", "note"],
+      "properties": {
+        "operators": {"type": "array", "minItems": 20, "items": {"type": "string"}},
+        "operator_families": {"type": "array", "minItems": 8, "items": {"type": "string"}},
+        "render_paths": {"type": "array", "minItems": 6, "items": {"type": "string"}},
+        "note": {"type": "string"}
+      }
+    },
+    "contracts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/contract"}
+    },
+    "representative_notes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/note"}
+    }
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "outcome": {
+      "type": "string",
+      "enum": [
+        "compile_failed",
+        "exact",
+        "exact_with_obligations",
+        "profile_dependent",
+        "runtime_trap",
+        "ub",
+        "unsupported"
+      ]
+    },
+    "render_path": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "path_id",
+        "language",
+        "compile_language",
+        "lang_style",
+        "expression_core_language",
+        "mapping_sources",
+        "template_name",
+        "wrapper_language"
+      ],
+      "properties": {
+        "path_id": {"type": "string"},
+        "language": {"type": "string"},
+        "compile_language": {"type": "string"},
+        "lang_style": {"type": "string"},
+        "expression_core_language": {"type": "string"},
+        "mapping_sources": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "template_name": {"type": ["string", "null"]},
+        "wrapper_language": {"type": ["string", "null"]}
+      }
+    },
+    "contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "contract_id",
+        "semantic_case_id",
+        "render_path",
+        "language",
+        "compile_language",
+        "mapping_sources",
+        "operator",
+        "operator_family",
+        "fcstm_expression",
+        "render_expression",
+        "render_status",
+        "target_semantics",
+        "definedness",
+        "z3_sort",
+        "z3_profile",
+        "value_expr",
+        "obligations",
+        "outcome",
+        "evidence",
+        "counterexamples"
+      ],
+      "properties": {
+        "contract_id": {"type": "string"},
+        "semantic_case_id": {"type": "string"},
+        "render_path": {"type": "string"},
+        "language": {"type": "string"},
+        "compile_language": {"type": "string"},
+        "mapping_sources": {"type": "array", "minItems": 1, "items": {"type": "string"}},
+        "operator": {"type": "string"},
+        "operator_family": {"type": "string"},
+        "fcstm_expression": {"type": "string"},
+        "render_expression": {"type": "string"},
+        "render_status": {"type": "string"},
+        "target_semantics": {"type": "string"},
+        "definedness": {"type": "string"},
+        "z3_sort": {"type": "string"},
+        "z3_profile": {"type": "string"},
+        "value_expr": {"type": "string"},
+        "obligations": {"type": "array", "items": {"$ref": "#/$defs/obligation"}},
+        "outcome": {"$ref": "#/$defs/outcome"},
+        "evidence": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/evidence"}},
+        "counterexamples": {"type": "array", "items": {"$ref": "#/$defs/counterexample"}}
+      }
+    },
+    "obligation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "predicate", "trigger", "evidence"],
+      "properties": {
+        "kind": {"type": "string"},
+        "predicate": {"type": "string"},
+        "trigger": {"type": "string"},
+        "evidence": {"type": "string"}
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "source", "summary"],
+      "properties": {
+        "kind": {"type": "string"},
+        "source": {"type": "string"},
+        "summary": {"type": "string"}
+      }
+    },
+    "counterexample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["case_id", "values", "expected_issue", "reproduction"],
+      "properties": {
+        "case_id": {"type": "string"},
+        "values": {"type": "object"},
+        "expected_issue": {"type": "string"},
+        "reproduction": {"type": "string"}
+      }
+    },
+    "note": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["topic", "summary"],
+      "properties": {
+        "topic": {"type": "string"},
+        "summary": {"type": "string"}
+      }
+    }
+  }
+}

--- a/tools/numeric_render_probe.py
+++ b/tools/numeric_render_probe.py
@@ -4210,7 +4210,7 @@ def _render_contract_expression(
         rendered = render(node=expr.to_ast_node())
     except GrammarParseError as err:
         # GrammarParseError: current FCSTM grammar rejects this expression
-        # shape; PR-6A records that as an unsupported contract row.
+        # shape; the alignment snapshot records that as an unsupported contract row.
         return {
             "status": "parse_failed",
             "error_type": type(err).__name__,
@@ -4596,7 +4596,7 @@ def _alignment_semantics_for_case(
                     "source_expression_defined",
                     "all source expression obligations hold",
                     "writeback source evaluation",
-                    "PR-6A alignment contract composes source expression obligations before writeback.",
+                    "The alignment contract composes source expression obligations before writeback.",
                 ),
                 _obligation(
                     "representable_in_target_width",
@@ -5183,10 +5183,24 @@ def validate_c_cpp_z3_alignment(payload: Mapping[str, Any]) -> List[str]:
         "evidence",
         "counterexamples",
     }
+    expected_cases = {
+        str(case["semantic_case_id"]): {
+            "operator": str(case["operator"]),
+            "operator_family": str(case["operator_family"]),
+            "fcstm_expression": str(case["fcstm_expression"]),
+        }
+        for case in _c_cpp_alignment_cases()
+    }
+    expected_contract_ids = {
+        "%s:%s" % (render_path, semantic_case_id)
+        for render_path in _C_CPP_ALIGNMENT_RENDER_PATHS
+        for semantic_case_id in expected_cases
+    }
+    seen_contract_ids: Dict[str, str] = {}
+    seen_contract_pairs: Dict[Tuple[str, str], str] = {}
     operators = set()
     families = set()
     contract_render_paths = set()
-    shift_obligations = set()
     for index, contract in enumerate(contracts):
         path = "contracts[%d]" % index
         if not isinstance(contract, Mapping):
@@ -5196,9 +5210,49 @@ def validate_c_cpp_z3_alignment(payload: Mapping[str, Any]) -> List[str]:
         if missing:
             errors.append("%s missing required key %s" % (path, missing[0]))
             continue
-        operators.add(contract.get("operator"))
+        contract_id = contract.get("contract_id")
+        semantic_case_id = contract.get("semantic_case_id")
+        render_path = contract.get("render_path")
+        operator_name = contract.get("operator")
+        operators.add(operator_name)
         families.add(contract.get("operator_family"))
-        contract_render_paths.add(contract.get("render_path"))
+        contract_render_paths.add(render_path)
+        if isinstance(contract_id, str):
+            previous_path = seen_contract_ids.get(contract_id)
+            if previous_path is not None:
+                errors.append(
+                    "%s.contract_id duplicates %s from %s"
+                    % (path, contract_id, previous_path)
+                )
+            else:
+                seen_contract_ids[contract_id] = path
+        if isinstance(render_path, str) and isinstance(semantic_case_id, str):
+            pair_key = (render_path, semantic_case_id)
+            previous_path = seen_contract_pairs.get(pair_key)
+            if previous_path is not None:
+                errors.append(
+                    "%s duplicates render_path/semantic_case_id %s:%s from %s"
+                    % (path, render_path, semantic_case_id, previous_path)
+                )
+            else:
+                seen_contract_pairs[pair_key] = path
+            expected_contract_id = "%s:%s" % pair_key
+            if contract_id != expected_contract_id:
+                errors.append(
+                    "%s.contract_id must equal %s" % (path, expected_contract_id)
+                )
+        if render_path not in _C_CPP_ALIGNMENT_RENDER_PATHS:
+            errors.append("%s.render_path is not a required C-family path" % path)
+        expected_case = expected_cases.get(str(semantic_case_id))
+        if expected_case is None:
+            errors.append("%s.semantic_case_id is not a required alignment case" % path)
+        else:
+            for key, expected_value in expected_case.items():
+                if contract.get(key) != expected_value:
+                    errors.append(
+                        "%s.%s must be %r for semantic case %s"
+                        % (path, key, expected_value, semantic_case_id)
+                    )
         if contract.get("outcome") not in _C_CPP_ALIGNMENT_OUTCOMES:
             errors.append(
                 "%s.outcome has invalid value %r" % (path, contract.get("outcome"))
@@ -5219,6 +5273,7 @@ def validate_c_cpp_z3_alignment(payload: Mapping[str, Any]) -> List[str]:
             if not isinstance(contract.get(key), str) or not contract.get(key):
                 errors.append("%s.%s must be a non-empty string" % (path, key))
         obligations = contract.get("obligations")
+        obligation_kinds = set()
         if not isinstance(obligations, list):
             errors.append("%s.obligations must be an array" % path)
         else:
@@ -5229,12 +5284,30 @@ def validate_c_cpp_z3_alignment(payload: Mapping[str, Any]) -> List[str]:
                         % (path, obligation_index)
                     )
                     continue
-                shift_obligations.add(obligation.get("kind"))
+                obligation_kinds.add(obligation.get("kind"))
                 errors.extend(
                     _validate_alignment_obligation(
                         obligation, "%s.obligations[%d]" % (path, obligation_index)
                     )
                 )
+        required_shift_kinds = set()
+        if operator_name == "<<":
+            required_shift_kinds = {
+                "valid_shift_count",
+                "non_negative_shift_count",
+                "no_signed_left_shift_ub",
+            }
+        elif operator_name == ">>":
+            required_shift_kinds = {
+                "valid_shift_count",
+                "non_negative_shift_count",
+                "signed_right_shift_profile",
+            }
+        if required_shift_kinds and not required_shift_kinds <= obligation_kinds:
+            missing = sorted(required_shift_kinds - obligation_kinds)
+            errors.append(
+                "%s shift obligations missing: %s" % (path, ", ".join(missing))
+            )
         evidence = contract.get("evidence")
         if not isinstance(evidence, list) or not evidence:
             errors.append("%s.evidence must be a non-empty array" % path)
@@ -5302,11 +5375,12 @@ def validate_c_cpp_z3_alignment(payload: Mapping[str, Any]) -> List[str]:
     for path_id in _C_CPP_ALIGNMENT_RENDER_PATHS:
         if path_id not in contract_render_paths:
             errors.append("contracts missing render_path %s" % path_id)
-    if not _C_CPP_ALIGNMENT_REQUIRED_SHIFT_OBLIGATIONS <= shift_obligations:
-        missing = sorted(
-            _C_CPP_ALIGNMENT_REQUIRED_SHIFT_OBLIGATIONS - shift_obligations
-        )
-        errors.append("shift obligations missing: %s" % ", ".join(missing))
+    missing_contract_ids = sorted(expected_contract_ids - set(seen_contract_ids))
+    extra_contract_ids = sorted(set(seen_contract_ids) - expected_contract_ids)
+    for contract_id in missing_contract_ids:
+        errors.append("contracts missing required contract_id %s" % contract_id)
+    for contract_id in extra_contract_ids:
+        errors.append("contracts contain unexpected contract_id %s" % contract_id)
     return errors
 
 

--- a/tools/numeric_render_probe.py
+++ b/tools/numeric_render_probe.py
@@ -6,10 +6,12 @@ native workloads. The C-family smoke modes compile and execute small programs
 whose expressions are rendered from the repository's R0
 ``render_mapping.json`` snapshot, so the probe follows the same renderer and
 template facts that later exhaustive harnesses will use. Shared JSON, mapping,
-and command-dispatch helpers are mode-neutral. The Python/Z3 baseline mode joins the same runner without replacing the
-C-family modes. Smoke case identifiers are render-path scoped; cross-artifact
-semantic joins should prefer the rendered FCSTM operator and source expression,
-or a future explicit semantic identifier, while render-path fields distinguish
+and command-dispatch helpers are mode-neutral. The Python/Z3 baseline mode
+joins the same runner without replacing the C-family modes. The C/C++ to Z3
+alignment mode adds a deterministic schema-level contract over those earlier
+facts. Smoke case identifiers are render-path scoped; cross-artifact semantic
+joins should prefer the rendered FCSTM operator and source expression, or a
+future explicit semantic identifier, while render-path fields distinguish
 target-language outputs for the same semantic expression.
 
 The module contains:
@@ -18,10 +20,12 @@ The module contains:
 * :func:`build_c_family_smoke_report` - Run C or C++ smoke cases from R0 mapping.
 * :func:`build_python_z3_baseline` - Build the Python/Z3 capability baseline.
 * :func:`check_python_z3_baseline` - Validate the generated or committed baseline.
+* :func:`build_c_cpp_z3_alignment` - Build the C/C++ to Z3 alignment snapshot.
+* :func:`check_c_cpp_z3_alignment` - Validate the committed alignment snapshot.
 * :func:`validate_probe_summary` - Validate the lightweight probe-summary contract.
 * :func:`_stable_json` - Serialize research artifacts consistently.
 * :func:`main` - Command-line entry point with ``env``, ``c-smoke``,
-  ``cpp-smoke`` and ``python-z3-baseline`` modes.
+  ``cpp-smoke``, ``python-z3-baseline`` and ``c-cpp-z3-alignment`` modes.
 
 Example::
 
@@ -38,6 +42,7 @@ Example::
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
@@ -78,6 +83,7 @@ from pyfcstm.model.expr import parse_expr_from_string  # noqa: E402
 from pyfcstm.render.expr import render_expr_node  # noqa: E402
 from pyfcstm.render.render import StateMachineCodeRenderer  # noqa: E402
 from pyfcstm.solver.expr import python_round_to_z3  # noqa: E402
+from pyfcstm.utils import add_settings_for_env  # noqa: E402
 from tools.numeric_render_mapping import build_render_mapping  # noqa: E402
 
 _JSON_OBJECT = Dict[str, Any]
@@ -87,6 +93,12 @@ _PYTHON_Z3_BASELINE_SNAPSHOT = (
     "%s/results/snapshots/python_z3_baseline.json" % _RESEARCH_PATH
 )
 _PYTHON_Z3_BASELINE_SCHEMA = "%s/schemas/python_z3_baseline.schema.json" % (
+    _RESEARCH_PATH
+)
+_C_CPP_Z3_ALIGNMENT_SNAPSHOT = (
+    "%s/results/snapshots/c_cpp_z3_alignment.json" % _RESEARCH_PATH
+)
+_C_CPP_Z3_ALIGNMENT_SCHEMA = "%s/schemas/c_cpp_z3_alignment.schema.json" % (
     _RESEARCH_PATH
 )
 _COMMANDS = [
@@ -120,6 +132,29 @@ _CPP_SANITIZER_FLAGS = [
 _Z3_SORTS = ["Int", "Real", "BitVec", "FP"]
 _Z3_SUPPORT_LEVELS = {"exact", "approximate", "uninterpreted", "unsupported"}
 _RISK_LEVELS = {"low", "medium", "high", "unknown"}
+_C_CPP_ALIGNMENT_OUTCOMES = {
+    "exact",
+    "exact_with_obligations",
+    "profile_dependent",
+    "unsupported",
+    "compile_failed",
+    "runtime_trap",
+    "ub",
+}
+_C_CPP_ALIGNMENT_RENDER_PATHS = [
+    "builtin_c_style",
+    "template_c_core",
+    "template_c_poll_core",
+    "builtin_cpp_style",
+    "template_cpp_c_core",
+    "template_cpp_poll_c_core",
+]
+_C_CPP_ALIGNMENT_REQUIRED_SHIFT_OBLIGATIONS = {
+    "valid_shift_count",
+    "non_negative_shift_count",
+    "no_signed_left_shift_ub",
+    "signed_right_shift_profile",
+}
 _UFUNC_NAMES = [
     "sin",
     "cos",
@@ -336,6 +371,23 @@ def _write_payload(output_path: Union[str, Path], payload: Mapping[str, Any]) ->
     path = Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(_stable_json(payload), encoding="utf-8")
+
+
+def _payload_sha256(payload: Any) -> str:
+    """
+    Return the SHA-256 digest for a stable JSON payload.
+
+    :param payload: JSON-compatible payload.
+    :type payload: Any
+    :return: Lowercase SHA-256 digest.
+    :rtype: str
+
+    Example::
+
+        >>> _payload_sha256({'b': 1, 'a': 2}) == _payload_sha256({'a': 2, 'b': 1})
+        True
+    """
+    return hashlib.sha256(_stable_json(payload).encode("utf-8")).hexdigest()
 
 
 def _probe_command(name: str) -> _JSON_OBJECT:
@@ -976,7 +1028,7 @@ def _render_case_expression(case: NumericSmokeCase, render_path: RenderPath) -> 
     from pyfcstm.render.expr import fn_expr_render
     from pyfcstm.utils import to_c_identifier
 
-    env = jinja2.Environment()
+    env = add_settings_for_env(jinja2.Environment())
     env.filters["to_c_identifier"] = to_c_identifier
     env.globals["to_c_identifier"] = to_c_identifier
     expr = parse_expr_from_string(case.fcstm_expression, mode="numeric")
@@ -1878,9 +1930,7 @@ def _render_template_python_expr(
     """
     try:
         expr = parse_expr_from_string(expr_text, mode="numeric")
-        rendered = renderer.env.globals["expr_render"](
-            expr.to_ast_node(), style=style
-        )
+        rendered = renderer.env.globals["expr_render"](expr.to_ast_node(), style=style)
     except GrammarParseError as err:
         # GrammarParseError: parse_expr_from_string rejects expressions outside
         # the current numeric grammar; preserve the failed probe row.
@@ -3012,8 +3062,9 @@ def _build_z3_capability_matrix(mapping: Mapping[str, Any]) -> List[_JSON_OBJECT
     return rows
 
 
-
-def _python_alignment_cases(mapping: Mapping[str, Any], repo_root: Union[str, Path]) -> List[_JSON_OBJECT]:
+def _python_alignment_cases(
+    mapping: Mapping[str, Any], repo_root: Union[str, Path]
+) -> List[_JSON_OBJECT]:
     """
     Build Python baseline cases using the shared probe join fields.
 
@@ -3030,7 +3081,9 @@ def _python_alignment_cases(mapping: Mapping[str, Any], repo_root: Union[str, Pa
         >>> {'case_id', 'operator', 'fcstm_expression', 'render_path', 'render_expression'} <= set(cases[0])
         True
     """
-    renderer = StateMachineCodeRenderer(str(Path(repo_root).resolve() / "templates/python"))
+    renderer = StateMachineCodeRenderer(
+        str(Path(repo_root).resolve() / "templates/python")
+    )
     semantic_cases = [
         ("round", "round", "round(A)"),
         ("abs", "abs", "abs(A)"),
@@ -3572,12 +3625,12 @@ def validate_python_z3_baseline(payload: Mapping[str, Any]) -> List[str]:
             sign_expr = template_by_key.get(("python_expr", "sign(A)"), {})
             if sign_expr.get("rendered") != 'self._sign(self._vars["A"])':
                 errors.append(
-                    "python_expr sign(A) must render through self._sign(self._vars[\"A\"])"
+                    'python_expr sign(A) must render through self._sign(self._vars["A"])'
                 )
             sign_scope = template_by_key.get(("python_scope_expr", "sign(A)"), {})
             if sign_scope.get("rendered") != 'self._sign(scope["A"])':
                 errors.append(
-                    "python_scope_expr sign(A) must render through self._sign(scope[\"A\"])"
+                    'python_scope_expr sign(A) must render through self._sign(scope["A"])'
                 )
         statement_rendered = render_paths.get("statement_rendered_expressions")
         if not isinstance(statement_rendered, list) or not statement_rendered:
@@ -3596,7 +3649,7 @@ def validate_python_z3_baseline(payload: Mapping[str, Any]) -> List[str]:
             sign_rendered = sign_assignment.get("rendered")
             if not isinstance(sign_rendered, str) or '_s(_v["A"])' not in sign_rendered:
                 errors.append(
-                    "python_runtime sign(A) assignment must render through _s(_v[\"A\"])"
+                    'python_runtime sign(A) assignment must render through _s(_v["A"])'
                 )
             if not any(
                 isinstance(item, Mapping)
@@ -3640,7 +3693,9 @@ def validate_python_z3_baseline(payload: Mapping[str, Any]) -> List[str]:
             )
         else:
             round_by_input = {
-                item.get("input"): item for item in round_cases if isinstance(item, Mapping)
+                item.get("input"): item
+                for item in round_cases
+                if isinstance(item, Mapping)
             }
             for value, expected_python, expected_z3 in [
                 ("-2.5", -2, "-2"),
@@ -3691,7 +3746,9 @@ def validate_python_z3_baseline(payload: Mapping[str, Any]) -> List[str]:
             and item.get("python_value") == -4
             for item in shift_cases
         ):
-            errors.append("python_runtime_samples.shift_cases must include -8 >> 1 == -4")
+            errors.append(
+                "python_runtime_samples.shift_cases must include -8 >> 1 == -4"
+            )
 
     z3_samples = payload.get("z3_representative_samples")
     if not isinstance(z3_samples, Mapping):
@@ -3732,8 +3789,7 @@ def validate_python_z3_baseline(payload: Mapping[str, Any]) -> List[str]:
                     "Z3 Int division mismatch cases must include a Python true-division mismatch"
                 )
             if not any(
-                isinstance(item, Mapping)
-                and item.get("modulo_matches_python") is False
+                isinstance(item, Mapping) and item.get("modulo_matches_python") is False
                 for item in mismatch_cases
             ):
                 errors.append(
@@ -3745,7 +3801,9 @@ def validate_python_z3_baseline(payload: Mapping[str, Any]) -> List[str]:
         errors.append("z3_capability_matrix must be a non-empty array")
     else:
         rows_by_operator = {
-            item.get("fcstm_operator"): item for item in matrix if isinstance(item, Mapping)
+            item.get("fcstm_operator"): item
+            for item in matrix
+            if isinstance(item, Mapping)
         }
         operators = set(rows_by_operator)
         for required in ["round", "sign", "cbrt", "~", "/", "%"]:
@@ -3754,9 +3812,10 @@ def validate_python_z3_baseline(payload: Mapping[str, Any]) -> List[str]:
         division_row = rows_by_operator.get("/")
         if isinstance(division_row, Mapping):
             division_int = division_row.get("z3_support", {}).get("Int", {})
-            if isinstance(division_int, Mapping) and division_int.get(
-                "status"
-            ) == "exact":
+            if (
+                isinstance(division_int, Mapping)
+                and division_int.get("status") == "exact"
+            ):
                 errors.append(
                     "z3_capability_matrix '/' Int support must not be exact for Python true-division baseline"
                 )
@@ -4022,6 +4081,1347 @@ def check_python_z3_baseline(
         "snapshot_path": _PYTHON_Z3_BASELINE_SNAPSHOT,
     }
 
+
+def _alignment_render_paths(mapping: Mapping[str, Any]) -> List[RenderPath]:
+    """
+    Return all C-family render paths required by the alignment pilot.
+
+    :param mapping: Render-mapping snapshot.
+    :type mapping: Mapping[str, Any]
+    :return: C and C++ render paths, including C++ paths that reuse C
+        expression templates.
+    :rtype: List[RenderPath]
+
+    Example::
+
+        >>> mapping = _load_render_mapping(Path('.').resolve(), _DEFAULT_MAPPING_PATH)
+        >>> len(_alignment_render_paths(mapping)) >= 4
+        True
+    """
+    return _render_paths_for_mode("c-smoke", mapping) + _render_paths_for_mode(
+        "cpp-smoke", mapping
+    )
+
+
+def _c_family_smoke_facts(
+    mode: str,
+    repo_root: Union[str, Path] = ".",
+    mapping_path: Union[str, Path] = _DEFAULT_MAPPING_PATH,
+) -> _JSON_OBJECT:
+    """
+    Build deterministic C-family smoke facts without native compilation.
+
+    The digest produced from this payload is the schema-level smoke-fact input
+    for the C/C++ alignment snapshot. Live ``c-smoke`` and ``cpp-smoke`` runs
+    may still record compiler outcomes under ``results/local/``, but this
+    helper stays toolchain-independent so ``--check`` remains usable on hosts
+    without a native C or C++ compiler.
+
+    :param mode: Smoke mode, either ``"c-smoke"`` or ``"cpp-smoke"``.
+    :type mode: str
+    :param repo_root: Repository root path, defaults to the current directory.
+    :type repo_root: Union[str, pathlib.Path], optional
+    :param mapping_path: Render-mapping snapshot path.
+    :type mapping_path: Union[str, pathlib.Path], optional
+    :return: Deterministic smoke-fact payload.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> facts = _c_family_smoke_facts('c-smoke')
+        >>> facts['mode']
+        'c-smoke-facts'
+    """
+    root = _as_repo_path(repo_root)
+    mapping_file = _resolve_mapping_path(root, mapping_path)
+    mapping = _load_render_mapping(root, mapping_file)
+    render_paths = _render_paths_for_mode(mode, mapping)
+    cases = []
+    for render_path in render_paths:
+        for case in _risk_cases():
+            rendered = _render_case_expression(case, render_path)
+            cases.append(
+                {
+                    "case_id": "%s:%s" % (render_path.path_id, case.case_id),
+                    "semantic_case_id": case.case_id,
+                    "operator": case.operator,
+                    "fcstm_expression": case.fcstm_expression,
+                    "render_path": render_path.path_id,
+                    "render_expression": rendered,
+                    "mapping_sources": list(render_path.mapping_sources),
+                    "expects_undefined_behavior": case.expects_undefined_behavior,
+                }
+            )
+    return {
+        "schema_version": 1,
+        "mode": "%s-facts" % mode,
+        "source_mapping_sha256": mapping.get("mapping_sha256", ""),
+        "render_paths": [
+            {
+                "path_id": path.path_id,
+                "language": path.language,
+                "compile_language": path.compile_language,
+                "lang_style": path.lang_style,
+                "expression_core_language": path.expression_core_language,
+                "mapping_sources": list(path.mapping_sources),
+                "template_name": path.template_name,
+                "wrapper_language": path.wrapper_language,
+            }
+            for path in render_paths
+        ],
+        "cases": cases,
+    }
+
+
+def _render_contract_expression(
+    expr_text: str, render_path: RenderPath
+) -> _JSON_OBJECT:
+    """
+    Render one alignment expression for a C-family render path.
+
+    :param expr_text: FCSTM expression text.
+    :type expr_text: str
+    :param render_path: Render path used for target-language output.
+    :type render_path: RenderPath
+    :return: Render result with ``status`` and either ``rendered`` or error
+        metadata.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> mapping = _load_render_mapping(Path('.').resolve(), _DEFAULT_MAPPING_PATH)
+        >>> path = _render_paths_for_mode('c-smoke', mapping)[0]
+        >>> _render_contract_expression('A + B', path)['status']
+        'rendered'
+    """
+    from pyfcstm.render.expr import fn_expr_render
+    from pyfcstm.utils import to_c_identifier
+
+    env = add_settings_for_env(jinja2.Environment())
+    env.filters["to_c_identifier"] = to_c_identifier
+    env.globals["to_c_identifier"] = to_c_identifier
+    render = partial(
+        fn_expr_render, templates=dict(render_path.render_templates), env=env
+    )
+    env.globals["expr_render"] = render
+    env.filters["expr_render"] = render
+    try:
+        expr = parse_expr_from_string(expr_text, mode="generic")
+        rendered = render(node=expr.to_ast_node())
+    except GrammarParseError as err:
+        # GrammarParseError: current FCSTM grammar rejects this expression
+        # shape; PR-6A records that as an unsupported contract row.
+        return {
+            "status": "parse_failed",
+            "error_type": type(err).__name__,
+            "error": str(err),
+        }
+    except (ValueError, TypeError) as err:
+        # ValueError: expression conversion rejected the parsed tree; TypeError:
+        # renderer/template helpers rejected the AST. Both are alignment facts.
+        return {
+            "status": "render_failed",
+            "error_type": type(err).__name__,
+            "error": str(err),
+        }
+    return {
+        "status": "rendered",
+        "rendered": rendered,
+        "ast_type": type(expr.to_ast_node()).__name__,
+    }
+
+
+def _obligation(kind: str, predicate: str, trigger: str, evidence: str) -> _JSON_OBJECT:
+    """
+    Build one alignment obligation row.
+
+    :param kind: Stable obligation kind.
+    :type kind: str
+    :param predicate: Z3-oriented predicate or structured-text condition.
+    :type predicate: str
+    :param trigger: Scenario that requires the obligation.
+    :type trigger: str
+    :param evidence: Evidence note for the obligation.
+    :type evidence: str
+    :return: JSON-compatible obligation.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> _obligation('divisor_nonzero', 'B != 0', 'division', 'C rule')['kind']
+        'divisor_nonzero'
+    """
+    return {
+        "kind": kind,
+        "predicate": predicate,
+        "trigger": trigger,
+        "evidence": evidence,
+    }
+
+
+def _counterexample(
+    case_id: str,
+    values: Mapping[str, Any],
+    expected_issue: str,
+    reproduction: str,
+) -> _JSON_OBJECT:
+    """
+    Build one compact counterexample row.
+
+    :param case_id: Stable counterexample identifier.
+    :type case_id: str
+    :param values: Input values for the example.
+    :type values: Mapping[str, Any]
+    :param expected_issue: Issue demonstrated by the example.
+    :type expected_issue: str
+    :param reproduction: Short reproduction expression or command.
+    :type reproduction: str
+    :return: JSON-compatible counterexample.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> _counterexample('div0', {'B': 0}, 'division by zero', 'A / B')['case_id']
+        'div0'
+    """
+    return {
+        "case_id": case_id,
+        "values": dict(values),
+        "expected_issue": expected_issue,
+        "reproduction": reproduction,
+    }
+
+
+def _c_cpp_alignment_cases() -> List[_JSON_OBJECT]:
+    """
+    Return semantic cases covered by the C/C++ alignment pilot.
+
+    :return: Semantic case definitions.
+    :rtype: List[Dict[str, Any]]
+
+    Example::
+
+        >>> any(case['operator'] == '~' for case in _c_cpp_alignment_cases())
+        True
+    """
+    return [
+        {
+            "semantic_case_id": "add",
+            "operator": "+",
+            "operator_family": "binary_arithmetic",
+            "fcstm_expression": "A + B",
+        },
+        {
+            "semantic_case_id": "subtract",
+            "operator": "-",
+            "operator_family": "binary_arithmetic",
+            "fcstm_expression": "A - B",
+        },
+        {
+            "semantic_case_id": "multiply",
+            "operator": "*",
+            "operator_family": "binary_arithmetic",
+            "fcstm_expression": "A * B",
+        },
+        {
+            "semantic_case_id": "divide",
+            "operator": "/",
+            "operator_family": "binary_arithmetic",
+            "fcstm_expression": "A / B",
+        },
+        {
+            "semantic_case_id": "modulo",
+            "operator": "%",
+            "operator_family": "binary_arithmetic",
+            "fcstm_expression": "A % B",
+        },
+        {
+            "semantic_case_id": "unary_minus",
+            "operator": "unary-",
+            "operator_family": "unary_arithmetic",
+            "fcstm_expression": "-A",
+        },
+        {
+            "semantic_case_id": "bitwise_not",
+            "operator": "~",
+            "operator_family": "bitwise",
+            "fcstm_expression": "~A",
+        },
+        {
+            "semantic_case_id": "bitwise_and",
+            "operator": "&",
+            "operator_family": "bitwise",
+            "fcstm_expression": "A & B",
+        },
+        {
+            "semantic_case_id": "bitwise_or",
+            "operator": "|",
+            "operator_family": "bitwise",
+            "fcstm_expression": "A | B",
+        },
+        {
+            "semantic_case_id": "bitwise_xor",
+            "operator": "^",
+            "operator_family": "bitwise",
+            "fcstm_expression": "A ^ B",
+        },
+        {
+            "semantic_case_id": "shift_left",
+            "operator": "<<",
+            "operator_family": "shift",
+            "fcstm_expression": "A << B",
+        },
+        {
+            "semantic_case_id": "shift_right",
+            "operator": ">>",
+            "operator_family": "shift",
+            "fcstm_expression": "A >> B",
+        },
+        {
+            "semantic_case_id": "less_than",
+            "operator": "<",
+            "operator_family": "comparison",
+            "fcstm_expression": "A < B",
+        },
+        {
+            "semantic_case_id": "less_equal",
+            "operator": "<=",
+            "operator_family": "comparison",
+            "fcstm_expression": "A <= B",
+        },
+        {
+            "semantic_case_id": "greater_than",
+            "operator": ">",
+            "operator_family": "comparison",
+            "fcstm_expression": "A > B",
+        },
+        {
+            "semantic_case_id": "greater_equal",
+            "operator": ">=",
+            "operator_family": "comparison",
+            "fcstm_expression": "A >= B",
+        },
+        {
+            "semantic_case_id": "equal",
+            "operator": "==",
+            "operator_family": "comparison",
+            "fcstm_expression": "A == B",
+        },
+        {
+            "semantic_case_id": "not_equal",
+            "operator": "!=",
+            "operator_family": "comparison",
+            "fcstm_expression": "A != B",
+        },
+        {
+            "semantic_case_id": "pow",
+            "operator": "pow",
+            "operator_family": "math",
+            "fcstm_expression": "A ** B",
+        },
+        {
+            "semantic_case_id": "round",
+            "operator": "round",
+            "operator_family": "math",
+            "fcstm_expression": "round(A)",
+        },
+        {
+            "semantic_case_id": "abs",
+            "operator": "abs",
+            "operator_family": "math",
+            "fcstm_expression": "abs(A)",
+        },
+        {
+            "semantic_case_id": "sign",
+            "operator": "sign",
+            "operator_family": "math",
+            "fcstm_expression": "sign(A)",
+        },
+        {
+            "semantic_case_id": "cbrt",
+            "operator": "cbrt",
+            "operator_family": "math",
+            "fcstm_expression": "cbrt(A)",
+        },
+        {
+            "semantic_case_id": "integer_constant",
+            "operator": "integer_constant",
+            "operator_family": "constant",
+            "fcstm_expression": "42",
+        },
+        {
+            "semantic_case_id": "float_constant",
+            "operator": "float_constant",
+            "operator_family": "constant",
+            "fcstm_expression": "3.5",
+        },
+        {
+            "semantic_case_id": "narrowing_writeback",
+            "operator": "writeback",
+            "operator_family": "writeback",
+            "fcstm_expression": "A ** B",
+        },
+    ]
+
+
+def _contract_common_evidence(
+    render_path: RenderPath, render_result: Mapping[str, Any]
+) -> List[_JSON_OBJECT]:
+    """
+    Build common evidence entries for one alignment row.
+
+    :param render_path: Render path represented by the row.
+    :type render_path: RenderPath
+    :param render_result: Render result for the row expression.
+    :type render_result: Mapping[str, Any]
+    :return: Evidence entries.
+    :rtype: List[Dict[str, Any]]
+
+    Example::
+
+        >>> mapping = _load_render_mapping(Path('.').resolve(), _DEFAULT_MAPPING_PATH)
+        >>> path = _render_paths_for_mode('c-smoke', mapping)[0]
+        >>> bool(_contract_common_evidence(path, {'status': 'rendered'}))
+        True
+    """
+    evidence = [
+        {
+            "kind": "render_mapping",
+            "source": source,
+            "summary": "Render path source recorded in render_mapping.json.",
+        }
+        for source in render_path.mapping_sources
+    ]
+    evidence.append(
+        {
+            "kind": "render_result",
+            "source": render_path.path_id,
+            "summary": "Expression render status is %s." % render_result.get("status"),
+        }
+    )
+    return evidence
+
+
+def _alignment_semantics_for_case(
+    case: Mapping[str, str], render_path: RenderPath, render_result: Mapping[str, Any]
+) -> _JSON_OBJECT:
+    """
+    Build semantic fields for one C/C++ alignment contract row.
+
+    :param case: Semantic case definition.
+    :type case: Mapping[str, str]
+    :param render_path: Render path represented by the row.
+    :type render_path: RenderPath
+    :param render_result: Render result for the row expression.
+    :type render_result: Mapping[str, Any]
+    :return: Semantic fields merged into the contract row.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> mapping = _load_render_mapping(Path('.').resolve(), _DEFAULT_MAPPING_PATH)
+        >>> path = _render_paths_for_mode('c-smoke', mapping)[0]
+        >>> data = _alignment_semantics_for_case(_c_cpp_alignment_cases()[0], path, {'status': 'rendered'})
+        >>> data['outcome']
+        'exact_with_obligations'
+    """
+    operator_name = case["operator"]
+    family = case["operator_family"]
+    language_prefix = "C++" if render_path.language == "cpp" else "C"
+    if render_result.get("status") != "rendered":
+        return {
+            "target_semantics": (
+                "Current FCSTM parser or renderer rejects this expression before "
+                "target-language semantics apply."
+            ),
+            "definedness": "unsupported_by_current_fcstm_grammar_or_renderer",
+            "z3_sort": "unsupported",
+            "z3_profile": "unsupported",
+            "value_expr": "unsupported",
+            "obligations": [],
+            "outcome": "unsupported",
+            "counterexamples": [
+                _counterexample(
+                    "%s:%s:parse" % (render_path.path_id, case["semantic_case_id"]),
+                    {"expression": case["fcstm_expression"]},
+                    str(render_result.get("error_type", "render_failed")),
+                    case["fcstm_expression"],
+                )
+            ],
+        }
+
+    if family == "comparison":
+        return {
+            "target_semantics": "%s relational comparison over promoted operands."
+            % language_prefix,
+            "definedness": "defined_if_operand_evaluation_is_defined",
+            "z3_sort": "Bool",
+            "z3_profile": "signed-fixed-width-candidate:int64",
+            "value_expr": "signed_bv_compare(%s, A, B)" % operator_name,
+            "obligations": [],
+            "outcome": "exact",
+            "counterexamples": [],
+        }
+    if family == "constant":
+        z3_sort = "BitVec(64)" if operator_name == "integer_constant" else "FP64"
+        z3_profile = (
+            "signed-fixed-width-candidate:int64"
+            if operator_name == "integer_constant"
+            else "float-double"
+        )
+        return {
+            "target_semantics": "%s literal rendering for %s."
+            % (language_prefix, operator_name),
+            "definedness": "defined",
+            "z3_sort": z3_sort,
+            "z3_profile": z3_profile,
+            "value_expr": "literal(%s)" % case["fcstm_expression"],
+            "obligations": [],
+            "outcome": "exact",
+            "counterexamples": [],
+        }
+    if family == "writeback":
+        return {
+            "target_semantics": (
+                "%s assignment of an expression result back into a generated "
+                "signed integer storage slot."
+            )
+            % language_prefix,
+            "definedness": "defined_if_source_expression_and_conversion_are_defined",
+            "z3_sort": "BitVec(64)",
+            "z3_profile": "promotion-and-writeback:int64",
+            "value_expr": "writeback_int64(value_expr(A ** B))",
+            "obligations": [
+                _obligation(
+                    "source_expression_defined",
+                    "all source expression obligations hold",
+                    "writeback source evaluation",
+                    "PR-6A alignment contract composes source expression obligations before writeback.",
+                ),
+                _obligation(
+                    "representable_in_target_width",
+                    "INT64_MIN <= mathematical_result <= INT64_MAX",
+                    "integer writeback",
+                    "C/C++ conversion to a signed integer target must not rely on out-of-range behavior.",
+                ),
+            ],
+            "outcome": "exact_with_obligations",
+            "counterexamples": [
+                _counterexample(
+                    "%s:writeback:pow-overflow" % render_path.path_id,
+                    {"A": 2, "B": 63, "target": "int64"},
+                    "mathematical result is outside signed 64-bit writeback range",
+                    "A ** B",
+                )
+            ],
+        }
+    if operator_name == "sign":
+        return {
+            "target_semantics": (
+                "%s render path currently emits a sign function call but C and "
+                "standard C++ do not provide a portable unary sign math function."
+            )
+            % language_prefix,
+            "definedness": "not_defined_by_portable_c_family_library",
+            "z3_sort": "unsupported",
+            "z3_profile": "math-library-availability",
+            "value_expr": "unsupported",
+            "obligations": [],
+            "outcome": "compile_failed",
+            "counterexamples": [
+                _counterexample(
+                    "%s:sign:compile" % render_path.path_id,
+                    {"A": -9},
+                    "portable C/C++ sign function is unavailable",
+                    str(render_result.get("rendered", "sign(A)")),
+                )
+            ],
+        }
+    if operator_name == "abs":
+        return {
+            "target_semantics": "%s absolute-value call selected by the render path."
+            % language_prefix,
+            "definedness": "profile_dependent_overload_and_min_value",
+            "z3_sort": "BitVec(64)",
+            "z3_profile": "math-overload-and-writeback:int64",
+            "value_expr": "if signed(A) < 0 then -A else A",
+            "obligations": [
+                _obligation(
+                    "abs_overload_matches_operand_width",
+                    "selected abs overload preserves the operand width",
+                    "math overload resolution",
+                    "C render paths may emit abs(A), which is not width-neutral for int64 operands.",
+                ),
+                _obligation(
+                    "no_abs_min",
+                    "A != INT_MIN(width)",
+                    "absolute value of signed minimum",
+                    "The negated signed minimum is not representable in the same signed width.",
+                ),
+            ],
+            "outcome": "profile_dependent",
+            "counterexamples": [
+                _counterexample(
+                    "%s:abs:min" % render_path.path_id,
+                    {"A": -128, "width": 8},
+                    "abs(INT_MIN) is not representable in the same signed width",
+                    str(render_result.get("rendered", "abs(A)")),
+                )
+            ],
+        }
+    if operator_name in {"pow", "round", "cbrt"}:
+        function_name = {"pow": "pow", "round": "round", "cbrt": "cbrt"}[operator_name]
+        return {
+            "target_semantics": "%s math-library %s evaluation."
+            % (language_prefix, function_name),
+            "definedness": "defined_if_math_result_is_supported_and_writeback_is_defined",
+            "z3_sort": "FP64",
+            "z3_profile": "float-double-math",
+            "value_expr": "%s_fp64(%s)" % (function_name, case["fcstm_expression"]),
+            "obligations": [
+                _obligation(
+                    "math_function_available",
+                    "%s is available in the selected language standard/library"
+                    % function_name,
+                    "math function call",
+                    "C-family smoke probes record compile/link facts for math functions.",
+                ),
+                _obligation(
+                    "finite_float_result",
+                    "isFinite(result)",
+                    "floating-point math result",
+                    "Later writeback or solver profiles must not silently collapse NaN or infinity.",
+                ),
+            ],
+            "outcome": "exact_with_obligations",
+            "counterexamples": [],
+        }
+    if operator_name in {"+", "-", "*"} or operator_name == "unary-":
+        predicate = (
+            "no_signed_overflow(%s)" % case["fcstm_expression"]
+            if operator_name != "unary-"
+            else "A != INT_MIN(width)"
+        )
+        return {
+            "target_semantics": "%s signed integer arithmetic over promoted operands."
+            % language_prefix,
+            "definedness": "defined_if_no_signed_overflow",
+            "z3_sort": "BitVec(64)",
+            "z3_profile": "signed-fixed-width-candidate:int64",
+            "value_expr": "signed_bv_%s(%s)"
+            % (case["semantic_case_id"], case["fcstm_expression"]),
+            "obligations": [
+                _obligation(
+                    "no_signed_overflow",
+                    predicate,
+                    "signed arithmetic",
+                    "BitVec wrap is only a candidate value; C/C++ signed overflow is not defined behavior.",
+                )
+            ],
+            "outcome": "exact_with_obligations",
+            "counterexamples": [
+                _counterexample(
+                    "%s:%s:overflow" % (render_path.path_id, case["semantic_case_id"]),
+                    {"A": 127, "B": 1, "width": 8},
+                    "signed overflow would be required to match BitVec wrap",
+                    case["fcstm_expression"],
+                )
+            ],
+        }
+    if operator_name in {"/", "%"}:
+        return {
+            "target_semantics": "%s signed integer %s over promoted operands."
+            % (language_prefix, "division" if operator_name == "/" else "remainder"),
+            "definedness": "defined_if_divisor_nonzero_and_min_div_minus_one_absent",
+            "z3_sort": "BitVec(64)",
+            "z3_profile": "signed-fixed-width-candidate:int64",
+            "value_expr": ("bvsdiv(A, B)" if operator_name == "/" else "bvsrem(A, B)"),
+            "obligations": [
+                _obligation(
+                    "divisor_nonzero",
+                    "B != 0",
+                    "division or remainder",
+                    "Division by zero is not a defined C/C++ integer operation.",
+                ),
+                _obligation(
+                    "no_min_div_minus_one",
+                    "not (A == INT_MIN(width) and B == -1)",
+                    "signed division or remainder",
+                    "The signed minimum divided by -1 is not representable.",
+                ),
+            ],
+            "outcome": "exact_with_obligations",
+            "counterexamples": [
+                _counterexample(
+                    "%s:%s:div-zero" % (render_path.path_id, case["semantic_case_id"]),
+                    {"A": 7, "B": 0},
+                    "division by zero",
+                    case["fcstm_expression"],
+                ),
+                _counterexample(
+                    "%s:%s:min-div-minus-one"
+                    % (render_path.path_id, case["semantic_case_id"]),
+                    {"A": -128, "B": -1, "width": 8},
+                    "signed minimum divided by -1",
+                    case["fcstm_expression"],
+                ),
+            ],
+        }
+    if family == "shift":
+        obligations = [
+            _obligation(
+                "valid_shift_count",
+                "B < width",
+                "shift count",
+                "C/C++ shifts require a count smaller than the promoted operand width.",
+            ),
+            _obligation(
+                "non_negative_shift_count",
+                "B >= 0",
+                "shift count",
+                "C/C++ shifts do not define negative shift counts.",
+            ),
+        ]
+        if operator_name == "<<":
+            obligations.append(
+                _obligation(
+                    "no_signed_left_shift_ub",
+                    "A >= 0 and left_shift_result_representable(A, B, width)",
+                    "signed left shift",
+                    "Signed left shift has additional definedness constraints beyond BitVec shift.",
+                )
+            )
+            outcome = "exact_with_obligations"
+            value_expr = "bvshl(A, B)"
+            counterexamples = [
+                _counterexample(
+                    "%s:shift-left:negative" % render_path.path_id,
+                    {"A": -1, "B": 1, "width": 8},
+                    "signed left shift of a negative value is not a portable defined operation",
+                    case["fcstm_expression"],
+                )
+            ]
+        else:
+            obligations.append(
+                _obligation(
+                    "signed_right_shift_profile",
+                    "profile selects arithmetic or logical right shift for negative lhs",
+                    "signed right shift",
+                    "Right shift of a negative signed value is implementation-defined/profile-dependent.",
+                )
+            )
+            outcome = "profile_dependent"
+            value_expr = "bvashr(A, B) under arithmetic-shift profile"
+            counterexamples = [
+                _counterexample(
+                    "%s:shift-right:negative" % render_path.path_id,
+                    {"A": -8, "B": 1, "width": 8},
+                    "negative signed right shift depends on implementation profile",
+                    case["fcstm_expression"],
+                )
+            ]
+        return {
+            "target_semantics": "%s signed integer shift." % language_prefix,
+            "definedness": "defined_if_shift_obligations_hold",
+            "z3_sort": "BitVec(64)",
+            "z3_profile": "signed-fixed-width-candidate:int64",
+            "value_expr": value_expr,
+            "obligations": obligations,
+            "outcome": outcome,
+            "counterexamples": counterexamples,
+        }
+    if family == "bitwise":
+        return {
+            "target_semantics": "%s signed integer bitwise operation."
+            % language_prefix,
+            "definedness": "profile_dependent_for_negative_signed_representation",
+            "z3_sort": "BitVec(64)",
+            "z3_profile": "signed-fixed-width-candidate:int64",
+            "value_expr": "bv%s(A, B)"
+            % {"&": "and", "|": "or", "^": "xor"}.get(operator_name, "not"),
+            "obligations": [
+                _obligation(
+                    "two_complement_representation_profile",
+                    "profile fixes signed representation as two's complement",
+                    "signed bitwise operation",
+                    "BitVec bitwise operations model representation bits, so signed representation is part of the profile.",
+                )
+            ],
+            "outcome": "profile_dependent",
+            "counterexamples": [
+                _counterexample(
+                    "%s:%s:negative-representation"
+                    % (render_path.path_id, case["semantic_case_id"]),
+                    {"A": -1, "B": 1},
+                    "negative signed operand requires an explicit representation profile",
+                    case["fcstm_expression"],
+                )
+            ],
+        }
+    return {
+        "target_semantics": "%s target semantics not classified yet." % language_prefix,
+        "definedness": "unsupported",
+        "z3_sort": "unsupported",
+        "z3_profile": "unsupported",
+        "value_expr": "unsupported",
+        "obligations": [],
+        "outcome": "unsupported",
+        "counterexamples": [
+            _counterexample(
+                "%s:%s:unclassified" % (render_path.path_id, case["semantic_case_id"]),
+                {},
+                "alignment case is not classified",
+                case["fcstm_expression"],
+            )
+        ],
+    }
+
+
+def _build_c_cpp_alignment_contracts(mapping: Mapping[str, Any]) -> List[_JSON_OBJECT]:
+    """
+    Build C/C++ alignment contract rows from mapping render paths.
+
+    :param mapping: Render-mapping snapshot.
+    :type mapping: Mapping[str, Any]
+    :return: Alignment contract rows.
+    :rtype: List[Dict[str, Any]]
+
+    Example::
+
+        >>> mapping = _load_render_mapping(Path('.').resolve(), _DEFAULT_MAPPING_PATH)
+        >>> contracts = _build_c_cpp_alignment_contracts(mapping)
+        >>> bool(contracts)
+        True
+    """
+    contracts = []
+    for render_path in _alignment_render_paths(mapping):
+        for case in _c_cpp_alignment_cases():
+            render_result = _render_contract_expression(
+                case["fcstm_expression"], render_path
+            )
+            semantics = _alignment_semantics_for_case(case, render_path, render_result)
+            rendered = render_result.get("rendered")
+            contracts.append(
+                {
+                    "contract_id": "%s:%s"
+                    % (render_path.path_id, case["semantic_case_id"]),
+                    "semantic_case_id": case["semantic_case_id"],
+                    "render_path": render_path.path_id,
+                    "language": render_path.language,
+                    "compile_language": render_path.compile_language,
+                    "mapping_sources": list(render_path.mapping_sources),
+                    "operator": case["operator"],
+                    "operator_family": case["operator_family"],
+                    "fcstm_expression": case["fcstm_expression"],
+                    "render_expression": rendered if isinstance(rendered, str) else "",
+                    "render_status": render_result.get("status", "unknown"),
+                    "target_semantics": semantics["target_semantics"],
+                    "definedness": semantics["definedness"],
+                    "z3_sort": semantics["z3_sort"],
+                    "z3_profile": semantics["z3_profile"],
+                    "value_expr": semantics["value_expr"],
+                    "obligations": semantics["obligations"],
+                    "outcome": semantics["outcome"],
+                    "evidence": _contract_common_evidence(render_path, render_result)
+                    + [
+                        {
+                            "kind": "contract_semantics",
+                            "source": case["semantic_case_id"],
+                            "summary": semantics["target_semantics"],
+                        }
+                    ],
+                    "counterexamples": semantics["counterexamples"],
+                }
+            )
+    return contracts
+
+
+def _load_python_z3_baseline_snapshot(repo_root: Path) -> _JSON_OBJECT:
+    """
+    Load the committed Python/Z3 baseline snapshot.
+
+    :param repo_root: Repository root.
+    :type repo_root: pathlib.Path
+    :return: Parsed Python/Z3 baseline snapshot.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> baseline = _load_python_z3_baseline_snapshot(Path('.').resolve())
+        >>> baseline['mode']
+        'python-z3-baseline'
+    """
+    return _read_json(repo_root / _PYTHON_Z3_BASELINE_SNAPSHOT)
+
+
+def build_c_cpp_z3_alignment(
+    repo_root: Union[str, Path] = ".",
+    mapping_path: Union[str, Path] = _DEFAULT_MAPPING_PATH,
+) -> _JSON_OBJECT:
+    """
+    Build the C/C++ to Z3 alignment contract snapshot.
+
+    :param repo_root: Repository root path, defaults to the current directory.
+    :type repo_root: Union[str, pathlib.Path], optional
+    :param mapping_path: Render-mapping snapshot path, defaults to the committed
+        R0 snapshot.
+    :type mapping_path: Union[str, pathlib.Path], optional
+    :return: JSON-compatible C/C++ alignment payload.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> alignment = build_c_cpp_z3_alignment('.')
+        >>> alignment['mode']
+        'c-cpp-z3-alignment'
+    """
+    root = _as_repo_path(repo_root)
+    mapping_file = _resolve_mapping_path(root, mapping_path)
+    mapping = _load_render_mapping(root, mapping_file)
+    mapping_sha = mapping.get("mapping_sha256")
+    if not isinstance(mapping_sha, str):
+        mapping_sha = ""
+    python_baseline = _load_python_z3_baseline_snapshot(root)
+    python_baseline_sha = _payload_sha256(_baseline_comparison_payload(python_baseline))
+    c_facts = _c_family_smoke_facts("c-smoke", root, mapping_file)
+    cpp_facts = _c_family_smoke_facts("cpp-smoke", root, mapping_file)
+    contracts = _build_c_cpp_alignment_contracts(mapping)
+    return {
+        "schema_version": 1,
+        "mode": "c-cpp-z3-alignment",
+        "languages": ["c", "cpp"],
+        "source_mapping_sha256": mapping_sha,
+        "render_mapping_sha256": mapping_sha,
+        "python_z3_baseline_sha256": python_baseline_sha,
+        "c_smoke_facts_sha256": _payload_sha256(c_facts),
+        "cpp_smoke_facts_sha256": _payload_sha256(cpp_facts),
+        "generator": {
+            "tool": "tools/numeric_render_probe.py",
+            "research_path": _RESEARCH_PATH,
+            "source_commit": _git_commit(root),
+            "source_commit_policy": "Best-effort commit at generation time; mapping, baseline and smoke fact digests are the stable comparison keys.",
+            "determinism": "No native compiler output, wall-clock timestamp or solver model value is stored in the committed alignment snapshot.",
+        },
+        "repository": {
+            "root": ".",
+            "render_mapping_snapshot": mapping_file.relative_to(root).as_posix(),
+            "python_z3_baseline_snapshot": _PYTHON_Z3_BASELINE_SNAPSHOT,
+            "schema_path": _C_CPP_Z3_ALIGNMENT_SCHEMA,
+        },
+        "contract_fields": {
+            "core_triple": ["value_expr", "obligations", "outcome"],
+            "required_fields": [
+                "render_path",
+                "operator",
+                "operator_family",
+                "fcstm_expression",
+                "target_semantics",
+                "definedness",
+                "z3_sort",
+                "z3_profile",
+                "value_expr",
+                "obligations",
+                "outcome",
+                "evidence",
+            ],
+            "outcome_enum": sorted(_C_CPP_ALIGNMENT_OUTCOMES),
+            "shift_obligation_kinds": sorted(
+                _C_CPP_ALIGNMENT_REQUIRED_SHIFT_OBLIGATIONS
+            ),
+        },
+        "render_paths": [
+            {
+                "path_id": path.path_id,
+                "language": path.language,
+                "compile_language": path.compile_language,
+                "lang_style": path.lang_style,
+                "expression_core_language": path.expression_core_language,
+                "mapping_sources": list(path.mapping_sources),
+                "template_name": path.template_name,
+                "wrapper_language": path.wrapper_language,
+            }
+            for path in _alignment_render_paths(mapping)
+        ],
+        "coverage": {
+            "operators": sorted({contract["operator"] for contract in contracts}),
+            "operator_families": sorted(
+                {contract["operator_family"] for contract in contracts}
+            ),
+            "render_paths": sorted({contract["render_path"] for contract in contracts}),
+            "note": "Each semantic case is expanded across all C-family render paths; unsupported parser/render cases remain explicit contract rows.",
+        },
+        "contracts": contracts,
+        "representative_notes": [
+            {
+                "topic": "bitvec-is-candidate-not-definedness",
+                "summary": "BitVec expressions describe candidate values only; C/C++ signed overflow, invalid shifts and division traps stay in obligations or non-exact outcomes.",
+            },
+            {
+                "topic": "cxx-render-path-split",
+                "summary": "The snapshot keeps builtin _CPP_STYLE separate from C++ templates that reuse C expression templates via base_lang: c.",
+            },
+            {
+                "topic": "toolchain-independent-check",
+                "summary": "The committed snapshot uses deterministic render and smoke facts; live native smoke output belongs in results/local/.",
+            },
+        ],
+    }
+
+
+def _validate_alignment_obligation(
+    obligation: Mapping[str, Any], path: str
+) -> List[str]:
+    """
+    Validate one C/C++ alignment obligation row.
+
+    :param obligation: Obligation payload.
+    :type obligation: Mapping[str, Any]
+    :param path: Diagnostic path.
+    :type path: str
+    :return: Validation diagnostics.
+    :rtype: List[str]
+
+    Example::
+
+        >>> _validate_alignment_obligation({'kind': 'x'}, 'o')[:1]
+        ['o.predicate must be a non-empty string']
+    """
+    errors = []
+    for key in ["kind", "predicate", "trigger", "evidence"]:
+        if not isinstance(obligation.get(key), str) or not obligation.get(key):
+            errors.append("%s.%s must be a non-empty string" % (path, key))
+    return errors
+
+
+def validate_c_cpp_z3_alignment(payload: Mapping[str, Any]) -> List[str]:
+    """
+    Validate the C/C++ to Z3 alignment contract.
+
+    :param payload: Alignment payload.
+    :type payload: Mapping[str, Any]
+    :return: Human-readable diagnostics.
+    :rtype: List[str]
+
+    Example::
+
+        >>> validate_c_cpp_z3_alignment({'schema_version': 1})[:2]
+        ['mode must be c-cpp-z3-alignment', 'languages must be [\"c\", \"cpp\"]']
+    """
+    errors: List[str] = []
+    if payload.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+    if payload.get("mode") != "c-cpp-z3-alignment":
+        errors.append("mode must be c-cpp-z3-alignment")
+    if payload.get("languages") != ["c", "cpp"]:
+        errors.append('languages must be ["c", "cpp"]')
+    for key in [
+        "source_mapping_sha256",
+        "render_mapping_sha256",
+        "python_z3_baseline_sha256",
+        "c_smoke_facts_sha256",
+        "cpp_smoke_facts_sha256",
+    ]:
+        value = payload.get(key)
+        if (
+            not isinstance(value, str)
+            or len(value) != 64
+            or any(ch not in "0123456789abcdef" for ch in value)
+        ):
+            errors.append("%s must be a lowercase 64-character sha256 hex string" % key)
+    if payload.get("source_mapping_sha256") != payload.get("render_mapping_sha256"):
+        errors.append("source_mapping_sha256 and render_mapping_sha256 must match")
+
+    fields = payload.get("contract_fields")
+    if not isinstance(fields, Mapping):
+        errors.append("contract_fields must be a mapping")
+    else:
+        if fields.get("core_triple") != ["value_expr", "obligations", "outcome"]:
+            errors.append("contract_fields.core_triple must name the core triple")
+        if set(fields.get("outcome_enum", [])) != _C_CPP_ALIGNMENT_OUTCOMES:
+            errors.append(
+                "contract_fields.outcome_enum must match the closed outcome enum"
+            )
+        if set(fields.get("shift_obligation_kinds", [])) != (
+            _C_CPP_ALIGNMENT_REQUIRED_SHIFT_OBLIGATIONS
+        ):
+            errors.append(
+                "contract_fields.shift_obligation_kinds must match required shift obligations"
+            )
+
+    render_paths = payload.get("render_paths")
+    if not isinstance(render_paths, list) or not render_paths:
+        errors.append("render_paths must be a non-empty array")
+    else:
+        render_path_ids = {
+            item.get("path_id") for item in render_paths if isinstance(item, Mapping)
+        }
+        for path_id in _C_CPP_ALIGNMENT_RENDER_PATHS:
+            if path_id not in render_path_ids:
+                errors.append("render_paths missing %s" % path_id)
+
+    contracts = payload.get("contracts")
+    if not isinstance(contracts, list) or not contracts:
+        errors.append("contracts must be a non-empty array")
+        return errors
+
+    required_contract_keys = {
+        "contract_id",
+        "semantic_case_id",
+        "render_path",
+        "operator",
+        "operator_family",
+        "fcstm_expression",
+        "render_expression",
+        "render_status",
+        "target_semantics",
+        "definedness",
+        "z3_sort",
+        "z3_profile",
+        "value_expr",
+        "obligations",
+        "outcome",
+        "evidence",
+        "counterexamples",
+    }
+    operators = set()
+    families = set()
+    contract_render_paths = set()
+    shift_obligations = set()
+    for index, contract in enumerate(contracts):
+        path = "contracts[%d]" % index
+        if not isinstance(contract, Mapping):
+            errors.append("%s must be a mapping" % path)
+            continue
+        missing = sorted(required_contract_keys - set(contract))
+        if missing:
+            errors.append("%s missing required key %s" % (path, missing[0]))
+            continue
+        operators.add(contract.get("operator"))
+        families.add(contract.get("operator_family"))
+        contract_render_paths.add(contract.get("render_path"))
+        if contract.get("outcome") not in _C_CPP_ALIGNMENT_OUTCOMES:
+            errors.append(
+                "%s.outcome has invalid value %r" % (path, contract.get("outcome"))
+            )
+        for key in [
+            "contract_id",
+            "semantic_case_id",
+            "render_path",
+            "operator",
+            "operator_family",
+            "fcstm_expression",
+            "target_semantics",
+            "definedness",
+            "z3_sort",
+            "z3_profile",
+            "value_expr",
+        ]:
+            if not isinstance(contract.get(key), str) or not contract.get(key):
+                errors.append("%s.%s must be a non-empty string" % (path, key))
+        obligations = contract.get("obligations")
+        if not isinstance(obligations, list):
+            errors.append("%s.obligations must be an array" % path)
+        else:
+            for obligation_index, obligation in enumerate(obligations):
+                if not isinstance(obligation, Mapping):
+                    errors.append(
+                        "%s.obligations[%d] must be a mapping"
+                        % (path, obligation_index)
+                    )
+                    continue
+                shift_obligations.add(obligation.get("kind"))
+                errors.extend(
+                    _validate_alignment_obligation(
+                        obligation, "%s.obligations[%d]" % (path, obligation_index)
+                    )
+                )
+        evidence = contract.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            errors.append("%s.evidence must be a non-empty array" % path)
+        counterexamples = contract.get("counterexamples")
+        if not isinstance(counterexamples, list):
+            errors.append("%s.counterexamples must be an array" % path)
+        elif (
+            contract.get("outcome")
+            in {
+                "profile_dependent",
+                "unsupported",
+                "compile_failed",
+                "runtime_trap",
+                "ub",
+            }
+            and not counterexamples
+        ):
+            errors.append(
+                "%s.%s outcome must include a counterexample"
+                % (path, contract.get("outcome"))
+            )
+
+    required_operators = {
+        "+",
+        "-",
+        "*",
+        "/",
+        "%",
+        "unary-",
+        "~",
+        "&",
+        "|",
+        "^",
+        "<<",
+        ">>",
+        "<",
+        "<=",
+        ">",
+        ">=",
+        "==",
+        "!=",
+        "pow",
+        "round",
+        "abs",
+        "sign",
+        "cbrt",
+        "integer_constant",
+        "float_constant",
+        "writeback",
+    }
+    for operator_name in sorted(required_operators - operators):
+        errors.append("contracts missing operator %s" % operator_name)
+    for family_name in [
+        "binary_arithmetic",
+        "unary_arithmetic",
+        "bitwise",
+        "shift",
+        "comparison",
+        "math",
+        "constant",
+        "writeback",
+    ]:
+        if family_name not in families:
+            errors.append("contracts missing operator_family %s" % family_name)
+    for path_id in _C_CPP_ALIGNMENT_RENDER_PATHS:
+        if path_id not in contract_render_paths:
+            errors.append("contracts missing render_path %s" % path_id)
+    if not _C_CPP_ALIGNMENT_REQUIRED_SHIFT_OBLIGATIONS <= shift_obligations:
+        missing = sorted(
+            _C_CPP_ALIGNMENT_REQUIRED_SHIFT_OBLIGATIONS - shift_obligations
+        )
+        errors.append("shift obligations missing: %s" % ", ".join(missing))
+    return errors
+
+
+def _c_cpp_alignment_comparison_payload(payload: Mapping[str, Any]) -> _JSON_OBJECT:
+    """
+    Return a deterministic comparison view of an alignment payload.
+
+    :param payload: Alignment payload.
+    :type payload: Mapping[str, Any]
+    :return: Payload with volatile provenance fields normalized.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> _c_cpp_alignment_comparison_payload({'generator': {'source_commit': 'x'}})['generator']['source_commit']
+        '<ignored>'
+    """
+    comparable = json.loads(_stable_json(payload))
+    generator = comparable.get("generator")
+    if isinstance(generator, dict):
+        generator["source_commit"] = "<ignored>"
+    repository = comparable.get("repository")
+    if isinstance(repository, dict):
+        repository["render_mapping_snapshot"] = _DEFAULT_MAPPING_PATH
+    return comparable
+
+
+def check_c_cpp_z3_alignment(
+    repo_root: Union[str, Path] = ".",
+    mapping_path: Union[str, Path] = _DEFAULT_MAPPING_PATH,
+) -> _JSON_OBJECT:
+    """
+    Build and validate the committed C/C++ to Z3 alignment snapshot.
+
+    :param repo_root: Repository root path, defaults to the current directory.
+    :type repo_root: Union[str, pathlib.Path], optional
+    :param mapping_path: Render-mapping snapshot path checked against live drift,
+        defaults to the committed R0 snapshot.
+    :type mapping_path: Union[str, pathlib.Path], optional
+    :return: Check result with ``ok`` and ``errors`` fields.
+    :rtype: Dict[str, Any]
+
+    Example::
+
+        >>> result = check_c_cpp_z3_alignment('.')
+        >>> isinstance(result['ok'], bool)
+        True
+    """
+    root = _as_repo_path(repo_root)
+    live = build_c_cpp_z3_alignment(root, mapping_path=mapping_path)
+    errors = [
+        "live alignment: %s" % error for error in validate_c_cpp_z3_alignment(live)
+    ]
+    live_mapping = build_render_mapping(root)
+    live_mapping_sha = live_mapping.get("mapping_sha256")
+    if live_mapping_sha != live.get("source_mapping_sha256"):
+        errors.append(
+            "render_mapping snapshot drift: snapshot %r does not match live %r"
+            % (live.get("source_mapping_sha256"), live_mapping_sha)
+        )
+    schema = None
+    schema_path = root / _C_CPP_Z3_ALIGNMENT_SCHEMA
+    try:
+        schema = _read_json(schema_path)
+    except (OSError, json.JSONDecodeError, ValueError) as err:
+        # OSError: schema cannot be read; JSONDecodeError: invalid JSON;
+        # ValueError: top-level schema JSON is not an object.
+        errors.append("schema cannot be loaded: %s" % err)
+    if schema is not None:
+        errors.extend(
+            "live schema: %s" % error
+            for error in _validate_payload_with_schema(live, schema)
+        )
+    snapshot_path = root / _C_CPP_Z3_ALIGNMENT_SNAPSHOT
+    snapshot_present = snapshot_path.is_file()
+    if not snapshot_present:
+        errors.append("expected snapshot is missing: %s" % snapshot_path)
+    else:
+        try:
+            snapshot = _read_json(snapshot_path)
+        except (OSError, json.JSONDecodeError, ValueError) as err:
+            # OSError: snapshot cannot be read; JSONDecodeError: invalid JSON;
+            # ValueError: top-level JSON is not an object.
+            errors.append("snapshot cannot be loaded: %s" % err)
+        else:
+            errors.extend(
+                "snapshot: %s" % error
+                for error in validate_c_cpp_z3_alignment(snapshot)
+            )
+            if schema is not None:
+                errors.extend(
+                    "snapshot schema: %s" % error
+                    for error in _validate_payload_with_schema(snapshot, schema)
+                )
+            snapshot_difference = _first_baseline_difference(
+                _c_cpp_alignment_comparison_payload(live),
+                _c_cpp_alignment_comparison_payload(snapshot),
+            )
+            if snapshot_difference:
+                errors.append(
+                    "snapshot does not match live alignment: %s" % snapshot_difference
+                )
+    return {
+        "ok": not errors,
+        "errors": errors,
+        "schema_version": live["schema_version"],
+        "source_mapping_sha256": live["source_mapping_sha256"],
+        "python_z3_baseline_sha256": live["python_z3_baseline_sha256"],
+        "c_smoke_facts_sha256": live["c_smoke_facts_sha256"],
+        "cpp_smoke_facts_sha256": live["cpp_smoke_facts_sha256"],
+        "snapshot_present": snapshot_present,
+        "snapshot_path": _C_CPP_Z3_ALIGNMENT_SNAPSHOT,
+    }
+
+
 def _build_arg_parser() -> argparse.ArgumentParser:
     """
     Build the probe command-line argument parser.
@@ -4043,11 +5443,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "mode",
         nargs="?",
         default="env",
-        choices=["env", "c-smoke", "cpp-smoke", "python-z3-baseline"],
+        choices=[
+            "env",
+            "c-smoke",
+            "cpp-smoke",
+            "python-z3-baseline",
+            "c-cpp-z3-alignment",
+        ],
         help=(
             "Probe mode. Current modes are 'env', 'c-smoke', 'cpp-smoke', "
-            "and 'python-z3-baseline'; later research PRs should append modes "
-            "here without replacing existing ones."
+            "'python-z3-baseline', and 'c-cpp-z3-alignment'; later research "
+            "PRs should append modes here without replacing existing ones."
         ),
     )
     parser.add_argument(
@@ -4126,14 +5532,20 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
     if args.mode == "env":
         if args.check:
-            parser.error("--check is currently supported only for python-z3-baseline")
+            parser.error(
+                "--check is supported only for python-z3-baseline and "
+                "c-cpp-z3-alignment"
+            )
         report = build_environment_report(args.repo_root)
         _write_or_print(report, args.output)
         return 0
 
     if args.mode in {"c-smoke", "cpp-smoke"}:
         if args.check:
-            parser.error("--check is currently supported only for python-z3-baseline")
+            parser.error(
+                "--check is supported only for python-z3-baseline and "
+                "c-cpp-z3-alignment"
+            )
         report = build_c_family_smoke_report(
             args.mode,
             repo_root=args.repo_root,
@@ -4150,6 +5562,15 @@ def main(argv: Optional[List[str]] = None) -> int:
             _write_or_print(result, args.output)
             return 0 if result["ok"] else 1
         report = build_python_z3_baseline(args.repo_root, mapping_path=args.mapping)
+        _write_or_print(report, args.output)
+        return 0
+
+    if args.mode == "c-cpp-z3-alignment":
+        if args.check:
+            result = check_c_cpp_z3_alignment(args.repo_root, mapping_path=args.mapping)
+            _write_or_print(result, args.output)
+            return 0 if result["ok"] else 1
+        report = build_c_cpp_z3_alignment(args.repo_root, mapping_path=args.mapping)
         _write_or_print(report, args.output)
         return 0
 


### PR DESCRIPTION
## 🟡 子 PR-6A：C/C++ ↔ Z3 对齐试点与 schema 契约

本 PR 是伞 PR [#281](https://github.com/HansBug/pyfcstm/pull/281) 下的 **子 PR-6A / D6a**。当前 PR 从 `dev/numeric-render-semantics-umbrella` 分支切出，前置依赖 [PR #284](https://github.com/HansBug/pyfcstm/pull/284)（C/C++ smoke probe）与 [PR #283](https://github.com/HansBug/pyfcstm/pull/283)（Python + Z3 baseline）均已合入伞分支。

本 PR 先以 empty commit 建立 review / CI / 计划校验入口；实现阶段只落库调研契约、schema、validator、snapshot 与文档，不直接修改 solver / fixed / template 产品语义。

> 本 PR 修到 ready-to-merge 后等待人工下一步指示，不自动 merge。

## 目标

为当前 FCSTM 数值表达式渲染到 C/C++ 后的真实语义，建立一套可审计、可校验、可被后续 PR-6B~6E 复用的 Z3 alignment contract 试点。

核心输出不是单个 Z3 expression，而是逐项记录：

```text
value_expr + obligations + outcome
```

其中：

- `value_expr`：目标语言运算结果在指定 Z3 profile 下的候选值表达；
- `obligations`：该候选值可代表 C/C++ defined behavior 时必须满足的条件；
- `outcome`：对齐结果状态；schema 中这是闭集枚举，允许值为 `exact`、`exact_with_obligations`、`profile_dependent`、`unsupported`、`compile_failed`、`runtime_trap`、`ub`。

## 与伞 PR-6A contract 字段的映射

schema 字段必须显式覆盖伞 PR #281 子 PR-6A 的 contract 骨架，而不只覆盖三元组载荷：

| 伞 PR 字段 | PR-6A schema 口径 |
|---|---|
| `render path` | `render_path`，并按 render path 分组记录 C/C++ 对齐事实 |
| operator / ufunc | `operator`、`operator_family`、`fcstm_expression` |
| `target semantics` | `target_semantics`，说明 C/C++ defined / implementation-defined / unsupported 语义来源 |
| `definedness` | `definedness` 独立字段；必要条件同时进入 `obligations` |
| `Z3 sort` | `z3_sort`，例如 `BitVec(8)`、`BitVec(width)`、`Real`、`FP64` |
| Z3 profile | `z3_profile`，描述 signed fixed-width、promotion/writeback、float/double 等 profile 族 |
| `Z3 expression` | `value_expr`，描述候选值表达；不单独代表行为已 defined |
| `obligations` | `obligations[]`，每项至少包含 `kind`、predicate / 描述、触发场景、evidence |
| `alignment status` | `outcome` 闭集枚举 |
| `evidence` | `evidence[]` 必填 |
| `counterexamples` | `counterexamples[]`；对 `profile_dependent`、`unsupported`、`compile_failed`、`runtime_trap`、`ub` 行必须非空，或提供等价 evidence 链说明为何无法构造可运行反例 |

## 非目标

- 不把 Z3 BitVec natural wrap 直接等同于 C/C++ signed semantics。
- 不把 C/C++ UB 的偶然运行输出当作默认语义。
- 不修改 solver / fixed / template 运行时产品语义。
- 不在本调研 PR 中新增或修改 `test/` 路径；调研自检放在 `tools/`、`research/`、schema check 与 gitignored `results/local/` 中。
- 不提交 heavy exhaustive 原始输出、编译产物或本地 toolchain cache。

## 计划交付物

预计新增或更新：

- `research/numeric-render-semantics/schemas/c_cpp_z3_alignment.schema.json`
  - 描述 C/C++ ↔ Z3 alignment contract 的稳定 JSON schema。
- `research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json`
  - 小型、可审阅、可复跑的 committed snapshot / summary。
- `tools/numeric_render_probe.py`
  - 追加稳定命令 `python tools/numeric_render_probe.py c-cpp-z3-alignment --check`；保留既有 `env`、`c-smoke`、`cpp-smoke`、`python-z3-baseline` 行为不退化。
- `research/numeric-render-semantics/probes.md` / `plan.md` / `README.md`
  - 说明 contract 字段、validator 复跑方式、PR-6B~6E 如何复用。

## 最小覆盖范围

每个纳入 contract 的行必须能追溯 render path、operator / ufunc、目标语言语义、Z3 profile、Z3 sort、`value_expr`、`obligations`、`outcome`、evidence 和必要 counterexample。

最小覆盖：

- render paths：对每个适用 operator / ufunc，至少区分并覆盖 builtin `_C_STYLE`、builtin `_CPP_STYLE` standalone expression、C template generated artifact、以及 `templates/cpp*` 中 `base_lang: c` 的 generated artifact；如某个 operator 在某路径不存在，snapshot 行必须以 `unsupported` / `compile_failed` / `profile_dependent` / `ub` 之一记录原因和 evidence，不能静默漏行。
- numeric / Z3 profiles：每个 integer operator contract 必须声明 operand/result profile，至少区分 signed fixed-width candidate、C/C++ default integer promotion / writeback profile、float/double math profile；snapshot 不提交 heavy exhaustive 输出，但必须提交能触发每类 obligation / unsupported outcome 的小型 evidence 或 counterexample。
- binary arithmetic：`+`、`-`、`*`、`/`、`%`
- unary arithmetic：unary `-`
- bitwise / shift：`~`、`&`、`|`、`^`、`<<`、`>>`
- comparisons：`<`、`<=`、`>`、`>=`、`==`、`!=`
- ufunc / math：`pow`、`round`、`abs`、`sign`、`cbrt`
- constants：integer / float constants 的 C/C++ render profile
- narrowing / writeback：表达式结果写回 fixed-width target 时的约束
- danger zones：signed overflow、division by zero、signed shift、`MIN/-1`、math function unsupported / compile failure
- shift obligation 最小粒度：`valid_shift_count`、`non_negative_shift_count`、`no_signed_left_shift_ub`、`signed_right_shift_profile`，不能只用一个笼统 `signed_shift` obligation 代替。

## validator / check 契约

稳定验收命令：

```bash
python tools/numeric_render_probe.py c-cpp-z3-alignment --check
```

该命令必须至少完成：

- 读取 committed `research/numeric-render-semantics/results/snapshots/c_cpp_z3_alignment.json`。
- 校验 `research/numeric-render-semantics/schemas/c_cpp_z3_alignment.schema.json`。
- 校验 required fields：`render_path`、`operator` / `operator_family`、`fcstm_expression`、`target_semantics`、`definedness`、`z3_sort`、`z3_profile`、`value_expr`、`obligations`、`outcome`、`evidence`。
- 校验 `outcome` 闭集 enum。
- 校验 mapping / baseline / C-family smoke facts 的关键 digest：至少包括 `render_mapping_sha256`、`python_z3_baseline_sha256`、`c_smoke_facts_sha256`、`cpp_smoke_facts_sha256` 或等价 committed fact digest。
- 在 native C/C++ toolchain 不可用时仍必须完成 schema、required-field、snapshot digest、mapping/baseline digest 校验；只有 live C/C++ regenerate 子步骤可标记 `unavailable` / `skipped`，且 skipped 状态必须写入 summary，不得静默通过。
- 至少拒绝：缺少 `value_expr`、缺少 `obligations`、缺少 `outcome`、缺少 render path / operator / target semantics / definedness / Z3 profile / Z3 sort / evidence、未知 `outcome`、以及 committed snapshot digest 与当前 committed mapping / baseline 不匹配。

## 验收标准

- PR body 与伞 PR #281 的子 PR-6A 范围一致，multiagent review 无 C/I 阻塞意见。
- alignment schema 能阻止关键字段缺失，snapshot 中每行都包含 `value_expr + obligations + outcome`，并覆盖上面的 contract 字段映射。
- validator 能检测 committed snapshot 与当前 mapping / Python-Z3 baseline / C-family smoke fact digest 的关键漂移。
- `python tools/numeric_render_mapping.py --check` 通过。
- `python tools/numeric_render_probe.py python-z3-baseline --check` 通过。
- `python tools/numeric_render_probe.py c-cpp-z3-alignment --check` 通过。
- C/C++ smoke probe 在本地可用 native toolchain 时可复跑；不可用时输出清晰 unavailable / skipped，不阻塞 schema-level check。
- `python -m py_compile tools/numeric_render_probe.py` 通过。
- `ruff check` / `ruff format --check` 针对变更 Python 文件通过。
- 实现阶段提交前运行 `make rst_auto`，并 review 生成 RST diff。
- 必要时运行 `SKIP_SLOW_TESTS=1 make unittest`，避免慢 native template 测试影响迭代效率。
- 最终 diff 不包含 `test/` 路径。

## 当前状态

- [x] empty PR 已创建，用于计划一致性 review。
- [x] codex reviewer 与 claude reviewer 已完成预审，均无 C；I 项已吸收到本版 PR body。
- [x] deepseek reviewer 已按要求多次通过 `codex-deepseek exec` 有界重试；provider 持续返回 503，未能产出独立评论，失败日志已在 PR comment 中记录。
- [x] 根据 C/I/M 意见修订 PR body。
- [x] 实现 schema / validator / snapshot / docs。
- [x] 本地验证与 push。
- [x] CI / codecov / multiagent 强对抗复审：GitHub Code Test 与 Release Test 全绿；当前 PR 未出现 codecov bot comment。
- [x] 修到 ready-to-merge，等待人工下一步指示；本 PR 不自动 merge。

