### PR TITLE
查询语言：定义 .fbmcq 文件与查询数据模型

### DIFF
--- a/docs/source/api_doc/bmc/ast.rst
+++ b/docs/source/api_doc/bmc/ast.rst
@@ -6,18 +6,6 @@ pyfcstm.bmc.ast
 .. automodule:: pyfcstm.bmc.ast
 
 
-FrameSelector
------------------------------------------------------
-
-.. autodata:: FrameSelector
-
-
-CanonicalDict
------------------------------------------------------
-
-.. autodata:: CanonicalDict
-
-
 \_\_all\_\_
 -----------------------------------------------------
 

--- a/docs/source/api_doc/bmc/ast.rst
+++ b/docs/source/api_doc/bmc/ast.rst
@@ -1,0 +1,182 @@
+pyfcstm.bmc.ast
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.ast
+
+.. automodule:: pyfcstm.bmc.ast
+
+
+FrameSelector
+-----------------------------------------------------
+
+.. autodata:: FrameSelector
+
+
+CanonicalDict
+-----------------------------------------------------
+
+.. autodata:: CanonicalDict
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+BmcExpr
+-----------------------------------------------------
+
+.. autoclass:: BmcExpr
+    :members: to_canonical
+
+
+BmcNumExpr
+-----------------------------------------------------
+
+.. autoclass:: BmcNumExpr
+
+
+BmcCondExpr
+-----------------------------------------------------
+
+.. autoclass:: BmcCondExpr
+
+
+IntLiteral
+-----------------------------------------------------
+
+.. autoclass:: IntLiteral
+    :members: __post_init__,value,raw,kind
+
+
+FloatLiteral
+-----------------------------------------------------
+
+.. autoclass:: FloatLiteral
+    :members: __post_init__,value,raw
+
+
+BoolLiteral
+-----------------------------------------------------
+
+.. autoclass:: BoolLiteral
+    :members: __post_init__,value,raw
+
+
+NameRef
+-----------------------------------------------------
+
+.. autoclass:: NameRef
+    :members: __post_init__,name
+
+
+MathConst
+-----------------------------------------------------
+
+.. autoclass:: MathConst
+    :members: __post_init__,name
+
+
+NumUnaryOp
+-----------------------------------------------------
+
+.. autoclass:: NumUnaryOp
+    :members: __post_init__,op,operand
+
+
+NumBinaryOp
+-----------------------------------------------------
+
+.. autoclass:: NumBinaryOp
+    :members: __post_init__,left,op,right
+
+
+NumConditionalOp
+-----------------------------------------------------
+
+.. autoclass:: NumConditionalOp
+    :members: __post_init__,condition,if_true,if_false
+
+
+UFuncCall
+-----------------------------------------------------
+
+.. autoclass:: UFuncCall
+    :members: __post_init__,func,operand
+
+
+CondUnaryOp
+-----------------------------------------------------
+
+.. autoclass:: CondUnaryOp
+    :members: __post_init__,op,operand
+
+
+NumericComparison
+-----------------------------------------------------
+
+.. autoclass:: NumericComparison
+    :members: __post_init__,left,op,right
+
+
+CondBinaryOp
+-----------------------------------------------------
+
+.. autoclass:: CondBinaryOp
+    :members: __post_init__,left,op,right
+
+
+CondConditionalOp
+-----------------------------------------------------
+
+.. autoclass:: CondConditionalOp
+    :members: __post_init__,condition,if_true,if_false
+
+
+FrameVar
+-----------------------------------------------------
+
+.. autoclass:: FrameVar
+    :members: __post_init__,name,spelling
+
+
+Cycle
+-----------------------------------------------------
+
+.. autoclass:: Cycle
+
+
+Active
+-----------------------------------------------------
+
+.. autoclass:: Active
+    :members: __post_init__,state_path,frame
+
+
+Terminated
+-----------------------------------------------------
+
+.. autoclass:: Terminated
+    :members: __post_init__,frame
+
+
+Event
+-----------------------------------------------------
+
+.. autoclass:: Event
+    :members: __post_init__,event_path,selector
+
+
+Case
+-----------------------------------------------------
+
+.. autoclass:: Case
+    :members: __post_init__,label,frame
+
+
+Called
+-----------------------------------------------------
+
+.. autoclass:: Called
+    :members: __post_init__,name,frame

--- a/docs/source/api_doc/bmc/ast.rst
+++ b/docs/source/api_doc/bmc/ast.rst
@@ -28,7 +28,7 @@ BmcExpr
 -----------------------------------------------------
 
 .. autoclass:: BmcExpr
-    :members: to_canonical
+    :members: to_canonical,__str__
 
 
 BmcNumExpr

--- a/docs/source/api_doc/bmc/errors.rst
+++ b/docs/source/api_doc/bmc/errors.rst
@@ -1,0 +1,42 @@
+pyfcstm.bmc.errors
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.errors
+
+.. automodule:: pyfcstm.bmc.errors
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+BmcError
+-----------------------------------------------------
+
+.. autoclass:: BmcError
+
+
+InvalidBmcQuery
+-----------------------------------------------------
+
+.. autoclass:: InvalidBmcQuery
+
+
+UnsupportedBmcQuery
+-----------------------------------------------------
+
+.. autoclass:: UnsupportedBmcQuery
+
+
+InvalidBmcEncoding
+-----------------------------------------------------
+
+.. autoclass:: InvalidBmcEncoding
+
+
+BmcBuildError
+-----------------------------------------------------
+
+.. autoclass:: BmcBuildError

--- a/docs/source/api_doc/bmc/index.rst
+++ b/docs/source/api_doc/bmc/index.rst
@@ -1,0 +1,19 @@
+pyfcstm.bmc
+========================================================
+
+.. currentmodule:: pyfcstm.bmc
+
+.. automodule:: pyfcstm.bmc
+
+
+.. toctree::
+    :maxdepth: 3
+
+    ast
+    errors
+    query
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__

--- a/docs/source/api_doc/bmc/query.rst
+++ b/docs/source/api_doc/bmc/query.rst
@@ -1,0 +1,79 @@
+pyfcstm.bmc.query
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.query
+
+.. automodule:: pyfcstm.bmc.query
+
+
+CanonicalDict
+-----------------------------------------------------
+
+.. autodata:: CanonicalDict
+
+
+FrameSelector
+-----------------------------------------------------
+
+.. autodata:: FrameSelector
+
+
+QuerySelector
+-----------------------------------------------------
+
+.. autodata:: QuerySelector
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+InitialSpec
+-----------------------------------------------------
+
+.. autoclass:: InitialSpec
+    :members: __post_init__,to_canonical,mode,state_path,predicate
+
+
+BmcAssumption
+-----------------------------------------------------
+
+.. autoclass:: BmcAssumption
+    :members: to_canonical
+
+
+FrameAssumption
+-----------------------------------------------------
+
+.. autoclass:: FrameAssumption
+    :members: __post_init__,kind,predicate,frame
+
+
+EventAssumption
+-----------------------------------------------------
+
+.. autoclass:: EventAssumption
+    :members: __post_init__,event_path,selector,expected
+
+
+EventCardinalityAssumption
+-----------------------------------------------------
+
+.. autoclass:: EventCardinalityAssumption
+    :members: __post_init__,kind,event_paths
+
+
+BmcProperty
+-----------------------------------------------------
+
+.. autoclass:: BmcProperty
+    :members: __post_init__,to_canonical,kind,bound,predicate,trigger,response,within
+
+
+BmcQuery
+-----------------------------------------------------
+
+.. autoclass:: BmcQuery
+    :members: __post_init__,to_canonical,property,initial,assumptions

--- a/docs/source/api_doc/bmc/query.rst
+++ b/docs/source/api_doc/bmc/query.rst
@@ -6,18 +6,6 @@ pyfcstm.bmc.query
 .. automodule:: pyfcstm.bmc.query
 
 
-CanonicalDict
------------------------------------------------------
-
-.. autodata:: CanonicalDict
-
-
-QuerySelector
------------------------------------------------------
-
-.. autodata:: QuerySelector
-
-
 \_\_all\_\_
 -----------------------------------------------------
 

--- a/docs/source/api_doc/bmc/query.rst
+++ b/docs/source/api_doc/bmc/query.rst
@@ -12,12 +12,6 @@ CanonicalDict
 .. autodata:: CanonicalDict
 
 
-FrameSelector
------------------------------------------------------
-
-.. autodata:: FrameSelector
-
-
 QuerySelector
 -----------------------------------------------------
 

--- a/docs/source/api_doc/bmc/query.rst
+++ b/docs/source/api_doc/bmc/query.rst
@@ -28,14 +28,14 @@ InitialSpec
 -----------------------------------------------------
 
 .. autoclass:: InitialSpec
-    :members: __post_init__,to_canonical,mode,state_path,predicate
+    :members: __post_init__,to_canonical,__str__,mode,state_path,predicate
 
 
 BmcAssumption
 -----------------------------------------------------
 
 .. autoclass:: BmcAssumption
-    :members: to_canonical
+    :members: to_canonical,__str__
 
 
 FrameAssumption
@@ -63,11 +63,11 @@ BmcProperty
 -----------------------------------------------------
 
 .. autoclass:: BmcProperty
-    :members: __post_init__,to_canonical,kind,bound,predicate,trigger,response,within
+    :members: __post_init__,to_canonical,__str__,kind,bound,predicate,trigger,response,within
 
 
 BmcQuery
 -----------------------------------------------------
 
 .. autoclass:: BmcQuery
-    :members: __post_init__,to_canonical,property,initial,assumptions
+    :members: __post_init__,to_canonical,__str__,property,initial,assumptions

--- a/docs/source/api_doc/index.rst
+++ b/docs/source/api_doc/index.rst
@@ -9,6 +9,7 @@ pyfcstm
 .. toctree::
     :maxdepth: 3
 
+    bmc/index
     config/index
     diagnostics/index
     dsl/index

--- a/docs/source/api_doc_en.rst
+++ b/docs/source/api_doc_en.rst
@@ -6,6 +6,7 @@ API Documentation
     :caption: API Documentation
     :hidden:
 
+    api_doc/bmc/index
     api_doc/config/index
     api_doc/diagnostics/index
     api_doc/dsl/index
@@ -20,6 +21,7 @@ API Documentation
     api_doc/utils/index
     api_doc/verify/index
 
+* :doc:`api_doc/bmc/index`
 * :doc:`api_doc/config/index`
 * :doc:`api_doc/diagnostics/index`
 * :doc:`api_doc/dsl/index`

--- a/docs/source/api_doc_zh.rst
+++ b/docs/source/api_doc_zh.rst
@@ -6,6 +6,7 @@ API 文档
     :caption: API 文档
     :hidden:
 
+    api_doc/bmc/index
     api_doc/config/index
     api_doc/diagnostics/index
     api_doc/dsl/index
@@ -20,6 +21,7 @@ API 文档
     api_doc/utils/index
     api_doc/verify/index
 
+* :doc:`api_doc/bmc/index`
 * :doc:`api_doc/config/index`
 * :doc:`api_doc/diagnostics/index`
 * :doc:`api_doc/dsl/index`

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -1,12 +1,12 @@
 """Public API for FCSTM bounded model checking query models.
 
 The BMC package is an independent root package for the FCSTM bounded model
-checking workstream.  This first slice exposes only parser-independent query
-and expression dataclasses.  It deliberately does not implement grammar
-parsing, semantic binding, solver lowering, witness replay, or verify-registry
-integration.
+checking workstream.  It exposes parser-independent query and expression
+dataclasses while deliberately leaving grammar parsing, semantic binding,
+solver lowering, witness replay, and verify-registry integration to separate
+layers.
 
-Module roadmap:
+Public module structure:
 
 .. list-table::
    :header-rows: 1

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -1,0 +1,134 @@
+"""Public API for FCSTM bounded model checking query models.
+
+The BMC package is an independent root package for the FCSTM bounded model
+checking workstream.  This first slice exposes only parser-independent query
+and expression dataclasses.  It deliberately does not implement grammar
+parsing, semantic binding, solver lowering, witness replay, or verify-registry
+integration.
+
+Module roadmap:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Area
+     - Public entry
+     - Purpose
+   * - Error hierarchy
+     - :class:`BmcError`, :class:`InvalidBmcQuery`,
+       :class:`UnsupportedBmcQuery`, :class:`InvalidBmcEncoding`,
+       :class:`BmcBuildError`
+     - Provide stable BMC-specific exception types without importing
+       ``pyfcstm.verify``.
+   * - Typed expression bases
+     - :class:`BmcExpr`, :class:`BmcNumExpr`, :class:`BmcCondExpr`
+     - Keep FCSTM numeric and condition expression categories explicit.
+   * - FCSTM-compatible numeric expressions
+     - :class:`IntLiteral`, :class:`FloatLiteral`, :class:`NameRef`,
+       :class:`MathConst`, :class:`NumUnaryOp`, :class:`NumBinaryOp`,
+       :class:`NumConditionalOp`, :class:`UFuncCall`
+     - Represent the current FCSTM ``num_expression`` shape.
+   * - FCSTM-compatible condition expressions
+     - :class:`BoolLiteral`, :class:`CondUnaryOp`,
+       :class:`NumericComparison`, :class:`CondBinaryOp`,
+       :class:`CondConditionalOp`
+     - Represent the current FCSTM ``cond_expression`` shape.
+   * - BMC-only query atoms
+     - :class:`FrameVar`, :class:`Cycle`, :class:`Active`,
+       :class:`Terminated`, :class:`Event`, :class:`Case`, :class:`Called`
+     - Represent frame variables, cycle counters, active state, selected event,
+       selected macro-step case, termination, and future abstract-call atoms.
+   * - Query root model
+     - :class:`InitialSpec`, :class:`FrameAssumption`,
+       :class:`EventAssumption`, :class:`EventCardinalityAssumption`,
+       :class:`BmcProperty`, :class:`BmcQuery`
+     - Capture top-level ``*.fbmcq`` query structure before parser, binder, or
+       solver-specific phases.
+
+Example::
+
+    >>> from pyfcstm.bmc import Active, BmcProperty, BmcQuery
+    >>> query = BmcQuery(property=BmcProperty("reach", 2, predicate=Active("Root.Done")))
+    >>> query.to_canonical()["property"]["kind"]
+    'reach'
+"""
+
+from pyfcstm.bmc.ast import (
+    Active,
+    BmcCondExpr,
+    BmcExpr,
+    BmcNumExpr,
+    BoolLiteral,
+    Called,
+    Case,
+    CondBinaryOp,
+    CondConditionalOp,
+    CondUnaryOp,
+    Cycle,
+    Event,
+    FloatLiteral,
+    FrameVar,
+    IntLiteral,
+    MathConst,
+    NameRef,
+    NumBinaryOp,
+    NumConditionalOp,
+    NumUnaryOp,
+    NumericComparison,
+    Terminated,
+    UFuncCall,
+)
+from pyfcstm.bmc.errors import (
+    BmcBuildError,
+    BmcError,
+    InvalidBmcEncoding,
+    InvalidBmcQuery,
+    UnsupportedBmcQuery,
+)
+from pyfcstm.bmc.query import (
+    BmcAssumption,
+    BmcProperty,
+    BmcQuery,
+    EventAssumption,
+    EventCardinalityAssumption,
+    FrameAssumption,
+    InitialSpec,
+)
+
+__all__ = [
+    "BmcError",
+    "InvalidBmcQuery",
+    "UnsupportedBmcQuery",
+    "InvalidBmcEncoding",
+    "BmcBuildError",
+    "BmcExpr",
+    "BmcNumExpr",
+    "BmcCondExpr",
+    "IntLiteral",
+    "FloatLiteral",
+    "BoolLiteral",
+    "NameRef",
+    "MathConst",
+    "NumUnaryOp",
+    "NumBinaryOp",
+    "NumConditionalOp",
+    "UFuncCall",
+    "CondUnaryOp",
+    "NumericComparison",
+    "CondBinaryOp",
+    "CondConditionalOp",
+    "FrameVar",
+    "Cycle",
+    "Active",
+    "Terminated",
+    "Event",
+    "Case",
+    "Called",
+    "InitialSpec",
+    "BmcAssumption",
+    "FrameAssumption",
+    "EventAssumption",
+    "EventCardinalityAssumption",
+    "BmcProperty",
+    "BmcQuery",
+]

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -6,6 +6,15 @@ dataclasses while deliberately leaving grammar parsing, semantic binding,
 solver lowering, witness replay, and verify-registry integration to separate
 layers.
 
+Package contracts:
+
+* BMC query objects are parser-independent and data-only in this package.
+* The root package must not depend on ``pyfcstm.verify`` or its registry.
+* :func:`str` on exported query and expression dataclasses is reserved for the
+  canonical ``.fbmcq`` query DSL spelling.
+* :func:`repr` remains the dataclass debugging representation; callers that need
+  stable machine comparison should use ``to_canonical()``.
+
 Public module structure:
 
 .. list-table::

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -18,12 +18,13 @@ Design contracts:
   not be rewritten into DSL text.
 * Numeric and condition expression categories stay separate at construction
   time, matching FCSTM ``num_expression`` and ``cond_expression``.
-* Expression-level structural checks intentionally use normal Python
+* FCSTM-compatible expression checks intentionally use normal Python
   ``ValueError`` / ``TypeError`` failures for malformed literals, operators,
-  and operand categories.  Query-level wrappers in :mod:`pyfcstm.bmc.query`
-  raise :class:`pyfcstm.bmc.errors.InvalidBmcQuery` for whole-query shape
-  validation, so parser and binder code should not assume one exception family
-  covers both layers.
+  and operand categories.  Query-facing BMC atom fields such as quoted paths,
+  frames, selectors, and atom spellings raise
+  :class:`pyfcstm.bmc.errors.InvalidBmcQuery`, matching the top-level query
+  wrappers in :mod:`pyfcstm.bmc.query`.  Parser and binder code should not
+  assume one exception family covers both layers.
 * Literal canonical values are kept JSON-portable.  Float literals that would
   overflow Python's finite ``float`` range are rejected at construction time,
   while raw text still preserves exact spelling for parity checks.
@@ -136,6 +137,7 @@ _FBMCQ_RESERVED_NAMES = {
     "cover",
     "trigger",
     "within",
+    "where",
     "current",
     "var",
     "cycle",
@@ -297,6 +299,11 @@ def _require_non_empty_string(value: object, field_name: str) -> None:
         raise ValueError(f"{field_name} must be a non-empty string.")
 
 
+def _require_non_empty_query_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise InvalidBmcQuery(f"{field_name} must be a non-empty string.")
+
+
 def _normalize_frame(
     frame: _FrameSelector, field_name: str = "frame"
 ) -> _FrameSelector:
@@ -400,6 +407,11 @@ class IntLiteral(BmcNumExpr):
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.raw, "raw")
+        if self.raw.startswith("0X"):
+            raise ValueError(
+                "Invalid FCSTM hexadecimal integer literal: uppercase '0X' "
+                f"prefix is not supported; use lowercase '0x': {self.raw!r}."
+            )
         inferred_kind = "hex" if self.raw.startswith("0x") else "decimal"
         if self.kind is None:
             kind = inferred_kind
@@ -528,7 +540,7 @@ class BoolLiteral(BmcCondExpr):
         return {"kind": "bool", "raw": self.raw, "value": self.value}
 
     def _to_dsl(self) -> str:
-        return self.raw
+        return "true" if self.value else "false"
 
 
 @dataclass(frozen=True)
@@ -928,8 +940,11 @@ class FrameVar(BmcNumExpr):
     spelling: str = "var_call"
 
     def __post_init__(self) -> None:
-        _require_non_empty_string(self.name, "name")
-        _validate_choice(self.spelling, {"var_call"}, "frame variable spelling")
+        _require_non_empty_query_string(self.name, "name")
+        if not isinstance(self.spelling, str) or self.spelling != "var_call":
+            raise InvalidBmcQuery(
+                f"Unsupported frame variable spelling: {self.spelling!r}."
+            )
 
     def _canonical_payload(self) -> _CanonicalDict:
         return {"name": self.name, "spelling": self.spelling}
@@ -978,7 +993,7 @@ class Active(BmcCondExpr):
     frame: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
-        _require_non_empty_string(self.state_path, "state_path")
+        _require_non_empty_query_string(self.state_path, "state_path")
         object.__setattr__(self, "frame", _normalize_frame(self.frame))
 
     def _canonical_payload(self) -> _CanonicalDict:
@@ -1046,7 +1061,7 @@ class Event(BmcCondExpr):
     selector: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
-        _require_non_empty_string(self.event_path, "event_path")
+        _require_non_empty_query_string(self.event_path, "event_path")
         object.__setattr__(
             self, "selector", _normalize_frame(self.selector, "selector")
         )
@@ -1081,7 +1096,7 @@ class Case(BmcCondExpr):
     frame: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
-        _require_non_empty_string(self.label, "label")
+        _require_non_empty_query_string(self.label, "label")
         object.__setattr__(self, "frame", _normalize_frame(self.frame))
 
     def _canonical_payload(self) -> _CanonicalDict:
@@ -1114,7 +1129,7 @@ class Called(BmcCondExpr):
     frame: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
-        _require_non_empty_string(self.name, "name")
+        _require_non_empty_query_string(self.name, "name")
         object.__setattr__(self, "frame", _normalize_frame(self.frame))
 
     def _canonical_payload(self) -> _CanonicalDict:

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -18,6 +18,15 @@ Design contracts:
   not be rewritten into DSL text.
 * Numeric and condition expression categories stay separate at construction
   time, matching FCSTM ``num_expression`` and ``cond_expression``.
+* Expression-level structural checks intentionally use normal Python
+  ``ValueError`` / ``TypeError`` failures for malformed literals, operators,
+  and operand categories.  Query-level wrappers in :mod:`pyfcstm.bmc.query`
+  raise :class:`pyfcstm.bmc.errors.InvalidBmcQuery` for whole-query shape
+  validation, so parser and binder code should not assume one exception family
+  covers both layers.
+* The event atom always prints its cycle selector explicitly, including
+  ``current``.  This keeps event queries visually distinct from frame-based
+  atoms such as ``active("Root.A")`` whose default frame may be omitted.
 
 The module contains:
 
@@ -42,6 +51,7 @@ from __future__ import annotations
 
 import json
 import re
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Union
 
@@ -169,7 +179,7 @@ _UFUNC_NAMES = {
 }
 
 
-class BmcExpr:
+class BmcExpr(ABC):
     """Base class for every BMC query expression node.
 
     Concrete subclasses provide a stable canonical form for tests, parser
@@ -222,9 +232,11 @@ class BmcExpr:
         """
         return self._to_dsl()
 
+    @abstractmethod
     def _canonical_payload(self) -> _CanonicalDict:
         raise NotImplementedError  # pragma: no cover
 
+    @abstractmethod
     def _to_dsl(self) -> str:
         raise NotImplementedError  # pragma: no cover
 
@@ -988,6 +1000,11 @@ class Terminated(BmcCondExpr):
 class Event(BmcCondExpr):
     """Boolean atom stating that an event is selected for a query cycle.
 
+    Event atoms always render their selector argument explicitly, even for the
+    default ``"current"`` selector.  The explicit spelling keeps event-cycle
+    selection separate from the optional frame shorthand used by state and case
+    atoms.
+
     :param event_path: Fully qualified or query-local event path string.
     :type event_path: str
     :param selector: Concrete cycle index or ``"current"``, defaults to
@@ -996,6 +1013,8 @@ class Event(BmcCondExpr):
 
     Example::
 
