### PR TITLE
修复组合 transition effect 后续问题伞 PR

### DIFF
--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -159,6 +159,7 @@ interface PublicTransitionSubject {
     canAnchor: boolean;
 }
 
+/** Return the user-facing subject and debug refs for effect diagnostics. */
 function publicTransitionSubjectForEffectDiagnostic(
     transition: TransitionInfo,
 ): PublicTransitionSubject {
@@ -170,7 +171,7 @@ function publicTransitionSubjectForEffectDiagnostic(
     if (!originRef) {
         return {
             statePath: transition.from_path,
-            transitionSpan: null,
+            transitionSpan,
             extraRefs,
             canAnchor: true,
         };

--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -109,25 +109,34 @@ function isLifecycleFreeLeaf(statePath: string, statesByPath: Map<string, StateI
 }
 
 function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
+    const subjects = new Map<TransitionInfo, PublicTransitionSubject>();
+    for (const transition of transitions) {
+        subjects.set(transition, publicTransitionSubjectForEffectDiagnostic(transition));
+    }
+
     const counts = new Map<string, number>();
     for (const transition of transitions) {
+        const subject = subjects.get(transition)!;
         for (const varName of transition.effect_self_assigns) {
-            const key = JSON.stringify([transition.from_path, varName]);
+            const key = JSON.stringify([subject.statePath, varName]);
             counts.set(key, (counts.get(key) ?? 0) + 1);
         }
     }
     const out: ModelDiagnosticJson[] = [];
     for (const transition of transitions) {
+        const subject = subjects.get(transition)!;
         for (const varName of transition.effect_self_assigns) {
             const refs: Record<string, unknown> = {
-                state_path: transition.from_path,
-                transition_span: null,
+                state_path: subject.statePath,
+                transition_span: subject.transitionSpan,
                 var_name: varName,
                 transition_index: transition.transition_index,
+                ...subject.extraRefs,
             };
             if (
-                transition.from_path !== '[*]' &&
-                counts.get(JSON.stringify([transition.from_path, varName])) === 1
+                subject.canAnchor &&
+                subject.statePath !== '[*]' &&
+                counts.get(JSON.stringify([subject.statePath, varName])) === 1
             ) {
                 refs.effect_self_assign_anchor = varName;
             }
@@ -141,6 +150,80 @@ function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDi
         }
     }
     return out;
+}
+
+interface PublicTransitionSubject {
+    statePath: string;
+    transitionSpan: ModelSpanJson | null;
+    extraRefs: Record<string, unknown>;
+    canAnchor: boolean;
+}
+
+function publicTransitionSubjectForEffectDiagnostic(
+    transition: TransitionInfo,
+): PublicTransitionSubject {
+    const originRef = transition.combo_origin_refs?.[0];
+    const transitionSpan = originRef?.transition_span ?? sourceSpan(transition);
+    const projectionKey = transition.combo_projection_key;
+    const extraRefs: Record<string, unknown> = {};
+
+    if (!originRef) {
+        return {
+            statePath: transition.from_path,
+            transitionSpan: null,
+            extraRefs,
+            canAnchor: true,
+        };
+    }
+
+    if (!Array.isArray(projectionKey) || projectionKey.length < 2) {
+        return {
+            statePath: transition.from_path,
+            transitionSpan,
+            extraRefs: {
+                from_path: transition.from_path,
+                generated_state_path: transition.from_path,
+                generated_from_path: transition.from_path,
+                generated_to_path: transition.to_path,
+                combo_origin_id: originRef.origin_id,
+            },
+            canAnchor: false,
+        };
+    }
+
+    let statePath = transition.from_path;
+    let canAnchor = false;
+    const [ownerPath, projectionKind, sourcePath] = projectionKey;
+    if (projectionKind === 'state') {
+        if (Array.isArray(sourcePath)) {
+            statePath = sourcePath.join('.');
+            canAnchor = true;
+        } else if (typeof sourcePath === 'string') {
+            statePath = sourcePath;
+            canAnchor = true;
+        }
+    } else if (projectionKind === 'entry') {
+        statePath = '[*]';
+        if (Array.isArray(ownerPath)) {
+            extraRefs.combo_owner_path = ownerPath.join('.');
+        } else if (typeof ownerPath === 'string') {
+            extraRefs.combo_owner_path = ownerPath;
+        }
+    }
+
+    return {
+        statePath,
+        transitionSpan,
+        extraRefs: {
+            ...extraRefs,
+            from_path: statePath,
+            generated_state_path: transition.from_path,
+            generated_from_path: transition.from_path,
+            generated_to_path: transition.to_path,
+            combo_origin_id: originRef.origin_id,
+        },
+        canAnchor,
+    };
 }
 
 function collectForcedOverridesNormalWarnings(transitions: TransitionInfo[]): ModelDiagnosticJson[] {

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -985,7 +985,7 @@ state Root {
                     severity: 'warning',
                     refs: {
                         state_path: 'Root.Active',
-                        transition_span: null,
+                        transition_span: {line: 16, column: 5, end_line: 16, end_column: 47},
                         var_name: 'stable',
                         effect_self_assign_anchor: 'stable',
                         transition_index: 5,
@@ -1332,7 +1332,7 @@ state Root {
                     .map(d => d.refs),
                 [expectedRefsWithSuggestedFix('W_EFFECT_SELF_ASSIGN', {
                     state_path: 'Root.A',
-                    transition_span: null,
+                    transition_span: {line: 7, column: 5, end_line: 11, end_column: 6},
                     var_name: 'x',
                     effect_self_assign_anchor: 'x',
                     transition_index: 1,

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -73,6 +73,18 @@ function expectedRefsWithSuggestedFix(code: string, refs: Record<string, unknown
     return packageModule.refsWithSuggestedFix(code, refs);
 }
 
+function sliceBySpan(source: string, span: {line: number; column: number; end_line: number; end_column: number}): string {
+    const lines = source.split('\n');
+    if (span.line === span.end_line) {
+        return (lines[span.line - 1] ?? '').slice(span.column - 1, span.end_column - 1);
+    }
+    return [
+        (lines[span.line - 1] ?? '').slice(span.column - 1),
+        ...lines.slice(span.line, span.end_line - 1),
+        (lines[span.end_line - 1] ?? '').slice(0, span.end_column - 1),
+    ].join('\n');
+}
+
 describe('diagnostics/inspect', () => {
     describe('basic structure', () => {
         it('returns top-level shape', async () => {
@@ -1326,6 +1338,166 @@ state Root {
                     transition_index: 1,
                 })],
             );
+        });
+
+        it('remaps combo terminal self-assignment diagnostics to authored source', async () => {
+            const source = `
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B :: E1 + E2 effect { x = x; };
+}
+`;
+            const report = inspectModel(await buildMachine(source));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 1);
+            const refs = diagnostics[0].refs as Record<string, unknown>;
+            assert.equal(refs.state_path, 'Root.A');
+            assert.equal(refs.from_path, 'Root.A');
+            assert.match(refs.generated_state_path as string, /^Root\.__combo_/);
+            assert.equal(refs.generated_from_path, refs.generated_state_path);
+            assert.equal(refs.generated_to_path, 'Root.B');
+            assert.equal(typeof refs.combo_origin_id, 'string');
+            assert.equal(refs.combo_owner_path, undefined);
+            assert.equal(refs.var_name, 'x');
+            assert.equal(refs.effect_self_assign_anchor, 'x');
+            assert.deepEqual((refs.suggested_fix as {anchor: unknown}).anchor, {
+                type: 'ref',
+                ref: 'refs.effect_self_assign_anchor',
+            });
+            assert.equal(
+                sliceBySpan(source, refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                'A -> B :: E1 + E2 effect { x = x; }',
+            );
+        });
+
+        it('remaps entry combo self-assignment diagnostics to initial subject', async () => {
+            const source = `
+def int x = 0;
+state Root {
+    state A;
+    [*] -> A : Boot + Ready effect { x = x; };
+}
+`;
+            const report = inspectModel(await buildMachine(source));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 1);
+            const refs = diagnostics[0].refs as Record<string, unknown>;
+            assert.equal(refs.state_path, '[*]');
+            assert.equal(refs.from_path, '[*]');
+            assert.equal(refs.combo_owner_path, 'Root');
+            assert.match(refs.generated_state_path as string, /^Root\.__combo_/);
+            assert.equal(refs.generated_from_path, refs.generated_state_path);
+            assert.equal(refs.generated_to_path, 'Root.A');
+            assert.equal(typeof refs.combo_origin_id, 'string');
+            assert.equal(refs.var_name, 'x');
+            assert.equal(refs.effect_self_assign_anchor, undefined);
+            assert.equal(refs.suggested_fix, undefined);
+            assert.equal(
+                sliceBySpan(source, refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                '[*] -> A : Boot + Ready effect { x = x; }',
+            );
+        });
+
+        it('keeps shared-prefix combo terminal self-assignment subjects authored', async () => {
+            const source = `
+def int x = 0;
+def int y = 0;
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+    A -> B :: E1 + E2 effect { x = x; };
+    A -> C :: E1 + E3 effect { y = y; };
+}
+`;
+            const report = inspectModel(await buildMachine(source));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 2);
+            const byVar = new Map(diagnostics.map(diag => [diag.refs.var_name, diag]));
+            assert.deepEqual([...byVar.keys()].sort(), ['x', 'y']);
+            for (const [varName, diag] of byVar) {
+                const refs = diag.refs as Record<string, unknown>;
+                assert.equal(refs.state_path, 'Root.A');
+                assert.equal(refs.from_path, 'Root.A');
+                assert.match(refs.generated_state_path as string, /^Root\.__combo_/);
+                assert.equal(refs.generated_from_path, refs.generated_state_path);
+                assert.ok(['Root.B', 'Root.C'].includes(refs.generated_to_path as string));
+                assert.equal(typeof refs.combo_origin_id, 'string');
+                assert.equal(refs.effect_self_assign_anchor, varName);
+                assert.deepEqual((refs.suggested_fix as {anchor: unknown}).anchor, {
+                    type: 'ref',
+                    ref: 'refs.effect_self_assign_anchor',
+                });
+            }
+            assert.equal(
+                sliceBySpan(source, byVar.get('x')!.refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                'A -> B :: E1 + E2 effect { x = x; }',
+            );
+            assert.equal(
+                sliceBySpan(source, byVar.get('y')!.refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                'A -> C :: E1 + E3 effect { y = y; }',
+            );
+        });
+
+        it('suppresses anchors for same-source combo terminal self-assignments', async () => {
+            const report = inspectModel(await buildMachine(`
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+    A -> B :: E1 + E2 effect { x = x; };
+    A -> C :: E3 + E4 effect { x = x; };
+}
+`));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 2);
+            assert.equal(diagnostics.every(diag => diag.refs.state_path === 'Root.A'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.from_path === 'Root.A'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.var_name === 'x'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.effect_self_assign_anchor === undefined), true);
+            assert.equal(diagnostics.every(diag => diag.refs.suggested_fix === undefined), true);
+            assert.deepEqual(
+                diagnostics.map(diag => diag.refs.generated_to_path).sort(),
+                ['Root.B', 'Root.C'],
+            );
+        });
+
+        it('suppresses anchors for plain and combo self-assignments on the same source', async () => {
+            const report = inspectModel(await buildMachine(`
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+    A -> B effect { x = x; };
+    A -> C :: E1 + E2 effect { x = x; };
+}
+`));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 2);
+            assert.equal(diagnostics.every(diag => diag.refs.state_path === 'Root.A'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.var_name === 'x'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.effect_self_assign_anchor === undefined), true);
+            assert.equal(diagnostics.every(diag => diag.refs.suggested_fix === undefined), true);
+            const plain = diagnostics.find(diag => diag.refs.generated_from_path === undefined);
+            const combo = diagnostics.find(diag => diag.refs.generated_from_path !== undefined);
+            assert.ok(plain);
+            assert.ok(combo);
+            assert.equal(plain!.refs.from_path, undefined);
+            assert.equal(combo!.refs.from_path, 'Root.A');
+            assert.equal(combo!.refs.generated_to_path, 'Root.C');
         });
     });
 

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -120,23 +120,34 @@ def _is_lifecycle_free_leaf(
 
 
 def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> List[ModelDiagnostic]:
+    transitions = list(transitions)
+    subjects_by_id = {
+        id(t): _public_transition_subject_for_effect_diagnostic(t)
+        for t in transitions
+    }
     counts = Counter(
-        (t.from_path, var_name)
+        (subjects_by_id[id(t)]['state_path'], var_name)
         for t in transitions
         for var_name in getattr(t, 'effect_self_assigns', ())
     )
     diagnostics: List[ModelDiagnostic] = []
     for t in transitions:
+        subject = subjects_by_id[id(t)]
         effect_self_assigns = getattr(t, 'effect_self_assigns', ())
         effect_self_assign_spans = getattr(t, 'effect_self_assign_spans', ())
         for index, var_name in enumerate(effect_self_assigns):
             refs = {
-                'state_path': t.from_path,
-                'transition_span': t.span,
+                'state_path': subject['state_path'],
+                'transition_span': subject['transition_span'],
                 'var_name': var_name,
                 'transition_index': t.transition_index,
             }
-            if t.from_path != '[*]' and counts[(t.from_path, var_name)] == 1:
+            refs.update(subject['extra_refs'])
+            if (
+                subject['can_anchor']
+                and subject['state_path'] != '[*]'
+                and counts[(subject['state_path'], var_name)] == 1
+            ):
                 refs['effect_self_assign_anchor'] = var_name
             diagnostics.append(ModelDiagnostic(
                 code='W_EFFECT_SELF_ASSIGN',
@@ -151,6 +162,69 @@ def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> Lis
                 refs=refs,
             ))
     return diagnostics
+
+
+def _public_transition_subject_for_effect_diagnostic(t: 'TransitionInfo') -> Dict[str, object]:
+    origin_ref = next(iter(getattr(t, 'combo_origin_refs', ())), None)
+    transition_span = getattr(origin_ref, 'transition_span', None) or t.span
+    projection_key = getattr(t, 'combo_projection_key', None)
+    extra_refs: Dict[str, object] = {}
+
+    if origin_ref is None:
+        return {
+            'state_path': t.from_path,
+            'transition_span': transition_span,
+            'extra_refs': extra_refs,
+            'can_anchor': True,
+        }
+
+    state_path = t.from_path
+    if projection_key is None or len(projection_key) < 2:
+        extra_refs.update({
+            'from_path': state_path,
+            'generated_state_path': t.from_path,
+            'generated_from_path': t.from_path,
+            'generated_to_path': t.to_path,
+            'combo_origin_id': origin_ref.origin_id,
+        })
+        return {
+            'state_path': state_path,
+            'transition_span': transition_span,
+            'extra_refs': extra_refs,
+            'can_anchor': False,
+        }
+
+    owner_path = projection_key[0]
+    projection_kind = projection_key[1]
+    can_anchor = False
+    if projection_kind == 'state' and len(projection_key) >= 3:
+        source_path = projection_key[2]
+        if isinstance(source_path, tuple):
+            state_path = '.'.join(source_path)
+            can_anchor = True
+        elif isinstance(source_path, str):
+            state_path = source_path
+            can_anchor = True
+    elif projection_kind == 'entry':
+        state_path = '[*]'
+        if isinstance(owner_path, tuple):
+            extra_refs['combo_owner_path'] = '.'.join(owner_path)
+        elif isinstance(owner_path, str):
+            extra_refs['combo_owner_path'] = owner_path
+
+    extra_refs.update({
+        'from_path': state_path,
+        'generated_state_path': t.from_path,
+        'generated_from_path': t.from_path,
+        'generated_to_path': t.to_path,
+        'combo_origin_id': origin_ref.origin_id,
+    })
+    return {
+        'state_path': state_path,
+        'transition_span': transition_span,
+        'extra_refs': extra_refs,
+        'can_anchor': can_anchor,
+    }
 
 
 def _forced_overrides_normal_warnings(transitions: Iterable['TransitionInfo']) -> List[ModelDiagnostic]:

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -165,6 +165,7 @@ def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> Lis
 
 
 def _public_transition_subject_for_effect_diagnostic(t: 'TransitionInfo') -> Dict[str, object]:
+    """Return the user-facing subject and debug refs for effect diagnostics."""
     origin_ref = next(iter(getattr(t, 'combo_origin_refs', ())), None)
     transition_span = getattr(origin_ref, 'transition_span', None) or t.span
     projection_key = getattr(t, 'combo_projection_key', None)

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -540,7 +540,7 @@ I_COMBO_PSEUDO_NAME_EXTENDED:
     state Root {
         state A;
         state B;
-        state __combo_root_a__e1_hbafca7f66598;
+        pseudo state __combo_root_a__e1_hbafca7f66598;
         [*] -> A;
         A -> B :: E1 + E2;
     }

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -409,17 +409,17 @@ E_COMBO_TRIGGER_NOT_EXPANDED:
   example_dsl: |
     state Root { state A; state B; A -> B :: Go + Done; }
 
-E_COMBO_RESERVED_STATE_NAME:
-  severity: error
+W_COMBO_RESERVED_PREFIX_STATE_KIND:
+  severity: warning
+  emit_tier: partial_static_pipeline
   span_object: state_identifier
   description: >-
-    A user-authored state name starts with the reserved automatic combo
-    pseudo-state prefix.
+    A non-pseudo state name starts with the automatic combo relay prefix.
   refs:
     state_name:
       type: str
       required: true
-      description: The reserved user-authored state name.
+      description: State name using the combo relay reserved prefix.
     state_path:
       type: str
       required: true
@@ -428,28 +428,129 @@ E_COMBO_RESERVED_STATE_NAME:
       type: str
       required: true
       description: Reserved prefix used by generated combo pseudo states.
+    state_kind:
+      type: str
+      required: true
+      description: Kind of user-authored state that used the reserved prefix.
+      enum: ['state', 'composite']
   for_llm:
     summary: >-
-      State names beginning with ``__combo_`` are reserved for generated
-      pseudo states created by combo transition trigger expansion.
+      A normal leaf or composite state uses the ``__combo_`` prefix reserved
+      for combo relay pseudo states. The model can still build, but the name is
+      visually ambiguous with generated relay nodes.
     recommended_actions:
       - kind: rename_state
         target: state_identifier
         rationale: >-
-          Rename the user-authored state so it does not collide with the
-          generated combo pseudo-state namespace.
+          Rename the user-authored state so readers and generated artifacts do
+          not confuse it with an expanded combo relay.
     do_not:
-      - "Do not use ``__combo_`` for hand-written states; the expander owns this namespace."
+      - "Do not fix this by declaring a business state as pseudo unless it is truly only a relay."
   example_dsl: |
     state Root { state __combo_user; [*] -> __combo_user; }
+
+W_COMBO_RELAY_PSEUDO_HAS_ACTIONS:
+  severity: warning
+  emit_tier: partial_static_pipeline
+  span_object: state_identifier
+  description: >-
+    A pseudo state in the combo relay namespace contains lifecycle or aspect
+    actions, so it is not a pure relay.
+  refs:
+    state_name:
+      type: str
+      required: true
+      description: Pseudo-state name using the combo relay reserved prefix.
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the pseudo state.
+    reserved_prefix:
+      type: str
+      required: true
+      description: Reserved prefix used by combo relay pseudo states.
+    action_kinds:
+      type: list[str]
+      required: true
+      description: Lifecycle or aspect action kinds present on the pseudo state.
+      item_enum: ['enter', 'during', 'exit', 'during_aspect']
+  for_llm:
+    summary: >-
+      A ``pseudo state __combo_*`` node is allowed so expanded combo DSL can be
+      reimported, but relay pseudo states should stay pure. Lifecycle or aspect
+      actions make the relay observable and may surprise readers.
+    recommended_actions:
+      - kind: move_action
+        target: lifecycle_action
+        rationale: >-
+          Move the action to the authored source or target state if it is
+          business behavior rather than routing metadata.
+      - kind: rename_pseudo
+        target: state_identifier
+        rationale: >-
+          If the pseudo state is intentionally user-authored and observable,
+          rename it outside the ``__combo_`` namespace.
+    do_not:
+      - "Do not add business logic to generated combo relay pseudo states."
+  example_dsl: |
+    def int x = 0; state Root { pseudo state __combo_user { enter { x = x + 1; } } state A; [*] -> A; }
+
+I_COMBO_PSEUDO_NAME_EXTENDED:
+  severity: info
+  emit_tier: partial_static_pipeline
+  span_object: state_identifier
+  description: >-
+    Combo trigger expansion extended a generated relay name's digest prefix to
+    avoid a same-scope name collision.
+  refs:
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the state where expansion allocated the relay.
+    pseudo_name:
+      type: str
+      required: true
+      description: Final generated pseudo-state name after digest extension.
+    payload_digest:
+      type: str
+      required: true
+      description: Full digest of the semantic payload that owns the relay.
+    default_digest_size:
+      type: int
+      required: true
+      description: Default visible digest length before extension.
+    final_digest_size:
+      type: int
+      required: true
+      description: Visible digest length used by the final generated name.
+  for_llm:
+    summary: >-
+      The combo expander found a same-scope name collision at the default
+      digest length and deterministically used a longer digest prefix. This is
+      informational and does not mean the model is invalid.
+    recommended_actions:
+      - kind: keep_generated_name
+        target: pseudo_state
+        rationale: >-
+          Leave the extended generated name as-is unless you are manually
+          rewriting the expanded relay chain.
+    do_not:
+      - "Do not shorten the digest manually; that can reintroduce the collision."
+  example_dsl: |
+    state Root {
+        state A;
+        state B;
+        state __combo_root_a__e1_hbafca7f66598;
+        [*] -> A;
+        A -> B :: E1 + E2;
+    }
 
 E_COMBO_PSEUDO_NAME_COLLISION:
   severity: error
   span_object: state_identifier
   description: >-
-    Combo trigger expansion generated the same pseudo-state name for distinct
-    semantic payloads, or a generated combo pseudo name collided with an
-    existing non-pseudo state.
+    Combo trigger expansion could not allocate a safe pseudo-state name even
+    after extending to the full payload digest.
   refs:
     state_path:
       type: str
@@ -465,9 +566,10 @@ E_COMBO_PSEUDO_NAME_COLLISION:
       description: Full digest of the semantic payload that attempted to claim the name.
   for_llm:
     summary: >-
-      The combo expander uses fixed digest12 pseudo names. If two distinct
-      canonical payloads truncate to the same visible name, expansion fails
-      fast rather than silently renaming or reusing the wrong pseudo state.
+      The combo expander first uses a short digest prefix and then lengthens it
+      deterministically on collision. If the full digest still cannot identify a
+      safe relay name in the owning scope, expansion fails rather than silently
+      reusing the wrong pseudo state.
     recommended_actions:
       - kind: report_internal_collision
         target: transition

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -2299,6 +2299,37 @@ W_EFFECT_SELF_ASSIGN:
       type: str
       required: true
       description: Source state path when known.
+    from_path:
+      type: str
+      required: false
+      description: >-
+        Public source path for combo terminal effect diagnostics after
+        authored-subject remapping. Ordinary self-assignment diagnostics may
+        omit this field and use ``state_path`` only.
+    generated_state_path:
+      type: str
+      required: false
+      description: >-
+        Generated combo pseudo state path kept only as secondary debug
+        provenance after the public subject is remapped.
+    generated_from_path:
+      type: str
+      required: false
+      description: Generated transition source path kept as secondary debug provenance.
+    generated_to_path:
+      type: str
+      required: false
+      description: Generated transition target path kept as secondary debug provenance.
+    combo_origin_id:
+      type: str
+      required: false
+      description: Original combo transition identifier for a generated terminal effect.
+    combo_owner_path:
+      type: str
+      required: false
+      description: >-
+        Owner composite path for entry combo diagnostics whose public subject
+        is the initial marker ``[*]``.
     transition_span:
       type: Span
       required: false

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -119,6 +119,8 @@ def _event_origin_from_id(
 
 _COMBO_STATE_PREFIX = "__combo_"
 _COMBO_DIGEST_SIZE = 12
+_COMBO_DIGEST_STEP = 4
+_COMBO_DIGEST_MAX_SIZE = 64
 _COMBO_DISPLAY_PREFIX = "combo after "
 
 
@@ -153,6 +155,30 @@ def _combo_payload_digest(payload: str) -> str:
         64
     """
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _combo_digest_sizes(digest: str) -> Tuple[int, ...]:
+    """
+    Return visible digest lengths used while allocating combo pseudo names.
+
+    :param digest: Full hexadecimal payload digest.
+    :type digest: str
+    :return: Digest prefix lengths from default size through the available
+        full digest length.
+    :rtype: Tuple[int, ...]
+
+    Example::
+
+        >>> _combo_digest_sizes("0" * 64)[:2]
+        (12, 16)
+    """
+    max_size = min(len(digest), _COMBO_DIGEST_MAX_SIZE)
+    if max_size <= _COMBO_DIGEST_SIZE:
+        return (max_size,)
+    sizes = list(range(_COMBO_DIGEST_SIZE, max_size + 1, _COMBO_DIGEST_STEP))
+    if sizes[-1] != max_size:
+        sizes.append(max_size)
+    return tuple(sizes)
 
 
 @dataclass(frozen=True)
@@ -2757,23 +2783,23 @@ def parse_dsl_node_to_state_machine(
         owner_node: Optional[dsl_nodes.StateDefinition] = None,
     ) -> State:
         current_path = tuple((*current_path, node.name))
-        is_exported_combo_pseudo = _is_exported_combo_pseudo_node(
-            node, owner_node
-        )
-        if node.name.startswith(_COMBO_STATE_PREFIX) and not is_exported_combo_pseudo:
+        is_exported_combo_pseudo = _is_exported_combo_pseudo_node(node, owner_node)
+        if node.name.startswith(_COMBO_STATE_PREFIX) and not node.is_pseudo:
             sink.emit(
                 ModelDiagnostic(
-                    code="E_COMBO_RESERVED_STATE_NAME",
-                    severity="error",
+                    code="W_COMBO_RESERVED_PREFIX_STATE_KIND",
+                    severity="warning",
                     message=(
-                        f"State name {node.name!r} uses reserved combo "
-                        f"prefix {_COMBO_STATE_PREFIX!r}:\n{node}"
+                        f"State name {node.name!r} uses combo relay reserved "
+                        f"prefix {_COMBO_STATE_PREFIX!r} but is not a pseudo "
+                        f"state:\n{node}"
                     ),
                     span=getattr(node, "_span", None),
                     refs={
                         "state_name": node.name,
                         "state_path": ".".join(current_path),
                         "reserved_prefix": _COMBO_STATE_PREFIX,
+                        "state_kind": "composite" if node.substates else "state",
                     },
                 )
             )
@@ -2805,6 +2831,19 @@ def parse_dsl_node_to_state_machine(
                 )
 
         named_functions = {}
+
+        def _ast_action_kinds(node: dsl_nodes.StateDefinition) -> List[str]:
+            kinds = []
+            if node.enters:
+                kinds.append("enter")
+            if node.durings:
+                kinds.append("during")
+            if node.exits:
+                kinds.append("exit")
+            if node.during_aspects:
+                kinds.append("during_aspect")
+            return kinds
+
         on_enters = []
         for enter_item in node.enters:
             on_stage = None
@@ -3215,6 +3254,28 @@ def parse_dsl_node_to_state_machine(
         )
         if is_exported_combo_pseudo:
             my_state._generated_combo_pseudo = True
+        if node.name.startswith(_COMBO_STATE_PREFIX) and node.is_pseudo:
+            action_kinds = _ast_action_kinds(node)
+            if action_kinds:
+                sink.emit(
+                    ModelDiagnostic(
+                        code="W_COMBO_RELAY_PSEUDO_HAS_ACTIONS",
+                        severity="warning",
+                        message=(
+                            f"Pseudo state {node.name!r} uses combo relay "
+                            f"reserved prefix {_COMBO_STATE_PREFIX!r} but "
+                            "contains lifecycle or aspect actions:\n"
+                            f"{node}"
+                        ),
+                        span=getattr(node, "_span", None),
+                        refs={
+                            "state_name": node.name,
+                            "state_path": ".".join(current_path),
+                            "reserved_prefix": _COMBO_STATE_PREFIX,
+                            "action_kinds": action_kinds,
+                        },
+                    )
+                )
         if my_state.is_pseudo and not my_state.is_leaf_state:
             sink.emit(
                 ModelDiagnostic(
@@ -3724,7 +3785,6 @@ def parse_dsl_node_to_state_machine(
             )
 
         combo_name_payloads: Dict[str, str] = {}
-        combo_digest_payloads: Dict[Tuple[Tuple[str, ...], str], str] = {}
 
         def _term_name_slug(term: dsl_nodes.ComboTriggerTerm) -> str:
             if isinstance(term, dsl_nodes.ComboGuardTerm):
@@ -3808,49 +3868,42 @@ def parse_dsl_node_to_state_machine(
             }
             payload = json.dumps(payload_obj, ensure_ascii=False, sort_keys=True)
             digest = _combo_payload_digest(payload)
-            short_digest = digest[:_COMBO_DIGEST_SIZE]
-            digest_key = (current_state.path, short_digest)
             source_label = (
                 "entry" if chooser_key[1] == "entry" else ".".join(chooser_key[2])
             )
             slug_parts = [to_identifier(source_label, strict_mode=True).lower()]
             slug_parts.extend(_term_name_slug(term) for term in consumed_terms)
             slug = sequence_safe(slug_parts)
-            name = f"{_COMBO_STATE_PREFIX}{slug}_h{short_digest}"
 
-            existing_digest_payload = combo_digest_payloads.get(digest_key)
-            if (
-                existing_digest_payload is not None
-                and existing_digest_payload != payload
-            ):
-                sink.emit(
-                    ModelDiagnostic(
-                        code="E_COMBO_PSEUDO_NAME_COLLISION",
-                        severity="error",
-                        message=(
-                            f"Generated combo pseudo state digest {short_digest!r} "
-                            "collides for distinct semantic payloads."
-                        ),
-                        span=None,
-                        refs={
-                            "state_path": ".".join(current_state.path),
-                            "pseudo_name": name,
-                            "payload_digest": digest,
-                        },
-                    )
-                )
-            elif existing_digest_payload is None:
-                combo_digest_payloads[digest_key] = payload
+            chosen_name = None
+            chosen_size = None
+            for digest_size in _combo_digest_sizes(digest):
+                candidate_digest = digest[:digest_size]
+                candidate_name = f"{_COMBO_STATE_PREFIX}{slug}_h{candidate_digest}"
 
-            existing_payload = combo_name_payloads.get(name)
-            if existing_payload is not None and existing_payload != payload:
+                existing_payload = combo_name_payloads.get(candidate_name)
+                if existing_payload is not None and existing_payload != payload:
+                    continue
+
+                existing_state = current_state.substates.get(candidate_name)
+                if (
+                    existing_state is not None
+                    and candidate_name not in combo_name_payloads
+                ):
+                    continue
+
+                chosen_name = candidate_name
+                chosen_size = digest_size
+                break
+            if chosen_name is None or chosen_size is None:
+                name = f"{_COMBO_STATE_PREFIX}{slug}_h{digest[:_COMBO_DIGEST_MAX_SIZE]}"
                 sink.emit(
                     ModelDiagnostic(
                         code="E_COMBO_PSEUDO_NAME_COLLISION",
                         severity="error",
                         message=(
                             f"Generated combo pseudo state name {name!r} collides "
-                            "for distinct semantic payloads."
+                            "even after extending to the full payload digest."
                         ),
                         span=None,
                         refs={
@@ -3860,29 +3913,33 @@ def parse_dsl_node_to_state_machine(
                         },
                     )
                 )
-            elif existing_payload is None:
-                combo_name_payloads[name] = payload
-
-            if name in current_state.substates:
-                state = current_state.substates[name]
-                if not state.is_pseudo:
+            else:
+                name = chosen_name
+                is_new_combo_name = name not in combo_name_payloads
+                if is_new_combo_name and chosen_size > _COMBO_DIGEST_SIZE:
                     sink.emit(
                         ModelDiagnostic(
-                            code="E_COMBO_PSEUDO_NAME_COLLISION",
-                            severity="error",
+                            code="I_COMBO_PSEUDO_NAME_EXTENDED",
+                            severity="info",
                             message=(
-                                f"Generated combo pseudo state name {name!r} "
-                                "collides with a non-pseudo state."
+                                "Combo pseudo relay name digest was extended "
+                                f"from {_COMBO_DIGEST_SIZE} to {chosen_size} "
+                                "characters to avoid an existing name."
                             ),
-                            span=state._span,
+                            span=None,
                             refs={
                                 "state_path": ".".join(current_state.path),
                                 "pseudo_name": name,
                                 "payload_digest": digest,
+                                "default_digest_size": _COMBO_DIGEST_SIZE,
+                                "final_digest_size": chosen_size,
                             },
                         )
                     )
-                return state
+                combo_name_payloads[name] = payload
+
+            if name in current_state.substates:
+                return current_state.substates[name]
 
             display = _COMBO_DISPLAY_PREFIX + " + ".join(term_texts)
             state = State(

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -128,7 +128,29 @@ def _is_exported_combo_pseudo_node(
     node: dsl_nodes.StateDefinition,
     owner_node: Optional[dsl_nodes.StateDefinition] = None,
 ) -> bool:
-    """Return whether an AST node is an exported generated combo pseudo state."""
+    """
+    Return whether an AST node is a same-process exported combo relay.
+
+    This helper recognizes only trusted AST object round trips. Text reimports
+    of ``pseudo state __combo_*`` remain plain pseudo states and do not regain
+    generated-relay metadata from the process-local trust registry.
+
+    :param node: State definition to inspect.
+    :type node: pyfcstm.dsl.node.StateDefinition
+    :param owner_node: Parent state definition used by the trust registry,
+        defaults to ``None``.
+    :type owner_node: pyfcstm.dsl.node.StateDefinition, optional
+    :return: ``True`` when ``node`` is a trusted generated combo pseudo state,
+        otherwise ``False``.
+    :rtype: bool
+
+    Example::
+
+        >>> from pyfcstm.dsl import node as dsl_nodes
+        >>> item = dsl_nodes.StateDefinition("__combo_user", is_pseudo=True)
+        >>> _is_exported_combo_pseudo_node(item)
+        False
+    """
     if not node.is_pseudo or not node.name.startswith(_COMBO_STATE_PREFIX):
         return False
     if owner_node is None:
@@ -2784,6 +2806,9 @@ def parse_dsl_node_to_state_machine(
     ) -> State:
         current_path = tuple((*current_path, node.name))
         is_exported_combo_pseudo = _is_exported_combo_pseudo_node(node, owner_node)
+        is_combo_relay_pseudo = (
+            node.name.startswith(_COMBO_STATE_PREFIX) and node.is_pseudo
+        )
         if node.name.startswith(_COMBO_STATE_PREFIX) and not node.is_pseudo:
             sink.emit(
                 ModelDiagnostic(
@@ -2930,7 +2955,11 @@ def parse_dsl_node_to_state_machine(
 
         on_durings = []
         for during_item in node.durings:
-            if not d_substates and during_item.aspect is not None:
+            if (
+                not d_substates
+                and during_item.aspect is not None
+                and not is_combo_relay_pseudo
+            ):
                 sink.emit(
                     ModelDiagnostic(
                         code="E_DURING_ASPECT_INVALID",
@@ -3130,7 +3159,7 @@ def parse_dsl_node_to_state_machine(
             # only meaningful on a composite state (it fans out to every
             # descendant leaf). On a leaf state there is nothing to fan
             # into, so the aspect is invalid.
-            if not d_substates:
+            if not d_substates and not is_combo_relay_pseudo:
                 sink.emit(
                     ModelDiagnostic(
                         code="E_DURING_ASPECT_INVALID",
@@ -3254,7 +3283,7 @@ def parse_dsl_node_to_state_machine(
         )
         if is_exported_combo_pseudo:
             my_state._generated_combo_pseudo = True
-        if node.name.startswith(_COMBO_STATE_PREFIX) and node.is_pseudo:
+        if is_combo_relay_pseudo:
             action_kinds = _ast_action_kinds(node)
             if action_kinds:
                 sink.emit(
@@ -3785,6 +3814,8 @@ def parse_dsl_node_to_state_machine(
             )
 
         combo_name_payloads: Dict[str, str] = {}
+        combo_exhausted_names: Set[str] = set()
+        combo_exhausted_payload_names: Dict[str, str] = {}
 
         def _term_name_slug(term: dsl_nodes.ComboTriggerTerm) -> str:
             if isinstance(term, dsl_nodes.ComboGuardTerm):
@@ -3820,6 +3851,17 @@ def parse_dsl_node_to_state_machine(
 
         def _combo_effect_signature(transnode) -> Tuple[str, ...]:
             return tuple(str(item) for item in transnode.post_operations)
+
+        def _combo_collision_recovery_name(name: str) -> str:
+            suffix = 1
+            while True:
+                candidate = f"{name}__collision_{suffix}"
+                if (
+                    candidate not in current_state.substates
+                    and candidate not in combo_name_payloads
+                ):
+                    return candidate
+                suffix += 1
 
         def _combo_origin_id(
             transnode,
@@ -3896,23 +3938,33 @@ def parse_dsl_node_to_state_machine(
                 chosen_size = digest_size
                 break
             if chosen_name is None or chosen_size is None:
-                name = f"{_COMBO_STATE_PREFIX}{slug}_h{digest[:_COMBO_DIGEST_MAX_SIZE]}"
-                sink.emit(
-                    ModelDiagnostic(
-                        code="E_COMBO_PSEUDO_NAME_COLLISION",
-                        severity="error",
-                        message=(
-                            f"Generated combo pseudo state name {name!r} collides "
-                            "even after extending to the full payload digest."
-                        ),
-                        span=None,
-                        refs={
-                            "state_path": ".".join(current_state.path),
-                            "pseudo_name": name,
-                            "payload_digest": digest,
-                        },
-                    )
+                collision_name = (
+                    f"{_COMBO_STATE_PREFIX}{slug}_h{digest[:_COMBO_DIGEST_MAX_SIZE]}"
                 )
+                name = combo_exhausted_payload_names.get(payload)
+                if name is None:
+                    if collision_name not in combo_exhausted_names:
+                        sink.emit(
+                            ModelDiagnostic(
+                                code="E_COMBO_PSEUDO_NAME_COLLISION",
+                                severity="error",
+                                message=(
+                                    "Generated combo pseudo state name "
+                                    f"{collision_name!r} collides even after "
+                                    "extending to the full payload digest."
+                                ),
+                                span=None,
+                                refs={
+                                    "state_path": ".".join(current_state.path),
+                                    "pseudo_name": collision_name,
+                                    "payload_digest": digest,
+                                },
+                            )
+                        )
+                        combo_exhausted_names.add(collision_name)
+                    name = _combo_collision_recovery_name(collision_name)
+                    combo_exhausted_payload_names[payload] = name
+                    combo_name_payloads[name] = payload
             else:
                 name = chosen_name
                 is_new_combo_name = name not in combo_name_payloads

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -2366,13 +2366,11 @@ class SimulationRuntime:
             vars_,
             is_validation_mode=is_validation_mode,
         )
-        if composite_frame.plain_before_pending:
-            for on_during_before in state.list_on_durings(aspect="before"):
-                self._execute_func(
-                    on_during_before, vars_, is_validation_mode=is_validation_mode
-                )
-            composite_frame.plain_before_pending = False
         target_state = state.substates[transition.to_state]
+        if not target_state.is_pseudo:
+            self._consume_plain_before_if_pending(
+                composite_frame, vars_, is_validation_mode=is_validation_mode
+            )
         self._enter_state(
             stack,
             target_state,
@@ -2384,6 +2382,65 @@ class SimulationRuntime:
         )
         if composite_frame in stack:
             composite_frame.mode = "active"
+
+    def _consume_plain_before_if_pending(
+        self,
+        frame: _Frame,
+        vars_: Dict[str, Union[int, float]],
+        is_validation_mode: bool = False,
+    ) -> None:
+        """
+        Run a composite frame's pending plain ``during before`` actions once.
+
+        Composite entry leaves ``plain_before_pending`` set until initial
+        routing selects a concrete non-pseudo child. Generated combo relays and
+        user-authored pseudo states are part of that routing chain, so they must
+        not consume the boundary action early.
+
+        :param frame: Composite frame that may hold a pending boundary action.
+        :type frame: _Frame
+        :param vars_: Variable mapping to mutate.
+        :type vars_: Dict[str, Union[int, float]]
+        :param is_validation_mode: Whether this is validation mode, defaults to
+            ``False``.
+        :type is_validation_mode: bool, optional
+        :return: ``None``.
+        :rtype: None
+        """
+        if not frame.plain_before_pending:
+            return
+        for on_during_before in frame.state.list_on_durings(aspect="before"):
+            self._execute_func(
+                on_during_before, vars_, is_validation_mode=is_validation_mode
+            )
+        frame.plain_before_pending = False
+
+    @staticmethod
+    def _clear_parent_plain_before_pending_after_pseudo_exit(
+        stack: List[_Frame], current_state: State
+    ) -> None:
+        """
+        Clear deferred plain-before state when initial pseudo routing exits.
+
+        A pseudo initial routing chain that reaches ``[*]`` has not selected a
+        child inside the owning composite, so the owner's pending plain
+        ``during before`` action must be discarded instead of executed or leaked
+        into later parent-continuation processing.
+
+        :param stack: Execution stack after the pseudo source frame was popped.
+        :type stack: List[_Frame]
+        :param current_state: Popped transition source state.
+        :type current_state: pyfcstm.model.State
+        :return: ``None``.
+        :rtype: None
+        """
+        if (
+            current_state.is_pseudo
+            and stack
+            and stack[-1].state is current_state.parent
+            and stack[-1].plain_before_pending
+        ):
+            stack[-1].plain_before_pending = False
 
     def _validate_initial_transition(
         self,
@@ -2543,6 +2600,9 @@ class SimulationRuntime:
         stack.pop()
 
         if transition.to_state == EXIT_STATE:
+            self._clear_parent_plain_before_pending_after_pseudo_exit(
+                stack, current_state
+            )
             ended = self._finalize_exit_to_parent(
                 stack, vars_, is_validation_mode=is_validation_mode
             )
@@ -2555,10 +2615,19 @@ class SimulationRuntime:
             else:
                 self.logger.debug(
                     f"Transition completed: {current_state_path} -> [*], ended={ended}"
-                )
+            )
             return ended
 
         target_state = current_state.parent.substates[transition.to_state]
+        if (
+            current_state.is_pseudo
+            and stack
+            and stack[-1].state is current_state.parent
+            and not target_state.is_pseudo
+        ):
+            self._consume_plain_before_if_pending(
+                stack[-1], vars_, is_validation_mode=is_validation_mode
+            )
         self._enter_state(
             stack,
             target_state,

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -2615,7 +2615,7 @@ class SimulationRuntime:
             else:
                 self.logger.debug(
                     f"Transition completed: {current_state_path} -> [*], ended={ended}"
-            )
+                )
             return ended
 
         target_state = current_state.parent.substates[transition.to_state]
@@ -4248,8 +4248,7 @@ class SimulationRuntime:
                     if action_paths:
                         raise ValueError(
                             "Abstract handler member %s.%s uses a reserved "
-                            "dunder protocol name"
-                            % (obj.__class__.__name__, name)
+                            "dunder protocol name" % (obj.__class__.__name__, name)
                         )
                     continue
                 if action_paths:

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -1240,6 +1240,46 @@ static const _{{ machine_class_name(model) }}TransitionInfo _{{ machine_class_na
 {% endfor %}
 };
 
+static int _{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    size_t frame_index,
+    int is_validation_mode)
+{
+    int pending_state_id;
+
+    if (frame_index >= context->stack_size || !context->stack[frame_index].plain_before_pending) {
+        return {{ machine_macro_name(model) }}_SUCCESS;
+    }
+
+    pending_state_id = context->stack[frame_index].state_id;
+    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+            machine,
+            pending_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    context->stack[frame_index].plain_before_pending = 0;
+    return {{ machine_macro_name(model) }}_SUCCESS;
+}
+
+static void _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int current_state_id)
+{
+    const _{{ machine_class_name(model) }}StateInfo *state_info;
+
+    state_info = &_{{ machine_class_name(model) }}_state_info[current_state_id];
+    if (!state_info->is_pseudo || context->stack_size == 0u) {
+        return;
+    }
+    if (context->stack[context->stack_size - 1u].state_id == state_info->parent_state_id &&
+        context->stack[context->stack_size - 1u].plain_before_pending) {
+        context->stack[context->stack_size - 1u].plain_before_pending = 0;
+    }
+}
+
 static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1260,16 +1300,14 @@ static int _{{ machine_class_name(model) }}_execute_initial_transition_on_contex
     if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
         return {{ machine_macro_name(model) }}_FAILURE;
     }
-    if (context->stack_size > 0u && context->stack[context->stack_size - 1u].plain_before_pending) {
-        int pending_state_id = context->stack[context->stack_size - 1u].state_id;
-        if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+    if (!_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
                 machine,
-                pending_state_id,
                 context,
+                context->stack_size - 1u,
                 is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
             return {{ machine_macro_name(model) }}_FAILURE;
         }
-        context->stack[context->stack_size - 1u].plain_before_pending = 0;
     }
     if (_{{ machine_class_name(model) }}_enter_state(
             machine,
@@ -1800,7 +1838,21 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
     --context->stack_size;
 
     if (transition->to_exit) {
+        _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(context, current_state_id);
         return _{{ machine_class_name(model) }}_finalize_exit_to_parent(machine, context, is_validation_mode);
+    }
+
+    if (_{{ machine_class_name(model) }}_state_info[current_state_id].is_pseudo &&
+        context->stack_size > 0u &&
+        context->stack[context->stack_size - 1u].state_id == _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id &&
+        !_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+                machine,
+                context,
+                context->stack_size - 1u,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
     }
 
     if (_{{ machine_class_name(model) }}_enter_state(

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -1339,6 +1339,46 @@ static const _{{ machine_class_name(model) }}TransitionInfo _{{ machine_class_na
 {% endfor %}
 };
 
+static int _{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    size_t frame_index,
+    int is_validation_mode)
+{
+    int pending_state_id;
+
+    if (frame_index >= context->stack_size || !context->stack[frame_index].plain_before_pending) {
+        return {{ machine_macro_name(model) }}_SUCCESS;
+    }
+
+    pending_state_id = context->stack[frame_index].state_id;
+    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+            machine,
+            pending_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    context->stack[frame_index].plain_before_pending = 0;
+    return {{ machine_macro_name(model) }}_SUCCESS;
+}
+
+static void _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int current_state_id)
+{
+    const _{{ machine_class_name(model) }}StateInfo *state_info;
+
+    state_info = &_{{ machine_class_name(model) }}_state_info[current_state_id];
+    if (!state_info->is_pseudo || context->stack_size == 0u) {
+        return;
+    }
+    if (context->stack[context->stack_size - 1u].state_id == state_info->parent_state_id &&
+        context->stack[context->stack_size - 1u].plain_before_pending) {
+        context->stack[context->stack_size - 1u].plain_before_pending = 0;
+    }
+}
+
 static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1359,16 +1399,14 @@ static int _{{ machine_class_name(model) }}_execute_initial_transition_on_contex
     if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
         return {{ machine_macro_name(model) }}_FAILURE;
     }
-    if (context->stack_size > 0u && context->stack[context->stack_size - 1u].plain_before_pending) {
-        int pending_state_id = context->stack[context->stack_size - 1u].state_id;
-        if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+    if (!_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
                 machine,
-                pending_state_id,
                 context,
+                context->stack_size - 1u,
                 is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
             return {{ machine_macro_name(model) }}_FAILURE;
         }
-        context->stack[context->stack_size - 1u].plain_before_pending = 0;
     }
     if (_{{ machine_class_name(model) }}_enter_state(
             machine,
@@ -1840,7 +1878,21 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
     --context->stack_size;
 
     if (transition->to_exit) {
+        _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(context, current_state_id);
         return _{{ machine_class_name(model) }}_finalize_exit_to_parent(machine, context, is_validation_mode);
+    }
+
+    if (_{{ machine_class_name(model) }}_state_info[current_state_id].is_pseudo &&
+        context->stack_size > 0u &&
+        context->stack[context->stack_size - 1u].state_id == _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id &&
+        !_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+                machine,
+                context,
+                context->stack_size - 1u,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
     }
 
     if (_{{ machine_class_name(model) }}_enter_state(

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -1026,13 +1026,10 @@ class {{ machine_class_name(model) }}:
         self._execute_transition_effect(
             transition, vars_, is_validation_mode=is_validation_mode
         )
-        if composite_frame.get("plain_before_pending", False):
-            self._execute_actions(
-                self._STATE_INFO[composite_frame["state"]]["during_before_actions"],
-                vars_,
-                is_validation_mode=is_validation_mode,
+        if not self._STATE_INFO[transition["target"]]["is_pseudo"]:
+            self._consume_plain_before_if_pending(
+                composite_frame, vars_, is_validation_mode=is_validation_mode
             )
-            composite_frame["plain_before_pending"] = False
         self._enter_state(
             stack,
             transition["target"],
@@ -1056,6 +1053,25 @@ class {{ machine_class_name(model) }}:
             attempt_initial_transition=False,
         )
         return self._validation_search_reaches_stable(sim_stack, sim_vars, event_names)
+
+    def _consume_plain_before_if_pending(self, frame, vars_, is_validation_mode=False):
+        if not frame.get("plain_before_pending", False):
+            return
+        self._execute_actions(
+            self._STATE_INFO[frame["state"]]["during_before_actions"],
+            vars_,
+            is_validation_mode=is_validation_mode,
+        )
+        frame["plain_before_pending"] = False
+
+    def _clear_parent_plain_before_pending_after_pseudo_exit(self, stack, current_path):
+        if not self._STATE_INFO[current_path]["is_pseudo"] or not stack:
+            return
+        parent_path = self._STATE_INFO[current_path]["parent"]
+        if stack[-1]["state"] == parent_path and stack[-1].get(
+            "plain_before_pending", False
+        ):
+            stack[-1]["plain_before_pending"] = False
 
     def _finalize_exit_to_parent(self, stack, vars_, is_validation_mode=False):
         if not stack:
@@ -1105,10 +1121,22 @@ class {{ machine_class_name(model) }}:
         stack.pop()
 
         if transition["to_exit"]:
+            self._clear_parent_plain_before_pending_after_pseudo_exit(
+                stack, current_path
+            )
             return self._finalize_exit_to_parent(
                 stack, vars_, is_validation_mode=is_validation_mode
             )
 
+        if (
+            self._STATE_INFO[current_path]["is_pseudo"]
+            and stack
+            and stack[-1]["state"] == self._STATE_INFO[current_path]["parent"]
+            and not self._STATE_INFO[transition["target"]]["is_pseudo"]
+        ):
+            self._consume_plain_before_if_pending(
+                stack[-1], vars_, is_validation_mode=is_validation_mode
+            )
         self._enter_state(
             stack,
             transition["target"],

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -1872,6 +1872,176 @@ class TestInspectModelRedundancySemantics:
         assert all('effect_self_assign_anchor' not in ref for ref in refs)
         assert all('suggested_fix' not in ref for ref in refs)
 
+    def test_effect_self_assign_combo_terminal_uses_authored_source(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B :: E1 + E2 effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 1
+        diag = diagnostics[0]
+        refs = diag.refs
+        assert refs['state_path'] == 'Root.A'
+        assert refs['from_path'] == 'Root.A'
+        assert refs['generated_state_path'].startswith('Root.__combo_')
+        assert refs['generated_from_path'] == refs['generated_state_path']
+        assert refs['generated_to_path'] == 'Root.B'
+        assert refs['combo_origin_id']
+        assert 'combo_owner_path' not in refs
+        assert refs['var_name'] == 'x'
+        assert refs['effect_self_assign_anchor'] == 'x'
+        assert refs['suggested_fix']['anchor'] == {
+            'type': 'ref',
+            'ref': 'refs.effect_self_assign_anchor',
+        }
+        assert _slice_by_span(dsl, refs['transition_span']).strip() == (
+            'A -> B :: E1 + E2 effect { x = x; }'
+        )
+        assert _slice_by_span(dsl, diag.span) == 'x = x;'
+        assert_all_diags_match_schema(diagnostics, context='combo-self-assign')
+
+    def test_effect_self_assign_entry_combo_uses_initial_subject(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            [*] -> A : Boot + Ready effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 1
+        diag = diagnostics[0]
+        refs = diag.refs
+        assert refs['state_path'] == '[*]'
+        assert refs['from_path'] == '[*]'
+        assert refs['combo_owner_path'] == 'Root'
+        assert refs['generated_state_path'].startswith('Root.__combo_')
+        assert refs['generated_from_path'] == refs['generated_state_path']
+        assert refs['generated_to_path'] == 'Root.A'
+        assert refs['combo_origin_id']
+        assert refs['var_name'] == 'x'
+        assert 'effect_self_assign_anchor' not in refs
+        assert 'suggested_fix' not in refs
+        assert _slice_by_span(dsl, refs['transition_span']).strip() == (
+            '[*] -> A : Boot + Ready effect { x = x; }'
+        )
+        assert _slice_by_span(dsl, diag.span) == 'x = x;'
+        assert_all_diags_match_schema(diagnostics, context='entry-combo-self-assign')
+
+    def test_effect_self_assign_combo_shared_prefix_terminal_subjects(self):
+        dsl = """
+        def int x = 0;
+        def int y = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B :: E1 + E2 effect { x = x; };
+            A -> C :: E1 + E3 effect { y = y; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 2
+        by_var = {diag.refs['var_name']: diag for diag in diagnostics}
+        assert set(by_var) == {'x', 'y'}
+        for var_name, diag in by_var.items():
+            refs = diag.refs
+            assert refs['state_path'] == 'Root.A'
+            assert refs['from_path'] == 'Root.A'
+            assert refs['generated_state_path'].startswith('Root.__combo_')
+            assert refs['generated_from_path'] == refs['generated_state_path']
+            assert refs['generated_to_path'] in {'Root.B', 'Root.C'}
+            assert refs['combo_origin_id']
+            assert refs['effect_self_assign_anchor'] == var_name
+            assert refs['suggested_fix']['anchor'] == {
+                'type': 'ref',
+                'ref': 'refs.effect_self_assign_anchor',
+            }
+            assert _slice_by_span(dsl, diag.span) == f'{var_name} = {var_name};'
+        assert _slice_by_span(dsl, by_var['x'].refs['transition_span']).strip() == (
+            'A -> B :: E1 + E2 effect { x = x; }'
+        )
+        assert _slice_by_span(dsl, by_var['y'].refs['transition_span']).strip() == (
+            'A -> C :: E1 + E3 effect { y = y; }'
+        )
+        assert_all_diags_match_schema(diagnostics, context='shared-prefix-self-assign')
+
+    def test_effect_self_assign_combo_shared_source_disambiguated(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B :: E1 + E2 effect { x = x; };
+            A -> C :: E3 + E4 effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 2
+        assert all(diag.refs['state_path'] == 'Root.A' for diag in diagnostics)
+        assert all(diag.refs['from_path'] == 'Root.A' for diag in diagnostics)
+        assert all(diag.refs['var_name'] == 'x' for diag in diagnostics)
+        assert all('effect_self_assign_anchor' not in diag.refs for diag in diagnostics)
+        assert all('suggested_fix' not in diag.refs for diag in diagnostics)
+        assert {diag.refs['generated_to_path'] for diag in diagnostics} == {
+            'Root.B',
+            'Root.C',
+        }
+        assert_all_diags_match_schema(diagnostics, context='shared-source-self-assign')
+
+    def test_effect_self_assign_combo_and_plain_same_source_suppress_anchor(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B effect { x = x; };
+            A -> C :: E1 + E2 effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 2
+        assert all(diag.refs['state_path'] == 'Root.A' for diag in diagnostics)
+        assert all(diag.refs['var_name'] == 'x' for diag in diagnostics)
+        assert all('effect_self_assign_anchor' not in diag.refs for diag in diagnostics)
+        assert all('suggested_fix' not in diag.refs for diag in diagnostics)
+        plain = next(diag for diag in diagnostics if 'generated_from_path' not in diag.refs)
+        combo = next(diag for diag in diagnostics if 'generated_from_path' in diag.refs)
+        assert 'from_path' not in plain.refs
+        assert combo.refs['from_path'] == 'Root.A'
+        assert combo.refs['generated_to_path'] == 'Root.C'
+        assert_all_diags_match_schema(diagnostics, context='plain-combo-self-assign')
+
     def test_initial_transition_self_assignment_does_not_get_fix(self):
         dsl = """
         def int x = 0;

--- a/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.fcstm
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.fcstm
@@ -1,0 +1,21 @@
+def int trace = 0;
+def int gate = 0;
+
+state Root {
+    enter {
+        gate = 1;
+        trace = trace * 10 + 7;
+    }
+    during before {
+        gate = gate + 1;
+        trace = trace * 10 + 1;
+    }
+    [*] -> Active : EntryA + [gate == 1] + EntryB effect {
+        gate = gate + 10;
+        trace = trace * 10 + 2;
+    }
+
+    state Active {
+        enter { trace = trace * 10 + 3; }
+    }
+}

--- a/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.yaml
@@ -1,0 +1,24 @@
+title: Combo initial guard after prefix sees pre plain-before variables
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - "Locks F-001 guard-pollution regression: parent plain during-before must not run between combo prefix and later guard term."
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+- validation
+steps:
+- cycle:
+  - Root.EntryA
+  - Root.EntryB
+  expect:
+    state: Root.Active
+    vars:
+      gate: 12
+      trace: 7213
+    ended: false

--- a/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.fcstm
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.fcstm
@@ -1,0 +1,10 @@
+def int trace = 0;
+
+state Root {
+    during before { trace = trace * 10 + 1; }
+    [*] -> Active : EntryA + EntryB effect { trace = trace * 10 + 2; }
+
+    state Active {
+        enter { trace = trace * 10 + 3; }
+    }
+}

--- a/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.yaml
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.yaml
@@ -1,0 +1,22 @@
+title: Combo initial pseudo chain defers plain during-before until terminal child
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - "Locks F-001: the generated initial pseudo chain is routing, so composite plain during-before runs after terminal effect and before the selected child enter."
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+steps:
+- cycle:
+  - Root.EntryA
+  - Root.EntryB
+  expect:
+    state: Root.Active
+    vars:
+      trace: 213
+    ended: false

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
@@ -1,13 +1,16 @@
-title: Composite initial guard can choose a terminal branch before plain during-before
-  mutation
+title: Composite initial guard can choose a terminal branch before any selected-child
+  plain during-before
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689585597
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
   notes:
   - Covers the final and is_ended variant where wrong initial selection prevents machine
     termination.
+  - F-001 clarifies that initial pseudo routing ending in [*] has no selected
+    non-pseudo child, so pending plain during-before is cleared instead of run.
 categories:
 - runtime
 - lifecycle
@@ -18,6 +21,6 @@ steps:
   expect:
     state: null
     vars:
-      flag: 1
-      trace: 234789
+      flag: 0
+      trace: 24789
     ended: true

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.fcstm
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.fcstm
@@ -1,0 +1,14 @@
+def int trace = 0;
+
+state Root {
+    during before { trace = trace * 10 + 1; }
+
+    pseudo state P {
+        enter { trace = trace * 10 + 2; }
+        during { trace = trace * 10 + 3; }
+        exit { trace = trace * 10 + 4; }
+    }
+
+    [*] -> P;
+    P -> [*] effect { trace = trace * 10 + 5; }
+}

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.yaml
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.yaml
@@ -1,0 +1,19 @@
+title: Manual initial pseudo exit clears pending plain before without running it
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - Locks that pseudo routing ending in [*] does not run parent plain during-before and does not leak the pending flag.
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+steps:
+- cycle: []
+  expect:
+    vars:
+      trace: 2345
+    ended: true

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.fcstm
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.fcstm
@@ -1,0 +1,18 @@
+def int trace = 0;
+
+state Root {
+    during before { trace = trace * 10 + 1; }
+
+    pseudo state P {
+        enter { trace = trace * 10 + 2; }
+        during { trace = trace * 10 + 3; }
+        exit { trace = trace * 10 + 4; }
+    }
+
+    state Active {
+        enter { trace = trace * 10 + 6; }
+    }
+
+    [*] -> P;
+    P -> Active effect { trace = trace * 10 + 5; }
+}

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.yaml
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.yaml
@@ -1,0 +1,21 @@
+title: Manual initial pseudo lifecycle keeps actions while deferring parent plain before
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - Locks F-001 for user-authored pseudo states, not only generated __combo relays.
+  - The trace pins pseudo enter/during, pseudo exit, terminal effect, parent plain during-before, and selected child enter.
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+steps:
+- cycle: []
+  expect:
+    state: Root.Active
+    vars:
+      trace: 234516
+    ended: false

--- a/test/model/test_combo_transition_expansion.py
+++ b/test/model/test_combo_transition_expansion.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 
 import pytest
@@ -575,14 +576,16 @@ class TestComboModelExpansion:
             for item in model.root_state.transitions
             if item.from_state != "INIT_STATE"
         ]
-        assert "local" in second_round_tripped.root_state.substates["A"].events[
-            "E2"
-        ].origins
-        assert "chain" not in second_round_tripped.root_state.substates["A"].events[
-            "E2"
-        ].origins
+        assert (
+            "local"
+            in second_round_tripped.root_state.substates["A"].events["E2"].origins
+        )
+        assert (
+            "chain"
+            not in second_round_tripped.root_state.substates["A"].events["E2"].origins
+        )
 
-    def test_mutated_trusted_combo_ast_export_is_rejected(self):
+    def test_mutated_trusted_combo_ast_export_uses_plain_validation(self):
         model = _build_model(
             """
             state Root {
@@ -604,14 +607,14 @@ class TestComboModelExpansion:
                 transition.to_state = "A"
                 break
 
+        _, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        assert "E_MISSING_STATE" in [item.code for item in diagnostics]
         with pytest.raises(ModelValidationError) as exc_info:
             parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        assert [item.code for item in exc_info.value.diagnostics] == ["E_MISSING_STATE"]
 
-    def test_generated_combo_pseudo_text_export_uses_reserved_prefix(self):
+    def test_generated_combo_pseudo_text_export_reimports_as_plain_relay(self):
         model = _build_model(
             """
             state Root {
@@ -624,17 +627,29 @@ class TestComboModelExpansion:
         )
 
         exported = str(model.to_ast_node())
-
-        assert "pseudo state __combo_" in exported
         parsed = parse_with_grammar_entry(exported, entry_name="state_machine_dsl")
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(parsed)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
+        round_tripped, diagnostics = parse_dsl_node_to_state_machine(
+            parsed, collect=True
         )
 
-    def test_forged_generated_combo_pseudo_marker_is_rejected(self):
+        assert "pseudo state __combo_" in exported
+        assert diagnostics == []
+        assert [
+            item.name
+            for item in round_tripped.root_state.substates.values()
+            if item.is_pseudo
+        ] == [
+            item.name for item in model.root_state.substates.values() if item.is_pseudo
+        ]
+        assert not any(
+            item.combo_origin_refs for item in round_tripped.root_state.transitions
+        )
+        runtime = SimulationRuntime(round_tripped)
+        runtime.cycle()
+        runtime.cycle(["Root.A.E1", "Root.A.E2"])
+        assert runtime.current_state.path == ("Root", "B")
+
+    def test_forged_generated_combo_pseudo_marker_does_not_block_pure_relay(self):
         program = parse_with_grammar_entry(
             """
             state Root {
@@ -646,12 +661,11 @@ class TestComboModelExpansion:
         )
         program.root_state.substates[0]._generated_combo_pseudo = True
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        assert diagnostics == []
+        assert model.root_state.substates["__combo_user"].is_pseudo
+        parse_dsl_node_to_state_machine(program)
 
     def test_nested_same_name_sources_keep_distinct_pseudo_names(self):
         model = _build_model(
@@ -748,44 +762,103 @@ class TestComboModelExpansion:
 
         assert _combo_names(base) == _combo_names(with_unrelated)
 
-    def test_reserved_combo_state_prefix_is_rejected(self):
+    @pytest.mark.parametrize(
+        ["source", "expected_kind"],
+        [
+            (
+                """
+                state Root {
+                    state __combo_user;
+                    [*] -> __combo_user;
+                }
+                """,
+                "state",
+            ),
+            (
+                """
+                state Root {
+                    state __combo_group {
+                        state Child;
+                        [*] -> Child;
+                    }
+                    [*] -> __combo_group;
+                }
+                """,
+                "composite",
+            ),
+        ],
+    )
+    def test_non_pseudo_reserved_prefix_warns_without_blocking(
+        self, source, expected_kind
+    ):
+        program = parse_with_grammar_entry(source, entry_name="state_machine_dsl")
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        assert model.root_state.substates
+        diagnostic = next(
+            item
+            for item in diagnostics
+            if item.code == "W_COMBO_RESERVED_PREFIX_STATE_KIND"
+        )
+        assert diagnostic.severity == "warning"
+        assert diagnostic.refs["reserved_prefix"] == "__combo_"
+        assert diagnostic.refs["state_kind"] == expected_kind
+        parse_dsl_node_to_state_machine(program)
+
+    def test_pure_reserved_prefix_pseudo_is_valid_relay_text(self):
         program = parse_with_grammar_entry(
             """
             state Root {
-                state __combo_user;
+                state Target;
+                pseudo state __combo_user named 'combo after UserEvent';
                 [*] -> __combo_user;
+                __combo_user -> Target :: Done;
             }
             """,
             entry_name="state_machine_dsl",
         )
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
 
-    def test_reserved_combo_pseudo_without_generated_shape_is_rejected(self):
+        assert diagnostics == []
+        assert model.root_state.substates["__combo_user"].is_pseudo
+        parse_dsl_node_to_state_machine(program)
+
+    def test_reserved_prefix_pseudo_with_actions_warns_without_blocking(self):
         program = parse_with_grammar_entry(
             """
+            def int x = 0;
             state Root {
-                pseudo state __combo_user;
+                pseudo state __combo_user {
+                    enter { x = x + 1; }
+                    during { x = x + 2; }
+                    exit { x = x + 3; }
+                }
+                state Target;
                 [*] -> __combo_user;
+                __combo_user -> Target :: Done;
             }
             """,
             entry_name="state_machine_dsl",
         )
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
 
-    def test_reserved_combo_export_shape_without_chain_is_rejected(self):
-        program = parse_with_grammar_entry(
+        assert model.root_state.substates["__combo_user"].is_pseudo
+        diagnostic = next(
+            item
+            for item in diagnostics
+            if item.code == "W_COMBO_RELAY_PSEUDO_HAS_ACTIONS"
+        )
+        assert diagnostic.severity == "warning"
+        assert diagnostic.refs["reserved_prefix"] == "__combo_"
+        assert diagnostic.refs["action_kinds"] == ["enter", "during", "exit"]
+        parse_dsl_node_to_state_machine(program)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
             """
             state Root {
                 state A;
@@ -793,18 +866,6 @@ class TestComboModelExpansion:
                 [*] -> A;
             }
             """,
-            entry_name="state_machine_dsl",
-        )
-
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
-
-    def test_reserved_combo_export_shape_without_declared_events_is_rejected(self):
-        program = parse_with_grammar_entry(
             """
             state Root {
                 state A;
@@ -815,18 +876,6 @@ class TestComboModelExpansion:
                 __combo_root_a__e1_hbafca7f66598 -> B : A.E2;
             }
             """,
-            entry_name="state_machine_dsl",
-        )
-
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
-
-    def test_reserved_combo_export_shape_with_wrong_digest_is_rejected(self):
-        program = parse_with_grammar_entry(
             """
             state Root {
                 state A {
@@ -840,40 +889,15 @@ class TestComboModelExpansion:
                 __combo_root_a__e1_h000000000000 -> B : A.E2;
             }
             """,
-            entry_name="state_machine_dsl",
-        )
+        ],
+    )
+    def test_legacy_export_shape_checks_are_plain_relay_reimports(self, source):
+        program = parse_with_grammar_entry(source, entry_name="state_machine_dsl")
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        _, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
 
-    def test_reserved_combo_export_shape_even_when_semantically_valid_is_rejected(self):
-        program = parse_with_grammar_entry(
-            """
-            state Root {
-                state A {
-                    event E1;
-                    event E2;
-                }
-                state B;
-                pseudo state __combo_root_a__e1_hbafca7f66598 named 'combo after E1';
-                [*] -> A;
-                A -> __combo_root_a__e1_hbafca7f66598 :: E1;
-                __combo_root_a__e1_hbafca7f66598 -> B : A.E2;
-            }
-            """,
-            entry_name="state_machine_dsl",
-        )
-
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        assert diagnostics == []
+        parse_dsl_node_to_state_machine(program)
 
     def test_collect_mode_does_not_duplicate_combo_endpoint_diagnostics(self):
         program = parse_with_grammar_entry(
@@ -894,17 +918,137 @@ class TestComboModelExpansion:
         ]
         assert [diag.refs["src"] for diag in dangling] == ["Missing", "Missing"]
 
-    def test_digest12_collision_fails_fast(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ["declaration", "expected_warning"],
+        [
+            ("state {name};", True),
+            ("pseudo state {name};", False),
+        ],
+    )
+    def test_hash_extension_resolves_collision_with_user_authored_state(
+        self, declaration, expected_warning
+    ):
+        base = _build_model(
+            """
+            state Root {
+                state S1;
+                state S2;
+                [*] -> S1;
+                S1 -> S2 :: E1 + E2;
+            }
+            """
+        )
+        default_name = next(
+            state.name
+            for state in base.root_state.substates.values()
+            if state.is_pseudo
+        )
+        occupied_declaration = declaration.format(name=default_name)
+        program = parse_with_grammar_entry(
+            f"""
+            state Root {{
+                state S1;
+                state S2;
+                {occupied_declaration}
+                [*] -> S1;
+                S1 -> S2 :: E1 + E2;
+            }}
+            """,
+            entry_name="state_machine_dsl",
+        )
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        combo_names = [
+            state.name
+            for state in model.root_state.substates.values()
+            if state.is_pseudo and state.name.startswith("__combo_")
+        ]
+        assert default_name in model.root_state.substates
+        if expected_warning:
+            assert default_name not in combo_names
+        else:
+            assert default_name in combo_names
+        generated_names = [
+            state.name
+            for state in model.root_state.substates.values()
+            if state.is_pseudo and state.extra_name == "combo after E1"
+        ]
+        assert len(generated_names) == 1
+        assert generated_names[0] != default_name
+        assert re.search(r"_h[0-9a-f]{16}$", generated_names[0])
+        info = next(
+            item for item in diagnostics if item.code == "I_COMBO_PSEUDO_NAME_EXTENDED"
+        )
+        assert info.severity == "info"
+        assert info.refs["default_digest_size"] == 12
+        assert info.refs["final_digest_size"] == 16
+        assert (
+            any(
+                item.code == "W_COMBO_RESERVED_PREFIX_STATE_KIND"
+                for item in diagnostics
+            )
+            is expected_warning
+        )
+        parse_dsl_node_to_state_machine(program)
+
+    def test_hash_extension_separates_distinct_payloads_sharing_prefix(
+        self, monkeypatch
+    ):
+        def shared_prefix_digest(payload):
+            digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+            return "a" * 12 + digest[12:]
+
+        monkeypatch.setattr(
+            model_module,
+            "_combo_payload_digest",
+            shared_prefix_digest,
+        )
         program = parse_with_grammar_entry(
             """
             state Root {
                 state S1;
                 state S2;
                 state S3;
+                state S4;
                 [*] -> S1;
                 S1 -> S2 :: E1 + E2;
-                S1 -> S3 :: E3 + E4;
+                S1 -> S4 :: E1;
+                S1 -> S3 :: E1 + E3;
             }
+            """,
+            entry_name="state_machine_dsl",
+        )
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        combo_names = [
+            state.name
+            for state in model.root_state.substates.values()
+            if state.is_pseudo
+        ]
+        assert len(combo_names) == 2
+        assert sorted(len(name.rsplit("_h", 1)[1]) for name in combo_names) == [12, 16]
+        assert [
+            item.refs["final_digest_size"]
+            for item in diagnostics
+            if item.code == "I_COMBO_PSEUDO_NAME_EXTENDED"
+        ] == [16]
+        parse_dsl_node_to_state_machine(program)
+
+    def test_full_digest_collision_fails_after_extension(self, monkeypatch):
+        occupied_names = "\n".join(
+            f"state __combo_root_s1__e1_h{'0' * size};" for size in range(12, 65, 4)
+        )
+        program = parse_with_grammar_entry(
+            f"""
+            state Root {{
+                state S1;
+                state S2;
+                {occupied_names}
+                [*] -> S1;
+                S1 -> S2 :: E1 + E2;
+            }}
             """,
             entry_name="state_machine_dsl",
         )
@@ -916,10 +1060,12 @@ class TestComboModelExpansion:
         )
         with pytest.raises(ModelValidationError) as exc_info:
             parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
+        collision = next(
+            diag
             for diag in exc_info.value.diagnostics
+            if diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
         )
+        assert collision.refs["pseudo_name"].endswith("0" * 64)
 
     def test_combo_pseudo_keeps_current_aspect_skip_behavior(self):
         model = _build_model(

--- a/test/model/test_combo_transition_expansion.py
+++ b/test/model/test_combo_transition_expansion.py
@@ -834,6 +834,7 @@ class TestComboModelExpansion:
                     enter { x = x + 1; }
                     during { x = x + 2; }
                     exit { x = x + 3; }
+                    >> during before { x = x + 4; }
                 }
                 state Target;
                 [*] -> __combo_user;
@@ -853,7 +854,15 @@ class TestComboModelExpansion:
         )
         assert diagnostic.severity == "warning"
         assert diagnostic.refs["reserved_prefix"] == "__combo_"
-        assert diagnostic.refs["action_kinds"] == ["enter", "during", "exit"]
+        assert diagnostic.refs["action_kinds"] == [
+            "enter",
+            "during",
+            "exit",
+            "during_aspect",
+        ]
+        assert {item.code for item in diagnostics} == {
+            "W_COMBO_RELAY_PSEUDO_HAS_ACTIONS"
+        }
         parse_dsl_node_to_state_machine(program)
 
     @pytest.mark.parametrize(
@@ -1066,6 +1075,19 @@ class TestComboModelExpansion:
             if diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
         )
         assert collision.refs["pseudo_name"].endswith("0" * 64)
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+        collect_collisions = [
+            diag for diag in diagnostics if diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
+        ]
+        assert len(collect_collisions) == 1
+        occupied_full_name = f"__combo_root_s1__e1_h{'0' * 64}"
+        assert model.root_state.substates[occupied_full_name].is_pseudo is False
+        assert all(
+            transition.from_state != occupied_full_name
+            and transition.to_state != occupied_full_name
+            for transition in model.root_state.transitions
+        )
 
     def test_combo_pseudo_keeps_current_aspect_skip_behavior(self):
         model = _build_model(


### PR DESCRIPTION
# 组合 transition effect 后续修复伞 PR

关联 issue：[#304](https://github.com/HansBug/pyfcstm/issues/304)

本伞 PR 用于承接 #304 大规模 multiagent 排查后的 accepted findings，并把修复拆成 A/B/C/D 四个可执行、可验收的 subPR。当前伞 PR 只承载计划、依赖关系、验收标准与进度同步；具体代码改动应进入下列表格中的 subPR，合并回本伞 PR 后再做整体验收。

## 当前状态

- 伞 PR 状态：🟢 A 运行时 / F-001 已通过 [PR #307](https://github.com/HansBug/pyfcstm/pull/307) 合入本伞 PR（merge commit [`ef9c3c4`](https://github.com/HansBug/pyfcstm/commit/ef9c3c4ed8c0ce6a207ba774b628c1ec5dcb636b)）；B 命名 / F-002 已通过 [PR #308](https://github.com/HansBug/pyfcstm/pull/308) 合入本伞 PR（merge commit [`c86b1b1`](https://github.com/HansBug/pyfcstm/commit/c86b1b1f77006b96ee408e56a9eb2a9e50fa2f48)）；C 溯源 / F-004 已通过 [PR #309](https://github.com/HansBug/pyfcstm/pull/309) 合入本伞 PR；D 整合已通过 [PR #310](https://github.com/HansBug/pyfcstm/pull/310) 合入本伞 PR（merge commit [`2013c0c`](https://github.com/HansBug/pyfcstm/commit/2013c0cb7926866bc7239380835aaff52c82dbdd)）；伞 PR 最新 head CI 57/57 全绿，final multiagent review 无 C/I 阻塞，已合入 `main`（merge commit [`af68721`](https://github.com/HansBug/pyfcstm/commit/af68721f03f05789eb6e17532460fd1c5a87dad8)）。
- 排查结论来源：#304 已完成 24/24 worker 执行与主会话 triage。
- 首轮 PR body review 已吸收：
  - [claude reviewer](https://github.com/HansBug/pyfcstm/pull/306#issuecomment-4850427627)：Overall I，要求补齐 runtime/template parity、hot-start/pending 泄漏、registry/schema 等可验收口径。
  - [deepseek reviewer](https://github.com/HansBug/pyfcstm/pull/306#issuecomment-4850432304)：Overall I，指出 F-001 不能只按 `__combo_` 名字处理，必须锁定 user-authored pseudo lifecycle 行为。
  - [codex reviewer](https://github.com/HansBug/pyfcstm/pull/306#issuecomment-4850453554)：Overall I，要求 template alignment、diagnostic registry/schema/jsfcstm 口径、quick-fix anchor disambiguation 成为硬验收。
- Accepted findings：
  - ✅ F-001：runtime semantic blocker，已通过 [PR #307](https://github.com/HansBug/pyfcstm/pull/307) 合入本伞 PR（merge commit [`ef9c3c4`](https://github.com/HansBug/pyfcstm/commit/ef9c3c4ed8c0ce6a207ba774b628c1ec5dcb636b)），见 [F-001 设计 comment](https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414)。
  - ✅ F-002：combo relay 命名 / hygiene 合同，已通过 [PR #308](https://github.com/HansBug/pyfcstm/pull/308) 合入本伞 PR（merge commit [`c86b1b1`](https://github.com/HansBug/pyfcstm/commit/c86b1b1f77006b96ee408e56a9eb2a9e50fa2f48)），设计依据见 [F-002 设计 comment](https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850205728)。
  - ✅ F-004：generic effect diagnostic provenance remap，已通过 [PR #309](https://github.com/HansBug/pyfcstm/pull/309) 合入本伞 PR（merge commit [`0dde13b`](https://github.com/HansBug/pyfcstm/commit/0dde13b2278283d44d4853851d5a1254d30a9ef1)），设计背景见 [F-004 设计 comment](https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850232671)。
- Rejected clarification：F-003 / A14 已标记为 fake positive case，不进入修复范围，见 [F-003 修正 comment](https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850147427)。

## 总目标

1. 修复 combo initial / pseudo routing chain 触发的 composite plain `during before` 过早执行问题，确保 runtime 语义与控制系统建模直觉一致。
2. 明确并实现 `__combo_` relay 命名 / hygiene 合同，使 expanded text DSL 可以安全 reimport，同时保留对脏 relay 形态和真实生成名冲突的诊断。
3. 修复 generic effect diagnostics 在 combo terminal edge 上泄漏 generated pseudo path 的 provenance 问题。
4. 最后进行跨层整体验收，确认 simulator、diagnostics、text export/reimport、template alignment 与 #304 findings 全部闭环。

## 非目标

- 不重新引入 F-003；ancestor `>> during before/after` 不作用于 generated combo pseudo relay，不 suppress `W_COMBO_GUARD_PREFIX_IMPLIED`。
- 不在 F-004 中扩大 inspect schema；先采用局部 remap 方案 B。
- 不把 F-002 做成普通 inspect analyzer 的大范围预扫；真实命名冲突仍由 AST→model / combo expansion 阶段处理。
- 不在本伞 PR 里混入 PLC、C++ 新模板、inspect 定长整数验证等其他路线。
- 不把 F-001 误改成 `enter` 语义变更；`enter` 仍是进入 composite/state 时立即执行。

## subPR 划分

| SubPR | 状态 | 对应 finding | 目标 | 实施方案 | 硬验收标准 | 前置依赖 |
|---|---|---|---|---|---|---|
| A 运行时 | ✅ [PR #307](https://github.com/HansBug/pyfcstm/pull/307) 已合入 | F-001 | 修复 accepted C：initial combo / pseudo routing chain 中 plain `during before` 过早执行。 | 只移动 `plain_before_pending` 消费点：进入 composite 后先保持 pending；initial transition target 为 pseudo state 时不消费 pending；routing chain 到达 selected non-pseudo child 时，在 terminal effect 后、child `enter` 前消费一次；`-> [*]` / 离开 owner 时清理 pending 且不执行；实现不得只检查 `__combo_` 名字，应基于 `state.is_pseudo` 与当前 initial-routing 上下文。 | 必须覆盖：A09 ordering 得到 `trace=213`；guard pollution 不再 rollback；ordinary initial transition 顺序不变；manual pure pseudo chain 行为锁定；含 user-authored pseudo `enter/during/exit` 的合法场景不被静默改坏且有明确期望顺序；pseudo `-> [*]` pending 不泄漏；hot start 不 replay；exit combo regression 不变；known affected built-in templates（`python`、`c`、`c_poll`、`cpp`、`cpp_poll`）有 focused alignment 证据，不能写成“若受影响”。 | 无 |
| B 命名 | ✅ [PR #308](https://github.com/HansBug/pyfcstm/pull/308) 已合入 | F-002 | 实现 combo relay 命名 / hygiene 合同。 | 用新合同替换旧的 blanket reserved-name 拒绝：纯 `pseudo state __combo_*;` 可 reimport；非 pseudo `__combo_` 发 `W_COMBO_RESERVED_PREFIX_STATE_KIND`；`__combo_` pseudo 带 lifecycle/aspect action 发 `W_COMBO_RELAY_PSEUDO_HAS_ACTIONS`；combo expansion 分配名时先 hash-extension fallback，只有无法安全分配时才报 `E_COMBO_PSEUDO_NAME_COLLISION`；`I_COMBO_PSEUDO_NAME_EXTENDED` 只作为 collect/debug 信息；旧 `E_COMBO_RESERVED_STATE_NAME` 从本合同覆盖的 `__combo_` reserved-prefix 场景中彻底移除，不保留兼容分支。 | A02/A20 text roundtrip 不再因纯 relay pseudo 被 `E_COMBO_RESERVED_STATE_NAME` 拒绝；现有引用 `E_COMBO_RESERVED_STATE_NAME` 的测试全部迁移为“纯 relay 通过 / 非 pseudo warning / relay pseudo action warning / true collision error”四类新断言；新 codes 写入 `pyfcstm/diagnostics/codes.yaml`，每个 code 都必须包含 `for_llm.summary`、`for_llm.recommended_actions`、`for_llm.do_not`，并通过 registry/schema/for_llm 测试；jsfcstm/编辑器侧若共享 registry，则通过既有 sync 脚本从 `codes.yaml` 自动生成并验证镜像，不允许手工复制漂移；12-char collision 变为 hash-extension，full digest exhaustion / 无法避让才 error；hash-extension 稳定、幂等、可 roundtrip。 | 无；B 自身测试不依赖 A 的 fixed ordering，但 D 必须在 A 合并后重跑 B 的关键 roundtrip/registry 场景。 |
| C 溯源 | ✅ [PR #309](https://github.com/HansBug/pyfcstm/pull/309) 已合入 | F-004 | 修复 generic effect diagnostic 对 combo terminal edge 的 public subject。 | 在 `W_EFFECT_SELF_ASSIGN` refs 构造处采用局部 provenance remap helper：优先从 `combo_origin_refs` 与 `combo_projection_key` 推回 authored subject；普通 source combo 回到 `Root.A` 这类 authored source；entry combo 回到现有 initial diagnostic 风格（建议 `state_path='[*]'`，并保留 owner path）；generated path 只作为 secondary debug refs；不扩大 inspect schema。 | 已通过 #309 覆盖：A21 最小复现中 `refs.state_path == 'Root.A'`，不再是 `Root.__combo...`；entry combo 不泄漏 pseudo；shared-prefix 多 terminal effects 都回到 authored source；`test_effect_self_assign_combo_shared_source_disambiguated` 这类场景覆盖“同一个 authored source、同一变量、两个不同 combo terminal edge”时两个 diagnostics 都不得设置不安全 `effect_self_assign_anchor`；普通 transition regression 不变。 | 无 |
| D 整合 | ✅ [PR #310](https://github.com/HansBug/pyfcstm/pull/310) 已合入 | 全部 | 做最终整体验收与文档/issue 同步。 | A/B/C 全部合入本伞 PR 后补跨层 smoke/fixture，重跑 focused suites 与默认 unittest；复查 #304 body 与伞 PR body 进度；触发 multiagent final review。 | 至少包含并落到具体测试/fixture 的场景：`combo_initial_plain_before_deferred`（trace=213）、`combo_initial_guard_not_polluted_by_plain_before`、`combo_manual_pseudo_lifecycle_order`（断言完整 lifecycle trace，而不是只断言 active state）、`combo_initial_pseudo_exit_clears_pending`、`combo_text_roundtrip_pure_relay_reimport`、`combo_reserved_prefix_hygiene`、`combo_relay_name_hash_extension`、`combo_effect_self_assign_public_subject`、`combo_entry_effect_self_assign_subject`、`test_effect_self_assign_combo_shared_source_disambiguated`、`combo_template_plain_before_alignment`；#304 中 F-001/F-002/F-004 均有修复 PR 链接与验收证据；本伞 PR CI 通过；Codecov 无阻塞覆盖问题；multiagent final review 无 C/I。 | A、B、C |

## 依赖图

```mermaid
flowchart TD
    A["A 运行时<br/>✅ 已合入 PR #307<br/>F-001 accepted C"]
    B["B 命名<br/>✅ 已合入 PR #308<br/>F-002 accepted I"]
    C["C 溯源<br/>✅ 已合入 PR #309<br/>F-004 accepted I"]
    D["D 整合<br/>✅ 已合入 PR #310<br/>final validation complete"]

    A --> D
    B --> D
    C --> D

    classDef pending fill:#fff7cc,stroke:#c8a600,color:#332900;
    classDef critical fill:#ffd7d7,stroke:#cc3333,color:#330000;
    classDef important fill:#ffe7cc,stroke:#cc7a00,color:#331a00;
    classDef ready fill:#d8f5d0,stroke:#3c9a36,color:#103300;
    classDef done fill:#d8f5d0,stroke:#3c9a36,color:#103300;

    class A done;
    class B done;
    class C done;
    class D done;
```

## 关键语义约束

### F-001：plain `during before` defer 不是 `enter` 变更

期望语义固定为：

```text
Composite.enter
→ initial transition / pseudo routing chain
→ terminal transition effect
→ Composite.during before
→ selected non-pseudo child.enter
```

实现时必须避免两类误修：

1. 只按 `__combo_` 前缀判断 relay，导致手写 pure pseudo routing chain 与 expanded text DSL 行为不一致。
2. 把 user-authored pseudo 的 lifecycle action 吞掉或重排到未定义位置。pseudo 自身 action 当前是合法模型行为；A 需要用测试锁定“parent plain `during before` defer”与“pseudo 自身 lifecycle 仍按 runtime 合同执行”之间的边界。

A 的 `combo_manual_pseudo_lifecycle_order` 场景需要记录完整 trace，例如用 parent plain `during before`、manual pseudo `enter/during/exit`、terminal effect、target child `enter` 各写入不同数字，断言完整顺序；不得只断言最终 active state。

### F-002：`__combo_` 是 relay 命名空间，不是 blanket error

- 旧 `E_COMBO_RESERVED_STATE_NAME` 不再作为 `__combo_` reserved-prefix 的 public contract；B 需要删除或迁移该 code 的现有测试引用，不能留下“旧 error 与新 warning 同时存在”的双轨语义。
- 纯 `pseudo state __combo_*;` 是 expanded text DSL 的合法 relay 表达。
- 非 pseudo `state __combo_*` / composite `state __combo_* { ... }` 是 hygiene warning，不是语义 error。
- `pseudo state __combo_*` 带 action 是 hygiene warning；它不再是干净 relay，但不应混同为普通命名冲突。
- 真正 error 只用于 combo expansion 无法安全生成 relay 名的情况。
- 新 diagnostic code 必须先进入 `pyfcstm/diagnostics/codes.yaml` 的正式 registry，并带完整 `for_llm` 元数据；jsfcstm/编辑器侧如果共享 registry，必须走现有 sync 脚本自动生成镜像并用 parity/resource tests 验证，禁止手工复制。

### F-004：public subject 与 generated debug refs 分离

面向用户/editor/quick-fix 的主 refs 必须指向 authored transition/source；generated pseudo path 只能作为 secondary debug 信息存在。quick-fix 必须证明 anchor 唯一，不能在两个 authored transition remap 到同一个 source/var 时给出危险自动修复；`test_effect_self_assign_combo_shared_source_disambiguated` 必须断言这种同 source/同 var 的双 terminal combo self-assign 不产生 unsafe `effect_self_assign_anchor`。

## 实施纪律

- 每个 subPR 应尽量只触碰自身层级，避免跨层大重构。
- A/B/C 可并行，但 D 必须等待 A/B/C 全部合并；D 需要在 A 合并后重跑 B 的关键 text roundtrip / registry 场景。
- F-001 是 C 级 blocker，优先级最高；如果资源有限，先做 A。
- F-002 / F-004 是 accepted I，不应因为设计扩张阻塞 F-001。
- 每个 subPR 合并后都要更新本伞 PR body 状态，并在 #304 下 comment 汇报进展。
- 本地迭代默认使用 `SKIP_SLOW_TESTS=1 make unittest`，除非 subPR 明确触及 slow template/native toolchain 路径。
- 修改 repository template source 后必须运行 `make tpl`，再跑相关 template tests。
- commit 前涉及 public Python API / docs 的变更需要运行 `make rst_auto` 并 review 生成结果。
- review 时需要检查 pydoc/reST 风格、异常捕获策略、测试边界是否符合 `CLAUDE.md`。

## 总体验收标准

- [x] A/B/C/D 四个 subPR 全部完成并合入本伞 PR。
- [x] F-001：runtime semantic regression 全部通过，并确认 `enter` 语义、hot start、exit combo 未被误改。
- [x] F-001：`python`、`c`、`c_poll`、`cpp`、`cpp_poll` built-in template alignment 有 focused 证据或对应模板实现已同步。
- [x] F-002：text DSL expanded relay reimport、hygiene warnings、hash-extension fallback、真实 collision error、旧 `E_COMBO_RESERVED_STATE_NAME` 测试迁移、registry/schema/for_llm、jsfcstm/编辑器 sync/parity 均有测试覆盖。
- [x] F-004：`W_EFFECT_SELF_ASSIGN` combo terminal provenance remap 有 normal / entry / shared-prefix / shared-source same-var anchor-disambiguation / ordinary regression 覆盖。
- [x] `SKIP_SLOW_TESTS=1 make unittest` 通过；触及 slow template/native 路径的 subPR 额外跑对应全量或 focused slow tests。
- [x] CI 全部通过，Codecov comment 无阻塞性覆盖问题。
- [x] multiagent final review 无 C/I 级问题；M 级问题已处理或明确不阻塞。
- [x] #304 body 已更新为修复完成状态，并已在本伞 PR 合入 `main` 后 comment + close。

## 当前待办

- [x] 创建伞 PR。
- [x] 完成首轮伞 PR body multiagent review。
- [x] 根据 review 修改本计划，补齐 C/I 级可验收缺口。
- [x] 开始 A 运行时 subPR：[PR #307](https://github.com/HansBug/pyfcstm/pull/307)。
- [x] 合并 B 命名 subPR：[PR #308](https://github.com/HansBug/pyfcstm/pull/308)。
- [x] 合并 A 运行时 subPR：[PR #307](https://github.com/HansBug/pyfcstm/pull/307)。
- [x] PR-A 合入后本地验证摘要：`python -m pytest -q test/simulate/test_semantic_fixtures.py --maxfail=8`、`SKIP_SLOW_TESTS=1 make unittest`、`make rst_auto` 均通过；#307 最新 head CI 62/62 通过。
- [x] 启动 D 整合 subPR：[PR #310](https://github.com/HansBug/pyfcstm/pull/310)。
- [x] 完成 PR-D 整体验收并合入本伞 PR：[PR #310](https://github.com/HansBug/pyfcstm/pull/310) 已合入（merge commit [`2013c0c`](https://github.com/HansBug/pyfcstm/commit/2013c0cb7926866bc7239380835aaff52c82dbdd)）。
- [x] 伞 PR 最新 head CI 57/57 全绿，并完成伞 PR final multiagent review（codex / claude / deepseek 均无 C/I）。








