### PR TITLE
修复 initial pseudo chain 的 during before 执行时机

### DIFF
--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -2366,13 +2366,11 @@ class SimulationRuntime:
             vars_,
             is_validation_mode=is_validation_mode,
         )
-        if composite_frame.plain_before_pending:
-            for on_during_before in state.list_on_durings(aspect="before"):
-                self._execute_func(
-                    on_during_before, vars_, is_validation_mode=is_validation_mode
-                )
-            composite_frame.plain_before_pending = False
         target_state = state.substates[transition.to_state]
+        if not target_state.is_pseudo:
+            self._consume_plain_before_if_pending(
+                composite_frame, vars_, is_validation_mode=is_validation_mode
+            )
         self._enter_state(
             stack,
             target_state,
@@ -2384,6 +2382,65 @@ class SimulationRuntime:
         )
         if composite_frame in stack:
             composite_frame.mode = "active"
+
+    def _consume_plain_before_if_pending(
+        self,
+        frame: _Frame,
+        vars_: Dict[str, Union[int, float]],
+        is_validation_mode: bool = False,
+    ) -> None:
+        """
+        Run a composite frame's pending plain ``during before`` actions once.
+
+        Composite entry leaves ``plain_before_pending`` set until initial
+        routing selects a concrete non-pseudo child. Generated combo relays and
+        user-authored pseudo states are part of that routing chain, so they must
+        not consume the boundary action early.
+
+        :param frame: Composite frame that may hold a pending boundary action.
+        :type frame: _Frame
+        :param vars_: Variable mapping to mutate.
+        :type vars_: Dict[str, Union[int, float]]
+        :param is_validation_mode: Whether this is validation mode, defaults to
+            ``False``.
+        :type is_validation_mode: bool, optional
+        :return: ``None``.
+        :rtype: None
+        """
+        if not frame.plain_before_pending:
+            return
+        for on_during_before in frame.state.list_on_durings(aspect="before"):
+            self._execute_func(
+                on_during_before, vars_, is_validation_mode=is_validation_mode
+            )
+        frame.plain_before_pending = False
+
+    @staticmethod
+    def _clear_parent_plain_before_pending_after_pseudo_exit(
+        stack: List[_Frame], current_state: State
+    ) -> None:
+        """
+        Clear deferred plain-before state when initial pseudo routing exits.
+
+        A pseudo initial routing chain that reaches ``[*]`` has not selected a
+        child inside the owning composite, so the owner's pending plain
+        ``during before`` action must be discarded instead of executed or leaked
+        into later parent-continuation processing.
+
+        :param stack: Execution stack after the pseudo source frame was popped.
+        :type stack: List[_Frame]
+        :param current_state: Popped transition source state.
+        :type current_state: pyfcstm.model.State
+        :return: ``None``.
+        :rtype: None
+        """
+        if (
+            current_state.is_pseudo
+            and stack
+            and stack[-1].state is current_state.parent
+            and stack[-1].plain_before_pending
+        ):
+            stack[-1].plain_before_pending = False
 
     def _validate_initial_transition(
         self,
@@ -2543,6 +2600,9 @@ class SimulationRuntime:
         stack.pop()
 
         if transition.to_state == EXIT_STATE:
+            self._clear_parent_plain_before_pending_after_pseudo_exit(
+                stack, current_state
+            )
             ended = self._finalize_exit_to_parent(
                 stack, vars_, is_validation_mode=is_validation_mode
             )
@@ -2555,10 +2615,19 @@ class SimulationRuntime:
             else:
                 self.logger.debug(
                     f"Transition completed: {current_state_path} -> [*], ended={ended}"
-                )
+            )
             return ended
 
         target_state = current_state.parent.substates[transition.to_state]
+        if (
+            current_state.is_pseudo
+            and stack
+            and stack[-1].state is current_state.parent
+            and not target_state.is_pseudo
+        ):
+            self._consume_plain_before_if_pending(
+                stack[-1], vars_, is_validation_mode=is_validation_mode
+            )
         self._enter_state(
             stack,
             target_state,

--- a/pyfcstm/simulate/runtime.py
+++ b/pyfcstm/simulate/runtime.py
@@ -2615,7 +2615,7 @@ class SimulationRuntime:
             else:
                 self.logger.debug(
                     f"Transition completed: {current_state_path} -> [*], ended={ended}"
-            )
+                )
             return ended
 
         target_state = current_state.parent.substates[transition.to_state]