+        >>> str(Event("Root.Idle.Start"))
+        'event("Root.Idle.Start", current)'
         >>> Event("Root.Idle.Start", selector=0).to_canonical()["event_path"]
         'Root.Idle.Start'
     """

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -428,11 +428,11 @@ class IntLiteral(BmcNumExpr):
                 )
             kind = self.kind
         if kind == "hex":
-            if not _HEX_INT_RE.match(self.raw):
+            if not _HEX_INT_RE.fullmatch(self.raw):
                 raise ValueError(
                     f"Invalid FCSTM hexadecimal integer literal: {self.raw!r}."
                 )
-        elif not _DECIMAL_INT_RE.match(self.raw):
+        elif not _DECIMAL_INT_RE.fullmatch(self.raw):
             raise ValueError(f"Invalid FCSTM decimal integer literal: {self.raw!r}.")
         object.__setattr__(self, "kind", kind)
 
@@ -476,7 +476,7 @@ class FloatLiteral(BmcNumExpr):
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.raw, "raw")
-        if not _FLOAT_RE.match(self.raw):
+        if not _FLOAT_RE.fullmatch(self.raw):
             raise ValueError(f"Invalid FCSTM floating-point literal: {self.raw!r}.")
         if not math.isfinite(float(self.raw)):
             raise ValueError(
@@ -575,7 +575,7 @@ class NameRef(BmcNumExpr):
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.name, "name")
-        if not _ID_RE.match(self.name):
+        if not _ID_RE.fullmatch(self.name):
             raise ValueError(f"Invalid FCSTM identifier: {self.name!r}.")
         if self.name in _BARE_NAME_RESERVED or self.name in _UFUNC_NAMES:
             raise ValueError(f"Reserved bare expression name: {self.name!r}.")

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -193,7 +193,7 @@ class BmcExpr(ABC):
 
     Concrete subclasses provide a stable canonical form for tests, parser
     handoff, and later binder diagnostics.  The canonical form contains only
-    plain dictionaries, tuples, strings, booleans, integers, floats, and
+    plain dictionaries, lists, strings, booleans, integers, floats, and
     ``None`` so it can be serialized or compared without importing grammar
     classes.
 

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -33,6 +33,8 @@ import re
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Union
 
+from pyfcstm.bmc.errors import InvalidBmcQuery
+
 try:
     from typing import Literal
 except ImportError:  # pragma: no cover - Python < 3.8 compatibility
@@ -246,13 +248,17 @@ def _require_non_empty_string(value: object, field_name: str) -> None:
         raise ValueError(f"{field_name} must be a non-empty string.")
 
 
-def _normalize_frame(frame: FrameSelector) -> FrameSelector:
+def _normalize_frame(frame: FrameSelector, field_name: str = "frame") -> FrameSelector:
     if frame == "current":
         return frame
     if isinstance(frame, bool) or not isinstance(frame, int):
-        raise ValueError("frame must be a non-negative integer or 'current'.")
+        raise InvalidBmcQuery(
+            f"{field_name} must be a non-negative integer or 'current'."
+        )
     if frame < 0:
-        raise ValueError("frame must be a non-negative integer or 'current'.")
+        raise InvalidBmcQuery(
+            f"{field_name} must be a non-negative integer or 'current'."
+        )
     return frame
 
 
@@ -833,7 +839,9 @@ class Event(BmcCondExpr):
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.event_path, "event_path")
-        object.__setattr__(self, "selector", _normalize_frame(self.selector))
+        object.__setattr__(
+            self, "selector", _normalize_frame(self.selector, "selector")
+        )
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"event_path": self.event_path, "selector": self.selector}

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -52,8 +52,8 @@ try:
 except ImportError:  # pragma: no cover - Python < 3.8 compatibility
     from typing_extensions import Literal
 
-FrameSelector = Union[int, Literal["current"]]
-CanonicalDict = Dict[str, Any]
+_FrameSelector = Union[int, Literal["current"]]
+_CanonicalDict = Dict[str, Any]
 
 _DECIMAL_INT_RE = re.compile(r"^[0-9]+$")
 _HEX_INT_RE = re.compile(r"^0x[0-9a-fA-F]+$")
@@ -191,7 +191,7 @@ class BmcExpr:
 
     _node_name: ClassVar[str] = "expr"
 
-    def to_canonical(self) -> CanonicalDict:
+    def to_canonical(self) -> _CanonicalDict:
         """Return a language-neutral canonical expression shape.
 
         :return: Canonical dictionary for this node.
@@ -222,7 +222,7 @@ class BmcExpr:
         """
         return self._to_dsl()
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         raise NotImplementedError  # pragma: no cover
 
     def _to_dsl(self) -> str:
@@ -259,7 +259,7 @@ class BmcCondExpr(BmcExpr):
     """
 
 
-def _canonical_expr(expr: BmcExpr) -> CanonicalDict:
+def _canonical_expr(expr: BmcExpr) -> _CanonicalDict:
     return expr.to_canonical()
 
 
@@ -269,7 +269,7 @@ def _require_instance(value: object, expected_type: type, field_name: str) -> No
 
 
 def _validate_choice(value: str, choices: set, field_name: str) -> None:
-    if value not in choices:
+    if not isinstance(value, str) or value not in choices:
         raise ValueError(f"Unsupported {field_name}: {value!r}.")
 
 
@@ -278,7 +278,9 @@ def _require_non_empty_string(value: object, field_name: str) -> None:
         raise ValueError(f"{field_name} must be a non-empty string.")
 
 
-def _normalize_frame(frame: FrameSelector, field_name: str = "frame") -> FrameSelector:
+def _normalize_frame(
+    frame: _FrameSelector, field_name: str = "frame"
+) -> _FrameSelector:
     if frame == "current":
         return frame
     if isinstance(frame, bool) or not isinstance(frame, int):
@@ -296,7 +298,7 @@ def _quote_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-def _frame_to_dsl(frame: FrameSelector) -> str:
+def _frame_to_dsl(frame: _FrameSelector) -> str:
     return "current" if frame == "current" else str(frame)
 
 
@@ -304,13 +306,15 @@ def _call_args_to_dsl(*args: str) -> str:
     return ", ".join(args)
 
 
-def _optional_frame_call_to_dsl(name: str, first_arg: str, frame: FrameSelector) -> str:
+def _optional_frame_call_to_dsl(
+    name: str, first_arg: str, frame: _FrameSelector
+) -> str:
     if frame == "current":
         return "%s(%s)" % (name, first_arg)
     return "%s(%s)" % (name, _call_args_to_dsl(first_arg, _frame_to_dsl(frame)))
 
 
-def _optional_unit_frame_call_to_dsl(name: str, frame: FrameSelector) -> str:
+def _optional_unit_frame_call_to_dsl(name: str, frame: _FrameSelector) -> str:
     if frame == "current":
         return "%s()" % name
     return "%s(%s)" % (name, _frame_to_dsl(frame))
@@ -401,7 +405,7 @@ class IntLiteral(BmcNumExpr):
         """
         return int(self.raw, 16 if self.kind == "hex" else 10)
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"kind": self.kind, "raw": self.raw, "value": self.value}
 
     def _to_dsl(self) -> str:
@@ -444,7 +448,7 @@ class FloatLiteral(BmcNumExpr):
         """
         return float(self.raw)
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"kind": "float", "raw": self.raw, "value": self.value}
 
     def _to_dsl(self) -> str:
@@ -487,7 +491,7 @@ class BoolLiteral(BmcCondExpr):
         """
         return self.raw.lower() == "true"
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"kind": "bool", "raw": self.raw, "value": self.value}
 
     def _to_dsl(self) -> str:
@@ -518,7 +522,7 @@ class NameRef(BmcNumExpr):
         if self.name in _BARE_NAME_RESERVED or self.name in _UFUNC_NAMES:
             raise ValueError(f"Reserved bare expression name: {self.name!r}.")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"name": self.name}
 
     def _to_dsl(self) -> str:
@@ -545,7 +549,7 @@ class MathConst(BmcNumExpr):
     def __post_init__(self) -> None:
         _validate_choice(self.name, _MATH_CONSTANTS, "math constant")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"name": self.name}
 
     def _to_dsl(self) -> str:
@@ -576,7 +580,7 @@ class NumUnaryOp(BmcNumExpr):
         _validate_choice(self.op, _NUM_UNARY_OPS, "numeric unary operator")
         _require_instance(self.operand, BmcNumExpr, "operand")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"op": self.op, "operand": _canonical_expr(self.operand)}
 
     def _to_dsl(self) -> str:
@@ -611,7 +615,7 @@ class NumBinaryOp(BmcNumExpr):
         _require_instance(self.right, BmcNumExpr, "right")
         _validate_choice(self.op, _NUM_BINARY_OPS, "numeric binary operator")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {
             "op": self.op,
             "left": _canonical_expr(self.left),
@@ -654,7 +658,7 @@ class NumConditionalOp(BmcNumExpr):
         _require_instance(self.if_true, BmcNumExpr, "if_true")
         _require_instance(self.if_false, BmcNumExpr, "if_false")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {
             "condition": _canonical_expr(self.condition),
             "if_true": _canonical_expr(self.if_true),
@@ -693,7 +697,7 @@ class UFuncCall(BmcNumExpr):
         _validate_choice(self.func, _UFUNC_NAMES, "ufunc")
         _require_instance(self.operand, BmcNumExpr, "operand")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"func": self.func, "operand": _canonical_expr(self.operand)}
 
     def _to_dsl(self) -> str:
@@ -726,7 +730,7 @@ class CondUnaryOp(BmcCondExpr):
         _require_instance(self.operand, BmcCondExpr, "operand")
         object.__setattr__(self, "op", op)
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"op": self.op, "operand": _canonical_expr(self.operand)}
 
     def _to_dsl(self) -> str:
@@ -761,7 +765,7 @@ class NumericComparison(BmcCondExpr):
         _require_instance(self.right, BmcNumExpr, "right")
         _validate_choice(self.op, _NUM_COMPARISON_OPS, "numeric comparison operator")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {
             "op": self.op,
             "left": _canonical_expr(self.left),
@@ -806,7 +810,7 @@ class CondBinaryOp(BmcCondExpr):
         _validate_choice(op, _COND_BINARY_OPS, "condition binary operator")
         object.__setattr__(self, "op", op)
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {
             "op": self.op,
             "left": _canonical_expr(self.left),
@@ -849,7 +853,7 @@ class CondConditionalOp(BmcCondExpr):
         _require_instance(self.if_true, BmcCondExpr, "if_true")
         _require_instance(self.if_false, BmcCondExpr, "if_false")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {
             "condition": _canonical_expr(self.condition),
             "if_true": _canonical_expr(self.if_true),
@@ -894,7 +898,7 @@ class FrameVar(BmcNumExpr):
         _require_non_empty_string(self.name, "name")
         _validate_choice(self.spelling, {"var_call"}, "frame variable spelling")
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"name": self.name, "spelling": self.spelling}
 
     def _to_dsl(self) -> str:
@@ -913,7 +917,7 @@ class Cycle(BmcNumExpr):
 
     _node_name: ClassVar[str] = "cycle"
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {}
 
     def _to_dsl(self) -> str:
@@ -938,13 +942,13 @@ class Active(BmcCondExpr):
     _node_name: ClassVar[str] = "active"
 
     state_path: str
-    frame: FrameSelector = "current"
+    frame: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.state_path, "state_path")
         object.__setattr__(self, "frame", _normalize_frame(self.frame))
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"state_path": self.state_path, "frame": self.frame}
 
     def _to_dsl(self) -> str:
@@ -968,12 +972,12 @@ class Terminated(BmcCondExpr):
 
     _node_name: ClassVar[str] = "terminated"
 
-    frame: FrameSelector = "current"
+    frame: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "frame", _normalize_frame(self.frame))
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"frame": self.frame}
 
     def _to_dsl(self) -> str:
@@ -999,7 +1003,7 @@ class Event(BmcCondExpr):
     _node_name: ClassVar[str] = "event"
 
     event_path: str
-    selector: FrameSelector = "current"
+    selector: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.event_path, "event_path")
@@ -1007,7 +1011,7 @@ class Event(BmcCondExpr):
             self, "selector", _normalize_frame(self.selector, "selector")
         )
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"event_path": self.event_path, "selector": self.selector}
 
     def _to_dsl(self) -> str:
@@ -1034,13 +1038,13 @@ class Case(BmcCondExpr):
     _node_name: ClassVar[str] = "case"
 
     label: str
-    frame: FrameSelector = "current"
+    frame: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.label, "label")
         object.__setattr__(self, "frame", _normalize_frame(self.frame))
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"label": self.label, "frame": self.frame}
 
     def _to_dsl(self) -> str:
@@ -1067,13 +1071,13 @@ class Called(BmcCondExpr):
     _node_name: ClassVar[str] = "called"
 
     name: str
-    frame: FrameSelector = "current"
+    frame: _FrameSelector = "current"
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.name, "name")
         object.__setattr__(self, "frame", _normalize_frame(self.frame))
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"name": self.name, "frame": self.frame}
 
     def _to_dsl(self) -> str:

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -8,6 +8,17 @@ are frozen dataclasses and expose :meth:`BmcExpr.to_canonical` so later parser
 parity tests can compare FCSTM and FBMCQ expressions through a stable,
 language-neutral shape.
 
+Design contracts:
+
+* Expression nodes are data-only; they do not bind names, inspect models, or
+  lower anything to Z3.
+* :func:`str` on every concrete expression returns canonical ``.fbmcq`` DSL
+  text.  This is the object-to-text half of the query round-trip contract.
+* :func:`repr` stays the dataclass-generated debugging representation and must
+  not be rewritten into DSL text.
+* Numeric and condition expression categories stay separate at construction
+  time, matching FCSTM ``num_expression`` and ``cond_expression``.
+
 The module contains:
 
 * :class:`BmcNumExpr` and :class:`BmcCondExpr` - Typed numeric and condition
@@ -29,6 +40,7 @@ Example::
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from typing import Any, ClassVar, Dict, Union
@@ -195,7 +207,25 @@ class BmcExpr:
         result.update(self._canonical_payload())
         return result
 
+    def __str__(self) -> str:
+        """Return the canonical ``.fbmcq`` DSL spelling for this expression.
+
+        :return: Query DSL text that can be parsed back into this expression
+            shape.
+        :rtype: str
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import IntLiteral
+            >>> str(IntLiteral("7"))
+            '7'
+        """
+        return self._to_dsl()
+
     def _canonical_payload(self) -> CanonicalDict:
+        raise NotImplementedError  # pragma: no cover
+
+    def _to_dsl(self) -> str:
         raise NotImplementedError  # pragma: no cover
 
 
@@ -262,6 +292,67 @@ def _normalize_frame(frame: FrameSelector, field_name: str = "frame") -> FrameSe
     return frame
 
 
+def _quote_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _frame_to_dsl(frame: FrameSelector) -> str:
+    return "current" if frame == "current" else str(frame)
+
+
+def _call_args_to_dsl(*args: str) -> str:
+    return ", ".join(args)
+
+
+def _optional_frame_call_to_dsl(name: str, first_arg: str, frame: FrameSelector) -> str:
+    if frame == "current":
+        return "%s(%s)" % (name, first_arg)
+    return "%s(%s)" % (name, _call_args_to_dsl(first_arg, _frame_to_dsl(frame)))
+
+
+def _optional_unit_frame_call_to_dsl(name: str, frame: FrameSelector) -> str:
+    if frame == "current":
+        return "%s()" % name
+    return "%s(%s)" % (name, _frame_to_dsl(frame))
+
+
+def _grouped(text: str) -> str:
+    return "(%s)" % text
+
+
+def _num_operand_to_dsl(expr: BmcNumExpr) -> str:
+    if isinstance(
+        expr,
+        (IntLiteral, FloatLiteral, NameRef, MathConst, UFuncCall, FrameVar, Cycle),
+    ):
+        return str(expr)
+    return _grouped(str(expr))
+
+
+def _cond_operand_to_dsl(expr: BmcCondExpr) -> str:
+    if isinstance(
+        expr,
+        (
+            BoolLiteral,
+            NumericComparison,
+            CondUnaryOp,
+            Active,
+            Terminated,
+            Event,
+            Case,
+            Called,
+        ),
+    ):
+        return str(expr)
+    return _grouped(str(expr))
+
+
+def _cond_unary_operand_to_dsl(expr: BmcCondExpr) -> str:
+    if isinstance(expr, (BoolLiteral, Active, Terminated, Event, Case, Called)):
+        return str(expr)
+    return _grouped(str(expr))
+
+
 @dataclass(frozen=True)
 class IntLiteral(BmcNumExpr):
     """Integer literal preserving raw token, numeric value, and literal kind.
@@ -313,6 +404,9 @@ class IntLiteral(BmcNumExpr):
     def _canonical_payload(self) -> CanonicalDict:
         return {"kind": self.kind, "raw": self.raw, "value": self.value}
 
+    def _to_dsl(self) -> str:
+        return self.raw
+
 
 @dataclass(frozen=True)
 class FloatLiteral(BmcNumExpr):
@@ -352,6 +446,9 @@ class FloatLiteral(BmcNumExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"kind": "float", "raw": self.raw, "value": self.value}
+
+    def _to_dsl(self) -> str:
+        return self.raw
 
 
 @dataclass(frozen=True)
@@ -393,6 +490,9 @@ class BoolLiteral(BmcCondExpr):
     def _canonical_payload(self) -> CanonicalDict:
         return {"kind": "bool", "raw": self.raw, "value": self.value}
 
+    def _to_dsl(self) -> str:
+        return self.raw
+
 
 @dataclass(frozen=True)
 class NameRef(BmcNumExpr):
@@ -421,6 +521,9 @@ class NameRef(BmcNumExpr):
     def _canonical_payload(self) -> CanonicalDict:
         return {"name": self.name}
 
+    def _to_dsl(self) -> str:
+        return self.name
+
 
 @dataclass(frozen=True)
 class MathConst(BmcNumExpr):
@@ -444,6 +547,9 @@ class MathConst(BmcNumExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"name": self.name}
+
+    def _to_dsl(self) -> str:
+        return self.name
 
 
 @dataclass(frozen=True)
@@ -472,6 +578,9 @@ class NumUnaryOp(BmcNumExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"op": self.op, "operand": _canonical_expr(self.operand)}
+
+    def _to_dsl(self) -> str:
+        return "%s%s" % (self.op, _num_operand_to_dsl(self.operand))
 
 
 @dataclass(frozen=True)
@@ -509,6 +618,13 @@ class NumBinaryOp(BmcNumExpr):
             "right": _canonical_expr(self.right),
         }
 
+    def _to_dsl(self) -> str:
+        return "%s %s %s" % (
+            _num_operand_to_dsl(self.left),
+            self.op,
+            _num_operand_to_dsl(self.right),
+        )
+
 
 @dataclass(frozen=True)
 class NumConditionalOp(BmcNumExpr):
@@ -545,6 +661,13 @@ class NumConditionalOp(BmcNumExpr):
             "if_false": _canonical_expr(self.if_false),
         }
 
+    def _to_dsl(self) -> str:
+        return "(%s) ? %s : %s" % (
+            self.condition,
+            _num_operand_to_dsl(self.if_true),
+            _num_operand_to_dsl(self.if_false),
+        )
+
 
 @dataclass(frozen=True)
 class UFuncCall(BmcNumExpr):
@@ -572,6 +695,9 @@ class UFuncCall(BmcNumExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"func": self.func, "operand": _canonical_expr(self.operand)}
+
+    def _to_dsl(self) -> str:
+        return "%s(%s)" % (self.func, self.operand)
 
 
 @dataclass(frozen=True)
@@ -602,6 +728,9 @@ class CondUnaryOp(BmcCondExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"op": self.op, "operand": _canonical_expr(self.operand)}
+
+    def _to_dsl(self) -> str:
+        return "%s%s" % (self.op, _cond_unary_operand_to_dsl(self.operand))
 
 
 @dataclass(frozen=True)
@@ -638,6 +767,13 @@ class NumericComparison(BmcCondExpr):
             "left": _canonical_expr(self.left),
             "right": _canonical_expr(self.right),
         }
+
+    def _to_dsl(self) -> str:
+        return "%s %s %s" % (
+            _num_operand_to_dsl(self.left),
+            self.op,
+            _num_operand_to_dsl(self.right),
+        )
 
 
 @dataclass(frozen=True)
@@ -677,6 +813,13 @@ class CondBinaryOp(BmcCondExpr):
             "right": _canonical_expr(self.right),
         }
 
+    def _to_dsl(self) -> str:
+        return "%s %s %s" % (
+            _cond_operand_to_dsl(self.left),
+            self.op,
+            _cond_operand_to_dsl(self.right),
+        )
+
 
 @dataclass(frozen=True)
 class CondConditionalOp(BmcCondExpr):
@@ -713,6 +856,13 @@ class CondConditionalOp(BmcCondExpr):
             "if_false": _canonical_expr(self.if_false),
         }
 
+    def _to_dsl(self) -> str:
+        return "(%s) ? %s : %s" % (
+            self.condition,
+            _cond_operand_to_dsl(self.if_true),
+            _cond_operand_to_dsl(self.if_false),
+        )
+
 
 @dataclass(frozen=True)
 class FrameVar(BmcNumExpr):
@@ -747,6 +897,9 @@ class FrameVar(BmcNumExpr):
     def _canonical_payload(self) -> CanonicalDict:
         return {"name": self.name, "spelling": self.spelling}
 
+    def _to_dsl(self) -> str:
+        return "var(%s)" % _quote_string(self.name)
+
 
 @dataclass(frozen=True)
 class Cycle(BmcNumExpr):
