### PR TITLE
PR-4：下游兼容性验收 runtime / verify / solver / 可视化

### DIFF
--- a/docs/source/api_doc/diagnostics/inspect.rst
+++ b/docs/source/api_doc/diagnostics/inspect.rst
@@ -36,6 +36,12 @@ VERIFY\_SHARED\_STATIC\_CODES
 .. autodata:: VERIFY_SHARED_STATIC_CODES
 
 
+COMBO\_GUARD\_VERIFY\_REPLACEMENT\_CODES
+-----------------------------------------------------
+
+.. autodata:: COMBO_GUARD_VERIFY_REPLACEMENT_CODES
+
+
 StateInfo
 -----------------------------------------------------
 

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -48,7 +48,7 @@ Examples::
 
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 from .analyzers import (
     build_use_def_graph,
@@ -87,6 +87,11 @@ KNOWN_SPANLESS_CODES = frozenset()
 VERIFY_SHARED_STATIC_CODES = frozenset({
     'W_UNREACHABLE_STATE',
 })
+
+COMBO_GUARD_VERIFY_REPLACEMENT_CODES = {
+    'W_DEAD_GUARD': 'W_COMBO_GUARD_CONST_FALSE',
+    'W_GUARD_TAUTOLOGY': 'W_COMBO_GUARD_CONST_TRUE',
+}
 
 
 _OP_PRECEDENCE = {
@@ -2030,17 +2035,105 @@ def _combo_generated_transition_by_payload(
     return None
 
 
+def _combo_guard_replacement_keys(
+        diagnostics: Sequence[ModelDiagnostic],
+) -> Dict[str, Set[Tuple[str, int]]]:
+    """Return combo guard replacement diagnostic keys by public code.
+
+    Generic verify guard diagnostics may be hidden only when a prior
+    combo-aware diagnostic already reports the same original trigger term.
+    Keys use ``(origin_id, term_index)`` because combo expansion may share one
+    generated edge across multiple author-written transitions.
+
+    :param diagnostics: Public diagnostics already collected before verify
+        adapter diagnostics are appended.
+    :type diagnostics: Sequence[pyfcstm.utils.validate.ModelDiagnostic]
+    :return: Mapping from combo-specific diagnostic code to covered terms.
+    :rtype: Dict[str, Set[Tuple[str, int]]]
+
+    Examples::
+
+        >>> diagnostic = ModelDiagnostic(
+        ...     code='W_COMBO_GUARD_CONST_TRUE',
+        ...     severity='warning',
+        ...     message='true',
+        ...     refs={'origin_id': 'origin', 'term_index': 2},
+        ... )
+        >>> _combo_guard_replacement_keys((diagnostic,))[
+        ...     'W_COMBO_GUARD_CONST_TRUE'
+        ... ]
+        {('origin', 2)}
+    """
+    keys: Dict[str, Set[Tuple[str, int]]] = {}
+    for diagnostic in diagnostics:
+        if diagnostic.code not in set(COMBO_GUARD_VERIFY_REPLACEMENT_CODES.values()):
+            continue
+        origin_id = diagnostic.refs.get('origin_id')
+        term_index = diagnostic.refs.get('term_index')
+        if (
+                isinstance(origin_id, str)
+                and isinstance(term_index, int)
+                and not isinstance(term_index, bool)
+        ):
+            keys.setdefault(diagnostic.code, set()).add((origin_id, term_index))
+    return keys
+
+
+def _combo_transition_has_guard_replacement(
+        transition: TransitionInfo,
+        replacement_keys: Set[Tuple[str, int]],
+) -> bool:
+    """Return whether all combo refs on a generated guard edge are covered.
+
+    :param transition: Matched generated combo transition.
+    :type transition: TransitionInfo
+    :param replacement_keys: Covered ``(origin_id, term_index)`` pairs for the
+        expected combo-specific diagnostic code.
+    :type replacement_keys: Set[Tuple[str, int]]
+    :return: ``True`` only when suppressing the generic diagnostic cannot hide
+        a source-level finding.
+    :rtype: bool
+
+    Examples::
+
+        >>> ref = ComboOriginRefInfo('origin', 0, 'prefix', True, '[x > 0]')
+        >>> transition = TransitionInfo(
+        ...     from_path='Root.__combo_a',
+        ...     to_path='Root.__combo_b',
+        ...     event=None,
+        ...     event_scope=None,
+        ...     guard='x > 0',
+        ...     effect=None,
+        ...     effect_self_assigns=(),
+        ...     is_forced=False,
+        ...     forced_origin=None,
+        ...     transition_index=0,
+        ...     combo_origin_refs=(ref,),
+        ... )
+        >>> _combo_transition_has_guard_replacement(transition, {('origin', 0)})
+        True
+        >>> _combo_transition_has_guard_replacement(transition, set())
+        False
+    """
+    refs = tuple(ref for ref in transition.combo_origin_refs if ref.consumes_term)
+    return bool(refs) and all(
+        (ref.origin_id, ref.term_index) in replacement_keys for ref in refs
+    )
+
+
 def _is_combo_generated_guard_verify_diagnostic(
         code: str,
         raw: Mapping[str, Any],
         transitions: Sequence[TransitionInfo],
+        combo_guard_replacement_keys: Mapping[str, Set[Tuple[str, int]]],
 ) -> bool:
-    """Return whether a raw generic guard diagnostic targets combo internals.
+    """Return whether a raw generic guard diagnostic has a combo replacement.
 
     Generic SMT guard diagnostics report transition-level facts. For combo
-    generated guard edges, the public inspect surface uses combo-specific
-    diagnostics so spans and refs point at the original trigger term instead
-    of the pseudo-state expansion.
+    generated guard edges, the public inspect surface may suppress them only
+    when combo-specific diagnostics already cover every original trigger term
+    represented by the generated edge. If no replacement exists, the raw
+    verify diagnostic remains visible rather than being silently swallowed.
 
     :param code: Raw verify diagnostic code.
     :type code: str
@@ -2048,6 +2141,9 @@ def _is_combo_generated_guard_verify_diagnostic(
     :type raw: Mapping[str, Any]
     :param transitions: Inspect transition payloads.
     :type transitions: Sequence[TransitionInfo]
+    :param combo_guard_replacement_keys: Combo-specific replacement coverage
+        keyed by public diagnostic code.
+    :type combo_guard_replacement_keys: Mapping[str, Set[Tuple[str, int]]]
     :return: ``True`` when the generic diagnostic should be suppressed.
     :rtype: bool
 
@@ -2081,32 +2177,54 @@ def _is_combo_generated_guard_verify_diagnostic(
         ...     'guard': 'x > 0',
         ...     'is_forced': False,
         ... }}}
+        >>> replacements = {
+        ...     'W_COMBO_GUARD_CONST_FALSE': {
+        ...         ('Root:S->T::: E1 + [x > 0] + E2', 1),
+        ...     },
+        ... }
         >>> _is_combo_generated_guard_verify_diagnostic(
         ...     'W_DEAD_GUARD',
         ...     raw,
         ...     (transition,),
+        ...     replacements,
         ... )
         True
+        >>> _is_combo_generated_guard_verify_diagnostic(
+        ...     'W_DEAD_GUARD',
+        ...     raw,
+        ...     (transition,),
+        ...     {},
+        ... )
+        False
         >>> _is_combo_generated_guard_verify_diagnostic(
         ...     'W_FORCED_GUARD_UNSAT',
         ...     raw,
         ...     (transition,),
+        ...     replacements,
         ... )
         False
     """
     # Keep this list intentionally narrow.  These two generic guard-level SMT
-    # diagnostics have combo-specific analyzer counterparts that project to
-    # the original trigger term.  Other transition-keyed verify diagnostics
-    # must stay visible until a combo-aware public diagnostic exists for them.
-    if code not in {'W_DEAD_GUARD', 'W_GUARD_TAUTOLOGY'}:
+    # diagnostics are suppressible only when a combo-specific analyzer
+    # counterpart already projects the same source term.  Other transition-keyed
+    # verify diagnostics must stay visible until a combo-aware public diagnostic
+    # exists for them.
+    replacement_code = COMBO_GUARD_VERIFY_REPLACEMENT_CODES.get(code)
+    if replacement_code is None:
         return False
     data = raw.get('data')
     if not isinstance(data, Mapping):
         return False
-    return _combo_generated_transition_by_payload(
+    transition = _combo_generated_transition_by_payload(
         transitions,
         data.get('transition'),
-    ) is not None
+    )
+    if transition is None:
+        return False
+    return _combo_transition_has_guard_replacement(
+        transition,
+        combo_guard_replacement_keys.get(replacement_code, set()),
+    )
 
 
 def _transition_span_by_payload(
@@ -2761,6 +2879,9 @@ def _verify_diagnostics_from_results(
         transitions: Sequence[TransitionInfo],
         events: Sequence[EventInfo],
         actions: Sequence[ActionInfo],
+        combo_guard_replacement_keys: Optional[
+            Mapping[str, Set[Tuple[str, int]]]
+        ] = None,
 ) -> Tuple[ModelDiagnostic, ...]:
     """Convert inspect-adapter results into public model diagnostics.
 
@@ -2780,6 +2901,9 @@ def _verify_diagnostics_from_results(
     :type events: Sequence[EventInfo]
     :param actions: Inspect action payloads.
     :type actions: Sequence[ActionInfo]
+    :param combo_guard_replacement_keys: Combo-specific guard replacement
+        coverage collected before verify diagnostics are appended.
+    :type combo_guard_replacement_keys: Mapping[str, Set[Tuple[str, int]]], optional
     :return: Converted verify diagnostics.
     :rtype: Tuple[ModelDiagnostic, ...]
 
@@ -2801,6 +2925,7 @@ def _verify_diagnostics_from_results(
         ()
     """
     diagnostics: List[ModelDiagnostic] = []
+    combo_guard_replacement_keys = combo_guard_replacement_keys or {}
     for result in results:
         if result.result_kind in {'unknown', 'timeout', 'undecidable_skip'}:
             continue
@@ -2815,6 +2940,7 @@ def _verify_diagnostics_from_results(
                     code,
                     raw,
                     transitions,
+                    combo_guard_replacement_keys,
                 ):
                     continue
                 refs = _verify_smt_refs(raw)
@@ -3024,6 +3150,7 @@ def inspect_model(
             transitions,
             events,
             actions,
+            combo_guard_replacement_keys=_combo_guard_replacement_keys(diagnostics),
         ))
     diagnostics = list(_catalog_emittable_diagnostics(diagnostics))
     diagnostics = list(_deduplicate_model_diagnostics(diagnostics))

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -1988,6 +1988,13 @@ def _combo_generated_transition_by_payload(
 
     Examples::
 
+        >>> ref = ComboOriginRefInfo(
+        ...     'Root:S->T::: E1 + [x > 0] + E2',
+        ...     1,
+        ...     'prefix',
+        ...     True,
+        ...     '[x > 0]',
+        ... )
         >>> transition = TransitionInfo(
         ...     from_path='Root.__combo_a',
         ...     to_path='Root.__combo_b',
@@ -1999,7 +2006,7 @@ def _combo_generated_transition_by_payload(
         ...     is_forced=False,
         ...     forced_origin=None,
         ...     transition_index=0,
-        ...     combo_origin_refs=(object(),),
+        ...     combo_origin_refs=(ref,),
         ... )
         >>> payload = {
         ...     'parent': 'Root',
@@ -2046,13 +2053,51 @@ def _is_combo_generated_guard_verify_diagnostic(
 
     Examples::
 
+        >>> ref = ComboOriginRefInfo(
+        ...     'Root:S->T::: E1 + [x > 0] + E2',
+        ...     1,
+        ...     'prefix',
+        ...     True,
+        ...     '[x > 0]',
+        ... )
+        >>> transition = TransitionInfo(
+        ...     from_path='Root.__combo_a',
+        ...     to_path='Root.__combo_b',
+        ...     event=None,
+        ...     event_scope=None,
+        ...     guard='x > 0',
+        ...     effect=None,
+        ...     effect_self_assigns=(),
+        ...     is_forced=False,
+        ...     forced_origin=None,
+        ...     transition_index=0,
+        ...     combo_origin_refs=(ref,),
+        ... )
+        >>> raw = {'data': {'transition': {
+        ...     'parent': 'Root',
+        ...     'from_state': '__combo_a',
+        ...     'to_state': '__combo_b',
+        ...     'event': None,
+        ...     'guard': 'x > 0',
+        ...     'is_forced': False,
+        ... }}}
         >>> _is_combo_generated_guard_verify_diagnostic(
-        ...     'W_EFFECT_SMT_NO_OP',
-        ...     {'data': {}},
-        ...     (),
+        ...     'W_DEAD_GUARD',
+        ...     raw,
+        ...     (transition,),
+        ... )
+        True
+        >>> _is_combo_generated_guard_verify_diagnostic(
+        ...     'W_FORCED_GUARD_UNSAT',
+        ...     raw,
+        ...     (transition,),
         ... )
         False
     """
+    # Keep this list intentionally narrow.  These two generic guard-level SMT
+    # diagnostics have combo-specific analyzer counterparts that project to
+    # the original trigger term.  Other transition-keyed verify diagnostics
+    # must stay visible until a combo-aware public diagnostic exists for them.
     if code not in {'W_DEAD_GUARD', 'W_GUARD_TAUTOLOGY'}:
         return False
     data = raw.get('data')

--- a/pyfcstm/diagnostics/inspect.py
+++ b/pyfcstm/diagnostics/inspect.py
@@ -1967,6 +1967,103 @@ def _transition_matches_payload(info: TransitionInfo, payload: Mapping[str, Any]
     )
 
 
+def _combo_generated_transition_by_payload(
+        transitions: Sequence[TransitionInfo],
+        payload: Optional[Mapping[str, Any]],
+) -> Optional[TransitionInfo]:
+    """Return the combo-generated transition matched by a raw payload.
+
+    Combo-trigger expansion creates internal pseudo-state edges whose
+    diagnostics should be projected back to the author-written combo term by
+    the combo analyzer instead of exposing ``__combo_*`` edges through generic
+    verify diagnostics. This helper identifies those internal edges without
+    changing the lower-level verify algorithms.
+
+    :param transitions: Inspect transition payloads.
+    :type transitions: Sequence[TransitionInfo]
+    :param payload: Raw verify transition payload.
+    :type payload: Optional[Mapping[str, Any]]
+    :return: Matching combo-generated transition, or ``None``.
+    :rtype: Optional[TransitionInfo]
+
+    Examples::
+
+        >>> transition = TransitionInfo(
+        ...     from_path='Root.__combo_a',
+        ...     to_path='Root.__combo_b',
+        ...     event=None,
+        ...     event_scope=None,
+        ...     guard='x > 0',
+        ...     effect=None,
+        ...     effect_self_assigns=(),
+        ...     is_forced=False,
+        ...     forced_origin=None,
+        ...     transition_index=0,
+        ...     combo_origin_refs=(object(),),
+        ... )
+        >>> payload = {
+        ...     'parent': 'Root',
+        ...     'from_state': '__combo_a',
+        ...     'to_state': '__combo_b',
+        ...     'event': None,
+        ...     'guard': 'x > 0',
+        ...     'is_forced': False,
+        ... }
+        >>> _combo_generated_transition_by_payload((transition,), payload) is transition
+        True
+    """
+    if payload is None:
+        return None
+    for transition in transitions:
+        if transition.combo_origin_refs and _transition_matches_payload(
+            transition,
+            payload,
+        ):
+            return transition
+    return None
+
+
+def _is_combo_generated_guard_verify_diagnostic(
+        code: str,
+        raw: Mapping[str, Any],
+        transitions: Sequence[TransitionInfo],
+) -> bool:
+    """Return whether a raw generic guard diagnostic targets combo internals.
+
+    Generic SMT guard diagnostics report transition-level facts. For combo
+    generated guard edges, the public inspect surface uses combo-specific
+    diagnostics so spans and refs point at the original trigger term instead
+    of the pseudo-state expansion.
+
+    :param code: Raw verify diagnostic code.
+    :type code: str
+    :param raw: Raw verify diagnostic dictionary.
+    :type raw: Mapping[str, Any]
+    :param transitions: Inspect transition payloads.
+    :type transitions: Sequence[TransitionInfo]
+    :return: ``True`` when the generic diagnostic should be suppressed.
+    :rtype: bool
+
+    Examples::
+
+        >>> _is_combo_generated_guard_verify_diagnostic(
+        ...     'W_EFFECT_SMT_NO_OP',
+        ...     {'data': {}},
+        ...     (),
+        ... )
+        False
+    """
+    if code not in {'W_DEAD_GUARD', 'W_GUARD_TAUTOLOGY'}:
+        return False
+    data = raw.get('data')
+    if not isinstance(data, Mapping):
+        return False
+    return _combo_generated_transition_by_payload(
+        transitions,
+        data.get('transition'),
+    ) is not None
+
+
 def _transition_span_by_payload(
         transitions: Sequence[TransitionInfo],
         payload: Optional[Mapping[str, Any]],
@@ -2668,6 +2765,12 @@ def _verify_diagnostics_from_results(
                     continue
                 code = raw.get('code')
                 if not isinstance(code, str):
+                    continue
+                if _is_combo_generated_guard_verify_diagnostic(
+                    code,
+                    raw,
+                    transitions,
+                ):
                     continue
                 refs = _verify_smt_refs(raw)
                 if refs is None:

--- a/test/diagnostics/test_combo_downstream_compat.py
+++ b/test/diagnostics/test_combo_downstream_compat.py
@@ -137,3 +137,54 @@ def test_inspect_suppresses_generic_guard_tautology_for_combo_const_true():
     codes = {item.code for item in report.diagnostics}
     assert "W_COMBO_GUARD_CONST_TRUE" in codes
     assert "W_GUARD_TAUTOLOGY" not in codes
+
+def test_inspect_keeps_generic_guard_tautology_without_combo_replacement():
+    """Inspect keeps raw tautology when combo analyzer has no source-level replacement."""
+    source = """
+    def int x = 1;
+    state Root {
+        state S;
+        state T;
+        [*] -> S;
+        S -> T :: E1 + [x / x == 1] + E2;
+    }
+    """
+
+    assert "W_GUARD_TAUTOLOGY" in _raw_verify_codes(source)
+
+    report = inspect_model(
+        parse_machine(source),
+        enable_verify=True,
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=5000,
+    )
+
+    codes = {item.code for item in report.diagnostics}
+    assert "W_COMBO_GUARD_CONST_TRUE" not in codes
+    assert "W_GUARD_TAUTOLOGY" in codes
+
+
+def test_inspect_keeps_generic_dead_guard_without_combo_replacement():
+    """Inspect keeps raw dead guard when combo analyzer has no replacement."""
+    source = """
+    def int x = 1;
+    state Root {
+        state S;
+        state T;
+        [*] -> S;
+        S -> T :: E1 + [x / x != 1] + E2;
+    }
+    """
+
+    assert "W_DEAD_GUARD" in _raw_verify_codes(source)
+
+    report = inspect_model(
+        parse_machine(source),
+        enable_verify=True,
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=5000,
+    )
+
+    codes = {item.code for item in report.diagnostics}
+    assert "W_COMBO_GUARD_CONST_FALSE" not in codes
+    assert "W_DEAD_GUARD" in codes

--- a/test/diagnostics/test_combo_downstream_compat.py
+++ b/test/diagnostics/test_combo_downstream_compat.py
@@ -3,11 +3,26 @@
 import pytest
 
 from pyfcstm.diagnostics import inspect_model
+from pyfcstm.verify.inspect_adapter import run_inspect_algorithms
 from test.diagnostics._schema_check import assert_all_diags_match_schema
 from test.testings.combo_runtime import parse_machine
 
 
 pytestmark = pytest.mark.unittest
+
+
+def _raw_verify_codes(source):
+    machine = parse_machine(source)
+    results = run_inspect_algorithms(
+        machine,
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=5000,
+    )
+    return [
+        diagnostic["code"]
+        for result in results
+        for diagnostic in result.diagnostics
+    ]
 
 
 def test_inspect_verify_smoke_keeps_combo_pseudo_reachable_without_internal_refs():
@@ -84,21 +99,18 @@ def test_inspect_suppresses_generic_dead_guard_for_combo_const_false():
     }
     """
 
+    assert "W_DEAD_GUARD" in _raw_verify_codes(source)
+
     report = inspect_model(
         parse_machine(source),
         enable_verify=True,
         max_complexity_tier="smt_linear",
-        smt_timeout_ms=200,
+        smt_timeout_ms=5000,
     )
 
     codes = {item.code for item in report.diagnostics}
     assert "W_COMBO_GUARD_CONST_FALSE" in codes
     assert "W_DEAD_GUARD" not in codes
-    assert not any(
-        "__combo_" in str(item.refs)
-        for item in report.diagnostics
-        if item.code in {"W_DEAD_GUARD", "W_GUARD_TAUTOLOGY"}
-    )
 
 
 def test_inspect_suppresses_generic_guard_tautology_for_combo_const_true():
@@ -113,18 +125,15 @@ def test_inspect_suppresses_generic_guard_tautology_for_combo_const_true():
     }
     """
 
+    assert "W_GUARD_TAUTOLOGY" in _raw_verify_codes(source)
+
     report = inspect_model(
         parse_machine(source),
         enable_verify=True,
         max_complexity_tier="smt_linear",
-        smt_timeout_ms=200,
+        smt_timeout_ms=5000,
     )
 
     codes = {item.code for item in report.diagnostics}
     assert "W_COMBO_GUARD_CONST_TRUE" in codes
     assert "W_GUARD_TAUTOLOGY" not in codes
-    assert not any(
-        "__combo_" in str(item.refs)
-        for item in report.diagnostics
-        if item.code in {"W_DEAD_GUARD", "W_GUARD_TAUTOLOGY"}
-    )

--- a/test/diagnostics/test_combo_downstream_compat.py
+++ b/test/diagnostics/test_combo_downstream_compat.py
@@ -70,3 +70,61 @@ def test_inspect_guard_warning_on_combo_transition_points_to_original_term():
     assert diagnostic.refs["origin_id"] in {
         item.origin_id for item in report.combo_origins
     }
+
+
+def test_inspect_suppresses_generic_dead_guard_for_combo_const_false():
+    """Combo const-false guard reports only the source-level combo warning."""
+    source = """
+    def int x = 0;
+    state Root {
+        state S;
+        state T;
+        [*] -> S;
+        S -> T :: E1 + [x > 0 && x < 0] + E2;
+    }
+    """
+
+    report = inspect_model(
+        parse_machine(source),
+        enable_verify=True,
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=200,
+    )
+
+    codes = {item.code for item in report.diagnostics}
+    assert "W_COMBO_GUARD_CONST_FALSE" in codes
+    assert "W_DEAD_GUARD" not in codes
+    assert not any(
+        "__combo_" in str(item.refs)
+        for item in report.diagnostics
+        if item.code in {"W_DEAD_GUARD", "W_GUARD_TAUTOLOGY"}
+    )
+
+
+def test_inspect_suppresses_generic_guard_tautology_for_combo_const_true():
+    """Combo const-true guard reports only the source-level combo warning."""
+    source = """
+    def int x = 0;
+    state Root {
+        state S;
+        state T;
+        [*] -> S;
+        S -> T :: E1 + [x >= 0 || x < 0] + E2;
+    }
+    """
+
+    report = inspect_model(
+        parse_machine(source),
+        enable_verify=True,
+        max_complexity_tier="smt_linear",
+        smt_timeout_ms=200,
+    )
+
+    codes = {item.code for item in report.diagnostics}
+    assert "W_COMBO_GUARD_CONST_TRUE" in codes
+    assert "W_GUARD_TAUTOLOGY" not in codes
+    assert not any(
+        "__combo_" in str(item.refs)
+        for item in report.diagnostics
+        if item.code in {"W_DEAD_GUARD", "W_GUARD_TAUTOLOGY"}
+    )

--- a/test/diagnostics/test_combo_downstream_compat.py
+++ b/test/diagnostics/test_combo_downstream_compat.py
@@ -1,0 +1,72 @@
+"""Downstream inspect compatibility tests for expanded combo trigger models."""
+
+import pytest
+
+from pyfcstm.diagnostics import inspect_model
+from test.diagnostics._schema_check import assert_all_diags_match_schema
+from test.testings.combo_runtime import parse_machine
+
+
+pytestmark = pytest.mark.unittest
+
+
+def test_inspect_verify_smoke_keeps_combo_pseudo_reachable_without_internal_refs():
+    """Inspect and verify adapters can consume generated combo pseudo chains."""
+    source = """
+    def int x = 1;
+    state Root {
+        state S { during { x = x + 1; } }
+        state T;
+        [*] -> S;
+        S -> T :: E1 + [x > 0] + E2;
+        T -> [*];
+    }
+    """
+    report = inspect_model(
+        parse_machine(source), enable_verify=True, smt_timeout_ms=200
+    )
+    payload = report.to_json()
+
+    assert_all_diags_match_schema(report.diagnostics, context="combo-downstream-smoke")
+    assert payload["combo_transitions"]
+    assert payload["combo_origins"]
+    assert all(item["combo_origin_refs"] for item in payload["combo_transitions"])
+
+    combo_state_paths = [
+        item["path"] for item in payload["states"] if item["is_pseudo"]
+    ]
+    assert combo_state_paths
+    assert set(combo_state_paths).issubset(set(report.reachability_graph["Root"]))
+
+    origin_ids = {item["origin_id"] for item in payload["combo_origins"]}
+    for transition in payload["combo_transitions"]:
+        for ref in transition["combo_origin_refs"]:
+            assert ref["origin_id"] in origin_ids
+            assert ref["term_span"] is not None
+            assert ref["transition_span"] is not None
+
+
+def test_inspect_guard_warning_on_combo_transition_points_to_original_term():
+    """Combo guard diagnostics keep refs on the original author-written term."""
+    source = """
+    def int x = 0;
+    state Root {
+        state A;
+        state B;
+        [*] -> A;
+        A -> B :: E1 + [(1 + 2) == 4] + E2;
+    }
+    """
+    report = inspect_model(
+        parse_machine(source), enable_verify=True, smt_timeout_ms=200
+    )
+    assert_all_diags_match_schema(report.diagnostics, context="combo-guard-refs")
+
+    diagnostic = next(
+        item for item in report.diagnostics if item.code == "W_COMBO_GUARD_CONST_FALSE"
+    )
+    assert diagnostic.refs["term_text"] == "[(1 + 2) == 4]"
+    assert diagnostic.refs["term_span"] == diagnostic.span
+    assert diagnostic.refs["origin_id"] in {
+        item.origin_id for item in report.combo_origins
+    }

--- a/test/entry/test_combo_visualization.py
+++ b/test/entry/test_combo_visualization.py
@@ -25,9 +25,31 @@ state Root {
 }
 """
 
+ENTRY_COMBO_SOURCE = """
+state Root {
+    state S;
+    state F;
+    [*] -> S : E1 + E2;
+    [*] -> F;
+}
+"""
 
-def _write_combo_file(path):
-    path.write_text(textwrap.dedent(COMBO_SOURCE).strip(), encoding="utf-8")
+EXIT_COMBO_SOURCE = """
+state Root {
+    state Parent {
+        state S;
+        [*] -> S;
+        S -> [*] :: E1 + E2;
+    }
+    state Done;
+    [*] -> Parent;
+    Parent -> Done;
+}
+"""
+
+
+def _write_combo_file(path, source=COMBO_SOURCE):
+    path.write_text(textwrap.dedent(source).strip(), encoding="utf-8")
 
 
 def _assert_combo_plantuml_contract(plantuml_text):
@@ -41,6 +63,26 @@ def _assert_combo_plantuml_contract(plantuml_text):
     assert "S.E2" in plantuml_text
 
 
+def _assert_entry_combo_plantuml_contract(plantuml_text):
+    assert plantuml_text.startswith("@startuml")
+    assert re.search(r"root___combo_entry_.*_h[0-9a-f]{12}", plantuml_text)
+    assert 'state "combo after E1"' in plantuml_text
+    assert "<<pseudo>> #line.dotted" in plantuml_text
+    assert "[*] -->" in plantuml_text
+    assert "E1" in plantuml_text
+    assert "E2" in plantuml_text
+
+
+def _assert_exit_combo_plantuml_contract(plantuml_text):
+    assert plantuml_text.startswith("@startuml")
+    assert re.search(r"root__parent___combo_.*_h[0-9a-f]{12}", plantuml_text)
+    assert 'state "combo after E1"' in plantuml_text
+    assert "<<pseudo>> #line.dotted" in plantuml_text
+    assert "S.E1" in plantuml_text
+    assert "S.E2" in plantuml_text
+    assert "--> [*]" in plantuml_text
+
+
 def test_build_plantuml_output_shows_combo_pseudo_chain(tmp_path):
     source_file = tmp_path / "combo.fcstm"
     _write_combo_file(source_file)
@@ -48,6 +90,24 @@ def test_build_plantuml_output_shows_combo_pseudo_chain(tmp_path):
     plantuml_text = build_plantuml_output(str(source_file))
 
     _assert_combo_plantuml_contract(plantuml_text)
+
+
+def test_build_plantuml_output_shows_entry_combo_pseudo_chain(tmp_path):
+    source_file = tmp_path / "entry_combo.fcstm"
+    _write_combo_file(source_file, ENTRY_COMBO_SOURCE)
+
+    plantuml_text = build_plantuml_output(str(source_file))
+
+    _assert_entry_combo_plantuml_contract(plantuml_text)
+
+
+def test_build_plantuml_output_shows_exit_combo_pseudo_chain(tmp_path):
+    source_file = tmp_path / "exit_combo.fcstm"
+    _write_combo_file(source_file, EXIT_COMBO_SOURCE)
+
+    plantuml_text = build_plantuml_output(str(source_file))
+
+    _assert_exit_combo_plantuml_contract(plantuml_text)
 
 
 def test_plantuml_cli_writes_combo_pseudo_chain(tmp_path):

--- a/test/entry/test_combo_visualization.py
+++ b/test/entry/test_combo_visualization.py
@@ -1,0 +1,104 @@
+"""PlantUML and visualize smoke tests for generated combo pseudo states."""
+
+import pathlib
+import re
+import textwrap
+
+import pytest
+from hbutils.testing import isolated_directory, simulate_entry
+
+from pyfcstm.entry import pyfcstmcli
+from pyfcstm.entry.plantuml import build_plantuml_output
+from pyfcstm.entry import visualize as visualize_module
+
+
+pytestmark = pytest.mark.unittest
+
+
+COMBO_SOURCE = """
+def int x = 1;
+state Root {
+    state S;
+    state T;
+    [*] -> S;
+    S -> T :: E1 + [x > 0] + E2;
+}
+"""
+
+
+def _write_combo_file(path):
+    path.write_text(textwrap.dedent(COMBO_SOURCE).strip(), encoding="utf-8")
+
+
+def _assert_combo_plantuml_contract(plantuml_text):
+    assert plantuml_text.startswith("@startuml")
+    assert re.search(r"root___combo_.*_h[0-9a-f]{12}", plantuml_text)
+    assert 'state "combo after E1"' in plantuml_text
+    assert 'state "combo after E1 + [x > 0]"' in plantuml_text
+    assert "<<pseudo>> #line.dotted" in plantuml_text
+    assert "S.E1" in plantuml_text
+    assert "x > 0" in plantuml_text
+    assert "S.E2" in plantuml_text
+
+
+def test_build_plantuml_output_shows_combo_pseudo_chain(tmp_path):
+    source_file = tmp_path / "combo.fcstm"
+    _write_combo_file(source_file)
+
+    plantuml_text = build_plantuml_output(str(source_file))
+
+    _assert_combo_plantuml_contract(plantuml_text)
+
+
+def test_plantuml_cli_writes_combo_pseudo_chain(tmp_path):
+    source_file = tmp_path / "combo.fcstm"
+    output_file = tmp_path / "combo.puml"
+    _write_combo_file(source_file)
+
+    result = simulate_entry(
+        pyfcstmcli,
+        ["pyfcstm", "plantuml", "-i", str(source_file), "-o", str(output_file)],
+    )
+
+    assert result.exitcode == 0
+    _assert_combo_plantuml_contract(output_file.read_text(encoding="utf-8"))
+
+
+def test_visualize_reuses_combo_plantuml_text_without_binary_snapshot(
+    tmp_path, monkeypatch
+):
+    source_file = tmp_path / "combo.fcstm"
+    _write_combo_file(source_file)
+    captured = []
+
+    def _render(plantuml_output, output_file, render_type, renderer, **kwargs):
+        _assert_combo_plantuml_contract(plantuml_output)
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+        output_file.write_text("%s:%s" % (render_type, renderer), encoding="utf-8")
+        captured.append((plantuml_output, output_file, render_type, renderer, kwargs))
+        return renderer
+
+    monkeypatch.setattr(visualize_module, "render_plantuml_diagram", _render)
+
+    with isolated_directory():
+        result = simulate_entry(
+            pyfcstmcli,
+            [
+                "pyfcstm",
+                "visualize",
+                "-i",
+                str(source_file),
+                "-o",
+                "out/diagram",
+                "-t",
+                "svg",
+                "--renderer",
+                "local",
+                "--no-open",
+            ],
+        )
+
+        assert result.exitcode == 0
+        assert pathlib.Path("out/diagram.svg").exists()
+        assert captured
+        assert captured[0][2] == "svg"

--- a/test/simulate/test_combo_runtime_compat.py
+++ b/test/simulate/test_combo_runtime_compat.py
@@ -1,0 +1,337 @@
+"""Runtime compatibility tests for expanded combo trigger pseudo chains."""
+
+import pytest
+
+from pyfcstm.simulate import SimulationRuntime
+from test.testings.combo_runtime import (
+    assert_combo_matches_manual_pseudo,
+    combo_projection_signature,
+    parse_machine,
+)
+
+
+pytestmark = pytest.mark.unittest
+
+
+def test_event_guard_event_success_matches_hand_written_pseudo_chain():
+    combo = """
+    def int x = 1;
+    state Root {
+        state S;
+        state T;
+        [*] -> S;
+        S -> T :: E1 + [x > 0] + E2;
+    }
+    """
+    manual = """
+    def int x = 1;
+    state Root {
+        state S;
+        pseudo state P1 named "combo after E1";
+        pseudo state P2 named "combo after E1 + [x > 0]";
+        state T;
+        [*] -> S;
+        S -> P1 :: E1;
+        P1 -> P2 : if [x > 0];
+        P2 -> T : /S.E2;
+    }
+    """
+
+    _, _, trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1", "Root.S.E2"]]
+    )
+
+    assert trace[-1]["state"] == "Root.T"
+    assert trace[-1]["consumed_events"] == ("Root.S.E1", "Root.S.E2")
+
+
+def test_missing_second_event_rolls_back_and_uses_later_fallback_transition():
+    combo = """
+    state Root {
+        state S;
+        state T;
+        state F;
+        [*] -> S;
+        S -> T :: E1 + E2;
+        S -> F :: E1;
+    }
+    """
+    manual = """
+    state Root {
+        state S;
+        pseudo state P named "combo after E1";
+        state T;
+        state F;
+        [*] -> S;
+        S -> P :: E1;
+        P -> T : /S.E2;
+        S -> F :: E1;
+    }
+    """
+
+    _, _, trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1"]]
+    )
+
+    assert trace[-1]["state"] == "Root.F"
+    assert trace[-1]["consumed_events"] == ("Root.S.E1",)
+
+
+def test_middle_guard_false_rolls_back_and_uses_later_fallback_transition():
+    combo = """
+    def int x = 0;
+    state Root {
+        state S;
+        state T;
+        state F;
+        [*] -> S;
+        S -> T :: E1 + [x > 0] + E2;
+        S -> F :: E1;
+    }
+    """
+    manual = """
+    def int x = 0;
+    state Root {
+        state S;
+        pseudo state P1 named "combo after E1";
+        pseudo state P2 named "combo after E1 + [x > 0]";
+        state T;
+        state F;
+        [*] -> S;
+        S -> P1 :: E1;
+        P1 -> P2 : if [x > 0];
+        P2 -> T : /S.E2;
+        S -> F :: E1;
+    }
+    """
+
+    _, _, trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1", "Root.S.E2"]]
+    )
+
+    assert trace[-1]["state"] == "Root.F"
+    assert trace[-1]["consumed_events"] == ("Root.S.E1",)
+    assert trace[-1]["unconsumed_events"] == ("Root.S.E2",)
+
+
+def test_terminal_effect_commits_only_for_successful_combo_path():
+    combo = """
+    def int x = 0;
+    state Root {
+        state S;
+        state T;
+        state F;
+        [*] -> S;
+        S -> T :: E1 + E2 effect { x = 1; }
+        S -> F :: E1 effect { x = 2; }
+    }
+    """
+    manual = """
+    def int x = 0;
+    state Root {
+        state S;
+        pseudo state P named "combo after E1";
+        state T;
+        state F;
+        [*] -> S;
+        S -> P :: E1;
+        P -> T : /S.E2 effect { x = 1; }
+        S -> F :: E1 effect { x = 2; }
+    }
+    """
+
+    _, _, success_trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1", "Root.S.E2"]]
+    )
+    _, _, fallback_trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1"]]
+    )
+
+    assert success_trace[-1]["state"] == "Root.T"
+    assert dict(success_trace[-1]["vars"])["x"] == 1
+    assert fallback_trace[-1]["state"] == "Root.F"
+    assert dict(fallback_trace[-1]["vars"])["x"] == 2
+
+
+def test_entry_combo_initial_transition_matches_hand_written_pseudo_chain():
+    combo = """
+    state Root {
+        state S;
+        state F;
+        [*] -> S : E1 + E2;
+        [*] -> F;
+    }
+    """
+    manual = """
+    state Root {
+        pseudo state P named "combo after E1";
+        state S;
+        state F;
+        [*] -> P : E1;
+        P -> S : E2;
+        [*] -> F;
+    }
+    """
+
+    _, _, success_trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [["Root.E1", "Root.E2"]]
+    )
+    _, _, fallback_trace = assert_combo_matches_manual_pseudo(combo, manual, [None])
+
+    assert success_trace[-1]["state"] == "Root.S"
+    assert fallback_trace[-1]["state"] == "Root.F"
+
+
+def test_exit_combo_parent_continuation_matches_hand_written_pseudo_chain():
+    combo = """
+    state Root {
+        state Parent {
+            state S;
+            [*] -> S;
+            S -> [*] :: E1 + E2;
+        }
+        state Done;
+        [*] -> Parent;
+        Parent -> Done;
+    }
+    """
+    manual = """
+    state Root {
+        state Parent {
+            state S;
+            pseudo state P named "combo after E1";
+            [*] -> S;
+            S -> P :: E1;
+            P -> [*] : /Parent.S.E2;
+        }
+        state Done;
+        [*] -> Parent;
+        Parent -> Done;
+    }
+    """
+
+    _, _, trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.Parent.S.E1", "Root.Parent.S.E2"]]
+    )
+
+    assert trace[-1]["state"] == "Root.Done"
+    assert trace[-1]["consumed_events"] == (
+        "Root.Parent.S.E1",
+        "Root.Parent.S.E2",
+    )
+
+
+def test_hot_start_to_event_gated_combo_pseudo_is_rejected():
+    model = parse_machine(
+        """
+        state Root {
+            state S;
+            state T;
+            [*] -> S;
+            S -> T :: E1 + E2;
+        }
+        """
+    )
+    pseudo = next(
+        state for state in model.root_state.substates.values() if state.is_pseudo
+    )
+
+    with pytest.raises(ValueError, match="cannot reach a stoppable state"):
+        SimulationRuntime(model, initial_state=pseudo.path, initial_vars={})
+
+
+def test_plain_pseudo_with_same_event_gate_has_same_hot_start_contract():
+    model = parse_machine(
+        """
+        state Root {
+            state S;
+            pseudo state P named "combo after E1";
+            state T;
+            [*] -> S;
+            S -> P :: E1;
+            P -> T : /S.E2;
+        }
+        """
+    )
+
+    with pytest.raises(
+        ValueError, match="Hot start target 'Root.P' cannot reach a stoppable state"
+    ):
+        SimulationRuntime(model, initial_state="Root.P", initial_vars={})
+
+
+def test_prefix_reuse_matches_shared_hand_written_pseudo_chain():
+    combo = """
+    state Root {
+        state S;
+        state A;
+        state B;
+        [*] -> S;
+        S -> A :: E1 + E2;
+        S -> B :: E1 + E3;
+    }
+    """
+    manual = """
+    state Root {
+        state S;
+        pseudo state P named "combo after E1";
+        state A;
+        state B;
+        [*] -> S;
+        S -> P :: E1;
+        P -> A : /S.E2;
+        P -> B : /S.E3;
+    }
+    """
+
+    combo_model, _, trace_to_a = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1", "Root.S.E2"]]
+    )
+    _, _, trace_to_b = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1", "Root.S.E3"]]
+    )
+
+    assert len(combo_projection_signature(combo_model)) == 3
+    assert trace_to_a[-1]["state"] == "Root.A"
+    assert trace_to_b[-1]["state"] == "Root.B"
+
+
+def test_priority_fence_matches_split_hand_written_pseudo_chains():
+    combo = """
+    state Root {
+        state S;
+        state A;
+        state B;
+        state F;
+        [*] -> S;
+        S -> A :: E1 + E2;
+        S -> F :: E1;
+        S -> B :: E1 + E3;
+    }
+    """
+    manual = """
+    state Root {
+        state S;
+        pseudo state P1 named "combo after E1";
+        pseudo state P2 named "combo after E1";
+        state A;
+        state B;
+        state F;
+        [*] -> S;
+        S -> P1 :: E1;
+        P1 -> A : /S.E2;
+        S -> F :: E1;
+        S -> P2 :: E1;
+        P2 -> B : /S.E3;
+    }
+    """
+
+    _, _, trace_to_a = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1", "Root.S.E2"]]
+    )
+    _, _, trace_to_f = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.S.E1", "Root.S.E3"]]
+    )
+
+    assert trace_to_a[-1]["state"] == "Root.A"
+    assert trace_to_f[-1]["state"] == "Root.F"

--- a/test/simulate/test_combo_runtime_compat.py
+++ b/test/simulate/test_combo_runtime_compat.py
@@ -221,6 +221,48 @@ def test_exit_combo_parent_continuation_matches_hand_written_pseudo_chain():
     )
 
 
+def test_exit_combo_parent_continuation_failure_rolls_back_to_source():
+    combo = """
+    def int x = 0;
+    state Root {
+        state Parent {
+            state S;
+            [*] -> S;
+            S -> [*] :: E1 + E2;
+        }
+        state Done;
+        [*] -> Parent;
+        Parent -> Done : if [x > 0];
+    }
+    """
+    manual = """
+    def int x = 0;
+    state Root {
+        state Parent {
+            state S;
+            pseudo state P named "combo after E1";
+            [*] -> S;
+            S -> P :: E1;
+            P -> [*] : /Parent.S.E2;
+        }
+        state Done;
+        [*] -> Parent;
+        Parent -> Done : if [x > 0];
+    }
+    """
+
+    _, _, trace = assert_combo_matches_manual_pseudo(
+        combo, manual, [None, ["Root.Parent.S.E1", "Root.Parent.S.E2"]]
+    )
+
+    assert trace[-1]["state"] == "Root.Parent.S"
+    assert trace[-1]["consumed_events"] == ()
+    assert trace[-1]["unconsumed_events"] == (
+        "Root.Parent.S.E1",
+        "Root.Parent.S.E2",
+    )
+
+
 def test_hot_start_to_event_gated_combo_pseudo_is_rejected():
     model = parse_machine(
         """

--- a/test/testings/combo_runtime.py
+++ b/test/testings/combo_runtime.py
@@ -1,0 +1,301 @@
+"""Helpers for comparing combo-trigger expansion with hand-written pseudo chains.
+
+The helpers in this module intentionally live under the Python test tree.  They
+only depend on production ``pyfcstm`` APIs, the Python standard library, and
+plain assertions so downstream compatibility tests can compare generated combo
+models with equivalent hand-written pseudo-state models without crossing into
+jsfcstm or editor test fixtures.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections import defaultdict
+from textwrap import dedent
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from pyfcstm.dsl import EXIT_STATE, INIT_STATE, parse_with_grammar_entry
+from pyfcstm.model import parse_dsl_node_to_state_machine
+from pyfcstm.model.model import State, StateMachine, Transition
+from pyfcstm.simulate import SimulationRuntime
+
+
+def parse_machine(source: str) -> StateMachine:
+    """Parse FCSTM DSL source into a validated state-machine model.
+
+    :param source: FCSTM DSL source text.
+    :type source: str
+    :return: Parsed state machine.
+    :rtype: pyfcstm.model.model.StateMachine
+
+    Example::
+
+        >>> machine = parse_machine('state Root { state A; [*] -> A; }')
+        >>> machine.root_state.name
+        'Root'
+    """
+    ast = parse_with_grammar_entry(dedent(source), "state_machine_dsl")
+    return parse_dsl_node_to_state_machine(ast)
+
+
+def _is_init_endpoint(endpoint: object) -> bool:
+    return endpoint is INIT_STATE or str(endpoint) == "INIT_STATE"
+
+
+def _is_exit_endpoint(endpoint: object) -> bool:
+    return endpoint is EXIT_STATE or str(endpoint) == "EXIT_STATE"
+
+
+def _state_path(path: Sequence[str]) -> str:
+    return ".".join(path)
+
+
+def _pseudo_label_maps(model: StateMachine) -> Dict[Tuple[str, ...], str]:
+    labels: Dict[Tuple[str, ...], str] = {}
+    for parent in model.walk_states():
+        counters: Dict[str, int] = defaultdict(int)
+        for state in parent.substates.values():
+            if not state.is_pseudo:
+                continue
+            display = state.extra_name or state.name
+            counters[display] += 1
+            labels[state.path] = "<pseudo:%s#%d>" % (display, counters[display])
+    return labels
+
+
+def _endpoint_label(
+    owner: State,
+    endpoint: object,
+    pseudo_labels: Mapping[Tuple[str, ...], str],
+) -> str:
+    if _is_init_endpoint(endpoint):
+        return "[*]"
+    if _is_exit_endpoint(endpoint):
+        return "[*]"
+
+    name = str(endpoint)
+    state = owner.substates.get(name)
+    if state is not None and state.is_pseudo:
+        return pseudo_labels[state.path]
+    return name
+
+
+def _event_name(transition: Transition) -> Optional[str]:
+    if transition.event is None:
+        return None
+    return transition.event.path_name
+
+
+def _guard_text(transition: Transition) -> Optional[str]:
+    if transition.guard is None:
+        return None
+    return str(transition.guard)
+
+
+def _effect_texts(transition: Transition) -> Tuple[str, ...]:
+    return tuple(str(item.to_ast_node()) for item in transition.effects)
+
+
+def pseudo_state_signature(model: StateMachine) -> Tuple[Tuple[str, str], ...]:
+    """Return a normalized pseudo-state signature for a model.
+
+    Generated combo states and hand-written pseudo states can have different
+    concrete identifiers.  This signature compares them by parent path and
+    display text, with an occurrence index for duplicate display texts under the
+    same parent.
+
+    :param model: State-machine model to summarize.
+    :type model: pyfcstm.model.model.StateMachine
+    :return: Normalized pseudo-state entries.
+    :rtype: tuple
+
+    Example::
+
+        >>> machine = parse_machine('state Root { pseudo state P named "gate"; state A; [*] -> P; P -> A; }')
+        >>> pseudo_state_signature(machine)
+        (('Root', '<pseudo:gate#1>'),)
+    """
+    labels = _pseudo_label_maps(model)
+    result = []
+    for state in model.walk_states():
+        if state.is_pseudo:
+            parent_path = _state_path(state.parent.path) if state.parent else ""
+            result.append((parent_path, labels[state.path]))
+    return tuple(result)
+
+
+def model_transition_signature(model: StateMachine) -> Tuple[Tuple[Any, ...], ...]:
+    """Return a normalized transition graph signature for runtime comparison.
+
+    The signature intentionally ignores combo provenance metadata.  It captures
+    the ordinary model surface consumed by runtime, verify, and visualization:
+    parent scope, normalized endpoints, canonical event path, guard text, and
+    transition effects.
+
+    :param model: State-machine model to summarize.
+    :type model: pyfcstm.model.model.StateMachine
+    :return: Ordered transition signature entries.
+    :rtype: tuple
+
+    Example::
+
+        >>> machine = parse_machine('state Root { state A; state B; [*] -> A; A -> B; }')
+        >>> model_transition_signature(machine)[0][:3]
+        ('Root', '[*]', 'A')
+    """
+    labels = _pseudo_label_maps(model)
+    result = []
+    for owner in model.walk_states():
+        for transition in owner.transitions:
+            result.append(
+                (
+                    _state_path(owner.path),
+                    _endpoint_label(owner, transition.from_state, labels),
+                    _endpoint_label(owner, transition.to_state, labels),
+                    _event_name(transition),
+                    _guard_text(transition),
+                    _effect_texts(transition),
+                )
+            )
+    return tuple(result)
+
+
+def combo_projection_signature(model: StateMachine) -> Tuple[Tuple[Any, ...], ...]:
+    """Return key combo-provenance fields for generated transitions.
+
+    :param model: State-machine model to summarize.
+    :type model: pyfcstm.model.model.StateMachine
+    :return: Ordered generated-transition provenance entries.
+    :rtype: tuple
+
+    Example::
+
+        >>> machine = parse_machine('state Root { state A; state B; [*] -> A; A -> B :: E1 + E2; }')
+        >>> len(combo_projection_signature(machine))
+        2
+    """
+    labels = _pseudo_label_maps(model)
+    result = []
+    for owner in model.walk_states():
+        for transition in owner.transitions:
+            if not transition.combo_origin_refs:
+                continue
+            result.append(
+                (
+                    _state_path(owner.path),
+                    _endpoint_label(owner, transition.from_state, labels),
+                    _endpoint_label(owner, transition.to_state, labels),
+                    _event_name(transition),
+                    _guard_text(transition),
+                    tuple(
+                        (
+                            ref.origin_id,
+                            ref.term_index,
+                            ref.role,
+                            ref.consumes_term,
+                            ref.term_text,
+                        )
+                        for ref in transition.combo_origin_refs
+                    ),
+                    transition.combo_projection_key,
+                    transition.combo_projection_order_key,
+                    transition.combo_reuse_group_id,
+                    transition.combo_priority_run_identity,
+                    transition.combo_priority_run_index,
+                )
+            )
+    return tuple(result)
+
+
+def _normalized_runtime_state(runtime: SimulationRuntime) -> str:
+    if runtime.is_ended:
+        return "<ended>"
+    return _state_path(runtime.current_state.path)
+
+
+def simulation_trace(
+    model: StateMachine,
+    cycle_events: Iterable[Any],
+    *,
+    initial_state: Optional[Any] = None,
+    initial_vars: Optional[Dict[str, Any]] = None,
+) -> Tuple[Dict[str, Any], ...]:
+    """Run a model and return stable per-cycle simulation metadata.
+
+    :param model: State-machine model to execute.
+    :type model: pyfcstm.model.model.StateMachine
+    :param cycle_events: Iterable of values to pass to consecutive
+        :meth:`pyfcstm.simulate.SimulationRuntime.cycle` calls.
+    :type cycle_events: Iterable[typing.Any]
+    :param initial_state: Optional hot-start state path.
+    :type initial_state: typing.Any, optional
+    :param initial_vars: Optional complete variable mapping for hot start.
+    :type initial_vars: dict, optional
+    :return: Tuple of per-cycle trace dictionaries.
+    :rtype: tuple
+
+    Example::
+
+        >>> machine = parse_machine('state Root { state A; [*] -> A; }')
+        >>> simulation_trace(machine, [None])[0]['state']
+        'Root.A'
+    """
+    kwargs = {}
+    if initial_state is not None:
+        kwargs["initial_state"] = initial_state
+    if initial_vars is not None:
+        kwargs["initial_vars"] = copy.deepcopy(initial_vars)
+    runtime = SimulationRuntime(model, **kwargs)
+
+    trace: List[Dict[str, Any]] = []
+    for events in cycle_events:
+        result = runtime.cycle(events)
+        trace.append(
+            {
+                "state": _normalized_runtime_state(runtime),
+                "vars": tuple(sorted(runtime.vars.items())),
+                "input_events": result.input_events,
+                "consumed_events": result.consumed_events,
+                "unconsumed_events": result.unconsumed_events,
+            }
+        )
+    return tuple(trace)
+
+
+def assert_combo_matches_manual_pseudo(
+    combo_source: str,
+    manual_source: str,
+    cycle_events: Iterable[Any],
+) -> Tuple[StateMachine, StateMachine, Tuple[Dict[str, Any], ...]]:
+    """Assert that combo DSL and a hand-written pseudo model are equivalent.
+
+    :param combo_source: FCSTM source using combo trigger syntax.
+    :type combo_source: str
+    :param manual_source: FCSTM source using explicit pseudo states.
+    :type manual_source: str
+    :param cycle_events: Consecutive event inputs for runtime comparison.
+    :type cycle_events: Iterable[typing.Any]
+    :return: Parsed combo model, parsed manual model, and the shared trace.
+    :rtype: tuple
+
+    Example::
+
+        >>> combo = 'state Root { state A; state B; [*] -> A; A -> B :: E1 + E2; }'
+        >>> manual = 'state Root { state A; pseudo state P named "combo after E1"; state B; [*] -> A; A -> P :: E1; P -> B : /A.E2; }'
+        >>> _, _, trace = assert_combo_matches_manual_pseudo(combo, manual, [None, ['Root.A.E1', 'Root.A.E2']])
+        >>> trace[-1]['state']
+        'Root.B'
+    """
+    combo_model = parse_machine(combo_source)
+    manual_model = parse_machine(manual_source)
+    events = list(cycle_events)
+
+    assert pseudo_state_signature(combo_model) == pseudo_state_signature(manual_model)
+    assert model_transition_signature(combo_model) == model_transition_signature(
+        manual_model
+    )
+
+    combo_trace = simulation_trace(combo_model, events)
+    manual_trace = simulation_trace(manual_model, events)
+    assert combo_trace == manual_trace
+    return combo_model, manual_model, combo_trace

--- a/test/testings/combo_runtime.py
+++ b/test/testings/combo_runtime.py
@@ -253,6 +253,7 @@ def simulation_trace(
         trace.append(
             {
                 "state": _normalized_runtime_state(runtime),
+                "value": result.value,
                 "vars": tuple(sorted(runtime.vars.items())),
                 "input_events": result.input_events,
                 "consumed_events": result.consumed_events,

--- a/test/verify/test_combo_downstream_compat.py
+++ b/test/verify/test_combo_downstream_compat.py
@@ -1,0 +1,68 @@
+"""SMT-local verification smoke tests for combo-generated guard transitions."""
+
+import pytest
+
+from pyfcstm.verify import dead_guard, guard_tautology
+from test.testings.combo_runtime import parse_machine
+
+
+pytestmark = pytest.mark.unittest
+
+
+def _variables(machine):
+    return tuple(machine.defines.values())
+
+
+def _combo_guard_transition(machine):
+    return next(
+        transition
+        for state in machine.walk_states()
+        for transition in state.transitions
+        if transition.combo_origin_refs and transition.guard is not None
+    )
+
+
+def test_dead_guard_consumes_combo_generated_guard_transition():
+    """The solver stack can prove an unsatisfiable combo guard transition."""
+    machine = parse_machine(
+        """
+        def int x = 0;
+        state Root {
+            state S;
+            state T;
+            [*] -> S;
+            S -> T :: E1 + [x > 0 && x < 0] + E2;
+        }
+        """
+    )
+    transition = _combo_guard_transition(machine)
+
+    result = dead_guard(transition, _variables(machine), smt_timeout_ms=200)
+
+    assert result.kind == "unsat"
+    assert result.diagnostics[0]["code"] == "W_DEAD_GUARD"
+    assert result.diagnostics[0]["data"]["transition"]["from_state"].startswith(
+        "__combo_"
+    )
+
+
+def test_guard_tautology_consumes_combo_generated_guard_transition():
+    """The solver stack can prove a tautological combo guard transition."""
+    machine = parse_machine(
+        """
+        def int x = 0;
+        state Root {
+            state S;
+            state T;
+            [*] -> S;
+            S -> T :: E1 + [x >= 0 || x < 0] + E2;
+        }
+        """
+    )
+    transition = _combo_guard_transition(machine)
+
+    result = guard_tautology(transition, _variables(machine), smt_timeout_ms=200)
+
+    assert result.kind == "unsat"
+    assert result.diagnostics[0]["code"] == "W_GUARD_TAUTOLOGY"
+    assert result.diagnostics[0]["data"]["transition"]["guard"] == ("x >= 0 || x < 0")


### PR DESCRIPTION
## 关联上游

- 伞 PR：#291
- 设计 issue：#279
- 前置 Sub PR：#297（PR-2，已合并）、#300（PR-3，已合并）

## 本 PR 目标

本 PR 是组合 transition trigger 语法糖的 **PR-4：下游兼容性验收**。

目标不是新增 runtime 语义，而是证明 PR-2 已经展开出的普通 pseudo state + ordinary transition 链可以被现有下游自然消费，并用测试锁定关键边界：

1. `SimulationRuntime` 对 combo pseudo chain 的 validation / rollback / fallback 行为正确；
2. verify / topology / solver 入口不会因为自动 combo pseudo state 产生虚假错误；
3. PlantUML / visualize 导出如实显示 generated pseudo state，且 `named` 文案稳定可读；
4. 若 smoke 暴露真实下游 bug，只允许做最小修复并补回归测试；如果需要新增 runtime transition primitive 或大改语义，必须停止并回到伞 PR #291 重新评估。

## 不做什么

- 不新增 combo 专用 runtime primitive。
- 不改变 combo 展开算法的 priority / sharing 语义；若发现展开模型本身不等价，优先回到 PR-2 范围修 expansion，而不是在 runtime 里补 hack。
- 不在 renderer 或 template 中增加 combo 专用特判。
- 不把 PR-5 的文档 / LLM guide / Python template semantic alignment 收进本 PR；本 PR 只做下游兼容性验收与必要最小修复。

## 执行原则

### 1. 展开模型是执行事实源

所有 runtime / verify / solver / PlantUML / visualize 检查都以 PR-2 生成的普通模型为事实源。combo provenance 只用于诊断和解释，不参与 runtime dispatch。

### 2. 失败先判定“展开模型 vs 手写 pseudo”等价性

任何 fixture 失败时，先构造或复用对应的手写 pseudo 等价模型做对照，至少比较：

- transition graph；
- generated pseudo state 集合；
- `named` 展示文案；
- simulation trace 逐 cycle 的 active state / vars / emitted events / transition result。

只有手写 pseudo 等价模型也复现同样失败，才把问题归为下游 runtime / verify / solver / visualize bug。

### 3. 手写 pseudo 等价 fixture 的来源

PR-2 已经提供了若干 combo 展开与 runtime smoke fixture，可复用这些文件里的 pattern 作为起点：

- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_combo_model_builds_pseudo_chain_and_runs_event_guard_event`
- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_combo_guard_false_rolls_back_to_source`
- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_guard_first_combo_runs_guard_before_event_term`
- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_multi_guard_combo_uses_pseudo_validation_for_all_guard_terms`
- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_entry_and_exit_combo_expand_under_owner_composite`
- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_combo_effect_runs_only_on_terminal_hop`
- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_priority_fence_prevents_late_combo_from_outranking_plain_event`
- `test/model/test_combo_transition_expansion.py::TestComboTransitionExpansion::test_different_chooser_transition_does_not_break_logical_combo_run`

但 PR-4 不能假设 PR-2 已覆盖所有下游边界。PR-4 新增 helper 和 fixture 时，优先放在 `test/testings/combo_runtime.py` 或同等 Python test tree helper 中，只 import `pyfcstm`、Python 标准库和 pytest，不 import Node.js / jsfcstm，不读取 `editors/jsfcstm/test/`。

等价 helper 需要从零补齐或复用现有断言，最低输出：

- `model_transition_signature(model)`：state path / pseudo flag / `extra_name` / transition from-to-event-guard-effect summary；
- `combo_projection_signature(model)`：`combo_transitions` / `combo_origins` 的关键字段；
- `simulation_trace(model, commands)`：逐 cycle active state、vars、emitted events、transition result。

如果某个 PR-4 fixture 没有现成 PR-2 对照，必须在同一个测试里写出最小手写 pseudo 模型，而不是只测 combo DSL。

### 4. 最小修复边界

如果确认为下游真实 bug：

- 修复必须局限在现有普通 state / transition / pseudo 消费语义内；
- 必须补一个能在无 combo 手写 pseudo 模型上复现的回归测试，避免把 bug 伪装成 combo 特判；
- 不允许引入 combo 专用 branch 或根据 `combo_origin_refs` 改 runtime 行为。

## TDD 计划

### A. SimulationRuntime 兼容性 fixture

先写失败优先的 simulation fixture，再实现最小必要改动或确认现有 runtime 已自然通过。每类 fixture 都要给出 combo DSL 与最小手写 pseudo 对照；下面 DSL 是最低锚点，可在实现时加变量 / effect / nested owner 细节。

1. **event-only success**
   ```fcstm
   state Root { state S; state T; [*] -> S; S -> T :: E1 + E2; }
   ```
   收到 `E1,E2` 后成功到达 `T`。

2. **缺事件 rollback / fallback**
   ```fcstm
   state Root { state S; state T; state F; [*] -> S; S -> T :: E1 + E2; S -> F :: E1; }
   ```
   只收到 `E1` 时前者 validation 失败并 fallback 到 `F`，不能停在中间 pseudo。

3. **中间 guard false rollback / fallback**
   ```fcstm
   def int x = 0;
   state Root { state S; state T; state F; [*] -> S; S -> T :: E1 + [x > 0] + E2; S -> F :: E1; }
   ```
   `x <= 0` 时失败并 fallback 到后续候选。

4. **effect commit 边界**
   ```fcstm
   def int x = 0;
   state Root { state S; state T; state F; [*] -> S; S -> T :: E1 + E2 effect { x = 1; } S -> F :: E1 effect { x = 2; } }
   ```
   失败的 combo 链不能提交 terminal effect；成功链只能提交最终实际路径上的 effect。

5. **entry combo**
   ```fcstm
   state Root { state S; state F; [*] -> S :: E1 + E2; [*] -> F; }
   ```
   owner / event scope / fallback 不漂移到 target child 或 pseudo state。

6. **exit combo / parent continuation**
   ```fcstm
   state Root { state Parent { state S; [*] -> S; S -> [*] :: E1 + E2; } state Done; [*] -> Parent; Parent -> Done; }
   ```
   嵌套 state 通过 combo 走向 `[ * ]` 或 parent continuation 时，exit / continuation / rollback 行为与手写 pseudo 等价。

7. **hot start / non-stoppable pseudo**
   ```fcstm
   state Root { state S; state T; [*] -> S; S -> T :: E1 + E2; }
   ```
   当前可执行 contract 已实测：hot start 到 generated combo pseudo 应抛 `ValueError`，错误消息包含 `cannot reach a stoppable state`。PR-4 测试要锁定这个具体行为；不得把 combo pseudo 当成用户业务稳定目标。

8. **prefix reuse**
   ```fcstm
   state Root { state S; state A; state B; [*] -> S; S -> A :: E1 + E2; S -> B :: E1 + E3; }
   ```
   shared prefix edge 的成功 / 失败路径符合源码顺序，不因为 sharing 形成 longest-match wins。另补 priority fence 对照：`E1+E2 / E1 / E1+E3` 输入 `E1+E3` 应选择中间 `E1` transition。

建议验证命令：`pytest test/simulate/test_combo_runtime_compat.py -q`（文件名可按实现调整，但必须在 Python `test/` tree 内）。

### B. verify / topology / solver smoke

基于同一组 combo fixture，至少覆盖：

1. `inspect_model(..., enable_verify=True)` 或对应 verify inspect adapter 能消费展开模型；
2. topology / reachability 不把 generated pseudo state 误判为用户业务不可达错误；
3. solver / guard reachability smoke 能处理 combo 展开后的 guard transition；
4. diagnostic refs 如果涉及 combo generated transition，优先通过 PR-3 已落地的 `combo_origin_refs` / `combo_transitions` / `combo_origins` 回溯到原始 combo transition 或 term；只有 provenance metadata 确实缺失且当前模型不是 combo-generated path 时，才允许降级为“不指向不存在对象”。

建议验证命令：`pytest test/verify test/diagnostics/test_combo_inspect_contract.py -q` 加新增定向测试文件。

### C. PlantUML / visualize snapshot

本 PR 明确区分两个入口：

1. **PlantUML 文本入口**：`pyfcstm.entry.plantuml.build_plantuml_output()` 与 CLI `pyfcstm plantuml -i input.fcstm -o output.puml`。snapshot 锁定 `.puml` 文本中的 generated pseudo state 名称、`named` 文案、关键 transition 标签；不做整文件 byte-for-byte golden，避免无关布局 / skinparam 抖动。
2. **visualize 入口**：`pyfcstm.entry.visualize` 复用 `build_plantuml_output()` 后交给 `plantumlcli` 渲染 PNG / SVG / PDF。PR-4 只做轻量 smoke：验证 `resolve_visualize_output_path()` 与 visualize 共享 PlantUML 文本入口；不把渲染出来的 PNG / SVG / PDF 二进制作为硬 snapshot，除非 CI 环境已有稳定 plantumlcli / Java / renderer。

代表性 fixture 至少覆盖 event + guard + event、entry combo、exit combo。snapshot 断言策略固定为 normalized text / substring 集合断言：

- 至少出现一个 `__combo_..._h????????????` pseudo state；
- 出现 `combo after ...` 的 `named` / display 文案；
- 出现原始 event / guard term 的可读 transition label；
- 不断言 PlantUML 行顺序之外的布局细节，不断言 rendered image bytes。

建议验证命令：`pytest test/entry/test_combo_visualization.py test/model/test_model_to_plantuml.py -q`（文件名可按实现调整）。

### D. 等价性辅助断言

增加测试 helper 时只允许放在 Python test tree 内，优先 `test/testings/`；只 import `pyfcstm`、Python 标准库和 pytest，不依赖 jsfcstm、Node.js 或 `editors/jsfcstm/test/`。helper 至少能比较：

- state path / pseudo flag / `named`；
- transition from/to/event/guard/effect summary；
- simulation trace；
- inspect 中 `combo_transitions` / `combo_origins` 的关键字段是否存在。

建议验证命令：新增 helper 自测可并入 `pytest test/simulate/test_combo_runtime_compat.py -q`，并额外运行 `python tools/check_test_boundary.py`。



## 代码影响面拉网式排查要求

本 PR 进入 ready 前还需要完成一轮 **严格限定在组合 transition trigger 新特性影响面内** 的代码层面拉网排查。该排查不是扩大语义排列组合矩阵，也不是引入新 runtime / solver / renderer 行为；目标是确认伞 PR #291 引入的 combo DSL、generated pseudo state、combo provenance metadata 和 diagnostics 字段不会打穿既有下游消费者。

### 排查边界

必须覆盖这些受影响代码面：

1. **Python DSL / model / import / inspect**：`pyfcstm/dsl/*`、`pyfcstm/model/model.py`、`pyfcstm/model/imports.py`、`pyfcstm/diagnostics/inspect.py` 中与 combo trigger、generated pseudo、`combo_origin_refs` / `combo_origins` / `combo_transitions` 相关的路径。
2. **Python diagnostics / verify / solver / topology**：combo analyzer、const-fold / design-health 中对 generated combo transition 的处理、verify inspect adapter、topology direct API、solver guard checks。
3. **SimulationRuntime 下游消费**：runtime 只消费展开后的普通 pseudo state + transition，不能出现 combo 专用 primitive 或依赖 provenance metadata 的执行分支。
4. **PlantUML / visualize**：只验证共享 PlantUML 文本入口和 generated pseudo 可读展示，不锁渲染图片二进制。
5. **jsfcstm / VSCode 下游**：AST builder、model builder/runtime/raw metadata、inspect JSON、diagnostics analyzer、editor range / related information。尤其要确认 JS 端只保留无需 solver 的 duplicate event warning，不强行实现 Python/Z3 型 combo guard warnings。
6. **测试边界与平台门禁**：Python tests 不调用 Node/jsfcstm；jsfcstm tests 不调用 Python；本地 slow-skip 与 GitHub CI 分工明确。

### 排查方法

- 每个排查结论必须来自 **源码阅读 + 至少一个可复现命令或最小 smoke**；如果某项只能人工审计，需要说明为什么不适合写成 PR-4 测试。
- 如果发现问题，必须在 PR comment 中给出：问题等级 C/I/M、影响范围、最小 FCSTM/代码复现、实际结果、期望结果、建议修复边界。
- 如果发现问题需要改 production 代码，必须先判断是否仍属于“下游消费普通展开模型的最小修复”；若需要新增 runtime primitive、改变 combo expansion 语义或 renderer/template 特判，必须停止并回到伞 PR #291 重新评估。
- 本轮拉网允许补 **轻量 smoke / contract / schema / range 测试**；不允许把 PR-5 的文档 / LLM guide / template semantic alignment 或大规模语义排列组合矩阵塞进 PR-4。

### 最低拉网验收项

- [ ] Python production diff audit：确认本 PR/伞 PR 中 combo 相关 production 改动的下游消费者清单完整，且 PR-4 当前没有新增 production 改动。
- [ ] Runtime audit：确认 `SimulationRuntime` 没有 combo 专用执行分支，已有 runtime fixture 足以覆盖 success / rollback / fallback / effect / entry / exit / prefix reuse / hot-start contract。
- [ ] Verify / solver / topology audit：确认 generated combo pseudo / guard transition 不导致虚假 unreachable、dead guard、tautology 或 schema refs 问题；必要时补 direct topology smoke。
- [ ] Inspect / diagnostics schema audit：确认 `combo_transitions` / `combo_origins` / `combo_origin_refs` 能被 schema 和下游 JSON consumer 稳定消费，diagnostic refs 不指向内部 pseudo 实现细节。
- [ ] jsfcstm / VSCode audit：确认 JS builder/runtime/inspect/range 消费 combo metadata 不崩；JS 端不实现需要 solver 的 guard warnings，只保留 duplicate event 这类无需求解器的 warning。
- [ ] Visualization audit：确认 PlantUML / visualize 仍复用公共 PlantUML 文本入口；generated pseudo state 如实显示且 `named` 文案可读。
- [ ] Test-boundary / CI audit：确认新增测试仍遵守 Python/JS 隔离，`python tools/check_test_boundary.py`、相关 pytest / npm test、`SKIP_SLOW_TESTS=1 make unittest`、GitHub CI 都有明确证据。

## 验收标准

- [ ] PR body 与伞 PR #291 中 PR-4 的目标、范围和验收标准一致，并经三路 reviewer 评论确认无 C/I 级问题。
- [ ] runtime 兼容性 fixture 覆盖 event-only、缺事件 rollback、guard false rollback、中间 guard false、entry fallback、exit parent continuation、effect commit、hot start / non-stoppable pseudo、prefix reuse。
- [ ] 失败 fixture 均先经过“combo 展开模型 vs 手写 pseudo 等价模型”判定；等价判定最低包含 transition graph、pseudo state 集合、`named` 文案和 simulation trace 逐 cycle 一致；若修下游 bug，必须同时有手写 pseudo 回归测试。
- [ ] verify / topology / solver smoke 通过，且不会因为 combo pseudo state 产生虚假错误；diagnostic refs 优先落到原始 combo transition / term 或 PR-3 已公开 provenance 字段。
- [ ] PlantUML 文本 snapshot 通过 normalized text / substring 集合断言如实显示 generated pseudo state，`named` 稳定可读；visualize 只 smoke 共享入口与输出路径，不锁 rendered image bytes。
- [ ] 不新增 runtime primitive，不引入 combo 专用 runtime hack，不改 renderer/template 特判。
- [ ] Python 与 JavaScript 单元测试边界仍满足仓库规则：Python tests 不调用 Node.js / jsfcstm，jsfcstm tests 不调用 Python。
- [ ] 需要修改 public Python API 或 docstring 时，按 CLAUDE.md 的 reST docstring 要求补齐 module/class/function doc、params、returns、Examples::，并在提交前运行 `make rst_auto`。
- [ ] 本地至少通过相关定向 pytest、`python tools/check_test_boundary.py`、`SKIP_SLOW_TESTS=1 make unittest`；GitHub CI 全绿。
