### PR TITLE
CI：接入模板 suite 按需运行

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -407,10 +407,10 @@ jobs:
         run: |
           make unittest IS_WIN=${{ env.IS_WIN }} IS_MAC=${{ env.IS_MAC }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: python
           name: codecov-umbrella
           fail_ci_if_error: false
@@ -652,10 +652,10 @@ jobs:
       - name: Upload jsfcstm coverage to Codecov
         # Mirror the python matrix: every matrix cell uploads, codecov
         # merges by flag. Avoids dropping coverage if one Node leg fails.
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./editors/jsfcstm/coverage/lcov.info
+          files: ./editors/jsfcstm/coverage/lcov.info
           flags: jsfcstm
           name: codecov-jsfcstm
           fail_ci_if_error: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -191,8 +191,6 @@ jobs:
         env:
           CI: 'true'
           SKIP_SLOW_TESTS: ''
-          PYFCSTM_TEMPLATE_SUITES: ''
-          PYFCSTM_SKIP_TEMPLATE_SUITES: ''
           TEMPLATE_SUITE: ${{ matrix.suite }}
           TEMPLATE_SUITE_REASON: ${{ matrix.reason }}
         shell: bash
@@ -351,7 +349,7 @@ jobs:
         shell: bash
         run: |
           choco install tree cloc wget curl make zip
-          choco install 7zip winrar  # unrar should be added
+          choco install 7zip
           choco install mingw
           choco install llvm
           echo "C:\\ProgramData\\chocolatey\\lib\\mingw\\tools\\install\\bin" >> $GITHUB_PATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,32 +3,273 @@ name: Code Test
 
 on:
   push:
-    paths:
-      # Source code
-      - 'pyfcstm/**'
-      - 'editors/jsfcstm/**'
-      - 'editors/fcstm.tmLanguage.json'
-      # Tests
-      - 'test/**'
-      # Templates (test/template/* compiles built-in templates)
-      - 'templates/**'
-      - 'tools/**'
-      # Build & dependency manifests
-      - 'setup.py'
-      - 'setup.cfg'
-      - 'pyproject.toml'
-      - 'MANIFEST.in'
-      - 'requirements*.txt'
-      # Test / coverage configuration
-      - 'pytest.ini'
-      - '.coveragerc'
-      - 'codecov.yml'
-      - 'Makefile'
-      # This workflow itself
-      - '.github/workflows/test.yml'
   workflow_dispatch:
+    inputs:
+      template_suites:
+        description: 'Comma-separated template suites to run fully, e.g. c,c_poll or all.'
+        required: false
+        default: ''
+      skip_template_suites:
+        description: 'Comma-separated manually selected template suites to skip.'
+        required: false
+        default: ''
 
 jobs:
+
+  detect_template_suites:
+    name: Detect template suites
+    runs-on: ubuntu-22.04
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'test skip') && !contains(github.event.head_commit.message, '[python skip]') }}
+    outputs:
+      template_matrix: ${{ steps.detect.outputs.template_matrix }}
+      selected_full_count: ${{ steps.detect.outputs.selected_full_count }}
+      selected_suites: ${{ steps.detect.outputs.selected_suites }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+      - name: Detect selected template suites
+        id: detect
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          DISPATCH_TEMPLATE_SUITES: ${{ github.event.inputs.template_suites }}
+          DISPATCH_SKIP_TEMPLATE_SUITES: ${{ github.event.inputs.skip_template_suites }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .ci/template-suites
+          changed_file=.ci/template-suites/changed-files.txt
+          message_file=.ci/template-suites/message.txt
+          detector_output=.ci/template-suites/detector.json
+          : > "$changed_file"
+          : > "$message_file"
+
+          include_args=()
+          skip_args=()
+          detector_event="${GITHUB_EVENT_NAME}"
+          zero_sha="0000000000000000000000000000000000000000"
+
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            printf '%s' "${HEAD_COMMIT_MSG:-}" > "$message_file"
+            if [ -z "${BEFORE_SHA:-}" ] || [ "${BEFORE_SHA}" = "$zero_sha" ]; then
+              echo "Push base SHA is unavailable; failing closed to all template full suites."
+              include_args=(--include-suites all)
+            elif git cat-file -e "${BEFORE_SHA}^{commit}" 2>/dev/null && git diff --name-only "${BEFORE_SHA}" "${HEAD_SHA}" > "$changed_file"; then
+              echo "Detected changed files between ${BEFORE_SHA} and ${HEAD_SHA}."
+            else
+              echo "Could not diff ${BEFORE_SHA}..${HEAD_SHA}; failing closed to all template full suites."
+              : > "$changed_file"
+              include_args=(--include-suites all)
+            fi
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            detector_event="workflow_dispatch"
+            dispatch_include="${DISPATCH_TEMPLATE_SUITES:-}"
+            dispatch_skip="${DISPATCH_SKIP_TEMPLATE_SUITES:-}"
+            if [ -n "$(printf '%s' "$dispatch_include" | tr -d '[:space:]')" ]; then
+              include_args=(--include-suites "$dispatch_include")
+              if [ -n "$(printf '%s' "$dispatch_skip" | tr -d '[:space:]')" ]; then
+                skip_args=(--skip-suites "$dispatch_skip")
+              fi
+            else
+              echo "workflow_dispatch has no positive template_suites input; failing closed to all template full suites."
+              if [ -n "$(printf '%s' "$dispatch_skip" | tr -d '[:space:]')" ]; then
+                echo "Ignoring skip_template_suites without positive template_suites so skip-only dispatch cannot narrow coverage."
+              fi
+              include_args=(--include-suites all)
+            fi
+          else
+            echo "Unsupported event ${GITHUB_EVENT_NAME}; failing closed to all template full suites."
+            detector_event="local"
+            include_args=(--include-suites all)
+          fi
+
+          python tools/detect_template_suites.py \
+            --changed-files "$changed_file" \
+            --commit-message-file "$message_file" \
+            --event-name "$detector_event" \
+            "${include_args[@]}" \
+            "${skip_args[@]}" \
+            --json > "$detector_output"
+
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          output_path = Path('.ci/template-suites/detector.json')
+          result = json.loads(output_path.read_text(encoding='utf-8'))
+          matrix = result.get('matrix', {'include': []})
+          selected_suites = result.get('selected_suites', [])
+          full_count = len(matrix.get('include', []))
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as out:
+              print('template_matrix=' + json.dumps(matrix, separators=(',', ':')), file=out)
+              print('selected_full_count=' + str(full_count), file=out)
+              print('selected_suites=' + ','.join(selected_suites), file=out)
+          with open(os.environ['GITHUB_STEP_SUMMARY'], 'a', encoding='utf-8') as summary:
+              print('## Template suite detector', file=summary)
+              print('', file=summary)
+              print('* Selected suites: `{0}`'.format(','.join(selected_suites) or '(none)'), file=summary)
+              print('* Dynamic full suite count: `{0}`'.format(full_count), file=summary)
+              print('', file=summary)
+              print('```json', file=summary)
+              print(json.dumps(result, indent=2, sort_keys=True), file=summary)
+              print('```', file=summary)
+          PY
+
+  template_representative:
+    name: Template representative
+    runs-on: ubuntu-22.04
+    if: ${{ !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'test skip') && !contains(github.event.head_commit.message, '[python skip]') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 20
+          submodules: 'recursive'
+      - name: Set up system dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tree cloc wget curl make zip cmake build-essential clang-format gcc g++ clang
+      - name: Set up python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade flake8 setuptools wheel twine
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+      - name: Run representative template alignment
+        env:
+          CI: 'true'
+          SKIP_SLOW_TESTS: ''
+        shell: bash
+        run: |
+          make template_unittest TEMPLATE_UNITTEST_ARGS="--include-suites template_representative"
+
+  template_full:
+    name: Template full (${{ matrix.suite }})
+    runs-on: ubuntu-22.04
+    needs: detect_template_suites
+    if: ${{ needs.detect_template_suites.result == 'success' && needs.detect_template_suites.outputs.selected_full_count != '0' && !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'test skip') && !contains(github.event.head_commit.message, '[python skip]') }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.detect_template_suites.outputs.template_matrix) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3.3.0
+        with:
+          fetch-depth: 20
+          submodules: 'recursive'
+      - name: Set up system dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tree cloc wget curl make zip cmake build-essential clang-format gcc g++ clang
+      - name: Set up python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade flake8 setuptools wheel twine
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
+      - name: Run selected template full suite
+        env:
+          CI: 'true'
+          SKIP_SLOW_TESTS: ''
+          PYFCSTM_TEMPLATE_SUITES: ''
+          PYFCSTM_SKIP_TEMPLATE_SUITES: ''
+          TEMPLATE_SUITE: ${{ matrix.suite }}
+          TEMPLATE_SUITE_REASON: ${{ matrix.reason }}
+        shell: bash
+        run: |
+          echo "Running template suite '${TEMPLATE_SUITE}' selected because '${TEMPLATE_SUITE_REASON}'."
+          make template_unittest TEMPLATE_UNITTEST_ARGS="--include-suites ${TEMPLATE_SUITE}"
+
+  template_suite_gate:
+    name: template-suite-gate
+    runs-on: ubuntu-22.04
+    needs:
+      - detect_template_suites
+      - unittest
+      - template_representative
+      - template_full
+    if: ${{ always() }}
+    steps:
+      - name: Check template suite results
+        env:
+          HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
+          DETECTOR_RESULT: ${{ needs.detect_template_suites.result }}
+          UNITTEST_RESULT: ${{ needs.unittest.result }}
+          REPRESENTATIVE_RESULT: ${{ needs.template_representative.result }}
+          TEMPLATE_FULL_RESULT: ${{ needs.template_full.result }}
+          SELECTED_FULL_COUNT: ${{ needs.detect_template_suites.outputs.selected_full_count }}
+          SELECTED_SUITES: ${{ needs.detect_template_suites.outputs.selected_suites }}
+        shell: bash
+        run: |
+          python - <<'PY'
+          import os
+          import sys
+
+          message = os.environ.get('HEAD_COMMIT_MSG') or ''
+          skipped_by_message = any(
+              token in message for token in ('ci skip', 'test skip', '[python skip]')
+          )
+          detector = os.environ.get('DETECTOR_RESULT') or ''
+          unittest = os.environ.get('UNITTEST_RESULT') or ''
+          representative = os.environ.get('REPRESENTATIVE_RESULT') or ''
+          template_full = os.environ.get('TEMPLATE_FULL_RESULT') or ''
+          selected_count_text = os.environ.get('SELECTED_FULL_COUNT') or '0'
+          selected_suites = os.environ.get('SELECTED_SUITES') or ''
+          try:
+              selected_count = int(selected_count_text)
+          except ValueError:
+              selected_count = -1
+
+          print('detector={0}'.format(detector))
+          print('unittest={0}'.format(unittest))
+          print('representative={0}'.format(representative))
+          print('template_full={0}'.format(template_full))
+          print('selected_full_count={0}'.format(selected_count_text))
+          print('selected_suites={0}'.format(selected_suites or '(none)'))
+
+          if skipped_by_message:
+              print('Code Test skip token detected; template-suite-gate succeeds after confirming skip semantics.')
+              sys.exit(0)
+
+          failures = []
+          if detector != 'success':
+              failures.append('detector job result is {0}'.format(detector))
+          if unittest != 'success':
+              failures.append('unittest job result is {0}'.format(unittest))
+          if representative != 'success':
+              failures.append('template representative job result is {0}'.format(representative))
+          if selected_count < 0:
+              failures.append('selected_full_count is not an integer: {0}'.format(selected_count_text))
+          elif selected_count == 0:
+              if template_full not in ('success', 'skipped'):
+                  failures.append('template full job should be skipped or success for empty matrix, got {0}'.format(template_full))
+          elif template_full != 'success':
+              failures.append('template full job result is {0} for {1} selected suite(s)'.format(template_full, selected_count))
+
+          if failures:
+              for failure in failures:
+                  print('ERROR: {0}'.format(failure))
+              sys.exit(1)
+          print('template-suite-gate passed')
+          PY
+
   unittest:
     name: Code test
     runs-on: ${{ matrix.os }}
@@ -135,22 +376,22 @@ jobs:
           if command -v tree >/dev/null 2>&1; then tree .; else echo "tree not available; skipping directory tree output"; fi
           if command -v cloc >/dev/null 2>&1; then cloc pyfcstm; else echo "cloc not available; skipping pyfcstm line count"; fi
           if command -v cloc >/dev/null 2>&1; then cloc test; else echo "cloc not available; skipping test line count"; fi
-      - name: Detect skip-slow flag in commit message
-        id: skipslow
+      - name: Enable lightweight template test subset
+        id: template_subset
         # Pass the commit message via env to avoid shell injection. Inline
         # `${{ github.event.head_commit.message }}` would be substituted as
         # raw shell tokens before bash sees the script, so any backtick,
         # bracket, or `key: value` pattern in the commit body could be
-        # mis-parsed as commands (broke PR-109 on first run).
+        # mis-parsed as commands.
         env:
           HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
         shell: bash
         run: |
+          echo "SKIP_SLOW_TESTS=1" >> "$GITHUB_ENV"
           if printf '%s' "$HEAD_COMMIT_MSG" | grep -q '\[skip-slow\]'; then
-            echo "SKIP_SLOW_TESTS=1" >> "$GITHUB_ENV"
-            echo "Detected [skip-slow] — native-toolchain template tests will be skipped."
+            echo "Detected legacy [skip-slow] — default Code Test already uses the lightweight template subset."
           else
-            echo "SKIP_SLOW_TESTS=" >> "$GITHUB_ENV"
+            echo "Default Code Test uses the lightweight template subset; selected full suites run in template_full jobs."
           fi
       - name: Run unittest
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
   detect_template_suites:
     name: Detect template suites
     runs-on: ubuntu-22.04
-    if: ${{ !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'test skip') && !contains(github.event.head_commit.message, '[python skip]') }}
     outputs:
       template_matrix: ${{ steps.detect.outputs.template_matrix }}
       selected_full_count: ${{ steps.detect.outputs.selected_full_count }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -233,11 +233,14 @@ jobs:
           unittest = os.environ.get('UNITTEST_RESULT') or ''
           representative = os.environ.get('REPRESENTATIVE_RESULT') or ''
           template_full = os.environ.get('TEMPLATE_FULL_RESULT') or ''
-          selected_count_text = os.environ.get('SELECTED_FULL_COUNT') or '0'
+          selected_count_text = os.environ.get('SELECTED_FULL_COUNT') or ''
           selected_suites = os.environ.get('SELECTED_SUITES') or ''
-          try:
-              selected_count = int(selected_count_text)
-          except ValueError:
+          if selected_count_text.strip():
+              try:
+                  selected_count = int(selected_count_text)
+              except ValueError:
+                  selected_count = -1
+          else:
               selected_count = -1
 
           print('detector={0}'.format(detector))

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+      - name: Set up python 3.11
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
       - name: Detect selected template suites
         id: detect
         env:
@@ -243,20 +247,21 @@ jobs:
           print('selected_full_count={0}'.format(selected_count_text))
           print('selected_suites={0}'.format(selected_suites or '(none)'))
 
-          if skipped_by_message:
-              print('Code Test skip token detected; template-suite-gate succeeds after confirming skip semantics.')
-              sys.exit(0)
-
           failures = []
           if detector != 'success':
               failures.append('detector job result is {0}'.format(detector))
+          if selected_count < 0:
+              failures.append('selected_full_count is not an integer: {0}'.format(selected_count_text))
+
+          if skipped_by_message and not failures:
+              print('Code Test skip token detected; expensive template jobs may be skipped after detector success.')
+              sys.exit(0)
+
           if unittest != 'success':
               failures.append('unittest job result is {0}'.format(unittest))
           if representative != 'success':
               failures.append('template representative job result is {0}'.format(representative))
-          if selected_count < 0:
-              failures.append('selected_full_count is not an integer: {0}'.format(selected_count_text))
-          elif selected_count == 0:
+          if selected_count == 0:
               if template_full not in ('success', 'skipped'):
                   failures.append('template full job should be skipped or success for empty matrix, got {0}'.format(template_full))
           elif template_full != 'success':

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,8 +193,10 @@ In GitHub Actions, `workflow_dispatch` accepts `template_suites` and `skip_templ
 positive `template_suites` value fails closed to `all`; a skip-only dispatch cannot narrow coverage to an empty matrix.
 The stable aggregate check is named `template-suite-gate`; branch protection should depend on that gate rather than on
 per-suite dynamic job names such as `Template full (c)`. Code-test skip tokens skip the expensive unittest/
-representative/full jobs only after detector success; unknown template labels, malformed detector output, or detector
-failures must still fail the stable gate. The dynamic full-suite job runs on Ubuntu with Python 3.11 and clears inherited
+representative/full jobs only after detector success; unknown template labels, malformed detector output, missing detector
+outputs, or detector failures must still fail the stable gate. These global skip tokens bypass selected/path-protected full
+suites only as whole-workflow skip controls; per-suite `[skip-tpl:*]` / `PYFCSTM_SKIP_TEMPLATE_SUITES` requests still
+cannot remove path-protected suites. The dynamic full-suite job runs on Ubuntu with Python 3.11 and clears inherited
 `SKIP_SLOW_TESTS` before invoking `make template_unittest`, so protected or manually selected full suites cannot be
 converted into false-green skips.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,9 +193,10 @@ In GitHub Actions, `workflow_dispatch` accepts `template_suites` and `skip_templ
 positive `template_suites` value fails closed to `all`; a skip-only dispatch cannot narrow coverage to an empty matrix.
 The stable aggregate check is named `template-suite-gate`; branch protection should depend on that gate rather than on
 per-suite dynamic job names such as `Template full (c)`. Code-test skip tokens skip the expensive unittest/
-representative/full jobs while the detector and gate may still report a stable successful skip summary. The dynamic full-suite job runs on
-Ubuntu with Python 3.11 and clears inherited `SKIP_SLOW_TESTS` before invoking `make template_unittest`, so protected or
-manually selected full suites cannot be converted into false-green skips.
+representative/full jobs only after detector success; unknown template labels, malformed detector output, or detector
+failures must still fail the stable gate. The dynamic full-suite job runs on Ubuntu with Python 3.11 and clears inherited
+`SKIP_SLOW_TESTS` before invoking `make template_unittest`, so protected or manually selected full suites cannot be
+converted into false-green skips.
 
 ### CI Workflow Commit-Message Triggers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,21 +116,23 @@ make unittest WORKERS=4                              # With parallel workers
 pytest test/simulate/test_semantic_fixtures.py -v
 pytest test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture -v
 
-# Fast path: skip native-toolchain template tests (test/template/c, test/template/c_poll)
-# which invoke real cmake/cc per case and consume ~85% of unittest wall time.
-SKIP_SLOW_TESTS=1 make unittest          # ~24s vs ~174s full local (~7x faster)
+# Fast path: run the same lightweight template subset used by the default Code Test workflow.
+SKIP_SLOW_TESTS=1 make unittest          # skips C-family full semantic/native alignment, keeps Python full + wrapper smoke
 ```
 
-The `SKIP_SLOW_TESTS=1` env var is read by [test/conftest.py](test/conftest.py). It auto-skips every test under
-[test/template/c/](test/template/c/) and [test/template/c_poll/](test/template/c_poll/) — these are the tests that
-compile C/C++ via cmake. Use it for iteration cycles that don't touch generated C runtime. The Python template,
-simulator, model, DSL, render, and verify tests all still run.
+The `SKIP_SLOW_TESTS=1` env var is read by [test/conftest.py](test/conftest.py). It skips the broad
+[test/template/c/](test/template/c/) and [test/template/c_poll/](test/template/c_poll/) paths, plus the full semantic
+alignment and explicit native-toolchain alignment tests under [test/template/cpp/](test/template/cpp/) and
+[test/template/cpp_poll/](test/template/cpp_poll/). C++ wrapper smoke tests, the Python template, simulator, model, DSL,
+render, and verify tests still run. This is now the default `Code Test` workflow subset; selected non-Python template
+full suites run in dedicated `template_full` jobs instead of the main unittest matrix.
 
 ### Template Suite Detector
 
-The repository now includes a tools-only detector for the planned template-suite CI split. In its initial state it is a
-repo-local helper with an explicit `--check` self-check; it is **not** part of the public `pyfcstm` package and does
-**not** change the default `make unittest` or GitHub Actions route yet.
+The repository includes a tools-only detector and runner for template-suite selection. They are repo-local helpers with
+explicit `--check` self-checks; they are **not** part of the public `pyfcstm` package. The default GitHub `Code Test`
+workflow uses the lightweight template subset from `SKIP_SLOW_TESTS=1 make unittest`, then runs representative and
+selected full template suites through dedicated jobs.
 
 ```bash
 python tools/detect_template_suites.py --check
@@ -187,6 +189,14 @@ dynamic suites; they cannot remove path-detected suites and cannot disable fixed
 tokens are hard failures, not warnings. The current JSON schema version is `template-suite-detector/v1`; renaming or
 removing fields requires a new schema version.
 
+In GitHub Actions, `workflow_dispatch` accepts `template_suites` and `skip_template_suites` inputs. A dispatch without a
+positive `template_suites` value fails closed to `all`; a skip-only dispatch cannot narrow coverage to an empty matrix.
+The stable aggregate check is named `template-suite-gate`; branch protection should depend on that gate rather than on
+per-suite dynamic job names such as `Template full (c)`. Code-test skip tokens skip the expensive detector/unittest/
+representative/full jobs while the gate reports a stable successful skip summary. The dynamic full-suite job runs on
+Ubuntu with Python 3.11 and clears inherited `SKIP_SLOW_TESTS` before invoking `make template_unittest`, so protected or
+manually selected full suites cannot be converted into false-green skips.
+
 ### CI Workflow Commit-Message Triggers
 
 [.github/workflows/test.yml](.github/workflows/test.yml) honors five magic substrings in the **head commit message**.
@@ -196,10 +206,10 @@ gate. Always grep your commit message against the table below before pushing.
 
 | Substring | Trigger | Effect |
 |---|---|---|
-| `ci skip` | head commit message contains this substring anywhere | Skips both `Code test` (unittest matrix), `jsfcstm test`, and `CLI Build` workflows entirely. Use for docs-only / comment-only commits. |
-| `test skip` | head commit message contains this substring anywhere | Skips both the `Code test` (Python unittest matrix) AND the `jsfcstm test` workflows. `CLI Build` still runs. |
-| `[skip-slow]` | head commit message contains this substring anywhere | Runs the full unittest workflow normally, but injects `SKIP_SLOW_TESTS=1` into the unittest step, which skips [test/template/c](test/template/c) and [test/template/c_poll](test/template/c_poll) (cmake/cc compile tests, ~85% of wall time). Use when iterating on changes that demonstrably can't affect the C/C++ runtime templates. |
-| `[python skip]` | head commit message contains this substring anywhere | Skips the `Code test` (Python unittest matrix) AND `CLI Build` jobs. The `jsfcstm test` job still runs. Use for jsfcstm-only changes (TypeScript / mocha updates) where the Python matrix would only burn CI minutes. |
+| `ci skip` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites), `jsfcstm test`, and `CLI Build`; the lightweight `template-suite-gate` may still report a successful skip summary for branch-protection stability. Use for docs-only / comment-only commits. |
+| `test skip` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites) and the `jsfcstm test` workflow. `CLI Build` still runs; `template-suite-gate` may still report a successful skip summary. |
+| `[skip-slow]` | head commit message contains this substring anywhere | Legacy compatibility token. The default `Code Test` unittest matrix already runs with `SKIP_SLOW_TESTS=1`; selected/path-protected full template suites still run in `template_full` jobs and explicitly clear `SKIP_SLOW_TESTS`. |
+| `[python skip]` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites) AND `CLI Build` jobs. The `jsfcstm test` job still runs; `template-suite-gate` may still report a successful skip summary. Use for jsfcstm-only changes (TypeScript / mocha updates) where the Python matrix would only burn CI minutes. |
 | `[js skip]` | head commit message contains this substring anywhere | Skips only the `jsfcstm test` workflow. The Python unittest matrix and `CLI Build` still run. Use for Python-only / Makefile changes that obviously can't affect the jsfcstm TypeScript build. |
 
 **Footgun:** because `contains()` is substring match, phrases like `"slow-test skip mechanism"` or `"document the ci skip flag"` will activate `test skip` / `ci skip` respectively. If you need to mention these tokens in a commit body, either rephrase (`"slow-test gating"`, `"document the ci-bypass flag"`) or quote them with characters that break the literal substring (e.g. `` `ci-skip` ``, `ci_skip`). When in doubt, run:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,8 +192,8 @@ removing fields requires a new schema version.
 In GitHub Actions, `workflow_dispatch` accepts `template_suites` and `skip_template_suites` inputs. A dispatch without a
 positive `template_suites` value fails closed to `all`; a skip-only dispatch cannot narrow coverage to an empty matrix.
 The stable aggregate check is named `template-suite-gate`; branch protection should depend on that gate rather than on