@@ -762,6 +915,9 @@ class Cycle(BmcNumExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {}
+
+    def _to_dsl(self) -> str:
+        return "cycle"
 
 
 @dataclass(frozen=True)
@@ -791,6 +947,11 @@ class Active(BmcCondExpr):
     def _canonical_payload(self) -> CanonicalDict:
         return {"state_path": self.state_path, "frame": self.frame}
 
+    def _to_dsl(self) -> str:
+        return _optional_frame_call_to_dsl(
+            "active", _quote_string(self.state_path), self.frame
+        )
+
 
 @dataclass(frozen=True)
 class Terminated(BmcCondExpr):
@@ -814,6 +975,9 @@ class Terminated(BmcCondExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"frame": self.frame}
+
+    def _to_dsl(self) -> str:
+        return _optional_unit_frame_call_to_dsl("terminated", self.frame)
 
 
 @dataclass(frozen=True)
@@ -846,6 +1010,11 @@ class Event(BmcCondExpr):
     def _canonical_payload(self) -> CanonicalDict:
         return {"event_path": self.event_path, "selector": self.selector}
 
+    def _to_dsl(self) -> str:
+        return "event(%s)" % _call_args_to_dsl(
+            _quote_string(self.event_path), _frame_to_dsl(self.selector)
+        )
+
 
 @dataclass(frozen=True)
 class Case(BmcCondExpr):
@@ -874,6 +1043,11 @@ class Case(BmcCondExpr):
     def _canonical_payload(self) -> CanonicalDict:
         return {"label": self.label, "frame": self.frame}
 
+    def _to_dsl(self) -> str:
+        return _optional_frame_call_to_dsl(
+            "case", _quote_string(self.label), self.frame
+        )
+
 
 @dataclass(frozen=True)
 class Called(BmcCondExpr):
@@ -901,6 +1075,11 @@ class Called(BmcCondExpr):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"name": self.name, "frame": self.frame}
+
+    def _to_dsl(self) -> str:
+        return _optional_frame_call_to_dsl(
+            "called", _quote_string(self.name), self.frame
+        )
 
 
 __all__ = [

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -1,0 +1,930 @@
+"""Typed expression data model for FCSTM BMC queries.
+
+This module defines the parser-independent expression objects used by
+``*.fbmcq`` queries.  The core expression nodes intentionally mirror the
+current FCSTM numeric and condition expression split, while BMC-only nodes add
+frame, cycle, active-state, event, case, and abstract-call atoms.  The objects
+are frozen dataclasses and expose :meth:`BmcExpr.to_canonical` so later parser
+parity tests can compare FCSTM and FBMCQ expressions through a stable,
+language-neutral shape.
+
+The module contains:
+
+* :class:`BmcNumExpr` and :class:`BmcCondExpr` - Typed numeric and condition
+  expression bases.
+* FCSTM-compatible nodes such as :class:`IntLiteral`, :class:`NameRef`,
+  :class:`NumBinaryOp`, :class:`NumericComparison`, and :class:`CondBinaryOp`.
+* BMC-only extension nodes such as :class:`FrameVar`, :class:`Cycle`,
+  :class:`Active`, :class:`Event`, :class:`Case`, and :class:`Called`.
+
+Example::
+
+    >>> from pyfcstm.bmc.ast import Active, IntLiteral, NameRef, NumericComparison
+    >>> expr = NumericComparison(NameRef("x"), "<=", IntLiteral("3"))
+    >>> expr.to_canonical()["op"]
+    '<='
+    >>> isinstance(Active("Root.Idle"), BmcCondExpr)
+    True
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, ClassVar, Dict, Union
+
+try:
+    from typing import Literal
+except ImportError:  # pragma: no cover - Python < 3.8 compatibility
+    from typing_extensions import Literal
+
+FrameSelector = Union[int, Literal["current"]]
+CanonicalDict = Dict[str, Any]
+
+_DECIMAL_INT_RE = re.compile(r"^[0-9]+$")
+_HEX_INT_RE = re.compile(r"^0x[0-9a-fA-F]+$")
+_FLOAT_RE = re.compile(
+    r"^(?:[0-9]+\.[0-9]*|\.[0-9]+)(?:[eE][+-]?[0-9]+)?$"
+    r"|^[0-9]+[eE][+-]?[0-9]+$"
+)
+_ID_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_FCSTM_RESERVED_NAMES = {
+    "import",
+    "def",
+    "event",
+    "as",
+    "named",
+    "pseudo",
+    "state",
+    "enter",
+    "exit",
+    "during",
+    "before",
+    "after",
+    "abstract",
+    "ref",
+    "effect",
+    "if",
+    "else",
+    "int",
+    "float",
+    "pi",
+    "E",
+    "tau",
+    "and",
+    "or",
+    "not",
+    "xor",
+    "implies",
+    "iff",
+    "True",
+    "true",
+    "TRUE",
+    "False",
+    "false",
+    "FALSE",
+}
+_FBMCQ_RESERVED_NAMES = {
+    "init",
+    "cold",
+    "terminated",
+    "assume",
+    "always",
+    "at",
+    "events",
+    "cardinality",
+    "any",
+    "at_most_one",
+    "check",
+    "reach",
+    "forbid",
+    "invariant",
+    "must_reach",
+    "exists_always",
+    "response",
+    "cover",
+    "trigger",
+    "within",
+    "current",
+    "var",
+    "cycle",
+    "active",
+    "case",
+    "called",
+}
+_BARE_NAME_RESERVED = _FCSTM_RESERVED_NAMES | _FBMCQ_RESERVED_NAMES
+
+_NUM_UNARY_OPS = {"+", "-"}
+_NUM_BINARY_OPS = {"**", "*", "/", "%", "+", "-", "<<", ">>", "&", "^", "|"}
+_NUM_COMPARISON_OPS = {"<", ">", "<=", ">=", "==", "!="}
+_COND_UNARY_ALIASES = {"not": "!"}
+_COND_UNARY_OPS = {"!"}
+_COND_BINARY_ALIASES = {
+    "and": "&&",
+    "or": "||",
+    "implies": "=>",
+}
+_COND_BINARY_OPS = {"==", "!=", "iff", "&&", "xor", "||", "=>"}
+_MATH_CONSTANTS = {"pi", "E", "tau"}
+_UFUNC_NAMES = {
+    "sin",
+    "cos",
+    "tan",
+    "asin",
+    "acos",
+    "atan",
+    "sinh",
+    "cosh",
+    "tanh",
+    "asinh",
+    "acosh",
+    "atanh",
+    "sqrt",
+    "cbrt",
+    "exp",
+    "log",
+    "log10",
+    "log2",
+    "log1p",
+    "abs",
+    "ceil",
+    "floor",
+    "round",
+    "trunc",
+    "sign",
+}
+
+
+class BmcExpr:
+    """Base class for every BMC query expression node.
+
+    Concrete subclasses provide a stable canonical form for tests, parser
+    handoff, and later binder diagnostics.  The canonical form contains only
+    plain dictionaries, tuples, strings, booleans, integers, floats, and
+    ``None`` so it can be serialized or compared without importing grammar
+    classes.
+
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import IntLiteral
+        >>> IntLiteral("7").to_canonical()["node"]
+        'int_literal'
+    """
+
+    _node_name: ClassVar[str] = "expr"
+
+    def to_canonical(self) -> CanonicalDict:
+        """Return a language-neutral canonical expression shape.
+
+        :return: Canonical dictionary for this node.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import BoolLiteral
+            >>> BoolLiteral("true").to_canonical()["value"]
+            True
+        """
+        result = {"node": self._node_name}
+        result.update(self._canonical_payload())
+        return result
+
+    def _canonical_payload(self) -> CanonicalDict:
+        raise NotImplementedError  # pragma: no cover
+
+
+class BmcNumExpr(BmcExpr):
+    """Base class for numeric BMC expressions.
+
+    Numeric expressions follow FCSTM ``num_expression`` shape and represent
+    integer, float, variable, frame-variable, cycle, and arithmetic operator
+    values.
+
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import BmcNumExpr, Cycle
+        >>> isinstance(Cycle(), BmcNumExpr)
+        True
+    """
+
+
+class BmcCondExpr(BmcExpr):
+    """Base class for condition BMC expressions.
+
+    Condition expressions follow FCSTM ``cond_expression`` shape and represent
+    boolean literals, comparisons, logical operators, active-state atoms, event
+    atoms, selected-case atoms, and abstract-call atoms.
+
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import Active, BmcCondExpr
+        >>> isinstance(Active("Root.A"), BmcCondExpr)
+        True
+    """
+
+
+def _canonical_expr(expr: BmcExpr) -> CanonicalDict:
+    return expr.to_canonical()
+
+
+def _require_instance(value: object, expected_type: type, field_name: str) -> None:
+    if not isinstance(value, expected_type):
+        raise TypeError(f"{field_name} must be {expected_type.__name__}.")
+
+
+def _validate_choice(value: str, choices: set, field_name: str) -> None:
+    if value not in choices:
+        raise ValueError(f"Unsupported {field_name}: {value!r}.")
+
+
+def _require_non_empty_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{field_name} must be a non-empty string.")
+
+
+def _normalize_frame(frame: FrameSelector) -> FrameSelector:
+    if frame == "current":
+        return frame
+    if isinstance(frame, bool) or not isinstance(frame, int):
+        raise ValueError("frame must be a non-negative integer or 'current'.")
+    if frame < 0:
+        raise ValueError("frame must be a non-negative integer or 'current'.")
+    return frame
+
+
+@dataclass(frozen=True)
+class IntLiteral(BmcNumExpr):
+    """Integer literal preserving raw token, numeric value, and literal kind.
+
+    :param raw: Raw integer token text such as ``"42"`` or ``"0x2A"``.
+    :type raw: str
+    :param kind: Literal kind, either ``"decimal"`` or ``"hex"``. If the raw
+        value starts with ``0x``, the kind is normalized to ``"hex"``.
+    :type kind: str, optional
+
+    Example::
+
+        >>> IntLiteral("0x2A").to_canonical()["kind"]
+        'hex'
+    """
+
+    _node_name: ClassVar[str] = "int_literal"
+
+    raw: str
+    kind: str = "decimal"
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.raw, "raw")
+        kind = "hex" if self.raw.startswith("0x") else self.kind
+        _validate_choice(kind, {"decimal", "hex"}, "integer literal kind")
+        if kind == "hex":
+            if not _HEX_INT_RE.match(self.raw):
+                raise ValueError(
+                    f"Invalid FCSTM hexadecimal integer literal: {self.raw!r}."
+                )
+        elif not _DECIMAL_INT_RE.match(self.raw):
+            raise ValueError(f"Invalid FCSTM decimal integer literal: {self.raw!r}.")
+        object.__setattr__(self, "kind", kind)
+
+    @property
+    def value(self) -> int:
+        """Return the integer value represented by ``raw``.
+
+        :return: Parsed integer value.
+        :rtype: int
+
+        Example::
+
+            >>> IntLiteral("0x10").value
+            16
+        """
+        return int(self.raw, 16 if self.kind == "hex" else 10)
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"kind": self.kind, "raw": self.raw, "value": self.value}
+
+
+@dataclass(frozen=True)
+class FloatLiteral(BmcNumExpr):
+    """Floating-point literal preserving the raw token text.
+
+    :param raw: Raw floating-point token text.
+    :type raw: str
+
+    Example::
+
+        >>> FloatLiteral("1e2").to_canonical()["value"]
+        100.0
+    """
+
+    _node_name: ClassVar[str] = "float_literal"
+
+    raw: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.raw, "raw")
+        if not _FLOAT_RE.match(self.raw):
+            raise ValueError(f"Invalid FCSTM floating-point literal: {self.raw!r}.")
+
+    @property
+    def value(self) -> float:
+        """Return the floating-point value represented by ``raw``.
+
+        :return: Parsed float value.
+        :rtype: float
+
+        Example::
+
+            >>> FloatLiteral("3.5").value
+            3.5
+        """
+        return float(self.raw)
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"kind": "float", "raw": self.raw, "value": self.value}
+
+
+@dataclass(frozen=True)
+class BoolLiteral(BmcCondExpr):
+    """Boolean literal preserving raw spelling and normalized value.
+
+    :param raw: Raw boolean token text such as ``"true"`` or ``"FALSE"``.
+    :type raw: str
+
+    Example::
+
+        >>> BoolLiteral("FALSE").to_canonical()["value"]
+        False
+    """
+
+    _node_name: ClassVar[str] = "bool_literal"
+
+    raw: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.raw, "raw")
+        if self.raw not in {"true", "True", "TRUE", "false", "False", "FALSE"}:
+            raise ValueError(f"Unsupported FCSTM boolean literal: {self.raw!r}.")
+
+    @property
+    def value(self) -> bool:
+        """Return the boolean value represented by ``raw``.
+
+        :return: Parsed boolean value.
+        :rtype: bool
+
+        Example::
+
+            >>> BoolLiteral("True").value
+            True
+        """
+        return self.raw.lower() == "true"
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"kind": "bool", "raw": self.raw, "value": self.value}
+
+
+@dataclass(frozen=True)
+class NameRef(BmcNumExpr):
+    """Bare FCSTM variable reference used as a numeric expression.
+
+    :param name: Variable name from the query expression.
+    :type name: str
+
+    Example::
+
+        >>> NameRef("counter").to_canonical()
+        {'node': 'name', 'name': 'counter'}
+    """
+
+    _node_name: ClassVar[str] = "name"
+
+    name: str
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.name, "name")
+        if not _ID_RE.match(self.name):
+            raise ValueError(f"Invalid FCSTM identifier: {self.name!r}.")
+        if self.name in _BARE_NAME_RESERVED or self.name in _UFUNC_NAMES:
+            raise ValueError(f"Reserved bare expression name: {self.name!r}.")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"name": self.name}
+
+
+@dataclass(frozen=True)
+class MathConst(BmcNumExpr):
+    """FCSTM mathematical constant expression.
+
+    :param name: Constant name, one of ``"pi"``, ``"E"``, or ``"tau"``.
+    :type name: str
+
+    Example::
+
+        >>> MathConst("pi").to_canonical()["name"]
+        'pi'
+    """
+
+    _node_name: ClassVar[str] = "math_const"
+
+    name: str
+
+    def __post_init__(self) -> None:
+        _validate_choice(self.name, _MATH_CONSTANTS, "math constant")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"name": self.name}
+
+
+@dataclass(frozen=True)
+class NumUnaryOp(BmcNumExpr):
+    """Numeric unary operator expression.
+
+    :param op: Unary operator, either ``"+"`` or ``"-"``.
+    :type op: str
+    :param operand: Numeric operand.
+    :type operand: BmcNumExpr
+
+    Example::
+
+        >>> NumUnaryOp("-", NameRef("x")).to_canonical()["op"]
+        '-'
+    """
+
+    _node_name: ClassVar[str] = "num_unary"
+
+    op: str
+    operand: BmcNumExpr
+
+    def __post_init__(self) -> None:
+        _validate_choice(self.op, _NUM_UNARY_OPS, "numeric unary operator")
+        _require_instance(self.operand, BmcNumExpr, "operand")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"op": self.op, "operand": _canonical_expr(self.operand)}
+
+
+@dataclass(frozen=True)
+class NumBinaryOp(BmcNumExpr):
+    """Numeric binary operator expression.
+
+    :param left: Left numeric operand.
+    :type left: BmcNumExpr
+    :param op: Numeric operator following FCSTM grammar spelling.
+    :type op: str
+    :param right: Right numeric operand.
+    :type right: BmcNumExpr
+
+    Example::
+
+        >>> NumBinaryOp(NameRef("x"), "+", IntLiteral("1")).to_canonical()["op"]
+        '+'
+    """
+
+    _node_name: ClassVar[str] = "num_binary"
+
+    left: BmcNumExpr
+    op: str
+    right: BmcNumExpr
+
+    def __post_init__(self) -> None:
+        _require_instance(self.left, BmcNumExpr, "left")
+        _require_instance(self.right, BmcNumExpr, "right")
+        _validate_choice(self.op, _NUM_BINARY_OPS, "numeric binary operator")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {
+            "op": self.op,
+            "left": _canonical_expr(self.left),
+            "right": _canonical_expr(self.right),
+        }
+
+
+@dataclass(frozen=True)
+class NumConditionalOp(BmcNumExpr):
+    """Numeric conditional expression with a condition selector.
+
+    :param condition: Condition deciding which branch is selected.
+    :type condition: BmcCondExpr
+    :param if_true: Numeric expression used when ``condition`` is true.
+    :type if_true: BmcNumExpr
+    :param if_false: Numeric expression used when ``condition`` is false.
+    :type if_false: BmcNumExpr
+
+    Example::
+
+        >>> NumConditionalOp(BoolLiteral("true"), IntLiteral("1"), IntLiteral("0")).to_canonical()["node"]
+        'num_conditional'
+    """
+
+    _node_name: ClassVar[str] = "num_conditional"
+
+    condition: BmcCondExpr
+    if_true: BmcNumExpr
+    if_false: BmcNumExpr
+
+    def __post_init__(self) -> None:
+        _require_instance(self.condition, BmcCondExpr, "condition")
+        _require_instance(self.if_true, BmcNumExpr, "if_true")
+        _require_instance(self.if_false, BmcNumExpr, "if_false")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {
+            "condition": _canonical_expr(self.condition),
+            "if_true": _canonical_expr(self.if_true),
+            "if_false": _canonical_expr(self.if_false),
+        }
+
+
+@dataclass(frozen=True)
+class UFuncCall(BmcNumExpr):
+    """FCSTM unary math function call.
+
+    :param func: Function name from FCSTM ``UFUNC_NAME``.
+    :type func: str
+    :param operand: Numeric function argument.
+    :type operand: BmcNumExpr
+
+    Example::
+
+        >>> UFuncCall("sqrt", NameRef("x")).to_canonical()["func"]
+        'sqrt'
+    """
+
+    _node_name: ClassVar[str] = "ufunc"
+
+    func: str
+    operand: BmcNumExpr
+
+    def __post_init__(self) -> None:
+        _validate_choice(self.func, _UFUNC_NAMES, "ufunc")
+        _require_instance(self.operand, BmcNumExpr, "operand")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"func": self.func, "operand": _canonical_expr(self.operand)}
+
+
+@dataclass(frozen=True)
+class CondUnaryOp(BmcCondExpr):
+    """Condition unary operator expression.
+
+    :param op: Unary condition operator, ``"!"`` or alias ``"not"``.
+    :type op: str
+    :param operand: Condition operand.
+    :type operand: BmcCondExpr
+
+    Example::
+
+        >>> CondUnaryOp("not", BoolLiteral("true")).to_canonical()["op"]
+        '!'
+    """
+
+    _node_name: ClassVar[str] = "cond_unary"
+
+    op: str
+    operand: BmcCondExpr
+
+    def __post_init__(self) -> None:
+        op = _COND_UNARY_ALIASES.get(self.op, self.op)
+        _validate_choice(op, _COND_UNARY_OPS, "condition unary operator")
+        _require_instance(self.operand, BmcCondExpr, "operand")
+        object.__setattr__(self, "op", op)
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"op": self.op, "operand": _canonical_expr(self.operand)}
+
+
+@dataclass(frozen=True)
+class NumericComparison(BmcCondExpr):
+    """Comparison between two numeric expressions.
+
+    :param left: Left numeric operand.
+    :type left: BmcNumExpr
+    :param op: Comparison operator.
+    :type op: str
+    :param right: Right numeric operand.
+    :type right: BmcNumExpr
+
+    Example::
+
+        >>> NumericComparison(NameRef("x"), "<", IntLiteral("2")).to_canonical()["op"]
+        '<'
+    """
+
+    _node_name: ClassVar[str] = "numeric_comparison"
+
+    left: BmcNumExpr
+    op: str
+    right: BmcNumExpr
+
+    def __post_init__(self) -> None:
+        _require_instance(self.left, BmcNumExpr, "left")
+        _require_instance(self.right, BmcNumExpr, "right")
+        _validate_choice(self.op, _NUM_COMPARISON_OPS, "numeric comparison operator")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {
+            "op": self.op,
+            "left": _canonical_expr(self.left),
+            "right": _canonical_expr(self.right),
+        }
+
+
+@dataclass(frozen=True)
+class CondBinaryOp(BmcCondExpr):
+    """Condition binary operator expression.
+
+    :param left: Left condition operand.
+    :type left: BmcCondExpr
+    :param op: Condition operator or FCSTM alias.
+    :type op: str
+    :param right: Right condition operand.
+    :type right: BmcCondExpr
+
+    Example::
+
+        >>> CondBinaryOp(BoolLiteral("true"), "and", BoolLiteral("false")).to_canonical()["op"]
+        '&&'
+    """
+
+    _node_name: ClassVar[str] = "cond_binary"
+
+    left: BmcCondExpr
+    op: str
+    right: BmcCondExpr
+
+    def __post_init__(self) -> None:
+        op = _COND_BINARY_ALIASES.get(self.op, self.op)
+        _require_instance(self.left, BmcCondExpr, "left")
+        _require_instance(self.right, BmcCondExpr, "right")
+        _validate_choice(op, _COND_BINARY_OPS, "condition binary operator")
+        object.__setattr__(self, "op", op)
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {
+            "op": self.op,
+            "left": _canonical_expr(self.left),
+            "right": _canonical_expr(self.right),
+        }
+
+
+@dataclass(frozen=True)
+class CondConditionalOp(BmcCondExpr):
+    """Condition conditional expression.
+
+    :param condition: Condition deciding which branch is selected.
+    :type condition: BmcCondExpr
+    :param if_true: Condition expression used when ``condition`` is true.
+    :type if_true: BmcCondExpr
+    :param if_false: Condition expression used when ``condition`` is false.
+    :type if_false: BmcCondExpr
+
+    Example::
+
+        >>> CondConditionalOp(BoolLiteral("true"), BoolLiteral("true"), BoolLiteral("false")).to_canonical()["node"]
+        'cond_conditional'
+    """
+
+    _node_name: ClassVar[str] = "cond_conditional"
+
+    condition: BmcCondExpr
+    if_true: BmcCondExpr
+    if_false: BmcCondExpr
+
+    def __post_init__(self) -> None:
+        _require_instance(self.condition, BmcCondExpr, "condition")
+        _require_instance(self.if_true, BmcCondExpr, "if_true")
+        _require_instance(self.if_false, BmcCondExpr, "if_false")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {
+            "condition": _canonical_expr(self.condition),
+            "if_true": _canonical_expr(self.if_true),
+            "if_false": _canonical_expr(self.if_false),
+        }
+
+
+@dataclass(frozen=True)
+class FrameVar(BmcNumExpr):
+    """Numeric reference produced by the query-level ``var("...")`` atom.
+
+    The query AST is frame-relative rather than solver-frame-indexed.  Later
+    binder and lowering phases decide which concrete frame a ``var("x")``
+    expression reads from.  The spelling field distinguishes this explicit
+    query atom from a bare :class:`NameRef` that still follows FCSTM ``ID``
+    lexical rules.
+
+    :param name: Persistent variable name carried by ``var("...")``.
+    :type name: str
+    :param spelling: Query spelling family, defaults to ``"var_call"``.
+    :type spelling: str, optional
+
+    Example::
+
+        >>> FrameVar("x").to_canonical()["spelling"]
+        'var_call'
+    """
+
+    _node_name: ClassVar[str] = "frame_var"
+
+    name: str
+    spelling: str = "var_call"
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.name, "name")
+        _validate_choice(self.spelling, {"var_call"}, "frame variable spelling")
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"name": self.name, "spelling": self.spelling}
+
+
+@dataclass(frozen=True)
+class Cycle(BmcNumExpr):
+    """Built-in numeric cycle expression for query predicates.
+
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> Cycle().to_canonical()
+        {'node': 'cycle'}
+    """
+
+    _node_name: ClassVar[str] = "cycle"
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {}
+
+
+@dataclass(frozen=True)
+class Active(BmcCondExpr):
+    """Boolean atom stating that a state is active at a frame.
+
+    :param state_path: Fully qualified or query-local state path string.
+    :type state_path: str
+    :param frame: Frame index or ``"current"``, defaults to ``"current"``.
+    :type frame: int or str, optional
+
+    Example::
+
+        >>> Active("Root.Idle").to_canonical()["frame"]
+        'current'
+    """
+
+    _node_name: ClassVar[str] = "active"
+
+    state_path: str
+    frame: FrameSelector = "current"
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.state_path, "state_path")
+        object.__setattr__(self, "frame", _normalize_frame(self.frame))
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"state_path": self.state_path, "frame": self.frame}
+
+
+@dataclass(frozen=True)
+class Terminated(BmcCondExpr):
+    """Boolean atom stating that execution is terminated at a frame.
+
+    :param frame: Frame index or ``"current"``, defaults to ``"current"``.
+    :type frame: int or str, optional
+
+    Example::
+
+        >>> Terminated().to_canonical()["node"]
+        'terminated'
+    """
+
+    _node_name: ClassVar[str] = "terminated"
+
+    frame: FrameSelector = "current"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "frame", _normalize_frame(self.frame))
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"frame": self.frame}
+
+
+@dataclass(frozen=True)
+class Event(BmcCondExpr):
+    """Boolean atom stating that an event is selected for a query cycle.
+
+    :param event_path: Fully qualified or query-local event path string.
+    :type event_path: str
+    :param selector: Concrete cycle index or ``"current"``, defaults to
+        ``"current"``.
+    :type selector: int or str, optional
+
+    Example::
+
+        >>> Event("Root.Idle.Start", selector=0).to_canonical()["event_path"]
+        'Root.Idle.Start'
+    """
+
+    _node_name: ClassVar[str] = "event"
+
+    event_path: str
+    selector: FrameSelector = "current"
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.event_path, "event_path")
+        object.__setattr__(self, "selector", _normalize_frame(self.selector))
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"event_path": self.event_path, "selector": self.selector}
+
+
+@dataclass(frozen=True)
+class Case(BmcCondExpr):
+    """Boolean atom stating that a macro-step case is selected at a frame.
+
+    :param label: Canonical macro-step case label.
+    :type label: str
+    :param frame: Frame index or ``"current"``, defaults to ``"current"``.
+    :type frame: int or str, optional
+
+    Example::
+
+        >>> Case("Root.A::fallback::Root.A::0", frame=1).to_canonical()["frame"]
+        1
+    """
+
+    _node_name: ClassVar[str] = "case"
+
+    label: str
+    frame: FrameSelector = "current"
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.label, "label")
+        object.__setattr__(self, "frame", _normalize_frame(self.frame))
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"label": self.label, "frame": self.frame}
+
+
+@dataclass(frozen=True)
+class Called(BmcCondExpr):
+    """Boolean atom for future abstract-call tracking.
+
+    :param name: Abstract action or hook name.
+    :type name: str
+    :param frame: Frame index or ``"current"``, defaults to ``"current"``.
+    :type frame: int or str, optional
+
+    Example::
+
+        >>> Called("Check", frame=2).to_canonical()["name"]
+        'Check'
+    """
+
+    _node_name: ClassVar[str] = "called"
+
+    name: str
+    frame: FrameSelector = "current"
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.name, "name")
+        object.__setattr__(self, "frame", _normalize_frame(self.frame))
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"name": self.name, "frame": self.frame}
+
+
+__all__ = [
+    "BmcExpr",
+    "BmcNumExpr",
+    "BmcCondExpr",
+    "IntLiteral",
+    "FloatLiteral",
+    "BoolLiteral",
+    "NameRef",
+    "MathConst",
+    "NumUnaryOp",
+    "NumBinaryOp",
+    "NumConditionalOp",
+    "UFuncCall",
+    "CondUnaryOp",
+    "NumericComparison",
+    "CondBinaryOp",
+    "CondConditionalOp",
+    "FrameVar",
+    "Cycle",
+    "Active",
+    "Terminated",
+    "Event",
+    "Case",
+    "Called",
+]

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -24,6 +24,12 @@ Design contracts:
   raise :class:`pyfcstm.bmc.errors.InvalidBmcQuery` for whole-query shape
   validation, so parser and binder code should not assume one exception family
   covers both layers.
+* Literal canonical values are kept JSON-portable.  Float literals that would
+  overflow Python's finite ``float`` range are rejected at construction time,
+  while raw text still preserves exact spelling for parity checks.
+* Identifier and path shape validation is shallow here: quoted query atoms only
+  require non-empty strings, and later binder layers resolve model paths and
+  reject impossible state, event, variable, case, or call names.
 * The event atom always prints its cycle selector explicitly, including
   ``current``.  This keeps event queries visually distinct from frame-based
   atoms such as ``active("Root.A")`` whose default frame may be omitted.
@@ -50,10 +56,11 @@ Example::
 from __future__ import annotations
 
 import json
+import math
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, ClassVar, Dict, Union
+from typing import Any, ClassVar, Dict, Optional, Union
 
 from pyfcstm.bmc.errors import InvalidBmcQuery
 
@@ -375,8 +382,9 @@ class IntLiteral(BmcNumExpr):
 
     :param raw: Raw integer token text such as ``"42"`` or ``"0x2A"``.
     :type raw: str
-    :param kind: Literal kind, either ``"decimal"`` or ``"hex"``. If the raw
-        value starts with ``0x``, the kind is normalized to ``"hex"``.
+    :param kind: Literal kind, either ``"decimal"`` or ``"hex"``. When omitted,
+        the kind is inferred from ``raw``.  Explicit kind values must match the
+        raw spelling.
     :type kind: str, optional
 
     Example::
@@ -388,12 +396,21 @@ class IntLiteral(BmcNumExpr):
     _node_name: ClassVar[str] = "int_literal"
 
     raw: str
-    kind: str = "decimal"
+    kind: Optional[str] = None
 
     def __post_init__(self) -> None:
         _require_non_empty_string(self.raw, "raw")
-        kind = "hex" if self.raw.startswith("0x") else self.kind
-        _validate_choice(kind, {"decimal", "hex"}, "integer literal kind")
+        inferred_kind = "hex" if self.raw.startswith("0x") else "decimal"
+        if self.kind is None:
+            kind = inferred_kind
+        else:
+            _validate_choice(self.kind, {"decimal", "hex"}, "integer literal kind")
+            if self.kind != inferred_kind:
+                raise ValueError(
+                    "Integer literal kind does not match raw spelling: "
+                    f"{self.raw!r} is {inferred_kind}, got {self.kind!r}."
+                )
+            kind = self.kind
         if kind == "hex":
             if not _HEX_INT_RE.match(self.raw):
                 raise ValueError(
@@ -445,6 +462,10 @@ class FloatLiteral(BmcNumExpr):
         _require_non_empty_string(self.raw, "raw")
         if not _FLOAT_RE.match(self.raw):
             raise ValueError(f"Invalid FCSTM floating-point literal: {self.raw!r}.")
+        if not math.isfinite(float(self.raw)):
+            raise ValueError(
+                f"FCSTM floating-point literal must be finite: {self.raw!r}."
+            )
 
     @property
     def value(self) -> float:

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -164,8 +164,9 @@ class BmcExpr:
     ``None`` so it can be serialized or compared without importing grammar
     classes.
 
-    :return: ``None``.
-    :rtype: None
+    :cvar _node_name: Canonical node tag emitted by
+        :meth:`BmcExpr.to_canonical`.
+    :type _node_name: str
 
     Example::
 
@@ -203,9 +204,6 @@ class BmcNumExpr(BmcExpr):
     integer, float, variable, frame-variable, cycle, and arithmetic operator
     values.
 
-    :return: ``None``.
-    :rtype: None
-
     Example::
 
         >>> from pyfcstm.bmc.ast import BmcNumExpr, Cycle
@@ -220,9 +218,6 @@ class BmcCondExpr(BmcExpr):
     Condition expressions follow FCSTM ``cond_expression`` shape and represent
     boolean literals, comparisons, logical operators, active-state atoms, event
     atoms, selected-case atoms, and abstract-call atoms.
-
-    :return: ``None``.
-    :rtype: None
 
     Example::
 
@@ -750,9 +745,6 @@ class FrameVar(BmcNumExpr):
 @dataclass(frozen=True)
 class Cycle(BmcNumExpr):
     """Built-in numeric cycle expression for query predicates.
-
-    :return: ``None``.
-    :rtype: None
 
     Example::
 

--- a/pyfcstm/bmc/ast.py
+++ b/pyfcstm/bmc/ast.py
@@ -26,8 +26,11 @@ Design contracts:
   wrappers in :mod:`pyfcstm.bmc.query`.  Parser and binder code should not
   assume one exception family covers both layers.
 * Literal canonical values are kept JSON-portable.  Float literals that would
-  overflow Python's finite ``float`` range are rejected at construction time,
-  while raw text still preserves exact spelling for parity checks.
+  overflow Python's finite ``float`` range are rejected at construction time.
+  Finite Python floats, including subnormal values and underflow-to-zero raw
+  spellings, are accepted because they match the current FCSTM literal
+  conversion boundary; raw text still preserves exact spelling for parity
+  checks and later encoding layers may impose stricter numeric policies.
 * Identifier and path shape validation is shallow here: quoted query atoms only
   require non-empty strings, and later binder layers resolve model paths and
   reject impossible state, event, variable, case, or call names.
@@ -229,8 +232,9 @@ class BmcExpr(ABC):
     def __str__(self) -> str:
         """Return the canonical ``.fbmcq`` DSL spelling for this expression.
 
-        :return: Query DSL text that can be parsed back into this expression
-            shape.
+        :return: Query DSL text that can be parsed back into the same canonical
+            semantic expression shape.  Operator aliases and literal spelling
+            such as boolean casing may be normalized by this canonical text.
         :rtype: str
 
         Example::
@@ -504,6 +508,10 @@ class FloatLiteral(BmcNumExpr):
 class BoolLiteral(BmcCondExpr):
     """Boolean literal preserving raw spelling and normalized value.
 
+    Canonical DSL output uses lowercase ``true`` / ``false`` even when ``raw``
+    records title-case or uppercase parser input.  The exact input spelling
+    remains available through :meth:`to_canonical`.
+
     :param raw: Raw boolean token text such as ``"true"`` or ``"FALSE"``.
     :type raw: str
 
@@ -546,6 +554,11 @@ class BoolLiteral(BmcCondExpr):
 @dataclass(frozen=True)
 class NameRef(BmcNumExpr):
     """Bare FCSTM variable reference used as a numeric expression.
+
+    Names that are reserved by FCSTM or FBMCQ syntax are rejected in bare form.
+    A model variable whose name collides with a FBMCQ query atom, such as
+    ``"cycle"`` or ``"event"``, should be represented through
+    :class:`FrameVar` and rendered as ``var("...")`` instead.
 
     :param name: Variable name from the query expression.
     :type name: str
@@ -921,7 +934,10 @@ class FrameVar(BmcNumExpr):
     binder and lowering phases decide which concrete frame a ``var("x")``
     expression reads from.  The spelling field distinguishes this explicit
     query atom from a bare :class:`NameRef` that still follows FCSTM ``ID``
-    lexical rules.
+    lexical rules.  The current data model accepts only the explicit
+    ``var("...")`` spelling family; the field is preserved in the canonical
+    form so parser tests can assert that bare names and frame-variable calls do
+    not collapse together.
 
     :param name: Persistent variable name carried by ``var("...")``.
     :type name: str
@@ -956,6 +972,11 @@ class FrameVar(BmcNumExpr):
 @dataclass(frozen=True)
 class Cycle(BmcNumExpr):
     """Built-in numeric cycle expression for query predicates.
+
+    ``cycle`` is a reserved bare numeric atom, not a function call.  This keeps
+    it close to FCSTM mathematical constants such as ``pi`` while BMC predicates
+    that require quoted model paths keep function-call spellings such as
+    ``active("Root.A")`` and ``event("Root.E", current)``.
 
     Example::
 

--- a/pyfcstm/bmc/errors.py
+++ b/pyfcstm/bmc/errors.py
@@ -1,0 +1,104 @@
+"""Exception hierarchy for FCSTM bounded model checking queries.
+
+The BMC package keeps query, encoding, and construction failures separate from
+parser, solver, and verification-registry concerns.  These exceptions are plain
+Python errors with stable names so later parser, binder, engine, and adapter
+layers can raise structured failures without importing ``pyfcstm.verify``.
+
+The module contains:
+
+* :class:`BmcError` - Base class for all BMC-specific errors.
+* :class:`InvalidBmcQuery` - Query model or semantic-query validation error.
+* :class:`UnsupportedBmcQuery` - Well-formed query that this implementation
+  deliberately does not support yet.
+* :class:`InvalidBmcEncoding` - Invalid symbolic encoding construction error.
+* :class:`BmcBuildError` - General BMC build or preparation error.
+
+Example::
+
+    >>> from pyfcstm.bmc.errors import BmcError, InvalidBmcQuery
+    >>> try:
+    ...     raise InvalidBmcQuery("bad bound")
+    ... except BmcError as err:
+    ...     str(err)
+    'bad bound'
+"""
+
+
+class BmcError(Exception):
+    """Base class for FCSTM BMC failures.
+
+    :param message: Human-readable error message.
+    :type message: str
+
+    Example::
+
+        >>> err = BmcError("query failed")
+        >>> str(err)
+        'query failed'
+    """
+
+
+class InvalidBmcQuery(BmcError):
+    """Raised when a BMC query model is structurally invalid.
+
+    :param message: Human-readable validation message.
+    :type message: str
+
+    Example::
+
+        >>> err = InvalidBmcQuery("mode must be cold")
+        >>> isinstance(err, BmcError)
+        True
+    """
+
+
+class UnsupportedBmcQuery(BmcError):
+    """Raised when a valid BMC query requests unsupported behavior.
+
+    :param message: Human-readable unsupported-feature message.
+    :type message: str
+
+    Example::
+
+        >>> err = UnsupportedBmcQuery("called() is not lowered yet")
+        >>> isinstance(err, BmcError)
+        True
+    """
+
+
+class InvalidBmcEncoding(BmcError):
+    """Raised when symbolic BMC encoding data is internally inconsistent.
+
+    :param message: Human-readable encoding message.
+    :type message: str
+
+    Example::
+
+        >>> err = InvalidBmcEncoding("missing frame")
+        >>> isinstance(err, BmcError)
+        True
+    """
+
+
+class BmcBuildError(BmcError):
+    """Raised when BMC preparation cannot build a usable context.
+
+    :param message: Human-readable build message.
+    :type message: str
+
+    Example::
+
+        >>> err = BmcBuildError("model binding failed")
+        >>> isinstance(err, BmcError)
+        True
+    """
+
+
+__all__ = [
+    "BmcError",
+    "InvalidBmcQuery",
+    "UnsupportedBmcQuery",
+    "InvalidBmcEncoding",
+    "BmcBuildError",
+]

--- a/pyfcstm/bmc/errors.py
+++ b/pyfcstm/bmc/errors.py
@@ -5,6 +5,14 @@ parser, solver, and verification-registry concerns.  These exceptions are plain
 Python errors with stable names so later parser, binder, engine, and adapter
 layers can raise structured failures without importing ``pyfcstm.verify``.
 
+Design contracts:
+
+* Error classes are intentionally thin and stable so parser, binder, engine, and
+  adapter layers can share them without coupling to each other.
+* Query data-model validation uses these BMC-specific exceptions for structural
+  failures, while expression category mix-ups still use normal Python type
+  errors where that is more precise.
+
 The module contains:
 
 * :class:`BmcError` - Base class for all BMC-specific errors.

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -50,8 +50,8 @@ except ImportError:  # pragma: no cover - Python < 3.8 compatibility
 from pyfcstm.bmc.ast import BmcCondExpr
 from pyfcstm.bmc.errors import InvalidBmcQuery
 
-CanonicalDict = Dict[str, Any]
-QuerySelector = Union[int, Literal["*"], str]
+_CanonicalDict = Dict[str, Any]
+_QuerySelector = Union[int, Literal["*"], str]
 
 _INITIAL_MODES = {"cold", "terminated", "state"}
 _FRAME_ASSUMPTION_KINDS = {"always", "at"}
@@ -67,7 +67,7 @@ _PROPERTY_KINDS = {
 }
 
 
-def _canonical_condition(expr: Optional[BmcCondExpr]) -> Optional[CanonicalDict]:
+def _canonical_condition(expr: Optional[BmcCondExpr]) -> Optional[_CanonicalDict]:
     if expr is None:
         return None
     return expr.to_canonical()
@@ -79,7 +79,7 @@ def _require_condition(value: Optional[BmcCondExpr], field_name: str) -> None:
 
 
 def _validate_choice(value: str, choices: set, field_name: str) -> None:
-    if value not in choices:
+    if not isinstance(value, str) or value not in choices:
         raise InvalidBmcQuery(f"Unsupported {field_name}: {value!r}.")
 
 
@@ -110,7 +110,7 @@ def _is_ascii_decimal(value: str) -> bool:
     return bool(value) and all("0" <= char <= "9" for char in value)
 
 
-def _normalize_selector(selector: QuerySelector) -> QuerySelector:
+def _normalize_selector(selector: _QuerySelector) -> _QuerySelector:
     if isinstance(selector, bool):
         raise InvalidBmcQuery(
             "selector must be '*', a non-negative integer, or an inclusive range."
@@ -140,7 +140,7 @@ def _quote_string(value: str) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
-def _selector_to_dsl(selector: QuerySelector) -> str:
+def _selector_to_dsl(selector: _QuerySelector) -> str:
     return str(selector)
 
 
@@ -194,7 +194,7 @@ class InitialSpec:
         if self.predicate is not None:
             _require_condition(self.predicate, "predicate")
 
-    def to_canonical(self) -> CanonicalDict:
+    def to_canonical(self) -> _CanonicalDict:
         """Return a stable canonical initial-spec dictionary.
 
         :return: Canonical initial specification.
@@ -248,7 +248,7 @@ class BmcAssumption(ABC):
 
     _node_name: ClassVar[str] = "assumption"
 
-    def to_canonical(self) -> CanonicalDict:
+    def to_canonical(self) -> _CanonicalDict:
         """Return a stable canonical assumption dictionary.
 
         :return: Canonical assumption dictionary.
@@ -279,7 +279,7 @@ class BmcAssumption(ABC):
         return self._to_dsl()
 
     @abstractmethod
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
@@ -322,7 +322,7 @@ class FrameAssumption(BmcAssumption):
             raise InvalidBmcQuery("frame is only valid for 'at' frame assumptions.")
         object.__setattr__(self, "frame", frame)
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {
             "kind": self.kind,
             "frame": self.frame,
@@ -357,7 +357,7 @@ class EventAssumption(BmcAssumption):
     _node_name: ClassVar[str] = "event_assumption"
 
     event_path: str
-    selector: QuerySelector = "*"
+    selector: _QuerySelector = "*"
     expected: bool = True
 
     def __post_init__(self) -> None:
@@ -367,7 +367,7 @@ class EventAssumption(BmcAssumption):
             raise InvalidBmcQuery("expected must be a boolean value.")
         object.__setattr__(self, "selector", selector)
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {
             "event_path": self.event_path,
             "selector": self.selector,
@@ -421,7 +421,7 @@ class EventCardinalityAssumption(BmcAssumption):
             raise InvalidBmcQuery("event_paths must contain non-empty strings.")
         object.__setattr__(self, "event_paths", event_paths)
 
-    def _canonical_payload(self) -> CanonicalDict:
+    def _canonical_payload(self) -> _CanonicalDict:
         return {"kind": self.kind, "event_paths": self.event_paths}
 
     def _to_dsl(self) -> str:
@@ -504,7 +504,7 @@ class BmcProperty:
         ):
             raise InvalidBmcQuery("single-body properties only accept predicate.")
 
-    def to_canonical(self) -> CanonicalDict:
+    def to_canonical(self) -> _CanonicalDict:
         """Return a stable canonical property dictionary.
 
         :return: Canonical property dictionary.
@@ -587,7 +587,7 @@ class BmcQuery:
             raise InvalidBmcQuery("assumptions must contain BmcAssumption objects.")
         object.__setattr__(self, "assumptions", assumptions)
 
-    def to_canonical(self) -> CanonicalDict:
+    def to_canonical(self) -> _CanonicalDict:
         """Return a stable canonical query dictionary.
 
         :return: Canonical query dictionary.

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -1,0 +1,513 @@
+"""Top-level FCSTM BMC query data model.
+
+The query model is intentionally parser-independent.  It captures the shape of
+``*.fbmcq`` files after syntax parsing but before model-aware semantic binding,
+state/event resolution, solver lowering, or witness replay.  Later BMC subPRs
+can construct these frozen dataclasses from ANTLR parse trees and then bind them
+against :class:`pyfcstm.model.StateMachine` objects.
+
+The module contains:
+
+* :class:`InitialSpec` - Cold, terminated, or state hot-start initial condition.
+* :class:`FrameAssumption`, :class:`EventAssumption`, and
+  :class:`EventCardinalityAssumption` - Environment assumptions.
+* :class:`BmcProperty` - Skeleton for reachability, safety, response, and cover
+  goals.
+* :class:`BmcQuery` - Complete query root object.
+
+Example::
+
+    >>> from pyfcstm.bmc.ast import Active
+    >>> from pyfcstm.bmc.query import BmcProperty, BmcQuery
+    >>> query = BmcQuery(property=BmcProperty("reach", 3, predicate=Active("Root.Done")))
+    >>> query.to_canonical()["property"]["kind"]
+    'reach'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, ClassVar, Dict, Optional, Tuple, Union
+
+try:
+    from typing import Literal
+except ImportError:  # pragma: no cover - Python < 3.8 compatibility
+    from typing_extensions import Literal
+
+from pyfcstm.bmc.ast import BmcCondExpr
+from pyfcstm.bmc.errors import InvalidBmcQuery
+
+CanonicalDict = Dict[str, Any]
+FrameSelector = Union[int, Literal["current"]]
+QuerySelector = Union[int, Literal["*"], str]
+
+_INITIAL_MODES = {"cold", "terminated", "state"}
+_FRAME_ASSUMPTION_KINDS = {"always", "at"}
+_EVENT_CARDINALITY_KINDS = {"any", "at_most_one"}
+_PROPERTY_KINDS = {
+    "reach",
+    "forbid",
+    "invariant",
+    "must_reach",
+    "exists_always",
+    "response",
+    "cover",
+}
+_PREDICATE_PROPERTY_KINDS = {
+    "reach",
+    "forbid",
+    "invariant",
+    "must_reach",
+    "exists_always",
+    "cover",
+}
+
+
+def _canonical_condition(expr: Optional[BmcCondExpr]) -> Optional[CanonicalDict]:
+    if expr is None:
+        return None
+    return expr.to_canonical()
+
+
+def _require_condition(value: Optional[BmcCondExpr], field_name: str) -> None:
+    if not isinstance(value, BmcCondExpr):
+        raise InvalidBmcQuery(f"{field_name} must be BmcCondExpr.")
+
+
+def _validate_choice(value: str, choices: set, field_name: str) -> None:
+    if value not in choices:
+        raise InvalidBmcQuery(f"Unsupported {field_name}: {value!r}.")
+
+
+def _require_non_empty_string(value: object, field_name: str) -> None:
+    if not isinstance(value, str) or not value:
+        raise InvalidBmcQuery(f"{field_name} must be a non-empty string.")
+
+
+def _normalize_positive_integer(value: int, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InvalidBmcQuery(f"{field_name} must be a positive integer.")
+    if value <= 0:
+        raise InvalidBmcQuery(f"{field_name} must be a positive integer.")
+    return value
+
+
+def _normalize_frame(frame: Optional[int]) -> Optional[int]:
+    if frame is None:
+        return None
+    if isinstance(frame, bool) or not isinstance(frame, int):
+        raise InvalidBmcQuery("frame must be a non-negative integer.")
+    if frame < 0:
+        raise InvalidBmcQuery("frame must be a non-negative integer.")
+    return frame
+
+
+def _normalize_selector(selector: QuerySelector) -> QuerySelector:
+    if isinstance(selector, bool):
+        raise InvalidBmcQuery(
+            "selector must be '*', a non-negative integer, or an inclusive range."
+        )
+    if isinstance(selector, int):
+        if selector < 0:
+            raise InvalidBmcQuery("selector must be non-negative.")
+        return selector
+    if isinstance(selector, str):
+        if selector == "*":
+            return selector
+        if selector.isdigit():
+            return selector
+        parts = selector.split("..")
+        if len(parts) == 2 and all(part.isdigit() for part in parts):
+            start, end = (int(parts[0]), int(parts[1]))
+            if start <= end:
+                return selector
+    raise InvalidBmcQuery(
+        "selector must be '*', a non-negative integer, or an inclusive range."
+    )
+
+
+@dataclass(frozen=True)
+class InitialSpec:
+    """Initial BMC frame specification.
+
+    :param mode: Initial mode: ``"cold"``, ``"terminated"``, or ``"state"``.
+        Defaults to ``"cold"``.
+    :type mode: str, optional
+    :param state_path: State path for ``mode="state"``, defaults to ``None``.
+    :type state_path: Optional[str], optional
+    :param predicate: Optional initial-state predicate that contributes only to
+        the initial condition, defaults to ``None``.
+    :type predicate: Optional[BmcCondExpr], optional
+
+    Example::
+
+        >>> InitialSpec().to_canonical()["mode"]
+        'cold'
+        >>> InitialSpec(mode="state", state_path="Root.Active").state_path
+        'Root.Active'
+    """
+
+    _node_name: ClassVar[str] = "initial_spec"
+
+    mode: str = "cold"
+    state_path: Optional[str] = None
+    predicate: Optional[BmcCondExpr] = None
+
+    def __post_init__(self) -> None:
+        _validate_choice(self.mode, _INITIAL_MODES, "initial mode")
+        if self.mode == "state" and (
+            not isinstance(self.state_path, str) or not self.state_path
+        ):
+            raise InvalidBmcQuery(
+                "state_path is required when initial mode is 'state'."
+            )
+        if self.mode != "state" and self.state_path is not None:
+            raise InvalidBmcQuery(
+                "state_path is only valid when initial mode is 'state'."
+            )
+        if self.predicate is not None:
+            _require_condition(self.predicate, "predicate")
+
+    def to_canonical(self) -> CanonicalDict:
+        """Return a stable canonical initial-spec dictionary.
+
+        :return: Canonical initial specification.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> InitialSpec().to_canonical()["node"]
+            'initial_spec'
+        """
+        return {
+            "node": self._node_name,
+            "mode": self.mode,
+            "state_path": self.state_path,
+            "predicate": _canonical_condition(self.predicate),
+        }
+
+
+class BmcAssumption:
+    """Base class for BMC environment assumptions.
+
+    :return: ``None``.
+    :rtype: None
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import BoolLiteral
+        >>> isinstance(FrameAssumption("always", BoolLiteral("true")), BmcAssumption)
+        True
+    """
+
+    _node_name: ClassVar[str] = "assumption"
+
+    def to_canonical(self) -> CanonicalDict:
+        """Return a stable canonical assumption dictionary.
+
+        :return: Canonical assumption dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import BoolLiteral
+            >>> FrameAssumption("always", BoolLiteral("true")).to_canonical()["node"]
+            'frame_assumption'
+        """
+        result = {"node": self._node_name}
+        result.update(self._canonical_payload())
+        return result
+
+    def _canonical_payload(self) -> CanonicalDict:
+        raise NotImplementedError  # pragma: no cover
+
+
+@dataclass(frozen=True)
+class FrameAssumption(BmcAssumption):
+    """Assumption over frame predicates.
+
+    :param kind: ``"always"`` for all frames or ``"at"`` for one frame.
+    :type kind: str
+    :param predicate: Condition predicate constrained by this assumption.
+    :type predicate: BmcCondExpr
+    :param frame: Required non-negative frame index for ``kind="at"``, defaults
+        to ``None``.
+    :type frame: Optional[int], optional
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import BoolLiteral
+        >>> FrameAssumption("at", BoolLiteral("true"), frame=0).to_canonical()["frame"]
+        0
+    """
+
+    _node_name: ClassVar[str] = "frame_assumption"
+
+    kind: str
+    predicate: BmcCondExpr
+    frame: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        _validate_choice(self.kind, _FRAME_ASSUMPTION_KINDS, "frame assumption kind")
+        _require_condition(self.predicate, "predicate")
+        frame = _normalize_frame(self.frame)
+        if self.kind == "at" and frame is None:
+            raise InvalidBmcQuery("frame is required for 'at' frame assumptions.")
+        if self.kind == "always" and frame is not None:
+            raise InvalidBmcQuery("frame is only valid for 'at' frame assumptions.")
+        object.__setattr__(self, "frame", frame)
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {
+            "kind": self.kind,
+            "frame": self.frame,
+            "predicate": self.predicate.to_canonical(),
+        }
+
+
+@dataclass(frozen=True)
+class EventAssumption(BmcAssumption):
+    """Assumption over one event selection expression.
+
+    :param event_path: Event path referenced by the query.
+    :type event_path: str
+    :param selector: Frame selector such as ``"*"``, ``0``, or ``"0..3"``.
+        Defaults to ``"*"``.
+    :type selector: int or str, optional
+    :param expected: Whether the event is expected to be true, defaults to
+        ``True``.
+    :type expected: bool, optional
+
+    Example::
+
+        >>> EventAssumption("Root.Start", selector="0..2").to_canonical()["selector"]
+        '0..2'
+    """
+
+    _node_name: ClassVar[str] = "event_assumption"
+
+    event_path: str
+    selector: QuerySelector = "*"
+    expected: bool = True
+
+    def __post_init__(self) -> None:
+        _require_non_empty_string(self.event_path, "event_path")
+        selector = _normalize_selector(self.selector)
+        if not isinstance(self.expected, bool):
+            raise InvalidBmcQuery("expected must be a boolean value.")
+        object.__setattr__(self, "selector", selector)
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {
+            "event_path": self.event_path,
+            "selector": self.selector,
+            "expected": self.expected,
+        }
+
+
+@dataclass(frozen=True)
+class EventCardinalityAssumption(BmcAssumption):
+    """Cardinality assumption over a group of event paths.
+
+    :param kind: Cardinality kind, either ``"any"`` or ``"at_most_one"``.
+    :type kind: str
+    :param event_paths: Event paths for ``"at_most_one"``. ``"any"`` uses an
+        empty tuple because it is equivalent to omitting the cardinality
+        assumption, defaults to ``()``.
+    :type event_paths: Tuple[str, ...], optional
+
+    Example::
+
+        >>> EventCardinalityAssumption("at_most_one", ("A.Go", "A.Stop")).to_canonical()["kind"]
+        'at_most_one'
+        >>> EventCardinalityAssumption("any").to_canonical()["event_paths"]
+        ()
+    """
+
+    _node_name: ClassVar[str] = "event_cardinality_assumption"
+
+    kind: str
+    event_paths: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _validate_choice(self.kind, _EVENT_CARDINALITY_KINDS, "event cardinality kind")
+        if isinstance(self.event_paths, str) or not isinstance(
+            self.event_paths, (list, tuple)
+        ):
+            raise InvalidBmcQuery("event_paths must be a sequence of strings.")
+        event_paths = tuple(self.event_paths)
+        if self.kind == "at_most_one" and not event_paths:
+            raise InvalidBmcQuery("event_paths must not be empty for at_most_one.")
+        if self.kind == "any" and event_paths:
+            raise InvalidBmcQuery("event_paths is only valid for at_most_one.")
+        if not all(isinstance(path, str) and path for path in event_paths):
+            raise InvalidBmcQuery("event_paths must contain non-empty strings.")
+        object.__setattr__(self, "event_paths", event_paths)
+
+    def _canonical_payload(self) -> CanonicalDict:
+        return {"kind": self.kind, "event_paths": self.event_paths}
+
+
+@dataclass(frozen=True)
+class BmcProperty:
+    """BMC query objective skeleton.
+
+    :param kind: Property kind such as ``"reach"``, ``"forbid"``,
+        ``"invariant"``, ``"must_reach"``, ``"exists_always"``,
+        ``"response"``, or ``"cover"``.
+    :type kind: str
+    :param bound: Positive inclusive query bound.
+    :type bound: int
+    :param predicate: Predicate for single-body properties, including
+        ``kind="cover"`` with a later binder-validated :class:`Case` predicate,
+        defaults to ``None``.
+    :type predicate: Optional[BmcCondExpr], optional
+    :param trigger: Trigger predicate for ``kind="response"``, defaults to
+        ``None``.
+    :type trigger: Optional[BmcCondExpr], optional
+    :param response: Response predicate for ``kind="response"``, defaults to
+        ``None``.
+    :type response: Optional[BmcCondExpr], optional
+    :param within: Positive response window for ``kind="response"``, defaults
+        to ``None``.
+    :type within: Optional[int], optional
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import Active
+        >>> BmcProperty("reach", 2, predicate=Active("Root.Done")).to_canonical()["bound"]
+        2
+    """
+
+    _node_name: ClassVar[str] = "property"
+
+    kind: str
+    bound: int
+    predicate: Optional[BmcCondExpr] = None
+    trigger: Optional[BmcCondExpr] = None
+    response: Optional[BmcCondExpr] = None
+    within: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        _validate_choice(self.kind, _PROPERTY_KINDS, "property kind")
+        object.__setattr__(
+            self, "bound", _normalize_positive_integer(self.bound, "bound")
+        )
+        if self.kind in _PREDICATE_PROPERTY_KINDS:
+            _require_condition(self.predicate, "property predicate")
+            if (
+                self.trigger is not None
+                or self.response is not None
+                or self.within is not None
+            ):
+                raise InvalidBmcQuery("single-body properties only accept predicate.")
+        elif self.kind == "response":
+            _require_condition(self.trigger, "response trigger")
+            _require_condition(self.response, "response predicate")
+            if self.within is None:
+                raise InvalidBmcQuery("response window is required.")
+            object.__setattr__(
+                self,
+                "within",
+                _normalize_positive_integer(self.within, "response window"),
+            )
+            if self.predicate is not None:
+                raise InvalidBmcQuery(
+                    "response properties only accept trigger, response predicate, and window."
+                )
+
+    def to_canonical(self) -> CanonicalDict:
+        """Return a stable canonical property dictionary.
+
+        :return: Canonical property dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import Active
+            >>> BmcProperty("forbid", 1, predicate=Active("Root.Bad")).to_canonical()["kind"]
+            'forbid'
+        """
+        return {
+            "node": self._node_name,
+            "kind": self.kind,
+            "bound": self.bound,
+            "predicate": _canonical_condition(self.predicate),
+            "trigger": _canonical_condition(self.trigger),
+            "response": _canonical_condition(self.response),
+            "within": self.within,
+        }
+
+
+@dataclass(frozen=True)
+class BmcQuery:
+    """Complete FCSTM BMC query root object.
+
+    :param property: Query objective.
+    :type property: BmcProperty
+    :param initial: Initial frame specification, defaults to
+        :class:`InitialSpec` with ``mode="cold"``.
+    :type initial: InitialSpec, optional
+    :param assumptions: Tuple of environment assumptions, defaults to empty.
+    :type assumptions: Tuple[BmcAssumption, ...], optional
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import Active
+        >>> query = BmcQuery(property=BmcProperty("reach", 1, predicate=Active("Root.Done")))
+        >>> query.initial.mode
+        'cold'
+    """
+
+    _node_name: ClassVar[str] = "bmc_query"
+
+    property: BmcProperty
+    initial: InitialSpec = field(default_factory=InitialSpec)
+    assumptions: Tuple[BmcAssumption, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.property, BmcProperty):
+            raise InvalidBmcQuery("property must be BmcProperty.")
+        if not isinstance(self.initial, InitialSpec):
+            raise InvalidBmcQuery("initial must be InitialSpec.")
+        if not isinstance(self.assumptions, (list, tuple)):
+            raise InvalidBmcQuery(
+                "assumptions must be a sequence of BmcAssumption objects."
+            )
+        assumptions = tuple(self.assumptions)
+        if not all(isinstance(assumption, BmcAssumption) for assumption in assumptions):
+            raise InvalidBmcQuery("assumptions must contain BmcAssumption objects.")
+        object.__setattr__(self, "assumptions", assumptions)
+
+    def to_canonical(self) -> CanonicalDict:
+        """Return a stable canonical query dictionary.
+
+        :return: Canonical query dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import Active
+            >>> query = BmcQuery(property=BmcProperty("reach", 1, predicate=Active("Root.Done")))
+            >>> query.to_canonical()["node"]
+            'bmc_query'
+        """
+        return {
+            "node": self._node_name,
+            "initial": self.initial.to_canonical(),
+            "assumptions": tuple(
+                assumption.to_canonical() for assumption in self.assumptions
+            ),
+            "property": self.property.to_canonical(),
+        }
+
+
+__all__ = [
+    "InitialSpec",
+    "BmcAssumption",
+    "FrameAssumption",
+    "EventAssumption",
+    "EventCardinalityAssumption",
+    "BmcProperty",
+    "BmcQuery",
+]

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -26,6 +26,7 @@ Example::
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, Optional, Tuple, Union
 
@@ -38,7 +39,6 @@ from pyfcstm.bmc.ast import BmcCondExpr
 from pyfcstm.bmc.errors import InvalidBmcQuery
 
 CanonicalDict = Dict[str, Any]
-FrameSelector = Union[int, Literal["current"]]
 QuerySelector = Union[int, Literal["*"], str]
 
 _INITIAL_MODES = {"cold", "terminated", "state"}
@@ -102,6 +102,10 @@ def _normalize_frame(frame: Optional[int]) -> Optional[int]:
     return frame
 
 
+def _is_ascii_decimal(value: str) -> bool:
+    return bool(value) and all("0" <= char <= "9" for char in value)
+
+
 def _normalize_selector(selector: QuerySelector) -> QuerySelector:
     if isinstance(selector, bool):
         raise InvalidBmcQuery(
@@ -114,13 +118,13 @@ def _normalize_selector(selector: QuerySelector) -> QuerySelector:
     if isinstance(selector, str):
         if selector == "*":
             return selector
-        if selector.isdigit():
+        if _is_ascii_decimal(selector):
             return int(selector)
         parts = selector.split("..")
-        if len(parts) == 2 and all(part.isdigit() for part in parts):
+        if len(parts) == 2 and all(_is_ascii_decimal(part) for part in parts):
             start, end = (int(parts[0]), int(parts[1]))
             if start <= end:
-                return selector
+                return "%d..%d" % (start, end)
     raise InvalidBmcQuery(
         "selector must be '*', a non-negative integer, or an inclusive range."
     )
@@ -187,7 +191,7 @@ class InitialSpec:
         }
 
 
-class BmcAssumption:
+class BmcAssumption(ABC):
     """Base class for BMC environment assumptions.
 
     :cvar _node_name: Canonical node tag emitted by
@@ -219,6 +223,7 @@ class BmcAssumption:
         result.update(self._canonical_payload())
         return result
 
+    @abstractmethod
     def _canonical_payload(self) -> CanonicalDict:
         raise NotImplementedError  # pragma: no cover
 

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -113,6 +113,15 @@ def _is_ascii_decimal(value: str) -> bool:
 
 
 def _normalize_selector(selector: _QuerySelector) -> _QuerySelector:
+    """Normalize event-assumption cycle selectors.
+
+    Decimal strings are accepted as user-facing convenience and normalized to
+    integers.  Inclusive ranges with leading zeros are normalized to canonical
+    decimal range text, and a degenerate range such as ``"03..03"`` collapses
+    to integer ``3``.  The event atom's ``"current"`` selector is intentionally
+    not accepted here because event assumptions quantify over concrete cycles
+    or ranges.
+    """
     if isinstance(selector, bool):
         raise InvalidBmcQuery(
             "selector must be '*', a non-negative integer, or an inclusive range."
@@ -164,7 +173,9 @@ class InitialSpec:
     :param state_path: State path for ``mode="state"``, defaults to ``None``.
     :type state_path: Optional[str], optional
     :param predicate: Optional initial-state predicate that contributes only to
-        the initial condition, defaults to ``None``.
+        the initial condition, defaults to ``None``.  The predicate is valid
+        for all modes and renders as a ``where`` clause, for example
+        ``init cold where active("Root.A");``.
     :type predicate: Optional[BmcCondExpr], optional
 
     Example::
@@ -183,12 +194,8 @@ class InitialSpec:
 
     def __post_init__(self) -> None:
         _validate_choice(self.mode, _INITIAL_MODES, "initial mode")
-        if self.mode == "state" and (
-            not isinstance(self.state_path, str) or not self.state_path
-        ):
-            raise InvalidBmcQuery(
-                "state_path is required when initial mode is 'state'."
-            )
+        if self.mode == "state":
+            _require_non_empty_string(self.state_path, "state_path")
         if self.mode != "state" and self.state_path is not None:
             raise InvalidBmcQuery(
                 "state_path is only valid when initial mode is 'state'."

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -390,7 +390,7 @@ class EventCardinalityAssumption(BmcAssumption):
     :type kind: str
     :param event_paths: Event paths for ``"at_most_one"``. ``"any"`` uses an
         empty tuple because it is equivalent to omitting the cardinality
-        assumption, defaults to ``()``.
+        assumption, defaults to ``()``.  ``"at_most_one"`` paths must be unique.
     :type event_paths: Tuple[str, ...], optional
 
     Example::
@@ -419,6 +419,8 @@ class EventCardinalityAssumption(BmcAssumption):
             raise InvalidBmcQuery("event_paths is only valid for at_most_one.")
         if not all(isinstance(path, str) and path for path in event_paths):
             raise InvalidBmcQuery("event_paths must contain non-empty strings.")
+        if len(set(event_paths)) != len(event_paths):
+            raise InvalidBmcQuery("event_paths must not contain duplicate paths.")
         object.__setattr__(self, "event_paths", event_paths)
 
     def _canonical_payload(self) -> _CanonicalDict:

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -15,7 +15,9 @@ Design contracts:
 * :func:`repr` remains the dataclass debugging representation and is not a DSL
   surface.
 * :meth:`to_canonical` is the language-neutral golden shape for parser,
-  binder, and compiler parity tests.
+  binder, and compiler parity tests.  Collection fields in canonical output use
+  JSON-stable ``list`` values even when the frozen dataclass stores them as
+  tuples internally.
 
 The module contains:
 
@@ -389,8 +391,9 @@ class EventCardinalityAssumption(BmcAssumption):
     :param kind: Cardinality kind, either ``"any"`` or ``"at_most_one"``.
     :type kind: str
     :param event_paths: Event paths for ``"at_most_one"``. ``"any"`` uses an
-        empty tuple because it is equivalent to omitting the cardinality
-        assumption, defaults to ``()``.  ``"at_most_one"`` paths must be unique.
+        empty tuple internally because it is equivalent to omitting the
+        cardinality assumption, defaults to ``()``.  ``"at_most_one"`` paths
+        must be unique.
     :type event_paths: Tuple[str, ...], optional
 
     Example::
@@ -398,7 +401,7 @@ class EventCardinalityAssumption(BmcAssumption):
         >>> EventCardinalityAssumption("at_most_one", ("A.Go", "A.Stop")).to_canonical()["kind"]
         'at_most_one'
         >>> EventCardinalityAssumption("any").to_canonical()["event_paths"]
-        ()
+        []
     """
 
     _node_name: ClassVar[str] = "event_cardinality_assumption"
@@ -424,7 +427,7 @@ class EventCardinalityAssumption(BmcAssumption):
         object.__setattr__(self, "event_paths", event_paths)
 
     def _canonical_payload(self) -> _CanonicalDict:
-        return {"kind": self.kind, "event_paths": self.event_paths}
+        return {"kind": self.kind, "event_paths": list(self.event_paths)}
 
     def _to_dsl(self) -> str:
         if self.kind == "any":
@@ -559,6 +562,7 @@ class BmcQuery:
         :class:`InitialSpec` with ``mode="cold"``.
     :type initial: InitialSpec, optional
     :param assumptions: Tuple of environment assumptions, defaults to empty.
+        Canonical output renders assumptions as a JSON-stable list.
     :type assumptions: Tuple[BmcAssumption, ...], optional
 
     Example::
@@ -605,9 +609,9 @@ class BmcQuery:
         return {
             "node": self._node_name,
             "initial": self.initial.to_canonical(),
-            "assumptions": tuple(
+            "assumptions": [
                 assumption.to_canonical() for assumption in self.assumptions
-            ),
+            ],
             "property": self.property.to_canonical(),
         }
 

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -2,9 +2,9 @@
 
 The query model is intentionally parser-independent.  It captures the shape of
 ``*.fbmcq`` files after syntax parsing but before model-aware semantic binding,
-state/event resolution, solver lowering, or witness replay.  Later BMC subPRs
-can construct these frozen dataclasses from ANTLR parse trees and then bind them
-against :class:`pyfcstm.model.StateMachine` objects.
+state/event resolution, solver lowering, or witness replay.  Parser and binder
+layers can construct these frozen dataclasses from ANTLR parse trees and then
+bind them against :class:`pyfcstm.model.StateMachine` objects.
 
 The module contains:
 
@@ -115,7 +115,7 @@ def _normalize_selector(selector: QuerySelector) -> QuerySelector:
         if selector == "*":
             return selector
         if selector.isdigit():
-            return selector
+            return int(selector)
         parts = selector.split("..")
         if len(parts) == 2 and all(part.isdigit() for part in parts):
             start, end = (int(parts[0]), int(parts[1]))
@@ -190,8 +190,9 @@ class InitialSpec:
 class BmcAssumption:
     """Base class for BMC environment assumptions.
 
-    :return: ``None``.
-    :rtype: None
+    :cvar _node_name: Canonical node tag emitted by
+        :meth:`BmcAssumption.to_canonical`.
+    :type _node_name: str
 
     Example::
 

--- a/pyfcstm/bmc/query.py
+++ b/pyfcstm/bmc/query.py
@@ -6,6 +6,17 @@ state/event resolution, solver lowering, or witness replay.  Parser and binder
 layers can construct these frozen dataclasses from ANTLR parse trees and then
 bind them against :class:`pyfcstm.model.StateMachine` objects.
 
+Design contracts:
+
+* Query objects are data-only and must not import ``pyfcstm.verify`` or solver
+  internals.
+* :func:`str` on every concrete query object returns canonical ``.fbmcq`` DSL
+  text that later parser work must accept for round-trip tests.
+* :func:`repr` remains the dataclass debugging representation and is not a DSL
+  surface.
+* :meth:`to_canonical` is the language-neutral golden shape for parser,
+  binder, and compiler parity tests.
+
 The module contains:
 
 * :class:`InitialSpec` - Cold, terminated, or state hot-start initial condition.
@@ -26,6 +37,7 @@ Example::
 
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, Optional, Tuple, Union
@@ -51,14 +63,6 @@ _PROPERTY_KINDS = {
     "must_reach",
     "exists_always",
     "response",
-    "cover",
-}
-_PREDICATE_PROPERTY_KINDS = {
-    "reach",
-    "forbid",
-    "invariant",
-    "must_reach",
-    "exists_always",
     "cover",
 }
 
@@ -124,10 +128,28 @@ def _normalize_selector(selector: QuerySelector) -> QuerySelector:
         if len(parts) == 2 and all(_is_ascii_decimal(part) for part in parts):
             start, end = (int(parts[0]), int(parts[1]))
             if start <= end:
+                if start == end:
+                    return start
                 return "%d..%d" % (start, end)
     raise InvalidBmcQuery(
         "selector must be '*', a non-negative integer, or an inclusive range."
     )
+
+
+def _quote_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _selector_to_dsl(selector: QuerySelector) -> str:
+    return str(selector)
+
+
+def _bool_to_dsl(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _format_block(lines: Tuple[str, ...]) -> str:
+    return "\n".join("    %s" % line for line in lines)
 
 
 @dataclass(frozen=True)
@@ -190,6 +212,25 @@ class InitialSpec:
             "predicate": _canonical_condition(self.predicate),
         }
 
+    def __str__(self) -> str:
+        """Return the canonical ``.fbmcq`` DSL spelling for this initial clause.
+
+        :return: Initial clause text.
+        :rtype: str
+
+        Example::
+
+            >>> str(InitialSpec())
+            'init cold;'
+        """
+        if self.mode == "state":
+            target = "state(%s)" % _quote_string(self.state_path or "")
+        else:
+            target = self.mode
+        if self.predicate is None:
+            return "init %s;" % target
+        return "init %s where %s;" % (target, self.predicate)
+
 
 class BmcAssumption(ABC):
     """Base class for BMC environment assumptions.
@@ -223,8 +264,26 @@ class BmcAssumption(ABC):
         result.update(self._canonical_payload())
         return result
 
+    def __str__(self) -> str:
+        """Return the canonical ``.fbmcq`` DSL spelling for this assumption.
+
+        :return: Assumption clause text.
+        :rtype: str
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import BoolLiteral
+            >>> str(FrameAssumption("always", BoolLiteral("true")))
+            'assume always: true;'
+        """
+        return self._to_dsl()
+
     @abstractmethod
     def _canonical_payload(self) -> CanonicalDict:
+        raise NotImplementedError  # pragma: no cover
+
+    @abstractmethod
+    def _to_dsl(self) -> str:
         raise NotImplementedError  # pragma: no cover
 
 
@@ -270,6 +329,11 @@ class FrameAssumption(BmcAssumption):
             "predicate": self.predicate.to_canonical(),
         }
 
+    def _to_dsl(self) -> str:
+        if self.kind == "always":
+            return "assume always: %s;" % self.predicate
+        return "assume at %d: %s;" % (self.frame, self.predicate)
+
 
 @dataclass(frozen=True)
 class EventAssumption(BmcAssumption):
@@ -309,6 +373,13 @@ class EventAssumption(BmcAssumption):
             "selector": self.selector,
             "expected": self.expected,
         }
+
+    def _to_dsl(self) -> str:
+        return "assume event(%s, %s) == %s;" % (
+            _quote_string(self.event_path),
+            _selector_to_dsl(self.selector),
+            _bool_to_dsl(self.expected),
+        )
 
 
 @dataclass(frozen=True)
@@ -352,6 +423,16 @@ class EventCardinalityAssumption(BmcAssumption):
 
     def _canonical_payload(self) -> CanonicalDict:
         return {"kind": self.kind, "event_paths": self.event_paths}
+
+    def _to_dsl(self) -> str:
+        if self.kind == "any":
+            return "assume events cardinality any;"
+        lines = tuple(
+            "%s%s"
+            % (_quote_string(path), "," if index < len(self.event_paths) - 1 else "")
+            for index, path in enumerate(self.event_paths)
+        )
+        return "assume events cardinality at_most_one {\n%s\n};" % _format_block(lines)
 
 
 @dataclass(frozen=True)
@@ -399,15 +480,7 @@ class BmcProperty:
         object.__setattr__(
             self, "bound", _normalize_positive_integer(self.bound, "bound")
         )
-        if self.kind in _PREDICATE_PROPERTY_KINDS:
-            _require_condition(self.predicate, "property predicate")
-            if (
-                self.trigger is not None
-                or self.response is not None
-                or self.within is not None
-            ):
-                raise InvalidBmcQuery("single-body properties only accept predicate.")
-        elif self.kind == "response":
+        if self.kind == "response":
             _require_condition(self.trigger, "response trigger")
             _require_condition(self.response, "response predicate")
             if self.within is None:
@@ -421,6 +494,15 @@ class BmcProperty:
                 raise InvalidBmcQuery(
                     "response properties only accept trigger, response predicate, and window."
                 )
+            return
+
+        _require_condition(self.predicate, "property predicate")
+        if (
+            self.trigger is not None
+            or self.response is not None
+            or self.within is not None
+        ):
+            raise InvalidBmcQuery("single-body properties only accept predicate.")
 
     def to_canonical(self) -> CanonicalDict:
         """Return a stable canonical property dictionary.
@@ -443,6 +525,26 @@ class BmcProperty:
             "response": _canonical_condition(self.response),
             "within": self.within,
         }
+
+    def __str__(self) -> str:
+        """Return the canonical ``.fbmcq`` DSL spelling for this property.
+
+        :return: Check clause text.
+        :rtype: str
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import Active
+            >>> str(BmcProperty("reach", 2, predicate=Active("Root.Done")))
+            'check reach <= 2: active("Root.Done");'
+        """
+        if self.kind == "response":
+            lines = (
+                "trigger %s" % self.trigger,
+                "-> within %d %s" % (self.within, self.response),
+            )
+            return "check response <= %d:\n%s;" % (self.bound, _format_block(lines))
+        return "check %s <= %d: %s;" % (self.kind, self.bound, self.predicate)
 
 
 @dataclass(frozen=True)
@@ -506,6 +608,24 @@ class BmcQuery:
             ),
             "property": self.property.to_canonical(),
         }
+
+    def __str__(self) -> str:
+        """Return the canonical ``.fbmcq`` DSL spelling for this query.
+
+        :return: Complete query file text.
+        :rtype: str
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import Active
+            >>> query = BmcQuery(property=BmcProperty("reach", 1, predicate=Active("Root.Done")))
+            >>> str(query).splitlines()[0]
+            'init cold;'
+        """
+        clauses = [str(self.initial)]
+        clauses.extend(str(assumption) for assumption in self.assumptions)
+        clauses.append(str(self.property))
+        return "\n\n".join(clauses)
 
 
 __all__ = [

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -1,0 +1,136 @@
+"""Public API tests for the BMC query model package."""
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.unittest
+def test_bmc_public_api_exports_exact_names():
+    """Top-level BMC imports expose the stable PR-1 public surface."""
+    bmc = importlib.import_module("pyfcstm.bmc")
+
+    expected = {
+        "BmcError",
+        "InvalidBmcQuery",
+        "UnsupportedBmcQuery",
+        "InvalidBmcEncoding",
+        "BmcBuildError",
+        "BmcExpr",
+        "BmcNumExpr",
+        "BmcCondExpr",
+        "IntLiteral",
+        "FloatLiteral",
+        "BoolLiteral",
+        "NameRef",
+        "MathConst",
+        "NumUnaryOp",
+        "NumBinaryOp",
+        "NumConditionalOp",
+        "UFuncCall",
+        "CondUnaryOp",
+        "NumericComparison",
+        "CondBinaryOp",
+        "CondConditionalOp",
+        "FrameVar",
+        "Cycle",
+        "Active",
+        "Terminated",
+        "Event",
+        "Case",
+        "Called",
+        "InitialSpec",
+        "BmcAssumption",
+        "FrameAssumption",
+        "EventAssumption",
+        "EventCardinalityAssumption",
+        "BmcProperty",
+        "BmcQuery",
+    }
+
+    assert set(bmc.__all__) == expected
+    for name in expected:
+        assert getattr(bmc, name).__name__ == name
+
+
+@pytest.mark.unittest
+def test_submodule_all_exports_are_exact():
+    """Submodules keep precise export sets for later parser and binder PRs."""
+    errors = importlib.import_module("pyfcstm.bmc.errors")
+    ast = importlib.import_module("pyfcstm.bmc.ast")
+    query = importlib.import_module("pyfcstm.bmc.query")
+
+    assert set(errors.__all__) == {
+        "BmcError",
+        "InvalidBmcQuery",
+        "UnsupportedBmcQuery",
+        "InvalidBmcEncoding",
+        "BmcBuildError",
+    }
+    assert set(ast.__all__) == {
+        "BmcExpr",
+        "BmcNumExpr",
+        "BmcCondExpr",
+        "IntLiteral",
+        "FloatLiteral",
+        "BoolLiteral",
+        "NameRef",
+        "MathConst",
+        "NumUnaryOp",
+        "NumBinaryOp",
+        "NumConditionalOp",
+        "UFuncCall",
+        "CondUnaryOp",
+        "NumericComparison",
+        "CondBinaryOp",
+        "CondConditionalOp",
+        "FrameVar",
+        "Cycle",
+        "Active",
+        "Terminated",
+        "Event",
+        "Case",
+        "Called",
+    }
+    assert set(query.__all__) == {
+        "InitialSpec",
+        "BmcAssumption",
+        "FrameAssumption",
+        "EventAssumption",
+        "EventCardinalityAssumption",
+        "BmcProperty",
+        "BmcQuery",
+    }
+
+
+@pytest.mark.unittest
+def test_bmc_does_not_import_verify_registry():
+    """The BMC root package remains independent from verify registry wiring."""
+    bmc = importlib.import_module("pyfcstm.bmc")
+
+    assert not hasattr(bmc, "REGISTRY")
+
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("pyfcstm.verify.bmc")
+
+
+@pytest.mark.unittest
+def test_bmc_import_does_not_load_verify_modules():
+    """Importing BMC in a fresh process keeps verify internals unloaded."""
+    code = (
+        "import sys; "
+        "import pyfcstm.bmc; "
+        "print(any(name.startswith('pyfcstm.verify') for name in sys.modules))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert result.stdout.strip() == "False"

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -9,7 +9,7 @@ import pytest
 
 @pytest.mark.unittest
 def test_bmc_public_api_exports_exact_names():
-    """Top-level BMC imports expose the stable PR-1 public surface."""
+    """Top-level BMC imports expose the stable public surface."""
     bmc = importlib.import_module("pyfcstm.bmc")
 
     expected = {
@@ -57,7 +57,7 @@ def test_bmc_public_api_exports_exact_names():
 
 @pytest.mark.unittest
 def test_submodule_all_exports_are_exact():
-    """Submodules keep precise export sets for later parser and binder PRs."""
+    """Submodules keep precise export sets for parser and binder layers."""
     errors = importlib.import_module("pyfcstm.bmc.errors")
     ast = importlib.import_module("pyfcstm.bmc.ast")
     query = importlib.import_module("pyfcstm.bmc.query")

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -61,6 +61,7 @@ def test_literal_canonical_forms_preserve_raw_kind_and_value():
     floating = FloatLiteral("3.5e1")
     fractional = FloatLiteral(".5")
     exponent = FloatLiteral("1e-3")
+    large_finite = FloatLiteral("1e308")
     truth = BoolLiteral("TRUE")
 
     assert decimal.to_canonical() == {
@@ -85,6 +86,8 @@ def test_literal_canonical_forms_preserve_raw_kind_and_value():
     }
     assert fractional.to_canonical()["value"] == 0.5
     assert exponent.to_canonical()["value"] == 0.001
+    assert large_finite.to_canonical()["raw"] == "1e308"
+    json.dumps(large_finite.to_canonical(), allow_nan=False)
     json.dumps(floating.to_canonical(), allow_nan=False)
     assert truth.to_canonical() == {
         "node": "bool_literal",
@@ -129,11 +132,11 @@ def _round_trip_cases():
         pytest.param(FloatLiteral("3.5e1"), "3.5e1", id="expr-float-exp"),
         pytest.param(FloatLiteral("1e-3"), "1e-3", id="expr-float-negative-exp"),
         pytest.param(BoolLiteral("true"), "true", id="expr-bool-lower-true"),
-        pytest.param(BoolLiteral("True"), "True", id="expr-bool-title-true"),
-        pytest.param(BoolLiteral("TRUE"), "TRUE", id="expr-bool-upper-true"),
+        pytest.param(BoolLiteral("True"), "true", id="expr-bool-title-true"),
+        pytest.param(BoolLiteral("TRUE"), "true", id="expr-bool-upper-true"),
         pytest.param(BoolLiteral("false"), "false", id="expr-bool-lower-false"),
-        pytest.param(BoolLiteral("False"), "False", id="expr-bool-title-false"),
-        pytest.param(BoolLiteral("FALSE"), "FALSE", id="expr-bool-upper-false"),
+        pytest.param(BoolLiteral("False"), "false", id="expr-bool-title-false"),
+        pytest.param(BoolLiteral("FALSE"), "false", id="expr-bool-upper-false"),
         pytest.param(x, "x", id="expr-name-x"),
         pytest.param(NameRef("counter_1"), "counter_1", id="expr-name-counter"),
         pytest.param(MathConst("pi"), "pi", id="expr-const-pi"),
@@ -497,6 +500,10 @@ def test_bmc_nodes_keep_dataclass_repr_for_debugging():
         representation = repr(node)
         assert representation.startswith("%s(" % node.__class__.__name__)
         assert representation.endswith(")")
+        fields = getattr(node, "__dataclass_fields__", {})
+        for field_name in fields:
+            if not field_name.startswith("_"):
+                assert "%s=" % field_name in representation
 
 
 @pytest.mark.unittest
@@ -610,6 +617,8 @@ def test_bool_literal_raw_families_share_values_but_keep_raw_spelling():
         False,
     ]
     assert BoolLiteral("True").to_canonical()["raw"] == "True"
+    assert str(BoolLiteral("True")) == "true"
+    assert str(BoolLiteral("FALSE")) == "false"
 
 
 @pytest.mark.unittest
@@ -837,20 +846,34 @@ def test_expression_model_rejects_invalid_literal_and_frame_values():
         NameRef("not-a-fcstm-id")
     with pytest.raises(ValueError, match="Reserved"):
         NameRef("cycle")
+    with pytest.raises(ValueError, match="Reserved"):
+        NameRef("where")
     with pytest.raises(ValueError, match="floating"):
         FloatLiteral("1")
     with pytest.raises(ValueError, match="finite"):
         FloatLiteral("1e999")
-    with pytest.raises(ValueError, match="decimal"):
+    with pytest.raises(ValueError, match="hexadecimal"):
         IntLiteral("0X2A")
+    with pytest.raises(ValueError, match="decimal"):
+        IntLiteral("-42")
     with pytest.raises(ValueError, match="hexadecimal"):
         IntLiteral("0x")
     with pytest.raises(ValueError, match="kind"):
         IntLiteral("0x2A", kind="decimal")
     with pytest.raises(ValueError, match="kind"):
         IntLiteral("42", kind="hex")
-    with pytest.raises(ValueError, match="spelling"):
+    with pytest.raises(InvalidBmcQuery, match="spelling"):
         FrameVar("x", spelling="bare")
+    with pytest.raises(InvalidBmcQuery, match="name"):
+        FrameVar("")
+    with pytest.raises(InvalidBmcQuery, match="state_path"):
+        Active("")
+    with pytest.raises(InvalidBmcQuery, match="event_path"):
+        Event("")
+    with pytest.raises(InvalidBmcQuery, match="label"):
+        Case("")
+    with pytest.raises(InvalidBmcQuery, match="name"):
+        Called("")
 
 
 @pytest.mark.unittest
@@ -895,6 +918,8 @@ def test_query_model_rejects_additional_invalid_structural_values():
         EventCardinalityAssumption("any", ("Root.E",))
     with pytest.raises(InvalidBmcQuery, match="event_paths"):
         EventCardinalityAssumption("at_most_one", ("Root.E", ""))
+    with pytest.raises(InvalidBmcQuery, match="duplicate"):
+        EventCardinalityAssumption("at_most_one", ("Root.E", "Root.E"))
     with pytest.raises(InvalidBmcQuery, match="property"):
         BmcQuery(property=cast(Any, Active("Root.Done")))
     with pytest.raises(InvalidBmcQuery, match="initial"):

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -1,5 +1,7 @@
 """Data model tests for FCSTM BMC query objects."""
 
+import json
+
 import pytest
 from typing import Any, cast
 
@@ -55,7 +57,7 @@ def test_error_hierarchy():
 def test_literal_canonical_forms_preserve_raw_kind_and_value():
     """Literal canonical forms keep enough information for grammar parity."""
     decimal = IntLiteral("42")
-    hexed = IntLiteral("0x2A", kind="hex")
+    hexed = IntLiteral("0x2A")
     floating = FloatLiteral("3.5e1")
     fractional = FloatLiteral(".5")
     exponent = FloatLiteral("1e-3")
@@ -73,6 +75,7 @@ def test_literal_canonical_forms_preserve_raw_kind_and_value():
         "raw": "0x2A",
         "value": 42,
     }
+    assert IntLiteral("0x2A", kind="hex") == hexed
     assert decimal != hexed
     assert floating.to_canonical() == {
         "node": "float_literal",
@@ -82,6 +85,7 @@ def test_literal_canonical_forms_preserve_raw_kind_and_value():
     }
     assert fractional.to_canonical()["value"] == 0.5
     assert exponent.to_canonical()["value"] == 0.001
+    json.dumps(floating.to_canonical(), allow_nan=False)
     assert truth.to_canonical() == {
         "node": "bool_literal",
         "kind": "bool",
@@ -835,10 +839,16 @@ def test_expression_model_rejects_invalid_literal_and_frame_values():
         NameRef("cycle")
     with pytest.raises(ValueError, match="floating"):
         FloatLiteral("1")
+    with pytest.raises(ValueError, match="finite"):
+        FloatLiteral("1e999")
     with pytest.raises(ValueError, match="decimal"):
         IntLiteral("0X2A")
     with pytest.raises(ValueError, match="hexadecimal"):
         IntLiteral("0x")
+    with pytest.raises(ValueError, match="kind"):
+        IntLiteral("0x2A", kind="decimal")
+    with pytest.raises(ValueError, match="kind"):
+        IntLiteral("42", kind="hex")
     with pytest.raises(ValueError, match="spelling"):
         FrameVar("x", spelling="bare")
 

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -88,6 +88,411 @@ def test_literal_canonical_forms_preserve_raw_kind_and_value():
     }
 
 
+def _round_trip_cases():
+    """Build query DSL spelling fixtures for the object-to-text contract."""
+    x = NameRef("x")
+    y = NameRef("y")
+    z = NameRef("z")
+    root_idle = Active("Root.Idle")
+    root_done = Active("Root.Done")
+    comparison = NumericComparison(
+        NumBinaryOp(x, "+", IntLiteral("1")), ">=", UFuncCall("sqrt", y)
+    )
+    condition = CondBinaryOp(
+        CondUnaryOp("!", CondBinaryOp(root_idle, "||", root_done)),
+        "=>",
+        comparison,
+    )
+    response = BmcProperty(
+        "response",
+        8,
+        trigger=Event("Root.Fault"),
+        response=Active("Root.Recovering"),
+        within=3,
+    )
+    cardinality = EventCardinalityAssumption("at_most_one", ("Root.Tick", "Root.Reset"))
+
+    return [
+        pytest.param(IntLiteral("0"), "0", id="expr-int-decimal-zero"),
+        pytest.param(IntLiteral("42"), "42", id="expr-int-decimal"),
+        pytest.param(IntLiteral("007"), "007", id="expr-int-leading-zero"),
+        pytest.param(IntLiteral("0x2A"), "0x2A", id="expr-int-hex-upper"),
+        pytest.param(IntLiteral("0xff"), "0xff", id="expr-int-hex-lower"),
+        pytest.param(FloatLiteral(".5"), ".5", id="expr-float-leading-dot"),
+        pytest.param(FloatLiteral("1."), "1.", id="expr-float-trailing-dot"),
+        pytest.param(FloatLiteral("3.5e1"), "3.5e1", id="expr-float-exp"),
+        pytest.param(FloatLiteral("1e-3"), "1e-3", id="expr-float-negative-exp"),
+        pytest.param(BoolLiteral("true"), "true", id="expr-bool-lower-true"),
+        pytest.param(BoolLiteral("True"), "True", id="expr-bool-title-true"),
+        pytest.param(BoolLiteral("TRUE"), "TRUE", id="expr-bool-upper-true"),
+        pytest.param(BoolLiteral("false"), "false", id="expr-bool-lower-false"),
+        pytest.param(BoolLiteral("False"), "False", id="expr-bool-title-false"),
+        pytest.param(BoolLiteral("FALSE"), "FALSE", id="expr-bool-upper-false"),
+        pytest.param(x, "x", id="expr-name-x"),
+        pytest.param(NameRef("counter_1"), "counter_1", id="expr-name-counter"),
+        pytest.param(MathConst("pi"), "pi", id="expr-const-pi"),
+        pytest.param(MathConst("E"), "E", id="expr-const-e"),
+        pytest.param(MathConst("tau"), "tau", id="expr-const-tau"),
+        pytest.param(NumUnaryOp("+", x), "+x", id="expr-num-unary-plus"),
+        pytest.param(NumUnaryOp("-", x), "-x", id="expr-num-unary-minus"),
+        pytest.param(
+            NumUnaryOp("-", NumBinaryOp(x, "+", IntLiteral("1"))),
+            "-(x + 1)",
+            id="expr-num-unary-grouped-binary",
+        ),
+        pytest.param(NumBinaryOp(x, "**", y), "x ** y", id="expr-num-pow"),
+        pytest.param(NumBinaryOp(x, "*", y), "x * y", id="expr-num-mul"),
+        pytest.param(NumBinaryOp(x, "/", y), "x / y", id="expr-num-div"),
+        pytest.param(NumBinaryOp(x, "%", y), "x % y", id="expr-num-mod"),
+        pytest.param(NumBinaryOp(x, "+", y), "x + y", id="expr-num-add"),
+        pytest.param(NumBinaryOp(x, "-", y), "x - y", id="expr-num-sub"),
+        pytest.param(NumBinaryOp(x, "<<", y), "x << y", id="expr-num-shl"),
+        pytest.param(NumBinaryOp(x, ">>", y), "x >> y", id="expr-num-shr"),
+        pytest.param(NumBinaryOp(x, "&", y), "x & y", id="expr-num-bit-and"),
+        pytest.param(NumBinaryOp(x, "^", y), "x ^ y", id="expr-num-bit-xor"),
+        pytest.param(NumBinaryOp(x, "|", y), "x | y", id="expr-num-bit-or"),
+        pytest.param(
+            NumBinaryOp(NumBinaryOp(x, "+", y), "*", IntLiteral("2")),
+            "(x + y) * 2",
+            id="expr-num-binary-left-group",
+        ),
+        pytest.param(
+            NumBinaryOp(x, "*", NumBinaryOp(y, "+", z)),
+            "x * (y + z)",
+            id="expr-num-binary-right-group",
+        ),
+        pytest.param(
+            NumConditionalOp(root_idle, NumBinaryOp(x, "+", y), MathConst("pi")),
+            '(active("Root.Idle")) ? (x + y) : pi',
+            id="expr-num-ternary",
+        ),
+        pytest.param(UFuncCall("sin", x), "sin(x)", id="expr-ufunc-sin"),
+        pytest.param(UFuncCall("cos", x), "cos(x)", id="expr-ufunc-cos"),
+        pytest.param(UFuncCall("tan", x), "tan(x)", id="expr-ufunc-tan"),
+        pytest.param(UFuncCall("asin", x), "asin(x)", id="expr-ufunc-asin"),
+        pytest.param(UFuncCall("acos", x), "acos(x)", id="expr-ufunc-acos"),
+        pytest.param(UFuncCall("atan", x), "atan(x)", id="expr-ufunc-atan"),
+        pytest.param(UFuncCall("sinh", x), "sinh(x)", id="expr-ufunc-sinh"),
+        pytest.param(UFuncCall("cosh", x), "cosh(x)", id="expr-ufunc-cosh"),
+        pytest.param(UFuncCall("tanh", x), "tanh(x)", id="expr-ufunc-tanh"),
+        pytest.param(UFuncCall("asinh", x), "asinh(x)", id="expr-ufunc-asinh"),
+        pytest.param(UFuncCall("acosh", x), "acosh(x)", id="expr-ufunc-acosh"),
+        pytest.param(UFuncCall("atanh", x), "atanh(x)", id="expr-ufunc-atanh"),
+        pytest.param(UFuncCall("sqrt", x), "sqrt(x)", id="expr-ufunc-sqrt"),
+        pytest.param(UFuncCall("cbrt", x), "cbrt(x)", id="expr-ufunc-cbrt"),
+        pytest.param(UFuncCall("exp", x), "exp(x)", id="expr-ufunc-exp"),
+        pytest.param(UFuncCall("log", x), "log(x)", id="expr-ufunc-log"),
+        pytest.param(UFuncCall("log10", x), "log10(x)", id="expr-ufunc-log10"),
+        pytest.param(UFuncCall("log2", x), "log2(x)", id="expr-ufunc-log2"),
+        pytest.param(UFuncCall("log1p", x), "log1p(x)", id="expr-ufunc-log1p"),
+        pytest.param(
+            UFuncCall("abs", NumUnaryOp("-", x)), "abs(-x)", id="expr-ufunc-abs"
+        ),
+        pytest.param(UFuncCall("ceil", x), "ceil(x)", id="expr-ufunc-ceil"),
+        pytest.param(UFuncCall("floor", x), "floor(x)", id="expr-ufunc-floor"),
+        pytest.param(UFuncCall("round", x), "round(x)", id="expr-ufunc-round"),
+        pytest.param(UFuncCall("trunc", x), "trunc(x)", id="expr-ufunc-trunc"),
+        pytest.param(UFuncCall("sign", x), "sign(x)", id="expr-ufunc-sign"),
+        pytest.param(
+            CondUnaryOp("!", root_idle),
+            '!active("Root.Idle")',
+            id="expr-cond-unary-bang",
+        ),
+        pytest.param(
+            CondUnaryOp("not", root_idle),
+            '!active("Root.Idle")',
+            id="expr-cond-unary-not",
+        ),
+        pytest.param(
+            CondUnaryOp("!", CondBinaryOp(root_idle, "&&", root_done)),
+            '!(active("Root.Idle") && active("Root.Done"))',
+            id="expr-cond-unary-grouped-binary",
+        ),
+        pytest.param(NumericComparison(x, "<", y), "x < y", id="expr-cmp-lt"),
+        pytest.param(NumericComparison(x, ">", y), "x > y", id="expr-cmp-gt"),
+        pytest.param(NumericComparison(x, "<=", y), "x <= y", id="expr-cmp-le"),
+        pytest.param(NumericComparison(x, ">=", y), "x >= y", id="expr-cmp-ge"),
+        pytest.param(NumericComparison(x, "==", y), "x == y", id="expr-cmp-eq"),
+        pytest.param(NumericComparison(x, "!=", y), "x != y", id="expr-cmp-ne"),
+        pytest.param(
+            CondBinaryOp(root_idle, "&&", root_done),
+            'active("Root.Idle") && active("Root.Done")',
+            id="expr-cond-and-symbol",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "and", root_done),
+            'active("Root.Idle") && active("Root.Done")',
+            id="expr-cond-and-alias",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "||", root_done),
+            'active("Root.Idle") || active("Root.Done")',
+            id="expr-cond-or-symbol",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "or", root_done),
+            'active("Root.Idle") || active("Root.Done")',
+            id="expr-cond-or-alias",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "xor", root_done),
+            'active("Root.Idle") xor active("Root.Done")',
+            id="expr-cond-xor",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "=>", root_done),
+            'active("Root.Idle") => active("Root.Done")',
+            id="expr-cond-implies-symbol",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "implies", root_done),
+            'active("Root.Idle") => active("Root.Done")',
+            id="expr-cond-implies-alias",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "iff", root_done),
+            'active("Root.Idle") iff active("Root.Done")',
+            id="expr-cond-iff",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "==", root_done),
+            'active("Root.Idle") == active("Root.Done")',
+            id="expr-cond-eq",
+        ),
+        pytest.param(
+            CondBinaryOp(root_idle, "!=", root_done),
+            'active("Root.Idle") != active("Root.Done")',
+            id="expr-cond-ne",
+        ),
+        pytest.param(
+            CondBinaryOp(
+                CondBinaryOp(root_idle, "&&", root_done), "xor", BoolLiteral("true")
+            ),
+            '(active("Root.Idle") && active("Root.Done")) xor true',
+            id="expr-cond-left-group",
+        ),
+        pytest.param(
+            CondBinaryOp(
+                root_idle, "&&", CondBinaryOp(root_done, "||", BoolLiteral("false"))
+            ),
+            'active("Root.Idle") && (active("Root.Done") || false)',
+            id="expr-cond-right-group",
+        ),
+        pytest.param(
+            CondConditionalOp(condition, root_done, CondUnaryOp("not", root_idle)),
+            '(!(active("Root.Idle") || active("Root.Done")) => (x + 1) >= sqrt(y)) ? active("Root.Done") : !active("Root.Idle")',
+            id="expr-cond-ternary",
+        ),
+        pytest.param(
+            FrameVar('quoted"var\\name'),
+            'var("quoted\\"var\\\\name")',
+            id="expr-frame-var-escaped",
+        ),
+        pytest.param(
+            FrameVar("中文变量"), 'var("中文变量")', id="expr-frame-var-unicode"
+        ),
+        pytest.param(FrameVar("cycle"), 'var("cycle")', id="expr-frame-var-reserved"),
+        pytest.param(Cycle(), "cycle", id="expr-cycle"),
+        pytest.param(
+            Active("Root.Idle"), 'active("Root.Idle")', id="expr-active-current"
+        ),
+        pytest.param(
+            Active("Root.Idle", frame=2),
+            'active("Root.Idle", 2)',
+            id="expr-active-frame",
+        ),
+        pytest.param(Terminated(), "terminated()", id="expr-terminated-current"),
+        pytest.param(Terminated(frame=3), "terminated(3)", id="expr-terminated-frame"),
+        pytest.param(
+            Event("Root.Idle.Start"),
+            'event("Root.Idle.Start", current)',
+            id="expr-event-current",
+        ),
+        pytest.param(
+            Event("Root.Idle.Start", selector=0),
+            'event("Root.Idle.Start", 0)',
+            id="expr-event-index",
+        ),
+        pytest.param(
+            Case("Root.A::transition::Root.B::0"),
+            'case("Root.A::transition::Root.B::0")',
+            id="expr-case-current",
+        ),
+        pytest.param(
+            Case("Root.A::transition::Root.B::0", frame=4),
+            'case("Root.A::transition::Root.B::0", 4)',
+            id="expr-case-frame",
+        ),
+        pytest.param(
+            Called("CheckLimit"), 'called("CheckLimit")', id="expr-called-current"
+        ),
+        pytest.param(
+            Called("CheckLimit", frame=5),
+            'called("CheckLimit", 5)',
+            id="expr-called-frame",
+        ),
+        pytest.param(InitialSpec(), "init cold;", id="query-init-cold"),
+        pytest.param(
+            InitialSpec(mode="terminated"),
+            "init terminated;",
+            id="query-init-terminated",
+        ),
+        pytest.param(
+            InitialSpec(mode="state", state_path="Root.Active"),
+            'init state("Root.Active");',
+            id="query-init-state",
+        ),
+        pytest.param(
+            InitialSpec(
+                mode="state",
+                state_path="Root.Active",
+                predicate=NumericComparison(FrameVar("x"), ">=", IntLiteral("0")),
+            ),
+            'init state("Root.Active") where var("x") >= 0;',
+            id="query-init-state-where",
+        ),
+        pytest.param(
+            FrameAssumption(
+                "always", NumericComparison(FrameVar("x"), "<=", IntLiteral("100"))
+            ),
+            'assume always: var("x") <= 100;',
+            id="query-assume-always",
+        ),
+        pytest.param(
+            FrameAssumption("at", Active("Root.Ready"), frame=2),
+            'assume at 2: active("Root.Ready");',
+            id="query-assume-at",
+        ),
+        pytest.param(
+            EventAssumption("Root.Tick"),
+            'assume event("Root.Tick", *) == true;',
+            id="query-assume-event-any",
+        ),
+        pytest.param(
+            EventAssumption("Root.Tick", selector="01..03"),
+            'assume event("Root.Tick", 1..3) == true;',
+            id="query-assume-event-range",
+        ),
+        pytest.param(
+            EventAssumption("Root.Tick", selector="02..02"),
+            'assume event("Root.Tick", 2) == true;',
+            id="query-assume-event-point-range",
+        ),
+        pytest.param(
+            EventAssumption("Root.Reset", selector=0, expected=False),
+            'assume event("Root.Reset", 0) == false;',
+            id="query-assume-event-false",
+        ),
+        pytest.param(
+            EventCardinalityAssumption("any"),
+            "assume events cardinality any;",
+            id="query-cardinality-any",
+        ),
+        pytest.param(
+            cardinality,
+            'assume events cardinality at_most_one {\n    "Root.Tick",\n    "Root.Reset"\n};',
+            id="query-cardinality-at-most-one",
+        ),
+        pytest.param(
+            BmcProperty("reach", 5, predicate=Active("Root.Done")),
+            'check reach <= 5: active("Root.Done");',
+            id="query-check-reach",
+        ),
+        pytest.param(
+            BmcProperty("forbid", 5, predicate=Active("Root.Bad")),
+            'check forbid <= 5: active("Root.Bad");',
+            id="query-check-forbid",
+        ),
+        pytest.param(
+            BmcProperty("invariant", 5, predicate=BoolLiteral("true")),
+            "check invariant <= 5: true;",
+            id="query-check-invariant",
+        ),
+        pytest.param(
+            BmcProperty("must_reach", 5, predicate=Active("Root.Done")),
+            'check must_reach <= 5: active("Root.Done");',
+            id="query-check-must-reach",
+        ),
+        pytest.param(
+            BmcProperty("exists_always", 5, predicate=Active("Root.Safe")),
+            'check exists_always <= 5: active("Root.Safe");',
+            id="query-check-exists-always",
+        ),
+        pytest.param(
+            BmcProperty("cover", 5, predicate=Case("Root.A::transition::Root.B::0")),
+            'check cover <= 5: case("Root.A::transition::Root.B::0");',
+            id="query-check-cover",
+        ),
+        pytest.param(
+            response,
+            'check response <= 8:\n    trigger event("Root.Fault", current)\n    -> within 3 active("Root.Recovering");',
+            id="query-check-response",
+        ),
+        pytest.param(
+            BmcQuery(property=BmcProperty("reach", 1, predicate=Active("Root.Done"))),
+            'init cold;\n\ncheck reach <= 1: active("Root.Done");',
+            id="query-root-minimal",
+        ),
+        pytest.param(
+            BmcQuery(
+                initial=InitialSpec(
+                    mode="state",
+                    state_path="Root.Active",
+                    predicate=NumericComparison(FrameVar("x"), ">=", IntLiteral("0")),
+                ),
+                assumptions=(
+                    FrameAssumption(
+                        "always",
+                        NumericComparison(FrameVar("x"), "<=", IntLiteral("100")),
+                    ),
+                    FrameAssumption("at", Active("Root.Ready"), frame=2),
+                    EventAssumption("Root.Tick", selector="01..03"),
+                    EventAssumption("Root.Reset", selector=0, expected=False),
+                    cardinality,
+                    EventCardinalityAssumption("any"),
+                ),
+                property=response,
+            ),
+            'init state("Root.Active") where var("x") >= 0;\n\n'
+            'assume always: var("x") <= 100;\n\n'
+            'assume at 2: active("Root.Ready");\n\n'
+            'assume event("Root.Tick", 1..3) == true;\n\n'
+            'assume event("Root.Reset", 0) == false;\n\n'
+            'assume events cardinality at_most_one {\n    "Root.Tick",\n    "Root.Reset"\n};\n\n'
+            "assume events cardinality any;\n\n"
+            'check response <= 8:\n    trigger event("Root.Fault", current)\n    -> within 3 active("Root.Recovering");',
+            id="query-root-full",
+        ),
+    ]
+
+
+ROUND_TRIP_CASES = _round_trip_cases()
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("node, expected", ROUND_TRIP_CASES)
+def test_bmc_nodes_render_canonical_query_dsl_spelling(node, expected):
+    """AST/query nodes stringify to canonical ``.fbmcq`` DSL spelling."""
+    assert str(node) == expected
+
+
+@pytest.mark.unittest
+def test_round_trip_fixture_count_is_intentionally_large():
+    """Round-trip coverage stays broad enough to protect parser follow-up work."""
+    assert len(ROUND_TRIP_CASES) >= 100
+
+
+@pytest.mark.unittest
+def test_bmc_nodes_keep_dataclass_repr_for_debugging():
+    """Concrete nodes retain the dataclass-generated ``repr`` shape."""
+    nodes = [param.values[0] for param in ROUND_TRIP_CASES]
+
+    for node in nodes:
+        representation = repr(node)
+        assert representation.startswith("%s(" % node.__class__.__name__)
+        assert representation.endswith(")")
+
+
 @pytest.mark.unittest
 def test_fcstm_compatible_expression_canonical_shapes():
     """Core expression nodes cover the FCSTM expression grammar shape."""
