### PR TITLE
查询语言：实现 .fbmcq 解析器与 AST 构建

### DIFF
--- a/docs/source/api_doc/bmc/errors.rst
+++ b/docs/source/api_doc/bmc/errors.rst
@@ -18,6 +18,12 @@ BmcError
 .. autoclass:: BmcError
 
 
+BmcQueryParseError
+-----------------------------------------------------
+
+.. autoclass:: BmcQueryParseError
+
+
 InvalidBmcQuery
 -----------------------------------------------------
 

--- a/docs/source/api_doc/bmc/index.rst
+++ b/docs/source/api_doc/bmc/index.rst
@@ -12,6 +12,8 @@ pyfcstm.bmc
     ast
     errors
     grammar/index
+    listener
+    parse
     query
 
 \_\_all\_\_

--- a/docs/source/api_doc/bmc/listener.rst
+++ b/docs/source/api_doc/bmc/listener.rst
@@ -1,0 +1,19 @@
+pyfcstm.bmc.listener
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.listener
+
+.. automodule:: pyfcstm.bmc.listener
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+BmcQueryParseListener
+-----------------------------------------------------
+
+.. autoclass:: BmcQueryParseListener
+    :members: __init__,exitQuery,exitBmc_num_expression_entry,exitBmc_cond_expression_entry,exitInit_clause,exitInit_target,exitAssume_clause,exitFrame_assume,exitEvent_assume,exitCardinality_assume,exitCheck_clause,exitProperty_kind,exitProperty_body,exitResponse_property_body,exitString_list,exitBool_cmp_op,exitEvent_range_selector,exitEvent_cycle_selector,exitFrame_selector,exitInteger_literal,exitParenExprNum,exitLiteralExprNum,exitIdExprNum,exitMathConstExprNum,exitFrameVarExprNum,exitCycleExprNum,exitUnaryExprNum,exitFuncExprNum,exitBinaryExprNum,exitConditionalCStyleExprNum,exitParenExprCond,exitLiteralExprCond,exitAtomExprCond,exitUnaryExprCond,exitBinaryExprFromNumCond,exitBinaryExprFromCondCond,exitBinaryExprCond,exitConditionalCStyleExprCond,exitBmc_boolean_atom,exitNum_literal,exitBool_literal,exitMath_const,exitString_literal

--- a/docs/source/api_doc/bmc/parse.rst
+++ b/docs/source/api_doc/bmc/parse.rst
@@ -1,0 +1,42 @@
+pyfcstm.bmc.parse
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.parse
+
+.. automodule:: pyfcstm.bmc.parse
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+build\_bmc\_ast\_from\_parse\_tree
+-----------------------------------------------------
+
+.. autofunction:: build_bmc_ast_from_parse_tree
+
+
+parse\_with\_bmc\_grammar\_entry
+-----------------------------------------------------
+
+.. autofunction:: parse_with_bmc_grammar_entry
+
+
+parse\_bmc\_query
+-----------------------------------------------------
+
+.. autofunction:: parse_bmc_query
+
+
+parse\_bmc\_num\_expression
+-----------------------------------------------------
+
+.. autofunction:: parse_bmc_num_expression
+
+
+parse\_bmc\_cond\_expression
+-----------------------------------------------------
+
+.. autofunction:: parse_bmc_cond_expression

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -10,6 +10,8 @@ Package contracts:
 
 * BMC query objects are parser-independent and data-only in this package.
 * The root package must not depend on ``pyfcstm.verify`` or its registry.
+* Parser entry points build parser-independent query objects and remain
+  separate from model-aware binding or solver lowering.
 * :func:`str` on exported query and expression dataclasses is reserved for the
   canonical ``.fbmcq`` query DSL spelling.
 * :func:`repr` remains the dataclass debugging representation; callers that need
@@ -24,11 +26,19 @@ Public module structure:
      - Public entry
      - Purpose
    * - Error hierarchy
-     - :class:`BmcError`, :class:`InvalidBmcQuery`,
+     - :class:`BmcError`, :class:`BmcQueryParseError`,
+       :class:`InvalidBmcQuery`,
        :class:`UnsupportedBmcQuery`, :class:`InvalidBmcEncoding`,
        :class:`BmcBuildError`
      - Provide stable BMC-specific exception types without importing
        ``pyfcstm.verify``.
+   * - Query parser
+     - :func:`parse_bmc_query`, :func:`parse_bmc_num_expression`,
+       :func:`parse_bmc_cond_expression`,
+       :func:`parse_with_bmc_grammar_entry`,
+       :func:`build_bmc_ast_from_parse_tree`
+     - Convert ``.fbmcq`` text or existing ANTLR parse trees into
+       parser-independent AST/query nodes.
    * - Typed expression bases
      - :class:`BmcExpr`, :class:`BmcNumExpr`, :class:`BmcCondExpr`
      - Keep FCSTM numeric and condition expression categories explicit.