-per-suite dynamic job names such as `Template full (c)`. Code-test skip tokens skip the expensive detector/unittest/
-representative/full jobs while the gate reports a stable successful skip summary. The dynamic full-suite job runs on
+per-suite dynamic job names such as `Template full (c)`. Code-test skip tokens skip the expensive unittest/
+representative/full jobs while the detector and gate may still report a stable successful skip summary. The dynamic full-suite job runs on
 Ubuntu with Python 3.11 and clears inherited `SKIP_SLOW_TESTS` before invoking `make template_unittest`, so protected or
 manually selected full suites cannot be converted into false-green skips.
 
@@ -206,10 +206,10 @@ gate. Always grep your commit message against the table below before pushing.
 
 | Substring | Trigger | Effect |
 |---|---|---|
-| `ci skip` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites), `jsfcstm test`, and `CLI Build`; the lightweight `template-suite-gate` may still report a successful skip summary for branch-protection stability. Use for docs-only / comment-only commits. |
-| `test skip` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites) and the `jsfcstm test` workflow. `CLI Build` still runs; `template-suite-gate` may still report a successful skip summary. |
+| `ci skip` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites), `jsfcstm test`, and `CLI Build`; the lightweight detector / `template-suite-gate` may still report a successful skip summary for branch-protection stability. Use for docs-only / comment-only commits. |
+| `test skip` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites) and the `jsfcstm test` workflow. `CLI Build` still runs; the lightweight detector / `template-suite-gate` may still report a successful skip summary. |
 | `[skip-slow]` | head commit message contains this substring anywhere | Legacy compatibility token. The default `Code Test` unittest matrix already runs with `SKIP_SLOW_TESTS=1`; selected/path-protected full template suites still run in `template_full` jobs and explicitly clear `SKIP_SLOW_TESTS`. |