@@ -449,7 +854,7 @@ def test_query_model_rejects_additional_invalid_structural_values():
         EventAssumption("Root.E", selector=-1)
     with pytest.raises(InvalidBmcQuery, match="selector"):
         EventAssumption("Root.E", selector="current")
-    for selector in ["²", "²..3", "３", "１..２"]:
+    for selector in ["²", "²..3", "３", "１..２", "3..2"]:
         with pytest.raises(InvalidBmcQuery, match="selector"):
             EventAssumption("Root.E", selector=selector)
     assert EventAssumption("Root.E", selector=0).to_canonical()["selector"] == 0

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -8,6 +8,7 @@ from pyfcstm.bmc import (
     BmcAssumption,
     BmcBuildError,
     BmcCondExpr,
+    BmcExpr,
     BmcError,
     BmcNumExpr,
     BmcProperty,
@@ -901,6 +902,15 @@ def test_query_model_rejects_additional_invalid_structural_values():
             property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
             assumptions=cast(Any, Active("Root.A")),
         )
+
+
+@pytest.mark.unittest
+def test_bmc_expression_bases_are_abstract():
+    """Expression category bases must not be instantiated directly."""
+
+    for base_cls in (BmcExpr, BmcNumExpr, BmcCondExpr):
+        with pytest.raises(TypeError, match="abstract"):
+            cast(Any, base_cls)()
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -128,7 +128,7 @@ def test_fcstm_compatible_expression_canonical_shapes():
 
 @pytest.mark.unittest
 def test_all_fcstm_operator_aliases_and_ufuncs_are_representable():
