### PR TITLE
修复 combo terminal effect diagnostic provenance

### DIFF
--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -159,6 +159,7 @@ interface PublicTransitionSubject {
     canAnchor: boolean;
 }
 
+/** Return the user-facing subject and debug refs for effect diagnostics. */
 function publicTransitionSubjectForEffectDiagnostic(
     transition: TransitionInfo,
 ): PublicTransitionSubject {
@@ -170,7 +171,7 @@ function publicTransitionSubjectForEffectDiagnostic(
     if (!originRef) {
         return {
             statePath: transition.from_path,
-            transitionSpan: null,
+            transitionSpan,
             extraRefs,
             canAnchor: true,
         };

--- a/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
+++ b/editors/jsfcstm/src/diagnostics/analyzers/redundancy.ts
@@ -109,25 +109,34 @@ function isLifecycleFreeLeaf(statePath: string, statesByPath: Map<string, StateI
 }
 
 function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDiagnosticJson[] {
+    const subjects = new Map<TransitionInfo, PublicTransitionSubject>();
+    for (const transition of transitions) {
+        subjects.set(transition, publicTransitionSubjectForEffectDiagnostic(transition));
+    }
+
     const counts = new Map<string, number>();
     for (const transition of transitions) {
+        const subject = subjects.get(transition)!;
         for (const varName of transition.effect_self_assigns) {
-            const key = JSON.stringify([transition.from_path, varName]);
+            const key = JSON.stringify([subject.statePath, varName]);
             counts.set(key, (counts.get(key) ?? 0) + 1);
         }
     }
     const out: ModelDiagnosticJson[] = [];
     for (const transition of transitions) {
+        const subject = subjects.get(transition)!;
         for (const varName of transition.effect_self_assigns) {
             const refs: Record<string, unknown> = {
-                state_path: transition.from_path,
-                transition_span: null,
+                state_path: subject.statePath,
+                transition_span: subject.transitionSpan,
                 var_name: varName,
                 transition_index: transition.transition_index,
+                ...subject.extraRefs,
             };
             if (
-                transition.from_path !== '[*]' &&
-                counts.get(JSON.stringify([transition.from_path, varName])) === 1
+                subject.canAnchor &&
+                subject.statePath !== '[*]' &&
+                counts.get(JSON.stringify([subject.statePath, varName])) === 1
             ) {
                 refs.effect_self_assign_anchor = varName;
             }
@@ -141,6 +150,80 @@ function collectEffectSelfAssignWarnings(transitions: TransitionInfo[]): ModelDi
         }
     }
     return out;
+}
+
+interface PublicTransitionSubject {
+    statePath: string;
+    transitionSpan: ModelSpanJson | null;
+    extraRefs: Record<string, unknown>;
+    canAnchor: boolean;
+}
+
+function publicTransitionSubjectForEffectDiagnostic(
+    transition: TransitionInfo,
+): PublicTransitionSubject {
+    const originRef = transition.combo_origin_refs?.[0];
+    const transitionSpan = originRef?.transition_span ?? sourceSpan(transition);
+    const projectionKey = transition.combo_projection_key;
+    const extraRefs: Record<string, unknown> = {};
+
+    if (!originRef) {
+        return {
+            statePath: transition.from_path,
+            transitionSpan: null,
+            extraRefs,
+            canAnchor: true,
+        };
+    }
+
+    if (!Array.isArray(projectionKey) || projectionKey.length < 2) {
+        return {
+            statePath: transition.from_path,
+            transitionSpan,
+            extraRefs: {
+                from_path: transition.from_path,
+                generated_state_path: transition.from_path,
+                generated_from_path: transition.from_path,
+                generated_to_path: transition.to_path,
+                combo_origin_id: originRef.origin_id,
+            },
+            canAnchor: false,
+        };
+    }
+
+    let statePath = transition.from_path;
+    let canAnchor = false;
+    const [ownerPath, projectionKind, sourcePath] = projectionKey;
+    if (projectionKind === 'state') {
+        if (Array.isArray(sourcePath)) {
+            statePath = sourcePath.join('.');
+            canAnchor = true;
+        } else if (typeof sourcePath === 'string') {
+            statePath = sourcePath;
+            canAnchor = true;
+        }
+    } else if (projectionKind === 'entry') {
+        statePath = '[*]';
+        if (Array.isArray(ownerPath)) {
+            extraRefs.combo_owner_path = ownerPath.join('.');
+        } else if (typeof ownerPath === 'string') {
+            extraRefs.combo_owner_path = ownerPath;
+        }
+    }
+
+    return {
+        statePath,
+        transitionSpan,
+        extraRefs: {
+            ...extraRefs,
+            from_path: statePath,
+            generated_state_path: transition.from_path,
+            generated_from_path: transition.from_path,
+            generated_to_path: transition.to_path,
+            combo_origin_id: originRef.origin_id,
+        },
+        canAnchor,
+    };
 }
 
 function collectForcedOverridesNormalWarnings(transitions: TransitionInfo[]): ModelDiagnosticJson[] {

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -985,7 +985,7 @@ state Root {
                     severity: 'warning',
                     refs: {
                         state_path: 'Root.Active',
-                        transition_span: null,
+                        transition_span: {line: 16, column: 5, end_line: 16, end_column: 47},
                         var_name: 'stable',
                         effect_self_assign_anchor: 'stable',
                         transition_index: 5,
@@ -1332,7 +1332,7 @@ state Root {
                     .map(d => d.refs),
                 [expectedRefsWithSuggestedFix('W_EFFECT_SELF_ASSIGN', {
                     state_path: 'Root.A',
-                    transition_span: null,
+                    transition_span: {line: 7, column: 5, end_line: 11, end_column: 6},
                     var_name: 'x',
                     effect_self_assign_anchor: 'x',
                     transition_index: 1,

--- a/editors/jsfcstm/test/diagnostics-inspect.test.ts
+++ b/editors/jsfcstm/test/diagnostics-inspect.test.ts
@@ -73,6 +73,18 @@ function expectedRefsWithSuggestedFix(code: string, refs: Record<string, unknown
     return packageModule.refsWithSuggestedFix(code, refs);
 }
 
+function sliceBySpan(source: string, span: {line: number; column: number; end_line: number; end_column: number}): string {
+    const lines = source.split('\n');
+    if (span.line === span.end_line) {
+        return (lines[span.line - 1] ?? '').slice(span.column - 1, span.end_column - 1);
+    }
+    return [
+        (lines[span.line - 1] ?? '').slice(span.column - 1),
+        ...lines.slice(span.line, span.end_line - 1),
+        (lines[span.end_line - 1] ?? '').slice(0, span.end_column - 1),
+    ].join('\n');
+}
+
 describe('diagnostics/inspect', () => {
     describe('basic structure', () => {
         it('returns top-level shape', async () => {
@@ -1326,6 +1338,166 @@ state Root {
                     transition_index: 1,
                 })],
             );
+        });
+
+        it('remaps combo terminal self-assignment diagnostics to authored source', async () => {
+            const source = `
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    [*] -> A;
+    A -> B :: E1 + E2 effect { x = x; };
+}
+`;
+            const report = inspectModel(await buildMachine(source));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 1);
+            const refs = diagnostics[0].refs as Record<string, unknown>;
+            assert.equal(refs.state_path, 'Root.A');
+            assert.equal(refs.from_path, 'Root.A');
+            assert.match(refs.generated_state_path as string, /^Root\.__combo_/);
+            assert.equal(refs.generated_from_path, refs.generated_state_path);
+            assert.equal(refs.generated_to_path, 'Root.B');
+            assert.equal(typeof refs.combo_origin_id, 'string');
+            assert.equal(refs.combo_owner_path, undefined);
+            assert.equal(refs.var_name, 'x');
+            assert.equal(refs.effect_self_assign_anchor, 'x');
+            assert.deepEqual((refs.suggested_fix as {anchor: unknown}).anchor, {
+                type: 'ref',
+                ref: 'refs.effect_self_assign_anchor',
+            });
+            assert.equal(
+                sliceBySpan(source, refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                'A -> B :: E1 + E2 effect { x = x; }',
+            );
+        });
+
+        it('remaps entry combo self-assignment diagnostics to initial subject', async () => {
+            const source = `
+def int x = 0;
+state Root {
+    state A;
+    [*] -> A : Boot + Ready effect { x = x; };
+}
+`;
+            const report = inspectModel(await buildMachine(source));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 1);
+            const refs = diagnostics[0].refs as Record<string, unknown>;
+            assert.equal(refs.state_path, '[*]');
+            assert.equal(refs.from_path, '[*]');
+            assert.equal(refs.combo_owner_path, 'Root');
+            assert.match(refs.generated_state_path as string, /^Root\.__combo_/);
+            assert.equal(refs.generated_from_path, refs.generated_state_path);
+            assert.equal(refs.generated_to_path, 'Root.A');
+            assert.equal(typeof refs.combo_origin_id, 'string');
+            assert.equal(refs.var_name, 'x');
+            assert.equal(refs.effect_self_assign_anchor, undefined);
+            assert.equal(refs.suggested_fix, undefined);
+            assert.equal(
+                sliceBySpan(source, refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                '[*] -> A : Boot + Ready effect { x = x; }',
+            );
+        });
+
+        it('keeps shared-prefix combo terminal self-assignment subjects authored', async () => {
+            const source = `
+def int x = 0;
+def int y = 0;
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+    A -> B :: E1 + E2 effect { x = x; };
+    A -> C :: E1 + E3 effect { y = y; };
+}
+`;
+            const report = inspectModel(await buildMachine(source));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 2);
+            const byVar = new Map(diagnostics.map(diag => [diag.refs.var_name, diag]));
+            assert.deepEqual([...byVar.keys()].sort(), ['x', 'y']);
+            for (const [varName, diag] of byVar) {
+                const refs = diag.refs as Record<string, unknown>;
+                assert.equal(refs.state_path, 'Root.A');
+                assert.equal(refs.from_path, 'Root.A');
+                assert.match(refs.generated_state_path as string, /^Root\.__combo_/);
+                assert.equal(refs.generated_from_path, refs.generated_state_path);
+                assert.ok(['Root.B', 'Root.C'].includes(refs.generated_to_path as string));
+                assert.equal(typeof refs.combo_origin_id, 'string');
+                assert.equal(refs.effect_self_assign_anchor, varName);
+                assert.deepEqual((refs.suggested_fix as {anchor: unknown}).anchor, {
+                    type: 'ref',
+                    ref: 'refs.effect_self_assign_anchor',
+                });
+            }
+            assert.equal(
+                sliceBySpan(source, byVar.get('x')!.refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                'A -> B :: E1 + E2 effect { x = x; }',
+            );
+            assert.equal(
+                sliceBySpan(source, byVar.get('y')!.refs.transition_span as {line: number; column: number; end_line: number; end_column: number}).trim(),
+                'A -> C :: E1 + E3 effect { y = y; }',
+            );
+        });
+
+        it('suppresses anchors for same-source combo terminal self-assignments', async () => {
+            const report = inspectModel(await buildMachine(`
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+    A -> B :: E1 + E2 effect { x = x; };
+    A -> C :: E3 + E4 effect { x = x; };
+}
+`));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 2);
+            assert.equal(diagnostics.every(diag => diag.refs.state_path === 'Root.A'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.from_path === 'Root.A'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.var_name === 'x'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.effect_self_assign_anchor === undefined), true);
+            assert.equal(diagnostics.every(diag => diag.refs.suggested_fix === undefined), true);
+            assert.deepEqual(
+                diagnostics.map(diag => diag.refs.generated_to_path).sort(),
+                ['Root.B', 'Root.C'],
+            );
+        });
+
+        it('suppresses anchors for plain and combo self-assignments on the same source', async () => {
+            const report = inspectModel(await buildMachine(`
+def int x = 0;
+state Root {
+    state A;
+    state B;
+    state C;
+    [*] -> A;
+    A -> B effect { x = x; };
+    A -> C :: E1 + E2 effect { x = x; };
+}
+`));
+            const diagnostics = report.diagnostics.filter(d => d.code === 'W_EFFECT_SELF_ASSIGN');
+
+            assert.equal(diagnostics.length, 2);
+            assert.equal(diagnostics.every(diag => diag.refs.state_path === 'Root.A'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.var_name === 'x'), true);
+            assert.equal(diagnostics.every(diag => diag.refs.effect_self_assign_anchor === undefined), true);
+            assert.equal(diagnostics.every(diag => diag.refs.suggested_fix === undefined), true);
+            const plain = diagnostics.find(diag => diag.refs.generated_from_path === undefined);
+            const combo = diagnostics.find(diag => diag.refs.generated_from_path !== undefined);
+            assert.ok(plain);
+            assert.ok(combo);
+            assert.equal(plain!.refs.from_path, undefined);
+            assert.equal(combo!.refs.from_path, 'Root.A');
+            assert.equal(combo!.refs.generated_to_path, 'Root.C');
         });
     });
 

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -120,23 +120,34 @@ def _is_lifecycle_free_leaf(
 
 
 def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> List[ModelDiagnostic]:
+    transitions = list(transitions)
+    subjects_by_id = {
+        id(t): _public_transition_subject_for_effect_diagnostic(t)
+        for t in transitions
+    }
     counts = Counter(
-        (t.from_path, var_name)
+        (subjects_by_id[id(t)]['state_path'], var_name)
         for t in transitions
         for var_name in getattr(t, 'effect_self_assigns', ())
     )
     diagnostics: List[ModelDiagnostic] = []
     for t in transitions:
+        subject = subjects_by_id[id(t)]
         effect_self_assigns = getattr(t, 'effect_self_assigns', ())
         effect_self_assign_spans = getattr(t, 'effect_self_assign_spans', ())
         for index, var_name in enumerate(effect_self_assigns):
             refs = {
-                'state_path': t.from_path,
-                'transition_span': t.span,
+                'state_path': subject['state_path'],
+                'transition_span': subject['transition_span'],
                 'var_name': var_name,
                 'transition_index': t.transition_index,
             }
-            if t.from_path != '[*]' and counts[(t.from_path, var_name)] == 1:
+            refs.update(subject['extra_refs'])
+            if (
+                subject['can_anchor']
+                and subject['state_path'] != '[*]'
+                and counts[(subject['state_path'], var_name)] == 1
+            ):
                 refs['effect_self_assign_anchor'] = var_name
             diagnostics.append(ModelDiagnostic(
                 code='W_EFFECT_SELF_ASSIGN',
@@ -151,6 +162,69 @@ def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> Lis
                 refs=refs,
             ))
     return diagnostics
+
+
+def _public_transition_subject_for_effect_diagnostic(t: 'TransitionInfo') -> Dict[str, object]:
+    origin_ref = next(iter(getattr(t, 'combo_origin_refs', ())), None)
+    transition_span = getattr(origin_ref, 'transition_span', None) or t.span
+    projection_key = getattr(t, 'combo_projection_key', None)
+    extra_refs: Dict[str, object] = {}
+
+    if origin_ref is None:
+        return {
+            'state_path': t.from_path,
+            'transition_span': transition_span,
+            'extra_refs': extra_refs,
+            'can_anchor': True,
+        }
+
+    state_path = t.from_path
+    if projection_key is None or len(projection_key) < 2:
+        extra_refs.update({
+            'from_path': state_path,
+            'generated_state_path': t.from_path,
+            'generated_from_path': t.from_path,
+            'generated_to_path': t.to_path,
+            'combo_origin_id': origin_ref.origin_id,
+        })
+        return {
+            'state_path': state_path,
+            'transition_span': transition_span,
+            'extra_refs': extra_refs,
+            'can_anchor': False,
+        }
+
+    owner_path = projection_key[0]
+    projection_kind = projection_key[1]
+    can_anchor = False
+    if projection_kind == 'state' and len(projection_key) >= 3:
+        source_path = projection_key[2]
+        if isinstance(source_path, tuple):
+            state_path = '.'.join(source_path)
+            can_anchor = True
+        elif isinstance(source_path, str):
+            state_path = source_path
+            can_anchor = True
+    elif projection_kind == 'entry':
+        state_path = '[*]'
+        if isinstance(owner_path, tuple):
+            extra_refs['combo_owner_path'] = '.'.join(owner_path)
+        elif isinstance(owner_path, str):
+            extra_refs['combo_owner_path'] = owner_path
+
+    extra_refs.update({
+        'from_path': state_path,
+        'generated_state_path': t.from_path,
+        'generated_from_path': t.from_path,
+        'generated_to_path': t.to_path,
+        'combo_origin_id': origin_ref.origin_id,
+    })
+    return {
+        'state_path': state_path,
+        'transition_span': transition_span,
+        'extra_refs': extra_refs,
+        'can_anchor': can_anchor,
+    }
 
 
 def _forced_overrides_normal_warnings(transitions: Iterable['TransitionInfo']) -> List[ModelDiagnostic]:

--- a/pyfcstm/diagnostics/analyzers/redundancy.py
+++ b/pyfcstm/diagnostics/analyzers/redundancy.py
@@ -165,6 +165,7 @@ def _effect_self_assign_warnings(transitions: Iterable['TransitionInfo']) -> Lis
 
 
 def _public_transition_subject_for_effect_diagnostic(t: 'TransitionInfo') -> Dict[str, object]:
+    """Return the user-facing subject and debug refs for effect diagnostics."""
     origin_ref = next(iter(getattr(t, 'combo_origin_refs', ())), None)
     transition_span = getattr(origin_ref, 'transition_span', None) or t.span
     projection_key = getattr(t, 'combo_projection_key', None)

--- a/pyfcstm/diagnostics/codes.yaml
+++ b/pyfcstm/diagnostics/codes.yaml
@@ -2299,6 +2299,37 @@ W_EFFECT_SELF_ASSIGN:
       type: str
       required: true
       description: Source state path when known.
+    from_path:
+      type: str
+      required: false
+      description: >-
+        Public source path for combo terminal effect diagnostics after
+        authored-subject remapping. Ordinary self-assignment diagnostics may
+        omit this field and use ``state_path`` only.
+    generated_state_path:
+      type: str
+      required: false
+      description: >-
+        Generated combo pseudo state path kept only as secondary debug
+        provenance after the public subject is remapped.
+    generated_from_path:
+      type: str
+      required: false
+      description: Generated transition source path kept as secondary debug provenance.
+    generated_to_path:
+      type: str
+      required: false
+      description: Generated transition target path kept as secondary debug provenance.
+    combo_origin_id:
+      type: str
+      required: false
+      description: Original combo transition identifier for a generated terminal effect.
+    combo_owner_path:
+      type: str
+      required: false
+      description: >-
+        Owner composite path for entry combo diagnostics whose public subject
+        is the initial marker ``[*]``.
     transition_span:
       type: Span
       required: false

--- a/test/diagnostics/test_inspect_model.py
+++ b/test/diagnostics/test_inspect_model.py
@@ -1872,6 +1872,176 @@ class TestInspectModelRedundancySemantics:
         assert all('effect_self_assign_anchor' not in ref for ref in refs)
         assert all('suggested_fix' not in ref for ref in refs)
 
+    def test_effect_self_assign_combo_terminal_uses_authored_source(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B :: E1 + E2 effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 1
+        diag = diagnostics[0]
+        refs = diag.refs
+        assert refs['state_path'] == 'Root.A'
+        assert refs['from_path'] == 'Root.A'
+        assert refs['generated_state_path'].startswith('Root.__combo_')
+        assert refs['generated_from_path'] == refs['generated_state_path']
+        assert refs['generated_to_path'] == 'Root.B'
+        assert refs['combo_origin_id']
+        assert 'combo_owner_path' not in refs
+        assert refs['var_name'] == 'x'
+        assert refs['effect_self_assign_anchor'] == 'x'
+        assert refs['suggested_fix']['anchor'] == {
+            'type': 'ref',
+            'ref': 'refs.effect_self_assign_anchor',
+        }
+        assert _slice_by_span(dsl, refs['transition_span']).strip() == (
+            'A -> B :: E1 + E2 effect { x = x; }'
+        )
+        assert _slice_by_span(dsl, diag.span) == 'x = x;'
+        assert_all_diags_match_schema(diagnostics, context='combo-self-assign')
+
+    def test_effect_self_assign_entry_combo_uses_initial_subject(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            [*] -> A : Boot + Ready effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 1
+        diag = diagnostics[0]
+        refs = diag.refs
+        assert refs['state_path'] == '[*]'
+        assert refs['from_path'] == '[*]'
+        assert refs['combo_owner_path'] == 'Root'
+        assert refs['generated_state_path'].startswith('Root.__combo_')
+        assert refs['generated_from_path'] == refs['generated_state_path']
+        assert refs['generated_to_path'] == 'Root.A'
+        assert refs['combo_origin_id']
+        assert refs['var_name'] == 'x'
+        assert 'effect_self_assign_anchor' not in refs
+        assert 'suggested_fix' not in refs
+        assert _slice_by_span(dsl, refs['transition_span']).strip() == (
+            '[*] -> A : Boot + Ready effect { x = x; }'
+        )
+        assert _slice_by_span(dsl, diag.span) == 'x = x;'
+        assert_all_diags_match_schema(diagnostics, context='entry-combo-self-assign')
+
+    def test_effect_self_assign_combo_shared_prefix_terminal_subjects(self):
+        dsl = """
+        def int x = 0;
+        def int y = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B :: E1 + E2 effect { x = x; };
+            A -> C :: E1 + E3 effect { y = y; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 2
+        by_var = {diag.refs['var_name']: diag for diag in diagnostics}
+        assert set(by_var) == {'x', 'y'}
+        for var_name, diag in by_var.items():
+            refs = diag.refs
+            assert refs['state_path'] == 'Root.A'
+            assert refs['from_path'] == 'Root.A'
+            assert refs['generated_state_path'].startswith('Root.__combo_')
+            assert refs['generated_from_path'] == refs['generated_state_path']
+            assert refs['generated_to_path'] in {'Root.B', 'Root.C'}
+            assert refs['combo_origin_id']
+            assert refs['effect_self_assign_anchor'] == var_name
+            assert refs['suggested_fix']['anchor'] == {
+                'type': 'ref',
+                'ref': 'refs.effect_self_assign_anchor',
+            }
+            assert _slice_by_span(dsl, diag.span) == f'{var_name} = {var_name};'
+        assert _slice_by_span(dsl, by_var['x'].refs['transition_span']).strip() == (
+            'A -> B :: E1 + E2 effect { x = x; }'
+        )
+        assert _slice_by_span(dsl, by_var['y'].refs['transition_span']).strip() == (
+            'A -> C :: E1 + E3 effect { y = y; }'
+        )
+        assert_all_diags_match_schema(diagnostics, context='shared-prefix-self-assign')
+
+    def test_effect_self_assign_combo_shared_source_disambiguated(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B :: E1 + E2 effect { x = x; };
+            A -> C :: E3 + E4 effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 2
+        assert all(diag.refs['state_path'] == 'Root.A' for diag in diagnostics)
+        assert all(diag.refs['from_path'] == 'Root.A' for diag in diagnostics)
+        assert all(diag.refs['var_name'] == 'x' for diag in diagnostics)
+        assert all('effect_self_assign_anchor' not in diag.refs for diag in diagnostics)
+        assert all('suggested_fix' not in diag.refs for diag in diagnostics)
+        assert {diag.refs['generated_to_path'] for diag in diagnostics} == {
+            'Root.B',
+            'Root.C',
+        }
+        assert_all_diags_match_schema(diagnostics, context='shared-source-self-assign')
+
+    def test_effect_self_assign_combo_and_plain_same_source_suppress_anchor(self):
+        dsl = """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B effect { x = x; };
+            A -> C :: E1 + E2 effect { x = x; };
+        }
+        """
+        report = inspect_model(_parse(dsl))
+        diagnostics = [
+            d for d in report.diagnostics
+            if d.code == 'W_EFFECT_SELF_ASSIGN'
+        ]
+        assert len(diagnostics) == 2
+        assert all(diag.refs['state_path'] == 'Root.A' for diag in diagnostics)
+        assert all(diag.refs['var_name'] == 'x' for diag in diagnostics)
+        assert all('effect_self_assign_anchor' not in diag.refs for diag in diagnostics)
+        assert all('suggested_fix' not in diag.refs for diag in diagnostics)
+        plain = next(diag for diag in diagnostics if 'generated_from_path' not in diag.refs)
+        combo = next(diag for diag in diagnostics if 'generated_from_path' in diag.refs)
+        assert 'from_path' not in plain.refs
+        assert combo.refs['from_path'] == 'Root.A'
+        assert combo.refs['generated_to_path'] == 'Root.C'
+        assert_all_diags_match_schema(diagnostics, context='plain-combo-self-assign')
+
     def test_initial_transition_self_assignment_does_not_get_fix(self):
         dsl = """
         def int x = 0;


### PR DESCRIPTION
# Combo terminal effect diagnostic provenance remap

关联：[#304](https://github.com/HansBug/pyfcstm/issues/304) / 伞 PR [#306](https://github.com/HansBug/pyfcstm/pull/306)

本 PR 承接 #306 中的 **C 溯源 / F-004**：修复 generic effect diagnostic（当前最小公开问题为 `W_EFFECT_SELF_ASSIGN`）在 combo terminal edge 上把 generated pseudo path 当成用户主定位对象的问题。

当前 PR 已完成计划 review、TDD、实现、首轮强对抗实现 review 与 I 级问题修复；现在进入最终 CI watch、final multi-agent review 与覆盖率收敛阶段。

## 当前状态

- PR 类型：F-004 diagnostics provenance subPR，已完成实现并推送 `d2491777`、`a2973b09`。
- Base：`dev/issue-304-combo-followup-umbrella`（PR #306 伞 PR 分支）；当前已核实 base tip 为 `1e174d37`，本分支无 conflict / 未合入上游内容。
- Scope：只处理 F-004 diagnostics provenance，不改 runtime 语义、不扩大 inspect structural schema。
- 首轮计划 review 已吸收：
  - [codex reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4850738265)：要求明确 `W_EFFECT_SELF_ASSIGN` generated debug refs 与 `codes.yaml` refs schema / parity tests 的关系，并 pin `transition_span` 来源。
  - [claude reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4850755929)：要求明确 `from_path` 是否输出、`transition_span` 来源、以及 combo/non-combo 同源同变量 anchor 合同。
  - [deepseek reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4850757764)：要求明确 `codes.yaml` 更新、anchor 计数 key、`from_path` 字段、entry combo anchor 行为。
- 二轮计划 review 已通过：
  - [codex reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4850788065)：ready-to-implement。
  - [claude reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4850799274)：ready-to-implement。
  - [deepseek reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4850805705)：ready-to-implement。
- 首轮实现 review 已处理：
  - [deepseek reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4851380210)：指出 JS non-combo `transition_span` parity gap；已在 `a2973b09` 修复。
  - [claude reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4851381398)：无 C/I。
  - [codex reviewer](https://github.com/HansBug/pyfcstm/pull/309#issuecomment-4851417364)：无 C/I。
- 当前下一步：等待最新 push 的 CI 全绿、三路 final review 与 Codecov / coverage comment（如出现）复核；ready 后不 merge，等待人工指示。

## 问题摘要

A21 的最小复现显示，合法 DSL：

```fcstm
def int x = 0;
state Root {
    state A;
    state B;
    [*] -> A;
    A -> B :: E1 + E2 effect { x = x; }
}
```

runtime 行为正常，但 `inspect_model(...).diagnostics` 中的 `W_EFFECT_SELF_ASSIGN.refs.state_path` 当前暴露类似：

```text
Root.__combo_root_a__e1_h...
```

这会误导 editor / quick-fix / LLM / reviewer，因为用户 DSL 的 authored source 是 `Root.A`，generated pseudo 只能作为维护者 debug provenance。

## 实施边界

### 目标

- `W_EFFECT_SELF_ASSIGN` 在 combo terminal effect 上的 public subject remap 到 authored source：
  - ordinary source combo：`refs.state_path == 'Root.A'`，并为 combo diagnostic 设置 `refs.from_path == 'Root.A'`；
  - entry combo：不泄漏 pseudo，优先对齐 existing initial diagnostics 风格，使用 `refs.state_path == '[*]'` 和 `refs.from_path == '[*]'`，并保留 owner / generated debug refs；
  - shared-prefix 多 terminal effects：各 diagnostic 都回到 authored source，同时 span / refs 仍能区分 terminal effect；
  - ordinary non-combo transition regression 仅指“没有同 public source / same variable combo duplicate 的普通 transition 现有 message、top-level span、refs、anchor 行为不变”。
- generated pseudo path 只能作为 secondary debug refs；本 PR 采用并声明下列 optional diagnostic refs：
  - `generated_state_path`（generated terminal source state path；当前等于 `generated_from_path`）；
  - `generated_from_path`；
  - `generated_to_path`；
  - `combo_origin_id`；
  - `combo_owner_path`（entry combo 等场景用于保留 owner context）。
- `refs.transition_span` 对 combo terminal edge 必须优先使用 `origin_ref.transition_span or t.span`，指向 authored combo transition；diagnostic top-level `span` 仍尽量指向具体 self-assign statement（例如 `x = x;`）。
- quick-fix anchor 采用保守安全合同：
  - 先计算 public subject（authored source / `[*]`）和 public `transition_span`；
  - `effect_self_assign_anchor` 只在同一 public subject + same variable 只有一个 occurrence 且 public subject 不是 `[*]` 时输出；
  - 不在本 PR 中尝试用 `transition_span` / statement span 扩展 suggested-fix anchor 唯一性，因为当前 `suggested_fix.anchor` 只引用 `refs.effect_self_assign_anchor`；
  - 因此同一个 authored source、同一变量的多个 combo terminal self-assign，或 ordinary transition 与 same-source combo terminal 共用同一变量时，都必须抑制 `effect_self_assign_anchor` / `suggested_fix`，避免 unsafe quick-fix。

### 诊断 registry / schema 合同

- “不扩大 inspect schema” 指不新增 / 不改 `TransitionInfo`、inspect structural JSON、`pyfcstm/diagnostics/schema.json` 的 transition shape；内部 generated edge fact source 仍保持不变。
- 本 PR **必须**更新 `pyfcstm/diagnostics/codes.yaml` 的 `W_EFFECT_SELF_ASSIGN.refs`，声明新增 optional diagnostic refs：`from_path`、`generated_state_path`、`generated_from_path`、`generated_to_path`、`combo_origin_id`、`combo_owner_path`。
- 新 refs 必须通过 existing schema/parity checks，例如 `test/diagnostics/_schema_check.py::assert_refs_match_schema` 覆盖到的 diagnostics tests 与 cross-end parity tests。
- 若 jsfcstm / editor diagnostic resource 由 `codes.yaml` 自动同步生成，本 PR 必须走既有 sync 脚本 / resource parity tests；禁止手工复制造成漂移。若确认该字段集不需要额外同步，也必须在 PR comment / validation summary 中说明证据。

### 非目标

- 不修改 `SimulationRuntime`、template runtime 或 combo expansion 语义；F-001 由 A 运行时 PR 负责。
- 不处理 `__combo_` relay 命名 / hygiene 合同；F-002 由 B 命名 PR 负责。
- 不重新引入 F-003；ancestor `>> during before/after` 不 suppress `W_COMBO_GUARD_PREFIX_IMPLIED`。
- 不扩大 inspect structural schema，不把 `TransitionInfo.from_path` 全局改为 authored path；内部事实源仍保持 generated edge。
- 不把所有 generic diagnostics 一次性重构；本 PR 只修 `W_EFFECT_SELF_ASSIGN`，helper 可保持局部、命名上可为后续复用留余地。
- 不扩展 suggested-fix schema，不新增 span-aware quick-fix anchor 表达；本轮只在现有 `refs.effect_self_assign_anchor` 合同下保守 suppress unsafe fixes。

## 计划改动

- 在 `pyfcstm/diagnostics/analyzers/redundancy.py` 中为 effect diagnostic 增加局部 public subject helper，例如 `_public_transition_subject_for_effect_diagnostic`。
- helper 优先使用 `TransitionInfo.combo_origin_refs` 与 `combo_projection_key` 推回 authored subject：
  - `(owner_path, 'state', source_path)` → `'.'.join(source_path)`；
  - `(owner_path, 'entry', 'INIT_MARKER')` → `'[*]'`，并保留 `combo_owner_path` / generated debug refs；
  - 未识别形态 fallback 到现有 generated `t.from_path`，避免捏造错误 provenance。
- helper 需要返回至少这些信息：public `state_path` / `from_path`、public `transition_span`、optional generated debug refs、optional `combo_owner_path`、optional `combo_origin_id`。
- 在 `W_EFFECT_SELF_ASSIGN` refs 构造与 duplicate-anchor 计数中使用 public subject，而不是 raw generated `from_path`。
- 更新 `pyfcstm/diagnostics/codes.yaml` 中 `W_EFFECT_SELF_ASSIGN.refs`，并同步 / 验证下游 generated diagnostic resources（如适用）。
- 保持普通 transition message、top-level diagnostic span、非重复场景 refs 与 anchor 行为不变；当普通 transition 与 same public source combo terminal 形成 same-var duplicate 时，按新安全合同 suppress anchor。

## TDD / 测试计划

优先新增或扩展 diagnostics tests，计划场景：

- `test_effect_self_assign_combo_terminal_uses_authored_source`
  - `A -> B :: E1 + E2 effect { x = x; }`
  - 断言 `refs.state_path == 'Root.A'`、`refs.from_path == 'Root.A'`、`refs.transition_span` 为 authored combo transition span、top-level `span` 指向 self-assign statement、generated debug refs 存在且不作为 public subject。
- `test_effect_self_assign_entry_combo_uses_initial_subject`
  - `[*] -> A : Boot + Ready effect { x = x; }`
  - 断言 subject 不泄漏 pseudo，采用 `[*]` 口径，保留 `combo_owner_path` / generated debug refs，并且不设置 `effect_self_assign_anchor` / `suggested_fix`。
- `test_effect_self_assign_combo_shared_prefix_terminal_subjects`
  - 同一 source 下 `E1 + E2 effect { x = x; }` 与 `E1 + E3 effect { y = y; }`
  - 断言两个 diagnostics 均回到 authored source，spans/vars/refs 分别对应 terminal effects；由于变量不同且各自唯一，anchor 可按现有合同保留（非 `[*]` 且 same public subject + var 唯一）。
- `test_effect_self_assign_combo_shared_source_disambiguated`
  - 同一 authored source、同一变量、两个不同 combo terminal edge：
    `A -> B :: E1 + E2 effect { x = x; }` 与 `A -> C :: E3 + E4 effect { x = x; }`
  - 断言两个 diagnostics 都不设置 `effect_self_assign_anchor` / `suggested_fix`，即使 statement spans 不同。
- `test_effect_self_assign_combo_and_plain_same_source_suppress_anchor`
  - 同一 authored source、同一变量，一个普通 transition self-assign + 一个 combo terminal self-assign；断言两者都不设置 `effect_self_assign_anchor` / `suggested_fix`。
- ordinary transition regression：普通 `A -> B effect { x = x; }` 且没有 same public source duplicate 时，现有 behavior 不变。
- schema/parity regression：所有新增 refs 均已在 `codes.yaml` 声明，并通过 `assert_refs_match_schema` 覆盖；必要时同步 jsfcstm diagnostic resources 并跑对应 resource tests。

## 验收标准

- 上述 focused tests 先失败后通过，TDD 证据保留在 commit / PR comment 中。
- `W_EFFECT_SELF_ASSIGN` combo terminal public refs 不再使用 `Root.__combo...` 作为主 subject；`state_path` / combo `from_path` 使用 authored subject。
- generated pseudo provenance 仅作为 secondary debug refs，且所有新增 refs 已在 `codes.yaml` registry/schema 中声明。
- combo terminal 的 `refs.transition_span` 优先来自 `origin_ref.transition_span or t.span`；top-level diagnostic `span` 仍指具体 self-assign statement。
- quick-fix anchor 对 shared-source same-var combo terminal，以及 combo/plain same-source same-var 场景安全 suppress。
- entry combo 使用 `[*]` subject，保留 owner/debug refs，不给 initial quick-fix anchor。
- 普通 transition regression 在无 same public source duplicate 的场景下不变。
- 不出现 broad `except Exception` / silent swallow；新增 docstring / pydoc 如有公共 helper/API 需符合 CLAUDE.md reST 规范。
- 如修改 public Python API / docs，commit 前运行 `make rst_auto` 并 review 生成结果；若无 public API/doc 变更，也要明确记录本次 `make rst_auto` 结果或不产生差异。
- 本地默认验证使用 `SKIP_SLOW_TESTS=1 make unittest` 或更 focused 的 diagnostics tests；最终 PR CI 全绿。
- Codecov comment 无阻塞覆盖问题；若覆盖率下降，补测试拉回。
- 三路 final code review 无 C/I 级问题；M 级已处理或明确不阻塞。

## 上游同步 / conflict 纪律

- 开发前和 final review 前都要确认 base PR #306 分支已同步到本 PR；若 #306 有更新，merge/rebase 进本分支并处理 conflict。
- reviewer 需要检查 conflict 处理是否丢失 #306 / #304 的设计约束。
- 本 PR 完成后不 merge，等待人工下一步指示。

