### PR TITLE
实现 combo relay 命名合同

### DIFF
--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -540,7 +540,7 @@ I_COMBO_PSEUDO_NAME_EXTENDED:
     state Root {
         state A;
         state B;
-        state __combo_root_a__e1_hbafca7f66598;
+        pseudo state __combo_root_a__e1_hbafca7f66598;
         [*] -> A;
         A -> B :: E1 + E2;
     }

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -409,17 +409,17 @@ E_COMBO_TRIGGER_NOT_EXPANDED:
   example_dsl: |
     state Root { state A; state B; A -> B :: Go + Done; }
 
-E_COMBO_RESERVED_STATE_NAME:
-  severity: error
+W_COMBO_RESERVED_PREFIX_STATE_KIND:
+  severity: warning
+  emit_tier: partial_static_pipeline
   span_object: state_identifier
   description: >-
-    A user-authored state name starts with the reserved automatic combo
-    pseudo-state prefix.
+    A non-pseudo state name starts with the automatic combo relay prefix.
   refs:
     state_name:
       type: str
       required: true
-      description: The reserved user-authored state name.
+      description: State name using the combo relay reserved prefix.
     state_path:
       type: str
       required: true
@@ -428,28 +428,129 @@ E_COMBO_RESERVED_STATE_NAME:
       type: str
       required: true
       description: Reserved prefix used by generated combo pseudo states.
+    state_kind:
+      type: str
+      required: true
+      description: Kind of user-authored state that used the reserved prefix.
+      enum: ['state', 'composite']
   for_llm:
     summary: >-
-      State names beginning with ``__combo_`` are reserved for generated
-      pseudo states created by combo transition trigger expansion.
+      A normal leaf or composite state uses the ``__combo_`` prefix reserved
+      for combo relay pseudo states. The model can still build, but the name is
+      visually ambiguous with generated relay nodes.
     recommended_actions:
       - kind: rename_state
         target: state_identifier
         rationale: >-
-          Rename the user-authored state so it does not collide with the
-          generated combo pseudo-state namespace.
+          Rename the user-authored state so readers and generated artifacts do
+          not confuse it with an expanded combo relay.
     do_not:
-      - "Do not use ``__combo_`` for hand-written states; the expander owns this namespace."
+      - "Do not fix this by declaring a business state as pseudo unless it is truly only a relay."
   example_dsl: |
     state Root { state __combo_user; [*] -> __combo_user; }
+
+W_COMBO_RELAY_PSEUDO_HAS_ACTIONS:
+  severity: warning
+  emit_tier: partial_static_pipeline
+  span_object: state_identifier
+  description: >-
+    A pseudo state in the combo relay namespace contains lifecycle or aspect
+    actions, so it is not a pure relay.
+  refs:
+    state_name:
+      type: str
+      required: true
+      description: Pseudo-state name using the combo relay reserved prefix.
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the pseudo state.
+    reserved_prefix:
+      type: str
+      required: true
+      description: Reserved prefix used by combo relay pseudo states.
+    action_kinds:
+      type: list[str]
+      required: true
+      description: Lifecycle or aspect action kinds present on the pseudo state.
+      item_enum: ['enter', 'during', 'exit', 'during_aspect']
+  for_llm:
+    summary: >-
+      A ``pseudo state __combo_*`` node is allowed so expanded combo DSL can be
+      reimported, but relay pseudo states should stay pure. Lifecycle or aspect
+      actions make the relay observable and may surprise readers.
+    recommended_actions:
+      - kind: move_action
+        target: lifecycle_action
+        rationale: >-
+          Move the action to the authored source or target state if it is
+          business behavior rather than routing metadata.
+      - kind: rename_pseudo
+        target: state_identifier
+        rationale: >-
+          If the pseudo state is intentionally user-authored and observable,
+          rename it outside the ``__combo_`` namespace.
+    do_not:
+      - "Do not add business logic to generated combo relay pseudo states."
+  example_dsl: |
+    def int x = 0; state Root { pseudo state __combo_user { enter { x = x + 1; } } state A; [*] -> A; }
+
+I_COMBO_PSEUDO_NAME_EXTENDED:
+  severity: info
+  emit_tier: partial_static_pipeline
+  span_object: state_identifier
+  description: >-
+    Combo trigger expansion extended a generated relay name's digest prefix to
+    avoid a same-scope name collision.
+  refs:
+    state_path:
+      type: str
+      required: true
+      description: Dotted path of the state where expansion allocated the relay.
+    pseudo_name:
+      type: str
+      required: true
+      description: Final generated pseudo-state name after digest extension.
+    payload_digest:
+      type: str
+      required: true
+      description: Full digest of the semantic payload that owns the relay.
+    default_digest_size:
+      type: int
+      required: true
+      description: Default visible digest length before extension.
+    final_digest_size:
+      type: int
+      required: true
+      description: Visible digest length used by the final generated name.
+  for_llm:
+    summary: >-
+      The combo expander found a same-scope name collision at the default
+      digest length and deterministically used a longer digest prefix. This is
+      informational and does not mean the model is invalid.
+    recommended_actions:
+      - kind: keep_generated_name
+        target: pseudo_state
+        rationale: >-
+          Leave the extended generated name as-is unless you are manually
+          rewriting the expanded relay chain.
+    do_not:
+      - "Do not shorten the digest manually; that can reintroduce the collision."
+  example_dsl: |
+    state Root {
+        state A;
+        state B;
+        state __combo_root_a__e1_hbafca7f66598;
+        [*] -> A;
+        A -> B :: E1 + E2;
+    }
 
 E_COMBO_PSEUDO_NAME_COLLISION:
   severity: error
   span_object: state_identifier
   description: >-
-    Combo trigger expansion generated the same pseudo-state name for distinct
-    semantic payloads, or a generated combo pseudo name collided with an
-    existing non-pseudo state.
+    Combo trigger expansion could not allocate a safe pseudo-state name even
+    after extending to the full payload digest.
   refs:
     state_path:
       type: str