-    """Expression model keeps the PR-1 anchor for FCSTM expression parity."""
+    """Expression model keeps the anchor for FCSTM expression parity."""
     x = NameRef("x")
     y = NameRef("y")
 
@@ -303,8 +303,7 @@ def test_initial_spec_and_property_skeletons():
         "expected": True,
     }
     assert (
-        EventAssumption("Root.Idle.Start", selector="3").to_canonical()["selector"]
-        == "3"
+        EventAssumption("Root.Idle.Start", selector="3").to_canonical()["selector"] == 3
     )
     assert cardinality.to_canonical()["event_paths"] == (
         "Root.Idle.Start",
@@ -439,7 +438,10 @@ def test_query_model_rejects_additional_invalid_structural_values():
         EventAssumption("Root.E", selector=True)
     with pytest.raises(InvalidBmcQuery, match="selector"):
         EventAssumption("Root.E", selector=-1)
+    with pytest.raises(InvalidBmcQuery, match="selector"):
+        EventAssumption("Root.E", selector="current")
     assert EventAssumption("Root.E", selector=0).to_canonical()["selector"] == 0
+    assert EventAssumption("Root.E", selector="0").to_canonical()["selector"] == 0
     with pytest.raises(InvalidBmcQuery, match="state_path"):
         InitialSpec(mode="cold", state_path="Root.A")
     with pytest.raises(InvalidBmcQuery, match="predicate"):

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -726,10 +726,10 @@ def test_initial_spec_and_property_skeletons():
     assert (
         EventAssumption("Root.Idle.Start", selector="3").to_canonical()["selector"] == 3
     )
-    assert cardinality.to_canonical()["event_paths"] == (
+    assert cardinality.to_canonical()["event_paths"] == [
         "Root.Idle.Start",
         "Root.Idle.Stop",
-    )
+    ]
     assert reach.to_canonical()["kind"] == "reach"
     assert response.to_canonical()["trigger"] == Event("Root.Idle.Start").to_canonical()
     assert response.to_canonical()["within"] == 3
@@ -760,13 +760,46 @@ def test_bmc_query_canonical_form_is_stable():
     assert query.to_canonical() == {
         "node": "bmc_query",
         "initial": InitialSpec().to_canonical(),
-        "assumptions": (
+        "assumptions": [
             FrameAssumption("at", BoolLiteral("true"), frame=0).to_canonical(),
-        ),
+        ],
         "property": BmcProperty(
             "forbid", bound=4, predicate=Active("Root.Bad")
         ).to_canonical(),
     }
+
+
+@pytest.mark.unittest
+def test_query_canonical_collections_survive_json_round_trip():
+    """Canonical query collections use JSON-stable list shapes."""
+    cardinality = EventCardinalityAssumption("at_most_one", ("Root.A", "Root.B"))
+    empty_cardinality = EventCardinalityAssumption("any")
+    query = BmcQuery(property=BmcProperty("reach", 1, predicate=Active("Root.Done")))
+    assumed_query = BmcQuery(
+        property=BmcProperty("forbid", 2, predicate=Active("Root.Bad")),
+        assumptions=(FrameAssumption("always", BoolLiteral("true")),),
+    )
+
+    for canonical in [
+        cardinality.to_canonical(),
+        empty_cardinality.to_canonical(),
+        query.to_canonical(),
+        assumed_query.to_canonical(),
+    ]:
+        assert json.loads(json.dumps(canonical, allow_nan=False)) == canonical
+
+    assert empty_cardinality.to_canonical()["event_paths"] == []
+    assert query.to_canonical()["assumptions"] == []
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("node", [case.values[0] for case in ROUND_TRIP_CASES])
+def test_round_trip_fixture_canonical_forms_are_json_stable(node):
+    """Every round-trip fixture emits JSON-stable canonical data."""
+    assert (
+        json.loads(json.dumps(node.to_canonical(), allow_nan=False))
+        == node.to_canonical()
+    )
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -901,6 +901,14 @@ def test_expression_model_rejects_invalid_literal_and_frame_values():
         IntLiteral("0X2A")
     with pytest.raises(ValueError, match="decimal"):
         IntLiteral("-42")
+    with pytest.raises(ValueError, match="decimal"):
+        IntLiteral("42\n")
+    with pytest.raises(ValueError, match="hexadecimal"):
+        IntLiteral("0x2A\n")
+    with pytest.raises(ValueError, match="floating"):
+        FloatLiteral("1.\n")
+    with pytest.raises(ValueError, match="identifier"):
+        NameRef("cycle\n")
     with pytest.raises(ValueError, match="hexadecimal"):
         IntLiteral("0x")
     with pytest.raises(ValueError, match="kind"):

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -1,0 +1,473 @@
+"""Data model tests for FCSTM BMC query objects."""
+
+import pytest
+
+from pyfcstm.bmc import (
+    Active,
+    BmcBuildError,
+    BmcCondExpr,
+    BmcError,
+    BmcNumExpr,
+    BmcProperty,
+    BmcQuery,
+    BoolLiteral,
+    Called,
+    Case,
+    CondBinaryOp,
+    CondConditionalOp,
+    CondUnaryOp,
+    Cycle,
+    Event,
+    EventAssumption,
+    EventCardinalityAssumption,
+    FloatLiteral,
+    FrameAssumption,
+    FrameVar,
+    InitialSpec,
+    IntLiteral,
+    InvalidBmcEncoding,
+    InvalidBmcQuery,
+    MathConst,
+    NameRef,
+    NumBinaryOp,
+    NumConditionalOp,
+    NumUnaryOp,
+    NumericComparison,
+    Terminated,
+    UFuncCall,
+    UnsupportedBmcQuery,
+)
+
+
+@pytest.mark.unittest
+def test_error_hierarchy():
+    """BMC errors expose phase-specific subclasses under one base."""
+    assert issubclass(InvalidBmcQuery, BmcError)
+    assert issubclass(UnsupportedBmcQuery, BmcError)
+    assert issubclass(InvalidBmcEncoding, BmcError)
+    assert issubclass(BmcBuildError, BmcError)
+
+
+@pytest.mark.unittest
+def test_literal_canonical_forms_preserve_raw_kind_and_value():
+    """Literal canonical forms keep enough information for grammar parity."""
+    decimal = IntLiteral("42")
+    hexed = IntLiteral("0x2A", kind="hex")
+    floating = FloatLiteral("3.5e1")
+    fractional = FloatLiteral(".5")
+    exponent = FloatLiteral("1e-3")
+    truth = BoolLiteral("TRUE")
+
+    assert decimal.to_canonical() == {
+        "node": "int_literal",
+        "kind": "decimal",
+        "raw": "42",
+        "value": 42,
+    }
+    assert hexed.to_canonical() == {
+        "node": "int_literal",
+        "kind": "hex",
+        "raw": "0x2A",
+        "value": 42,
+    }
+    assert decimal != hexed
+    assert floating.to_canonical() == {
+        "node": "float_literal",
+        "kind": "float",
+        "raw": "3.5e1",
+        "value": 35.0,
+    }
+    assert fractional.to_canonical()["value"] == 0.5
+    assert exponent.to_canonical()["value"] == 0.001
+    assert truth.to_canonical() == {
+        "node": "bool_literal",
+        "kind": "bool",
+        "raw": "TRUE",
+        "value": True,
+    }
+
+
+@pytest.mark.unittest
+def test_fcstm_compatible_expression_canonical_shapes():
+    """Core expression nodes cover the FCSTM expression grammar shape."""
+    x = NameRef("x")
+    y = NameRef("y")
+    comparison = NumericComparison(x, "<", IntLiteral("10"))
+    condition = CondBinaryOp(comparison, "and", CondUnaryOp("not", Active("Root.Idle")))
+    numeric = NumConditionalOp(condition, UFuncCall("sqrt", x), MathConst("pi"))
+
+    assert NumUnaryOp("-", x).to_canonical() == {
+        "node": "num_unary",
+        "op": "-",
+        "operand": x.to_canonical(),
+    }
+    assert NumBinaryOp(x, "**", y).to_canonical() == {
+        "node": "num_binary",
+        "op": "**",
+        "left": x.to_canonical(),
+        "right": y.to_canonical(),
+    }
+    assert condition.to_canonical()["op"] == "&&"
+    assert condition.right.to_canonical()["op"] == "!"
+    assert numeric.to_canonical() == {
+        "node": "num_conditional",
+        "condition": condition.to_canonical(),
+        "if_true": UFuncCall("sqrt", x).to_canonical(),
+        "if_false": MathConst("pi").to_canonical(),
+    }
+    assert (
+        CondBinaryOp(
+            BoolLiteral("true"), "implies", BoolLiteral("FALSE")
+        ).to_canonical()["op"]
+        == "=>"
+    )
+    assert CondConditionalOp(
+        condition, BoolLiteral("true"), BoolLiteral("false")
+    ).to_canonical()["node"] == ("cond_conditional")
+
+
+@pytest.mark.unittest
+def test_all_fcstm_operator_aliases_and_ufuncs_are_representable():
+    """Expression model keeps the PR-1 anchor for FCSTM expression parity."""
+    x = NameRef("x")
+    y = NameRef("y")
+
+    for op in ["**", "*", "/", "%", "+", "-", "<<", ">>", "&", "^", "|"]:
+        assert NumBinaryOp(x, op, y).to_canonical()["op"] == op
+    for op in ["<", ">", "<=", ">=", "==", "!="]:
+        assert NumericComparison(x, op, y).to_canonical()["op"] == op
+    for raw_op, canonical_op in [
+        ("&&", "&&"),
+        ("and", "&&"),
+        ("||", "||"),
+        ("or", "||"),
+        ("=>", "=>"),
+        ("implies", "=>"),
+        ("xor", "xor"),
+        ("iff", "iff"),
+        ("==", "=="),
+        ("!=", "!="),
+    ]:
+        assert (
+            CondBinaryOp(
+                BoolLiteral("true"), raw_op, BoolLiteral("false")
+            ).to_canonical()["op"]
+            == canonical_op
+        )
+    for func in [
+        "sin",
+        "cos",
+        "tan",
+        "asin",
+        "acos",
+        "atan",
+        "sinh",
+        "cosh",
+        "tanh",
+        "asinh",
+        "acosh",
+        "atanh",
+        "sqrt",
+        "cbrt",
+        "exp",
+        "log",
+        "log10",
+        "log2",
+        "log1p",
+        "abs",
+        "ceil",
+        "floor",
+        "round",
+        "trunc",
+        "sign",
+    ]:
+        assert UFuncCall(func, x).to_canonical()["func"] == func
+
+
+@pytest.mark.unittest
+def test_bool_literal_raw_families_share_values_but_keep_raw_spelling():
+    """Boolean canonical shape preserves parser spelling while normalizing value."""
+    assert [BoolLiteral(raw).value for raw in ["true", "True", "TRUE"]] == [
+        True,
+        True,
+        True,
+    ]
+    assert [BoolLiteral(raw).value for raw in ["false", "False", "FALSE"]] == [
+        False,
+        False,
+        False,
+    ]
+    assert BoolLiteral("True").to_canonical()["raw"] == "True"
+
+
+@pytest.mark.unittest
+def test_bmc_only_nodes_have_expected_types_and_canonical_forms():
+    """BMC extension atoms stay typed as numeric or conditional nodes."""
+    numeric_nodes = [FrameVar("x"), Cycle()]
+    condition_nodes = [
+        Active("Root.Idle"),
+        Terminated(),
+        Event("Root.Idle.Start", selector=0),
+        Event("Root.Idle.Start", selector="current"),
+        Case("Root.Idle::transition::Root.Done::0", frame=1),
+        Called("CheckLimit", frame=2),
+    ]
+
+    assert all(isinstance(node, BmcNumExpr) for node in numeric_nodes)
+    assert all(isinstance(node, BmcCondExpr) for node in condition_nodes)
+    assert FrameVar("x").to_canonical() == {
+        "node": "frame_var",
+        "name": "x",
+        "spelling": "var_call",
+    }
+    assert Cycle().to_canonical() == {"node": "cycle"}
+    assert Active("Root.Idle").to_canonical() == {
+        "node": "active",
+        "state_path": "Root.Idle",
+        "frame": "current",
+    }
+    assert Event("Root.Idle.Start", selector="current").to_canonical() == {
+        "node": "event",
+        "event_path": "Root.Idle.Start",
+        "selector": "current",
+    }
+    assert Terminated(frame=2).to_canonical() == {
+        "node": "terminated",
+        "frame": 2,
+    }
+    assert Case("Root.Idle::transition::Root.Done::0", frame=1).to_canonical() == {
+        "node": "case",
+        "label": "Root.Idle::transition::Root.Done::0",
+        "frame": 1,
+    }
+    assert Called("CheckLimit", frame=2).to_canonical() == {
+        "node": "called",
+        "name": "CheckLimit",
+        "frame": 2,
+    }
+
+
+@pytest.mark.unittest
+def test_shallow_expression_type_validation():
+    """Expression constructors reject numeric/condition subtype mix-ups early."""
+    with pytest.raises(TypeError, match="BmcNumExpr"):
+        NumBinaryOp(Active("Root.A"), "+", IntLiteral("1"))
+    with pytest.raises(TypeError, match="BmcCondExpr"):
+        CondBinaryOp(Cycle(), "&&", BoolLiteral("true"))
+    with pytest.raises(TypeError, match="BmcCondExpr"):
+        NumConditionalOp(Cycle(), IntLiteral("1"), IntLiteral("0"))
+    with pytest.raises(ValueError, match="Unsupported"):
+        CondBinaryOp(BoolLiteral("true"), "&&&", BoolLiteral("false"))
+
+
+@pytest.mark.unittest
+def test_initial_spec_and_property_skeletons():
+    """Top-level query model represents default init, assumptions, and properties."""
+    init = InitialSpec()
+    frame_assumption = FrameAssumption(
+        "always", NumericComparison(NameRef("x"), "<=", IntLiteral("10"))
+    )
+    event_assumption = EventAssumption(
+        "Root.Idle.Start", selector="0..3", expected=True
+    )
+    cardinality = EventCardinalityAssumption(
+        "at_most_one",
+        event_paths=("Root.Idle.Start", "Root.Idle.Stop"),
+    )
+    reach = BmcProperty("reach", bound=5, predicate=Active("Root.Done"))
+    response = BmcProperty(
+        "response",
+        bound=7,
+        trigger=Event("Root.Idle.Start"),
+        response=Active("Root.Done"),
+        within=3,
+    )
+    cover = BmcProperty(
+        "cover", bound=3, predicate=Case("Root.Idle::transition::Root.Done::0")
+    )
+
+    assert init.to_canonical() == {
+        "node": "initial_spec",
+        "mode": "cold",
+        "state_path": None,
+        "predicate": None,
+    }
+    assert (
+        frame_assumption.to_canonical()["predicate"]
+        == NumericComparison(NameRef("x"), "<=", IntLiteral("10")).to_canonical()
+    )
+    assert event_assumption.to_canonical() == {
+        "node": "event_assumption",
+        "event_path": "Root.Idle.Start",
+        "selector": "0..3",
+        "expected": True,
+    }
+    assert (
+        EventAssumption("Root.Idle.Start", selector="3").to_canonical()["selector"]
+        == "3"
+    )
+    assert cardinality.to_canonical()["event_paths"] == (
+        "Root.Idle.Start",
+        "Root.Idle.Stop",
+    )
+    assert reach.to_canonical()["kind"] == "reach"
+    assert response.to_canonical()["trigger"] == Event("Root.Idle.Start").to_canonical()
+    assert response.to_canonical()["within"] == 3
+    assert (
+        cover.to_canonical()["predicate"]
+        == Case("Root.Idle::transition::Root.Done::0").to_canonical()
+    )
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("kind", ["forbid", "invariant", "must_reach", "exists_always"])
+def test_predicate_property_kinds_are_supported(kind):
+    """Predicate-only property kinds share the same structural contract."""
+    prop = BmcProperty(kind, bound=2, predicate=Active("Root.Target"))
+
+    assert prop.to_canonical()["kind"] == kind
+    assert prop.to_canonical()["predicate"] == Active("Root.Target").to_canonical()
+
+
+@pytest.mark.unittest
+def test_bmc_query_canonical_form_is_stable():
+    """BmcQuery composes top-level fields into a stable canonical dump."""
+    query = BmcQuery(
+        property=BmcProperty("forbid", bound=4, predicate=Active("Root.Bad")),
+        assumptions=(FrameAssumption("at", BoolLiteral("true"), frame=0),),
+    )
+
+    assert query.to_canonical() == {
+        "node": "bmc_query",
+        "initial": InitialSpec().to_canonical(),
+        "assumptions": (
+            FrameAssumption("at", BoolLiteral("true"), frame=0).to_canonical(),
+        ),
+        "property": BmcProperty(
+            "forbid", bound=4, predicate=Active("Root.Bad")
+        ).to_canonical(),
+    }
+
+
+@pytest.mark.unittest
+def test_query_model_rejects_invalid_skeleton_values():
+    """Model skeletons validate enums and simple structural constraints."""
+    with pytest.raises(InvalidBmcQuery, match="mode"):
+        InitialSpec(mode="warm")
+    with pytest.raises(InvalidBmcQuery, match="state_path"):
+        InitialSpec(mode="state")
+    with pytest.raises(InvalidBmcQuery, match="bound"):
+        BmcProperty("reach", bound=0, predicate=Active("Root.Done"))
+    with pytest.raises(InvalidBmcQuery, match="kind"):
+        BmcProperty("eventually", bound=3, predicate=Active("Root.Done"))
+    with pytest.raises(InvalidBmcQuery, match="property"):
+        BmcProperty("reach", bound=3)
+    with pytest.raises(InvalidBmcQuery, match="frame"):
+        FrameAssumption("at", BoolLiteral("true"))
+    with pytest.raises(InvalidBmcQuery, match="event_path"):
+        EventAssumption("")
+    with pytest.raises(InvalidBmcQuery, match="selector"):
+        EventAssumption("Root.E", selector="bad")
+    with pytest.raises(InvalidBmcQuery, match="selector"):
+        EventAssumption("Root.E", selector=[])
+    with pytest.raises(InvalidBmcQuery, match="expected"):
+        EventAssumption("Root.E", expected="true")
+    with pytest.raises(InvalidBmcQuery, match="only accept predicate"):
+        BmcProperty(
+            "reach",
+            bound=3,
+            predicate=Active("Root.Done"),
+            trigger=Event("Root.E"),
+        )
+    with pytest.raises(InvalidBmcQuery, match="response window"):
+        BmcProperty(
+            "response",
+            bound=3,
+            trigger=Event("Root.E"),
+            response=Active("Root.B"),
+        )
+    with pytest.raises(InvalidBmcQuery, match="only accept trigger"):
+        BmcProperty(
+            "response",
+            bound=3,
+            predicate=Active("Root.A"),
+            trigger=Event("Root.E"),
+            response=Active("Root.B"),
+            within=1,
+        )
+    with pytest.raises(InvalidBmcQuery, match="property predicate"):
+        BmcProperty("cover", bound=3)
+
+
+@pytest.mark.unittest
+def test_expression_model_rejects_invalid_literal_and_frame_values():
+    """Expression model shallow checks catch malformed literal and frame values."""
+    with pytest.raises(ValueError, match="non-empty"):
+        IntLiteral("")
+    with pytest.raises(ValueError, match="boolean"):
+        BoolLiteral("maybe")
+    with pytest.raises(ValueError, match="frame"):
+        Active("Root.A", frame="next")
+    with pytest.raises(ValueError, match="frame"):
+        Event("Root.E", selector=-1)
+    with pytest.raises(ValueError, match="identifier"):
+        NameRef("not-a-fcstm-id")
+    with pytest.raises(ValueError, match="Reserved"):
+        NameRef("cycle")
+    with pytest.raises(ValueError, match="floating"):
+        FloatLiteral("1")
+    with pytest.raises(ValueError, match="decimal"):
+        IntLiteral("0X2A")
+    with pytest.raises(ValueError, match="hexadecimal"):
+        IntLiteral("0x")
+    with pytest.raises(ValueError, match="spelling"):
+        FrameVar("x", spelling="bare")
+
+
+@pytest.mark.unittest
+def test_query_model_rejects_additional_invalid_structural_values():
+    """Query model rejects wrong primitive types and malformed containers."""
+    with pytest.raises(InvalidBmcQuery, match="bound"):
+        BmcProperty("reach", bound=True, predicate=Active("Root.Done"))
+    with pytest.raises(InvalidBmcQuery, match="bound"):
+        BmcProperty("reach", bound=-1, predicate=Active("Root.Done"))
+    with pytest.raises(InvalidBmcQuery, match="frame"):
+        FrameAssumption("at", BoolLiteral("true"), frame=True)
+    with pytest.raises(InvalidBmcQuery, match="frame"):
+        FrameAssumption("at", BoolLiteral("true"), frame=-1)
+    with pytest.raises(InvalidBmcQuery, match="selector"):
+        EventAssumption("Root.E", selector=True)
+    with pytest.raises(InvalidBmcQuery, match="selector"):
+        EventAssumption("Root.E", selector=-1)
+    assert EventAssumption("Root.E", selector=0).to_canonical()["selector"] == 0
+    with pytest.raises(InvalidBmcQuery, match="state_path"):
+        InitialSpec(mode="cold", state_path="Root.A")
+    with pytest.raises(InvalidBmcQuery, match="predicate"):
+        InitialSpec(predicate=Cycle())
+    with pytest.raises(InvalidBmcQuery, match="frame"):
+        FrameAssumption("always", BoolLiteral("true"), frame=0)
+    with pytest.raises(InvalidBmcQuery, match="event_paths"):
+        EventCardinalityAssumption("at_most_one", ())
+    with pytest.raises(InvalidBmcQuery, match="event_paths"):
+        EventCardinalityAssumption("at_most_one", "Root.E")
+    with pytest.raises(InvalidBmcQuery, match="only valid"):
+        EventCardinalityAssumption("any", ("Root.E",))
+    with pytest.raises(InvalidBmcQuery, match="event_paths"):
+        EventCardinalityAssumption("at_most_one", ("Root.E", ""))
+    with pytest.raises(InvalidBmcQuery, match="property"):
+        BmcQuery(property=Active("Root.Done"))
+    with pytest.raises(InvalidBmcQuery, match="initial"):
+        BmcQuery(
+            property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
+            initial=Active("Root.A"),
+        )
+    with pytest.raises(InvalidBmcQuery, match="assumptions"):
+        BmcQuery(
+            property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
+            assumptions=(Active("Root.A"),),
+        )
+    with pytest.raises(InvalidBmcQuery, match="assumptions"):
+        BmcQuery(
+            property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
+            assumptions=Active("Root.A"),
+        )

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -4,6 +4,7 @@ import pytest
 
 from pyfcstm.bmc import (
     Active,
+    BmcAssumption,
     BmcBuildError,
     BmcCondExpr,
     BmcError,
@@ -440,8 +441,15 @@ def test_query_model_rejects_additional_invalid_structural_values():
         EventAssumption("Root.E", selector=-1)
     with pytest.raises(InvalidBmcQuery, match="selector"):
         EventAssumption("Root.E", selector="current")
+    for selector in ["²", "²..3", "３", "１..２"]:
+        with pytest.raises(InvalidBmcQuery, match="selector"):
+            EventAssumption("Root.E", selector=selector)
     assert EventAssumption("Root.E", selector=0).to_canonical()["selector"] == 0
     assert EventAssumption("Root.E", selector="0").to_canonical()["selector"] == 0
+    assert (
+        EventAssumption("Root.E", selector="01..02").to_canonical()["selector"]
+        == "1..2"
+    )
     with pytest.raises(InvalidBmcQuery, match="state_path"):
         InitialSpec(mode="cold", state_path="Root.A")
     with pytest.raises(InvalidBmcQuery, match="predicate"):
@@ -473,3 +481,14 @@ def test_query_model_rejects_additional_invalid_structural_values():
             property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
             assumptions=Active("Root.A"),
         )
+
+
+@pytest.mark.unittest
+def test_bmc_assumption_base_requires_canonical_payload():
+    """Public assumption subclasses must implement canonical payloads."""
+
+    class FakeAssumption(BmcAssumption):
+        pass
+
+    with pytest.raises(TypeError, match="abstract"):
+        FakeAssumption()

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -406,10 +406,18 @@ def test_expression_model_rejects_invalid_literal_and_frame_values():
         IntLiteral("")
     with pytest.raises(ValueError, match="boolean"):
         BoolLiteral("maybe")
-    with pytest.raises(ValueError, match="frame"):
-        Active("Root.A", frame="next")
-    with pytest.raises(ValueError, match="frame"):
-        Event("Root.E", selector=-1)
+    for invalid_frame in ["next", True, -1, []]:
+        with pytest.raises(InvalidBmcQuery, match="frame"):
+            Active("Root.A", frame=invalid_frame)
+        with pytest.raises(InvalidBmcQuery, match="frame"):
+            Terminated(frame=invalid_frame)
+        with pytest.raises(InvalidBmcQuery, match="frame"):
+            Case("Root.A::fallback::Root.A::0", frame=invalid_frame)
+        with pytest.raises(InvalidBmcQuery, match="frame"):
+            Called("Check", frame=invalid_frame)
+    for invalid_selector in ["next", True, -1, []]:
+        with pytest.raises(InvalidBmcQuery, match="selector"):
+            Event("Root.E", selector=invalid_selector)
     with pytest.raises(ValueError, match="identifier"):
         NameRef("not-a-fcstm-id")
     with pytest.raises(ValueError, match="Reserved"):

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -347,6 +347,16 @@ def _round_trip_cases():
             id="query-init-terminated",
         ),
         pytest.param(
+            InitialSpec(mode="cold", predicate=Active("Root.Ready")),
+            'init cold where active("Root.Ready");',
+            id="query-init-cold-where",
+        ),
+        pytest.param(
+            InitialSpec(mode="terminated", predicate=Terminated()),
+            "init terminated where terminated();",
+            id="query-init-terminated-where",
+        ),
+        pytest.param(
             InitialSpec(mode="state", state_path="Root.Active"),
             'init state("Root.Active");',
             id="query-init-state",
@@ -811,6 +821,8 @@ def test_query_model_rejects_invalid_skeleton_values():
         InitialSpec(mode=cast(Any, []))
     with pytest.raises(InvalidBmcQuery, match="state_path"):
         InitialSpec(mode="state")
+    with pytest.raises(InvalidBmcQuery, match="state_path"):
+        InitialSpec(mode="state", state_path=cast(Any, 42))
     with pytest.raises(InvalidBmcQuery, match="bound"):
         BmcProperty("reach", bound=0, predicate=Active("Root.Done"))
     with pytest.raises(InvalidBmcQuery, match="kind"):
@@ -935,6 +947,8 @@ def test_query_model_rejects_additional_invalid_structural_values():
         EventAssumption("Root.E", selector="01..02").to_canonical()["selector"]
         == "1..2"
     )