@@ -90,9 +100,17 @@ from pyfcstm.bmc.ast import (
 from pyfcstm.bmc.errors import (
     BmcBuildError,
     BmcError,
+    BmcQueryParseError,
     InvalidBmcEncoding,
     InvalidBmcQuery,
     UnsupportedBmcQuery,
+)
+from pyfcstm.bmc.parse import (
+    build_bmc_ast_from_parse_tree,
+    parse_bmc_cond_expression,
+    parse_bmc_num_expression,
+    parse_bmc_query,
+    parse_with_bmc_grammar_entry,
 )
 from pyfcstm.bmc.query import (
     BmcAssumption,
@@ -106,10 +124,16 @@ from pyfcstm.bmc.query import (
 
 __all__ = [
     "BmcError",
+    "BmcQueryParseError",
     "InvalidBmcQuery",
     "UnsupportedBmcQuery",
     "InvalidBmcEncoding",
     "BmcBuildError",
+    "parse_bmc_query",
+    "parse_bmc_num_expression",
+    "parse_bmc_cond_expression",
+    "parse_with_bmc_grammar_entry",
+    "build_bmc_ast_from_parse_tree",
     "BmcExpr",
     "BmcNumExpr",
     "BmcCondExpr",

--- a/pyfcstm/bmc/errors.py
+++ b/pyfcstm/bmc/errors.py
@@ -9,6 +9,9 @@ Design contracts:
 
 * Error classes are intentionally thin and stable so parser, binder, engine, and
   adapter layers can share them without coupling to each other.
+* :class:`BmcQueryParseError` is reserved for syntax-facing failures before a
+  well-formed query object exists. :class:`InvalidBmcQuery` remains the
+  structural query-model validation error after AST objects are being built.
 * Query data-model validation uses these BMC-specific exceptions for structural
   failures, while expression category mix-ups still use normal Python type
   errors where that is more precise.
@@ -16,6 +19,8 @@ Design contracts:
 The module contains:
 
 * :class:`BmcError` - Base class for all BMC-specific errors.
+* :class:`BmcQueryParseError` - Syntax, lexical, entry-point, or parse-tree
+  construction error.
 * :class:`InvalidBmcQuery` - Query model or semantic-query validation error.
 * :class:`UnsupportedBmcQuery` - Well-formed query that this implementation
   deliberately does not support yet.
@@ -44,6 +49,26 @@ class BmcError(Exception):
         >>> err = BmcError("query failed")
         >>> str(err)
         'query failed'
+    """
+
+
+class BmcQueryParseError(BmcError):
+    """Raised when ``.fbmcq`` text or parse trees cannot build BMC AST nodes.
+
+    This exception covers lexical syntax diagnostics, parser syntax
+    diagnostics, unfinished parsing, unknown text entry points, and parse-tree
+    roots that the listener did not map to a BMC AST object. It deliberately
+    does not cover model-aware validation or query structural validation, which
+    use :class:`InvalidBmcQuery`.
+
+    :param message: Human-readable parse failure message.
+    :type message: str
+
+    Example::
+
+        >>> err = BmcQueryParseError("syntax error")
+        >>> isinstance(err, BmcError)
+        True
     """
 
 
@@ -105,6 +130,7 @@ class BmcBuildError(BmcError):
 
 __all__ = [
     "BmcError",
+    "BmcQueryParseError",
     "InvalidBmcQuery",
     "UnsupportedBmcQuery",
     "InvalidBmcEncoding",

--- a/pyfcstm/bmc/listener.py
+++ b/pyfcstm/bmc/listener.py
@@ -54,6 +54,7 @@ from pyfcstm.bmc.ast import (
 )
 from pyfcstm.bmc.grammar.BmcQueryParser import BmcQueryParser
 from pyfcstm.bmc.grammar.BmcQueryParserListener import BmcQueryParserListener
+from pyfcstm.bmc.errors import InvalidBmcQuery
 from pyfcstm.bmc.query import (
     BmcProperty,
     BmcQuery,
@@ -281,11 +282,17 @@ class BmcQueryParseListener(BmcQueryParserListener):
         bound = self.nodes[ctx.integer_literal()]
         body = self.nodes[ctx.property_body()]
         if kind == "response":
+            if not isinstance(body, tuple):
+                raise InvalidBmcQuery(
+                    "response properties require a trigger/within/response body."
+                )
             trigger, within, response = body
             self.nodes[ctx] = BmcProperty(
                 kind, bound, trigger=trigger, response=response, within=within
             )
         else:
+            if isinstance(body, tuple):
+                raise InvalidBmcQuery("single-body properties only accept predicate.")
             self.nodes[ctx] = BmcProperty(kind, bound, predicate=body)
 
     def exitProperty_kind(self, ctx: BmcQueryParser.Property_kindContext) -> None:

--- a/pyfcstm/bmc/listener.py
+++ b/pyfcstm/bmc/listener.py
@@ -1,0 +1,576 @@
+"""ANTLR listener that builds parser-independent FCSTM BMC query AST nodes.
+
+The listener mirrors :mod:`pyfcstm.dsl.listener`: it walks generated ANTLR parse
+contexts bottom-up and stores the constructed object in ``nodes[ctx]``. The
+module intentionally performs syntax-to-AST construction only. It does not
+resolve model paths, validate event scope, lower expressions to Z3, or touch the
+verify registry.
+
+The module contains:
+
+* :class:`BmcQueryParseListener` - Context-to-node listener for ``.fbmcq`` query
+  files and expression entry rules.
+
+Example::
+
+    >>> from antlr4 import CommonTokenStream, InputStream, ParseTreeWalker
+    >>> from pyfcstm.bmc.grammar.BmcQueryLexer import BmcQueryLexer
+    >>> from pyfcstm.bmc.grammar.BmcQueryParser import BmcQueryParser
+    >>> listener = BmcQueryParseListener()
+    >>> lexer = BmcQueryLexer(InputStream('check reach <= 1: true;'))
+    >>> parser = BmcQueryParser(CommonTokenStream(lexer))
+    >>> tree = parser.query()
+    >>> ParseTreeWalker().walk(listener, tree)
+    >>> listener.nodes[tree].property.kind
+    'reach'
+"""
+
+from __future__ import annotations
+
+import ast as py_ast
+from typing import Any, Dict, List, cast
+
+from pyfcstm.bmc.ast import (
+    Active,
+    BoolLiteral,
+    Called,
+    Case,
+    CondBinaryOp,
+    CondConditionalOp,
+    CondUnaryOp,
+    Cycle,
+    Event,
+    FloatLiteral,
+    FrameVar,
+    IntLiteral,
+    MathConst,
+    NameRef,
+    NumBinaryOp,
+    NumConditionalOp,
+    NumUnaryOp,
+    NumericComparison,
+    Terminated,
+    UFuncCall,
+)
+from pyfcstm.bmc.grammar.BmcQueryParser import BmcQueryParser
+from pyfcstm.bmc.grammar.BmcQueryParserListener import BmcQueryParserListener
+from pyfcstm.bmc.query import (
+    BmcProperty,
+    BmcQuery,
+    EventAssumption,
+    EventCardinalityAssumption,
+    FrameAssumption,
+    InitialSpec,
+)
+
+
+def _decode_string_literal(raw_text: str) -> str:
+    """Decode a grammar-accepted string literal token.
+
+    :param raw_text: Token text including surrounding quotes.
+    :type raw_text: str
+    :return: Decoded Python string value.
+    :rtype: str
+
+    Example::
+
+        >>> _decode_string_literal('"Root.A"')
+        'Root.A'
+    """
+    return py_ast.literal_eval(raw_text)
+
+
+def _int_value(raw_text: str) -> int:
+    """Return the integer value for a decimal grammar literal.
+
+    :param raw_text: Decimal literal token text.
+    :type raw_text: str
+    :return: Parsed integer value.
+    :rtype: int
+
+    Example::
+
+        >>> _int_value('001')
+        1
+    """
+    return int(raw_text, 10)
+
+
+class BmcQueryParseListener(BmcQueryParserListener):
+    """Build BMC query model nodes from generated ANTLR parse contexts.
+
+    :ivar nodes: Mapping from parse context objects to AST/query nodes.
+    :vartype nodes: Dict[object, object]
+
+    Example::
+
+        >>> listener = BmcQueryParseListener()
+        >>> listener.nodes
+        {}
+    """
+
+    def __init__(self) -> None:
+        """Initialize the listener node mapping.
+
+        :return: ``None``.
+        :rtype: None
+
+        Example::
+
+            >>> BmcQueryParseListener().nodes
+            {}
+        """
+        super().__init__()
+        self.nodes: Dict[object, Any] = {}
+
+    def _optional_frame(self, ctx: object) -> Any:
+        """Return ``current`` for omitted frames or the mapped selector value."""
+        if ctx is None:
+            return "current"
+        return self.nodes[ctx]
+
+    def _string_value(self, ctx: object) -> str:
+        """Return a decoded string literal value from a mapped context."""
+        return cast(str, self.nodes[ctx])
+
+    def exitQuery(self, ctx: BmcQueryParser.QueryContext) -> None:
+        """Build the top-level :class:`pyfcstm.bmc.query.BmcQuery`.
+
+        :param ctx: Query parse context.
+        :type ctx: BmcQueryParser.QueryContext
+        :return: ``None``.
+        :rtype: None
+        """
+        initial = self.nodes[ctx.init_clause()] if ctx.init_clause() else InitialSpec()
+        assumption_contexts = cast(
+            List[BmcQueryParser.Assume_clauseContext], ctx.assume_clause()
+        )
+        assumptions = tuple(self.nodes[item] for item in assumption_contexts)
+        self.nodes[ctx] = BmcQuery(
+            property=self.nodes[ctx.check_clause()],
+            initial=initial,
+            assumptions=assumptions,
+        )
+
+    def exitBmc_num_expression_entry(
+        self, ctx: BmcQueryParser.Bmc_num_expression_entryContext
+    ) -> None:
+        """Bind a numeric expression entry to its expression node.
+
+        :param ctx: Numeric expression entry parse context.
+        :type ctx: BmcQueryParser.Bmc_num_expression_entryContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = self.nodes[ctx.bmc_num_expression()]
+
+    def exitBmc_cond_expression_entry(
+        self, ctx: BmcQueryParser.Bmc_cond_expression_entryContext
+    ) -> None:
+        """Bind a condition expression entry to its expression node.
+
+        :param ctx: Condition expression entry parse context.
+        :type ctx: BmcQueryParser.Bmc_cond_expression_entryContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = self.nodes[ctx.bmc_cond_expression()]
+
+    def exitInit_clause(self, ctx: BmcQueryParser.Init_clauseContext) -> None:
+        """Build an initial clause node.
+
+        :param ctx: Initial clause parse context.
+        :type ctx: BmcQueryParser.Init_clauseContext
+        :return: ``None``.
+        :rtype: None
+        """
+        target = self.nodes[ctx.init_target()]
+        predicate = self.nodes[ctx.bmc_cond_expression()] if ctx.WHERE() else None
+        mode = target[0]
+        state_path = target[1] if mode == "state" else None
+        self.nodes[ctx] = InitialSpec(
+            mode=mode, state_path=state_path, predicate=predicate
+        )
+
+    def exitInit_target(self, ctx: BmcQueryParser.Init_targetContext) -> None:
+        """Build an initial-target tuple used by :meth:`exitInit_clause`.
+
+        :param ctx: Initial-target parse context.
+        :type ctx: BmcQueryParser.Init_targetContext
+        :return: ``None``.
+        :rtype: None
+        """
+        if ctx.COLD():
+            self.nodes[ctx] = ("cold", None)
+        elif ctx.TERMINATED():
+            self.nodes[ctx] = ("terminated", None)
+        else:
+            self.nodes[ctx] = ("state", self.nodes[ctx.string_literal()])
+
+    def exitAssume_clause(self, ctx: BmcQueryParser.Assume_clauseContext) -> None:
+        """Bind an assumption wrapper to its concrete assumption node.
+
+        :param ctx: Assumption wrapper parse context.
+        :type ctx: BmcQueryParser.Assume_clauseContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = self.nodes[
+            ctx.frame_assume() or ctx.event_assume() or ctx.cardinality_assume()
+        ]
+
+    def exitFrame_assume(self, ctx: BmcQueryParser.Frame_assumeContext) -> None:
+        """Build a frame assumption node.
+
+        :param ctx: Frame assumption parse context.
+        :type ctx: BmcQueryParser.Frame_assumeContext
+        :return: ``None``.
+        :rtype: None
+        """
+        predicate = self.nodes[ctx.bmc_cond_expression()]
+        if ctx.ALWAYS():
+            self.nodes[ctx] = FrameAssumption("always", predicate)
+        else:
+            self.nodes[ctx] = FrameAssumption(
+                "at", predicate, frame=self.nodes[ctx.integer_literal()]
+            )
+
+    def exitEvent_assume(self, ctx: BmcQueryParser.Event_assumeContext) -> None:
+        """Build an event assumption and normalize ``!=`` polarity.
+
+        :param ctx: Event assumption parse context.
+        :type ctx: BmcQueryParser.Event_assumeContext
+        :return: ``None``.
+        :rtype: None
+        """
+        bool_value = self.nodes[ctx.bool_literal()].value
+        op = self.nodes[ctx.bool_cmp_op()]
+        expected = bool_value if op == "==" else not bool_value
+        self.nodes[ctx] = EventAssumption(
+            self.nodes[ctx.string_literal()],
+            selector=self.nodes[ctx.event_range_selector()],
+            expected=expected,
+        )
+
+    def exitCardinality_assume(
+        self, ctx: BmcQueryParser.Cardinality_assumeContext
+    ) -> None:
+        """Build an event-cardinality assumption node.
+
+        :param ctx: Event-cardinality assumption parse context.
+        :type ctx: BmcQueryParser.Cardinality_assumeContext
+        :return: ``None``.
+        :rtype: None
+        """
+        if ctx.ANY():
+            self.nodes[ctx] = EventCardinalityAssumption("any")
+        else:
+            self.nodes[ctx] = EventCardinalityAssumption(
+                "at_most_one", tuple(self.nodes[ctx.string_list()])
+            )
+
+    def exitCheck_clause(self, ctx: BmcQueryParser.Check_clauseContext) -> None:
+        """Build the query property from a check clause.
+
+        :param ctx: Check clause parse context.
+        :type ctx: BmcQueryParser.Check_clauseContext
+        :return: ``None``.
+        :rtype: None
+        """
+        kind = self.nodes[ctx.property_kind()]
+        bound = self.nodes[ctx.integer_literal()]
+        body = self.nodes[ctx.property_body()]
+        if kind == "response":
+            trigger, within, response = body
+            self.nodes[ctx] = BmcProperty(
+                kind, bound, trigger=trigger, response=response, within=within
+            )
+        else:
+            self.nodes[ctx] = BmcProperty(kind, bound, predicate=body)
+
+    def exitProperty_kind(self, ctx: BmcQueryParser.Property_kindContext) -> None:
+        """Bind a property kind context to its text.
+
+        :param ctx: Property-kind parse context.
+        :type ctx: BmcQueryParser.Property_kindContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = ctx.getText()
+
+    def exitProperty_body(self, ctx: BmcQueryParser.Property_bodyContext) -> None:
+        """Bind a property body to a response tuple or condition predicate.
+
+        :param ctx: Property body parse context.
+        :type ctx: BmcQueryParser.Property_bodyContext
+        :return: ``None``.
+        :rtype: None
+        """
+        child = ctx.response_property_body() or ctx.bmc_cond_expression()
+        self.nodes[ctx] = self.nodes[child]
+
+    def exitResponse_property_body(
+        self, ctx: BmcQueryParser.Response_property_bodyContext
+    ) -> None:
+        """Build a response body tuple ``(trigger, within, response)``.
+
+        :param ctx: Response property body parse context.
+        :type ctx: BmcQueryParser.Response_property_bodyContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = (
+            self.nodes[ctx.bmc_cond_expression(0)],
+            self.nodes[ctx.integer_literal()],
+            self.nodes[ctx.bmc_cond_expression(1)],
+        )
+
+    def exitString_list(self, ctx: BmcQueryParser.String_listContext) -> None:
+        """Build a tuple of decoded string literals.
+
+        :param ctx: String-list parse context.
+        :type ctx: BmcQueryParser.String_listContext
+        :return: ``None``.
+        :rtype: None
+        """
+        string_contexts = cast(
+            List[BmcQueryParser.String_literalContext], ctx.string_literal()
+        )
+        self.nodes[ctx] = tuple(self.nodes[item] for item in string_contexts)
+
+    def exitBool_cmp_op(self, ctx: BmcQueryParser.Bool_cmp_opContext) -> None:
+        """Bind a boolean comparison operator context to its spelling.
+
+        :param ctx: Boolean comparison operator parse context.
+        :type ctx: BmcQueryParser.Bool_cmp_opContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = ctx.getText()
+
+    def exitEvent_range_selector(
+        self, ctx: BmcQueryParser.Event_range_selectorContext
+    ) -> None:
+        """Build an event-assumption range selector.
+
+        :param ctx: Event range selector parse context.
+        :type ctx: BmcQueryParser.Event_range_selectorContext
+        :return: ``None``.
+        :rtype: None
+        """
+        if ctx.STAR():
+            self.nodes[ctx] = "*"
+        elif ctx.RANGE_INT():
+            self.nodes[ctx] = "".join(cast(Any, ctx.RANGE_INT()).getText().split())
+        else:
+            items = cast(
+                List[BmcQueryParser.Integer_literalContext], ctx.integer_literal()
+            )
+            if len(items) == 1:
+                self.nodes[ctx] = self.nodes[items[0]]
+            else:
+                self.nodes[ctx] = "%d..%d" % (
+                    self.nodes[items[0]],
+                    self.nodes[items[1]],
+                )
+
+    def exitEvent_cycle_selector(
+        self, ctx: BmcQueryParser.Event_cycle_selectorContext
+    ) -> None:
+        """Build an event atom cycle selector.
+
+        :param ctx: Event cycle selector parse context.
+        :type ctx: BmcQueryParser.Event_cycle_selectorContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = (
+            "current" if ctx.CURRENT() else self.nodes[ctx.integer_literal()]
+        )
+
+    def exitFrame_selector(self, ctx: BmcQueryParser.Frame_selectorContext) -> None:
+        """Build an optional-frame atom selector.
+
+        :param ctx: Frame selector parse context.
+        :type ctx: BmcQueryParser.Frame_selectorContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = (
+            "current" if ctx.CURRENT() else self.nodes[ctx.integer_literal()]
+        )
+
+    def exitInteger_literal(self, ctx: BmcQueryParser.Integer_literalContext) -> None:
+        """Build an integer value for query bounds and selectors.
+
+        :param ctx: Integer literal parse context.
+        :type ctx: BmcQueryParser.Integer_literalContext
+        :return: ``None``.
+        :rtype: None
+        """
+        self.nodes[ctx] = _int_value(cast(Any, ctx.INT()).getText())
+
+    def exitParenExprNum(self, ctx: BmcQueryParser.ParenExprNumContext) -> None:
+        """Bind a parenthesized numeric expression to its inner node."""
+        self.nodes[ctx] = self.nodes[ctx.bmc_num_expression()]
+
+    def exitLiteralExprNum(self, ctx: BmcQueryParser.LiteralExprNumContext) -> None:
+        """Bind a numeric literal expression to its literal node."""
+        self.nodes[ctx] = self.nodes[ctx.num_literal()]
+
+    def exitIdExprNum(self, ctx: BmcQueryParser.IdExprNumContext) -> None:
+        """Build a bare numeric name reference."""
+        self.nodes[ctx] = NameRef(cast(Any, ctx.ID()).getText())
+
+    def exitMathConstExprNum(self, ctx: BmcQueryParser.MathConstExprNumContext) -> None:
+        """Bind a math-constant numeric expression to its constant node."""
+        self.nodes[ctx] = self.nodes[ctx.math_const()]
+
+    def exitFrameVarExprNum(self, ctx: BmcQueryParser.FrameVarExprNumContext) -> None:
+        """Build a query-level ``var("...")`` numeric atom."""
+        self.nodes[ctx] = FrameVar(self._string_value(ctx.string_literal()))
+
+    def exitCycleExprNum(self, ctx: BmcQueryParser.CycleExprNumContext) -> None:
+        """Build the built-in ``cycle`` numeric atom."""
+        self.nodes[ctx] = Cycle()
+
+    def exitUnaryExprNum(self, ctx: BmcQueryParser.UnaryExprNumContext) -> None:
+        """Build a numeric unary expression."""
+        self.nodes[ctx] = NumUnaryOp(
+            cast(Any, ctx.op).text, self.nodes[ctx.bmc_num_expression()]
+        )
+
+    def exitFuncExprNum(self, ctx: BmcQueryParser.FuncExprNumContext) -> None:
+        """Build a unary math function expression."""
+        self.nodes[ctx] = UFuncCall(
+            cast(Any, ctx.func_name).text, self.nodes[ctx.bmc_num_expression()]
+        )
+
+    def exitBinaryExprNum(self, ctx: BmcQueryParser.BinaryExprNumContext) -> None:
+        """Build a numeric binary expression."""
+        self.nodes[ctx] = NumBinaryOp(
+            self.nodes[ctx.bmc_num_expression(0)],
+            cast(Any, ctx.op).text,
+            self.nodes[ctx.bmc_num_expression(1)],
+        )
+
+    def exitConditionalCStyleExprNum(
+        self, ctx: BmcQueryParser.ConditionalCStyleExprNumContext
+    ) -> None:
+        """Build a numeric ternary expression."""
+        self.nodes[ctx] = NumConditionalOp(
+            self.nodes[ctx.bmc_cond_expression()],
+            self.nodes[ctx.bmc_num_expression(0)],
+            self.nodes[ctx.bmc_num_expression(1)],
+        )
+
+    def exitParenExprCond(self, ctx: BmcQueryParser.ParenExprCondContext) -> None:
+        """Bind a parenthesized condition expression to its inner node."""
+        self.nodes[ctx] = self.nodes[ctx.bmc_cond_expression()]
+
+    def exitLiteralExprCond(self, ctx: BmcQueryParser.LiteralExprCondContext) -> None:
+        """Bind a boolean literal condition expression to its literal node."""
+        self.nodes[ctx] = self.nodes[ctx.bool_literal()]
+
+    def exitAtomExprCond(self, ctx: BmcQueryParser.AtomExprCondContext) -> None:
+        """Bind a condition atom expression to its atom node."""
+        self.nodes[ctx] = self.nodes[ctx.bmc_boolean_atom()]
+
+    def exitUnaryExprCond(self, ctx: BmcQueryParser.UnaryExprCondContext) -> None:
+        """Build a condition unary expression."""
+        self.nodes[ctx] = CondUnaryOp(
+            cast(Any, ctx.op).text, self.nodes[ctx.bmc_cond_expression()]
+        )
+
+    def exitBinaryExprFromNumCond(
+        self, ctx: BmcQueryParser.BinaryExprFromNumCondContext
+    ) -> None:
+        """Build a numeric comparison condition expression."""
+        self.nodes[ctx] = NumericComparison(
+            self.nodes[ctx.bmc_num_expression(0)],
+            cast(Any, ctx.op).text,
+            self.nodes[ctx.bmc_num_expression(1)],
+        )
+
+    def exitBinaryExprFromCondCond(
+        self, ctx: BmcQueryParser.BinaryExprFromCondCondContext
+    ) -> None:
+        """Build a condition equality, inequality, or ``iff`` expression."""
+        self.nodes[ctx] = CondBinaryOp(
+            self.nodes[ctx.bmc_cond_expression(0)],
+            cast(Any, ctx.op).text,
+            self.nodes[ctx.bmc_cond_expression(1)],
+        )
+
+    def exitBinaryExprCond(self, ctx: BmcQueryParser.BinaryExprCondContext) -> None:
+        """Build a logical binary condition expression."""
+        self.nodes[ctx] = CondBinaryOp(
+            self.nodes[ctx.bmc_cond_expression(0)],
+            cast(Any, ctx.op).text,
+            self.nodes[ctx.bmc_cond_expression(1)],
+        )
+
+    def exitConditionalCStyleExprCond(
+        self, ctx: BmcQueryParser.ConditionalCStyleExprCondContext
+    ) -> None:
+        """Build a condition ternary expression."""
+        self.nodes[ctx] = CondConditionalOp(
+            self.nodes[ctx.bmc_cond_expression(0)],
+            self.nodes[ctx.bmc_cond_expression(1)],
+            self.nodes[ctx.bmc_cond_expression(2)],
+        )
+
+    def exitBmc_boolean_atom(self, ctx: BmcQueryParser.Bmc_boolean_atomContext) -> None:
+        """Build one BMC-only boolean atom."""
+        frame = self._optional_frame(ctx.frame_selector())
+        if ctx.ACTIVE():
+            self.nodes[ctx] = Active(
+                self._string_value(ctx.string_literal()), frame=frame
+            )
+        elif ctx.TERMINATED():
+            self.nodes[ctx] = Terminated(frame=frame)
+        elif ctx.EVENT():
+            self.nodes[ctx] = Event(
+                self._string_value(ctx.string_literal()),
+                selector=self.nodes[ctx.event_cycle_selector()],
+            )
+        elif ctx.CASE():
+            self.nodes[ctx] = Case(
+                self._string_value(ctx.string_literal()), frame=frame
+            )
+        elif ctx.CALLED():
+            self.nodes[ctx] = Called(
+                self._string_value(ctx.string_literal()), frame=frame
+            )
+        else:
+            raise AssertionError(
+                "Unknown BMC boolean atom: %s" % ctx.getText()
+            )  # pragma: no cover
+
+    def exitNum_literal(self, ctx: BmcQueryParser.Num_literalContext) -> None:
+        """Build an integer or floating-point literal expression node."""
+        if ctx.INT():
+            self.nodes[ctx] = IntLiteral(cast(Any, ctx.INT()).getText(), kind="decimal")
+        elif ctx.HEX_INT():
+            self.nodes[ctx] = IntLiteral(cast(Any, ctx.HEX_INT()).getText(), kind="hex")
+        elif ctx.FLOAT():
+            self.nodes[ctx] = FloatLiteral(cast(Any, ctx.FLOAT()).getText())
+        else:
+            raise AssertionError(
+                "Unknown numeric literal: %s" % ctx.getText()
+            )  # pragma: no cover
+
+    def exitBool_literal(self, ctx: BmcQueryParser.Bool_literalContext) -> None:
+        """Build a boolean literal expression node."""
+        self.nodes[ctx] = BoolLiteral(ctx.getText())
+
+    def exitMath_const(self, ctx: BmcQueryParser.Math_constContext) -> None:
+        """Build a math-constant expression node."""
+        self.nodes[ctx] = MathConst(ctx.getText())
+
+    def exitString_literal(self, ctx: BmcQueryParser.String_literalContext) -> None:
+        """Decode a string literal token into a Python string."""
+        self.nodes[ctx] = _decode_string_literal(cast(Any, ctx.STRING()).getText())
+
+
+__all__ = ["BmcQueryParseListener"]

--- a/pyfcstm/bmc/parse.py
+++ b/pyfcstm/bmc/parse.py
@@ -33,7 +33,7 @@ from typing import Any, Callable, Dict, List, cast
 
 from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, Token
 from antlr4.error.ErrorListener import ErrorListener
-from antlr4.tree.Tree import ParseTreeWalker
+from antlr4.tree.Tree import ErrorNode, ParseTreeWalker
 
 from pyfcstm.bmc.ast import BmcCondExpr, BmcNumExpr
 from pyfcstm.bmc.errors import BmcQueryParseError
@@ -48,6 +48,7 @@ _SUPPORTED_ENTRIES = {
     "bmc_num_expression_entry",
     "bmc_cond_expression_entry",
 }
+_SUPPORTED_ENTRY_TEXT = ", ".join(sorted(_SUPPORTED_ENTRIES))
 
 
 class _CollectingBmcErrorListener(ErrorListener):
@@ -177,6 +178,36 @@ def _build_parser(
     return parser
 
 
+def _find_error_node_text(parse_tree: ParserRuleContext) -> str:
+    """Return the first ANTLR recovery-node text within ``parse_tree``.
+
+    Callers that provide their own parse trees may bypass the collecting error
+    listener used by :func:`parse_with_bmc_grammar_entry`.  ANTLR can still
+    recover from malformed input by inserting :class:`antlr4.tree.Tree.ErrorNode`
+    objects into the tree.  Detecting those nodes before listener walking keeps
+    the public parse-tree builder from leaking low-level literal-conversion
+    failures.
+
+    :param parse_tree: Root parse-tree context to inspect.
+    :type parse_tree: antlr4.ParserRuleContext
+    :return: Text for the first recovery node, or ``""`` when none exists.
+    :rtype: str
+
+    Example::
+
+        >>> _find_error_node_text(ParserRuleContext())
+        ''
+    """
+    pending = [parse_tree]
+    while pending:
+        node = pending.pop()
+        if isinstance(node, ErrorNode):
+            return node.getText()
+        for index in range(node.getChildCount() - 1, -1, -1):
+            pending.append(node.getChild(index))
+    return ""
+
+
 def build_bmc_ast_from_parse_tree(parse_tree: ParserRuleContext) -> Any:
     """Build a BMC AST object from an already-created ANTLR parse tree.
 
@@ -185,8 +216,9 @@ def build_bmc_ast_from_parse_tree(parse_tree: ParserRuleContext) -> Any:
     :return: AST or query object mapped for ``parse_tree``.
     :rtype: object
     :raises TypeError: If ``parse_tree`` is not an ANTLR parser context.
-    :raises pyfcstm.bmc.errors.BmcQueryParseError: If the listener does not
-        map the provided root context.
+    :raises pyfcstm.bmc.errors.BmcQueryParseError: If the parse tree contains
+        ANTLR recovery nodes, the listener cannot map a recovered child context,
+        or the listener does not map the provided root context.
 
     Example::
 
@@ -199,9 +231,22 @@ def build_bmc_ast_from_parse_tree(parse_tree: ParserRuleContext) -> Any:
     """
     if not isinstance(parse_tree, ParserRuleContext):
         raise TypeError("parse_tree must be ParserRuleContext.")
+    error_node_text = _find_error_node_text(parse_tree)
+    if error_node_text:
+        raise BmcQueryParseError(
+            "BMC parse tree contains ANTLR recovery node %r." % error_node_text
+        )
     listener = BmcQueryParseListener()
     walker = ParseTreeWalker()
-    walker.walk(listener, parse_tree)
+    try:
+        walker.walk(listener, parse_tree)
+    except KeyError as err:
+        # KeyError: ANTLR error recovery can leave required child contexts
+        # present-but-unmapped, for example ``active("S", )`` creates an empty
+        # frame_selector context. Surface this as a stable parse-tree error.
+        raise BmcQueryParseError(
+            "BMC parse tree construction failed because a child context was not mapped."
+        ) from err
     try:
         return listener.nodes[parse_tree]
     except KeyError as err:
@@ -236,9 +281,17 @@ def parse_with_bmc_grammar_entry(
         >>> node = parse_with_bmc_grammar_entry('cycle + 1', 'bmc_num_expression_entry')
         >>> node.to_canonical()['node']
         'num_binary'
+
+    .. note::
+        The currently supported text entries already end in ``EOF`` in the
+        grammar.  ``force_finished`` is kept for API parity with
+        :mod:`pyfcstm.dsl.parse` and as an extra guard for future entries.
     """
     if entry_name not in _SUPPORTED_ENTRIES:
-        raise BmcQueryParseError("Unsupported BMC grammar entry: %r." % entry_name)
+        raise BmcQueryParseError(
+            "Unsupported BMC grammar entry: %r. Supported entries: %s."
+            % (entry_name, _SUPPORTED_ENTRY_TEXT)
+        )
 
     error_listener = _CollectingBmcErrorListener()
     lexer = _build_lexer(input_text, error_listener)

--- a/pyfcstm/bmc/parse.py
+++ b/pyfcstm/bmc/parse.py
@@ -1,0 +1,332 @@
+"""Parse ``.fbmcq`` query text into parser-independent BMC AST objects.
+
+This module is the public parsing entry point for FCSTM BMC Query files. It is
+structured after :mod:`pyfcstm.dsl.parse`: ANTLR lexer/parser classes perform
+syntax recognition, :class:`pyfcstm.bmc.listener.BmcQueryParseListener` builds
+query objects, and syntax-facing errors are reported through
+:class:`pyfcstm.bmc.errors.BmcQueryParseError`.
+
+The parser layer is intentionally narrow. It does not import model classes,
+Z3, or verify-registry code; model-aware binding and solver lowering belong to
+later BMC modules.
+
+The module contains:
+
+* :func:`parse_with_bmc_grammar_entry` - Parse text through one supported entry
+  rule.
+* :func:`build_bmc_ast_from_parse_tree` - Walk an already-created parse tree and
+  return the mapped AST object.
+* :func:`parse_bmc_query`, :func:`parse_bmc_num_expression`, and
+  :func:`parse_bmc_cond_expression` - Convenience entry points.
+
+Example::
+
+    >>> from pyfcstm.bmc.parse import parse_bmc_query
+    >>> query = parse_bmc_query('check reach <= 1: true;')
+    >>> query.property.kind
+    'reach'
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, cast
+
+from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, Token
+from antlr4.error.ErrorListener import ErrorListener
+from antlr4.tree.Tree import ParseTreeWalker
+
+from pyfcstm.bmc.ast import BmcCondExpr, BmcNumExpr
+from pyfcstm.bmc.errors import BmcQueryParseError
+from pyfcstm.bmc.grammar.BmcQueryLexer import BmcQueryLexer
+from pyfcstm.bmc.grammar.BmcQueryParser import BmcQueryParser
+from pyfcstm.bmc.listener import BmcQueryParseListener
+from pyfcstm.bmc.query import BmcQuery
+
+_ParserEntry = Callable[[BmcQueryParser], ParserRuleContext]
+_SUPPORTED_ENTRIES = {
+    "query",
+    "bmc_num_expression_entry",
+    "bmc_cond_expression_entry",
+}
+
+
+class _CollectingBmcErrorListener(ErrorListener):
+    """Collect ANTLR syntax diagnostics for BMC query parsing.
+
+    :ivar messages: Human-readable diagnostics reported by lexer and parser.
+    :vartype messages: List[str]
+
+    Example::
+
+        >>> listener = _CollectingBmcErrorListener()
+        >>> listener.messages
+        []
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty diagnostic buffer.
+
+        :return: ``None``.
+        :rtype: None
+        """
+        super().__init__()
+        self.messages: List[str] = []
+
+    def syntaxError(self, recognizer, offendingSymbol, line, column, msg, e) -> None:
+        """Record an ANTLR syntax error callback.
+
+        :param recognizer: Lexer or parser instance that reported the error.
+        :type recognizer: object
+        :param offendingSymbol: Token or text near the failure.
+        :type offendingSymbol: object
+        :param line: One-based input line number.
+        :type line: int
+        :param column: Zero-based input column number.
+        :type column: int
+        :param msg: ANTLR diagnostic message.
+        :type msg: str
+        :param e: Optional ANTLR recognition exception.
+        :type e: object
+        :return: ``None``.
+        :rtype: None
+        """
+        symbol_text = getattr(offendingSymbol, "text", None)
+        if symbol_text is None and offendingSymbol is not None:
+            symbol_text = str(offendingSymbol)
+        near = " near %r" % symbol_text if symbol_text is not None else ""
+        self.messages.append("line %d:%d%s: %s" % (line, column, near, msg))
+
+    def check_errors(self) -> None:
+        """Raise :class:`BmcQueryParseError` if diagnostics were collected.
+
+        :return: ``None``.
+        :rtype: None
+        :raises pyfcstm.bmc.errors.BmcQueryParseError: If syntax diagnostics
+            were recorded.
+
+        Example::
+
+            >>> listener = _CollectingBmcErrorListener()
+            >>> listener.check_errors()
+        """
+        if self.messages:
+            raise BmcQueryParseError("; ".join(self.messages))
+
+    def check_unfinished_parsing_error(self, stream: CommonTokenStream) -> None:
+        """Record an error when a parse entry leaves tokens unconsumed.
+
+        :param stream: Token stream used by the parser.
+        :type stream: antlr4.CommonTokenStream
+        :return: ``None``.
+        :rtype: None
+        """
+        if stream.LA(1) != Token.EOF:
+            token = cast(Any, stream.LT(1))
+            self.messages.append(
+                "line %d:%d near %r: parser did not consume the full input"
+                % (token.line, token.column, token.text)
+            )
+
+
+def _build_lexer(
+    input_text: str, error_listener: _CollectingBmcErrorListener
+) -> BmcQueryLexer:
+    """Build a BMC query lexer with the shared collecting error listener.
+
+    :param input_text: Query or expression text.
+    :type input_text: str
+    :param error_listener: Error listener that receives lexer diagnostics.
+    :type error_listener: _CollectingBmcErrorListener
+    :return: Configured BMC query lexer.
+    :rtype: pyfcstm.bmc.grammar.BmcQueryLexer.BmcQueryLexer
+
+    Example::
+
+        >>> listener = _CollectingBmcErrorListener()
+        >>> _build_lexer('true', listener).grammarFileName
+        'BmcQueryLexer.g4'
+    """
+    lexer = BmcQueryLexer(InputStream(input_text))
+    lexer.removeErrorListeners()
+    lexer.addErrorListener(error_listener)
+    return lexer
+
+
+def _build_parser(
+    stream: CommonTokenStream, error_listener: _CollectingBmcErrorListener
+) -> BmcQueryParser:
+    """Build a BMC query parser with collecting syntax diagnostics.
+
+    :param stream: Token stream produced by :func:`_build_lexer`.
+    :type stream: antlr4.CommonTokenStream
+    :param error_listener: Error listener that receives parser diagnostics.
+    :type error_listener: _CollectingBmcErrorListener
+    :return: Configured BMC query parser.
+    :rtype: pyfcstm.bmc.grammar.BmcQueryParser.BmcQueryParser
+
+    Example::
+
+        >>> listener = _CollectingBmcErrorListener()
+        >>> lexer = _build_lexer('true', listener)
+        >>> _build_parser(CommonTokenStream(lexer), listener).grammarFileName
+        'BmcQueryParser.g4'
+    """
+    parser = BmcQueryParser(stream)
+    parser.removeErrorListeners()
+    parser.addErrorListener(error_listener)
+    return parser
+
+
+def build_bmc_ast_from_parse_tree(parse_tree: ParserRuleContext) -> Any:
+    """Build a BMC AST object from an already-created ANTLR parse tree.
+
+    :param parse_tree: Root parse-tree context to walk.
+    :type parse_tree: antlr4.ParserRuleContext
+    :return: AST or query object mapped for ``parse_tree``.
+    :rtype: object
+    :raises TypeError: If ``parse_tree`` is not an ANTLR parser context.
+    :raises pyfcstm.bmc.errors.BmcQueryParseError: If the listener does not
+        map the provided root context.
+
+    Example::
+
+        >>> from antlr4 import CommonTokenStream, InputStream
+        >>> lexer = BmcQueryLexer(InputStream('1'))
+        >>> parser = BmcQueryParser(CommonTokenStream(lexer))
+        >>> tree = parser.bmc_num_expression_entry()
+        >>> build_bmc_ast_from_parse_tree(tree).value
+        1
+    """
+    if not isinstance(parse_tree, ParserRuleContext):
+        raise TypeError("parse_tree must be ParserRuleContext.")
+    listener = BmcQueryParseListener()
+    walker = ParseTreeWalker()
+    walker.walk(listener, parse_tree)
+    try:
+        return listener.nodes[parse_tree]
+    except KeyError as err:
+        # KeyError: listener.nodes has no root mapping when the supplied
+        # parse-tree context is outside the supported BMC builder surface.
+        raise BmcQueryParseError(
+            "No BMC AST node was built for parse tree root %s."
+            % type(parse_tree).__name__
+        ) from err
+
+
+def parse_with_bmc_grammar_entry(
+    input_text: str, entry_name: str, force_finished: bool = True
+) -> Any:
+    """Parse text with a supported BMC grammar entry rule.
+
+    :param input_text: Query or expression text.
+    :type input_text: str
+    :param entry_name: One of ``"query"``, ``"bmc_num_expression_entry"``, or
+        ``"bmc_cond_expression_entry"``.
+    :type entry_name: str
+    :param force_finished: Whether the token stream must be exhausted after the
+        entry rule, defaults to ``True``.
+    :type force_finished: bool, optional
+    :return: AST object produced by the entry rule.
+    :rtype: object
+    :raises pyfcstm.bmc.errors.BmcQueryParseError: If ``entry_name`` is
+        unsupported or parsing fails.
+
+    Example::
+
+        >>> node = parse_with_bmc_grammar_entry('cycle + 1', 'bmc_num_expression_entry')
+        >>> node.to_canonical()['node']
+        'num_binary'
+    """
+    if entry_name not in _SUPPORTED_ENTRIES:
+        raise BmcQueryParseError("Unsupported BMC grammar entry: %r." % entry_name)
+
+    error_listener = _CollectingBmcErrorListener()
+    lexer = _build_lexer(input_text, error_listener)
+    stream = CommonTokenStream(lexer)
+    parser = _build_parser(stream, error_listener)
+
+    entry: Dict[str, _ParserEntry] = {
+        "query": BmcQueryParser.query,
+        "bmc_num_expression_entry": BmcQueryParser.bmc_num_expression_entry,
+        "bmc_cond_expression_entry": BmcQueryParser.bmc_cond_expression_entry,
+    }
+    parse_tree = entry[entry_name](parser)
+    if force_finished:
+        error_listener.check_unfinished_parsing_error(stream)
+    error_listener.check_errors()
+    return build_bmc_ast_from_parse_tree(parse_tree)
+
+
+def parse_bmc_query(input_text: str) -> BmcQuery:
+    """Parse a complete ``.fbmcq`` query.
+
+    :param input_text: Complete query text.
+    :type input_text: str
+    :return: Parsed query object.
+    :rtype: pyfcstm.bmc.query.BmcQuery
+    :raises pyfcstm.bmc.errors.BmcQueryParseError: If syntax parsing fails.
+    :raises pyfcstm.bmc.errors.InvalidBmcQuery: If the parsed query is
+        structurally invalid, for example ``check ... <= 0``.
+
+    Example::
+
+        >>> parse_bmc_query('check reach <= 1: true;').property.bound
+        1
+    """
+    result = parse_with_bmc_grammar_entry(input_text, "query")
+    if not isinstance(result, BmcQuery):
+        raise BmcQueryParseError("BMC query entry did not produce BmcQuery.")
+    return result
+
+
+def parse_bmc_num_expression(input_text: str) -> BmcNumExpr:
+    """Parse a standalone BMC numeric expression.
+
+    :param input_text: Numeric expression text.
+    :type input_text: str
+    :return: Parsed numeric expression object.
+    :rtype: pyfcstm.bmc.ast.BmcNumExpr
+    :raises pyfcstm.bmc.errors.BmcQueryParseError: If syntax parsing fails.
+
+    Example::
+
+        >>> parse_bmc_num_expression('cycle + 1').to_canonical()['op']
+        '+'
+    """
+    result = parse_with_bmc_grammar_entry(input_text, "bmc_num_expression_entry")
+    if not isinstance(result, BmcNumExpr):
+        raise BmcQueryParseError(
+            "BMC numeric-expression entry did not produce BmcNumExpr."
+        )
+    return result
+
+
+def parse_bmc_cond_expression(input_text: str) -> BmcCondExpr:
+    """Parse a standalone BMC condition expression.
+
+    :param input_text: Condition expression text.
+    :type input_text: str
+    :return: Parsed condition expression object.
+    :rtype: pyfcstm.bmc.ast.BmcCondExpr
+    :raises pyfcstm.bmc.errors.BmcQueryParseError: If syntax parsing fails.
+
+    Example::
+
+        >>> parse_bmc_cond_expression('active("Root.A")').to_canonical()['node']
+        'active'
+    """
+    result = parse_with_bmc_grammar_entry(input_text, "bmc_cond_expression_entry")
+    if not isinstance(result, BmcCondExpr):
+        raise BmcQueryParseError(
+            "BMC condition-expression entry did not produce BmcCondExpr."
+        )
+    return result
+
+
+__all__ = [
+    "parse_bmc_query",
+    "parse_bmc_num_expression",
+    "parse_bmc_cond_expression",
+    "parse_with_bmc_grammar_entry",
+    "build_bmc_ast_from_parse_tree",
+]

--- a/pyfcstm/bmc/parse.py
+++ b/pyfcstm/bmc/parse.py
@@ -179,18 +179,19 @@ def _build_parser(
 
 
 def _find_error_node_text(parse_tree: ParserRuleContext) -> str:
-    """Return the first ANTLR recovery-node text within ``parse_tree``.
+    """Return the first ANTLR recovery marker within ``parse_tree``.
 
     Callers that provide their own parse trees may bypass the collecting error
     listener used by :func:`parse_with_bmc_grammar_entry`.  ANTLR can still
     recover from malformed input by inserting :class:`antlr4.tree.Tree.ErrorNode`
-    objects into the tree.  Detecting those nodes before listener walking keeps
-    the public parse-tree builder from leaking low-level literal-conversion
-    failures.
+    objects, attaching a recognition exception to a parser context, or creating
+    an empty generated child context for a missing nonterminal.  Detecting those
+    recovery markers before listener walking keeps the public parse-tree builder
+    from leaking low-level literal-conversion failures.
 
     :param parse_tree: Root parse-tree context to inspect.
     :type parse_tree: antlr4.ParserRuleContext
-    :return: Text for the first recovery node, or ``""`` when none exists.
+    :return: Text for the first recovery marker, or ``""`` when none exists.
     :rtype: str
 
     Example::
@@ -202,7 +203,20 @@ def _find_error_node_text(parse_tree: ParserRuleContext) -> str:
     while pending:
         node = pending.pop()
         if isinstance(node, ErrorNode):
-            return node.getText()
+            return "recovery node %r" % node.getText()
+        if isinstance(node, ParserRuleContext):
+            exception = getattr(node, "exception", None)
+            if exception is not None:
+                return "recovered %s after %s" % (
+                    type(node).__name__,
+                    type(exception).__name__,
+                )
+            if (
+                type(node) is not ParserRuleContext
+                and node.getChildCount() == 0
+                and node.getText() == ""
+            ):
+                return "empty recovered %s" % type(node).__name__
         for index in range(node.getChildCount() - 1, -1, -1):
             pending.append(node.getChild(index))
     return ""
@@ -217,8 +231,10 @@ def build_bmc_ast_from_parse_tree(parse_tree: ParserRuleContext) -> Any:
     :rtype: object
     :raises TypeError: If ``parse_tree`` is not an ANTLR parser context.
     :raises pyfcstm.bmc.errors.BmcQueryParseError: If the parse tree contains
-        ANTLR recovery nodes, the listener cannot map a recovered child context,
-        or the listener does not map the provided root context.
+        ANTLR recovery markers, the listener cannot map a recovered child
+        context, or the listener does not map the provided root context.
+    :raises pyfcstm.bmc.errors.InvalidBmcQuery: If a syntactically valid query
+        parse tree fails structural query-model validation.
 
     Example::
 
@@ -234,7 +250,7 @@ def build_bmc_ast_from_parse_tree(parse_tree: ParserRuleContext) -> Any:
     error_node_text = _find_error_node_text(parse_tree)
     if error_node_text:
         raise BmcQueryParseError(
-            "BMC parse tree contains ANTLR recovery node %r." % error_node_text
+            "BMC parse tree contains ANTLR recovery marker: %s." % error_node_text
         )
     listener = BmcQueryParseListener()
     walker = ParseTreeWalker()

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -14,10 +14,16 @@ def test_bmc_public_api_exports_exact_names():
 
     expected = {
         "BmcError",
+        "BmcQueryParseError",
         "InvalidBmcQuery",
         "UnsupportedBmcQuery",
         "InvalidBmcEncoding",
         "BmcBuildError",
+        "parse_bmc_query",
+        "parse_bmc_num_expression",
+        "parse_bmc_cond_expression",
+        "parse_with_bmc_grammar_entry",
+        "build_bmc_ast_from_parse_tree",
         "BmcExpr",
         "BmcNumExpr",
         "BmcCondExpr",
@@ -61,9 +67,11 @@ def test_submodule_all_exports_are_exact():
     errors = importlib.import_module("pyfcstm.bmc.errors")
     ast = importlib.import_module("pyfcstm.bmc.ast")
     query = importlib.import_module("pyfcstm.bmc.query")
+    parse = importlib.import_module("pyfcstm.bmc.parse")
 
     assert set(errors.__all__) == {
         "BmcError",
+        "BmcQueryParseError",
         "InvalidBmcQuery",
         "UnsupportedBmcQuery",
         "InvalidBmcEncoding",
@@ -103,6 +111,13 @@ def test_submodule_all_exports_are_exact():
         "BmcProperty",
         "BmcQuery",
     }
+    assert set(parse.__all__) == {
+        "parse_bmc_query",
+        "parse_bmc_num_expression",
+        "parse_bmc_cond_expression",
+        "parse_with_bmc_grammar_entry",
+        "build_bmc_ast_from_parse_tree",
+    }
 
 
 @pytest.mark.unittest
@@ -122,7 +137,11 @@ def test_bmc_import_does_not_load_verify_modules():
     code = (
         "import sys; "
         "import pyfcstm.bmc; "
-        "print(any(name.startswith('pyfcstm.verify') for name in sys.modules))"
+        "bad = ["
+        "name for name in sys.modules "
+        "if name == 'z3' or name.startswith('pyfcstm.verify')"
+        "]; "
+        "print(bad)"
     )
 
     result = subprocess.run(
@@ -133,4 +152,4 @@ def test_bmc_import_does_not_load_verify_modules():
         universal_newlines=True,
     )
 
-    assert result.stdout.strip() == "False"
+    assert result.stdout.strip() == "[]"

--- a/test/bmc/test_query_expression_parity.py
+++ b/test/bmc/test_query_expression_parity.py
@@ -1,0 +1,426 @@
+"""Strict expression-parity tests between FCSTM DSL and FBMCQ parsers."""
+
+from typing import Any, cast
+
+import pytest
+
+from pyfcstm.bmc import ast as bmc_nodes
+from pyfcstm.bmc.parse import parse_bmc_cond_expression, parse_bmc_num_expression
+from pyfcstm.dsl import node as fcstm_nodes
+from pyfcstm.dsl.parse import parse_with_grammar_entry
+
+_NUMERIC_OPS = {"**", "*", "/", "%", "+", "-", "<<", ">>", "&", "^", "|"}
+_NUMERIC_COMPARISONS = {"<", ">", "<=", ">=", "==", "!="}
+_CONDITION_OPS = {"==", "!=", "iff", "&&", "xor", "||", "=>"}
+
+
+def _strip_paren(expr: fcstm_nodes.Expr) -> fcstm_nodes.Expr:
+    """Remove FCSTM-only parenthesis nodes for semantic-shape comparison.
+
+    :param expr: FCSTM expression node.
+    :type expr: pyfcstm.dsl.node.Expr
+    :return: Expression with transparent :class:`pyfcstm.dsl.node.Paren`
+        wrappers removed.
+    :rtype: pyfcstm.dsl.node.Expr
+
+    Example::
+
+        >>> from pyfcstm.dsl.node import Integer, Paren
+        >>> _strip_paren(Paren(Integer("1"))).raw
+        '1'
+    """
+    while isinstance(expr, fcstm_nodes.Paren):
+        expr = expr.expr
+    return expr
+
+
+def _is_fcstm_condition_expr(expr: fcstm_nodes.Expr) -> bool:
+    """Return whether a FCSTM node is a condition expression in the parity subset.
+
+    :param expr: FCSTM expression node.
+    :type expr: pyfcstm.dsl.node.Expr
+    :return: ``True`` when ``expr`` belongs to the condition-expression
+        category.
+    :rtype: bool
+
+    Example::
+
+        >>> from pyfcstm.dsl.node import Boolean
+        >>> _is_fcstm_condition_expr(Boolean("true"))
+        True
+    """
+    expr = _strip_paren(expr)
+    if isinstance(expr, fcstm_nodes.Boolean):
+        return True
+    if isinstance(expr, fcstm_nodes.UnaryOp):
+        return expr.op == "!" and _is_fcstm_condition_expr(expr.expr)
+    if isinstance(expr, fcstm_nodes.ConditionalOp):
+        return _is_fcstm_condition_expr(expr.value_true) and _is_fcstm_condition_expr(
+            expr.value_false
+        )
+    if isinstance(expr, fcstm_nodes.BinaryOp):
+        if expr.op in {"&&", "xor", "||", "=>", "iff"}:
+            return True
+        if expr.op in {"==", "!="}:
+            return _is_fcstm_condition_expr(expr.expr1) and _is_fcstm_condition_expr(
+                expr.expr2
+            )
+        if expr.op in {"<", ">", "<=", ">="}:
+            return True
+    return False
+
+
+def _to_bmc_num(expr: fcstm_nodes.Expr) -> bmc_nodes.BmcNumExpr:
+    """Convert a FCSTM numeric expression and narrow its type for helpers.
+
+    :param expr: FCSTM expression known by the grammar context to be numeric.
+    :type expr: pyfcstm.dsl.node.Expr
+    :return: Equivalent BMC numeric expression.
+    :rtype: pyfcstm.bmc.ast.BmcNumExpr
+
+    Example::
+
+        >>> from pyfcstm.dsl.node import Integer
+        >>> _to_bmc_num(Integer("1")).to_canonical()["value"]
+        1
+    """
+    return cast(bmc_nodes.BmcNumExpr, _fcstm_to_bmc_expr(expr, "num"))
+
+
+def _to_bmc_cond(expr: fcstm_nodes.Expr) -> bmc_nodes.BmcCondExpr:
+    """Convert a FCSTM condition expression and narrow its helper type.
+
+    :param expr: FCSTM expression known by the grammar context to be a
+        condition expression.
+    :type expr: pyfcstm.dsl.node.Expr
+    :return: Equivalent BMC condition expression.
+    :rtype: pyfcstm.bmc.ast.BmcCondExpr
+
+    Example::
+
+        >>> from pyfcstm.dsl.node import Boolean
+        >>> _to_bmc_cond(Boolean("true")).to_canonical()["value"]
+        True
+    """
+    return cast(bmc_nodes.BmcCondExpr, _fcstm_to_bmc_expr(expr, "cond"))
+
+
+def _fcstm_to_bmc_expr(expr: fcstm_nodes.Expr, category: str) -> bmc_nodes.BmcExpr:
+    """Convert a FCSTM expression AST node into the matching BMC AST node.
+
+    :param expr: FCSTM expression node parsed from ``num_expression`` or
+        ``cond_expression``.
+    :type expr: pyfcstm.dsl.node.Expr
+    :param category: Expression category, either ``"num"`` or ``"cond"``.
+    :type category: str
+    :return: Equivalent BMC expression node.
+    :rtype: pyfcstm.bmc.ast.BmcExpr
+
+    Example::
+
+        >>> from pyfcstm.dsl.node import Integer
+        >>> _fcstm_to_bmc_expr(Integer("1"), "num").to_canonical()["value"]
+        1
+    """
+    expr = _strip_paren(expr)
+    if isinstance(expr, fcstm_nodes.Integer):
+        return bmc_nodes.IntLiteral(expr.raw, kind="decimal")
+    if isinstance(expr, fcstm_nodes.HexInt):
+        return bmc_nodes.IntLiteral(expr.raw, kind="hex")
+    if isinstance(expr, fcstm_nodes.Float):
+        return bmc_nodes.FloatLiteral(expr.raw)
+    if isinstance(expr, fcstm_nodes.Boolean):
+        return bmc_nodes.BoolLiteral(expr.raw)
+    if isinstance(expr, fcstm_nodes.Constant):
+        return bmc_nodes.MathConst(expr.raw)
+    if isinstance(expr, fcstm_nodes.Name):
+        return bmc_nodes.NameRef(expr.name)
+    if isinstance(expr, fcstm_nodes.UnaryOp):
+        if category == "num":
+            return bmc_nodes.NumUnaryOp(expr.op, _to_bmc_num(expr.expr))
+        return bmc_nodes.CondUnaryOp(expr.op, _to_bmc_cond(expr.expr))
+    if isinstance(expr, fcstm_nodes.UFunc):
+        return bmc_nodes.UFuncCall(expr.func, _to_bmc_num(expr.expr))
+    if isinstance(expr, fcstm_nodes.ConditionalOp):
+        condition = _to_bmc_cond(expr.cond)
+        if category == "num":
+            return bmc_nodes.NumConditionalOp(
+                condition,
+                _to_bmc_num(expr.value_true),
+                _to_bmc_num(expr.value_false),
+            )
+        return bmc_nodes.CondConditionalOp(
+            condition,
+            _to_bmc_cond(expr.value_true),
+            _to_bmc_cond(expr.value_false),
+        )
+    if isinstance(expr, fcstm_nodes.BinaryOp):
+        if category == "num" and expr.op in _NUMERIC_OPS:
+            return bmc_nodes.NumBinaryOp(
+                _to_bmc_num(expr.expr1),
+                expr.op,
+                _to_bmc_num(expr.expr2),
+            )
+        if expr.op in _NUMERIC_COMPARISONS and not (
+            expr.op in {"==", "!="}
+            and _is_fcstm_condition_expr(expr.expr1)
+            and _is_fcstm_condition_expr(expr.expr2)
+        ):
+            return bmc_nodes.NumericComparison(
+                _to_bmc_num(expr.expr1),
+                expr.op,
+                _to_bmc_num(expr.expr2),
+            )
+        if expr.op in _CONDITION_OPS:
+            return bmc_nodes.CondBinaryOp(
+                _to_bmc_cond(expr.expr1),
+                expr.op,
+                _to_bmc_cond(expr.expr2),
+            )
+    raise TypeError("Unsupported FCSTM parity expression: %r." % (expr,))
+
+
+def _bmc_to_fcstm_expr(expr: bmc_nodes.BmcExpr) -> fcstm_nodes.Expr:
+    """Convert a BMC expression AST node into the matching FCSTM AST node.
+
+    :param expr: BMC expression node from the FCSTM-compatible subset.
+    :type expr: pyfcstm.bmc.ast.BmcExpr
+    :return: Equivalent FCSTM expression node.
+    :rtype: pyfcstm.dsl.node.Expr
+
+    Example::
+
+        >>> _bmc_to_fcstm_expr(bmc_nodes.IntLiteral("1")).raw
+        '1'
+    """
+    if isinstance(expr, bmc_nodes.IntLiteral):
+        if expr.kind == "hex":
+            return fcstm_nodes.HexInt(expr.raw)
+        return fcstm_nodes.Integer(expr.raw)
+    if isinstance(expr, bmc_nodes.FloatLiteral):
+        return fcstm_nodes.Float(expr.raw)
+    if isinstance(expr, bmc_nodes.BoolLiteral):
+        return fcstm_nodes.Boolean(expr.raw)
+    if isinstance(expr, bmc_nodes.NameRef):
+        return fcstm_nodes.Name(expr.name)
+    if isinstance(expr, bmc_nodes.MathConst):
+        return fcstm_nodes.Constant(expr.name)
+    if isinstance(expr, bmc_nodes.NumUnaryOp):
+        return fcstm_nodes.UnaryOp(expr.op, _bmc_to_fcstm_expr(expr.operand))
+    if isinstance(expr, bmc_nodes.NumBinaryOp):
+        return fcstm_nodes.BinaryOp(
+            _bmc_to_fcstm_expr(expr.left), expr.op, _bmc_to_fcstm_expr(expr.right)
+        )
+    if isinstance(expr, bmc_nodes.NumConditionalOp):
+        return fcstm_nodes.ConditionalOp(
+            _bmc_to_fcstm_expr(expr.condition),
+            _bmc_to_fcstm_expr(expr.if_true),
+            _bmc_to_fcstm_expr(expr.if_false),
+        )
+    if isinstance(expr, bmc_nodes.UFuncCall):
+        return fcstm_nodes.UFunc(expr.func, _bmc_to_fcstm_expr(expr.operand))
+    if isinstance(expr, bmc_nodes.CondUnaryOp):
+        return fcstm_nodes.UnaryOp(expr.op, _bmc_to_fcstm_expr(expr.operand))
+    if isinstance(expr, bmc_nodes.NumericComparison):
+        return fcstm_nodes.BinaryOp(
+            _bmc_to_fcstm_expr(expr.left), expr.op, _bmc_to_fcstm_expr(expr.right)
+        )
+    if isinstance(expr, bmc_nodes.CondBinaryOp):
+        return fcstm_nodes.BinaryOp(
+            _bmc_to_fcstm_expr(expr.left), expr.op, _bmc_to_fcstm_expr(expr.right)
+        )
+    if isinstance(expr, bmc_nodes.CondConditionalOp):
+        return fcstm_nodes.ConditionalOp(
+            _bmc_to_fcstm_expr(expr.condition),
+            _bmc_to_fcstm_expr(expr.if_true),
+            _bmc_to_fcstm_expr(expr.if_false),
+        )
+    raise TypeError("Unsupported BMC parity expression: %r." % (expr,))
+
+
+def _shared_shape_from_bmc(expr: bmc_nodes.BmcExpr) -> Any:
+    """Project a BMC expression to a strict JSON-like parity shape.
+
+    :param expr: BMC expression node.
+    :type expr: pyfcstm.bmc.ast.BmcExpr
+    :return: Shared parity shape.  Boolean raw spelling is normalized because
+        FCSTM stores boolean literals in lowercase.
+    :rtype: object
+
+    Example::
+
+        >>> _shared_shape_from_bmc(bmc_nodes.BoolLiteral("TRUE"))["raw"]
+        'true'
+    """
+    canonical = expr.to_canonical()
+    if canonical["node"] == "bool_literal":
+        canonical = dict(canonical)
+        canonical["raw"] = canonical["raw"].lower()
+    return canonical
+
+
+def _shared_shape_from_fcstm(expr: fcstm_nodes.Expr, category: str) -> Any:
+    """Project a FCSTM expression to the same shared parity shape as BMC.
+
+    :param expr: FCSTM expression node.
+    :type expr: pyfcstm.dsl.node.Expr
+    :param category: Expression category, either ``"num"`` or ``"cond"``.
+    :type category: str
+    :return: Shared parity shape.
+    :rtype: object
+
+    Example::
+
+        >>> _shared_shape_from_fcstm(fcstm_nodes.Integer("1"), "num")["value"]
+        1
+    """
+    return _shared_shape_from_bmc(_fcstm_to_bmc_expr(expr, category))
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "expression",
+    [
+        pytest.param("0", id="zero"),
+        pytest.param("00", id="double-zero"),
+        pytest.param("01", id="leading-zero-one"),
+        pytest.param("001", id="leading-zero-many"),
+        pytest.param("42", id="decimal"),
+        pytest.param("0x2A", id="hex-upper"),
+        pytest.param("0xff", id="hex-lower"),
+        pytest.param(".5", id="float-leading-dot"),
+        pytest.param("1.", id="float-trailing-dot"),
+        pytest.param("1e-3", id="float-exp-negative"),
+        pytest.param("2.5E+7", id="float-exp-positive"),
+        pytest.param("x", id="name-x"),
+        pytest.param("_x", id="name-underscore"),
+        pytest.param("x1", id="name-digit-suffix"),
+        pytest.param("counter_value", id="name-underscore-word"),
+        pytest.param("pi", id="pi"),
+        pytest.param("E", id="e"),
+        pytest.param("tau", id="tau"),
+        pytest.param("+x", id="unary-plus"),
+        pytest.param("-x", id="unary-minus"),
+        pytest.param("--x", id="double-unary"),
+        pytest.param("-(x + 1)", id="unary-grouped"),
+        pytest.param("a + b * c", id="precedence-mul"),
+        pytest.param("a ** b ** c", id="right-pow"),
+        pytest.param("a << b + c", id="shift-add"),
+        pytest.param("a & b ^ c | d", id="bitwise-chain"),
+        pytest.param("(a + b) * (c - d)", id="explicit-groups"),
+        pytest.param("sin(x)", id="sin"),
+        pytest.param("cos(x)", id="cos"),
+        pytest.param("tan(x)", id="tan"),
+        pytest.param("asin(x)", id="asin"),
+        pytest.param("acos(x)", id="acos"),
+        pytest.param("atan(x)", id="atan"),
+        pytest.param("sinh(x)", id="sinh"),
+        pytest.param("cosh(x)", id="cosh"),
+        pytest.param("tanh(x)", id="tanh"),
+        pytest.param("asinh(x)", id="asinh"),
+        pytest.param("acosh(x)", id="acosh"),
+        pytest.param("atanh(x)", id="atanh"),
+        pytest.param("sqrt(x)", id="sqrt"),
+        pytest.param("cbrt(x)", id="cbrt"),
+        pytest.param("exp(x)", id="exp"),
+        pytest.param("log(x)", id="log"),
+        pytest.param("log10(x)", id="log10"),
+        pytest.param("log2(x)", id="log2"),
+        pytest.param("log1p(x)", id="log1p"),
+        pytest.param("abs(-x)", id="abs"),
+        pytest.param("ceil(x)", id="ceil"),
+        pytest.param("floor(x)", id="floor"),
+        pytest.param("round(x)", id="round"),
+        pytest.param("trunc(x)", id="trunc"),
+        pytest.param("sign(x)", id="sign"),
+        pytest.param("(x > 0) ? 1 : 2", id="conditional"),
+        pytest.param("((x + 1) >= y) ? (a + b) : (c * d)", id="conditional-complex"),
+    ],
+)
+def test_fcstm_and_fbmcq_numeric_expression_ast_shapes_are_bidirectionally_aligned(
+    expression,
+):
+    """Numeric expressions parse to ASTs that convert strictly both ways."""
+    fcstm_node = parse_with_grammar_entry(expression, "num_expression")
+    bmc_node = parse_bmc_num_expression(expression)
+
+    converted_bmc = _fcstm_to_bmc_expr(fcstm_node, "num")
+    converted_fcstm = _bmc_to_fcstm_expr(bmc_node)
+
+    assert _shared_shape_from_bmc(converted_bmc) == _shared_shape_from_bmc(bmc_node)
+    assert _shared_shape_from_fcstm(converted_fcstm, "num") == _shared_shape_from_fcstm(
+        fcstm_node, "num"
+    )
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "expression",
+    [
+        pytest.param("true", id="true"),
+        pytest.param("True", id="true-title"),
+        pytest.param("TRUE", id="true-upper"),
+        pytest.param("false", id="false"),
+        pytest.param("False", id="false-title"),
+        pytest.param("FALSE", id="false-upper"),
+        pytest.param("x < y", id="lt"),
+        pytest.param("x > y", id="gt"),
+        pytest.param("x <= y", id="le"),
+        pytest.param("x >= y", id="ge"),
+        pytest.param("x == y", id="num-eq"),
+        pytest.param("x != y", id="num-ne"),
+        pytest.param("!(x > 0)", id="bang"),
+        pytest.param("not (x > 0)", id="not-keyword"),
+        pytest.param("x > 0 && y > 0", id="and-symbol"),
+        pytest.param("x > 0 and y > 0", id="and-keyword"),
+        pytest.param("x > 0 xor y > 0", id="xor"),
+        pytest.param("x > 0 || y > 0", id="or-symbol"),
+        pytest.param("x > 0 or y > 0", id="or-keyword"),
+        pytest.param("x > 0 => y > 0", id="implies-symbol"),
+        pytest.param("x > 0 implies y > 0", id="implies-keyword"),
+        pytest.param("x > 0 iff y > 0", id="iff"),
+        pytest.param("(x > 0) == (y > 0)", id="cond-eq"),
+        pytest.param("(x > 0) != (y > 0)", id="cond-ne"),
+        pytest.param("x > 0 => y > 0 => z > 0", id="right-implies"),
+        pytest.param("(x > 0 && y > 0) || z > 0", id="group-left"),
+        pytest.param("x > 0 && (y > 0 || z > 0)", id="group-right"),
+        pytest.param("(x > 0) ? true : false", id="conditional-bool"),
+        pytest.param(
+            "(x > 0) ? (y > 0 && z > 0) : (a <= b)",
+            id="conditional-complex",
+        ),
+    ],
+)
+def test_fcstm_and_fbmcq_condition_expression_ast_shapes_are_bidirectionally_aligned(
+    expression,
+):
+    """Condition expressions parse to ASTs that convert strictly both ways."""
+    fcstm_node = parse_with_grammar_entry(expression, "cond_expression")
+    bmc_node = parse_bmc_cond_expression(expression)
+
+    converted_bmc = _fcstm_to_bmc_expr(fcstm_node, "cond")
+    converted_fcstm = _bmc_to_fcstm_expr(bmc_node)
+
+    assert _shared_shape_from_bmc(converted_bmc) == _shared_shape_from_bmc(bmc_node)
+    assert _shared_shape_from_fcstm(
+        converted_fcstm, "cond"
+    ) == _shared_shape_from_fcstm(fcstm_node, "cond")
+
+
+@pytest.mark.unittest
+def test_bmc_boolean_raw_spellings_are_preserved_beyond_fcstm_parity_shape():
+    """FBMCQ keeps boolean spelling even though FCSTM normalizes raw casing."""
+    assert parse_bmc_cond_expression("True").to_canonical()["raw"] == "True"
+    assert parse_bmc_cond_expression("TRUE").to_canonical()["raw"] == "TRUE"
+    assert parse_bmc_cond_expression("False").to_canonical()["raw"] == "False"
+    assert parse_bmc_cond_expression("FALSE").to_canonical()["raw"] == "FALSE"
+
+
+@pytest.mark.unittest
+def test_parity_projection_rejects_non_fcstm_bmc_atoms():
+    """Bidirectional parity helpers intentionally reject BMC-only atoms."""
+    with pytest.raises(TypeError, match="Unsupported BMC parity expression"):
+        _bmc_to_fcstm_expr(bmc_nodes.Cycle())
+
+    with pytest.raises(TypeError, match="Unsupported FCSTM parity expression"):
+        _fcstm_to_bmc_expr(cast(fcstm_nodes.Expr, fcstm_nodes.ASTNode()), "num")

--- a/test/bmc/test_query_model.py
+++ b/test/bmc/test_query_model.py
@@ -15,6 +15,7 @@ from pyfcstm.bmc import (
     BmcNumExpr,
     BmcProperty,
     BmcQuery,
+    BmcQueryParseError,
     BoolLiteral,
     Called,
     Case,
@@ -47,6 +48,7 @@ from pyfcstm.bmc import (
 @pytest.mark.unittest
 def test_error_hierarchy():
     """BMC errors expose phase-specific subclasses under one base."""
+    assert issubclass(BmcQueryParseError, BmcError)
     assert issubclass(InvalidBmcQuery, BmcError)
     assert issubclass(UnsupportedBmcQuery, BmcError)
     assert issubclass(InvalidBmcEncoding, BmcError)

--- a/test/bmc/test_query_parser.py
+++ b/test/bmc/test_query_parser.py
@@ -22,6 +22,7 @@ from pyfcstm.bmc.parse import (
     _CollectingBmcErrorListener,
     _build_lexer,
     _build_parser,
+    _find_error_node_text,
     build_bmc_ast_from_parse_tree,
     parse_bmc_cond_expression,
     parse_bmc_num_expression,
@@ -521,7 +522,7 @@ def test_build_bmc_ast_from_existing_parse_tree():
 @pytest.mark.unittest
 def test_parse_helpers_report_invalid_inputs_and_unmapped_trees(monkeypatch):
     """Parser helpers expose typed parse errors instead of raw ANTLR details."""
-    with pytest.raises(BmcQueryParseError, match="Unsupported BMC grammar entry"):
+    with pytest.raises(BmcQueryParseError, match="Supported entries"):
         parse_with_bmc_grammar_entry("true", "missing_entry")
     with pytest.raises(BmcQueryParseError):
         parse_bmc_query("check reach <= : true;")
@@ -554,6 +555,48 @@ def test_parse_helpers_report_invalid_inputs_and_unmapped_trees(monkeypatch):
     monkeypatch.setattr(parse_module, "parse_with_bmc_grammar_entry", _cond_wrong_type)
     with pytest.raises(BmcQueryParseError, match="BmcCondExpr"):
         parse_module.parse_bmc_cond_expression("true")
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "text, entry_name, expected",
+    [
+        pytest.param(
+            "check reach <= : true;",
+            "query",
+            "recovery node",
+            id="missing-query-bound",
+        ),
+        pytest.param(
+            'active("Root.A")',
+            "bmc_num_expression_entry",
+            "recovery node",
+            id="condition-atom-in-numeric-entry",
+        ),
+        pytest.param(
+            'event("Root.E")',
+            "bmc_cond_expression_entry",
+            "recovery node",
+            id="missing-event-selector",
+        ),
+        pytest.param(
+            'check reach <= 1: active("Root.A", );',
+            "query",
+            "child context",
+            id="empty-frame-selector",
+        ),
+    ],
+)
+def test_build_bmc_ast_from_recovered_parse_trees_reports_bmc_parse_error(
+    text, entry_name, expected
+):
+    """Recovered ANTLR parse trees do not leak listener ``KeyError`` failures."""
+    lexer = BmcQueryLexer(InputStream(text))
+    parser = BmcQueryParser(CommonTokenStream(lexer))
+    tree = getattr(parser, entry_name)()
+
+    with pytest.raises(BmcQueryParseError, match=expected):
+        build_bmc_ast_from_parse_tree(tree)
 
 
 @pytest.mark.unittest
@@ -612,6 +655,8 @@ def test_internal_error_listener_branches_and_parser_builders():
     unfinished_stream.fill()
     unfinished_listener.check_unfinished_parsing_error(unfinished_stream)
     assert "parser did not consume the full input" in unfinished_listener.messages[0]
+
+    assert _find_error_node_text(ParserRuleContext()) == ""
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_query_parser.py
+++ b/test/bmc/test_query_parser.py
@@ -537,6 +537,15 @@ def test_parse_helpers_report_invalid_inputs_and_unmapped_trees(monkeypatch):
 
     parse_module = importlib.import_module("pyfcstm.bmc.parse")
 
+    def _raise_key_error_on_walk(self, listener, parse_tree):
+        raise KeyError("missing recovered child")
+
+    monkeypatch.setattr(parse_module.ParseTreeWalker, "walk", _raise_key_error_on_walk)
+    with pytest.raises(BmcQueryParseError, match="child context"):
+        build_bmc_ast_from_parse_tree(ParserRuleContext())
+    monkeypatch.undo()
+    parse_module = importlib.import_module("pyfcstm.bmc.parse")
+
     def _query_wrong_type(*args, **kwargs):
         return BoolLiteral("true")
 
@@ -570,20 +579,62 @@ def test_parse_helpers_report_invalid_inputs_and_unmapped_trees(monkeypatch):
         pytest.param(
             'active("Root.A")',
             "bmc_num_expression_entry",
-            "recovery node",
+            "recovered Bmc_num_expressionContext",
             id="condition-atom-in-numeric-entry",
         ),
         pytest.param(
             'event("Root.E")',
             "bmc_cond_expression_entry",
-            "recovery node",
+            "recovered Bmc_boolean_atomContext",
             id="missing-event-selector",
         ),
         pytest.param(
             'check reach <= 1: active("Root.A", );',
             "query",
-            "child context",
+            "recovered Frame_selectorContext",
             id="empty-frame-selector",
+        ),
+        pytest.param(
+            "check reach <=",
+            "query",
+            "recovered Check_clauseContext",
+            id="missing-bound-without-error-node",
+        ),
+        pytest.param(
+            "check <= 1: true;",
+            "query",
+            "empty recovered Property_kindContext",
+            id="missing-property-kind-without-error-node",
+        ),
+        pytest.param(
+            'event("Root.E", )',
+            "bmc_cond_expression_entry",
+            "recovered Event_cycle_selectorContext",
+            id="missing-event-cycle-without-error-node",
+        ),
+        pytest.param(
+            "",
+            "bool_literal",
+            "empty recovered Bool_literalContext",
+            id="empty-bool-literal-subrule",
+        ),
+        pytest.param(
+            "",
+            "num_literal",
+            "empty recovered Num_literalContext",
+            id="empty-num-literal-subrule",
+        ),
+        pytest.param(
+            "",
+            "event_range_selector",
+            "recovered Event_range_selectorContext",
+            id="empty-event-range-selector-subrule",
+        ),
+        pytest.param(
+            "",
+            "bmc_boolean_atom",
+            "recovered Bmc_boolean_atomContext",
+            id="empty-boolean-atom-subrule",
         ),
     ],
 )

--- a/test/bmc/test_query_parser.py
+++ b/test/bmc/test_query_parser.py
@@ -1,0 +1,693 @@
+"""Parser-to-AST tests for FCSTM BMC query files."""
+
+import importlib
+import subprocess
+import sys
+from typing import cast
+
+import pytest
+from antlr4 import CommonTokenStream, InputStream, ParserRuleContext
+
+from pyfcstm.bmc.ast import (
+    Active,
+    BmcCondExpr,
+    BmcNumExpr,
+    BoolLiteral,
+    Cycle,
+)
+from pyfcstm.bmc.errors import BmcQueryParseError, InvalidBmcQuery
+from pyfcstm.bmc.grammar.BmcQueryLexer import BmcQueryLexer
+from pyfcstm.bmc.grammar.BmcQueryParser import BmcQueryParser
+from pyfcstm.bmc.parse import (
+    _CollectingBmcErrorListener,
+    _build_lexer,
+    _build_parser,
+    build_bmc_ast_from_parse_tree,
+    parse_bmc_cond_expression,
+    parse_bmc_num_expression,
+    parse_bmc_query,
+    parse_with_bmc_grammar_entry,
+)
+from pyfcstm.bmc.query import BmcProperty, BmcQuery
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "query_text, expected",
+    [
+        pytest.param(
+            "check reach <= 1: true;",
+            {
+                "initial": {"mode": "cold", "predicate": None},
+                "assumption_count": 0,
+                "property": {
+                    "kind": "reach",
+                    "bound": 1,
+                    "predicate": {
+                        "node": "bool_literal",
+                        "raw": "true",
+                        "value": True,
+                    },
+                },
+            },
+            id="default-cold-reach",
+        ),
+        pytest.param(
+            "init cold; check forbid <= 2: false;",
+            {
+                "initial": {"mode": "cold", "predicate": None},
+                "assumption_count": 0,
+                "property": {
+                    "kind": "forbid",
+                    "bound": 2,
+                    "predicate": {
+                        "node": "bool_literal",
+                        "raw": "false",
+                        "value": False,
+                    },
+                },
+            },
+            id="explicit-cold-forbid",
+        ),
+        pytest.param(
+            "init terminated; check invariant <= 3: terminated();",
+            {
+                "initial": {"mode": "terminated", "predicate": None},
+                "assumption_count": 0,
+                "property": {
+                    "kind": "invariant",
+                    "bound": 3,
+                    "predicate": {"node": "terminated", "frame": "current"},
+                },
+            },
+            id="terminated-invariant",
+        ),
+        pytest.param(
+            'init state("Root.A") where var("x") >= 0; '
+            'check must_reach <= 4: active("Root.Done", current);',
+            {
+                "initial": {
+                    "mode": "state",
+                    "state_path": "Root.A",
+                    "predicate": {
+                        "node": "numeric_comparison",
+                        "op": ">=",
+                    },
+                },
+                "assumption_count": 0,
+                "property": {
+                    "kind": "must_reach",
+                    "bound": 4,
+                    "predicate": {
+                        "node": "active",
+                        "state_path": "Root.Done",
+                        "frame": "current",
+                    },
+                },
+            },
+            id="state-where-must-reach",
+        ),
+        pytest.param(
+            'assume always: var("x") <= 10; '
+            'assume at 2: active("Root.Ready", 2); '
+            'assume event("Root.Tick", *) == false; '
+            'assume event("Root.Reset", 01.. 03) != false; '
+            "assume events cardinality any; "
+            'assume events cardinality at_most_one {"Root.Tick", "Root.Reset"}; '
+            'check exists_always <= 5: case("safe", 4);',
+            {
+                "initial": {"mode": "cold", "predicate": None},
+                "assumption_count": 6,
+                "property": {
+                    "kind": "exists_always",
+                    "bound": 5,
+                    "predicate": {"node": "case", "label": "safe", "frame": 4},
+                },
+            },
+            id="all-assumption-families",
+        ),
+        pytest.param(
+            'check response <= 8: trigger event("Root.Fault", current) '
+            '-> within 3 active("Root.Recovering");',
+            {
+                "initial": {"mode": "cold", "predicate": None},
+                "assumption_count": 0,
+                "property": {
+                    "kind": "response",
+                    "bound": 8,
+                    "trigger": {
+                        "node": "event",
+                        "event_path": "Root.Fault",
+                        "selector": "current",
+                    },
+                    "response": {
+                        "node": "active",
+                        "state_path": "Root.Recovering",
+                        "frame": "current",
+                    },
+                    "within": 3,
+                },
+            },
+            id="response-property",
+        ),
+        pytest.param(
+            'check cover <= 01: called("CheckLimit", 05);',
+            {
+                "initial": {"mode": "cold", "predicate": None},
+                "assumption_count": 0,
+                "property": {
+                    "kind": "cover",
+                    "bound": 1,
+                    "predicate": {
+                        "node": "called",
+                        "name": "CheckLimit",
+                        "frame": 5,
+                    },
+                },
+            },
+            id="leading-zero-bound-and-frame",
+        ),
+    ],
+)
+def test_parse_bmc_query_builds_expected_canonical_shape(query_text, expected):
+    """Complete queries build parser-independent query objects."""
+    query = parse_bmc_query(query_text)
+    canonical = query.to_canonical()
+
+    assert isinstance(query, BmcQuery)
+    assert canonical["initial"]["mode"] == expected["initial"]["mode"]
+    assert canonical["initial"].get("state_path") == expected["initial"].get(
+        "state_path"
+    )
+    if expected["initial"]["predicate"] is None:
+        assert canonical["initial"]["predicate"] is None
+    else:
+        assert (
+            canonical["initial"]["predicate"]["node"]
+            == expected["initial"]["predicate"]["node"]
+        )
+        assert (
+            canonical["initial"]["predicate"]["op"]
+            == expected["initial"]["predicate"]["op"]
+        )
+    assert len(canonical["assumptions"]) == expected["assumption_count"]
+    assert canonical["property"]["kind"] == expected["property"]["kind"]
+    assert canonical["property"]["bound"] == expected["property"]["bound"]
+    for key, value in expected["property"].items():
+        if key in {"kind", "bound"}:
+            continue
+        if isinstance(value, dict):
+            assert canonical["property"][key].items() >= value.items()
+        else:
+            assert canonical["property"][key] == value
+
+
+@pytest.mark.unittest
+def test_parse_bmc_query_assumption_details_are_normalized():
+    """Assumption parser branches preserve polarity and selector semantics."""
+    query = parse_bmc_query(
+        'assume always: var("x") <= 10; '
+        'assume at 2: active("Root.Ready"); '
+        'assume event("Root.Tick", *) == false; '
+        'assume event("Root.Reset", 01 .. 03) != false; '
+        'assume event("Root.Point", 007) == TRUE; '
+        "assume events cardinality any; "
+        'assume events cardinality at_most_one {"Root.Tick", "Root.Reset"}; '
+        'check reach <= 2: active("Root.Done");'
+    )
+    assumptions = query.to_canonical()["assumptions"]
+
+    assert assumptions[0]["kind"] == "always"
+    assert assumptions[0]["predicate"]["node"] == "numeric_comparison"
+    assert assumptions[1]["kind"] == "at"
+    assert assumptions[1]["frame"] == 2
+    assert assumptions[2] == {
+        "node": "event_assumption",
+        "event_path": "Root.Tick",
+        "selector": "*",
+        "expected": False,
+    }
+    assert assumptions[3] == {
+        "node": "event_assumption",
+        "event_path": "Root.Reset",
+        "selector": "1..3",
+        "expected": True,
+    }
+    assert assumptions[4] == {
+        "node": "event_assumption",
+        "event_path": "Root.Point",
+        "selector": 7,
+        "expected": True,
+    }
+    assert assumptions[5] == {
+        "node": "event_cardinality_assumption",
+        "kind": "any",
+        "event_paths": [],
+    }
+    assert assumptions[6] == {
+        "node": "event_cardinality_assumption",
+        "kind": "at_most_one",
+        "event_paths": ["Root.Tick", "Root.Reset"],
+    }
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        pytest.param("0", {"node": "int_literal", "raw": "0", "value": 0}, id="zero"),
+        pytest.param(
+            "001",
+            {"node": "int_literal", "raw": "001", "value": 1},
+            id="leading-zero",
+        ),
+        pytest.param(
+            "0x2A",
+            {"node": "int_literal", "kind": "hex", "raw": "0x2A", "value": 42},
+            id="hex",
+        ),
+        pytest.param(
+            ".5",
+            {"node": "float_literal", "raw": ".5", "value": 0.5},
+            id="float-leading-dot",
+        ),
+        pytest.param("pi", {"node": "math_const", "name": "pi"}, id="pi"),
+        pytest.param("x", {"node": "name", "name": "x"}, id="name"),
+        pytest.param('var("x")', {"node": "frame_var", "name": "x"}, id="var"),
+        pytest.param("cycle", {"node": "cycle"}, id="cycle"),
+        pytest.param("+x", {"node": "num_unary", "op": "+"}, id="unary-plus"),
+        pytest.param("-x", {"node": "num_unary", "op": "-"}, id="unary-minus"),
+        pytest.param("sin(x)", {"node": "ufunc", "func": "sin"}, id="ufunc"),
+        pytest.param("x ** y", {"node": "num_binary", "op": "**"}, id="pow"),
+        pytest.param("x * y", {"node": "num_binary", "op": "*"}, id="mul"),
+        pytest.param("x / y", {"node": "num_binary", "op": "/"}, id="div"),
+        pytest.param("x % y", {"node": "num_binary", "op": "%"}, id="mod"),
+        pytest.param("x + y", {"node": "num_binary", "op": "+"}, id="add"),
+        pytest.param("x - y", {"node": "num_binary", "op": "-"}, id="sub"),
+        pytest.param("x << y", {"node": "num_binary", "op": "<<"}, id="shl"),
+        pytest.param("x >> y", {"node": "num_binary", "op": ">>"}, id="shr"),
+        pytest.param("x & y", {"node": "num_binary", "op": "&"}, id="band"),
+        pytest.param("x ^ y", {"node": "num_binary", "op": "^"}, id="bxor"),
+        pytest.param("x | y", {"node": "num_binary", "op": "|"}, id="bor"),
+        pytest.param(
+            '(active("Root.A")) ? 1 : 2',
+            {"node": "num_conditional"},
+            id="numeric-conditional",
+        ),
+    ],
+)
+def test_parse_bmc_num_expression_builds_each_numeric_node(expression, expected):
+    """Numeric expression parser covers every listener numeric exit branch."""
+    node = parse_bmc_num_expression(expression)
+    canonical = node.to_canonical()
+
+    assert isinstance(node, BmcNumExpr)
+    assert canonical.items() >= expected.items()
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "expression, expected",
+    [
+        pytest.param(
+            "TRUE",
+            {"node": "bool_literal", "raw": "TRUE", "value": True},
+            id="bool-upper",
+        ),
+        pytest.param(
+            'active("Root.A")',
+            {"node": "active", "state_path": "Root.A", "frame": "current"},
+            id="active-default",
+        ),
+        pytest.param(
+            'active("Root.A", current)',
+            {"node": "active", "state_path": "Root.A", "frame": "current"},
+            id="active-current",
+        ),
+        pytest.param(
+            'active("Root.A", 2)',
+            {"node": "active", "state_path": "Root.A", "frame": 2},
+            id="active-frame",
+        ),
+        pytest.param(
+            "terminated()",
+            {"node": "terminated", "frame": "current"},
+            id="terminated-default",
+        ),
+        pytest.param(
+            "terminated(current)",
+            {"node": "terminated", "frame": "current"},
+            id="terminated-current",
+        ),
+        pytest.param(
+            "terminated(3)",
+            {"node": "terminated", "frame": 3},
+            id="terminated-frame",
+        ),
+        pytest.param(
+            'event("Root.E", current)',
+            {"node": "event", "event_path": "Root.E", "selector": "current"},
+            id="event-current",
+        ),
+        pytest.param(
+            'event("Root.E", 0)',
+            {"node": "event", "event_path": "Root.E", "selector": 0},
+            id="event-index",
+        ),
+        pytest.param(
+            'case("label")',
+            {"node": "case", "label": "label", "frame": "current"},
+            id="case-default",
+        ),
+        pytest.param(
+            'case("label", 4)',
+            {"node": "case", "label": "label", "frame": 4},
+            id="case-frame",
+        ),
+        pytest.param(
+            'called("hook")',
+            {"node": "called", "name": "hook", "frame": "current"},
+            id="called-default",
+        ),
+        pytest.param(
+            'called("hook", 5)',
+            {"node": "called", "name": "hook", "frame": 5},
+            id="called-frame",
+        ),
+        pytest.param("!true", {"node": "cond_unary", "op": "!"}, id="bang"),
+        pytest.param("not true", {"node": "cond_unary", "op": "!"}, id="not"),
+        pytest.param("x < y", {"node": "numeric_comparison", "op": "<"}, id="lt"),
+        pytest.param("x > y", {"node": "numeric_comparison", "op": ">"}, id="gt"),
+        pytest.param("x <= y", {"node": "numeric_comparison", "op": "<="}, id="le"),
+        pytest.param("x >= y", {"node": "numeric_comparison", "op": ">="}, id="ge"),
+        pytest.param("x == y", {"node": "numeric_comparison", "op": "=="}, id="eq"),
+        pytest.param("x != y", {"node": "numeric_comparison", "op": "!="}, id="ne"),
+        pytest.param(
+            "true == false",
+            {"node": "cond_binary", "op": "=="},
+            id="cond-eq",
+        ),
+        pytest.param(
+            "true != false",
+            {"node": "cond_binary", "op": "!="},
+            id="cond-ne",
+        ),
+        pytest.param(
+            "true iff false",
+            {"node": "cond_binary", "op": "iff"},
+            id="iff",
+        ),
+        pytest.param("true && false", {"node": "cond_binary", "op": "&&"}, id="and"),
+        pytest.param(
+            "true and false", {"node": "cond_binary", "op": "&&"}, id="and-kw"
+        ),
+        pytest.param("true xor false", {"node": "cond_binary", "op": "xor"}, id="xor"),
+        pytest.param("true || false", {"node": "cond_binary", "op": "||"}, id="or"),
+        pytest.param("true or false", {"node": "cond_binary", "op": "||"}, id="or-kw"),
+        pytest.param("true => false", {"node": "cond_binary", "op": "=>"}, id="impl"),
+        pytest.param(
+            "true implies false",
+            {"node": "cond_binary", "op": "=>"},
+            id="impl-kw",
+        ),
+        pytest.param(
+            "(x > 0) ? true : false",
+            {"node": "cond_conditional"},
+            id="cond-conditional",
+        ),
+    ],
+)
+def test_parse_bmc_cond_expression_builds_each_condition_node(expression, expected):
+    """Condition parser covers every listener condition and BMC atom branch."""
+    node = parse_bmc_cond_expression(expression)
+    canonical = node.to_canonical()
+
+    assert isinstance(node, BmcCondExpr)
+    assert canonical.items() >= expected.items()
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "text, parser_func, expected_text",
+    [
+        pytest.param(
+            'var("a\\n")', parse_bmc_num_expression, 'var("a\\n")', id="newline"
+        ),
+        pytest.param('var("a\\t")', parse_bmc_num_expression, 'var("a\\t")', id="tab"),
+        pytest.param(
+            'var("a\\\\b")', parse_bmc_num_expression, 'var("a\\\\b")', id="slash"
+        ),
+        pytest.param(
+            'var("\\"quoted\\"")',
+            parse_bmc_num_expression,
+            'var("\\"quoted\\"")',
+            id="double-quote",
+        ),
+        pytest.param(
+            "var('\\'quoted\\'')",
+            parse_bmc_num_expression,
+            "var(\"'quoted'\")",
+            id="single-quote",
+        ),
+        pytest.param(
+            'var("\\x41")', parse_bmc_num_expression, 'var("A")', id="hex-escape"
+        ),
+        pytest.param(
+            'var("\\u4e2d")',
+            parse_bmc_num_expression,
+            'var("中")',
+            id="unicode-escape",
+        ),
+        pytest.param(
+            'active("\\u6839.\\x41")',
+            parse_bmc_cond_expression,
+            'active("根.A")',
+            id="active-escaped-path",
+        ),
+    ],
+)
+def test_string_literals_decode_and_render_canonical_json_text(
+    text, parser_func, expected_text
+):
+    """String literal escapes decode through the listener and round-trip."""
+    node = parser_func(text)
+
+    assert str(node) == expected_text
+    reparsed = parser_func(str(node))
+    assert reparsed.to_canonical() == node.to_canonical()
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "entry_name, text, expected_type",
+    [
+        pytest.param("query", "check reach <= 1: true;", BmcQuery, id="query"),
+        pytest.param("bmc_num_expression_entry", "cycle + 1", BmcNumExpr, id="numeric"),
+        pytest.param(
+            "bmc_cond_expression_entry", 'active("Root.A")', BmcCondExpr, id="cond"
+        ),
+    ],
+)
+def test_parse_with_bmc_grammar_entry_dispatches_supported_entries(
+    entry_name, text, expected_type
+):
+    """The public generic parser dispatches exactly the supported entries."""
+    result = parse_with_bmc_grammar_entry(text, entry_name)
+
+    assert isinstance(result, expected_type)
+
+
+@pytest.mark.unittest
+def test_parse_entry_force_finished_flag_is_accepted():
+    """The generic parser exposes the same force-finished knob as FCSTM DSL."""
+    assert parse_with_bmc_grammar_entry(
+        "cycle", "bmc_num_expression_entry", force_finished=False
+    ).to_canonical() == {"node": "cycle"}
+
+
+@pytest.mark.unittest
+def test_build_bmc_ast_from_existing_parse_tree():
+    """An already-created ANTLR context can be walked into a BMC AST node."""
+    lexer = BmcQueryLexer(InputStream("cycle + 1"))
+    parser = BmcQueryParser(CommonTokenStream(lexer))
+    tree = parser.bmc_num_expression_entry()
+
+    node = build_bmc_ast_from_parse_tree(tree)
+
+    assert node.to_canonical()["node"] == "num_binary"
+    assert node.to_canonical()["op"] == "+"
+
+
+@pytest.mark.unittest
+def test_parse_helpers_report_invalid_inputs_and_unmapped_trees(monkeypatch):
+    """Parser helpers expose typed parse errors instead of raw ANTLR details."""
+    with pytest.raises(BmcQueryParseError, match="Unsupported BMC grammar entry"):
+        parse_with_bmc_grammar_entry("true", "missing_entry")
+    with pytest.raises(BmcQueryParseError):
+        parse_bmc_query("check reach <= : true;")
+    with pytest.raises(BmcQueryParseError):
+        parse_bmc_query("check reach <= 1: true; garbage")
+    with pytest.raises(BmcQueryParseError):
+        parse_bmc_cond_expression("x + 1")
+    with pytest.raises(TypeError, match="ParserRuleContext"):
+        build_bmc_ast_from_parse_tree(cast(ParserRuleContext, "not a parse tree"))
+    with pytest.raises(BmcQueryParseError, match="No BMC AST node"):
+        build_bmc_ast_from_parse_tree(ParserRuleContext())
+
+    parse_module = importlib.import_module("pyfcstm.bmc.parse")
+
+    def _query_wrong_type(*args, **kwargs):
+        return BoolLiteral("true")
+
+    def _num_wrong_type(*args, **kwargs):
+        return BoolLiteral("true")
+
+    def _cond_wrong_type(*args, **kwargs):
+        return Cycle()
+
+    monkeypatch.setattr(parse_module, "parse_with_bmc_grammar_entry", _query_wrong_type)
+    with pytest.raises(BmcQueryParseError, match="BmcQuery"):
+        parse_module.parse_bmc_query("check reach <= 1: true;")
+    monkeypatch.setattr(parse_module, "parse_with_bmc_grammar_entry", _num_wrong_type)
+    with pytest.raises(BmcQueryParseError, match="BmcNumExpr"):
+        parse_module.parse_bmc_num_expression("1")
+    monkeypatch.setattr(parse_module, "parse_with_bmc_grammar_entry", _cond_wrong_type)
+    with pytest.raises(BmcQueryParseError, match="BmcCondExpr"):
+        parse_module.parse_bmc_cond_expression("true")
+
+
+@pytest.mark.unittest
+def test_query_model_validation_errors_surface_after_successful_syntax_parse():
+    """Syntax-valid zero bounds are rejected by the structural query model."""
+    with pytest.raises(InvalidBmcQuery, match="bound"):
+        parse_bmc_query("check reach <= 0: true;")
+    with pytest.raises(InvalidBmcQuery, match="bound"):
+        parse_bmc_query("check reach <= 00: true;")
+    assert parse_bmc_query("check reach <= 01: true;").property.bound == 1
+    with pytest.raises(InvalidBmcQuery, match="response window"):
+        parse_bmc_query("check response <= 1: trigger true -> within 0 true;")
+    assert (
+        parse_bmc_query(
+            "check response <= 001: trigger true -> within 001 true;"
+        ).property.within
+        == 1
+    )
+    with pytest.raises(InvalidBmcQuery, match="selector"):
+        parse_bmc_query(
+            'assume event("Root.E", 5..3) == false; check reach <= 1: true;'
+        )
+
+
+@pytest.mark.unittest
+def test_internal_error_listener_branches_and_parser_builders():
+    """Collecting listener helper branches are deterministic and typed."""
+    listener = _CollectingBmcErrorListener()
+    lexer = _build_lexer("true", listener)
+    parser = _build_parser(CommonTokenStream(lexer), listener)
+
+    assert lexer.grammarFileName == "BmcQueryLexer.g4"
+    assert parser.grammarFileName == "BmcQueryParser.g4"
+    listener.check_errors()
+
+    listener.syntaxError(None, None, 1, 2, "missing token", None)
+    listener.syntaxError(None, object(), 3, 4, "bad object", None)
+    assert "line 1:2" in listener.messages[0]
+    assert "near" not in listener.messages[0]
+    assert "near" in listener.messages[1]
+    with pytest.raises(BmcQueryParseError, match="missing token"):
+        listener.check_errors()
+
+    eof_listener = _CollectingBmcErrorListener()
+    eof_stream = CommonTokenStream(BmcQueryLexer(InputStream("")))
+    eof_stream.fill()
+    eof_listener.check_unfinished_parsing_error(eof_stream)
+    assert eof_listener.messages == []
+
+    unfinished_listener = _CollectingBmcErrorListener()
+    unfinished_stream = CommonTokenStream(BmcQueryLexer(InputStream("true true")))
+    unfinished_stream.fill()
+    unfinished_listener.check_unfinished_parsing_error(unfinished_stream)
+    assert "parser did not consume the full input" in unfinished_listener.messages[0]
+
+
+@pytest.mark.unittest
+def test_parse_import_does_not_load_model_verify_or_z3_modules():
+    """Parser imports stay independent from model, verify registry, and Z3."""
+    code = (
+        "import sys; "
+        "from pyfcstm.bmc.parse import parse_bmc_query; "
+        "parse_bmc_query('check reach <= 1: true;'); "
+        "bad = ["
+        "name for name in sys.modules "
+        "if name == 'z3' "
+        "or name.startswith('pyfcstm.model') "
+        "or name.startswith('pyfcstm.verify')"
+        "]; "
+        "print(bad)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert result.stdout.strip() == "[]"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "builder, canonical_text",
+    [
+        pytest.param(
+            lambda: parse_bmc_query(
+                'init state("Root.A") where var("x") >= 0; '
+                'assume event("Root.Tick", 1.. 3) != false; '
+                'check reach <= 01: active("Root.Done");'
+            ),
+            (
+                'init state("Root.A") where var("x") >= 0;\n\n'
+                'assume event("Root.Tick", 1..3) == true;\n\n'
+                'check reach <= 1: active("Root.Done");'
+            ),
+            id="query",
+        ),
+        pytest.param(
+            lambda: parse_bmc_num_expression("cycle + 01"), "cycle + 01", id="num"
+        ),
+        pytest.param(
+            lambda: parse_bmc_cond_expression("true and false"),
+            "true && false",
+            id="cond",
+        ),
+    ],
+)
+def test_parsed_nodes_stringify_to_canonical_round_trip_text(builder, canonical_text):
+    """Parser output keeps the object ``str`` round-trip contract."""
+    node = builder()
+
+    assert str(node) == canonical_text
+    if isinstance(node, BmcQuery):
+        reparsed = parse_bmc_query(str(node))
+    elif isinstance(node, BmcNumExpr):
+        reparsed = parse_bmc_num_expression(str(node))
+    else:
+        reparsed = parse_bmc_cond_expression(str(node))
+    assert reparsed.to_canonical() == node.to_canonical()
+
+
+@pytest.mark.unittest
+def test_parser_typing_helpers_are_used_by_static_interfaces():
+    """Callable signatures used in parser dispatch remain object-returning."""
+    funcs = [
+        parse_bmc_query,
+        parse_bmc_num_expression,
+        parse_bmc_cond_expression,
+    ]
+
+    assert all(callable(func) for func in funcs)
+    assert isinstance(
+        BmcProperty("reach", 1, predicate=Active("Root.Done")), BmcProperty
+    )

--- a/test/bmc/test_query_parser.py
+++ b/test/bmc/test_query_parser.py
@@ -564,6 +564,10 @@ def test_query_model_validation_errors_surface_after_successful_syntax_parse():
     with pytest.raises(InvalidBmcQuery, match="bound"):
         parse_bmc_query("check reach <= 00: true;")
     assert parse_bmc_query("check reach <= 01: true;").property.bound == 1
+    with pytest.raises(InvalidBmcQuery, match="response properties"):
+        parse_bmc_query("check response <= 1: true;")
+    with pytest.raises(InvalidBmcQuery, match="single-body properties"):
+        parse_bmc_query("check reach <= 1: trigger true -> within 1 true;")
     with pytest.raises(InvalidBmcQuery, match="response window"):
         parse_bmc_query("check response <= 1: trigger true -> within 0 true;")
     assert (

--- a/test/bmc/test_query_parser_matrix.py
+++ b/test/bmc/test_query_parser_matrix.py
@@ -1,0 +1,1454 @@
+"""High-volume parser matrix tests for FCSTM BMC query AST nodes.
+
+The parser matrix deliberately keeps the generated ``.fbmcq`` syntax and the
+expected parser-independent AST objects next to each other.  This makes the
+coverage requirements auditable: every concrete expression/query node introduced
+by the parser has at least forty standalone FBMCQ parse cases, every
+FCSTM-compatible expression node has at least forty strict FCSTM-vs-FBMCQ
+alignment cases, and one hundred complete medium/high-complexity query files are
+parsed and round-tripped as integrated trees.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Tuple
+
+import pytest
+
+from pyfcstm.bmc import ast as bmc_nodes
+from pyfcstm.bmc import query as bmc_query_nodes
+from pyfcstm.bmc.parse import (
+    parse_bmc_cond_expression,
+    parse_bmc_num_expression,
+    parse_bmc_query,
+)
+from pyfcstm.dsl.parse import parse_with_grammar_entry
+from test.bmc.test_query_expression_parity import (
+    _bmc_to_fcstm_expr,
+    _fcstm_to_bmc_expr,
+    _shared_shape_from_bmc,
+    _shared_shape_from_fcstm,
+)
+
+
+class NodeParseCase(NamedTuple):
+    """One FBMCQ parse case for a concrete node target.
+
+    :param target: Human-readable concrete node name tracked by the coverage
+        audit.
+    :type target: str
+    :param source: FBMCQ source text parsed by this case.
+    :type source: str
+    :param entry: Parser entry category: ``"num"``, ``"cond"``, or
+        ``"query"``.
+    :type entry: str
+    :param expected: Canonical expected object or selected query sub-object.
+    :type expected: object
+    :param selector: Function that extracts the asserted object from the parsed
+        root.
+    :type selector: Callable[[object], object]
+
+    Example::
+
+        >>> case = _expression_case("IntLiteral", "1", bmc_nodes.IntLiteral("1"))
+        >>> case.target
+        'IntLiteral'
+    """
+
+    target: str
+    source: str
+    entry: str
+    expected: Any
+    selector: Callable[[Any], Any]
+
+
+class ParityCase(NamedTuple):
+    """One FCSTM/FBMCQ expression alignment case.
+
+    :param target: Concrete FBMCQ node expected at the root of the aligned
+        expression.
+    :type target: str
+    :param expression: Expression parsed through both FCSTM and FBMCQ grammar
+        entries.
+    :type expression: str
+    :param category: Expression category: ``"num"`` or ``"cond"``.
+    :type category: str
+
+    Example::
+
+        >>> ParityCase("IntLiteral", "1", "num").category
+        'num'
+    """
+
+    target: str
+    expression: str
+    category: str
+
+
+class ComplexQueryCase(NamedTuple):
+    """One complete medium/high-complexity FBMCQ file case.
+
+    :param case_index: Stable case index used by test ids and assertions.
+    :type case_index: int
+    :param source: Complete FBMCQ query source text.
+    :type source: str
+    :param expected: Expected parser-independent query object.
+    :type expected: pyfcstm.bmc.query.BmcQuery
+
+    Example::
+
+        >>> case = _complex_query_cases()[0]
+        >>> case.case_index
+        0
+    """
+
+    case_index: int
+    source: str
+    expected: bmc_query_nodes.BmcQuery
+
+
+_REQUIRED_STANDALONE_NODES = (
+    "IntLiteral",
+    "FloatLiteral",
+    "BoolLiteral",
+    "NameRef",
+    "MathConst",
+    "NumUnaryOp",
+    "NumBinaryOp",
+    "NumConditionalOp",
+    "UFuncCall",
+    "CondUnaryOp",
+    "NumericComparison",
+    "CondBinaryOp",
+    "CondConditionalOp",
+    "FrameVar",
+    "Cycle",
+    "Active",
+    "Terminated",
+    "Event",
+    "Case",
+    "Called",
+    "InitialSpec",
+    "FrameAssumption",
+    "EventAssumption",
+    "EventCardinalityAssumption",
+    "BmcProperty",
+    "BmcQuery",
+)
+
+_REQUIRED_PARITY_NODES = (
+    "IntLiteral",
+    "FloatLiteral",
+    "BoolLiteral",
+    "NameRef",
+    "MathConst",
+    "NumUnaryOp",
+    "NumBinaryOp",
+    "NumConditionalOp",
+    "UFuncCall",
+    "CondUnaryOp",
+    "NumericComparison",
+    "CondBinaryOp",
+    "CondConditionalOp",
+)
+
+_UFUNC_NAMES = (
+    "sin",
+    "cos",
+    "tan",
+    "asin",
+    "acos",
+    "atan",
+    "sinh",
+    "cosh",
+    "tanh",
+    "asinh",
+    "acosh",
+    "atanh",
+    "sqrt",
+    "cbrt",
+    "exp",
+    "log",
+    "log10",
+    "log2",
+    "log1p",
+    "abs",
+    "ceil",
+    "floor",
+    "round",
+    "trunc",
+    "sign",
+)
+
+_NUM_BINARY_OPS = ("**", "*", "/", "%", "+", "-", "<<", ">>", "&", "^", "|")
+_NUM_COMPARE_OPS = ("<", ">", "<=", ">=", "==", "!=")
+_COND_BINARY_OPS = ("&&", "and", "||", "or", "xor", "=>", "implies", "iff", "==", "!=")
+_PROPERTY_KINDS = (
+    "reach",
+    "forbid",
+    "invariant",
+    "must_reach",
+    "exists_always",
+    "cover",
+)
+
+
+def _entry_for_expression(expr: bmc_nodes.BmcExpr) -> str:
+    """Return the parser entry category for an expression object.
+
+    :param expr: Expression object under test.
+    :type expr: pyfcstm.bmc.ast.BmcExpr
+    :return: ``"num"`` for numeric expressions, otherwise ``"cond"``.
+    :rtype: str
+
+    Example::
+
+        >>> _entry_for_expression(bmc_nodes.Cycle())
+        'num'
+    """
+    if isinstance(expr, bmc_nodes.BmcNumExpr):
+        return "num"
+    return "cond"
+
+
+def _parse_entry(entry: str, source: str) -> Any:
+    """Parse source text using the matrix-selected entry point.
+
+    :param entry: Parser entry category.
+    :type entry: str
+    :param source: Source text for that entry.
+    :type source: str
+    :return: Parsed AST/query object.
+    :rtype: object
+
+    Example::
+
+        >>> _parse_entry("num", "1").to_canonical()["value"]
+        1
+    """
+    if entry == "num":
+        return parse_bmc_num_expression(source)
+    if entry == "cond":
+        return parse_bmc_cond_expression(source)
+    return parse_bmc_query(source)
+
+
+def _root(value: Any) -> Any:
+    """Return a parsed root unchanged for expression and query-root cases.
+
+    :param value: Parsed object.
+    :type value: object
+    :return: The same object.
+    :rtype: object
+
+    Example::
+
+        >>> _root(1)
+        1
+    """
+    return value
+
+
+def _query_initial(value: bmc_query_nodes.BmcQuery) -> bmc_query_nodes.InitialSpec:
+    """Select the initial clause from a parsed query.
+
+    :param value: Parsed query object.
+    :type value: pyfcstm.bmc.query.BmcQuery
+    :return: Query initial specification.
+    :rtype: pyfcstm.bmc.query.InitialSpec
+
+    Example::
+
+        >>> _query_initial(parse_bmc_query('check reach <= 1: true;')).mode
+        'cold'
+    """
+    return value.initial
+
+
+def _query_first_assumption(
+    value: bmc_query_nodes.BmcQuery,
+) -> bmc_query_nodes.BmcAssumption:
+    """Select the first assumption from a parsed query.
+
+    :param value: Parsed query object.
+    :type value: pyfcstm.bmc.query.BmcQuery
+    :return: First assumption.
+    :rtype: pyfcstm.bmc.query.BmcAssumption
+
+    Example::
+
+        >>> query = parse_bmc_query('assume always: true; check reach <= 1: true;')
+        >>> _query_first_assumption(query).to_canonical()['kind']
+        'always'
+    """
+    return value.assumptions[0]
+
+
+def _query_property(value: bmc_query_nodes.BmcQuery) -> bmc_query_nodes.BmcProperty:
+    """Select the property from a parsed query.
+
+    :param value: Parsed query object.
+    :type value: pyfcstm.bmc.query.BmcQuery
+    :return: Query property.
+    :rtype: pyfcstm.bmc.query.BmcProperty
+
+    Example::
+
+        >>> _query_property(parse_bmc_query('check reach <= 1: true;')).kind
+        'reach'
+    """
+    return value.property
+
+
+def _canonical(value: Any) -> Any:
+    """Return the canonical dictionary for a BMC object.
+
+    :param value: Object with ``to_canonical``.
+    :type value: object
+    :return: Canonical dictionary.
+    :rtype: object
+
+    Example::
+
+        >>> _canonical(bmc_nodes.IntLiteral("1"))["node"]
+        'int_literal'
+    """
+    return value.to_canonical()
+
+
+def _expression_case(
+    target: str, source: str, expected: bmc_nodes.BmcExpr
+) -> NodeParseCase:
+    """Build one standalone expression parser case.
+
+    :param target: Concrete node name.
+    :type target: str
+    :param source: FBMCQ expression source text.
+    :type source: str
+    :param expected: Expected expression object.
+    :type expected: pyfcstm.bmc.ast.BmcExpr
+    :return: Matrix parse case.
+    :rtype: NodeParseCase
+
+    Example::
+
+        >>> _expression_case("Cycle", "cycle", bmc_nodes.Cycle()).entry
+        'num'
+    """
+    return NodeParseCase(
+        target, source, _entry_for_expression(expected), expected, _root
+    )
+
+
+def _query_case(
+    target: str,
+    source: str,
+    expected: Any,
+    selector: Callable[[Any], Any],
+) -> NodeParseCase:
+    """Build one standalone query parser case.
+
+    :param target: Concrete query node name.
+    :type target: str
+    :param source: Complete FBMCQ query source text.
+    :type source: str
+    :param expected: Expected selected query object.
+    :type expected: object
+    :param selector: Parsed-query selector for ``expected``.
+    :type selector: Callable[[object], object]
+    :return: Matrix parse case.
+    :rtype: NodeParseCase
+
+    Example::
+
+        >>> prop = bmc_query_nodes.BmcProperty("reach", 1, predicate=bmc_nodes.BoolLiteral("true"))
+        >>> _query_case("BmcProperty", str(prop), prop, _query_property).entry
+        'query'
+    """
+    return NodeParseCase(target, source, "query", expected, selector)
+
+
+def _decorated_expression_sources(base: str, count: int = 40) -> List[str]:
+    """Return whitespace/comment/parenthesis variants for one expression.
+
+    :param base: Base expression text.
+    :type base: str
+    :param count: Number of variants to return, defaults to ``40``.
+    :type count: int, optional
+    :return: Source variants that parse to the same root expression.
+    :rtype: list
+
+    Example::
+
+        >>> len(_decorated_expression_sources("cycle", 3))
+        3
+    """
+    variants = []
+    for index in range(count):
+        style = index % 10
+        if style == 0:
+            text = base
+        elif style == 1:
+            text = "  %s  " % base
+        elif style == 2:
+            text = "(%s)" % base
+        elif style == 3:
+            text = "/* before_%d */ %s" % (index, base)
+        elif style == 4:
+            text = "%s /* after_%d */" % (base, index)
+        elif style == 5:
+            text = "/* left_%d */ (%s) /* right_%d */" % (index, base, index)
+        elif style == 6:
+            text = "// line_%d\n%s" % (index, base)
+        elif style == 7:
+            text = "# hash_%d\n%s" % (index, base)
+        elif style == 8:
+            text = "(\n%s\n)" % base
+        else:
+            text = "\n\t%s\n" % base
+        variants.append(text)
+    return variants
+
+
+def _string(index: int, prefix: str) -> str:
+    """Return a stable query string value with occasional escaped characters.
+
+    :param index: Case index.
+    :type index: int
+    :param prefix: Value prefix.
+    :type prefix: str
+    :return: String value for a quoted FBMCQ atom.
+    :rtype: str
+
+    Example::
+
+        >>> _string(1, "Root.State")
+        'Root.State1'
+    """
+    if index % 10 == 7:
+        return '%s%d."quoted"' % (prefix, index)
+    if index % 10 == 8:
+        return "%s%d.中文" % (prefix, index)
+    if index % 10 == 9:
+        return "%s%d.back\\slash" % (prefix, index)
+    return "%s%d" % (prefix, index)
+
+
+def _num_leaf(index: int) -> bmc_nodes.BmcNumExpr:
+    """Return a numeric leaf expression used by matrix factories.
+
+    :param index: Case index.
+    :type index: int
+    :return: Numeric expression leaf.
+    :rtype: pyfcstm.bmc.ast.BmcNumExpr
+
+    Example::
+
+        >>> isinstance(_num_leaf(0), bmc_nodes.BmcNumExpr)
+        True
+    """
+    choices = (
+        bmc_nodes.NameRef("x%d" % index),
+        bmc_nodes.IntLiteral(str(index + 1)),
+        bmc_nodes.FloatLiteral("%d.%d" % (index + 1, index % 10)),
+        bmc_nodes.MathConst(("pi", "E", "tau")[index % 3]),
+        bmc_nodes.FrameVar(_string(index, "var")),
+        bmc_nodes.Cycle(),
+    )
+    return choices[index % len(choices)]
+
+
+def _comparison(index: int) -> bmc_nodes.NumericComparison:
+    """Return a numeric comparison with varied operators and operands.
+
+    :param index: Case index.
+    :type index: int
+    :return: Numeric comparison expression.
+    :rtype: pyfcstm.bmc.ast.NumericComparison
+
+    Example::
+
+        >>> _comparison(0).to_canonical()["node"]
+        'numeric_comparison'
+    """
+    left = bmc_nodes.NumBinaryOp(
+        _num_leaf(index),
+        _NUM_BINARY_OPS[index % len(_NUM_BINARY_OPS)],
+        _num_leaf(index + 1),
+    )
+    right = bmc_nodes.UFuncCall(
+        _UFUNC_NAMES[index % len(_UFUNC_NAMES)], _num_leaf(index + 2)
+    )
+    return bmc_nodes.NumericComparison(
+        left, _NUM_COMPARE_OPS[index % len(_NUM_COMPARE_OPS)], right
+    )
+
+
+def _condition(index: int) -> bmc_nodes.BmcCondExpr:
+    """Return a medium-complexity condition expression.
+
+    :param index: Case index.
+    :type index: int
+    :return: Condition expression.
+    :rtype: pyfcstm.bmc.ast.BmcCondExpr
+
+    Example::
+
+        >>> isinstance(_condition(0), bmc_nodes.BmcCondExpr)
+        True
+    """
+    active = bmc_nodes.Active(_string(index, "Root.State"), frame=index % 5)
+    event = bmc_nodes.Event(_string(index, "Root.Event"), selector=index % 4)
+    selected_case = bmc_nodes.Case(_string(index, "Root.Case"), frame=(index + 1) % 5)
+    called = bmc_nodes.Called(_string(index, "Hook"), frame=(index + 2) % 5)
+    left = bmc_nodes.CondBinaryOp(_comparison(index), "&&", active)
+    right = bmc_nodes.CondBinaryOp(
+        event, "xor", bmc_nodes.CondBinaryOp(selected_case, "||", called)
+    )
+    implication = bmc_nodes.CondBinaryOp(left, "=>", right)
+    if index % 3 == 0:
+        return bmc_nodes.CondConditionalOp(
+            _comparison(index + 3), implication, bmc_nodes.BoolLiteral("false")
+        )
+    if index % 3 == 1:
+        return bmc_nodes.CondUnaryOp("!", implication)
+    return bmc_nodes.CondBinaryOp(
+        implication, "iff", bmc_nodes.Terminated(frame=index % 5)
+    )
+
+
+def _single_property(index: int) -> bmc_query_nodes.BmcProperty:
+    """Return a non-response property for generated complete query cases.
+
+    :param index: Case index.
+    :type index: int
+    :return: Property object.
+    :rtype: pyfcstm.bmc.query.BmcProperty
+
+    Example::
+
+        >>> _single_property(0).bound
+        1
+    """
+    return bmc_query_nodes.BmcProperty(
+        _PROPERTY_KINDS[index % len(_PROPERTY_KINDS)],
+        bound=index + 1,
+        predicate=_condition(index),
+    )
+
+
+def _response_property(index: int) -> bmc_query_nodes.BmcProperty:
+    """Return a response property for generated complete query cases.
+
+    :param index: Case index.
+    :type index: int
+    :return: Response property object.
+    :rtype: pyfcstm.bmc.query.BmcProperty
+
+    Example::
+
+        >>> _response_property(0).kind
+        'response'
+    """
+    return bmc_query_nodes.BmcProperty(
+        "response",
+        bound=index + 2,
+        trigger=_condition(index),
+        response=_condition(index + 1),
+        within=(index % 7) + 1,
+    )
+
+
+def _query_with_initial(
+    initial: bmc_query_nodes.InitialSpec, index: int
+) -> bmc_query_nodes.BmcQuery:
+    """Embed an initial spec in a complete parseable query.
+
+    :param initial: Initial specification under test.
+    :type initial: pyfcstm.bmc.query.InitialSpec
+    :param index: Case index.
+    :type index: int
+    :return: Complete query object.
+    :rtype: pyfcstm.bmc.query.BmcQuery
+
+    Example::
+
+        >>> _query_with_initial(bmc_query_nodes.InitialSpec(), 0).initial.mode
+        'cold'
+    """
+    return bmc_query_nodes.BmcQuery(initial=initial, property=_single_property(index))
+
+
+def _query_with_assumption(
+    assumption: bmc_query_nodes.BmcAssumption, index: int
+) -> bmc_query_nodes.BmcQuery:
+    """Embed an assumption in a complete parseable query.
+
+    :param assumption: Assumption under test.
+    :type assumption: pyfcstm.bmc.query.BmcAssumption
+    :param index: Case index.
+    :type index: int
+    :return: Complete query object.
+    :rtype: pyfcstm.bmc.query.BmcQuery
+
+    Example::
+
+        >>> assumption = bmc_query_nodes.FrameAssumption("always", bmc_nodes.BoolLiteral("true"))
+        >>> len(_query_with_assumption(assumption, 0).assumptions)
+        1
+    """
+    return bmc_query_nodes.BmcQuery(
+        assumptions=(assumption,), property=_single_property(index)
+    )
+
+
+def _initial_specs() -> List[bmc_query_nodes.InitialSpec]:
+    """Return at least forty initial specifications.
+
+    :return: Initial specifications.
+    :rtype: list
+
+    Example::
+
+        >>> len(_initial_specs()) >= 40
+        True
+    """
+    specs = []
+    for index in range(40):
+        mode = index % 6
+        if mode == 0:
+            spec = bmc_query_nodes.InitialSpec()
+        elif mode == 1:
+            spec = bmc_query_nodes.InitialSpec(mode="terminated")
+        elif mode == 2:
+            spec = bmc_query_nodes.InitialSpec(
+                mode="state", state_path=_string(index, "Root.Init")
+            )
+        elif mode == 3:
+            spec = bmc_query_nodes.InitialSpec(mode="cold", predicate=_condition(index))
+        elif mode == 4:
+            spec = bmc_query_nodes.InitialSpec(
+                mode="terminated", predicate=_condition(index)
+            )
+        else:
+            spec = bmc_query_nodes.InitialSpec(
+                mode="state",
+                state_path=_string(index, "Root.Init"),
+                predicate=_condition(index),
+            )
+        specs.append(spec)
+    return specs
+
+
+def _frame_assumptions() -> List[bmc_query_nodes.FrameAssumption]:
+    """Return at least forty frame assumptions.
+
+    :return: Frame assumptions.
+    :rtype: list
+
+    Example::
+
+        >>> len(_frame_assumptions()) >= 40
+        True
+    """
+    assumptions = []
+    for index in range(40):
+        if index % 2 == 0:
+            assumptions.append(
+                bmc_query_nodes.FrameAssumption("always", _condition(index))
+            )
+        else:
+            assumptions.append(
+                bmc_query_nodes.FrameAssumption(
+                    "at", _condition(index), frame=index % 9
+                )
+            )
+    return assumptions
+
+
+def _event_assumptions() -> List[bmc_query_nodes.EventAssumption]:
+    """Return at least forty event assumptions.
+
+    :return: Event assumptions.
+    :rtype: list
+
+    Example::
+
+        >>> len(_event_assumptions()) >= 40
+        True
+    """
+    selectors: Tuple[Any, ...] = ("*", 0, 1, "0..3", "01..03", "02..02", 7)
+    return [
+        bmc_query_nodes.EventAssumption(
+            _string(index, "Root.Event"),
+            selector=selectors[index % len(selectors)],
+            expected=index % 3 != 0,
+        )
+        for index in range(40)
+    ]
+
+
+def _event_cardinality_assumptions() -> List[
+    bmc_query_nodes.EventCardinalityAssumption
+]:
+    """Return at least forty event-cardinality assumptions.
+
+    :return: Event-cardinality assumptions.
+    :rtype: list
+
+    Example::
+
+        >>> len(_event_cardinality_assumptions()) >= 40
+        True
+    """
+    assumptions = []
+    for index in range(40):
+        if index % 4 == 0:
+            assumptions.append(bmc_query_nodes.EventCardinalityAssumption("any"))
+        else:
+            assumptions.append(
+                bmc_query_nodes.EventCardinalityAssumption(
+                    "at_most_one",
+                    tuple(
+                        _string(index + offset, "Root.Event")
+                        for offset in range(2 + index % 3)
+                    ),
+                )
+            )
+    return assumptions
+
+
+def _properties() -> List[bmc_query_nodes.BmcProperty]:
+    """Return at least forty BMC properties.
+
+    :return: BMC properties.
+    :rtype: list
+
+    Example::
+
+        >>> len(_properties()) >= 40
+        True
+    """
+    properties = []
+    for index in range(40):
+        if index % 7 == 6:
+            properties.append(_response_property(index))
+        else:
+            properties.append(_single_property(index))
+    return properties
+
+
+def _complex_query(index: int) -> bmc_query_nodes.BmcQuery:
+    """Return a complete query with several clauses and nested predicates.
+
+    :param index: Case index.
+    :type index: int
+    :return: Complete BMC query object.
+    :rtype: pyfcstm.bmc.query.BmcQuery
+
+    Example::
+
+        >>> len(_complex_query(0).assumptions) >= 5
+        True
+    """
+    initial = _initial_specs()[index % 40]
+    event_a = _string(index, "Root.Event")
+    event_b = _string(index + 1, "Root.Event")
+    event_c = _string(index + 2, "Root.Event")
+    assumptions = (
+        bmc_query_nodes.FrameAssumption("always", _condition(index)),
+        bmc_query_nodes.FrameAssumption("at", _condition(index + 1), frame=index % 10),
+        bmc_query_nodes.EventAssumption(event_a, selector="*", expected=index % 2 == 0),
+        bmc_query_nodes.EventAssumption(
+            event_b,
+            selector="%d..%d" % (index % 3, index % 3 + 2),
+            expected=index % 3 != 0,
+        ),
+        bmc_query_nodes.EventCardinalityAssumption(
+            "at_most_one", (event_a, event_b, event_c)
+        ),
+        bmc_query_nodes.EventCardinalityAssumption("any"),
+    )
+    property_node = (
+        _response_property(index) if index % 5 == 0 else _single_property(index)
+    )
+    return bmc_query_nodes.BmcQuery(
+        initial=initial,
+        assumptions=assumptions,
+        property=property_node,
+    )
+
+
+def _expression_node_cases() -> List[NodeParseCase]:
+    """Build standalone FBMCQ expression cases for every concrete expression node.
+
+    :return: Matrix cases.
+    :rtype: list
+
+    Example::
+
+        >>> any(case.target == "Cycle" for case in _expression_node_cases())
+        True
+    """
+    cases: List[NodeParseCase] = []
+
+    int_values = ["0", "00", "01", "001", "42"] + [str(index) for index in range(2, 25)]
+    int_values.extend("0x%X" % index for index in range(1, 14))
+    for index, raw in enumerate(int_values[:40]):
+        expr = bmc_nodes.IntLiteral(raw)
+        cases.append(
+            _expression_case(
+                "IntLiteral", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    float_values = ["%d.%d" % (index + 1, index % 10) for index in range(12)]
+    float_values.extend(".%d" % (index + 1) for index in range(10))
+    float_values.extend("%de-%d" % (index + 1, index % 5 + 1) for index in range(10))
+    float_values.extend("%dE+%d" % (index + 1, index % 4 + 1) for index in range(8))
+    for index, raw in enumerate(float_values[:40]):
+        expr = bmc_nodes.FloatLiteral(raw)
+        cases.append(
+            _expression_case(
+                "FloatLiteral", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    bool_values = ("true", "True", "TRUE", "false", "False", "FALSE")
+    for index in range(40):
+        raw = bool_values[index % len(bool_values)]
+        expr = bmc_nodes.BoolLiteral(raw)
+        cases.append(
+            _expression_case(
+                "BoolLiteral", _decorated_expression_sources(raw)[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.NameRef("var_%d" % index)
+        cases.append(
+            _expression_case(
+                "NameRef", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    const_values = ("pi", "E", "tau")
+    for index in range(40):
+        expr = bmc_nodes.MathConst(const_values[index % len(const_values)])
+        cases.append(
+            _expression_case(
+                "MathConst", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        operand = _num_leaf(index)
+        expr = bmc_nodes.NumUnaryOp(("+", "-")[index % 2], operand)
+        cases.append(
+            _expression_case(
+                "NumUnaryOp", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.NumBinaryOp(
+            _num_leaf(index),
+            _NUM_BINARY_OPS[index % len(_NUM_BINARY_OPS)],
+            _num_leaf(index + 1),
+        )
+        cases.append(
+            _expression_case(
+                "NumBinaryOp", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.NumConditionalOp(
+            _condition(index),
+            bmc_nodes.NumBinaryOp(_num_leaf(index), "+", _num_leaf(index + 1)),
+            bmc_nodes.UFuncCall(
+                _UFUNC_NAMES[index % len(_UFUNC_NAMES)], _num_leaf(index + 2)
+            ),
+        )
+        cases.append(
+            _expression_case(
+                "NumConditionalOp",
+                _decorated_expression_sources(str(expr))[index],
+                expr,
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.UFuncCall(
+            _UFUNC_NAMES[index % len(_UFUNC_NAMES)], _num_leaf(index)
+        )
+        cases.append(
+            _expression_case(
+                "UFuncCall", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        operand = (
+            _condition(index)
+            if index % 2
+            else bmc_nodes.Active(_string(index, "Root.State"))
+        )
+        expr = bmc_nodes.CondUnaryOp(("!", "not")[index % 2], operand)
+        cases.append(
+            _expression_case(
+                "CondUnaryOp", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = _comparison(index)
+        cases.append(
+            _expression_case(
+                "NumericComparison",
+                _decorated_expression_sources(str(expr))[index],
+                expr,
+            )
+        )
+
+    for index in range(40):
+        left = (
+            _condition(index)
+            if index % 2
+            else bmc_nodes.Active(_string(index, "Root.Left"))
+        )
+        right = (
+            _condition(index + 1)
+            if index % 3
+            else bmc_nodes.Event(_string(index, "Root.Right"))
+        )
+        expr = bmc_nodes.CondBinaryOp(
+            left, _COND_BINARY_OPS[index % len(_COND_BINARY_OPS)], right
+        )
+        cases.append(
+            _expression_case(
+                "CondBinaryOp", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.CondConditionalOp(
+            _comparison(index),
+            _condition(index),
+            bmc_nodes.CondUnaryOp("!", _condition(index + 1)),
+        )
+        cases.append(
+            _expression_case(
+                "CondConditionalOp",
+                _decorated_expression_sources(str(expr))[index],
+                expr,
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.FrameVar(_string(index, "var"))
+        cases.append(
+            _expression_case(
+                "FrameVar", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index, source in enumerate(_decorated_expression_sources("cycle")):
+        cases.append(_expression_case("Cycle", source, bmc_nodes.Cycle()))
+
+    for index in range(40):
+        expr = bmc_nodes.Active(
+            _string(index, "Root.State"),
+            frame="current" if index % 3 == 0 else index % 8,
+        )
+        cases.append(
+            _expression_case(
+                "Active", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.Terminated(frame="current" if index % 3 == 0 else index % 8)
+        cases.append(
+            _expression_case(
+                "Terminated", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.Event(
+            _string(index, "Root.Event"),
+            selector="current" if index % 3 == 0 else index % 8,
+        )
+        cases.append(
+            _expression_case(
+                "Event", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.Case(
+            _string(index, "Root.Case"),
+            frame="current" if index % 3 == 0 else index % 8,
+        )
+        cases.append(
+            _expression_case(
+                "Case", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    for index in range(40):
+        expr = bmc_nodes.Called(
+            _string(index, "Hook"), frame="current" if index % 3 == 0 else index % 8
+        )
+        cases.append(
+            _expression_case(
+                "Called", _decorated_expression_sources(str(expr))[index], expr
+            )
+        )
+
+    return cases
+
+
+def _query_node_cases() -> List[NodeParseCase]:
+    """Build standalone FBMCQ complete-query cases for query-level nodes.
+
+    :return: Matrix cases.
+    :rtype: list
+
+    Example::
+
+        >>> any(case.target == "BmcQuery" for case in _query_node_cases())
+        True
+    """
+    cases: List[NodeParseCase] = []
+
+    for index, initial in enumerate(_initial_specs()):
+        query = _query_with_initial(initial, index)
+        cases.append(_query_case("InitialSpec", str(query), initial, _query_initial))
+
+    for index, assumption in enumerate(_frame_assumptions()):
+        query = _query_with_assumption(assumption, index)
+        cases.append(
+            _query_case(
+                "FrameAssumption", str(query), assumption, _query_first_assumption
+            )
+        )
+
+    for index, assumption in enumerate(_event_assumptions()):
+        query = _query_with_assumption(assumption, index)
+        cases.append(
+            _query_case(
+                "EventAssumption", str(query), assumption, _query_first_assumption
+            )
+        )
+
+    for index, assumption in enumerate(_event_cardinality_assumptions()):
+        query = _query_with_assumption(assumption, index)
+        cases.append(
+            _query_case(
+                "EventCardinalityAssumption",
+                str(query),
+                assumption,
+                _query_first_assumption,
+            )
+        )
+
+    for index, property_node in enumerate(_properties()):
+        query = bmc_query_nodes.BmcQuery(property=property_node)
+        cases.append(
+            _query_case("BmcProperty", str(query), property_node, _query_property)
+        )
+
+    for index in range(40):
+        query = _complex_query(index)
+        cases.append(_query_case("BmcQuery", str(query), query, _root))
+
+    return cases
+
+
+def _standalone_node_cases() -> List[NodeParseCase]:
+    """Return all standalone node parser cases.
+
+    :return: Expression and query matrix cases.
+    :rtype: list
+
+    Example::
+
+        >>> len(_standalone_node_cases()) >= 40 * len(_REQUIRED_STANDALONE_NODES)
+        True
+    """
+    return _expression_node_cases() + _query_node_cases()
+
+
+def _parity_cases() -> List[ParityCase]:
+    """Return FCSTM-compatible expression alignment cases.
+
+    :return: Parity matrix cases.
+    :rtype: list
+
+    Example::
+
+        >>> len(_parity_cases()) >= 40 * len(_REQUIRED_PARITY_NODES)
+        True
+    """
+    cases: List[ParityCase] = []
+
+    int_expressions = ["0", "00", "01", "001", "42"] + [
+        str(index) for index in range(2, 25)
+    ]
+    int_expressions.extend("0x%X" % index for index in range(1, 14))
+    cases.extend(
+        ParityCase("IntLiteral", expression, "num")
+        for expression in int_expressions[:40]
+    )
+
+    float_expressions = ["%d.%d" % (index + 1, index % 10) for index in range(12)]
+    float_expressions.extend(".%d" % (index + 1) for index in range(10))
+    float_expressions.extend(
+        "%de-%d" % (index + 1, index % 5 + 1) for index in range(10)
+    )
+    float_expressions.extend(
+        "%dE+%d" % (index + 1, index % 4 + 1) for index in range(8)
+    )
+    cases.extend(
+        ParityCase("FloatLiteral", expression, "num")
+        for expression in float_expressions[:40]
+    )
+
+    bool_values = ("true", "True", "TRUE", "false", "False", "FALSE")
+    for index in range(40):
+        raw = bool_values[index % len(bool_values)]
+        expression = raw if index % 2 == 0 else "(%s)" % raw
+        cases.append(ParityCase("BoolLiteral", expression, "cond"))
+
+    for index in range(40):
+        cases.append(ParityCase("NameRef", "var_%d" % index, "num"))
+
+    const_values = ("pi", "E", "tau")
+    for index in range(40):
+        expression = const_values[index % len(const_values)]
+        if index % 2:
+            expression = "(%s)" % expression
+        cases.append(ParityCase("MathConst", expression, "num"))
+
+    for index in range(40):
+        operand = "var_%d" % index if index % 3 else "(var_%d + 1)" % index
+        cases.append(
+            ParityCase("NumUnaryOp", "%s%s" % (("+", "-")[index % 2], operand), "num")
+        )
+
+    for index in range(40):
+        left = "a_%d" % index
+        right = "b_%d + %d" % (index, index + 1) if index % 2 else "b_%d" % index
+        cases.append(
+            ParityCase(
+                "NumBinaryOp",
+                "%s %s %s"
+                % (left, _NUM_BINARY_OPS[index % len(_NUM_BINARY_OPS)], right),
+                "num",
+            )
+        )
+
+    for index in range(40):
+        cases.append(
+            ParityCase(
+                "NumConditionalOp",
+                "((x_%d + 1) >= y_%d) ? (a_%d + b_%d) : (c_%d * d_%d)"
+                % (index, index, index, index, index, index),
+                "num",
+            )
+        )
+
+    for index in range(40):
+        operand = "-x_%d" % index if index % 3 == 0 else "x_%d + 1" % index
+        cases.append(
+            ParityCase(
+                "UFuncCall",
+                "%s(%s)" % (_UFUNC_NAMES[index % len(_UFUNC_NAMES)], operand),
+                "num",
+            )
+        )
+
+    for index in range(40):
+        op = "!" if index % 2 == 0 else "not "
+        cases.append(
+            ParityCase(
+                "CondUnaryOp", "%s(x_%d > 0 && y_%d > 0)" % (op, index, index), "cond"
+            )
+        )
+
+    for index in range(40):
+        expression = "(x_%d + 1) %s sqrt(y_%d)" % (
+            index,
+            _NUM_COMPARE_OPS[index % len(_NUM_COMPARE_OPS)],
+            index,
+        )
+        cases.append(ParityCase("NumericComparison", expression, "cond"))
+
+    cond_ops = ("&&", "and", "||", "or", "xor", "=>", "implies", "iff", "==", "!=")
+    for index in range(40):
+        left = "x_%d > 0" % index
+        right = "y_%d <= z_%d" % (index, index)
+        cases.append(
+            ParityCase(
+                "CondBinaryOp",
+                "(%s) %s (%s)" % (left, cond_ops[index % len(cond_ops)], right),
+                "cond",
+            )
+        )
+
+    for index in range(40):
+        expression = "(x_%d > 0) ? (y_%d > 0 && z_%d > 0) : (a_%d <= b_%d)" % (
+            index,
+            index,
+            index,
+            index,
+            index,
+        )
+        cases.append(ParityCase("CondConditionalOp", expression, "cond"))
+
+    return cases
+
+
+def _complex_query_source(index: int, query: bmc_query_nodes.BmcQuery) -> str:
+    """Return a nontrivial source variant for a complex query object.
+
+    :param index: Case index.
+    :type index: int
+    :param query: Query object whose semantics should be parsed back.
+    :type query: pyfcstm.bmc.query.BmcQuery
+    :return: Complete FBMCQ source with harmless trivia or operator aliases.
+    :rtype: str
+
+    Example::
+
+        >>> _complex_query_source(0, _complex_query(0)).lstrip().startswith('//')
+        True
+    """
+    source = str(query)
+    if index % 2 == 0:
+        source = source.replace(" && ", " and ", 1)
+    if index % 3 == 0:
+        source = source.replace(" || ", " or ", 1)
+    if index % 4 == 0:
+        source = source.replace(" => ", " implies ", 1)
+    if index % 5 == 0:
+        source = source.replace(
+            "\n\n", "\n\n/* integrated matrix case %d */\n" % index, 1
+        )
+    if index % 7 == 0:
+        source = source.replace(
+            "check ", "# property clause for case %d\ncheck " % index, 1
+        )
+    return "// complex fbmcq case %d\n%s\n" % (index, source)
+
+
+def _complex_query_cases() -> List[ComplexQueryCase]:
+    """Return one hundred complete medium/high-complexity query cases.
+
+    :return: Complex integrated query cases.
+    :rtype: list
+
+    Example::
+
+        >>> len(_complex_query_cases())
+        100
+    """
+    cases = []
+    for index in range(100):
+        query = _complex_query(index)
+        cases.append(
+            ComplexQueryCase(index, _complex_query_source(index, query), query)
+        )
+    return cases
+
+
+STANDALONE_NODE_CASES = _standalone_node_cases()
+PARITY_CASES = _parity_cases()
+COMPLEX_QUERY_CASES = _complex_query_cases()
+
+
+def _case_counts(cases: Iterable[Any]) -> Dict[str, int]:
+    """Count matrix cases by target node name.
+
+    :param cases: Cases with a ``target`` field.
+    :type cases: Iterable[object]
+    :return: Counts keyed by target name.
+    :rtype: Dict[str, int]
+
+    Example::
+
+        >>> _case_counts([ParityCase("IntLiteral", "1", "num")])["IntLiteral"]
+        1
+    """
+    counts: Dict[str, int] = {}
+    for case in cases:
+        counts[case.target] = counts.get(case.target, 0) + 1
+    return counts
+
+
+def _round_trip_canonical(value: Any) -> Any:
+    """Return canonical data normalized for canonical-text round trips.
+
+    :param value: Canonical dictionary/list/scalar or object with
+        ``to_canonical``.
+    :type value: object
+    :return: Canonical value with spelling-only boolean raw casing normalized.
+    :rtype: object
+
+    Example::
+
+        >>> _round_trip_canonical(bmc_nodes.BoolLiteral("TRUE"))["raw"]
+        'true'
+    """
+    if hasattr(value, "to_canonical"):
+        value = value.to_canonical()
+    if isinstance(value, dict):
+        normalized = {key: _round_trip_canonical(child) for key, child in value.items()}
+        if normalized.get("node") == "bool_literal" and "raw" in normalized:
+            normalized["raw"] = str(normalized["raw"]).lower()
+        return normalized
+    if isinstance(value, list):
+        return [_round_trip_canonical(child) for child in value]
+    return value
+
+
+def _canonical_node_count(value: Any) -> int:
+    """Count nested canonical dictionaries that carry a ``node`` tag.
+
+    :param value: Canonical dictionary/list/scalar.
+    :type value: object
+    :return: Number of node-tagged dictionaries in ``value``.
+    :rtype: int
+
+    Example::
+
+        >>> _canonical_node_count({"node": "x", "child": {"node": "y"}})
+        2
+    """
+    if isinstance(value, dict):
+        current = 1 if "node" in value else 0
+        return current + sum(_canonical_node_count(child) for child in value.values())
+    if isinstance(value, list):
+        return sum(_canonical_node_count(child) for child in value)
+    return 0
+
+
+@pytest.mark.unittest
+def test_standalone_fbmcq_matrix_has_forty_cases_per_concrete_node():
+    """Every concrete parser node has at least forty standalone FBMCQ cases."""
+    counts = _case_counts(STANDALONE_NODE_CASES)
+
+    assert set(counts) == set(_REQUIRED_STANDALONE_NODES)
+    assert all(counts[node] >= 40 for node in _REQUIRED_STANDALONE_NODES)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "case",
+    STANDALONE_NODE_CASES,
+    ids=lambda case: "%s:%s" % (case.target, case.source.replace("\n", "\\n")[:48]),
+)
+def test_standalone_fbmcq_matrix_parses_expected_ast_node(case: NodeParseCase):
+    """Standalone FBMCQ cases parse to the exact expected canonical node."""
+    parsed_root = _parse_entry(case.entry, case.source)
+    parsed_node = case.selector(parsed_root)
+
+    assert parsed_node.__class__ is case.expected.__class__
+    assert _canonical(parsed_node) == _canonical(case.expected)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "case",
+    STANDALONE_NODE_CASES,
+    ids=lambda case: "%s:%s" % (case.target, case.source.replace("\n", "\\n")[:48]),
+)
+def test_standalone_fbmcq_matrix_round_trips_through_canonical_text(
+    case: NodeParseCase,
+):
+    """Every standalone matrix case round-trips through ``str(node)``."""
+    parsed_root = _parse_entry(case.entry, case.source)
+    parsed_node = case.selector(parsed_root)
+    if case.entry == "query":
+        canonical_text = str(parsed_root)
+        reparsed_root = parse_bmc_query(canonical_text)
+        reparsed_node = case.selector(reparsed_root)
+    else:
+        canonical_text = str(parsed_node)
+        reparsed_node = _parse_entry(case.entry, canonical_text)
+
+    assert reparsed_node.__class__ is parsed_node.__class__
+    assert _round_trip_canonical(reparsed_node) == _round_trip_canonical(parsed_node)
+
+
+@pytest.mark.unittest
+def test_fcstm_fbmcq_parity_matrix_has_forty_cases_per_compatible_node():
+    """Every FCSTM-compatible expression node has forty strict parity cases."""
+    counts = _case_counts(PARITY_CASES)
+
+    assert set(counts) == set(_REQUIRED_PARITY_NODES)
+    assert all(counts[node] >= 40 for node in _REQUIRED_PARITY_NODES)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "case",
+    PARITY_CASES,
+    ids=lambda case: "%s:%s" % (case.target, case.expression[:60]),
+)
+def test_fcstm_fbmcq_parity_matrix_aligns_ast_shapes(case: ParityCase):
+    """FCSTM and FBMCQ expression parsers produce bidirectionally aligned ASTs."""
+    if case.category == "num":
+        fcstm_node = parse_with_grammar_entry(case.expression, "num_expression")
+        bmc_node = parse_bmc_num_expression(case.expression)
+    else:
+        fcstm_node = parse_with_grammar_entry(case.expression, "cond_expression")
+        bmc_node = parse_bmc_cond_expression(case.expression)
+
+    converted_bmc = _fcstm_to_bmc_expr(fcstm_node, case.category)
+    converted_fcstm = _bmc_to_fcstm_expr(bmc_node)
+
+    assert converted_bmc.__class__.__name__ == case.target
+    assert bmc_node.__class__.__name__ == case.target
+    assert _shared_shape_from_bmc(converted_bmc) == _shared_shape_from_bmc(bmc_node)
+    assert _shared_shape_from_fcstm(
+        converted_fcstm, case.category
+    ) == _shared_shape_from_fcstm(fcstm_node, case.category)
+
+
+@pytest.mark.unittest
+def test_complex_query_matrix_has_one_hundred_integrated_cases():
+    """The integrated matrix contains exactly one hundred complex query files."""
+    assert len(COMPLEX_QUERY_CASES) == 100
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "case",
+    COMPLEX_QUERY_CASES,
+    ids=lambda case: "complex-%03d" % case.case_index,
+)
+def test_complex_query_matrix_parses_expected_tree(case: ComplexQueryCase):
+    """Complex complete FBMCQ files parse into the exact expected AST tree."""
+    parsed = parse_bmc_query(case.source)
+
+    assert parsed.to_canonical() == case.expected.to_canonical()
+    assert len(parsed.assumptions) >= 5
+    assert _canonical_node_count(parsed.to_canonical()) >= 50
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "case",
+    COMPLEX_QUERY_CASES,
+    ids=lambda case: "complex-round-trip-%03d" % case.case_index,
+)
+def test_complex_query_matrix_round_trips_canonical_text(case: ComplexQueryCase):
+    """Complex complete FBMCQ files survive canonical string round-trip."""
+    parsed = parse_bmc_query(case.source)
+    canonical_text = str(parsed)
+    reparsed = parse_bmc_query(canonical_text)
+
+    assert _round_trip_canonical(reparsed) == _round_trip_canonical(parsed)

--- a/test/bmc/test_query_text_round_trip.py
+++ b/test/bmc/test_query_text_round_trip.py
@@ -3,7 +3,9 @@
 These tests make the parser object's string contract directly auditable:
 every case parses source text into an AST/query object, checks the exact
 canonical ``.fbmcq`` text returned by :func:`str`, reparses that text, and
-requires the second stringification to stay byte-for-byte stable.
+requires the canonical stringification to stay byte-for-byte stable while
+the structural comparison only normalizes parser-preserved boolean token
+spelling.
 """
 
 from __future__ import annotations
@@ -12,6 +14,7 @@ from typing import Any, Callable, Dict, List, NamedTuple
 
 import pytest
 
+from pyfcstm.bmc.errors import BmcQueryParseError
 from pyfcstm.bmc.parse import (
     parse_bmc_cond_expression,
     parse_bmc_num_expression,
@@ -64,6 +67,13 @@ def _parse_case(case: TextRoundTripCase) -> Any:
 def _round_trip_canonical(value: Any) -> Any:
     """Return canonical data normalized for canonical-text round trips.
 
+    The text-level round-trip assertion remains byte-for-byte exact. This
+    helper only normalizes the ``bool_literal.raw`` spelling that ANTLR keeps
+    from the first parse so structural equality can compare source text such
+    as ``TRUE`` with canonical text such as ``true``. No other node spelling is
+    relaxed here; future parser nodes must add explicit tests before gaining
+    normalization.
+
     :param value: Object with ``to_canonical`` or JSON-like canonical data.
     :type value: object
     :return: Canonical data with spelling-only boolean raw casing normalized.
@@ -78,6 +88,10 @@ def _round_trip_canonical(value: Any) -> Any:
         value = value.to_canonical()
     if isinstance(value, dict):
         normalized = {key: _round_trip_canonical(child) for key, child in value.items()}
+        # BmcBoolLiteral preserves original token spelling in ``raw`` while
+        # ``str()`` canonicalizes boolean text to lowercase. Keep this as the
+        # only structural normalization so new node spellings cannot drift
+        # silently.
         if normalized.get("node") == "bool_literal" and "raw" in normalized:
             normalized["raw"] = str(normalized["raw"]).lower()
         return normalized
@@ -149,6 +163,7 @@ CONDITION_TEXT_ROUND_TRIP_CASES: List[TextRoundTripCase] = [
     TextRoundTripCase("cond", 'var("x") <= cycle', 'var("x") <= cycle'),
     TextRoundTripCase("cond", 'active("Root.A")', 'active("Root.A")'),
     TextRoundTripCase("cond", 'active("Root.A", current)', 'active("Root.A")'),
+    TextRoundTripCase("cond", 'active("Root.A", 0)', 'active("Root.A", 0)'),
     TextRoundTripCase("cond", 'active("Root.A", 2)', 'active("Root.A", 2)'),
     TextRoundTripCase("cond", 'active("Root.\\"A\\"")', 'active("Root.\\"A\\"")'),
     TextRoundTripCase("cond", "terminated()", "terminated()"),
@@ -157,6 +172,7 @@ CONDITION_TEXT_ROUND_TRIP_CASES: List[TextRoundTripCase] = [
     TextRoundTripCase(
         "cond", 'event("Root.Start", current)', 'event("Root.Start", current)'
     ),
+    TextRoundTripCase("cond", 'event("Root.Start", 0)', 'event("Root.Start", 0)'),
     TextRoundTripCase("cond", 'event("Root.Start", 3)', 'event("Root.Start", 3)'),
     TextRoundTripCase("cond", 'case("safe")', 'case("safe")'),
     TextRoundTripCase("cond", 'case("safe", current)', 'case("safe")'),
@@ -242,6 +258,11 @@ QUERY_TEXT_ROUND_TRIP_CASES: List[TextRoundTripCase] = [
     ),
     TextRoundTripCase(
         "query",
+        'init state("Root.Idle"); check reach <= 1: true;',
+        'init state("Root.Idle");\n\ncheck reach <= 1: true;',
+    ),
+    TextRoundTripCase(
+        "query",
         'init state("Root.A") where var("x") == 0; check reach <= 5: active("Root.B");',
         'init state("Root.A") where var("x") == 0;\n\ncheck reach <= 5: active("Root.B");',
     ),
@@ -262,8 +283,23 @@ QUERY_TEXT_ROUND_TRIP_CASES: List[TextRoundTripCase] = [
     ),
     TextRoundTripCase(
         "query",
+        'assume event("Zero", 0) == true; check reach <= 1: event("Zero", 0);',
+        'init cold;\n\nassume event("Zero", 0) == true;\n\ncheck reach <= 1: event("Zero", 0);',
+    ),
+    TextRoundTripCase(
+        "query",
         'assume event("Reset", 01 .. 03) != false; check reach <= 1: true;',
         'init cold;\n\nassume event("Reset", 1..3) == true;\n\ncheck reach <= 1: true;',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume event("Reset", 01 .. 03) != true; check reach <= 1: true;',
+        'init cold;\n\nassume event("Reset", 1..3) == false;\n\ncheck reach <= 1: true;',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume event("Reset", 01 .. 03) == FALSE; check reach <= 1: true;',
+        'init cold;\n\nassume event("Reset", 1..3) == false;\n\ncheck reach <= 1: true;',
     ),
     TextRoundTripCase(
         "query",
@@ -324,6 +360,13 @@ TEXT_ROUND_TRIP_CASES = (
 )
 
 
+NEGATIVE_TEXT_ROUND_TRIP_SOURCES: List[TextRoundTripCase] = [
+    TextRoundTripCase("cond", 'event("Root.Start")', ""),
+    TextRoundTripCase("cond", 'event("Tick", *)', ""),
+    TextRoundTripCase("query", 'init cold; check reach <= 1: event("Tick", *);', ""),
+]
+
+
 @pytest.mark.unittest
 def test_text_round_trip_case_count_is_intentionally_large():
     """The direct text round-trip suite stays broad enough to catch drift."""
@@ -353,3 +396,21 @@ def test_parsed_fbmcq_nodes_stringify_to_reparseable_canonical_text(
     )
     assert str(reparsed) == canonical_text
     assert _round_trip_canonical(reparsed) == _round_trip_canonical(parsed)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "case",
+    NEGATIVE_TEXT_ROUND_TRIP_SOURCES,
+    ids=lambda case: "%s:%s" % (case.entry, case.source.replace("\n", "\\n")[:72]),
+)
+def test_round_trip_boundary_sources_are_rejected(case: TextRoundTripCase):
+    """Document parser boundaries that must fail before text round-tripping.
+
+    ``event`` predicates intentionally require an explicit frame selector, and
+    the wildcard ``*`` selector belongs only to query-level event assumptions.
+    These rejected sources protect round-trip tests from accidentally blessing
+    malformed or context-only syntax.
+    """
+    with pytest.raises(BmcQueryParseError):
+        _parse_case(case)

--- a/test/bmc/test_query_text_round_trip.py
+++ b/test/bmc/test_query_text_round_trip.py
@@ -1,0 +1,355 @@
+"""Canonical text round-trip tests for FBMCQ parser outputs.
+
+These tests make the parser object's string contract directly auditable:
+every case parses source text into an AST/query object, checks the exact
+canonical ``.fbmcq`` text returned by :func:`str`, reparses that text, and
+requires the second stringification to stay byte-for-byte stable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, NamedTuple
+
+import pytest
+
+from pyfcstm.bmc.parse import (
+    parse_bmc_cond_expression,
+    parse_bmc_num_expression,
+    parse_bmc_query,
+)
+
+
+class TextRoundTripCase(NamedTuple):
+    """One parser text round-trip case.
+
+    :param entry: Parser entry category: ``"num"``, ``"cond"``, or ``"query"``.
+    :type entry: str
+    :param source: Original source text accepted by the parser.
+    :type source: str
+    :param expected_text: Exact canonical text expected from ``str(parsed)``.
+    :type expected_text: str
+
+    Example::
+
+        >>> TextRoundTripCase("num", "1", "1").entry
+        'num'
+    """
+
+    entry: str
+    source: str
+    expected_text: str
+
+
+def _parse_case(case: TextRoundTripCase) -> Any:
+    """Parse a text round-trip case through its selected public entry.
+
+    :param case: Round-trip case descriptor.
+    :type case: TextRoundTripCase
+    :return: Parsed AST/query object.
+    :rtype: object
+
+    Example::
+
+        >>> _parse_case(TextRoundTripCase("num", "1", "1")).to_canonical()["value"]
+        1
+    """
+    parsers: Dict[str, Callable[[str], Any]] = {
+        "num": parse_bmc_num_expression,
+        "cond": parse_bmc_cond_expression,
+        "query": parse_bmc_query,
+    }
+    return parsers[case.entry](case.source)
+
+
+def _round_trip_canonical(value: Any) -> Any:
+    """Return canonical data normalized for canonical-text round trips.
+
+    :param value: Object with ``to_canonical`` or JSON-like canonical data.
+    :type value: object
+    :return: Canonical data with spelling-only boolean raw casing normalized.
+    :rtype: object
+
+    Example::
+
+        >>> _round_trip_canonical(parse_bmc_cond_expression("TRUE"))["raw"]
+        'true'
+    """
+    if hasattr(value, "to_canonical"):
+        value = value.to_canonical()
+    if isinstance(value, dict):
+        normalized = {key: _round_trip_canonical(child) for key, child in value.items()}
+        if normalized.get("node") == "bool_literal" and "raw" in normalized:
+            normalized["raw"] = str(normalized["raw"]).lower()
+        return normalized
+    if isinstance(value, list):
+        return [_round_trip_canonical(child) for child in value]
+    return value
+
+
+NUMERIC_TEXT_ROUND_TRIP_CASES: List[TextRoundTripCase] = [
+    TextRoundTripCase("num", "0", "0"),
+    TextRoundTripCase("num", "00", "00"),
+    TextRoundTripCase("num", "001", "001"),
+    TextRoundTripCase("num", "42", "42"),
+    TextRoundTripCase("num", "0x1", "0x1"),
+    TextRoundTripCase("num", "0x2A", "0x2A"),
+    TextRoundTripCase("num", "1.0", "1.0"),
+    TextRoundTripCase("num", ".5", ".5"),
+    TextRoundTripCase("num", "5.", "5."),
+    TextRoundTripCase("num", "1e-3", "1e-3"),
+    TextRoundTripCase("num", "2E+4", "2E+4"),
+    TextRoundTripCase("num", "counter", "counter"),
+    TextRoundTripCase("num", "var_7", "var_7"),
+    TextRoundTripCase("num", "pi", "pi"),
+    TextRoundTripCase("num", "E", "E"),
+    TextRoundTripCase("num", "tau", "tau"),
+    TextRoundTripCase("num", "+counter", "+counter"),
+    TextRoundTripCase("num", "-counter", "-counter"),
+    TextRoundTripCase("num", "-(counter + 1)", "-(counter + 1)"),
+    TextRoundTripCase("num", "counter + 1", "counter + 1"),
+    TextRoundTripCase("num", "counter - 1", "counter - 1"),
+    TextRoundTripCase("num", "counter * 2", "counter * 2"),
+    TextRoundTripCase("num", "counter / 2", "counter / 2"),
+    TextRoundTripCase("num", "counter % 2", "counter % 2"),
+    TextRoundTripCase("num", "counter << 1", "counter << 1"),
+    TextRoundTripCase("num", "counter >> 1", "counter >> 1"),
+    TextRoundTripCase("num", "counter & 3", "counter & 3"),
+    TextRoundTripCase("num", "counter ^ 3", "counter ^ 3"),
+    TextRoundTripCase("num", "counter | 3", "counter | 3"),
+    TextRoundTripCase("num", "counter ** 2", "counter ** 2"),
+    TextRoundTripCase("num", "(counter + 1) * 2", "(counter + 1) * 2"),
+    TextRoundTripCase("num", "counter * (limit + 1)", "counter * (limit + 1)"),
+    TextRoundTripCase("num", "sqrt(counter)", "sqrt(counter)"),
+    TextRoundTripCase("num", "sin(counter + 1)", "sin(counter + 1)"),
+    TextRoundTripCase("num", 'log1p(var("x"))', 'log1p(var("x"))'),
+    TextRoundTripCase("num", 'var("counter")', 'var("counter")'),
+    TextRoundTripCase("num", 'var("变量")', 'var("变量")'),
+    TextRoundTripCase("num", "cycle", "cycle"),
+    TextRoundTripCase("num", "cycle + 1", "cycle + 1"),
+    TextRoundTripCase(
+        "num", '(active("Root.A")) ? 1 : 0', '(active("Root.A")) ? 1 : 0'
+    ),
+    TextRoundTripCase(
+        "num",
+        '(cycle <= 3) ? var("x") + 1 : sqrt(var("y"))',
+        '(cycle <= 3) ? (var("x") + 1) : sqrt(var("y"))',
+    ),
+]
+
+CONDITION_TEXT_ROUND_TRIP_CASES: List[TextRoundTripCase] = [
+    TextRoundTripCase("cond", "true", "true"),
+    TextRoundTripCase("cond", "TRUE", "true"),
+    TextRoundTripCase("cond", "False", "false"),
+    TextRoundTripCase("cond", "counter < 3", "counter < 3"),
+    TextRoundTripCase("cond", "counter > 3", "counter > 3"),
+    TextRoundTripCase("cond", "counter <= 3", "counter <= 3"),
+    TextRoundTripCase("cond", "counter >= 3", "counter >= 3"),
+    TextRoundTripCase("cond", "counter == 3", "counter == 3"),
+    TextRoundTripCase("cond", "counter != 3", "counter != 3"),
+    TextRoundTripCase("cond", 'var("x") <= cycle', 'var("x") <= cycle'),
+    TextRoundTripCase("cond", 'active("Root.A")', 'active("Root.A")'),
+    TextRoundTripCase("cond", 'active("Root.A", current)', 'active("Root.A")'),
+    TextRoundTripCase("cond", 'active("Root.A", 2)', 'active("Root.A", 2)'),
+    TextRoundTripCase("cond", 'active("Root.\\"A\\"")', 'active("Root.\\"A\\"")'),
+    TextRoundTripCase("cond", "terminated()", "terminated()"),
+    TextRoundTripCase("cond", "terminated(current)", "terminated()"),
+    TextRoundTripCase("cond", "terminated(4)", "terminated(4)"),
+    TextRoundTripCase(
+        "cond", 'event("Root.Start", current)', 'event("Root.Start", current)'
+    ),
+    TextRoundTripCase("cond", 'event("Root.Start", 3)', 'event("Root.Start", 3)'),
+    TextRoundTripCase("cond", 'case("safe")', 'case("safe")'),
+    TextRoundTripCase("cond", 'case("safe", current)', 'case("safe")'),
+    TextRoundTripCase("cond", 'case("safe", 5)', 'case("safe", 5)'),
+    TextRoundTripCase("cond", 'called("Hook")', 'called("Hook")'),
+    TextRoundTripCase("cond", 'called("Hook", current)', 'called("Hook")'),
+    TextRoundTripCase("cond", 'called("Hook", 6)', 'called("Hook", 6)'),
+    TextRoundTripCase("cond", '!active("Root.A")', '!active("Root.A")'),
+    TextRoundTripCase("cond", 'not active("Root.A")', '!active("Root.A")'),
+    TextRoundTripCase(
+        "cond", '!(active("Root.A") && true)', '!(active("Root.A") && true)'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") && active("B")', 'active("A") && active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") and active("B")', 'active("A") && active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") || active("B")', 'active("A") || active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") or active("B")', 'active("A") || active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") xor active("B")', 'active("A") xor active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") => active("B")', 'active("A") => active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") implies active("B")', 'active("A") => active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") iff active("B")', 'active("A") iff active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") == active("B")', 'active("A") == active("B")'
+    ),
+    TextRoundTripCase(
+        "cond", 'active("A") != active("B")', 'active("A") != active("B")'
+    ),
+    TextRoundTripCase(
+        "cond",
+        '(active("A") && active("B")) || active("C")',
+        '(active("A") && active("B")) || active("C")',
+    ),
+    TextRoundTripCase(
+        "cond",
+        'active("A") && (active("B") || active("C"))',
+        'active("A") && (active("B") || active("C"))',
+    ),
+    TextRoundTripCase(
+        "cond",
+        '(cycle <= 3) ? active("A") : active("B")',
+        '(cycle <= 3) ? active("A") : active("B")',
+    ),
+    TextRoundTripCase(
+        "cond",
+        '(active("A")) ? (cycle <= 2) : (var("x") >= 1)',
+        '(active("A")) ? cycle <= 2 : var("x") >= 1',
+    ),
+]
+
+QUERY_TEXT_ROUND_TRIP_CASES: List[TextRoundTripCase] = [
+    TextRoundTripCase(
+        "query", "check reach <= 1: true;", "init cold;\n\ncheck reach <= 1: true;"
+    ),
+    TextRoundTripCase(
+        "query",
+        "init cold; check forbid <= 2: false;",
+        "init cold;\n\ncheck forbid <= 2: false;",
+    ),
+    TextRoundTripCase(
+        "query",
+        "init terminated; check invariant <= 3: terminated(current);",
+        "init terminated;\n\ncheck invariant <= 3: terminated();",
+    ),
+    TextRoundTripCase(
+        "query",
+        'init state("Root.A"); check reach <= 4: active("Root.B", current);',
+        'init state("Root.A");\n\ncheck reach <= 4: active("Root.B");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'init state("Root.A") where var("x") == 0; check reach <= 5: active("Root.B");',
+        'init state("Root.A") where var("x") == 0;\n\ncheck reach <= 5: active("Root.B");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume always: cycle <= 10; check reach <= 10: active("Done");',
+        'init cold;\n\nassume always: cycle <= 10;\n\ncheck reach <= 10: active("Done");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume at 02: active("Ready", current); check forbid <= 3: active("Bad");',
+        'init cold;\n\nassume at 2: active("Ready");\n\ncheck forbid <= 3: active("Bad");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume event("Tick", *) == false; check reach <= 1: true;',
+        'init cold;\n\nassume event("Tick", *) == false;\n\ncheck reach <= 1: true;',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume event("Reset", 01 .. 03) != false; check reach <= 1: true;',
+        'init cold;\n\nassume event("Reset", 1..3) == true;\n\ncheck reach <= 1: true;',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume event("Point", 007) == TRUE; check reach <= 1: true;',
+        'init cold;\n\nassume event("Point", 7) == true;\n\ncheck reach <= 1: true;',
+    ),
+    TextRoundTripCase(
+        "query",
+        "assume events cardinality any; check reach <= 1: true;",
+        "init cold;\n\nassume events cardinality any;\n\ncheck reach <= 1: true;",
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume events cardinality at_most_one {"A", "B"}; check reach <= 1: true;',
+        'init cold;\n\nassume events cardinality at_most_one {\n    "A",\n    "B"\n};\n\ncheck reach <= 1: true;',
+    ),
+    TextRoundTripCase(
+        "query",
+        'check must_reach <= 6: called("Hook", current);',
+        'init cold;\n\ncheck must_reach <= 6: called("Hook");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'check exists_always <= 7: case("safe", 2);',
+        'init cold;\n\ncheck exists_always <= 7: case("safe", 2);',
+    ),
+    TextRoundTripCase(
+        "query",
+        'check cover <= 8: event("E", current);',
+        'init cold;\n\ncheck cover <= 8: event("E", current);',
+    ),
+    TextRoundTripCase(
+        "query",
+        'check response <= 9: trigger event("Fault", current) -> within 3 active("Recover", current);',
+        'init cold;\n\ncheck response <= 9:\n    trigger event("Fault", current)\n    -> within 3 active("Recover");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'init state("Root.Idle") where var("counter") == 0; assume always: cycle <= 10; assume at 2: active("Root.Ready", 2); check reach <= 10: active("Root.Done");',
+        'init state("Root.Idle") where var("counter") == 0;\n\nassume always: cycle <= 10;\n\nassume at 2: active("Root.Ready", 2);\n\ncheck reach <= 10: active("Root.Done");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume always: (active("A") and !active("B")); assume event("Start", 0..2) == true; check invariant <= 4: active("A") implies !active("Bad");',
+        'init cold;\n\nassume always: active("A") && !active("B");\n\nassume event("Start", 0..2) == true;\n\ncheck invariant <= 4: active("A") => !active("Bad");',
+    ),
+    TextRoundTripCase(
+        "query",
+        'assume events cardinality at_most_one {"Tick", "Reset", "Stop"}; check forbid <= 5: (cycle <= 4) ? active("Bad") : false;',
+        'init cold;\n\nassume events cardinality at_most_one {\n    "Tick",\n    "Reset",\n    "Stop"\n};\n\ncheck forbid <= 5: (cycle <= 4) ? active("Bad") : false;',
+    ),
+]
+
+TEXT_ROUND_TRIP_CASES = (
+    NUMERIC_TEXT_ROUND_TRIP_CASES
+    + CONDITION_TEXT_ROUND_TRIP_CASES
+    + QUERY_TEXT_ROUND_TRIP_CASES
+)
+
+
+@pytest.mark.unittest
+def test_text_round_trip_case_count_is_intentionally_large():
+    """The direct text round-trip suite stays broad enough to catch drift."""
+    assert len(NUMERIC_TEXT_ROUND_TRIP_CASES) >= 40
+    assert len(CONDITION_TEXT_ROUND_TRIP_CASES) >= 40
+    assert len(QUERY_TEXT_ROUND_TRIP_CASES) >= 18
+    assert len(TEXT_ROUND_TRIP_CASES) >= 100
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "case",
+    TEXT_ROUND_TRIP_CASES,
+    ids=lambda case: "%s:%s" % (case.entry, case.source.replace("\n", "\\n")[:72]),
+)
+def test_parsed_fbmcq_nodes_stringify_to_reparseable_canonical_text(
+    case: TextRoundTripCase,
+):
+    """Parsed AST/query objects stringify to exact, stable, reparseable DSL text."""
+    parsed = _parse_case(case)
+    canonical_text = str(parsed)
+
+    assert canonical_text == case.expected_text
+
+    reparsed = _parse_case(
+        TextRoundTripCase(case.entry, canonical_text, canonical_text)
+    )
+    assert str(reparsed) == canonical_text
+    assert _round_trip_canonical(reparsed) == _round_trip_canonical(parsed)


### PR DESCRIPTION
## 当前阶段

这是 BMC 系列的 **PR-3 实现 PR**。计划审查已完成并进入实现阶段；当前分支已提交 `pyfcstm.bmc.parse` / `pyfcstm.bmc.listener`、`BmcQueryParseError`、FCSTM/FBMCQ expression parity 测试、完整 query parser 测试与高容量 parser matrix。

当前目标是在 CI、Codecov 与三方强对抗 review 中继续迭代，直到 C/I 问题清零并达到 ready-to-merge；本 PR 仍不自行合并，等待后续明确指示。

## 上游依据与一致性

| 来源 | 本 PR 对齐方式 |
|---|---|
| 伞 PR [#305](https://github.com/HansBug/pyfcstm/pull/305) 的 PR-3 行 | 本 PR 实现“查询语言：实现 `.fbmcq` 解析器与 AST 构建”。 |
| PR-1 [#315](https://github.com/HansBug/pyfcstm/pull/315) | 复用已合入的 `pyfcstm.bmc.ast` / `query` parser-independent 数据模型、`__str__` canonical DSL round-trip 契约、`to_canonical()` golden shape。 |
| PR-2 [#323](https://github.com/HansBug/pyfcstm/pull/323) | 复用已合入的 `.fbmcq` ANTLR grammar、`BmcQueryLexer/Parser/Listener`、`make fcstm_antlr_build` / `make fbmcq_antlr_build` / `make antlr_build`。 |
| integer spelling 同步 | 继续执行 [#305 comment](https://github.com/HansBug/pyfcstm/pull/305#issuecomment-4873974923)：grammar 接受 `0` / `00` / `01` / `001`；AST builder / query model 对 query bound 与 response window 执行 `N > 0`，`01` / `001` value 规范化为 `1`。 |
| optional frame selector 同步 | 继续执行 [#305 comment](https://github.com/HansBug/pyfcstm/pull/305#issuecomment-4874230900)：`active` / `terminated` / `case` / `called` 支持省略、`current`、显式整数三类 frame selector。 |
| 本轮新增讨论 | FCSTM/FBMCQ expression parity 必须采用 pytest parameterize 的双向转换严格对齐：同一表达式文本分别经 FCSTM 与 FBMCQ parser 解析，测试 helper 提供双向 canonical projection，互相转换后必须严格相等。 |
| 模块路径修订 | 本 PR 有意采用 `pyfcstm.bmc.parse` + `pyfcstm.bmc.listener`，对齐现有 `pyfcstm.dsl.parse` + `pyfcstm.dsl.listener`。伞 PR 早期写作 `pyfcstm.bmc.parser` 是建议模块名，本 PR 将同步伞 PR body 使后续 subPR 以 `pyfcstm.bmc.parse` 为 public parse module。 |

## 技术目标

1. 提供 `.fbmcq` 查询 parser public API：完整 query、numeric expression、condition expression、任意 grammar entry 解析。
2. 采用 **listener-based** 实现方式，对齐 `pyfcstm.dsl.listener.GrammarParseListener` 的 context-to-node mapping 风格。
3. 将 ANTLR parse tree 构建为 PR-1 的 `BmcQuery` / `BmcProperty` / `InitialSpec` / assumption / typed expression AST。
4. 建立 FCSTM expression 与 FBMCQ expression 的双向 parity 测试门禁，防止 `.fbmcq` 表达式系统与主 FCSTM DSL 漂移。
5. 确保所有新增手写代码 line + branch coverage 严格 100%，generated grammar 文件除外。
6. 保持 BMC 根模块独立：不得 import `z3`、不得 import 或接入 `pyfcstm.verify.registry`，不得提前实现 binder / model-aware 语义。

## 拟新增/修改文件

| 路径 | 计划内容 |
|---|---|
| `pyfcstm/bmc/parse.py` | Public parse module，对齐 `pyfcstm.dsl.parse`：ANTLR 调度入口、错误监听、`parse_bmc_query`、`parse_bmc_num_expression`、`parse_bmc_cond_expression`、`parse_with_bmc_grammar_entry`、`build_bmc_ast_from_parse_tree`。 |
| `pyfcstm/bmc/listener.py` | Listener-based AST builder，对齐 `pyfcstm.dsl.listener`：`BmcQueryParseListener(BmcQueryParserListener)` 在 `exit*` 回调中 bottom-up 构造 AST，并通过 `self.nodes[ctx]` 保存 context-to-node mapping。 |
| `pyfcstm/bmc/errors.py` | 新增 `BmcQueryParseError(BmcError)` 作为 syntax / lexical / unfinished parse / unmapped parse-tree root 错误；保留 `InvalidBmcQuery` 负责 AST/query structural well-formedness。 |
| `pyfcstm/bmc/__init__.py` | 导出 parse API；更新 module roadmap list-table。 |
| `test/bmc/test_query_parser.py` | query / assumption / property / BMC atom / round-trip / parse error 测试。 |
| `test/bmc/test_query_expression_parity.py` | FCSTM/FBMCQ 双向 expression parity 专项测试。 |
| `test/bmc/helpers/` 或同级 test helper | 仅测试侧 canonical projection helper：FCSTM AST ↔ FBMCQ AST 双向转换与 shape 对比。 |
| `docs/source/api_doc/...` | `make rst_auto RANGE_DIR=bmc` 生成的 API RST 更新。 |

## Public parser API 契约

计划实现以下函数，命名可在 review 后微调，但能力必须保留：

```python
def parse_bmc_query(input_text: str) -> BmcQuery: ...

def parse_bmc_num_expression(input_text: str) -> BmcNumExpr: ...

def parse_bmc_cond_expression(input_text: str) -> BmcCondExpr: ...

def parse_with_bmc_grammar_entry(
    input_text: str,
    entry_name: str,
    force_finished: bool = True,
) -> Any: ...

def build_bmc_ast_from_parse_tree(parse_tree: ParserRuleContext) -> Any: ...
```

要求：

- API 风格对齐 `pyfcstm.dsl.parse.parse_with_grammar_entry`，但不复用 FCSTM parser。
- `parse_with_bmc_grammar_entry` 的文本入口首轮显式支持 `query`、`bmc_num_expression_entry`、`bmc_cond_expression_entry` 三个完整 entry；未知 `entry_name` 抛 `BmcQueryParseError`，不得静默调用任意 parser method。
- `build_bmc_ast_from_parse_tree` 支持调用者自己构造 ANTLR parse tree 后交给 listener 构建 AST；只要 listener 对该 root context 建立了 `self.nodes[root]` 就返回对应 AST，未映射 root 抛 `BmcQueryParseError` 而不是裸 `KeyError`。这满足“从任意 ANTLR node 构建 AST”的灵活性，同时不扩大 text entry API。
- syntax / lexical / unfinished parsing / invalid entry / unmapped root 抛 `BmcQueryParseError`；AST/query structural well-formedness 抛 `InvalidBmcQuery`；model-aware binder 规则不在本 PR 下沉。

## Listener-based AST 构建方案

| parse tree 片段 | AST 结果 |
|---|---|
| `query` | `BmcQuery(initial=..., assumptions=(...), property=...)`；省略 `init` 规范化为 `InitialSpec(mode="cold")`。 |
| `init_clause` | `InitialSpec("cold")` / `InitialSpec("terminated")` / `InitialSpec("state", state_path=...)`，`where` 存入 `predicate`。 |
| `frame_assume` | `FrameAssumption("always", predicate)` 或 `FrameAssumption("at", predicate, frame=k)`。 |
| `event_assume` | `EventAssumption(path, selector, expected)`；`!= true/false` 在 builder 层规范化 polarity。 |
| `cardinality_assume` | `EventCardinalityAssumption("any")` 或 `EventCardinalityAssumption("at_most_one", paths)`。 |
| `check_clause` | 非 response 构造 `BmcProperty(kind, bound, predicate=...)`；response 构造 trigger / within / response。 |
| `bmc_num_expression` | `IntLiteral` / `FloatLiteral` / `NameRef` / `MathConst` / `FrameVar` / `Cycle` / `NumUnaryOp` / `NumBinaryOp` / `NumConditionalOp` / `UFuncCall`。 |
| `bmc_cond_expression` | `BoolLiteral` / BMC boolean atom / `CondUnaryOp` / `NumericComparison` / `CondBinaryOp` / `CondConditionalOp`。 |
| `bmc_boolean_atom` | `Active` / `Terminated` / `Event` / `Case` / `Called`，optional frame selector 映射到 `"current"` 或整数；`Event` 必须使用显式 `event_cycle_selector`。 |
| `frame_selector` | `CURRENT` → `"current"`；`integer_literal` → 非负整数；省略 frame 的 `active` / `terminated` / `case` / `called` 规范化为 `"current"`。 |
| `event_cycle_selector` | `CURRENT` → `"current"`；`integer_literal` → 非负整数；只服务 `event("...", selector)`，不与 optional frame selector 混淆。 |
| `string_literal` | 用 `ast.literal_eval` 解码，行为对齐 FCSTM DSL listener；测试覆盖 grammar 允许的 escape 子集，listener 不接受绕过 lexer 的 Python raw/bytes/f-string literal。 |
| `event_range_selector` | `*`、整数、`a..b`、`RANGE_INT` 统一规范化；反向 range 是否 invalid 以现有 `EventAssumption` structural validation 为准，bound-aware 规则留给 PR-4。 |

## FCSTM/FBMCQ 双向 expression parity 测试方案

测试不得只比较字符串。计划使用 `pytest.mark.parametrize` 构造表达式矩阵，然后：

1. 用 FCSTM 侧 parser 解析同一表达式文本：
   - numeric：`parse_with_grammar_entry(text, "num_expression")`
   - condition：`parse_with_grammar_entry(text, "cond_expression")`
2. 用 FBMCQ 侧 parser 解析同一表达式文本：
   - numeric：`parse_bmc_num_expression(text)`
   - condition：`parse_bmc_cond_expression(text)`
3. 测试 helper 提供两个方向的 projection：
   - `fcstm_expr_to_shape(fcstm_node)`
   - `fbmcq_expr_to_fcstm_compatible_shape(fbmcq_node)`
   - `fbmcq_expr_to_shape(fbmcq_node)`
   - `fcstm_expr_to_fbmcq_compatible_shape(fcstm_node)`
4. projection shape 冻结为 JSON-stable nested dict/list/primitive，不使用实现类实例作为比较对象；最少字段为 `category`、`node`、literal `kind/raw/value`、operator `op`、`func`、`name`、`left/right/operand/condition/if_true/if_false` 等固定键。helper 只能做结构投影和已定义 alias canonicalization，不能因为某侧 parser 缺字段而降级比较。
5. 严格断言双向转换后 shape 绝对相等，并额外断言 literal kind/value、operator alias、numeric/condition category。decimal / hex / float 的 raw spelling 由两侧 AST 严格比较；boolean raw spelling 因 FCSTM `Boolean.__post_init__` 会归一化为小写，跨 parser 只比较 canonical value / shape，`true/True/TRUE/false/False/FALSE` raw family 由 FBMCQ AST 或 lexer/token fixture 单独覆盖。

最低 parameterize 矩阵：

| 类别 | 必测样例 |
|---|---|
| decimal int | `0`、`00`、`01`、`001`、`42` |
| hex int | `0x0`、`0x2A`、`0xff` |
| float | `1.0`、`.5`、`1.`、`1e-3`、`2.5E+7` |
| bool | `true`、`True`、`TRUE`、`false`、`False`、`FALSE` |
| names | `x`、`_x`、`x1`、`counter_value` |
| constants | `pi`、`E`、`tau` |
| numeric unary/binary | `+`、`-`、`**`、`*`、`/`、`%`、`+`、`-`、`<<`、`>>`、`&`、`^`、`|` |
| comparisons | `<`、`>`、`<=`、`>=`、`==`、`!=` |
| logical operators | `!`、`not`、`&&`、`and`、`||`、`or`、`xor`、`=>`、`implies`、`iff`、condition `==` / `!=` |
| precedence/associativity | `a + b * c`、`a ** b ** c`、`a << b + c`、`a < b && c < d || e < f`、`p => q => r` 类似结构 |
| ternary | numeric ternary 与 condition ternary |
| ufunc | 全部 FCSTM `UFUNC_NAME`，包括 `sin`、`sqrt`、`round`、`sign` 等 |
| parentheses | 单层、多层、改变优先级的括号 |

BMC-only extension 不参与 FCSTM 双向 parity，但必须有独立 positive / negative typing fixture：

- positive：`var("x")`、`var("cycle")`、`cycle`、`active("S")`、`active("S", current)`、`active("S", 2)`、`terminated()`、`terminated(current)`、`terminated(3)`、`event("E", current)`、`event("E", 0)`、`case("L")`、`case("L", current)`、`case("L", 4)`、`called("H")`、`called("H", current)`、`called("H", 5)`。
- negative：`active("A") + 1`、`cycle and true`、`var("x") and active("A")`、`event("E", *)` 等必须在 parser/type layer 被拒绝或按语法层错误报告。

## Round-trip / canonical 契约

- `str(query)` 必须生成 canonical `.fbmcq` DSL。
- `parse_bmc_query(str(query)).to_canonical() == query.to_canonical()`。
- 所有 concrete AST node 保持 `__repr__` dataclass debug 形态；不要把 `__repr__` 改成 DSL surface。
- `str(expr)` 可以 canonicalize alias / bool casing / optional `current`，但 round-trip 后 canonical shape 必须不变。

## 本 PR 明确不做

- 不做 model path / event / variable resolution。
- 不做 `cover` body 必须裸 `case(...)` 的 binder 规则。
- 不做 `assume always` 禁止 `event` / `case` / `called` 的 binder 规则。
- 不做 `event(..., current)` 上下文限制。
- 不做 `called(...)` compiler unsupported lowering。
- 不接 `pyfcstm.verify.registry`。
- 不 import / 调用 Z3。
- 不修改 `.fbmcq` grammar，除非 review 证明 PR-2 grammar 与 PR-3 AST 构建存在硬阻塞；若需改 grammar，必须同时跑 `make antlr_build` 并更新 PR body 说明。

## TDD 执行方案

1. 先写 `test/bmc/test_query_parser.py` 的 top-level query matrix：省略 init、三种 init、where、三种 assumption、七类 property、response、cover。
2. 写 `test/bmc/test_query_expression_parity.py` 的 FCSTM/FBMCQ 双向 parameterize parity helper 和矩阵。
3. 写 BMC-only atom positive / negative typing tests。
4. 写 query / expr `str()` round-trip tests。
5. 写 parse API 灵活性 tests：`parse_with_bmc_grammar_entry` 的三个合法 entry、非法 entry 的 `BmcQueryParseError`、`build_bmc_ast_from_parse_tree` 对 query root / expression root 的直接 parse-tree 构建，以及 unmapped root 的结构化错误。
6. 写 string literal escape / unescape tests：覆盖双引号、单引号、`\"`、`\'`、`\n`、`\t`、`\\`、`\xNN`、`\uNNNN`，并确认 `str()` canonical output 可再次 parse。
7. 写 parse error / unfinished parsing / invalid bound/window tests。
8. 写 subprocess import guard：在干净 Python 子进程中 `from pyfcstm.bmc.parse import parse_bmc_query`，随后断言 `sys.modules` 未出现 `z3`、`pyfcstm.verify`、`pyfcstm.verify.registry`、`pyfcstm.model`。
9. 再实现 `parse.py` / `listener.py`，保持最小实现直至测试通过。
10. 更新 `__init__.py` module roadmap 和 public exports。
11. 执行 `make rst_auto RANGE_DIR=bmc` 并 review generated RST。

## 当前实现摘要

已实现内容：

- `pyfcstm/bmc/parse.py`：提供 `parse_bmc_query`、`parse_bmc_num_expression`、`parse_bmc_cond_expression`、`parse_with_bmc_grammar_entry`、`build_bmc_ast_from_parse_tree`，并用 `BmcQueryParseError` 汇总 syntax / lexical / unfinished parsing / invalid entry / unmapped root。
- `pyfcstm/bmc/listener.py`：对齐 `pyfcstm.dsl.listener` 的 listener-based bottom-up `self.nodes[ctx]` 构建方式，覆盖 query、init、assumption、property、response、numeric expression、condition expression、BMC-only atom、frame selector、event cycle selector、string literal、event range selector 等 grammar surface。
- `pyfcstm/bmc/errors.py` / `pyfcstm/bmc/__init__.py`：公开 `BmcQueryParseError` 与 parser public API，并保持 BMC 根模块不依赖 `z3` / `pyfcstm.verify` / `pyfcstm.model`。
- `test/bmc/test_query_parser.py`：覆盖 parser API、query/assumption/property shape、string escape、parse errors、invalid structural bounds/windows、subprocess import guard、round-trip。
- `test/bmc/test_query_expression_parity.py`：同一表达式文本分别经 FCSTM 与 FBMCQ parser 解析，并通过双向 conversion helper 严格比较 canonical shape。
- `test/bmc/test_query_parser_matrix.py`：每个 concrete AST/query node 至少 40 条 standalone FBMCQ parse case；每个 FCSTM-compatible expression node 至少 40 条 FCSTM/FBMCQ parity case；100 条中高复杂度完整 `.fbmcq` query 集成 parse + round-trip case。
- `docs/source/api_doc/bmc/*.rst`：通过 `make rst_auto RANGE_DIR=bmc` 更新。

本地已完成的主要验收：

- `pytest test/bmc -q`：`3382 passed`。
- BMC 手写代码 line + branch coverage：`pyfcstm/bmc` 排除 3 个 ANTLR generated Python 文件后 `100%`；`parse.py` / `listener.py` / `errors.py` 单独 `100%`。
- `ruff check pyfcstm/bmc test/bmc --exclude pyfcstm/bmc/grammar`：通过。
- `ruff format --check pyfcstm/bmc test/bmc`：通过。
- optional `pyright` smoke（手写 BMC 文件 + `test/bmc`，排除 generated grammar）：`0 errors`。
- `SKIP_SLOW_TESTS=1 make unittest`：`44960 passed, 730 skipped, 67 deselected`。

## 本地验收命令

实现阶段提交前至少执行：

```bash
pytest test/bmc -q
COVERAGE_FILE=/tmp/pyfcstm-bmc-parser.sqlite coverage run --branch --source=pyfcstm/bmc -m pytest test/bmc -q
COVERAGE_FILE=/tmp/pyfcstm-bmc-parser.sqlite coverage report --omit='pyfcstm/bmc/grammar/BmcQueryLexer.py,pyfcstm/bmc/grammar/BmcQueryParser.py,pyfcstm/bmc/grammar/BmcQueryParserListener.py' --fail-under=100
COVERAGE_FILE=/tmp/pyfcstm-bmc-parser.sqlite coverage report --include='pyfcstm/bmc/parse.py,pyfcstm/bmc/listener.py,pyfcstm/bmc/errors.py' --fail-under=100
ruff check pyfcstm/bmc test/bmc --exclude pyfcstm/bmc/grammar
ruff format --check pyfcstm/bmc test/bmc
# Optional local type smoke if pyright is available; generated grammar files must stay excluded.
pyright pyfcstm/bmc/__init__.py pyfcstm/bmc/ast.py pyfcstm/bmc/errors.py pyfcstm/bmc/query.py pyfcstm/bmc/parse.py pyfcstm/bmc/listener.py test/bmc
SKIP_SLOW_TESTS=1 make unittest
```

如 PR-3 实现确实触及 grammar 或 generated 文件，再额外执行：

```bash
make antlr_build
git diff -- pyfcstm/dsl/grammar
python -m py_compile pyfcstm/bmc/grammar/*.py
```

## PR 完成验收标准

- [ ] PR body 与伞 PR [#305](https://github.com/HansBug/pyfcstm/pull/305) 的 PR-3 行、相关 comment、PR-1/PR-2 已落地事实一致。
- [ ] `parse_bmc_query` / expression parse API / three-entry text parse API / arbitrary mapped parse-tree builder API 可用，非法 entry 和 unmapped root 均抛 `BmcQueryParseError`。
- [ ] listener-based AST builder 覆盖完整 query grammar，并对齐 `pyfcstm.dsl` 的 context-to-node 风格；`frame_selector` 与 `event_cycle_selector` 分别覆盖。
- [ ] FCSTM/FBMCQ expression parity 使用 pytest parameterize + 双向 conversion helper 严格比较，shape schema 固定，boolean raw spelling 例外由 FBMCQ raw-family fixture 单独覆盖。
- [ ] BMC-only atom positive / negative typing fixture 覆盖 optional frame selector、`var`、`cycle`、`event`。
- [ ] query 与 expression round-trip 全面覆盖。
- [ ] 新增手写代码 line + branch coverage 100%，generated grammar 文件除外。
- [ ] `__init__.py` 文档保持 list-table module roadmap，新增 public API 有 reST docstring、`:param:` / `:type:` / `:return:` / `:rtype:` / `:raises:` / `Example::`。
- [ ] 不引入 broad catch；如必须 catch，严格遵守 CLAUDE.md exception policy。
- [ ] 不 import `z3` / `pyfcstm.verify.registry` / `pyfcstm.model`；有基于 `sys.modules` 的 subprocess import guard。
- [ ] 本地 slow-skip unittest 通过，CI 全绿。
- [ ] 三方强对抗 code review 与 codecov coverage review 的 C/I 问题清零；M 问题尽量处理但不无限阻塞。

## Review 要求

本 PR 计划审查阶段需要 reviewer 重点检查：

1. 与伞 PR PR-3 行和之前讨论是否完全一致。
2. listener-based 方案是否足以覆盖 `.fbmcq` grammar 全部 labeled alternatives。
3. 双向 FCSTM/FBMCQ parity 测试是否足够锁死表达式一致性。
4. 100% line/branch coverage 验收是否可无脑执行。
5. 是否有不该进入 PR-3 的 binder/model/Z3/verify scope 泄漏。
6. pydoc / `__init__.py` / generated RST 要求是否足够明确。

实现阶段 reviewer 还必须做强对抗错误构造，不能只读代码给泛泛意见：

- 必须主动构造并运行 malformed `.fbmcq`、类型错配表达式、未消费 token、string escape、optional frame selector、event cycle selector、precedence/associativity、round-trip canonicalization、FCSTM/FBMCQ expression parity 等反例。
- 若报告 C/I/M 问题，必须尽量给出可复制的最小输入、实际命令、期望/实际结果；C/I 问题没有 reproduction 不应轻易下结论。
- 必须检查现有高容量测试是否真的覆盖错误路径、边界 spelling、所有 concrete AST/query node、100 条中高复杂度 query、line + branch 100% 门禁，而不是只看测试数量。
- 必须确认没有 binder/model/Z3/verify scope 泄漏，并用 import/module guard 或静态搜索给出证据。

当前状态：实现已提交并推送；等待 CI、Codecov 与三方强对抗 code review 结果；不自行合并。