@@ -465,9 +566,10 @@ E_COMBO_PSEUDO_NAME_COLLISION:
       description: Full digest of the semantic payload that attempted to claim the name.
   for_llm:
     summary: >-
-      The combo expander uses fixed digest12 pseudo names. If two distinct
-      canonical payloads truncate to the same visible name, expansion fails
-      fast rather than silently renaming or reusing the wrong pseudo state.
+      The combo expander first uses a short digest prefix and then lengthens it
+      deterministically on collision. If the full digest still cannot identify a
+      safe relay name in the owning scope, expansion fails rather than silently
+      reusing the wrong pseudo state.
     recommended_actions:
       - kind: report_internal_collision
         target: transition

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -119,6 +119,8 @@ def _event_origin_from_id(
 
 _COMBO_STATE_PREFIX = "__combo_"
 _COMBO_DIGEST_SIZE = 12
+_COMBO_DIGEST_STEP = 4
+_COMBO_DIGEST_MAX_SIZE = 64
 _COMBO_DISPLAY_PREFIX = "combo after "
 
 
@@ -153,6 +155,30 @@ def _combo_payload_digest(payload: str) -> str:
         64
     """
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _combo_digest_sizes(digest: str) -> Tuple[int, ...]:
+    """
+    Return visible digest lengths used while allocating combo pseudo names.
+
+    :param digest: Full hexadecimal payload digest.
+    :type digest: str
+    :return: Digest prefix lengths from default size through the available
+        full digest length.
+    :rtype: Tuple[int, ...]
+
+    Example::
+
+        >>> _combo_digest_sizes("0" * 64)[:2]
+        (12, 16)
+    """
+    max_size = min(len(digest), _COMBO_DIGEST_MAX_SIZE)
+    if max_size <= _COMBO_DIGEST_SIZE:
+        return (max_size,)
+    sizes = list(range(_COMBO_DIGEST_SIZE, max_size + 1, _COMBO_DIGEST_STEP))
+    if sizes[-1] != max_size:
+        sizes.append(max_size)
+    return tuple(sizes)
 
 
 @dataclass(frozen=True)
@@ -2757,23 +2783,23 @@ def parse_dsl_node_to_state_machine(
         owner_node: Optional[dsl_nodes.StateDefinition] = None,
     ) -> State:
         current_path = tuple((*current_path, node.name))
-        is_exported_combo_pseudo = _is_exported_combo_pseudo_node(
-            node, owner_node
-        )
-        if node.name.startswith(_COMBO_STATE_PREFIX) and not is_exported_combo_pseudo:
+        is_exported_combo_pseudo = _is_exported_combo_pseudo_node(node, owner_node)
+        if node.name.startswith(_COMBO_STATE_PREFIX) and not node.is_pseudo:
             sink.emit(
                 ModelDiagnostic(
-                    code="E_COMBO_RESERVED_STATE_NAME",
-                    severity="error",
+                    code="W_COMBO_RESERVED_PREFIX_STATE_KIND",
+                    severity="warning",
                     message=(
-                        f"State name {node.name!r} uses reserved combo "
-                        f"prefix {_COMBO_STATE_PREFIX!r}:\n{node}"
+                        f"State name {node.name!r} uses combo relay reserved "
+                        f"prefix {_COMBO_STATE_PREFIX!r} but is not a pseudo "
+                        f"state:\n{node}"
                     ),
                     span=getattr(node, "_span", None),
                     refs={
                         "state_name": node.name,
                         "state_path": ".".join(current_path),
                         "reserved_prefix": _COMBO_STATE_PREFIX,
+                        "state_kind": "composite" if node.substates else "state",
                     },
                 )
             )
@@ -2805,6 +2831,19 @@ def parse_dsl_node_to_state_machine(
                 )
 
         named_functions = {}
+
+        def _ast_action_kinds(node: dsl_nodes.StateDefinition) -> List[str]:
+            kinds = []
+            if node.enters:
+                kinds.append("enter")
+            if node.durings:
+                kinds.append("during")
+            if node.exits:
+                kinds.append("exit")
+            if node.during_aspects:
+                kinds.append("during_aspect")
+            return kinds
+
         on_enters = []
         for enter_item in node.enters:
             on_stage = None
@@ -3215,6 +3254,28 @@ def parse_dsl_node_to_state_machine(
         )
         if is_exported_combo_pseudo:
             my_state._generated_combo_pseudo = True
+        if node.name.startswith(_COMBO_STATE_PREFIX) and node.is_pseudo:
+            action_kinds = _ast_action_kinds(node)
+            if action_kinds:
+                sink.emit(
+                    ModelDiagnostic(
+                        code="W_COMBO_RELAY_PSEUDO_HAS_ACTIONS",
+                        severity="warning",
+                        message=(
+                            f"Pseudo state {node.name!r} uses combo relay "
+                            f"reserved prefix {_COMBO_STATE_PREFIX!r} but "
+                            "contains lifecycle or aspect actions:\n"
+                            f"{node}"
+                        ),
+                        span=getattr(node, "_span", None),
+                        refs={
+                            "state_name": node.name,
+                            "state_path": ".".join(current_path),
+                            "reserved_prefix": _COMBO_STATE_PREFIX,
+                            "action_kinds": action_kinds,
+                        },
+                    )
+                )
         if my_state.is_pseudo and not my_state.is_leaf_state:
             sink.emit(
                 ModelDiagnostic(
@@ -3724,7 +3785,6 @@ def parse_dsl_node_to_state_machine(
             )
 
         combo_name_payloads: Dict[str, str] = {}
-        combo_digest_payloads: Dict[Tuple[Tuple[str, ...], str], str] = {}
 
         def _term_name_slug(term: dsl_nodes.ComboTriggerTerm) -> str:
             if isinstance(term, dsl_nodes.ComboGuardTerm):
@@ -3808,49 +3868,42 @@ def parse_dsl_node_to_state_machine(
             }
             payload = json.dumps(payload_obj, ensure_ascii=False, sort_keys=True)
             digest = _combo_payload_digest(payload)
-            short_digest = digest[:_COMBO_DIGEST_SIZE]
-            digest_key = (current_state.path, short_digest)
             source_label = (
                 "entry" if chooser_key[1] == "entry" else ".".join(chooser_key[2])
             )
             slug_parts = [to_identifier(source_label, strict_mode=True).lower()]
             slug_parts.extend(_term_name_slug(term) for term in consumed_terms)
             slug = sequence_safe(slug_parts)
-            name = f"{_COMBO_STATE_PREFIX}{slug}_h{short_digest}"
 
-            existing_digest_payload = combo_digest_payloads.get(digest_key)
-            if (
-                existing_digest_payload is not None
-                and existing_digest_payload != payload
-            ):
-                sink.emit(
-                    ModelDiagnostic(
-                        code="E_COMBO_PSEUDO_NAME_COLLISION",
-                        severity="error",
-                        message=(
-                            f"Generated combo pseudo state digest {short_digest!r} "
-                            "collides for distinct semantic payloads."
-                        ),
-                        span=None,
-                        refs={
-                            "state_path": ".".join(current_state.path),
-                            "pseudo_name": name,
-                            "payload_digest": digest,
-                        },
-                    )
-                )
-            elif existing_digest_payload is None:
-                combo_digest_payloads[digest_key] = payload
+            chosen_name = None
+            chosen_size = None
+            for digest_size in _combo_digest_sizes(digest):
+                candidate_digest = digest[:digest_size]
+                candidate_name = f"{_COMBO_STATE_PREFIX}{slug}_h{candidate_digest}"
 
-            existing_payload = combo_name_payloads.get(name)
-            if existing_payload is not None and existing_payload != payload:
+                existing_payload = combo_name_payloads.get(candidate_name)
+                if existing_payload is not None and existing_payload != payload:
+                    continue
+
+                existing_state = current_state.substates.get(candidate_name)
+                if (
+                    existing_state is not None
+                    and candidate_name not in combo_name_payloads
+                ):
+                    continue
+
+                chosen_name = candidate_name
+                chosen_size = digest_size
+                break
+            if chosen_name is None or chosen_size is None:
+                name = f"{_COMBO_STATE_PREFIX}{slug}_h{digest[:_COMBO_DIGEST_MAX_SIZE]}"
                 sink.emit(
                     ModelDiagnostic(
                         code="E_COMBO_PSEUDO_NAME_COLLISION",
                         severity="error",
                         message=(
                             f"Generated combo pseudo state name {name!r} collides "
-                            "for distinct semantic payloads."
+                            "even after extending to the full payload digest."
                         ),
                         span=None,
                         refs={
@@ -3860,29 +3913,33 @@ def parse_dsl_node_to_state_machine(
                         },
                     )
                 )
-            elif existing_payload is None:
-                combo_name_payloads[name] = payload
-
-            if name in current_state.substates:
-                state = current_state.substates[name]
-                if not state.is_pseudo:
+            else:
+                name = chosen_name
+                is_new_combo_name = name not in combo_name_payloads
+                if is_new_combo_name and chosen_size > _COMBO_DIGEST_SIZE:
                     sink.emit(
                         ModelDiagnostic(
-                            code="E_COMBO_PSEUDO_NAME_COLLISION",
-                            severity="error",
+                            code="I_COMBO_PSEUDO_NAME_EXTENDED",
+                            severity="info",
                             message=(
-                                f"Generated combo pseudo state name {name!r} "
-                                "collides with a non-pseudo state."
+                                "Combo pseudo relay name digest was extended "
+                                f"from {_COMBO_DIGEST_SIZE} to {chosen_size} "
+                                "characters to avoid an existing name."
                             ),
-                            span=state._span,
+                            span=None,
                             refs={
                                 "state_path": ".".join(current_state.path),
                                 "pseudo_name": name,
                                 "payload_digest": digest,
+                                "default_digest_size": _COMBO_DIGEST_SIZE,
+                                "final_digest_size": chosen_size,
                             },
                         )
                     )
-                return state
+                combo_name_payloads[name] = payload
+
+            if name in current_state.substates:
+                return current_state.substates[name]
 
             display = _COMBO_DISPLAY_PREFIX + " + ".join(term_texts)
             state = State(

--- a/pyfcstm/model/model.py
+++ b/pyfcstm/model/model.py
@@ -128,7 +128,29 @@ def _is_exported_combo_pseudo_node(
     node: dsl_nodes.StateDefinition,
     owner_node: Optional[dsl_nodes.StateDefinition] = None,
 ) -> bool:
-    """Return whether an AST node is an exported generated combo pseudo state."""
+    """
+    Return whether an AST node is a same-process exported combo relay.
+
+    This helper recognizes only trusted AST object round trips. Text reimports
+    of ``pseudo state __combo_*`` remain plain pseudo states and do not regain
+    generated-relay metadata from the process-local trust registry.
+
+    :param node: State definition to inspect.
+    :type node: pyfcstm.dsl.node.StateDefinition
+    :param owner_node: Parent state definition used by the trust registry,
+        defaults to ``None``.
+    :type owner_node: pyfcstm.dsl.node.StateDefinition, optional
+    :return: ``True`` when ``node`` is a trusted generated combo pseudo state,
+        otherwise ``False``.
+    :rtype: bool
+
+    Example::
+
+        >>> from pyfcstm.dsl import node as dsl_nodes
+        >>> item = dsl_nodes.StateDefinition("__combo_user", is_pseudo=True)
+        >>> _is_exported_combo_pseudo_node(item)
+        False
+    """
     if not node.is_pseudo or not node.name.startswith(_COMBO_STATE_PREFIX):
         return False
     if owner_node is None:
@@ -2784,6 +2806,9 @@ def parse_dsl_node_to_state_machine(
     ) -> State:
         current_path = tuple((*current_path, node.name))
         is_exported_combo_pseudo = _is_exported_combo_pseudo_node(node, owner_node)
+        is_combo_relay_pseudo = (
+            node.name.startswith(_COMBO_STATE_PREFIX) and node.is_pseudo
+        )
         if node.name.startswith(_COMBO_STATE_PREFIX) and not node.is_pseudo:
             sink.emit(
                 ModelDiagnostic(
@@ -2930,7 +2955,11 @@ def parse_dsl_node_to_state_machine(
 
         on_durings = []
         for during_item in node.durings:
-            if not d_substates and during_item.aspect is not None:
+            if (
+                not d_substates
+                and during_item.aspect is not None
+                and not is_combo_relay_pseudo
+            ):
                 sink.emit(
                     ModelDiagnostic(
                         code="E_DURING_ASPECT_INVALID",
@@ -3130,7 +3159,7 @@ def parse_dsl_node_to_state_machine(
             # only meaningful on a composite state (it fans out to every
             # descendant leaf). On a leaf state there is nothing to fan
             # into, so the aspect is invalid.
-            if not d_substates:
+            if not d_substates and not is_combo_relay_pseudo:
                 sink.emit(
                     ModelDiagnostic(
                         code="E_DURING_ASPECT_INVALID",
@@ -3254,7 +3283,7 @@ def parse_dsl_node_to_state_machine(
         )
         if is_exported_combo_pseudo:
             my_state._generated_combo_pseudo = True
-        if node.name.startswith(_COMBO_STATE_PREFIX) and node.is_pseudo:
+        if is_combo_relay_pseudo:
             action_kinds = _ast_action_kinds(node)
             if action_kinds:
                 sink.emit(
@@ -3785,6 +3814,8 @@ def parse_dsl_node_to_state_machine(
             )
 
         combo_name_payloads: Dict[str, str] = {}
+        combo_exhausted_names: Set[str] = set()
+        combo_exhausted_payload_names: Dict[str, str] = {}
 
         def _term_name_slug(term: dsl_nodes.ComboTriggerTerm) -> str:
             if isinstance(term, dsl_nodes.ComboGuardTerm):
@@ -3820,6 +3851,17 @@ def parse_dsl_node_to_state_machine(
 
         def _combo_effect_signature(transnode) -> Tuple[str, ...]:
             return tuple(str(item) for item in transnode.post_operations)
+
+        def _combo_collision_recovery_name(name: str) -> str:
+            suffix = 1
+            while True:
+                candidate = f"{name}__collision_{suffix}"
+                if (
+                    candidate not in current_state.substates
+                    and candidate not in combo_name_payloads
+                ):
+                    return candidate
+                suffix += 1
 
         def _combo_origin_id(
             transnode,
@@ -3896,23 +3938,33 @@ def parse_dsl_node_to_state_machine(
                 chosen_size = digest_size
                 break
             if chosen_name is None or chosen_size is None:
-                name = f"{_COMBO_STATE_PREFIX}{slug}_h{digest[:_COMBO_DIGEST_MAX_SIZE]}"
-                sink.emit(
-                    ModelDiagnostic(
-                        code="E_COMBO_PSEUDO_NAME_COLLISION",
-                        severity="error",
-                        message=(
-                            f"Generated combo pseudo state name {name!r} collides "
-                            "even after extending to the full payload digest."
-                        ),
-                        span=None,
-                        refs={
-                            "state_path": ".".join(current_state.path),
-                            "pseudo_name": name,
-                            "payload_digest": digest,
-                        },
-                    )
+                collision_name = (
+                    f"{_COMBO_STATE_PREFIX}{slug}_h{digest[:_COMBO_DIGEST_MAX_SIZE]}"
                 )
+                name = combo_exhausted_payload_names.get(payload)
+                if name is None:
+                    if collision_name not in combo_exhausted_names:
+                        sink.emit(
+                            ModelDiagnostic(
+                                code="E_COMBO_PSEUDO_NAME_COLLISION",
+                                severity="error",
+                                message=(
+                                    "Generated combo pseudo state name "
+                                    f"{collision_name!r} collides even after "
+                                    "extending to the full payload digest."
+                                ),
+                                span=None,
+                                refs={
+                                    "state_path": ".".join(current_state.path),
+                                    "pseudo_name": collision_name,
+                                    "payload_digest": digest,
+                                },
+                            )
+                        )
+                        combo_exhausted_names.add(collision_name)
+                    name = _combo_collision_recovery_name(collision_name)
+                    combo_exhausted_payload_names[payload] = name
+                    combo_name_payloads[name] = payload
             else:
                 name = chosen_name
                 is_new_combo_name = name not in combo_name_payloads

--- a/test/model/test_combo_transition_expansion.py
+++ b/test/model/test_combo_transition_expansion.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 
 import pytest
@@ -575,14 +576,16 @@ class TestComboModelExpansion:
             for item in model.root_state.transitions
             if item.from_state != "INIT_STATE"
         ]
-        assert "local" in second_round_tripped.root_state.substates["A"].events[
-            "E2"
-        ].origins
-        assert "chain" not in second_round_tripped.root_state.substates["A"].events[
-            "E2"
-        ].origins
+        assert (
+            "local"
+            in second_round_tripped.root_state.substates["A"].events["E2"].origins
+        )
+        assert (
+            "chain"
+            not in second_round_tripped.root_state.substates["A"].events["E2"].origins
+        )
 
-    def test_mutated_trusted_combo_ast_export_is_rejected(self):
+    def test_mutated_trusted_combo_ast_export_uses_plain_validation(self):
         model = _build_model(
             """
             state Root {
@@ -604,14 +607,14 @@ class TestComboModelExpansion:
                 transition.to_state = "A"
                 break
 
+        _, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        assert "E_MISSING_STATE" in [item.code for item in diagnostics]
         with pytest.raises(ModelValidationError) as exc_info:
             parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        assert [item.code for item in exc_info.value.diagnostics] == ["E_MISSING_STATE"]
 
-    def test_generated_combo_pseudo_text_export_uses_reserved_prefix(self):
+    def test_generated_combo_pseudo_text_export_reimports_as_plain_relay(self):
         model = _build_model(
             """
             state Root {
@@ -624,17 +627,29 @@ class TestComboModelExpansion:
         )
 
         exported = str(model.to_ast_node())
-
-        assert "pseudo state __combo_" in exported
         parsed = parse_with_grammar_entry(exported, entry_name="state_machine_dsl")
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(parsed)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
+        round_tripped, diagnostics = parse_dsl_node_to_state_machine(
+            parsed, collect=True
         )
 
-    def test_forged_generated_combo_pseudo_marker_is_rejected(self):
+        assert "pseudo state __combo_" in exported
+        assert diagnostics == []
+        assert [
+            item.name
+            for item in round_tripped.root_state.substates.values()
+            if item.is_pseudo
+        ] == [
+            item.name for item in model.root_state.substates.values() if item.is_pseudo
+        ]
+        assert not any(
+            item.combo_origin_refs for item in round_tripped.root_state.transitions
+        )
+        runtime = SimulationRuntime(round_tripped)
+        runtime.cycle()
+        runtime.cycle(["Root.A.E1", "Root.A.E2"])
+        assert runtime.current_state.path == ("Root", "B")
+
+    def test_forged_generated_combo_pseudo_marker_does_not_block_pure_relay(self):
         program = parse_with_grammar_entry(
             """
             state Root {
@@ -646,12 +661,11 @@ class TestComboModelExpansion:
         )
         program.root_state.substates[0]._generated_combo_pseudo = True
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        assert diagnostics == []
+        assert model.root_state.substates["__combo_user"].is_pseudo
+        parse_dsl_node_to_state_machine(program)
 
     def test_nested_same_name_sources_keep_distinct_pseudo_names(self):
         model = _build_model(
@@ -748,44 +762,103 @@ class TestComboModelExpansion:
 
         assert _combo_names(base) == _combo_names(with_unrelated)
 
-    def test_reserved_combo_state_prefix_is_rejected(self):
+    @pytest.mark.parametrize(
+        ["source", "expected_kind"],
+        [
+            (
+                """
+                state Root {
+                    state __combo_user;
+                    [*] -> __combo_user;
+                }
+                """,
+                "state",
+            ),
+            (
+                """
+                state Root {
+                    state __combo_group {
+                        state Child;
+                        [*] -> Child;
+                    }
+                    [*] -> __combo_group;
+                }
+                """,
+                "composite",
+            ),
+        ],
+    )
+    def test_non_pseudo_reserved_prefix_warns_without_blocking(
+        self, source, expected_kind
+    ):
+        program = parse_with_grammar_entry(source, entry_name="state_machine_dsl")
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        assert model.root_state.substates
+        diagnostic = next(
+            item
+            for item in diagnostics
+            if item.code == "W_COMBO_RESERVED_PREFIX_STATE_KIND"
+        )
+        assert diagnostic.severity == "warning"
+        assert diagnostic.refs["reserved_prefix"] == "__combo_"
+        assert diagnostic.refs["state_kind"] == expected_kind
+        parse_dsl_node_to_state_machine(program)
+
+    def test_pure_reserved_prefix_pseudo_is_valid_relay_text(self):
         program = parse_with_grammar_entry(
             """
             state Root {
-                state __combo_user;
+                state Target;
+                pseudo state __combo_user named 'combo after UserEvent';
                 [*] -> __combo_user;
+                __combo_user -> Target :: Done;
             }
             """,
             entry_name="state_machine_dsl",
         )
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
 
-    def test_reserved_combo_pseudo_without_generated_shape_is_rejected(self):
+        assert diagnostics == []
+        assert model.root_state.substates["__combo_user"].is_pseudo
+        parse_dsl_node_to_state_machine(program)
+
+    def test_reserved_prefix_pseudo_with_actions_warns_without_blocking(self):
         program = parse_with_grammar_entry(
             """
+            def int x = 0;
             state Root {
-                pseudo state __combo_user;
+                pseudo state __combo_user {
+                    enter { x = x + 1; }
+                    during { x = x + 2; }
+                    exit { x = x + 3; }
+                }
+                state Target;
                 [*] -> __combo_user;
+                __combo_user -> Target :: Done;
             }
             """,
             entry_name="state_machine_dsl",
         )
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
 
-    def test_reserved_combo_export_shape_without_chain_is_rejected(self):
-        program = parse_with_grammar_entry(
+        assert model.root_state.substates["__combo_user"].is_pseudo
+        diagnostic = next(
+            item
+            for item in diagnostics
+            if item.code == "W_COMBO_RELAY_PSEUDO_HAS_ACTIONS"
+        )
+        assert diagnostic.severity == "warning"
+        assert diagnostic.refs["reserved_prefix"] == "__combo_"
+        assert diagnostic.refs["action_kinds"] == ["enter", "during", "exit"]
+        parse_dsl_node_to_state_machine(program)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
             """
             state Root {
                 state A;
@@ -793,18 +866,6 @@ class TestComboModelExpansion:
                 [*] -> A;
             }
             """,
-            entry_name="state_machine_dsl",
-        )
-
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
-
-    def test_reserved_combo_export_shape_without_declared_events_is_rejected(self):
-        program = parse_with_grammar_entry(
             """
             state Root {
                 state A;
@@ -815,18 +876,6 @@ class TestComboModelExpansion:
                 __combo_root_a__e1_hbafca7f66598 -> B : A.E2;
             }
             """,
-            entry_name="state_machine_dsl",
-        )
-
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
-
-    def test_reserved_combo_export_shape_with_wrong_digest_is_rejected(self):
-        program = parse_with_grammar_entry(
             """
             state Root {
                 state A {
@@ -840,40 +889,15 @@ class TestComboModelExpansion:
                 __combo_root_a__e1_h000000000000 -> B : A.E2;
             }
             """,
-            entry_name="state_machine_dsl",
-        )
+        ],
+    )
+    def test_legacy_export_shape_checks_are_plain_relay_reimports(self, source):
+        program = parse_with_grammar_entry(source, entry_name="state_machine_dsl")
 
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        _, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
 
-    def test_reserved_combo_export_shape_even_when_semantically_valid_is_rejected(self):
-        program = parse_with_grammar_entry(
-            """
-            state Root {
-                state A {
-                    event E1;
-                    event E2;
-                }
-                state B;
-                pseudo state __combo_root_a__e1_hbafca7f66598 named 'combo after E1';
-                [*] -> A;
-                A -> __combo_root_a__e1_hbafca7f66598 :: E1;
-                __combo_root_a__e1_hbafca7f66598 -> B : A.E2;
-            }
-            """,
-            entry_name="state_machine_dsl",
-        )
-
-        with pytest.raises(ModelValidationError) as exc_info:
-            parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_RESERVED_STATE_NAME"
-            for diag in exc_info.value.diagnostics
-        )
+        assert diagnostics == []
+        parse_dsl_node_to_state_machine(program)
 
     def test_collect_mode_does_not_duplicate_combo_endpoint_diagnostics(self):
         program = parse_with_grammar_entry(
@@ -894,17 +918,137 @@ class TestComboModelExpansion:
         ]
         assert [diag.refs["src"] for diag in dangling] == ["Missing", "Missing"]
 
-    def test_digest12_collision_fails_fast(self, monkeypatch):
+    @pytest.mark.parametrize(
+        ["declaration", "expected_warning"],
+        [
+            ("state {name};", True),
+            ("pseudo state {name};", False),
+        ],
+    )
+    def test_hash_extension_resolves_collision_with_user_authored_state(
+        self, declaration, expected_warning
+    ):
+        base = _build_model(
+            """
+            state Root {
+                state S1;
+                state S2;
+                [*] -> S1;
+                S1 -> S2 :: E1 + E2;
+            }
+            """
+        )
+        default_name = next(
+            state.name
+            for state in base.root_state.substates.values()
+            if state.is_pseudo
+        )
+        occupied_declaration = declaration.format(name=default_name)
+        program = parse_with_grammar_entry(
+            f"""
+            state Root {{
+                state S1;
+                state S2;
+                {occupied_declaration}
+                [*] -> S1;
+                S1 -> S2 :: E1 + E2;
+            }}
+            """,
+            entry_name="state_machine_dsl",
+        )
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        combo_names = [
+            state.name
+            for state in model.root_state.substates.values()
+            if state.is_pseudo and state.name.startswith("__combo_")
+        ]
+        assert default_name in model.root_state.substates
+        if expected_warning:
+            assert default_name not in combo_names
+        else:
+            assert default_name in combo_names
+        generated_names = [
+            state.name
+            for state in model.root_state.substates.values()
+            if state.is_pseudo and state.extra_name == "combo after E1"
+        ]
+        assert len(generated_names) == 1
+        assert generated_names[0] != default_name
+        assert re.search(r"_h[0-9a-f]{16}$", generated_names[0])
+        info = next(
+            item for item in diagnostics if item.code == "I_COMBO_PSEUDO_NAME_EXTENDED"
+        )
+        assert info.severity == "info"
+        assert info.refs["default_digest_size"] == 12
+        assert info.refs["final_digest_size"] == 16
+        assert (
+            any(
+                item.code == "W_COMBO_RESERVED_PREFIX_STATE_KIND"
+                for item in diagnostics
+            )
+            is expected_warning
+        )
+        parse_dsl_node_to_state_machine(program)
+
+    def test_hash_extension_separates_distinct_payloads_sharing_prefix(
+        self, monkeypatch
+    ):
+        def shared_prefix_digest(payload):
+            digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+            return "a" * 12 + digest[12:]
+
+        monkeypatch.setattr(
+            model_module,
+            "_combo_payload_digest",
+            shared_prefix_digest,
+        )
         program = parse_with_grammar_entry(
             """
             state Root {
                 state S1;
                 state S2;
                 state S3;
+                state S4;
                 [*] -> S1;
                 S1 -> S2 :: E1 + E2;
-                S1 -> S3 :: E3 + E4;
+                S1 -> S4 :: E1;
+                S1 -> S3 :: E1 + E3;
             }
+            """,
+            entry_name="state_machine_dsl",
+        )
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+
+        combo_names = [
+            state.name
+            for state in model.root_state.substates.values()
+            if state.is_pseudo
+        ]
+        assert len(combo_names) == 2
+        assert sorted(len(name.rsplit("_h", 1)[1]) for name in combo_names) == [12, 16]
+        assert [
+            item.refs["final_digest_size"]
+            for item in diagnostics
+            if item.code == "I_COMBO_PSEUDO_NAME_EXTENDED"
+        ] == [16]
+        parse_dsl_node_to_state_machine(program)
+
+    def test_full_digest_collision_fails_after_extension(self, monkeypatch):
+        occupied_names = "\n".join(
+            f"state __combo_root_s1__e1_h{'0' * size};" for size in range(12, 65, 4)
+        )
+        program = parse_with_grammar_entry(
+            f"""
+            state Root {{
+                state S1;
+                state S2;
+                {occupied_names}
+                [*] -> S1;
+                S1 -> S2 :: E1 + E2;
+            }}
             """,
             entry_name="state_machine_dsl",
         )
@@ -916,10 +1060,12 @@ class TestComboModelExpansion:
         )
         with pytest.raises(ModelValidationError) as exc_info:
             parse_dsl_node_to_state_machine(program)