+    assert EventAssumption("Root.E", selector="007").to_canonical()["selector"] == 7
+    assert EventAssumption("Root.E", selector="03..03").to_canonical()["selector"] == 3
     with pytest.raises(InvalidBmcQuery, match="state_path"):
         InitialSpec(mode="cold", state_path="Root.A")
     with pytest.raises(InvalidBmcQuery, match="predicate"):

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -1,6 +1,7 @@
 """Data model tests for FCSTM BMC query objects."""
 
 import pytest
+from typing import Any, cast
 
 from pyfcstm.bmc import (
     Active,
@@ -657,11 +658,11 @@ def test_bmc_only_nodes_have_expected_types_and_canonical_forms():
 def test_shallow_expression_type_validation():
     """Expression constructors reject numeric/condition subtype mix-ups early."""
     with pytest.raises(TypeError, match="BmcNumExpr"):
-        NumBinaryOp(Active("Root.A"), "+", IntLiteral("1"))
+        NumBinaryOp(cast(Any, Active("Root.A")), "+", IntLiteral("1"))
     with pytest.raises(TypeError, match="BmcCondExpr"):
-        CondBinaryOp(Cycle(), "&&", BoolLiteral("true"))
+        CondBinaryOp(cast(Any, Cycle()), "&&", BoolLiteral("true"))
     with pytest.raises(TypeError, match="BmcCondExpr"):
-        NumConditionalOp(Cycle(), IntLiteral("1"), IntLiteral("0"))
+        NumConditionalOp(cast(Any, Cycle()), IntLiteral("1"), IntLiteral("0"))
     with pytest.raises(ValueError, match="Unsupported"):
         CondBinaryOp(BoolLiteral("true"), "&&&", BoolLiteral("false"))
 
@@ -759,6 +760,8 @@ def test_query_model_rejects_invalid_skeleton_values():
     """Model skeletons validate enums and simple structural constraints."""
     with pytest.raises(InvalidBmcQuery, match="mode"):
         InitialSpec(mode="warm")
+    with pytest.raises(InvalidBmcQuery, match="mode"):
+        InitialSpec(mode=cast(Any, []))
     with pytest.raises(InvalidBmcQuery, match="state_path"):
         InitialSpec(mode="state")
     with pytest.raises(InvalidBmcQuery, match="bound"):
@@ -767,6 +770,8 @@ def test_query_model_rejects_invalid_skeleton_values():
         BmcProperty("eventually", bound=3, predicate=Active("Root.Done"))
     with pytest.raises(InvalidBmcQuery, match="property"):
         BmcProperty("reach", bound=3)
+    with pytest.raises(InvalidBmcQuery, match="kind"):
+        FrameAssumption(cast(Any, []), BoolLiteral("true"))
     with pytest.raises(InvalidBmcQuery, match="frame"):
         FrameAssumption("at", BoolLiteral("true"))
     with pytest.raises(InvalidBmcQuery, match="event_path"):
@@ -774,9 +779,9 @@ def test_query_model_rejects_invalid_skeleton_values():
     with pytest.raises(InvalidBmcQuery, match="selector"):
         EventAssumption("Root.E", selector="bad")
     with pytest.raises(InvalidBmcQuery, match="selector"):
-        EventAssumption("Root.E", selector=[])
+        EventAssumption("Root.E", selector=cast(Any, []))
     with pytest.raises(InvalidBmcQuery, match="expected"):
-        EventAssumption("Root.E", expected="true")
+        EventAssumption("Root.E", expected=cast(Any, "true"))
     with pytest.raises(InvalidBmcQuery, match="only accept predicate"):
         BmcProperty(
             "reach",
@@ -866,33 +871,35 @@ def test_query_model_rejects_additional_invalid_structural_values():
     with pytest.raises(InvalidBmcQuery, match="state_path"):
         InitialSpec(mode="cold", state_path="Root.A")
     with pytest.raises(InvalidBmcQuery, match="predicate"):
-        InitialSpec(predicate=Cycle())
+        InitialSpec(predicate=cast(Any, Cycle()))
     with pytest.raises(InvalidBmcQuery, match="frame"):
         FrameAssumption("always", BoolLiteral("true"), frame=0)
+    with pytest.raises(InvalidBmcQuery, match="kind"):
+        EventCardinalityAssumption(cast(Any, []))
     with pytest.raises(InvalidBmcQuery, match="event_paths"):
         EventCardinalityAssumption("at_most_one", ())
     with pytest.raises(InvalidBmcQuery, match="event_paths"):
-        EventCardinalityAssumption("at_most_one", "Root.E")
+        EventCardinalityAssumption("at_most_one", cast(Any, "Root.E"))
     with pytest.raises(InvalidBmcQuery, match="only valid"):
         EventCardinalityAssumption("any", ("Root.E",))
     with pytest.raises(InvalidBmcQuery, match="event_paths"):
         EventCardinalityAssumption("at_most_one", ("Root.E", ""))
     with pytest.raises(InvalidBmcQuery, match="property"):
-        BmcQuery(property=Active("Root.Done"))
+        BmcQuery(property=cast(Any, Active("Root.Done")))
     with pytest.raises(InvalidBmcQuery, match="initial"):
         BmcQuery(
             property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
-            initial=Active("Root.A"),
+            initial=cast(Any, Active("Root.A")),
         )
     with pytest.raises(InvalidBmcQuery, match="assumptions"):
         BmcQuery(
             property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
-            assumptions=(Active("Root.A"),),
+            assumptions=cast(Any, (Active("Root.A"),)),
         )
     with pytest.raises(InvalidBmcQuery, match="assumptions"):
         BmcQuery(
             property=BmcProperty("reach", bound=1, predicate=Active("Root.Done")),
-            assumptions=Active("Root.A"),
+            assumptions=cast(Any, Active("Root.A")),
         )
 
 
@@ -904,4 +911,4 @@ def test_bmc_assumption_base_requires_canonical_payload():
         pass
 
     with pytest.raises(TypeError, match="abstract"):
-        FakeAssumption()
+        cast(Any, FakeAssumption)()


### PR DESCRIPTION
## 背景

本 PR 是 [伞 PR #305](https://github.com/HansBug/pyfcstm/pull/305) 的 PR-1：**查询语言：定义 `.fbmcq` 文件与查询数据模型**。

本 PR 只建立 FCSTM BMC Query 的 Python 数据模型和 public API 占位，不实现 `.fbmcq` ANTLR grammar、parser、semantic binder、solver lowering、BMC engine、witness replay，也不接入 `pyfcstm.verify.registry`。

## 当前 ready 状态

- 最新 HEAD：`a9ea53dd fix(bmc): reject multiline query tokens [skip-slow]`。
- 最新本地验证：`python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py`、`pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing --cov-fail-under=100`（267 passed，`pyfcstm/bmc` 行覆盖率 100%、分支覆盖率 100%）、`python -m doctest pyfcstm/bmc/*.py`、`ruff check pyfcstm/bmc test/bmc`、`ruff format --check pyfcstm/bmc test/bmc` 均通过。
- CI 状态：PR #315 的 Code Test、Docs Check、Release Test、CLI Build、Template representative 与 `template-suite-gate` 均通过；Template full、Docs generated resources、jsfcstm test 为本次路由下预期 skipped。
- 多 reviewer 状态：codex reviewer、deepseek reviewer、claude reviewer 均已对最新 HEAD 做上下文独立强对抗复审，结论均为 C=0、I=0；仅剩非阻塞 M 级观察。
- 当前结论：PR-1 已达到 ready-to-merge 状态；等待维护者下一步合并指示。

## 技术目标

- 新建独立根模块 `pyfcstm.bmc`。
- 新增 `pyfcstm.bmc.ast`、`pyfcstm.bmc.query`、`pyfcstm.bmc.errors`。
- 定义 `BmcQuery`、`InitialSpec`、`BmcProperty`、assumption 数据模型。
- 定义 typed `BmcNumExpr` / `BmcCondExpr`、FCSTM-compatible canonical expression shape、BMC-only extension nodes。
- 所有 concrete BMC AST / query node 都必须具备 `__str__` 与 `__repr__`：`__str__` 返回 canonical `.fbmcq` DSL spelling；`__repr__` 保留 dataclass 原装调试形态，不额外手写成 DSL。
- 固化 public API `__all__`，为 PR-2/PR-3 grammar/parser 与 PR-4 binder 提供稳定目标对象。

## 非目标

- 不新增或修改 ANTLR grammar。
- 不实现 `parse_bmc_query(...)`。
- 不实现 model-aware binder、state/event path resolution、Z3 lowering、`BmcEngine`。
- 不修改 `pyfcstm.verify.registry`；verify 适配按伞 PR 规划留到 PR-13。
- 不引入新 runtime 依赖。
- 不把 PR-4 binder negative typing matrix 提前做成完整 semantic validation；PR-1 只做数据模型层的浅层类型与枚举约束。

## Public API 精确集合

| 模块 | `__all__` 必须包含 | 说明 |
|---|---|---|
| `pyfcstm.bmc.errors` | `BmcError`, `InvalidBmcQuery`, `UnsupportedBmcQuery`, `InvalidBmcEncoding`, `BmcBuildError` | BMC 查询、编码、构建阶段的结构化异常基类与子类。 |
| `pyfcstm.bmc.ast` | `BmcExpr`, `BmcNumExpr`, `BmcCondExpr`, `IntLiteral`, `FloatLiteral`, `BoolLiteral`, `NameRef`, `MathConst`, `NumUnaryOp`, `NumBinaryOp`, `NumConditionalOp`, `UFuncCall`, `CondUnaryOp`, `NumericComparison`, `CondBinaryOp`, `CondConditionalOp`, `FrameVar`, `Cycle`, `Active`, `Terminated`, `Event`, `Case`, `Called` | FCSTM-compatible expression core 与 BMC-only extension nodes。 |
| `pyfcstm.bmc.query` | `InitialSpec`, `BmcAssumption`, `FrameAssumption`, `EventAssumption`, `EventCardinalityAssumption`, `BmcProperty`, `BmcQuery` | 查询文件的 top-level AST / model skeleton。 |
| `pyfcstm.bmc` | 上述三个模块 public names 的并集 | 作为用户与后续 parser/binder subPR 的稳定 import surface。 |

## canonical expression shape 契约

- 每个 expression node 提供稳定 `to_canonical()` 结果，返回 plain `dict` / `list` / primitive 组成的 JSON-stable language-neutral 结构，可直接作为 PR-3 FCSTM/FBMCQ expression parity fixture 的 golden 锚点；冻结 dataclass 内部为了不可变性仍可保存 tuple，但 `to_canonical()` 不输出 tuple，避免 JSON round-trip 后形态漂移。
- literal 保留可区分的 `raw`、`value`、`kind` 字段：例如十进制 `42` 与十六进制 `0x2A` 不会在 canonical form 中混淆。
- boolean literal 支持 `true` / `True` / `TRUE` / `false` / `False` / `FALSE`，canonical value 归一但 raw spelling 保留。
- math constant 保留 canonical name，例如 `pi` / `E` / `tau`。
- operator alias canonicalization 与 FCSTM grammar 兼容：`!` / `not` 归一为 `!`，`&&` / `and` 归一为 `&&`，`||` / `or` 归一为 `||`，`=>` / `implies` 归一为 `=>`；`xor` 与 `iff` 保留 canonical keyword。
- `FrameVar`、`Cycle` 是 `BmcNumExpr`；`Active`、`Terminated`、`Event`、`Case`、`Called` 是 `BmcCondExpr`。
- `FrameVar(name, spelling="var_call")` 表达 `.fbmcq` 的 `var("...")` 原子；它是 query-level frame-relative 变量引用，不在 PR-1 里绑定具体 solver frame。
- `Event(path, selector="current"|int)` 使用 query 语义的 event cycle selector 命名；event range / `*` 只在 `EventAssumption` 里表达。
- `BmcProperty(kind="response")` 显式保存 `trigger`、`response`、`within` 三个字段；`within` 是 response window，不与 top-level bound 混淆。
- `BmcProperty(kind="cover")` 在 PR-1 数据层仍使用 `predicate=Case(...)` 表达 grammar 层的 `bmc_cond_expression` body；PR-4 binder 再强制 cover body 必须是裸 `Case`。
- PR-1 采用浅层 subtype 校验：算术 unary/binary/ufunc/ternary 的 numeric operand 必须是 `BmcNumExpr`，condition operand 必须是 `BmcCondExpr`；完整 semantic negative matrix 留给 PR-4 binder。
- `str(node)` 是 query DSL round-trip surface：表达式节点必须按 FCSTM AST 的做法输出可重新解析的 DSL 文本，并在必要位置补括号，避免 precedence / associativity 改变 AST shape；字符串参数用 canonical 双引号转义。
- explicit frame / selector 字段不能在 `__str__` 中丢失：默认 `current` 可用短写（例如 `active("Root.A")`、`terminated()`、`case("...")`），非默认 frame / selector 必须输出 normalized 显式参数（例如 `active("Root.A", 2)`、`event("Root.E", 0)`）。后续 grammar/parser subPR 必须接受或等价构造这些 object-level spelling，不能只覆盖示例中的默认形态。
- `__repr__` 的契约是保留 dataclass 生成的 `ClassName(field=...)` 调试形态；不要把 `repr(node)` 改成 DSL，也不要让 `repr` 成为 parser-facing API。

## 执行方案

1. TDD 添加 `test/bmc/test_query_model.py` 与 `test/bmc/test_bmc_public_api.py`，其中 `test_query_model.py` 必须使用 `pytest.mark.parametrize` 承载不少于 100 条 round-trip spelling fixtures，并覆盖 concrete node 的 `__str__` canonical `.fbmcq` spelling、dataclass `__repr__` 调试形态、canonical dump 与 shallow validation。
2. 新建 `pyfcstm/bmc/` 包：
   - `__init__.py`：导出 public API，并用 `.. list-table::` 写清 module roadmap。
   - `errors.py`：定义 BMC query / encoding / build 错误类型。
   - `ast.py`：定义 canonical expression shape、typed BMC expression base、BMC-only nodes。
   - `query.py`：定义 `InitialSpec`、assumptions、`BmcProperty`、`BmcQuery`。
3. 用 frozen dataclass 保持对象可等值比较、可测试、可作为后续 normalized dump 的稳定来源。
4. 每个 public class / function 写 reST docstring：class 按 CLAUDE.md class/dataclass 模板包含 `:param:` / `:type:` / `Example::`；public function / method 按 function 模板包含 `:return:` / `:rtype:` / `Example::`。
5. 提交前运行：
   - `make rst_auto RANGE_DIR=bmc`
   - `python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py`
   - `python -c "import doctest; from pyfcstm import bmc; from pyfcstm.bmc import ast, errors, query; raise SystemExit(sum(doctest.testmod(m).failed for m in (bmc, ast, errors, query)))"`
   - `ruff check pyfcstm/bmc test/bmc`
   - `ruff format --check pyfcstm/bmc test/bmc`
   - `pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing`
   - `SKIP_SLOW_TESTS=1 make unittest`

## 验收标准

- `test/bmc/test_query_model.py` 与 `test/bmc/test_bmc_public_api.py` 存在且全部通过。
- `InitialSpec(mode="cold")` 可表达默认 init。
- query model 可表达 frame assumptions、event assumptions、event cardinality assumptions、`reach` / `forbid` / `invariant` / `must_reach` / `exists_always` / `response` / `cover` property skeleton。
- canonical nodes 覆盖 decimal / hex / float / bool / name / const / unary / binary / ternary / ufunc。
- 所有 concrete expression/query node 的 `str(node)` 都有 DSL spelling 断言；复杂表达式覆盖括号、operator alias normalization、quoted string escaping、BMC-only atom 的 default/current 短写与 explicit frame/selector 长写。
- round-trip spelling fixtures 必须通过 `pytest.mark.parametrize` 集中维护，数量不少于 100 条；本 PR 当前覆盖 119 条，后续新增 concrete node / DSL spelling 分支时必须同步扩展该参数化表。
- 所有 concrete expression/query node 的 `repr(node)` 保留 dataclass 原装 `ClassName(...)` 调试形态，并由测试覆盖；不得把 `repr` 改成 DSL。
- BMC-only extension nodes 覆盖 `FrameVar`、`Cycle`、`Active`、`Terminated`、`Event`、`Case`、`Called`。
- typed bases 能区分 `BmcNumExpr` 与 `BmcCondExpr`，并按本 PR 的浅层 subtype 校验策略保留 PR-4 negative typing matrix 的结构锚点。
- `to_canonical()` golden 能区分 literal raw/kind/value、operator canonical alias、FCSTM-compatible core 与 BMC-only nodes。
- `__all__` 为精确集合，`from pyfcstm.bmc import ...` 可导入所有 public API。
- `pyfcstm/bmc/__init__.py` docstring 包含 `.. list-table::` roadmap。
- `make rst_auto RANGE_DIR=bmc` 通过并生成对应 API RST。
- `python -c "import doctest; from pyfcstm import bmc; from pyfcstm.bmc import ast, errors, query; raise SystemExit(sum(doctest.testmod(m).failed for m in (bmc, ast, errors, query)))"` 通过。
- `pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing` 显示 `pyfcstm/bmc` 行覆盖率与分支覆盖率均为 100%；新增/修改 AST/query node 或其 `__str__` 分支时仍必须保持 100%。
- 不出现 `pyfcstm.verify.registry` 接入或 `pyfcstm.verify.bmc` 新模块。
- Python 3.7-3.14 兼容：不使用 `list[str]`、`X | Y`、`dataclasses` 的新版本-only 选项；无新增 runtime dependency。
- 本 PR CI 全绿；codecov 若指出 `pyfcstm/bmc/` public class / public method 的显式分支未覆盖，则补测后再标记 ready。

## 已完成本地验证

- `make rst_auto RANGE_DIR=bmc`
- `python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py`
- `python -c "import doctest; from pyfcstm import bmc; from pyfcstm.bmc import ast, errors, query; raise SystemExit(sum(doctest.testmod(m).failed for m in (bmc, ast, errors, query)))"`
- `ruff check pyfcstm/bmc test/bmc`
- `ruff format --check pyfcstm/bmc test/bmc`
- `pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing --cov-fail-under=100`：263 passed，`pyfcstm/bmc` 行覆盖率 100%、分支覆盖率 100%。
- `SKIP_SLOW_TESTS=1 make unittest`：41799 passed，730 skipped，67 deselected。

## review 后修复

- 移除代码与测试 docstring 中的 workflow metadata 措辞，避免把 PR 编号、slice/subPR 等流程词写入 code-facing 文本。
- 将 `EventAssumption(selector="3")` 的 canonical selector 归一为整数 `3`，并补充 `selector="current"` 在 event assumption 中应被拒绝的负例。
- 调整本 PR docstring 验收口径：class/dataclass 使用 CLAUDE.md class 模板；public function / method 使用 function 模板。
- 将 `Active` / `Terminated` / `Event` / `Case` / `Called` 的 frame / selector 非法值收敛为 `InvalidBmcQuery`，避免数据模型层泄漏裸 `ValueError`。
- `SKIP_SLOW_TESTS=1 make unittest`：41557 passed，730 skipped，67 deselected。
- 按新增 round-trip 要求补齐 `__str__` DSL spelling 与 dataclass `__repr__` 覆盖；当前通过 119 条 `pytest.mark.parametrize` spelling fixtures 覆盖 concrete expression/query node；`pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing --cov-fail-under=100`：263 passed，`pyfcstm/bmc` 行覆盖率 100%、分支覆盖率 100%。
- 将 `BmcExpr` / `BmcNumExpr` / `BmcCondExpr` 改为 ABC 抽象基类，与 `BmcAssumption` 的构造期抽象约束一致，并补测三类 expression base 不能直接实例化。
- 在 `pyfcstm.bmc.ast` 模块契约中明确 expression 层 `ValueError` / `TypeError` 与 query 层 `InvalidBmcQuery` 的异常边界，避免后续 parser/binder 误以为一个异常族覆盖全部数据模型校验。
- 在 `Event` 文档中明确默认 `current` selector 也必须显式输出为 `event("...", current)`，区别于 frame-based atoms 的短写。
- 将 PR body 的 doctest 验证命令改为逐模块 `doctest.testmod`，避免 `python -m doctest pyfcstm/bmc/*.py` 对 `ast.py` basename 误测 stdlib `ast` 模块。

- 将 `FloatLiteral` 的 canonical `value` 收敛为严格 JSON 可移植值：构造期拒绝会溢出为非有限 Python `float` 的 spelling（例如 `1e999`），并补充 `allow_nan=False` 序列化断言。
- 将 `IntLiteral(raw, kind=...)` 的显式 kind 改为必须与 raw spelling 一致，避免 `IntLiteral("0x2A", kind="decimal")` 静默归一为 hex；对应 decimal/hex 错配负例已覆盖。
- 最新本地验证：`make rst_auto RANGE_DIR=bmc`、`python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py`、逐模块 `doctest.testmod`、`ruff check pyfcstm/bmc test/bmc`、`ruff format --check pyfcstm/bmc test/bmc`、`pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing --cov-fail-under=100`（263 passed，行/分支 100%）、`SKIP_SLOW_TESTS=1 make unittest`（41799 passed，730 skipped，67 deselected）均通过。

## 与伞 PR 的一致性

对应伞 PR #305 子 PR 表中的 PR-1 行：

> 建立 FCSTM BMC Query 的 Python 数据模型和 public API 占位，并冻结 FCSTM-compatible expression core 与 BMC-only extension node 的 canonical 形态。

本 PR 完成后，PR-2 可以在该模型基础上接入 `.fbmcq` ANTLR grammar，PR-3 可以把 parse tree 构造成这些数据模型，PR-4 可以在这些类型之上实现 semantic binder。










- 将 query-level collection canonical 输出统一为 JSON-stable `list`：`EventCardinalityAssumption.to_canonical()["event_paths"]` 与 `BmcQuery.to_canonical()["assumptions"]` 不再输出 tuple；补充所有 119 条 round-trip fixture 的 `json.dumps(..., allow_nan=False)` / `json.loads(...)` 等值回归，防止 parser/binder golden 在 JSON 持久化后发生 list/tuple 漂移。
- 最新本地验证补充：`python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py`、逐模块 doctest、`ruff check pyfcstm/bmc test/bmc`、`ruff format --check pyfcstm/bmc test/bmc`、`pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing --cov-fail-under=100`（263 passed，行/分支 100%）、`SKIP_SLOW_TESTS=1 make unittest`（41799 passed，730 skipped，67 deselected）均通过。