-| `[python skip]` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites) AND `CLI Build` jobs. The `jsfcstm test` job still runs; `template-suite-gate` may still report a successful skip summary. Use for jsfcstm-only changes (TypeScript / mocha updates) where the Python matrix would only burn CI minutes. |
+| `[python skip]` | head commit message contains this substring anywhere | Skips the expensive Code Test test jobs (`Code test`, representative, and selected full suites) AND `CLI Build` jobs. The `jsfcstm test` job still runs; the lightweight detector / `template-suite-gate` may still report a successful skip summary. Use for jsfcstm-only changes (TypeScript / mocha updates) where the Python matrix would only burn CI minutes. |
 | `[js skip]` | head commit message contains this substring anywhere | Skips only the `jsfcstm test` workflow. The Python unittest matrix and `CLI Build` still run. Use for Python-only / Makefile changes that obviously can't affect the jsfcstm TypeScript build. |
 
 **Footgun:** because `contains()` is substring match, phrases like `"slow-test skip mechanism"` or `"document the ci skip flag"` will activate `test skip` / `ci skip` respectively. If you need to mention these tokens in a commit body, either rephrase (`"slow-test gating"`, `"document the ci-bypass flag"`) or quote them with characters that break the literal substring (e.g. `` `ci-skip` ``, `ci_skip`). When in doubt, run:


### PR DESCRIPTION
## 定位

这是伞 PR [#295](https://github.com/HansBug/pyfcstm/pull/295) 的第三个子 PR，负责把前两步已经落地的 tools-only detector / runner 接入 GitHub Actions。目标是把普通 `Code Test` 从“默认所有模板 full semantic fixture”切换为“默认轻量 + representative + path/tag/env 选择的 template full”，同时保留 fail-closed、native-toolchain 显式 opt-in 和现有 skip token 语义。

## 目标

1. 修改 `.github/workflows/test.yml`，删除 workflow-level `on.push.paths` gating，避免 required check 因路径过滤而 pending。
2. 新增 detector job，使用 `tools/detect_template_suites.py` 计算 dynamic template full matrix，并把 diff/message/dispatch input 的异常处理为 fail-closed。
3. 默认 `Code test` matrix 只跑轻量模板策略：non-template tests、`template_core`、Python template full、完整 C++ / C++ poll wrapper smoke；不再无条件跑 `c/c_poll/cpp/cpp_poll` full semantic fixture。
4. 新增单一 Linux/Python representative job，运行 `template_representative` 的 10 个固定 shared semantic cases。
5. 新增 dynamic template full job，按 detector/tag/env/path 加跑 `python,c,c_poll,cpp,cpp_poll` full suites。
6. 新增稳定命名的 aggregate gate job（`template-suite-gate`），统一检查 detector、representative 和 selected template full 状态；空 matrix 明确成功，detector/selected suite 失败则失败，并作为后续 branch protection / required check 绑定目标，不能绑定 dynamic suite job 名。
7. 更新 `CLAUDE.md` 的 CI 触发说明和常用本地/手动触发命令。

## 非目标

- 不修改 DSL/model/render/template runtime 语义。
- 不把 CI helper 移入 `pyfcstm/` public package。
- 不在 `test/` 下新增 tooling 单元测试；验证走 `tools/* --check`、本地命令和 CI。
- 不合并或改变 `.github/workflows/native-toolchain.yml` 的显式 native profile matrix。
- 不改变 Python 与 jsfcstm 测试树独立性。

## 执行方案

1. `.github/workflows/test.yml`
   - 删除 `on.push.paths` / `paths-ignore` 类 workflow-level gating。
   - 为 `workflow_dispatch` 增加 `template_suites` / `skip_template_suites` 字符串输入。
   - 增加 `detect_template_suites` job：
     - checkout 使用 `fetch-depth: 0`（或等价 fetch），确保 `github.event.before..github.sha` 可 diff。
     - `push` 使用 `github.event.before..github.sha` 计算 changed files；base 缺失、zero SHA、diff 失败时 fail-closed 到 `all`。
     - `workflow_dispatch` 只有正向 `template_suites` 才算显式 suite input；没有可靠 changed-files 且没有正向 `template_suites` 时 fail-closed 到 `all`；单独填写 `skip_template_suites` 不得把无 diff dispatch 收窄为空。
     - commit message 经文件传入 detector，避免 shell injection。
     - 输出 compact JSON：detector result、dynamic matrix、selected full count、summary。
   - 修改 `unittest` job：默认设置 `SKIP_SLOW_TESTS=1`，继续运行 `make unittest`，从而覆盖 non-template tests、`template_core`、Python full 和完整 `test/template/cpp/test_cpp_wrapper.py` / `test/template/cpp_poll/test_cpp_poll_wrapper.py` wrapper smoke。
   - 新增 `template_representative` job：Ubuntu + Python 3.11，运行 `make template_unittest TEMPLATE_UNITTEST_ARGS="--include-suites template_representative"`，保证先 `tpl`。
   - 新增 `template_full` job：单一 `ubuntu-22.04` + Python 3.11，从 detector matrix 展开 selected dynamic full suites，并运行 `make template_unittest TEMPLATE_UNITTEST_ARGS="--include-suites <suite>"`；该 job/step 必须显式清空 `SKIP_SLOW_TESTS`，防止 full suite 被 inherited fast-path 环境误跳过。
   - 新增稳定命名的 `template-suite-gate` job：`always()` 运行；作为后续 branch protection / required check 绑定目标，不能把 required check 绑定到 dynamic matrix job 名；无 selected full suite 时接受 `template_full` skipped，detector failure、representative failure、selected suite failure、cancelled 均失败。
   - Job `if:` 语义草稿：`unittest`、`template_representative`、`template_full` 遵循现有 Code Test skip token（`ci skip` / `test skip` / `[python skip]` 跳过）；`detect_template_suites` 与 `template-suite-gate` 使用 `always()` 风格保持稳定可见，但 gate 在上述 skip token 命中时明确成功，不要求被跳过的 jobs 成功。
   - Gate 决策表：`ci skip` / `test skip` / `[python skip]` 命中时 gate 成功并说明 Code Test 家族被跳过；普通无标签时 detector + unittest + representative 必须成功，template_full 可 skipped；`[tpl:*]` 或 path-detected selected suites 时 detector + unittest + representative + all selected template_full 必须成功；unknown label/env 或 detector failure 时 gate 失败；selected template_full cancelled/failure/timed out 时 gate 失败。
   - `[skip-slow]` 只影响默认 `unittest` 的 fast-path 环境，不得删除 path-detected protected suites；若 `[skip-slow]` 与 path change 同时出现，dynamic `template_full` 仍必须运行 protected suites，并通过清空 `SKIP_SLOW_TESTS` 避免 false-green。
2. `CLAUDE.md`
   - 更新 `[skip-slow]` 描述为兼容 token；默认 Code Test 已轻量化，并对齐 `test/conftest.py` 的现实 skip 范围（`c/c_poll` 全路径以及 `cpp/cpp_poll` semantic/native alignment，wrapper smoke 保留）。
   - 记录 `[tpl:*]` / `[skip-tpl:*]` 多标签、workflow_dispatch inputs、aggregate gate 和强制 all 的用法。
3. 验证
   - 运行 `python tools/detect_template_suites.py --check`。
   - 运行 `python tools/run_template_suites.py --check`。
   - 运行 `python -m doctest tools/template_suites.py tools/run_template_suites.py`。
   - 运行 `ruff check tools/template_suites.py tools/detect_template_suites.py tools/run_template_suites.py` 与 `ruff format --check ...`。
   - 运行 `make rst_auto`。
   - 本地快速验收使用 `SKIP_SLOW_TESTS=1 make unittest`；PR-3 自身依赖 CI 证明 workflow routing。

## 验收标准

- `.github/workflows/test.yml` 不再有 workflow-level `on.push.paths` 或 `paths-ignore` 做 suite gating。
- 普通无标签提交的 `Run unittest` 耗时接近既有 `[skip-slow]` 量级，PR body/comment 记录至少一个实际 CI run 链接和耗时。
- `[tpl:c] [tpl:c_poll]` 能同时触发两个 full suite；`[tpl:all]` 能触发所有 dynamic full suites。
- 修改 `templates/c/**` 自动选择 `c+cpp`；修改 `templates/c_poll/**` 自动选择 `c_poll+cpp_poll`；修改 shared renderer/DSL/model/semantic fixture/package tooling 自动选择 all。
- 未选择的 template full 不运行，但 `template_core`、Python template full、完整 C++ / C++ poll wrapper smoke 和 representative job 仍运行。
- `template-suite-gate` 在 detector 失败、unknown label/env、selected suite 失败/取消/超时时失败；无 selected full suite 时明确成功；后续 required check / branch protection 绑定此稳定 gate，而不是 dynamic matrix job 名。
- `native-toolchain.yml` 仍独立；普通 suite selection 不改变 explicit native profile matrix。
- `Code Test`、`jsfcstm test`、`CLI Build` 既有 skip token 语义未被误改。
- 工具仍只在 `tools/`，不进入 `pyfcstm/`；不新增 `test/` tooling 单测。



## CI 证据（落地后回填）

合并前必须在本节或 PR comment 回填真实 CI 链接与 detector summary，至少覆盖：

| 场景 | 必须证明的内容 | Run 链接 / 结果 |
|---|---|---|
| 普通无标签提交 | 默认 `Run unittest` 接近既有 `[skip-slow]` 量级；`template_full` 空 matrix/skipped；gate 成功 | ✅ [`28344825337`](https://github.com/HansBug/pyfcstm/actions/runs/28344825337)：`Detect template suites` 11s，`Template representative` 1m57s，`Template full (${{ matrix.suite }})` skipped，`template-suite-gate` 3s；`Code test` jobs 约 2m31s-11m52s，全部成功 |
| `[tpl:c] [tpl:c_poll]` | 同时触发 `c` 与 `c_poll` dynamic full；gate 等待并汇总成功 | ✅ tools 语义由 PR-1/PR-2 自检覆盖；PR-3 workflow 侧用 all-full run [`28344011257`](https://github.com/HansBug/pyfcstm/actions/runs/28344011257) 证明 dynamic matrix 能展开并等待多个 full suites。该 run 中 `Template full (c)` 6m29s、`Template full (c_poll)` 6m29s、`Template full (cpp)` 4m43s、`Template full (cpp_poll)` 4m51s、`Template full (python)` 1m27s 全部成功 |
| `templates/c/**` 改动 | path auto-detect 选择 protected `c+cpp`，且 skip 不能删除 protected suites | ✅ tools 检测语义由 `python tools/detect_template_suites.py --check` 覆盖；workflow path plumbing 已由 all-full run [`28344011257`](https://github.com/HansBug/pyfcstm/actions/runs/28344011257) 证明 changed files → selected suites → dynamic matrix → gate 串接成功 |
| shared renderer / DSL / model / semantic fixture / package tooling 改动 | fail-closed / protected `all` 路由生效 | ✅ [`28344011257`](https://github.com/HansBug/pyfcstm/actions/runs/28344011257)：`.github/workflows/test.yml` 变更命中 protected/all 路由，gate 环境显示 `SELECTED_FULL_COUNT: 5`、`SELECTED_SUITES: python,c,c_poll,cpp,cpp_poll`，所有 dynamic full jobs 与 gate 成功 |
| unknown label/env | detector/gate 失败，而不是 warning-only 或 false-green | ✅ 本地反事实验证覆盖：`python tools/detect_template_suites.py --check`、`python tools/run_template_suites.py --check`，以及 `tools/template_suites.py` / `tools/run_template_suites.py` doctest；前置 reviewer 也复现并确认 `[tpl:java] ci skip` 不再被 gate 掩盖 |
| `workflow_dispatch` skip-only | 没有正向 `template_suites` 时不得把无 diff dispatch 收窄为空；应 fail-closed 到 `all` 或 hard fail | ✅ workflow 脚本逻辑已明确 skip-only dispatch 忽略 skip 并 `--include-suites all`；本地 `actionlint .github/workflows/test.yml` 与 detector/runner `--check` 通过；合并后可用手动 dispatch 继续抽样 |

## 前置 review 修正记录

- 已明确 `workflow_dispatch` 的“显式 suite input”必须是正向 `template_suites`；skip-only 不得制造空 matrix false-green。
- 已明确 `template_full` 单一 Ubuntu/Python 3.11，并显式清空 `SKIP_SLOW_TESTS`。
- 已明确 `template-suite-gate` 是稳定 gate / required check 目标，并补充 skip/no-skip/dynamic 场景决策表。
- 已明确 detector checkout/fetch 必须能可靠 diff，失败则 fail-closed 到 `all`。
- 已明确 `[skip-slow]` 与 path-detected protected suites 的优先级：默认 job 可快跑，但 protected dynamic full 不可被 legacy fast path 删除。
- 本 PR 不改 detector JSON schema；若未来字段变更，必须 bump schema version。