-        assert any(
-            diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
+        collision = next(
+            diag
             for diag in exc_info.value.diagnostics
+            if diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
         )
+        assert collision.refs["pseudo_name"].endswith("0" * 64)
 
     def test_combo_pseudo_keeps_current_aspect_skip_behavior(self):
         model = _build_model(

--- a/test/model/test_combo_transition_expansion.py
+++ b/test/model/test_combo_transition_expansion.py
@@ -834,6 +834,7 @@ class TestComboModelExpansion:
                     enter { x = x + 1; }
                     during { x = x + 2; }
                     exit { x = x + 3; }
+                    >> during before { x = x + 4; }
                 }
                 state Target;
                 [*] -> __combo_user;
@@ -853,7 +854,15 @@ class TestComboModelExpansion:
         )
         assert diagnostic.severity == "warning"
         assert diagnostic.refs["reserved_prefix"] == "__combo_"
-        assert diagnostic.refs["action_kinds"] == ["enter", "during", "exit"]
+        assert diagnostic.refs["action_kinds"] == [
+            "enter",
+            "during",
+            "exit",
+            "during_aspect",
+        ]
+        assert {item.code for item in diagnostics} == {
+            "W_COMBO_RELAY_PSEUDO_HAS_ACTIONS"
+        }
         parse_dsl_node_to_state_machine(program)
 
     @pytest.mark.parametrize(
@@ -1066,6 +1075,19 @@ class TestComboModelExpansion:
             if diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
         )
         assert collision.refs["pseudo_name"].endswith("0" * 64)