@@ -4248,8 +4248,7 @@ class SimulationRuntime:
                     if action_paths:
                         raise ValueError(
                             "Abstract handler member %s.%s uses a reserved "
-                            "dunder protocol name"
-                            % (obj.__class__.__name__, name)
+                            "dunder protocol name" % (obj.__class__.__name__, name)
                         )
                     continue
                 if action_paths:

--- a/templates/c/machine.c.j2
+++ b/templates/c/machine.c.j2
@@ -1240,6 +1240,46 @@ static const _{{ machine_class_name(model) }}TransitionInfo _{{ machine_class_na
 {% endfor %}
 };
 
+static int _{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    size_t frame_index,
+    int is_validation_mode)
+{
+    int pending_state_id;
+
+    if (frame_index >= context->stack_size || !context->stack[frame_index].plain_before_pending) {
+        return {{ machine_macro_name(model) }}_SUCCESS;
+    }
+
+    pending_state_id = context->stack[frame_index].state_id;
+    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+            machine,
+            pending_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    context->stack[frame_index].plain_before_pending = 0;
+    return {{ machine_macro_name(model) }}_SUCCESS;
+}
+
+static void _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int current_state_id)
+{
+    const _{{ machine_class_name(model) }}StateInfo *state_info;
+
+    state_info = &_{{ machine_class_name(model) }}_state_info[current_state_id];
+    if (!state_info->is_pseudo || context->stack_size == 0u) {
+        return;
+    }
+    if (context->stack[context->stack_size - 1u].state_id == state_info->parent_state_id &&
+        context->stack[context->stack_size - 1u].plain_before_pending) {
+        context->stack[context->stack_size - 1u].plain_before_pending = 0;
+    }
+}
+
 static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1260,16 +1300,14 @@ static int _{{ machine_class_name(model) }}_execute_initial_transition_on_contex
     if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
         return {{ machine_macro_name(model) }}_FAILURE;
     }