+
+        model, diagnostics = parse_dsl_node_to_state_machine(program, collect=True)
+        collect_collisions = [
+            diag for diag in diagnostics if diag.code == "E_COMBO_PSEUDO_NAME_COLLISION"
+        ]
+        assert len(collect_collisions) == 1
+        occupied_full_name = f"__combo_root_s1__e1_h{'0' * 64}"
+        assert model.root_state.substates[occupied_full_name].is_pseudo is False
+        assert all(
+            transition.from_state != occupied_full_name
+            and transition.to_state != occupied_full_name
+            for transition in model.root_state.transitions
+        )
 
     def test_combo_pseudo_keeps_current_aspect_skip_behavior(self):
         model = _build_model(


### PR DESCRIPTION
# B 命名：实现 combo relay 命名 / hygiene 合同

上游伞 PR：[#306](https://github.com/HansBug/pyfcstm/pull/306)  
关联 issue：[#304](https://github.com/HansBug/pyfcstm/issues/304)  
对应 finding：F-002（combo relay 命名 / hygiene 合同），设计依据见 [F-002 设计 comment](https://github.com/HansBug/pyfcstm/issues/304#issuecomment-4850205728)。

## 当前状态

- 状态：🟢 计划已通过 multiagent review 并按 I/M 意见修订，进入实现阶段。
- 本 PR 是 #306 的 subPR B，只处理 combo relay 命名 / hygiene 合同。
- 本 PR 不修 F-001 runtime `plain_before_pending` 时机，也不修 F-004 effect diagnostic provenance；这些分别由 A/C 处理，D 负责最终整合。

## 与上游伞 PR 的一致性

本 PR 覆盖 #306 表格中 `B 命名` 的要求：

- 纯 `pseudo state __combo_*;` 可作为 expanded text DSL relay reimport。
- 非 pseudo `__combo_` state / composite 不再报旧 blanket error，改为 `W_COMBO_RESERVED_PREFIX_STATE_KIND` warning。
- `pseudo state __combo_*` 带 lifecycle/aspect action 改为 `W_COMBO_RELAY_PSEUDO_HAS_ACTIONS` warning。
- combo expansion 分配 relay 名时先做 hash-extension fallback，只有无法安全分配时才报 `E_COMBO_PSEUDO_NAME_COLLISION`。
- `I_COMBO_PSEUDO_NAME_EXTENDED` 只作为 collect/debug info，不阻塞 build。
- 旧 `E_COMBO_RESERVED_STATE_NAME` 从 `__combo_` reserved-prefix 合同中彻底迁移/移除，不保留双轨语义。
- 新 diagnostic codes 必须进入 `pyfcstm/diagnostics/codes.yaml`，带完整 `for_llm` 元数据，并同步/验证 jsfcstm/编辑器共享 registry。

## 非目标

- 不改变 combo trigger 展开后的 effect 挂载语义。
- 不改变 simulator / template runtime 的 `during before` 时机。
- 不扩大 inspect schema，不处理 `W_EFFECT_SELF_ASSIGN` provenance remap。
- 不引入兼容旧 `E_COMBO_RESERVED_STATE_NAME` 行为的分支；本路线要求清理历史遗留。

## 实施计划

| 步骤 | 内容 | 产物 / 验收 |
|---|---|---|
| 1 | TDD：先补 failing tests，锁定新命名合同。 | 纯 relay text reimport 通过；非 pseudo `__combo_` warning；relay pseudo action warning；现有旧 error 测试被迁移。 |
| 2 | 更新 model import / validation 逻辑。 | `pyfcstm/model/model.py` 不再 blanket emit `E_COMBO_RESERVED_STATE_NAME`；旧 code 从 `__combo_` reserved-prefix public contract 中删除/停用，不保留 emit 分支；`_is_exported_combo_pseudo_node` 只保留 process-local trusted metadata 用途，不再作为纯 relay reimport 的唯一豁免入口；按 state kind/action kind 发新 warning；pure relay pseudo 不阻塞。 |
| 3 | 实现 combo pseudo name hash-extension fallback。 | 从默认 12 hex（`_COMBO_DIGEST_SIZE`）开始；冲突时按 +4 步进（16 → 20 → … → 64，即 SHA-256 full digest）；若伸长后成功避让，emit `I_COMBO_PSEUDO_NAME_EXTENDED`（info，不阻塞）；若 full 64 hex 仍冲突或产生不同 payload 同名，emit `E_COMBO_PSEUDO_NAME_COLLISION`（error，阻塞）；算法必须保证 deterministic、idempotent、roundtrip stable。 |
| 4 | 更新 diagnostics registry 与跨端共享资源。 | `pyfcstm/diagnostics/codes.yaml` 新增/迁移 codes，带 `for_llm.summary`、`for_llm.recommended_actions`、`for_llm.do_not`；更新既有 `E_COMBO_PSEUDO_NAME_COLLISION` 文案中固定 digest12 的过期描述；通过 `editors/jsfcstm/scripts/sync-runtime-assets.js` / npm sync 脚本生成共享 registry 镜像并跑 resource/parity tests（按仓库实际脚本名）。 |
| 5 | 回归与文档生成。 | `make rst_auto`（如 API/RST 受影响）；`SKIP_SLOW_TESTS=1 make unittest`；必要时 jsfcstm diagnostics resource/parity tests。 |

## 硬验收标准

- [ ] A02/A20 text roundtrip 不再因纯 `pseudo state __combo_*;` 被 `E_COMBO_RESERVED_STATE_NAME` 拒绝。
- [ ] 非 pseudo `state __combo_user;` / composite `state __combo_group { ... }` 触发 `W_COMBO_RESERVED_PREFIX_STATE_KIND` warning，且不阻塞 model build。
- [ ] `pseudo state __combo_user` 带 `enter` / `during` / `exit` / aspect action 时触发 `W_COMBO_RELAY_PSEUDO_HAS_ACTIONS` warning，且不混同为普通命名冲突。
- [ ] 现有引用 `E_COMBO_RESERVED_STATE_NAME` 的测试全部迁移到新合同；不保留旧 `__combo_` blanket error 双轨语义；最终 `rg E_COMBO_RESERVED_STATE_NAME pyfcstm test editors` 不应再出现 reserved-prefix 合同实现或断言。
- [ ] 旧测试迁移矩阵必须覆盖四类：pure relay pass / non-pseudo warning / relay pseudo action warning / true collision error。
- [ ] combo expansion 默认 12 hex name 冲突时优先伸长 hash；成功伸长时 emit `I_COMBO_PSEUDO_NAME_EXTENDED`，并保持 deterministic / idempotent / roundtrip stable。
- [ ] hash-extension 测试矩阵必须覆盖：12 hex collision with existing user-authored state → 16/20/... 成功；同一 payload 同一 owner scope 重复生成可安全复用；不同 payload 共享 12 hex prefix 伸长后分离；monkeypatch digest 到 64 hex 仍无法避让时才 `E_COMBO_PSEUDO_NAME_COLLISION`。
- [ ] full digest exhaustion（64 hex）或同 scope 下无法安全避让时才 emit `E_COMBO_PSEUDO_NAME_COLLISION`。
- [ ] 新/改 codes 全部在 `pyfcstm/diagnostics/codes.yaml` 注册，包含完整 `for_llm` 元数据，并通过 registry/schema/resource tests。
- [ ] jsfcstm/编辑器共享 registry 必须通过既有 sync 脚本生成镜像并跑 parity/resource tests；不允许手工复制漂移。
- [ ] 本地 `SKIP_SLOW_TESTS=1 make unittest` 通过；CI 通过；Codecov comment 无阻塞覆盖问题。
- [ ] multiagent final review 无 C/I；M 级问题已处理或明确不阻塞。

## 测试计划

- Python model tests：combo transition expansion、reserved-prefix hygiene、hash-extension fallback、collect diagnostics。
  - `test_text_roundtrip_pure_relay_pseudo_reimport`：export → reimport → model build 成功。
  - `test_text_roundtrip_does_not_require_generated_marker`：reimport 后不依赖 process-local marker 也能保留 expanded behavior。
  - `test_reserved_prefix_warning_does_not_raise_in_strict_mode`：warning 在 `collect=False` strict mode 下不抛 `ModelValidationError`。
  - `test_hash_extension_resolves_digest12_collision` / `test_hash_extension_exhausted_full_digest_collision`：覆盖伸长成功与 64 hex 耗尽。
- Diagnostics registry tests：`codes.yaml` schema、required refs、`for_llm` completeness。
- jsfcstm/editor tests：如果 `codes.yaml` 同步影响共享资源，执行对应 sync/resource/parity tests。
- 默认本地测试使用：

```bash
SKIP_SLOW_TESTS=1 make unittest
```

## 风险与边界

- B 可独立于 A 开工，但 D 阶段必须在 A 合并后重跑 B 的 text roundtrip / registry 关键场景。
- 纯 relay pseudo text reimport 不恢复 process-local trusted combo metadata；只要求 expanded runtime behavior、event scope、terminal effect 保真。
- Warning 不能因 `collect=False` strict mode 被误当成 error 抛出；error 只保留给真实 collision / 无法安全生成 relay name。



## Plan review 已吸收意见

- 已吸收 claude/codex/deepseek 对计划的 M/I 级意见：hash-extension 算法规格、旧 `E_COMBO_RESERVED_STATE_NAME` 迁移矩阵、四类旧测试迁移、`collect=False` warning 不抛错、jsfcstm sync 具体入口、`for_llm` 完整性、`E_COMBO_PSEUDO_NAME_COLLISION` 过期文案更新。
- 计划 review comments：
  - claude reviewer：https://github.com/HansBug/pyfcstm/pull/308#issuecomment-4850688505
  - codex reviewer：https://github.com/HansBug/pyfcstm/pull/308#issuecomment-4850690086
  - deepseek reviewer：https://github.com/HansBug/pyfcstm/pull/308#issuecomment-4850691668