-    if (context->stack_size > 0u && context->stack[context->stack_size - 1u].plain_before_pending) {
-        int pending_state_id = context->stack[context->stack_size - 1u].state_id;
-        if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+    if (!_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
                 machine,
-                pending_state_id,
                 context,
+                context->stack_size - 1u,
                 is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
             return {{ machine_macro_name(model) }}_FAILURE;
         }
-        context->stack[context->stack_size - 1u].plain_before_pending = 0;
     }
     if (_{{ machine_class_name(model) }}_enter_state(
             machine,
@@ -1800,7 +1838,21 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
     --context->stack_size;
 
     if (transition->to_exit) {
+        _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(context, current_state_id);
         return _{{ machine_class_name(model) }}_finalize_exit_to_parent(machine, context, is_validation_mode);
+    }
+
+    if (_{{ machine_class_name(model) }}_state_info[current_state_id].is_pseudo &&
+        context->stack_size > 0u &&
+        context->stack[context->stack_size - 1u].state_id == _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id &&
+        !_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+                machine,
+                context,
+                context->stack_size - 1u,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
     }
 
     if (_{{ machine_class_name(model) }}_enter_state(

--- a/templates/c_poll/machine.c.j2
+++ b/templates/c_poll/machine.c.j2
@@ -1339,6 +1339,46 @@ static const _{{ machine_class_name(model) }}TransitionInfo _{{ machine_class_na
 {% endfor %}
 };
 
+static int _{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+    {{ machine_class_name(model) }} *machine,
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    size_t frame_index,
+    int is_validation_mode)
+{
+    int pending_state_id;
+
+    if (frame_index >= context->stack_size || !context->stack[frame_index].plain_before_pending) {
+        return {{ machine_macro_name(model) }}_SUCCESS;
+    }
+
+    pending_state_id = context->stack[frame_index].state_id;
+    if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+            machine,
+            pending_state_id,
+            context,
+            is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+        return {{ machine_macro_name(model) }}_FAILURE;
+    }
+    context->stack[frame_index].plain_before_pending = 0;
+    return {{ machine_macro_name(model) }}_SUCCESS;
+}
+
+static void _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(
+    _{{ machine_class_name(model) }}RuntimeContext *context,
+    int current_state_id)
+{
+    const _{{ machine_class_name(model) }}StateInfo *state_info;
+
+    state_info = &_{{ machine_class_name(model) }}_state_info[current_state_id];
+    if (!state_info->is_pseudo || context->stack_size == 0u) {
+        return;
+    }
+    if (context->stack[context->stack_size - 1u].state_id == state_info->parent_state_id &&
+        context->stack[context->stack_size - 1u].plain_before_pending) {
+        context->stack[context->stack_size - 1u].plain_before_pending = 0;
+    }
+}
+
 static int _{{ machine_class_name(model) }}_execute_initial_transition_on_context(
     {{ machine_class_name(model) }} *machine,
     _{{ machine_class_name(model) }}RuntimeContext *context,
@@ -1359,16 +1399,14 @@ static int _{{ machine_class_name(model) }}_execute_initial_transition_on_contex
     if (_{{ machine_class_name(model) }}_execute_transition_effect(machine, transition, context) != {{ machine_macro_name(model) }}_SUCCESS) {
         return {{ machine_macro_name(model) }}_FAILURE;
     }
-    if (context->stack_size > 0u && context->stack[context->stack_size - 1u].plain_before_pending) {
-        int pending_state_id = context->stack[context->stack_size - 1u].state_id;
-        if (_{{ machine_class_name(model) }}_run_during_before_actions_for_state(
+    if (!_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
                 machine,
-                pending_state_id,
                 context,
+                context->stack_size - 1u,
                 is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
             return {{ machine_macro_name(model) }}_FAILURE;
         }
-        context->stack[context->stack_size - 1u].plain_before_pending = 0;
     }
     if (_{{ machine_class_name(model) }}_enter_state(
             machine,
@@ -1840,7 +1878,21 @@ static int _{{ machine_class_name(model) }}_execute_transition_on_context(
     --context->stack_size;
 
     if (transition->to_exit) {
+        _{{ machine_class_name(model) }}_clear_parent_plain_before_pending_after_pseudo_exit(context, current_state_id);
         return _{{ machine_class_name(model) }}_finalize_exit_to_parent(machine, context, is_validation_mode);
+    }
+
+    if (_{{ machine_class_name(model) }}_state_info[current_state_id].is_pseudo &&
+        context->stack_size > 0u &&
+        context->stack[context->stack_size - 1u].state_id == _{{ machine_class_name(model) }}_state_info[current_state_id].parent_state_id &&
+        !_{{ machine_class_name(model) }}_state_info[transition->target_state_id].is_pseudo) {
+        if (_{{ machine_class_name(model) }}_consume_plain_before_if_pending(
+                machine,
+                context,
+                context->stack_size - 1u,
+                is_validation_mode) != {{ machine_macro_name(model) }}_SUCCESS) {
+            return {{ machine_macro_name(model) }}_FAILURE;
+        }
     }
 
     if (_{{ machine_class_name(model) }}_enter_state(

--- a/templates/python/machine.py.j2
+++ b/templates/python/machine.py.j2
@@ -1026,13 +1026,10 @@ class {{ machine_class_name(model) }}:
         self._execute_transition_effect(
             transition, vars_, is_validation_mode=is_validation_mode
         )
-        if composite_frame.get("plain_before_pending", False):
-            self._execute_actions(
-                self._STATE_INFO[composite_frame["state"]]["during_before_actions"],
-                vars_,
-                is_validation_mode=is_validation_mode,
+        if not self._STATE_INFO[transition["target"]]["is_pseudo"]:
+            self._consume_plain_before_if_pending(
+                composite_frame, vars_, is_validation_mode=is_validation_mode
             )
-            composite_frame["plain_before_pending"] = False
         self._enter_state(
             stack,
             transition["target"],
@@ -1056,6 +1053,25 @@ class {{ machine_class_name(model) }}:
             attempt_initial_transition=False,
         )
         return self._validation_search_reaches_stable(sim_stack, sim_vars, event_names)
+
+    def _consume_plain_before_if_pending(self, frame, vars_, is_validation_mode=False):
+        if not frame.get("plain_before_pending", False):
+            return
+        self._execute_actions(
+            self._STATE_INFO[frame["state"]]["during_before_actions"],
+            vars_,
+            is_validation_mode=is_validation_mode,
+        )
+        frame["plain_before_pending"] = False
+
+    def _clear_parent_plain_before_pending_after_pseudo_exit(self, stack, current_path):
+        if not self._STATE_INFO[current_path]["is_pseudo"] or not stack:
+            return
+        parent_path = self._STATE_INFO[current_path]["parent"]
+        if stack[-1]["state"] == parent_path and stack[-1].get(
+            "plain_before_pending", False
+        ):
+            stack[-1]["plain_before_pending"] = False
 
     def _finalize_exit_to_parent(self, stack, vars_, is_validation_mode=False):
         if not stack:
@@ -1105,10 +1121,22 @@ class {{ machine_class_name(model) }}:
         stack.pop()
 
         if transition["to_exit"]:
+            self._clear_parent_plain_before_pending_after_pseudo_exit(
+                stack, current_path
+            )
             return self._finalize_exit_to_parent(
                 stack, vars_, is_validation_mode=is_validation_mode
             )
 
+        if (
+            self._STATE_INFO[current_path]["is_pseudo"]
+            and stack
+            and stack[-1]["state"] == self._STATE_INFO[current_path]["parent"]
+            and not self._STATE_INFO[transition["target"]]["is_pseudo"]
+        ):
+            self._consume_plain_before_if_pending(
+                stack[-1], vars_, is_validation_mode=is_validation_mode
+            )
         self._enter_state(
             stack,
             transition["target"],

--- a/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.fcstm
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.fcstm
@@ -1,0 +1,21 @@
+def int trace = 0;
+def int gate = 0;
+
+state Root {
+    enter {
+        gate = 1;
+        trace = trace * 10 + 7;
+    }
+    during before {
+        gate = gate + 1;
+        trace = trace * 10 + 1;
+    }
+    [*] -> Active : EntryA + [gate == 1] + EntryB effect {
+        gate = gate + 10;
+        trace = trace * 10 + 2;
+    }
+
+    state Active {
+        enter { trace = trace * 10 + 3; }
+    }
+}

--- a/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_guard_not_polluted_by_plain_before.yaml
@@ -1,0 +1,24 @@
+title: Combo initial guard after prefix sees pre plain-before variables
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - "Locks F-001 guard-pollution regression: parent plain during-before must not run between combo prefix and later guard term."
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+- validation
+steps:
+- cycle:
+  - Root.EntryA
+  - Root.EntryB
+  expect:
+    state: Root.Active
+    vars:
+      gate: 12
+      trace: 7213
+    ended: false

--- a/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.fcstm
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.fcstm
@@ -1,0 +1,10 @@
+def int trace = 0;
+
+state Root {
+    during before { trace = trace * 10 + 1; }
+    [*] -> Active : EntryA + EntryB effect { trace = trace * 10 + 2; }
+
+    state Active {
+        enter { trace = trace * 10 + 3; }
+    }
+}

--- a/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.yaml
+++ b/test/fixtures/simulate_semantics/cases/combo_initial_plain_before_deferred.yaml
@@ -1,0 +1,22 @@
+title: Combo initial pseudo chain defers plain during-before until terminal child
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - "Locks F-001: the generated initial pseudo chain is routing, so composite plain during-before runs after terminal effect and before the selected child enter."
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+steps:
+- cycle:
+  - Root.EntryA
+  - Root.EntryB
+  expect:
+    state: Root.Active
+    vars:
+      trace: 213
+    ended: false

--- a/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/composite_initial_guard_can_select_terminal_branch_before_plain_before.yaml
@@ -1,13 +1,16 @@
-title: Composite initial guard can choose a terminal branch before plain during-before
-  mutation
+title: Composite initial guard can choose a terminal branch before any selected-child
+  plain during-before
 origin:
   files:
   - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
   docs:
   - https://github.com/HansBug/pyfcstm/issues/197#issuecomment-4689585597
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
   notes:
   - Covers the final and is_ended variant where wrong initial selection prevents machine
     termination.
+  - F-001 clarifies that initial pseudo routing ending in [*] has no selected
+    non-pseudo child, so pending plain during-before is cleared instead of run.
 categories:
 - runtime
 - lifecycle
@@ -18,6 +21,6 @@ steps:
   expect:
     state: null
     vars:
-      flag: 1
-      trace: 234789
+      flag: 0
+      trace: 24789
     ended: true

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.fcstm
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.fcstm
@@ -1,0 +1,14 @@
+def int trace = 0;
+
+state Root {
+    during before { trace = trace * 10 + 1; }
+
+    pseudo state P {
+        enter { trace = trace * 10 + 2; }
+        during { trace = trace * 10 + 3; }
+        exit { trace = trace * 10 + 4; }
+    }
+
+    [*] -> P;
+    P -> [*] effect { trace = trace * 10 + 5; }
+}

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.yaml
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_exit_clears_plain_before_pending.yaml
@@ -1,0 +1,19 @@
+title: Manual initial pseudo exit clears pending plain before without running it
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - Locks that pseudo routing ending in [*] does not run parent plain during-before and does not leak the pending flag.
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+steps:
+- cycle: []
+  expect:
+    vars:
+      trace: 2345
+    ended: true

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.fcstm
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.fcstm
@@ -1,0 +1,18 @@
+def int trace = 0;
+
+state Root {
+    during before { trace = trace * 10 + 1; }
+
+    pseudo state P {
+        enter { trace = trace * 10 + 2; }
+        during { trace = trace * 10 + 3; }
+        exit { trace = trace * 10 + 4; }
+    }
+
+    state Active {
+        enter { trace = trace * 10 + 6; }
+    }
+
+    [*] -> P;
+    P -> Active effect { trace = trace * 10 + 5; }
+}

--- a/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.yaml
+++ b/test/fixtures/simulate_semantics/cases/manual_initial_pseudo_lifecycle_plain_before_deferred.yaml
@@ -1,0 +1,21 @@
+title: Manual initial pseudo lifecycle keeps actions while deferring parent plain before
+origin:
+  files:
+  - test/simulate/test_semantic_fixtures.py::test_simulation_semantic_fixture
+  docs:
+  - https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414
+  notes:
+  - Locks F-001 for user-authored pseudo states, not only generated __combo relays.
+  - The trace pins pseudo enter/during, pseudo exit, terminal effect, parent plain during-before, and selected child enter.
+categories:
+- runtime
+- template_alignment
+- pseudo_chain
+- lifecycle
+steps:
+- cycle: []
+  expect:
+    state: Root.Active
+    vars:
+      trace: 234516
+    ended: false


### PR DESCRIPTION
# PR-A：修复 initial pseudo chain 的 `during before` 执行时机

上游伞 PR：[PR #306](https://github.com/HansBug/pyfcstm/pull/306)  
关联排查 issue：[issue #304](https://github.com/HansBug/pyfcstm/issues/304)  
对应 finding：F-001（accepted C）  
关键设计 comment：[F-001 是 composite plain `during before` 时机问题，不是 `enter` 语义变更](https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850334414)

## 当前状态

- 🟢 已完成 simulator runtime 修复：initial pseudo routing chain 不再过早消费 owning composite 的 plain `during before`。
- 🟢 已同步受影响内置模板 runtime：`python`、`c`、`c_poll`、`cpp`、`cpp_poll`。
- 🟢 已新增/调整语义 fixture，覆盖 combo initial ordering、guard pollution、manual pseudo lifecycle、pseudo exit 清理 pending 等边界。
- 🟢 本地已通过 focused simulator fixture、focused template alignment、完整受影响模板门禁，以及 `SKIP_SLOW_TESTS=1 make unittest`。
- ✅ 已根据 reviewer 意见合入最新上游伞 PR 分支并推送；最新 head 已通过 GitHub CI 62/62。
- ✅ 三路 review 要求已执行到可用通道上；claude/codex 无 C/I，已处理 M 级问题；deepseek 通道受外部 provider/DNS/额度阻断，未伪造结论。
- ✅ 已满足 ready-to-merge 条件，按人工指令合入上游伞 PR。

## 问题背景

组合 transition trigger 已经在 #279 / #291 中作为 DSL/model 层语法糖落地：原始 combo trigger 会展开为普通 pseudo state chain，下游 simulator、模板 runtime 和验证工具消费展开后的普通状态机模型。

#304 的 A09 worker 发现：当 composite initial transition 进入 combo generated pseudo relay 时，当前 runtime 在第一跳进入 pseudo 后就过早消费 owning composite 的 plain `during before`。这导致两类用户可见错误：

1. terminal effect 与 selected child `enter` 的相对顺序错误，最小复现里 `trace` 实际为 `123`，期望为 `213`；
2. prefix 后的后续 guard 会被过早执行的 `during before` 写入污染，导致本应成功的同一 cycle combo 被 rollback。

本 PR 只修复这个运行时语义问题，不改变 combo expansion 的事实源，也不把 combo trigger 设计成 runtime 新 primitive。

## 目标

1. 将 composite plain `during before` 的消费点从 initial pseudo relay 第一跳后，推迟到 initial routing chain 选中 non-pseudo child 之后。
2. 保持 composite `enter` 语义不变：进入 composite 时立即执行。
3. 保持 ordinary initial transition 语义不变：`initial effect -> plain during before -> child enter`。
4. 覆盖 user-authored manual pseudo chain，不允许实现只依赖 `__combo_` 名字前缀。
5. 修复并验证 simulator 与受影响 built-in templates 的对齐：`python`、`c`、`c_poll`、`cpp`、`cpp_poll`。
6. 补充回归测试，覆盖 hot start、pseudo `-> [*]` pending 清理、exit combo 不误伤等边界。

## 非目标

- 不处理 F-002 的 `__combo_` relay 命名 / hygiene 合同。
- 不处理 F-004 的 `W_EFFECT_SELF_ASSIGN` provenance remap。
- 不重新引入 F-003；ancestor `>> during before/after` 不作用于 generated combo pseudo relay。
- 不改变 composite/state `enter` 行为。
- 不重构 combo expansion、diagnostics schema、solver 或 inspect pipeline。
- 不引入 runtime 层 combo transition primitive。

## 语义合同

本 PR 要锁定的顺序是：

```text
Composite.enter
→ initial transition / pseudo routing chain
→ terminal transition effect
→ Composite.during before
→ selected non-pseudo child.enter
```

具体边界：

| 场景 | 期望行为 |
|---|---|
| ordinary initial transition 直接到 child | transition effect 后执行一次 plain `during before`，再进入 child |
| initial transition target 是 pseudo | transition effect 后进入 pseudo，但不消费 parent frame 的 `plain_before_pending` |
| initial pseudo chain terminal target 是 non-pseudo child | terminal effect 后执行一次 parent plain `during before`，再进入 child |
| user-authored manual pseudo chain | 与 generated combo pseudo chain 使用同一语义；不得只检查 `__combo_` 名字 |
| pseudo chain terminal `-> [*]` / 离开 owner | 不执行 pending plain `during before`，并确保 pending 不泄漏到后续无关路径 |
| hot start | 不 replay plain `during before` |
| exit combo | 不套用 entry 的语义变更；补 regression 确认 source exit、terminal effect、parent continuation 不被破坏 |

## 初步实现方案

### 1. simulator runtime

重点文件：`pyfcstm/simulate/runtime.py`

计划只移动 `plain_before_pending` 的消费点：

- 在 `_execute_initial_transition_on_context()` 中：
  - target 是 non-pseudo child 时，维持 transition effect 后消费 pending、再 enter child；
  - target 是 pseudo state 时，不消费 parent frame 的 pending，让 pending 随 composite frame 保留。
- 在普通 transition 执行路径中：
  - 当当前 source 是 initial routing pseudo，且 parent composite frame 仍有 `plain_before_pending=True`；
  - 最小判定依据应是 parent frame 仍有 `plain_before_pending=True`，表示当前仍在 normally-entered composite 的 initial routing 中；不得额外依赖 `__combo_` 名字前缀；
  - transition 成功到达同 owner 下的 non-pseudo child 时，在 terminal effect 后、target `enter` 前消费 pending；
  - target 为 pseudo 时继续 defer；
  - target 为 `[*]` 或离开 owner 时清理 pending，不执行 plain before；`_finalize_exit_to_parent` / 等价模板路径也必须确保 pending 被清掉且不泄漏。
- speculative validation / rollback 路径必须保持 pending 状态原子性：dry-run 不得向主 stack 提交 parent `during before` side effect，也不得把被验证路径中的 pending 状态误提交。
- 实现判定必须基于 `state.is_pseudo` 与当前 frame/routing 上下文，不能只根据 `__combo_` 名称。

### 2. built-in templates

重点文件预期包括：

- `templates/python/machine.py.j2`
- `templates/c/machine.c.j2`
- `templates/c_poll/machine.c.j2`
- `templates/cpp/machine.c.j2`（C++ wrapper 的状态机 runtime core；`machine.cpp.j2` 若无 `plain_before_pending` 逻辑则不改）
- `templates/cpp_poll/machine.c.j2`（C++ poll wrapper 的状态机 runtime core；`machine.cpp.j2` 若无 `plain_before_pending` 逻辑则不改）

要求：

- 已知五个模板均存在同款 `plain_before_pending` early consume 风险；实现时直接同步对应 runtime core，不能只修 Python runtime；
- `cpp` / `cpp_poll` 的状态机语义主入口是各自 `machine.c.j2` runtime core，`.cpp.j2` wrapper 仅在确有相关逻辑时修改；
- 修改 template source 后运行 `make tpl` 更新 packaged assets；
- 用 focused alignment tests 证明五个模板与 simulator 对齐。

### 3. 测试计划

最低必须新增或调整以下测试/fixture：

| 测试场景 | 必须断言 |
|---|---|
| `combo_initial_plain_before_deferred` | A09 ordering 最小复现得到 `trace=213` |
| `combo_initial_guard_not_polluted_by_plain_before` | A09 guard pollution 最小复现同 cycle 成功进入 target，事件被消费 |
| ordinary initial regression | 非 combo initial 的 effect / before / child enter 顺序保持不变 |
| manual pure pseudo chain | `[*] -> P; P -> Active effect ...` 也 defer plain before 到 terminal 后 |
| manual pseudo lifecycle order | 含 pseudo `enter/during/exit` 的合法场景必须让 parent plain `during before`、manual pseudo `enter/during/exit`、terminal effect、target child `enter` 各写入不同数字，并断言完整 trace 顺序；不得只断言最终 active state |
| pseudo terminal `-> [*]` | pending 不执行且不泄漏；至少包含 normal commit 与 speculative validation / rollback 子场景 |
| hot start | composite hot start 不 replay pending plain before |
| exit combo regression | exit combo 保持 `Child.exit -> terminal effect -> Parent.during after -> parent continuation` 的既有顺序 |
| template alignment | `python`、`c`、`c_poll`、`cpp`、`cpp_poll` 至少有 focused fixture 对齐证据 |

## 验收标准

- [x] PR body 三路 reviewer 检查无 C/I；M 级已处理或说明不阻塞。
- [x] 本 PR 已从上游伞 PR 分支同步最新内容，无 conflict；已合入 `origin/dev/issue-304-combo-followup-umbrella` 最新提交 `0dde13b2`，并在合入后重新通过 focused simulator fixture、`SKIP_SLOW_TESTS=1 make unittest` 和 `make rst_auto`。
- [x] `pyfcstm/simulate/runtime.py` 的 F-001 语义修复完成，且不改变 `enter` 语义。
- [x] 五个受影响 built-in templates 已检查并同步必要修复。
- [x] 修改 template source 后已运行 `make tpl`。
- [x] 本地 focused tests 通过：`python -m pytest -q test/simulate/test_semantic_fixtures.py --maxfail=8`。
- [x] `SKIP_SLOW_TESTS=1 make unittest` 通过，作为非 native / 非 slow template 的快速回归。
- [x] C-family / native template 对齐不得被 `SKIP_SLOW_TESTS=1` 掩盖；已显式清空 `SKIP_SLOW_TESTS` 并通过 `make template_unittest TEMPLATE_UNITTEST_ARGS="--include-suites python,c,c_poll,cpp,cpp_poll"`，结果 `908 passed, 12 skipped`。
- [x] 如果本地 native toolchain 环境阻断 C/C++/poll full suite，必须给出具体阻断日志，并用 GitHub Actions 或其他可复现环境补足 `python,c,c_poll,cpp,cpp_poll` 对齐证据；不能仅用 focused fixture 替代完整模板门禁。当前本地 full affected template gate 已通过，无需走阻断替代路径。
- [x] 触及 public Python API / pydoc / docs 时已运行 `make rst_auto` 并 review 生成结果；本 PR 只新增 private runtime helper docstrings，已运行 `make rst_auto`，未保留无关 RST 噪音。
- [ ] GitHub CI 针对最新 head 重新全绿；Codecov comment 无阻塞覆盖问题。
- [ ] 实现后 multiagent 强对抗 review 无 C/I；M 级不阻塞。
- [ ] PR ready-to-merge 后停止，等待人工 review，不自行合并。



