### PR TITLE
宏步语义：定义 source 与 case 契约

### DIFF
--- a/docs/source/api_doc/bmc/index.rst
+++ b/docs/source/api_doc/bmc/index.rst
@@ -13,7 +13,9 @@ pyfcstm.bmc
     domain
     errors
     grammar/index
+    macro
     query
+    source
 
 \_\_all\_\_
 -----------------------------------------------------

--- a/docs/source/api_doc/bmc/macro.rst
+++ b/docs/source/api_doc/bmc/macro.rst
@@ -1,0 +1,114 @@
+pyfcstm.bmc.macro
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.macro
+
+.. automodule:: pyfcstm.bmc.macro
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+BoolTemplate
+-----------------------------------------------------
+
+.. autoclass:: BoolTemplate
+    :members: __post_init__,true,false,atom,not_,and_,or_,variables,evaluate,to_canonical,kind,name,operands
+
+
+EventUse
+-----------------------------------------------------
+
+.. autoclass:: EventUse
+    :members: __post_init__,to_canonical,event_id,path,polarity,reason
+
+
+VarUpdate
+-----------------------------------------------------
+
+.. autoclass:: VarUpdate
+    :members: __post_init__,to_canonical,variable_id,variable_name,expression,is_carry
+
+
+CycleCase
+-----------------------------------------------------
+
+.. autoclass:: CycleCase
+    :members: __post_init__,to_canonical,kind,source_state_id,source_state_path,target_state_id,target_state_path,label,condition,var_update,used_events,failed_conditions,domain,is_diagnostic
+
+
+PartitionCheckResult
+-----------------------------------------------------
+
+.. autoclass:: PartitionCheckResult
+    :members: to_canonical,variables,assignment_count,bucket_count
+
+
+MacroStepFormal
+-----------------------------------------------------
+
+.. autoclass:: MacroStepFormal
+    :members: __post_init__,cases,verify_partition,to_canonical,source,success_cases,delta_cases,build_diagnostic_conditions
+
+
+carry\_var\_updates
+-----------------------------------------------------
+
+.. autofunction:: carry_var_updates
+
+
+var\_update\_for
+-----------------------------------------------------
+
+.. autofunction:: var_update_for
+
+
+build\_var\_updates
+-----------------------------------------------------
+
+.. autofunction:: build_var_updates
+
+
+case\_antecedent\_condition
+-----------------------------------------------------
+
+.. autofunction:: case_antecedent_condition
+
+
+terminated\_absorb\_case
+-----------------------------------------------------
+
+.. autofunction:: terminated_absorb_case
+
+
+diagnostic\_absorb\_case
+-----------------------------------------------------
+
+.. autofunction:: diagnostic_absorb_case
+
+
+build\_fallback\_case
+-----------------------------------------------------
+
+.. autofunction:: build_fallback_case
+
+
+build\_semantic\_delta\_case
+-----------------------------------------------------
+
+.. autofunction:: build_semantic_delta_case
+
+
+verify\_boolean\_partition
+-----------------------------------------------------
+
+.. autofunction:: verify_boolean_partition
+
+
+verify\_source\_partition
+-----------------------------------------------------
+
+.. autofunction:: verify_source_partition

--- a/docs/source/api_doc/bmc/source.rst
+++ b/docs/source/api_doc/bmc/source.rst
@@ -1,0 +1,61 @@
+pyfcstm.bmc.source
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.source
+
+.. automodule:: pyfcstm.bmc.source
+
+
+TERMINATE\_CASE\_PATH
+-----------------------------------------------------
+
+.. autodata:: TERMINATE_CASE_PATH
+
+
+DIAGNOSTIC\_CASE\_PATH
+-----------------------------------------------------
+
+.. autodata:: DIAGNOSTIC_CASE_PATH
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+MacroStepSource
+-----------------------------------------------------
+
+.. autoclass:: MacroStepSource
+    :members: __post_init__,allows_semantic_delta,uses_stable_fallback,to_canonical,to_semantic_canonical,kind,origin,source_state_id,source_state_path,domain
+
+
+entry\_source
+-----------------------------------------------------
+
+.. autofunction:: entry_source
+
+
+stable\_leaf\_source
+-----------------------------------------------------
+
+.. autofunction:: stable_leaf_source
+
+
+terminated\_source
+-----------------------------------------------------
+
+.. autofunction:: terminated_source
+
+
+diagnostic\_source
+-----------------------------------------------------
+
+.. autofunction:: diagnostic_source
+
+
+source\_from\_initial\_spec
+-----------------------------------------------------
+
+.. autofunction:: source_from_initial_spec

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -1,14 +1,16 @@
-"""Public API for FCSTM bounded model checking query models.
+"""Public API for FCSTM bounded model checking data contracts.
 
 The BMC package is an independent root package for the FCSTM bounded model
 checking workstream.  It exposes parser-independent query and expression
-dataclasses while deliberately leaving grammar parsing, semantic binding,
-solver lowering, witness replay, and verify-registry integration to separate
-layers.
+dataclasses, domain numbering snapshots, and macro-step source/case contracts
+while deliberately leaving grammar parsing, semantic binding, solver lowering,
+witness replay, and verify-registry integration to separate layers.
 
 Package contracts:
 
 * BMC query objects are parser-independent and data-only in this package.
+* Macro-step contracts are solver-independent and do not import ``z3`` from the
+  root package.
 * The root package must not depend on ``pyfcstm.verify`` or its registry.
 * :func:`str` on exported query and expression dataclasses is reserved for the
   canonical ``.fbmcq`` query DSL spelling.
@@ -54,6 +56,19 @@ Public module structure:
        :func:`build_bmc_domain`
      - Number model states, events, persistent variables, frames, steps,
        sentinel states, and event-input slots before solver lowering.
+   * - Macro-step sources
+     - :class:`MacroStepSource`, :func:`source_from_initial_spec`,
+       :func:`entry_source`, :func:`stable_leaf_source`,
+       :func:`terminated_source`, :func:`diagnostic_source`
+     - Describe initial and recurrence source profiles without reading
+       initial ``where`` predicates or building solver relations.
+   * - Macro-step cases
+     - :class:`BoolTemplate`, :class:`EventUse`, :class:`VarUpdate`,
+       :class:`CycleCase`, :class:`MacroStepFormal`,
+       :func:`build_fallback_case`, :func:`build_semantic_delta_case`,
+       :func:`verify_source_partition`
+     - Freeze case labels, bare conditions, explicit variable writeback,
+       absorb/fallback/delta helpers, and build-time partition self-checks.
    * - Query root model
      - :class:`InitialSpec`, :class:`FrameAssumption`,
        :class:`EventAssumption`, :class:`EventCardinalityAssumption`,
@@ -114,6 +129,24 @@ from pyfcstm.bmc.errors import (
     InvalidBmcQuery,
     UnsupportedBmcQuery,
 )
+from pyfcstm.bmc.macro import (
+    BoolTemplate,
+    CycleCase,
+    EventUse,
+    MacroStepFormal,
+    PartitionCheckResult,
+    VarUpdate,
+    build_fallback_case,
+    build_semantic_delta_case,
+    build_var_updates,
+    carry_var_updates,
+    case_antecedent_condition,
+    diagnostic_absorb_case,
+    terminated_absorb_case,
+    var_update_for,
+    verify_boolean_partition,
+    verify_source_partition,
+)
 from pyfcstm.bmc.query import (
     BmcAssumption,
     BmcProperty,
@@ -122,6 +155,16 @@ from pyfcstm.bmc.query import (
     EventCardinalityAssumption,
     FrameAssumption,
     InitialSpec,
+)
+from pyfcstm.bmc.source import (
+    DIAGNOSTIC_CASE_PATH,
+    TERMINATE_CASE_PATH,
+    MacroStepSource,
+    diagnostic_source,
+    entry_source,
+    source_from_initial_spec,
+    stable_leaf_source,
+    terminated_source,
 )
 
 __all__ = [
@@ -171,4 +214,28 @@ __all__ = [
     "EventInputRef",
     "BmcDomain",
     "build_bmc_domain",
+    "TERMINATE_CASE_PATH",
+    "DIAGNOSTIC_CASE_PATH",
+    "MacroStepSource",
+    "entry_source",
+    "stable_leaf_source",
+    "terminated_source",
+    "diagnostic_source",
+    "source_from_initial_spec",
+    "BoolTemplate",
+    "EventUse",
+    "VarUpdate",
+    "CycleCase",
+    "PartitionCheckResult",
+    "MacroStepFormal",
+    "carry_var_updates",
+    "var_update_for",
+    "build_var_updates",
+    "case_antecedent_condition",
+    "terminated_absorb_case",
+    "diagnostic_absorb_case",
+    "build_fallback_case",
+    "build_semantic_delta_case",
+    "verify_boolean_partition",
+    "verify_source_partition",
 ]

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -1004,9 +1004,11 @@ class MacroStepFormal:
                 raise InvalidBmcEncoding("case source id must match formal source.")
             if case.source_state_path != self.source.source_state_path:
                 raise InvalidBmcEncoding("case source path must match formal source.")
+            self._validate_case_domain_contract(case)
         for case in self.success_cases:
             if case.kind == "delta":
                 raise InvalidBmcEncoding("success_cases must not contain delta cases.")
+            self._validate_success_case_shape(case)
         if self.delta_cases and not self.source.allows_semantic_delta:
             raise InvalidBmcEncoding("delta_cases require an entry source.")
         if self.source.kind != "entry" and self.build_diagnostic_conditions:
@@ -1023,6 +1025,41 @@ class MacroStepFormal:
         for case in self.delta_cases:
             if case.kind != "delta":
                 raise InvalidBmcEncoding("delta_cases may only contain delta cases.")
+
+    def _validate_case_domain_contract(self, case: CycleCase) -> None:
+        if self.source.domain is not None:
+            case._validate_against_domain(self.source.domain)
+
+    def _validate_success_case_shape(self, case: CycleCase) -> None:
+        if self.source.kind == "stable_leaf":
+            if case.kind not in {"transition", "fallback"}:
+                raise InvalidBmcEncoding(
+                    "stable leaf success cases may only be transition or fallback."
+                )
+            if (
+                case.target_state_id < 0
+                or case.target_state_path in _RESERVED_CASE_PATHS
+            ):
+                raise InvalidBmcEncoding(
+                    "stable leaf success cases must target model states."
+                )
+            if case.kind == "fallback" and (
+                case.target_state_id != self.source.source_state_id
+                or case.target_state_path != self.source.source_state_path
+            ):
+                raise InvalidBmcEncoding("fallback cases must self-loop source.")
+        elif self.source.kind == "entry":
+            if case.kind not in {"transition", "initial", "diagnostic"}:
+                raise InvalidBmcEncoding(
+                    "entry success cases may only be transition, initial, or diagnostic."
+                )
+            if case.kind in {"transition", "initial"} and (
+                case.target_state_id < 0
+                or case.target_state_path in _RESERVED_CASE_PATHS
+            ):
+                raise InvalidBmcEncoding(
+                    "entry transition and initial cases must target model states."
+                )
 
     def _validate_sentinel_absorb(self, sentinel_id: int) -> None:
         if self.delta_cases:

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -15,9 +15,10 @@ Design contracts:
   gamma`` before emitting ``A => R``.
 * :class:`VarUpdate` entries are explicit and complete.  Carry-over variables
   are represented as writeback entries rather than left unconstrained.
-* Fallback and semantic-delta helpers subtract only accepted/build-diagnostic
-  conditions required by the issue design.  Failed candidate metadata is kept
-  for diagnostics and never removes uncovered regions.
+* Fallback and semantic-delta helpers subtract only ordinary accepted
+  success-case conditions and the build-diagnostic conditions required by the
+  issue design.  Failed candidate metadata is kept for diagnostics and never
+  removes uncovered regions.
 * Partition verification is a build-time/test-time self-check.  It returns a
   diagnostic summary or raises :class:`pyfcstm.bmc.errors.BmcBuildError`; it
   never produces clauses for ``Core_N`` or ``Phi_N``.
@@ -61,6 +62,7 @@ from pyfcstm.bmc.source import (
 _CanonicalDict = Dict[str, Any]
 _BOOL_KINDS = {"true", "false", "atom", "not", "and", "or"}
 _CASE_KINDS = {"transition", "fallback", "initial", "absorb", "diagnostic", "delta"}
+_ACCEPTED_CASE_KINDS = {"transition", "initial"}
 _EVENT_POLARITIES = {"positive", "negative"}
 _EVENT_REASONS = {"trigger", "priority", "fallback", "descent", "assumption"}
 _RESERVED_CASE_PATHS = {TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH}
@@ -636,6 +638,41 @@ def _validate_non_reserved_condition_atoms(
             )
 
 
+def _normalize_accepted_cases(
+    accepted_cases: Sequence["CycleCase"],
+    source: MacroStepSource,
+    helper_name: str,
+) -> Tuple["CycleCase", ...]:
+    if not isinstance(accepted_cases, (list, tuple)):
+        raise InvalidBmcEncoding("accepted_cases must be a sequence.")
+    accepted = tuple(accepted_cases)
+    if not all(isinstance(item, CycleCase) for item in accepted):
+        raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
+    for case in accepted:
+        if case.kind not in _ACCEPTED_CASE_KINDS:
+            raise InvalidBmcEncoding(
+                "accepted_cases for %s may only contain ordinary accepted cases."
+                % helper_name
+            )
+        if case.is_diagnostic:
+            raise InvalidBmcEncoding(
+                "accepted_cases for %s must not contain diagnostic cases." % helper_name
+            )
+        if case.target_state_id < 0 or case.target_state_path in _RESERVED_CASE_PATHS:
+            raise InvalidBmcEncoding(
+                "accepted_cases for %s must target model states." % helper_name
+            )
+        if case.source_state_id != source.source_state_id:
+            raise InvalidBmcEncoding(
+                "accepted case source id must match %s source." % helper_name
+            )
+        if case.source_state_path != source.source_state_path:
+            raise InvalidBmcEncoding(
+                "accepted case source path must match %s source." % helper_name
+            )
+    return accepted
+
+
 @dataclass(frozen=True)
 class CycleCase:
     """One macro-step relation case before solver lowering.
@@ -1188,20 +1225,7 @@ def build_fallback_case(
     ordinal = _validate_index(ordinal, "ordinal")
     if ordinal < 0:
         raise InvalidBmcEncoding("ordinal must be non-negative.")
-    if not isinstance(accepted_cases, (list, tuple)):
-        raise InvalidBmcEncoding("accepted_cases must be a sequence.")
-    accepted = tuple(accepted_cases)
-    if not all(isinstance(item, CycleCase) for item in accepted):
-        raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
-    for case in accepted:
-        if case.source_state_id != source.source_state_id:
-            raise InvalidBmcEncoding(
-                "accepted case source id must match fallback source."
-            )
-        if case.source_state_path != source.source_state_path:
-            raise InvalidBmcEncoding(
-                "accepted case source path must match fallback source."
-            )
+    accepted = _normalize_accepted_cases(accepted_cases, source, "fallback")
     if not isinstance(failed_conditions, (list, tuple)):
         raise InvalidBmcEncoding("failed_conditions must be a sequence.")
     failed = tuple(failed_conditions)
@@ -1278,18 +1302,7 @@ def build_semantic_delta_case(
     ordinal = _validate_index(ordinal, "ordinal")
     if ordinal < 0:
         raise InvalidBmcEncoding("ordinal must be non-negative.")
-    if not isinstance(accepted_cases, (list, tuple)):
-        raise InvalidBmcEncoding("accepted_cases must be a sequence.")
-    accepted = tuple(accepted_cases)
-    if not all(isinstance(item, CycleCase) for item in accepted):
-        raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
-    for case in accepted:
-        if case.source_state_id != source.source_state_id:
-            raise InvalidBmcEncoding("accepted case source id must match delta source.")
-        if case.source_state_path != source.source_state_path:
-            raise InvalidBmcEncoding(
-                "accepted case source path must match delta source."
-            )
+    accepted = _normalize_accepted_cases(accepted_cases, source, "delta")
     if not isinstance(build_diagnostic_conditions, (list, tuple)):
         raise InvalidBmcEncoding("build_diagnostic_conditions must be a sequence.")
     diagnostics = tuple(build_diagnostic_conditions)

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -1,0 +1,1472 @@
+"""Macro-step case contracts for FCSTM bounded model checking.
+
+The macro contract layer defines the data objects exchanged between future
+macro-step expansion and solver-relation lowering.  It does not traverse a
+runtime state machine, build Z3 transition relations, or append partition
+repair constraints to user formulas.  Instead, it makes the shape of each case
+explicit: source and target ids, stable labels, event uses, a bare case
+condition ``gamma``, and an explicit writeback recipe for every persistent
+variable.
+
+Design contracts:
+
+* :class:`CycleCase.condition` is the bare case condition.  It never includes
+  the pre-state source guard; later relation builders form ``source_guard and
+  gamma`` before emitting ``A => R``.
+* :class:`VarUpdate` entries are explicit and complete.  Carry-over variables
+  are represented as writeback entries rather than left unconstrained.
+* Fallback and semantic-delta helpers subtract only accepted/build-diagnostic
+  conditions required by the issue design.  Failed candidate metadata is kept
+  for diagnostics and never removes uncovered regions.
+* Partition verification is a build-time/test-time self-check.  It returns a
+  diagnostic summary or raises :class:`pyfcstm.bmc.errors.BmcBuildError`; it
+  never produces clauses for ``Core_N`` or ``Phi_N``.
+
+The module contains:
+
+* :class:`BoolTemplate` - Small solver-independent boolean recipe for contract
+  tests and partition self-checks.
+* :class:`EventUse` and :class:`VarUpdate` - Event-use and writeback metadata.
+* :class:`CycleCase` - One macro-step relation case.
+* :class:`MacroStepFormal` - Source-local buckets of success, delta, and build
+  diagnostic conditions.
+* Helper constructors for absorb, fallback, semantic-delta, and partition
+  checks.
+
+Example::
+
+    >>> from pyfcstm.bmc.domain import build_bmc_domain
+    >>> from pyfcstm.bmc.macro import terminated_absorb_case
+    >>> from pyfcstm.model import load_state_machine_from_text
+    >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+    >>> terminated_absorb_case(domain).label
+    '__terminate__::absorb::__terminate__::0'
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+
+from pyfcstm.bmc.domain import STATE_DIAGNOSTIC_ID, STATE_TERMINATE_ID, BmcDomain
+from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcDomain, InvalidBmcEncoding
+from pyfcstm.bmc.source import (
+    DIAGNOSTIC_CASE_PATH,
+    TERMINATE_CASE_PATH,
+    MacroStepSource,
+)
+
+_CanonicalDict = Dict[str, Any]
+_BOOL_KINDS = {"true", "false", "atom", "not", "and", "or"}
+_CASE_KINDS = {"transition", "fallback", "initial", "absorb", "diagnostic", "delta"}
+_EVENT_POLARITIES = {"positive", "negative"}
+_EVENT_REASONS = {"trigger", "priority", "fallback", "descent", "assumption"}
+_RESERVED_CASE_PATHS = {TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH}
+
+
+def _require_non_empty_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise InvalidBmcEncoding("%s must be a non-empty string." % field_name)
+    return value
+
+
+def _validate_index(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InvalidBmcEncoding("%s must be an integer." % field_name)
+    return value
+
+
+def _validate_choice(value: object, choices: set, field_name: str) -> str:
+    if not isinstance(value, str) or value not in choices:
+        raise InvalidBmcEncoding("Unsupported %s: %r." % (field_name, value))
+    return value
+
+
+def _canonical_key(item: Any) -> str:
+    if hasattr(item, "to_canonical"):
+        value = item.to_canonical()
+    else:
+        value = item
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+@dataclass(frozen=True)
+class BoolTemplate:
+    """Solver-independent boolean condition recipe.
+
+    ``BoolTemplate`` is intentionally small.  It is sufficient for macro contract
+    tests and partition proofs, while later solver lowering can map
+    richer case recipes into Z3 without changing the surrounding case contract.
+
+    :param kind: ``"true"``, ``"false"``, ``"atom"``, ``"not"``,
+        ``"and"``, or ``"or"``.
+    :type kind: str
+    :param name: Atom name for ``kind="atom"``, defaults to ``None``.
+    :type name: str, optional
+    :param operands: Child boolean templates for composite nodes, defaults to
+        an empty tuple.
+    :type operands: Tuple[BoolTemplate, ...], optional
+
+    Example::
+
+        >>> gamma = BoolTemplate.atom('gamma')
+        >>> BoolTemplate.not_(gamma).evaluate({'gamma': False})
+        True
+    """
+
+    kind: str
+    name: Optional[str] = None
+    operands: Tuple["BoolTemplate", ...] = ()
+
+    def __post_init__(self) -> None:
+        kind = _validate_choice(self.kind, _BOOL_KINDS, "boolean template kind")
+        object.__setattr__(self, "kind", kind)
+        operands = tuple(self.operands)
+        if not all(isinstance(item, BoolTemplate) for item in operands):
+            raise InvalidBmcEncoding("operands must contain BoolTemplate objects.")
+        if kind == "atom":
+            object.__setattr__(
+                self,
+                "name",
+                _require_non_empty_string(self.name, "atom name"),
+            )
+            if operands:
+                raise InvalidBmcEncoding("atom templates cannot have operands.")
+        elif kind in {"true", "false"}:
+            if self.name is not None:
+                raise InvalidBmcEncoding("constant templates cannot have names.")
+            if operands:
+                raise InvalidBmcEncoding("constant templates cannot have operands.")
+        elif kind == "not":
+            if self.name is not None:
+                raise InvalidBmcEncoding("not templates cannot have names.")
+            if len(operands) != 1:
+                raise InvalidBmcEncoding("not templates must have one operand.")
+        else:
+            if self.name is not None:
+                raise InvalidBmcEncoding("compound templates cannot have names.")
+            if not operands:
+                raise InvalidBmcEncoding("compound templates must have operands.")
+            operands = tuple(sorted(operands, key=_canonical_key))
+        object.__setattr__(self, "operands", operands)
+
+    @classmethod
+    def true(cls) -> "BoolTemplate":
+        """Return the constant true condition.
+
+        :return: Constant true condition.
+        :rtype: BoolTemplate
+
+        Example::
+
+            >>> BoolTemplate.true().evaluate({})
+            True
+        """
+        return cls("true")
+
+    @classmethod
+    def false(cls) -> "BoolTemplate":
+        """Return the constant false condition.
+
+        :return: Constant false condition.
+        :rtype: BoolTemplate
+
+        Example::
+
+            >>> BoolTemplate.false().evaluate({})
+            False
+        """
+        return cls("false")
+
+    @classmethod
+    def atom(cls, name: str) -> "BoolTemplate":
+        """Return an atom condition.
+
+        :param name: Atom name.
+        :type name: str
+        :return: Atom condition.
+        :rtype: BoolTemplate
+
+        Example::
+
+            >>> BoolTemplate.atom('go').variables
+            ('go',)
+        """
+        return cls("atom", name=name)
+
+    @classmethod
+    def not_(cls, operand: "BoolTemplate") -> "BoolTemplate":
+        """Return logical negation of ``operand``.
+
+        :param operand: Operand condition.
+        :type operand: BoolTemplate
+        :return: Negated condition.
+        :rtype: BoolTemplate
+
+        Example::
+
+            >>> BoolTemplate.not_(BoolTemplate.false()).evaluate({})
+            True
+        """
+        return cls("not", operands=(operand,))
+
+    @classmethod
+    def and_(cls, *operands: "BoolTemplate") -> "BoolTemplate":
+        """Return logical conjunction of ``operands``.
+
+        :param operands: Operand conditions.
+        :type operands: BoolTemplate
+        :return: Conjunction, or constant true for an empty input.
+        :rtype: BoolTemplate
+
+        Example::
+
+            >>> BoolTemplate.and_().evaluate({})
+            True
+        """
+        if not operands:
+            return cls.true()
+        if not all(isinstance(item, BoolTemplate) for item in operands):
+            raise InvalidBmcEncoding("operands must contain BoolTemplate objects.")
+        if len(operands) == 1:
+            return operands[0]
+        return cls("and", operands=tuple(operands))
+
+    @classmethod
+    def or_(cls, *operands: "BoolTemplate") -> "BoolTemplate":
+        """Return logical disjunction of ``operands``.
+
+        :param operands: Operand conditions.
+        :type operands: BoolTemplate
+        :return: Disjunction, or constant false for an empty input.
+        :rtype: BoolTemplate
+
+        Example::
+
+            >>> BoolTemplate.or_().evaluate({})
+            False
+        """
+        if not operands:
+            return cls.false()
+        if not all(isinstance(item, BoolTemplate) for item in operands):
+            raise InvalidBmcEncoding("operands must contain BoolTemplate objects.")
+        if len(operands) == 1:
+            return operands[0]
+        return cls("or", operands=tuple(operands))
+
+    @property
+    def variables(self) -> Tuple[str, ...]:
+        """Return atom names referenced by this template.
+
+        :return: Sorted unique atom names.
+        :rtype: Tuple[str, ...]
+
+        Example::
+
+            >>> BoolTemplate.or_(BoolTemplate.atom('b'), BoolTemplate.atom('a')).variables
+            ('a', 'b')
+        """
+        if self.kind == "atom":
+            return (self.name or "",)
+        values = set()
+        for operand in self.operands:
+            values.update(operand.variables)
+        return tuple(sorted(values))
+
+    def evaluate(self, values: Mapping[str, bool]) -> bool:
+        """Evaluate this template on a boolean assignment.
+
+        :param values: Mapping from atom names to booleans.
+        :type values: Mapping[str, bool]
+        :return: Evaluated boolean value.
+        :rtype: bool
+        :raises BmcBuildError: If an atom is missing or a value is not boolean.
+
+        Example::
+
+            >>> expr = BoolTemplate.and_(BoolTemplate.atom('a'), BoolTemplate.not_(BoolTemplate.atom('b')))
+            >>> expr.evaluate({'a': True, 'b': False})
+            True
+        """
+        if self.kind == "true":
+            return True
+        if self.kind == "false":
+            return False
+        if self.kind == "atom":
+            if self.name not in values:
+                raise BmcBuildError("missing boolean assignment for %r." % self.name)
+            value = values[self.name]
+            if not isinstance(value, bool):
+                raise BmcBuildError("boolean assignment %r must be bool." % self.name)
+            return value
+        if self.kind == "not":
+            return not self.operands[0].evaluate(values)
+        if self.kind == "and":
+            return all(operand.evaluate(values) for operand in self.operands)
+        if self.kind == "or":
+            return any(operand.evaluate(values) for operand in self.operands)
+        raise BmcBuildError("unsupported boolean template kind: %r." % self.kind)
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable condition recipe.
+
+        :return: Canonical condition dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> BoolTemplate.atom('gamma').to_canonical()['name']
+            'gamma'
+        """
+        result = {"node": "bool_template", "kind": self.kind}
+        if self.kind == "atom":
+            result["name"] = self.name
+        if self.operands:
+            result["operands"] = [item.to_canonical() for item in self.operands]
+        return result
+
+
+@dataclass(frozen=True)
+class EventUse:
+    """Event input usage metadata for one case.
+
+    :param event_id: Domain event id.
+    :type event_id: int
+    :param path: Fully qualified event path.
+    :type path: str
+    :param polarity: ``"positive"`` or ``"negative"``.
+    :type polarity: str
+    :param reason: Usage reason such as ``"trigger"`` or ``"priority"``.
+    :type reason: str
+
+    Example::
+
+        >>> EventUse(0, 'Root.Go', 'positive', 'trigger').polarity
+        'positive'
+    """
+
+    event_id: int
+    path: str
+    polarity: str
+    reason: str
+
+    def __post_init__(self) -> None:
+        event_id = _validate_index(self.event_id, "event_id")
+        if event_id < 0:
+            raise InvalidBmcEncoding("event_id must be non-negative.")
+        object.__setattr__(self, "event_id", event_id)
+        object.__setattr__(
+            self,
+            "path",
+            _require_non_empty_string(self.path, "event path"),
+        )
+        object.__setattr__(
+            self,
+            "polarity",
+            _validate_choice(self.polarity, _EVENT_POLARITIES, "event polarity"),
+        )
+        object.__setattr__(
+            self,
+            "reason",
+            _validate_choice(self.reason, _EVENT_REASONS, "event reason"),
+        )
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable event-use dictionary.
+
+        :return: Canonical event-use metadata.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> EventUse(0, 'Root.Go', 'positive', 'trigger').to_canonical()['reason']
+            'trigger'
+        """
+        return {
+            "node": "event_use",
+            "event_id": self.event_id,
+            "path": self.path,
+            "polarity": self.polarity,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class VarUpdate:
+    """Persistent-variable writeback recipe for one macro-step case.
+
+    :param variable_id: Domain variable id.
+    :type variable_id: int
+    :param variable_name: Persistent variable name.
+    :type variable_name: str
+    :param expression: Stable expression digest or recipe key used by later
+        lowering.
+    :type expression: str
+    :param is_carry: Whether this update is explicit carry-over, defaults to
+        ``False``.
+    :type is_carry: bool, optional
+
+    Example::
+
+        >>> VarUpdate(0, 'x', 'pre:x', is_carry=True).is_carry
+        True
+    """
+
+    variable_id: int
+    variable_name: str
+    expression: str
+    is_carry: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "variable_id",
+            _validate_index(self.variable_id, "variable_id"),
+        )
+        if self.variable_id < 0:
+            raise InvalidBmcEncoding("variable_id must be non-negative.")
+        object.__setattr__(
+            self,
+            "variable_name",
+            _require_non_empty_string(self.variable_name, "variable_name"),
+        )
+        object.__setattr__(
+            self,
+            "expression",
+            _require_non_empty_string(self.expression, "expression"),
+        )
+        if not isinstance(self.is_carry, bool):
+            raise InvalidBmcEncoding("is_carry must be a boolean.")
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable variable update dictionary.
+
+        :return: Canonical variable update.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> VarUpdate(0, 'x', 'pre:x').to_canonical()['variable_name']
+            'x'
+        """
+        return {
+            "node": "var_update",
+            "variable_id": self.variable_id,
+            "variable_name": self.variable_name,
+            "expression": self.expression,
+            "is_carry": self.is_carry,
+        }
+
+
+def carry_var_updates(domain: BmcDomain) -> Tuple[VarUpdate, ...]:
+    """Return explicit carry-over updates for every persistent variable.
+
+    :param domain: Domain snapshot whose variables should be carried.
+    :type domain: BmcDomain
+    :return: Complete carry-over update tuple sorted by variable id.
+    :rtype: Tuple[VarUpdate, ...]
+    :raises InvalidBmcEncoding: If ``domain`` is not a BMC domain.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('def int x = 0; state Root;'), 1)
+        >>> carry_var_updates(domain)[0].expression
+        'pre:x'
+    """
+    if not isinstance(domain, BmcDomain):
+        raise InvalidBmcEncoding("domain must be BmcDomain.")
+    return tuple(
+        VarUpdate(entry.id, entry.name, "pre:%s" % entry.name, is_carry=True)
+        for entry in domain.variables
+    )
+
+
+def var_update_for(
+    domain: BmcDomain,
+    variable: object,
+    expression: str,
+    is_carry: bool = False,
+) -> VarUpdate:
+    """Build one variable update from a domain variable id or name.
+
+    :param domain: Domain snapshot that owns the variable.
+    :type domain: BmcDomain
+    :param variable: Variable id or name.
+    :type variable: int or str
+    :param expression: Stable expression digest or recipe key.
+    :type expression: str
+    :param is_carry: Whether this update is carry-over, defaults to ``False``.
+    :type is_carry: bool, optional
+    :return: Variable update entry.
+    :rtype: VarUpdate
+    :raises InvalidBmcEncoding: If ``variable`` cannot be resolved.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('def int x = 0; state Root;'), 1)
+        >>> var_update_for(domain, 'x', 'x+1').variable_id
+        0
+    """
+    if not isinstance(domain, BmcDomain):
+        raise InvalidBmcEncoding("domain must be BmcDomain.")
+    try:
+        if isinstance(variable, str):
+            entry = domain.variable_by_name(variable)
+        elif isinstance(variable, bool) or not isinstance(variable, int):
+            raise InvalidBmcEncoding("variable must be a variable id or name.")
+        else:
+            entry = domain.variable_by_id(variable)
+    except InvalidBmcDomain as err:
+        # InvalidBmcDomain: BmcDomain lookup rejects unknown variable ids or
+        # names supplied by this writeback recipe constructor.
+        raise InvalidBmcEncoding(str(err)) from err
+    return VarUpdate(entry.id, entry.name, expression, is_carry=is_carry)
+
+
+def build_var_updates(
+    domain: BmcDomain,
+    updates: Sequence[VarUpdate],
+) -> Tuple[VarUpdate, ...]:
+    """Validate and normalize a complete writeback tuple.
+
+    :param domain: Domain snapshot whose persistent variables must be covered.
+    :type domain: BmcDomain
+    :param updates: Candidate variable updates.
+    :type updates: Sequence[VarUpdate]
+    :return: Updates sorted by variable id.
+    :rtype: Tuple[VarUpdate, ...]
+    :raises InvalidBmcEncoding: If an update is missing, duplicated, or
+        references an unknown variable.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('def int x = 0; state Root;'), 1)
+        >>> build_var_updates(domain, carry_var_updates(domain))[0].variable_name
+        'x'
+    """
+    if not isinstance(domain, BmcDomain):
+        raise InvalidBmcEncoding("domain must be BmcDomain.")
+    if not isinstance(updates, (list, tuple)):
+        raise InvalidBmcEncoding("updates must be a sequence.")
+    items = tuple(updates)
+    if not all(isinstance(item, VarUpdate) for item in items):
+        raise InvalidBmcEncoding("updates must contain VarUpdate objects.")
+
+    by_id = {}
+    by_name = {}
+    for item in items:
+        if item.variable_id in by_id:
+            raise InvalidBmcEncoding(
+                "Duplicate variable update id: %r." % item.variable_id
+            )
+        if item.variable_name in by_name:
+            raise InvalidBmcEncoding(
+                "Duplicate variable update name: %r." % item.variable_name
+            )
+        try:
+            entry = domain.variable_by_id(item.variable_id)
+        except InvalidBmcDomain as err:
+            # InvalidBmcDomain: domain.variable_by_id rejects unknown variable ids
+            # supplied by this macro-step writeback recipe.
+            raise InvalidBmcEncoding(str(err)) from err
+        if entry.name != item.variable_name:
+            raise InvalidBmcEncoding("Variable update id/name mismatch.")
+        by_id[item.variable_id] = item
+        by_name[item.variable_name] = item
+
+    expected_ids = tuple(entry.id for entry in domain.variables)
+    actual_ids = tuple(sorted(by_id))
+    if actual_ids != expected_ids:
+        raise InvalidBmcEncoding("var_update must cover every persistent variable.")
+    return tuple(by_id[index] for index in expected_ids)
+
+
+def _expected_case_path(domain: BmcDomain, state_id: int) -> str:
+    try:
+        if state_id == STATE_TERMINATE_ID:
+            domain.state_by_id(STATE_TERMINATE_ID)
+            return TERMINATE_CASE_PATH
+        if state_id == STATE_DIAGNOSTIC_ID:
+            domain.state_by_id(STATE_DIAGNOSTIC_ID)
+            return DIAGNOSTIC_CASE_PATH
+        entry = domain.state_by_id(state_id)
+        if entry.path in _RESERVED_CASE_PATHS:
+            raise InvalidBmcEncoding(
+                "Model case path must not use reserved macro-step paths."
+            )
+        return entry.path
+    except InvalidBmcDomain as err:
+        # InvalidBmcDomain: BmcDomain lookup rejects unknown source or target ids
+        # supplied by this macro-step case contract.
+        raise InvalidBmcEncoding(str(err)) from err
+
+
+def _validate_case_state(
+    domain: BmcDomain, state_id: int, path: str, role: str
+) -> None:
+    expected = _expected_case_path(domain, state_id)
+    if path != expected:
+        raise InvalidBmcEncoding("%s path does not match %s id." % (role, role))
+
+
+def _derive_is_diagnostic(kind: str, target_state_id: int) -> bool:
+    return kind in {"diagnostic", "delta"} or (
+        kind == "absorb" and target_state_id == STATE_DIAGNOSTIC_ID
+    )
+
+
+@dataclass(frozen=True)
+class CycleCase:
+    """One macro-step relation case before solver lowering.
+
+    :param kind: Case kind such as ``"transition"``, ``"fallback"``,
+        ``"absorb"``, or ``"delta"``.
+    :type kind: str
+    :param source_state_id: Domain state id of the source boundary.
+    :type source_state_id: int
+    :param source_state_path: Source path used by the case label.
+    :type source_state_path: str
+    :param target_state_id: Domain state id of the target boundary.
+    :type target_state_id: int
+    :param target_state_path: Target path used by the case label.
+    :type target_state_path: str
+    :param label: Stable label in
+        ``source_path::case_kind::target_path::ordinal`` form.
+    :type label: str
+    :param condition: Bare case condition ``gamma`` without a source guard.
+    :type condition: BoolTemplate
+    :param var_update: Explicit updates for every persistent variable.
+    :type var_update: Tuple[VarUpdate, ...]
+    :param used_events: Event inputs read by this case, defaults to ``()``.
+    :type used_events: Tuple[EventUse, ...], optional
+    :param failed_conditions: Diagnostic-only failed candidate conditions,
+        defaults to ``()``.
+    :type failed_conditions: Tuple[BoolTemplate, ...], optional
+    :param domain: Optional domain used for eager validation, defaults to
+        ``None``.
+    :type domain: BmcDomain, optional
+
+    :ivar is_diagnostic: Derived diagnostic classification.  It is true for
+        ``delta`` cases and diagnostic absorb cases.
+    :vartype is_diagnostic: bool
+
+    Example::
+
+        >>> case = CycleCase('transition', 0, 'Root', 0, 'Root', 'Root::transition::Root::0', BoolTemplate.true(), ())
+        >>> case.condition.evaluate({})
+        True
+    """
+
+    kind: str
+    source_state_id: int
+    source_state_path: str
+    target_state_id: int
+    target_state_path: str
+    label: str
+    condition: BoolTemplate
+    var_update: Tuple[VarUpdate, ...]
+    used_events: Tuple[EventUse, ...] = ()
+    failed_conditions: Tuple[BoolTemplate, ...] = ()
+    domain: Optional[BmcDomain] = field(default=None, repr=False, compare=False)
+    is_diagnostic: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        kind = _validate_choice(self.kind, _CASE_KINDS, "case kind")
+        source_id = _validate_index(self.source_state_id, "source_state_id")
+        target_id = _validate_index(self.target_state_id, "target_state_id")
+        source_path = _require_non_empty_string(
+            self.source_state_path,
+            "source_state_path",
+        )
+        target_path = _require_non_empty_string(
+            self.target_state_path,
+            "target_state_path",
+        )
+        label = _require_non_empty_string(self.label, "label")
+        if not isinstance(self.condition, BoolTemplate):
+            raise InvalidBmcEncoding("condition must be BoolTemplate.")
+        used_events = tuple(self.used_events)
+        if not all(isinstance(item, EventUse) for item in used_events):
+            raise InvalidBmcEncoding("used_events must contain EventUse objects.")
+        failed_conditions = tuple(self.failed_conditions)
+        if not all(isinstance(item, BoolTemplate) for item in failed_conditions):
+            raise InvalidBmcEncoding(
+                "failed_conditions must contain BoolTemplate objects."
+            )
+        var_update = tuple(self.var_update)
+        if not all(isinstance(item, VarUpdate) for item in var_update):
+            raise InvalidBmcEncoding("var_update must contain VarUpdate objects.")
+
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "source_state_id", source_id)
+        object.__setattr__(self, "target_state_id", target_id)
+        object.__setattr__(self, "source_state_path", source_path)
+        object.__setattr__(self, "target_state_path", target_path)
+        object.__setattr__(self, "label", label)
+        object.__setattr__(
+            self,
+            "used_events",
+            tuple(sorted(used_events, key=_canonical_key)),
+        )
+        object.__setattr__(
+            self,
+            "failed_conditions",
+            tuple(sorted(failed_conditions, key=_canonical_key)),
+        )
+        object.__setattr__(
+            self,
+            "var_update",
+            tuple(sorted(var_update, key=lambda item: item.variable_id)),
+        )
+        object.__setattr__(
+            self, "is_diagnostic", _derive_is_diagnostic(kind, target_id)
+        )
+
+        self._validate_label()
+        self._validate_kind_shape()
+        if self.domain is not None:
+            if not isinstance(self.domain, BmcDomain):
+                raise InvalidBmcEncoding("domain must be BmcDomain.")
+            self._validate_against_domain(self.domain)
+
+    def _validate_label(self) -> None:
+        parts = self.label.split("::")
+        if len(parts) != 4:
+            raise InvalidBmcEncoding("label must use source::kind::target::ordinal.")
+        source_path, kind, target_path, ordinal = parts
+        if source_path != self.source_state_path:
+            raise InvalidBmcEncoding("label source path does not match case source.")
+        if kind != self.kind:
+            raise InvalidBmcEncoding("label case kind does not match case kind.")
+        if target_path != self.target_state_path:
+            raise InvalidBmcEncoding("label target path does not match case target.")
+        if not ordinal or not all("0" <= char <= "9" for char in ordinal):
+            raise InvalidBmcEncoding("label ordinal must be a decimal integer.")
+
+    def _validate_kind_shape(self) -> None:
+        if self.kind == "absorb":
+            if self.source_state_id != self.target_state_id:
+                raise InvalidBmcEncoding("absorb cases must self-loop.")
+            if self.source_state_id not in {STATE_TERMINATE_ID, STATE_DIAGNOSTIC_ID}:
+                raise InvalidBmcEncoding("absorb cases must use sentinel states.")
+        if self.kind in {"delta", "diagnostic"}:
+            if self.target_state_id != STATE_DIAGNOSTIC_ID:
+                raise InvalidBmcEncoding(
+                    "diagnostic and delta cases target diagnostic."
+                )
+
+    def _validate_against_domain(self, domain: BmcDomain) -> None:
+        _validate_case_state(
+            domain,
+            self.source_state_id,
+            self.source_state_path,
+            "source",
+        )
+        _validate_case_state(
+            domain,
+            self.target_state_id,
+            self.target_state_path,
+            "target",
+        )
+        for event_use in self.used_events:
+            try:
+                event = domain.event_by_id(event_use.event_id)
+            except InvalidBmcDomain as err:
+                # InvalidBmcDomain: BmcDomain lookup rejects unknown event ids
+                # referenced by this case's event-use metadata.
+                raise InvalidBmcEncoding(str(err)) from err
+            if event.path != event_use.path:
+                raise InvalidBmcEncoding("EventUse path does not match event id.")
+        object.__setattr__(
+            self,
+            "var_update",
+            build_var_updates(domain, self.var_update),
+        )
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable case dictionary.
+
+        :return: Canonical cycle-case dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> case = CycleCase('transition', 0, 'Root', 0, 'Root', 'Root::transition::Root::0', BoolTemplate.true(), ())
+            >>> case.to_canonical()['is_diagnostic']
+            False
+        """
+        return {
+            "node": "cycle_case",
+            "kind": self.kind,
+            "source_state_id": self.source_state_id,
+            "source_state_path": self.source_state_path,
+            "target_state_id": self.target_state_id,
+            "target_state_path": self.target_state_path,
+            "label": self.label,
+            "is_diagnostic": self.is_diagnostic,
+            "used_events": [item.to_canonical() for item in self.used_events],
+            "condition": self.condition.to_canonical(),
+            "var_update": [item.to_canonical() for item in self.var_update],
+            "failed_conditions": [
+                item.to_canonical() for item in self.failed_conditions
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class PartitionCheckResult:
+    """Summary of a source-local boolean partition self-check.
+
+    :param variables: Boolean atom names enumerated by the truth-table check.
+    :type variables: Tuple[str, ...]
+    :param assignment_count: Number of assignments checked.
+    :type assignment_count: int
+    :param bucket_count: Number of partition buckets.
+    :type bucket_count: int
+
+    Example::
+
+        >>> PartitionCheckResult(('a',), 2, 2).to_canonical()['assignment_count']
+        2
+    """
+
+    variables: Tuple[str, ...]
+    assignment_count: int
+    bucket_count: int
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable partition-check summary.
+
+        :return: Canonical self-check summary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> PartitionCheckResult((), 1, 1).to_canonical()['node']
+            'partition_check_result'
+        """
+        return {
+            "node": "partition_check_result",
+            "variables": list(self.variables),
+            "assignment_count": self.assignment_count,
+            "bucket_count": self.bucket_count,
+            "scope": "build-time-self-check",
+        }
+
+
+@dataclass(frozen=True)
+class MacroStepFormal:
+    """Source-local macro-step case buckets.
+
+    :param source: Source profile that produced these buckets.
+    :type source: MacroStepSource
+    :param success_cases: Ordinary relation cases such as transitions,
+        fallbacks, and absorbs.
+    :type success_cases: Tuple[CycleCase, ...]
+    :param delta_cases: Semantic delta relation cases, defaults to ``()``.
+    :type delta_cases: Tuple[CycleCase, ...], optional
+    :param build_diagnostic_conditions: Build/encoder diagnostic conditions,
+        defaults to ``()``.
+    :type build_diagnostic_conditions: Tuple[BoolTemplate, ...], optional
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.bmc.macro import MacroStepFormal, terminated_absorb_case
+        >>> from pyfcstm.bmc.source import terminated_source
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> formal = MacroStepFormal(terminated_source(domain), (terminated_absorb_case(domain),))
+        >>> formal.cases[0].kind
+        'absorb'
+    """
+
+    source: MacroStepSource
+    success_cases: Tuple[CycleCase, ...]
+    delta_cases: Tuple[CycleCase, ...] = ()
+    build_diagnostic_conditions: Tuple[BoolTemplate, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, MacroStepSource):
+            raise InvalidBmcEncoding("source must be MacroStepSource.")
+        if not isinstance(self.success_cases, (list, tuple)):
+            raise InvalidBmcEncoding("success_cases must be a sequence.")
+        if not isinstance(self.delta_cases, (list, tuple)):
+            raise InvalidBmcEncoding("delta_cases must be a sequence.")
+        if not isinstance(self.build_diagnostic_conditions, (list, tuple)):
+            raise InvalidBmcEncoding("build_diagnostic_conditions must be a sequence.")
+        success_cases = tuple(self.success_cases)
+        delta_cases = tuple(self.delta_cases)
+        diagnostics = tuple(self.build_diagnostic_conditions)
+        if not all(isinstance(item, CycleCase) for item in success_cases):
+            raise InvalidBmcEncoding("success_cases must contain CycleCase objects.")
+        if not all(isinstance(item, CycleCase) for item in delta_cases):
+            raise InvalidBmcEncoding("delta_cases must contain CycleCase objects.")
+        if not all(isinstance(item, BoolTemplate) for item in diagnostics):
+            raise InvalidBmcEncoding(
+                "build_diagnostic_conditions must contain BoolTemplate objects."
+            )
+        success_cases = tuple(sorted(success_cases, key=lambda item: item.label))
+        delta_cases = tuple(sorted(delta_cases, key=lambda item: item.label))
+        diagnostics = tuple(sorted(diagnostics, key=_canonical_key))
+        object.__setattr__(self, "success_cases", success_cases)
+        object.__setattr__(self, "delta_cases", delta_cases)
+        object.__setattr__(self, "build_diagnostic_conditions", diagnostics)
+        self._validate_buckets()
+
+    @property
+    def cases(self) -> Tuple[CycleCase, ...]:
+        """Return ordinary and delta relation cases in stable order.
+
+        :return: ``success_cases + delta_cases``.
+        :rtype: Tuple[CycleCase, ...]
+
+        Example::
+
+            >>> source = MacroStepSource('entry', 'initial', 0, 'Root')
+            >>> MacroStepFormal(source, (), ()).cases
+            Traceback (most recent call last):
+            ...
+            pyfcstm.bmc.errors.InvalidBmcEncoding: MacroStepFormal must contain at least one relation case.
+        """
+        return self.success_cases + self.delta_cases
+
+    def _validate_buckets(self) -> None:
+        if not self.success_cases and not self.delta_cases:
+            raise InvalidBmcEncoding(
+                "MacroStepFormal must contain at least one relation case."
+            )
+        labels = set()
+        for case in self.cases:
+            if case.label in labels:
+                raise InvalidBmcEncoding("Duplicate cycle case label: %r." % case.label)
+            labels.add(case.label)
+            if case.source_state_id != self.source.source_state_id:
+                raise InvalidBmcEncoding("case source id must match formal source.")
+            if case.source_state_path != self.source.source_state_path:
+                raise InvalidBmcEncoding("case source path must match formal source.")
+        for case in self.success_cases:
+            if case.kind == "delta":
+                raise InvalidBmcEncoding("success_cases must not contain delta cases.")
+        if self.delta_cases and not self.source.allows_semantic_delta:
+            raise InvalidBmcEncoding("delta_cases require an entry source.")
+        if self.source.kind != "entry" and self.build_diagnostic_conditions:
+            raise InvalidBmcEncoding(
+                "build diagnostics are only recorded on entry source formals."
+            )
+        if self.source.kind == "stable_leaf":
+            if not any(case.kind == "fallback" for case in self.success_cases):
+                raise InvalidBmcEncoding("stable leaf formal requires a fallback case.")
+        if self.source.kind == "terminated":
+            self._validate_sentinel_absorb(STATE_TERMINATE_ID)
+        if self.source.kind == "diagnostic":
+            self._validate_sentinel_absorb(STATE_DIAGNOSTIC_ID)
+        for case in self.delta_cases:
+            if case.kind != "delta":
+                raise InvalidBmcEncoding("delta_cases may only contain delta cases.")
+
+    def _validate_sentinel_absorb(self, sentinel_id: int) -> None:
+        if self.delta_cases:
+            raise InvalidBmcEncoding("sentinel absorb formals cannot have delta cases.")
+        if len(self.success_cases) != 1:
+            raise InvalidBmcEncoding("sentinel absorb formal must contain one case.")
+        case = self.success_cases[0]
+        if case.kind != "absorb":
+            raise InvalidBmcEncoding("sentinel formal case must be absorb.")
+        if case.source_state_id != sentinel_id or case.target_state_id != sentinel_id:
+            raise InvalidBmcEncoding("sentinel absorb case must self-loop sentinel id.")
+
+    def verify_partition(
+        self,
+        max_assignments: int = 4096,
+    ) -> PartitionCheckResult:
+        """Verify local case buckets with the truth-table self-checker.
+
+        :param max_assignments: Maximum assignments to enumerate, defaults to
+            ``4096``.
+        :type max_assignments: int, optional
+        :return: Partition self-check summary.
+        :rtype: PartitionCheckResult
+        :raises BmcBuildError: If the buckets overlap, leave a gap, or cannot
+            be checked within the assignment budget.
+
+        Example::
+
+            >>> source = MacroStepSource('entry', 'initial', 0, 'Root')
+            >>> case = CycleCase('delta', 0, 'Root', -2, '__diagnostic__', 'Root::delta::__diagnostic__::0', BoolTemplate.true(), ())
+            >>> MacroStepFormal(source, (), (case,)).verify_partition().bucket_count
+            1
+        """
+        return verify_source_partition(
+            self.source,
+            self.success_cases,
+            self.delta_cases,
+            self.build_diagnostic_conditions,
+            max_assignments=max_assignments,
+        )
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable formal dictionary.
+
+        :return: Canonical macro-step formal.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> source = MacroStepSource('entry', 'initial', 0, 'Root')
+            >>> case = CycleCase('delta', 0, 'Root', -2, '__diagnostic__', 'Root::delta::__diagnostic__::0', BoolTemplate.true(), ())
+            >>> MacroStepFormal(source, (), (case,)).to_canonical()['source']['kind']
+            'entry'
+        """
+        return {
+            "node": "macro_step_formal",
+            "source": self.source.to_canonical(),
+            "success_cases": [case.to_canonical() for case in self.success_cases],
+            "delta_cases": [case.to_canonical() for case in self.delta_cases],
+            "build_diagnostic_conditions": [
+                item.to_canonical() for item in self.build_diagnostic_conditions
+            ],
+        }
+
+
+def case_antecedent_condition(case: CycleCase) -> BoolTemplate:
+    """Return ``source_guard and gamma`` for diagnostic comparison.
+
+    The returned recipe mirrors the later relation-builder boundary but
+    is still solver-independent.  It proves that the source guard is composed
+    outside :attr:`CycleCase.condition`.
+
+    :param case: Case whose antecedent should be represented.
+    :type case: CycleCase
+    :return: Source-guarded antecedent recipe.
+    :rtype: BoolTemplate
+    :raises InvalidBmcEncoding: If ``case`` is not a cycle case.
+
+    Example::
+
+        >>> case = CycleCase(
+        ...     'transition', 0, 'Root', 0, 'Root',
+        ...     'Root::transition::Root::0', BoolTemplate.atom('g'), ()
+        ... )
+        >>> case_antecedent_condition(case).variables
+        ('g', 'source_state:0')
+    """
+    if not isinstance(case, CycleCase):
+        raise InvalidBmcEncoding("case must be CycleCase.")
+    return BoolTemplate.and_(
+        BoolTemplate.atom("source_state:%d" % case.source_state_id),
+        case.condition,
+    )
+
+
+def terminated_absorb_case(domain: BmcDomain) -> CycleCase:
+    """Build the terminate sentinel absorb case.
+
+    :param domain: Domain snapshot whose sentinel and variables are used.
+    :type domain: BmcDomain
+    :return: Terminated self-loop absorb case.
+    :rtype: CycleCase
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> terminated_absorb_case(domain).is_diagnostic
+        False
+    """
+    return CycleCase(
+        "absorb",
+        STATE_TERMINATE_ID,
+        TERMINATE_CASE_PATH,
+        STATE_TERMINATE_ID,
+        TERMINATE_CASE_PATH,
+        "%s::absorb::%s::0" % (TERMINATE_CASE_PATH, TERMINATE_CASE_PATH),
+        BoolTemplate.true(),
+        carry_var_updates(domain),
+        domain=domain,
+    )
+
+
+def diagnostic_absorb_case(domain: BmcDomain) -> CycleCase:
+    """Build the diagnostic sentinel absorb case.
+
+    :param domain: Domain snapshot whose sentinel and variables are used.
+    :type domain: BmcDomain
+    :return: Diagnostic self-loop absorb case.
+    :rtype: CycleCase
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> diagnostic_absorb_case(domain).is_diagnostic
+        True
+    """
+    return CycleCase(
+        "absorb",
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::absorb::%s::0" % (DIAGNOSTIC_CASE_PATH, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        carry_var_updates(domain),
+        domain=domain,
+    )
+
+
+def _case_label(source_path: str, kind: str, target_path: str, ordinal: int) -> str:
+    return "%s::%s::%s::%d" % (source_path, kind, target_path, ordinal)
+
+
+def build_fallback_case(
+    domain: BmcDomain,
+    source: MacroStepSource,
+    accepted_cases: Sequence[CycleCase],
+    failed_conditions: Sequence[BoolTemplate] = (),
+    ordinal: int = 0,
+) -> CycleCase:
+    """Build a stable leaf fallback self-cycle.
+
+    The fallback condition negates only accepted case conditions.  Failed
+    candidate conditions are copied as metadata and do not shrink the fallback
+    region.
+
+    :param domain: Domain snapshot whose variables are carried.
+    :type domain: BmcDomain
+    :param source: Stable leaf source.
+    :type source: MacroStepSource
+    :param accepted_cases: Accepted ordinary cases for the same source.
+    :type accepted_cases: Sequence[CycleCase]
+    :param failed_conditions: Diagnostic-only failed conditions, defaults to
+        ``()``.
+    :type failed_conditions: Sequence[BoolTemplate], optional
+    :param ordinal: Label ordinal, defaults to ``0``.
+    :type ordinal: int, optional
+    :return: Fallback case.
+    :rtype: CycleCase
+    :raises InvalidBmcEncoding: If ``source`` is not a stable leaf source.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.bmc.source import stable_leaf_source
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> source = stable_leaf_source(domain, 'Root')
+        >>> build_fallback_case(domain, source, ()).condition.evaluate({})
+        True
+    """
+    if not isinstance(source, MacroStepSource) or source.kind != "stable_leaf":
+        raise InvalidBmcEncoding("fallback case requires a stable_leaf source.")
+    ordinal = _validate_index(ordinal, "ordinal")
+    if ordinal < 0:
+        raise InvalidBmcEncoding("ordinal must be non-negative.")
+    if not isinstance(accepted_cases, (list, tuple)):
+        raise InvalidBmcEncoding("accepted_cases must be a sequence.")
+    accepted = tuple(accepted_cases)
+    if not all(isinstance(item, CycleCase) for item in accepted):
+        raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
+    for case in accepted:
+        if case.source_state_id != source.source_state_id:
+            raise InvalidBmcEncoding(
+                "accepted case source id must match fallback source."
+            )
+        if case.source_state_path != source.source_state_path:
+            raise InvalidBmcEncoding(
+                "accepted case source path must match fallback source."
+            )
+    if not isinstance(failed_conditions, (list, tuple)):
+        raise InvalidBmcEncoding("failed_conditions must be a sequence.")
+    failed = tuple(failed_conditions)
+    if not all(isinstance(item, BoolTemplate) for item in failed):
+        raise InvalidBmcEncoding("failed_conditions must contain BoolTemplate objects.")
+    condition = BoolTemplate.not_(
+        BoolTemplate.or_(*[case.condition for case in accepted])
+    )
+    return CycleCase(
+        "fallback",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        _case_label(
+            source.source_state_path,
+            "fallback",
+            source.source_state_path,
+            ordinal,
+        ),
+        condition,
+        carry_var_updates(domain),
+        failed_conditions=failed,
+        domain=domain,
+    )
+
+
+def build_semantic_delta_case(
+    domain: BmcDomain,
+    source: MacroStepSource,
+    accepted_cases: Sequence[CycleCase],
+    build_diagnostic_conditions: Sequence[BoolTemplate] = (),
+    failed_conditions: Sequence[BoolTemplate] = (),
+    ordinal: int = 0,
+) -> CycleCase:
+    """Build a non-stoppable entry uncovered-region delta case.
+
+    The delta condition negates accepted case conditions and build-diagnostic
+    conditions.  Failed candidate conditions are copied as metadata only.
+
+    :param domain: Domain snapshot whose variables are carried.
+    :type domain: BmcDomain
+    :param source: Initial entry source.
+    :type source: MacroStepSource
+    :param accepted_cases: Accepted ordinary success cases.
+    :type accepted_cases: Sequence[CycleCase]
+    :param build_diagnostic_conditions: Build diagnostic conditions excluded
+        from semantic delta, defaults to ``()``.
+    :type build_diagnostic_conditions: Sequence[BoolTemplate], optional
+    :param failed_conditions: Diagnostic-only failed candidate conditions,
+        defaults to ``()``.
+    :type failed_conditions: Sequence[BoolTemplate], optional
+    :param ordinal: Label ordinal, defaults to ``0``.
+    :type ordinal: int, optional
+    :return: Semantic delta case targeting the diagnostic sentinel.
+    :rtype: CycleCase
+    :raises InvalidBmcEncoding: If ``source`` does not allow semantic delta.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.bmc.source import entry_source
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> case = build_semantic_delta_case(domain, entry_source(domain), ())
+        >>> case.target_state_id
+        -2
+    """
+    if not isinstance(source, MacroStepSource) or not source.allows_semantic_delta:
+        raise InvalidBmcEncoding("semantic delta case requires an entry source.")
+    ordinal = _validate_index(ordinal, "ordinal")
+    if ordinal < 0:
+        raise InvalidBmcEncoding("ordinal must be non-negative.")
+    if not isinstance(accepted_cases, (list, tuple)):
+        raise InvalidBmcEncoding("accepted_cases must be a sequence.")
+    accepted = tuple(accepted_cases)
+    if not all(isinstance(item, CycleCase) for item in accepted):
+        raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
+    for case in accepted:
+        if case.source_state_id != source.source_state_id:
+            raise InvalidBmcEncoding("accepted case source id must match delta source.")
+        if case.source_state_path != source.source_state_path:
+            raise InvalidBmcEncoding(
+                "accepted case source path must match delta source."
+            )
+    if not isinstance(build_diagnostic_conditions, (list, tuple)):
+        raise InvalidBmcEncoding("build_diagnostic_conditions must be a sequence.")
+    diagnostics = tuple(build_diagnostic_conditions)
+    if not all(isinstance(item, BoolTemplate) for item in diagnostics):
+        raise InvalidBmcEncoding(
+            "build_diagnostic_conditions must contain BoolTemplate objects."
+        )
+    if not isinstance(failed_conditions, (list, tuple)):
+        raise InvalidBmcEncoding("failed_conditions must be a sequence.")
+    failed = tuple(failed_conditions)
+    if not all(isinstance(item, BoolTemplate) for item in failed):
+        raise InvalidBmcEncoding("failed_conditions must contain BoolTemplate objects.")
+    excluded = [case.condition for case in accepted]
+    excluded.extend(diagnostics)
+    condition = BoolTemplate.not_(BoolTemplate.or_(*excluded))
+    return CycleCase(
+        "delta",
+        source.source_state_id,
+        source.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        _case_label(
+            source.source_state_path,
+            "delta",
+            DIAGNOSTIC_CASE_PATH,
+            ordinal,
+        ),
+        condition,
+        carry_var_updates(domain),
+        failed_conditions=failed,
+        domain=domain,
+    )
+
+
+def verify_boolean_partition(
+    buckets: Sequence[BoolTemplate],
+    variables: Optional[Sequence[str]] = None,
+    max_assignments: int = 4096,
+) -> PartitionCheckResult:
+    """Verify that boolean buckets are complete and pairwise disjoint.
+
+    This helper is deliberately a self-check.  It enumerates a small synthetic
+    boolean universe and raises :class:`BmcBuildError` on gaps, overlaps, or an
+    assignment budget overflow.  It returns only a summary and never returns
+    solver clauses.
+
+    :param buckets: Boolean bucket conditions.
+    :type buckets: Sequence[BoolTemplate]
+    :param variables: Optional explicit universe variables, defaults to the
+        union of bucket atoms.
+    :type variables: Sequence[str], optional
+    :param max_assignments: Maximum truth-table assignments, defaults to
+        ``4096``.
+    :type max_assignments: int, optional
+    :return: Partition self-check summary.
+    :rtype: PartitionCheckResult
+    :raises BmcBuildError: If the partition is not exactly-one or cannot be
+        checked.
+
+    Example::
+
+        >>> a = BoolTemplate.atom('a')
+        >>> verify_boolean_partition((a, BoolTemplate.not_(a))).assignment_count
+        2
+    """
+    if not isinstance(buckets, (list, tuple)):
+        raise BmcBuildError("partition buckets must be a sequence.")
+    items = tuple(buckets)
+    if not items:
+        raise BmcBuildError("partition must contain at least one bucket.")
+    if not all(isinstance(item, BoolTemplate) for item in items):
+        raise BmcBuildError("partition buckets must be BoolTemplate objects.")
+    if isinstance(max_assignments, bool) or not isinstance(max_assignments, int):
+        raise BmcBuildError("max_assignments must be a positive integer.")
+    if max_assignments <= 0:
+        raise BmcBuildError("max_assignments must be a positive integer.")
+
+    if variables is None:
+        names = sorted(
+            set(itertools.chain.from_iterable(item.variables for item in items))
+        )
+    else:
+        if not isinstance(variables, (list, tuple)):
+            raise BmcBuildError("partition variables must be a sequence.")
+        raw_names = tuple(variables)
+        if not all(isinstance(name, str) and name for name in raw_names):
+            raise BmcBuildError("partition variables must be non-empty strings.")
+        names = sorted(set(raw_names))
+    assignment_count = 2 ** len(names)
+    if assignment_count > max_assignments:
+        raise BmcBuildError("partition check exceeded assignment budget.")
+
+    for values in itertools.product((False, True), repeat=len(names)):
+        assignment = dict(zip(names, values))
+        true_indexes = [
+            index for index, item in enumerate(items) if item.evaluate(assignment)
+        ]
+        if len(true_indexes) != 1:
+            if true_indexes:
+                raise BmcBuildError(
+                    "partition buckets overlap at assignment %r: %r."
+                    % (assignment, true_indexes)
+                )
+            raise BmcBuildError("partition leaves a gap at assignment %r." % assignment)
+    return PartitionCheckResult(tuple(names), assignment_count, len(items))
+
+
+def verify_source_partition(
+    source: MacroStepSource,
+    success_cases: Sequence[CycleCase],
+    delta_cases: Sequence[CycleCase] = (),
+    build_diagnostic_conditions: Sequence[BoolTemplate] = (),
+    max_assignments: int = 4096,
+) -> PartitionCheckResult:
+    """Verify one source's local case partition.
+
+    :param source: Macro-step source profile.
+    :type source: MacroStepSource
+    :param success_cases: Ordinary success cases.
+    :type success_cases: Sequence[CycleCase]
+    :param delta_cases: Semantic delta cases, defaults to ``()``.
+    :type delta_cases: Sequence[CycleCase], optional
+    :param build_diagnostic_conditions: Build diagnostic conditions, defaults
+        to ``()``.
+    :type build_diagnostic_conditions: Sequence[BoolTemplate], optional
+    :param max_assignments: Maximum truth-table assignments, defaults to
+        ``4096``.
+    :type max_assignments: int, optional
+    :return: Partition self-check summary.
+    :rtype: PartitionCheckResult
+    :raises BmcBuildError: If the buckets are not complete and disjoint.
+    :raises InvalidBmcEncoding: If delta cases are used for a source that does
+        not allow semantic delta.
+
+    Example::
+
+        >>> source = MacroStepSource('entry', 'initial', 0, 'Root')
+        >>> delta = CycleCase(
+        ...     'delta', 0, 'Root', -2, '__diagnostic__',
+        ...     'Root::delta::__diagnostic__::0', BoolTemplate.true(), ()
+        ... )
+        >>> verify_source_partition(source, (), (delta,)).bucket_count
+        1
+    """
+    if not isinstance(source, MacroStepSource):
+        raise InvalidBmcEncoding("source must be MacroStepSource.")
+    if not isinstance(success_cases, (list, tuple)):
+        raise InvalidBmcEncoding("success_cases must be a sequence.")
+    if not isinstance(delta_cases, (list, tuple)):
+        raise InvalidBmcEncoding("delta_cases must be a sequence.")
+    if not isinstance(build_diagnostic_conditions, (list, tuple)):
+        raise InvalidBmcEncoding("build_diagnostic_conditions must be a sequence.")
+    success = tuple(success_cases)
+    delta = tuple(delta_cases)
+    diagnostics = tuple(build_diagnostic_conditions)
+    if delta and not source.allows_semantic_delta:
+        raise InvalidBmcEncoding("delta cases require an entry source.")
+    for case in success + delta:
+        if not isinstance(case, CycleCase):
+            raise InvalidBmcEncoding("partition cases must be CycleCase objects.")
+        if case.source_state_id != source.source_state_id:
+            raise InvalidBmcEncoding("partition case source id mismatch.")
+        if case.source_state_path != source.source_state_path:
+            raise InvalidBmcEncoding("partition case source path mismatch.")
+    for case in success:
+        if case.kind == "delta":
+            raise InvalidBmcEncoding("success_cases must not contain delta cases.")
+    for case in delta:
+        if case.kind != "delta":
+            raise InvalidBmcEncoding("delta_cases may only contain delta cases.")
+    if not all(isinstance(item, BoolTemplate) for item in diagnostics):
+        raise InvalidBmcEncoding(
+            "build_diagnostic_conditions must contain BoolTemplate objects."
+        )
+    buckets = [case.condition for case in success]
+    buckets.extend(case.condition for case in delta)
+    if diagnostics:
+        buckets.append(BoolTemplate.or_(*diagnostics))
+    return verify_boolean_partition(buckets, max_assignments=max_assignments)
+
+
+__all__ = [
+    "BoolTemplate",
+    "EventUse",
+    "VarUpdate",
+    "CycleCase",
+    "PartitionCheckResult",
+    "MacroStepFormal",
+    "carry_var_updates",
+    "var_update_for",
+    "build_var_updates",
+    "case_antecedent_condition",
+    "terminated_absorb_case",
+    "diagnostic_absorb_case",
+    "build_fallback_case",
+    "build_semantic_delta_case",
+    "verify_boolean_partition",
+    "verify_source_partition",
+]

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -15,10 +15,12 @@ Design contracts:
   gamma`` before emitting ``A => R``.
 * :class:`VarUpdate` entries are explicit and complete.  Carry-over variables
   are represented as writeback entries rather than left unconstrained.
-* Fallback and semantic-delta helpers subtract only ordinary accepted
-  success-case conditions and the build-diagnostic conditions required by the
-  issue design.  Failed candidate metadata is kept for diagnostics and never
-  removes uncovered regions.
+* Fallback and semantic-delta helpers subtract only their source-appropriate
+  ordinary accepted success-case conditions: stable fallback accepts transition
+  cases only, while entry semantic delta accepts transition or initial cases.
+  Build-diagnostic conditions are excluded only where the issue design requires
+  them.  Failed candidate metadata is kept for diagnostics and never removes
+  uncovered regions.
 * Partition verification is a build-time/test-time self-check.  It returns a
   diagnostic summary or raises :class:`pyfcstm.bmc.errors.BmcBuildError`; it
   never produces clauses for ``Core_N`` or ``Phi_N``.
@@ -642,14 +644,18 @@ def _normalize_accepted_cases(
     accepted_cases: Sequence["CycleCase"],
     source: MacroStepSource,
     helper_name: str,
+    allowed_kinds: Sequence[str],
 ) -> Tuple["CycleCase", ...]:
     if not isinstance(accepted_cases, (list, tuple)):
         raise InvalidBmcEncoding("accepted_cases must be a sequence.")
     accepted = tuple(accepted_cases)
+    allowed = tuple(allowed_kinds)
+    if not allowed or any(kind not in _ACCEPTED_CASE_KINDS for kind in allowed):
+        raise InvalidBmcEncoding("accepted case kind policy is invalid.")
     if not all(isinstance(item, CycleCase) for item in accepted):
         raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
     for case in accepted:
-        if case.kind not in _ACCEPTED_CASE_KINDS:
+        if case.kind not in allowed:
             raise InvalidBmcEncoding(
                 "accepted_cases for %s may only contain ordinary accepted cases."
                 % helper_name
@@ -1236,7 +1242,8 @@ def build_fallback_case(
     :type domain: BmcDomain
     :param source: Stable leaf source.
     :type source: MacroStepSource
-    :param accepted_cases: Accepted ordinary cases for the same source.
+    :param accepted_cases: Accepted transition cases for the same stable leaf
+        source.
     :type accepted_cases: Sequence[CycleCase]
     :param failed_conditions: Diagnostic-only failed conditions, defaults to
         ``()``.
@@ -1262,7 +1269,12 @@ def build_fallback_case(
     ordinal = _validate_index(ordinal, "ordinal")
     if ordinal < 0:
         raise InvalidBmcEncoding("ordinal must be non-negative.")
-    accepted = _normalize_accepted_cases(accepted_cases, source, "fallback")
+    accepted = _normalize_accepted_cases(
+        accepted_cases,
+        source,
+        "fallback",
+        ("transition",),
+    )
     if not isinstance(failed_conditions, (list, tuple)):
         raise InvalidBmcEncoding("failed_conditions must be a sequence.")
     failed = tuple(failed_conditions)
@@ -1310,7 +1322,8 @@ def build_semantic_delta_case(
     :type domain: BmcDomain
     :param source: Initial entry source.
     :type source: MacroStepSource
-    :param accepted_cases: Accepted ordinary success cases.
+    :param accepted_cases: Accepted transition or initial success cases for the
+        same entry source.
     :type accepted_cases: Sequence[CycleCase]
     :param build_diagnostic_conditions: Build diagnostic conditions excluded
         from semantic delta, defaults to ``()``.
@@ -1339,7 +1352,12 @@ def build_semantic_delta_case(
     ordinal = _validate_index(ordinal, "ordinal")
     if ordinal < 0:
         raise InvalidBmcEncoding("ordinal must be non-negative.")
-    accepted = _normalize_accepted_cases(accepted_cases, source, "delta")
+    accepted = _normalize_accepted_cases(
+        accepted_cases,
+        source,
+        "delta",
+        ("transition", "initial"),
+    )
     if not isinstance(build_diagnostic_conditions, (list, tuple)):
         raise InvalidBmcEncoding("build_diagnostic_conditions must be a sequence.")
     diagnostics = tuple(build_diagnostic_conditions)

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -274,11 +274,17 @@ class BoolTemplate:
             ('a', 'b')
         """
         if self.kind == "atom":
-            return (self.name or "",)
+            return (self._atom_name(),)
         values = set()
         for operand in self.operands:
             values.update(operand.variables)
         return tuple(sorted(values))
+
+    def _atom_name(self) -> str:
+        name = self.name
+        if name is None:
+            raise BmcBuildError("atom template is missing a name.")
+        return name
 
     def evaluate(self, values: Mapping[str, bool]) -> bool:
         """Evaluate this template on a boolean assignment.
@@ -300,11 +306,12 @@ class BoolTemplate:
         if self.kind == "false":
             return False
         if self.kind == "atom":
-            if self.name not in values:
-                raise BmcBuildError("missing boolean assignment for %r." % self.name)
-            value = values[self.name]
+            name = self._atom_name()
+            if name not in values:
+                raise BmcBuildError("missing boolean assignment for %r." % name)
+            value = values[name]
             if not isinstance(value, bool):
-                raise BmcBuildError("boolean assignment %r must be bool." % self.name)
+                raise BmcBuildError("boolean assignment %r must be bool." % name)
             return value
         if self.kind == "not":
             return not self.operands[0].evaluate(values)
@@ -325,9 +332,9 @@ class BoolTemplate:
             >>> BoolTemplate.atom('gamma').to_canonical()['name']
             'gamma'
         """
-        result = {"node": "bool_template", "kind": self.kind}
+        result: _CanonicalDict = {"node": "bool_template", "kind": self.kind}
         if self.kind == "atom":
-            result["name"] = self.name
+            result["name"] = self._atom_name()
         if self.operands:
             result["operands"] = [item.to_canonical() for item in self.operands]
         return result
@@ -657,8 +664,8 @@ def _normalize_accepted_cases(
     for case in accepted:
         if case.kind not in allowed:
             raise InvalidBmcEncoding(
-                "accepted_cases for %s may only contain ordinary accepted cases."
-                % helper_name
+                "accepted_cases for %s may only contain ordinary accepted "
+                "cases with kinds %r." % (helper_name, allowed)
             )
         if case.is_diagnostic:
             raise InvalidBmcEncoding(

--- a/pyfcstm/bmc/source.py
+++ b/pyfcstm/bmc/source.py
@@ -1,0 +1,547 @@
+"""Macro-step source profiles for FCSTM bounded model checking.
+
+A macro-step source describes the state boundary from which one symbolic
+``cycle`` starts before the later macro expander enumerates concrete
+:class:`pyfcstm.bmc.macro.CycleCase` objects.  The source layer is deliberately
+solver-independent: it consumes the numbered :class:`pyfcstm.bmc.domain.BmcDomain`
+snapshot and records only stable ids, display paths, source kind, and origin.
+Initial ``where`` predicates stay outside this module and are compiled into the
+initial-frame formula by later query/binder layers.
+
+Design contracts:
+
+* ``entry`` sources are initial-only and model cold entry or hot non-stoppable
+  states whose uncovered branch may become semantic diagnostic delta.
+* ``stable_leaf`` sources point at non-sentinel stoppable leaves and use the
+  same macro-step semantics for initial hot starts and recurrence frames.
+* ``terminated`` and ``diagnostic`` sources use fixed sentinel ids and reserved
+  case-label paths so user states with similar names cannot impersonate them.
+* Constructors validate against :class:`pyfcstm.bmc.domain.BmcDomain` eagerly;
+  direct dataclass construction remains possible for tests but still performs
+  the same validation when a domain is supplied.
+
+The module contains:
+
+* :class:`MacroStepSource` - Immutable source profile consumed by macro-step
+  case expansion.
+* :func:`entry_source`, :func:`stable_leaf_source`,
+  :func:`terminated_source`, and :func:`diagnostic_source` - Validated source
+  constructors.
+* :func:`source_from_initial_spec` - Convert query initial specifications into
+  source profiles without reading the initial predicate.
+
+Example::
+
+    >>> from pyfcstm.bmc.domain import build_bmc_domain
+    >>> from pyfcstm.bmc.query import InitialSpec
+    >>> from pyfcstm.bmc.source import source_from_initial_spec
+    >>> from pyfcstm.model import load_state_machine_from_text
+    >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+    >>> source = source_from_initial_spec(domain, InitialSpec())
+    >>> source.kind
+    'entry'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Union
+
+from pyfcstm.bmc.domain import (
+    STATE_DIAGNOSTIC_ID,
+    STATE_TERMINATE_ID,
+    BmcDomain,
+    StateDomainEntry,
+)
+from pyfcstm.bmc.errors import InvalidBmcDomain, InvalidBmcEncoding, InvalidBmcQuery
+from pyfcstm.bmc.query import InitialSpec
+
+TERMINATE_CASE_PATH = "__terminate__"
+DIAGNOSTIC_CASE_PATH = "__diagnostic__"
+
+_CanonicalDict = Dict[str, Any]
+_StateRef = Union[int, str, StateDomainEntry]
+_SOURCE_KINDS = {"entry", "stable_leaf", "terminated", "diagnostic"}
+_SOURCE_ORIGINS = {"initial", "recurrence"}
+_RESERVED_CASE_PATHS = {TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH}
+
+
+def _validate_choice(value: object, choices: set, field_name: str) -> str:
+    if not isinstance(value, str) or value not in choices:
+        raise InvalidBmcEncoding("Unsupported %s: %r." % (field_name, value))
+    return value
+
+
+def _require_non_empty_string(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise InvalidBmcEncoding("%s must be a non-empty string." % field_name)
+    return value
+
+
+def _validate_state_id(value: object, field_name: str = "state id") -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InvalidBmcEncoding("%s must be an integer." % field_name)
+    return value
+
+
+def _resolve_state_entry(domain: BmcDomain, state: _StateRef) -> StateDomainEntry:
+    if not isinstance(domain, BmcDomain):
+        raise InvalidBmcEncoding("domain must be BmcDomain.")
+    try:
+        if isinstance(state, StateDomainEntry):
+            return domain.state_by_id(state.id)
+        if isinstance(state, str):
+            return domain.state_by_path(state)
+        if isinstance(state, bool) or not isinstance(state, int):
+            raise InvalidBmcEncoding("state must be a state id, path, or entry.")
+        return domain.state_by_id(state)
+    except InvalidBmcDomain as err:
+        # InvalidBmcDomain: BmcDomain lookup rejects unknown state ids or paths
+        # supplied to a macro-step source constructor.
+        raise InvalidBmcEncoding(str(err)) from err
+
+
+def _root_state_entry(domain: BmcDomain) -> StateDomainEntry:
+    if not isinstance(domain, BmcDomain):
+        raise InvalidBmcEncoding("domain must be BmcDomain.")
+    roots = [entry for entry in domain.states if entry.is_root]
+    if len(roots) != 1:
+        raise InvalidBmcEncoding("domain must contain exactly one model root state.")
+    return roots[0]
+
+
+@dataclass(frozen=True)
+class MacroStepSource:
+    """Source profile for one symbolic macro-step.
+
+    :param kind: Source kind: ``"entry"``, ``"stable_leaf"``,
+        ``"terminated"``, or ``"diagnostic"``.
+    :type kind: str
+    :param origin: ``"initial"`` for the ``F_0 -> F_1`` source, or
+        ``"recurrence"`` for recurrence-frame sources.
+    :type origin: str
+    :param source_state_id: Domain state id for the source.  Sentinel sources
+        use the fixed negative sentinel ids.
+    :type source_state_id: int
+    :param source_state_path: Source path used by macro-case labels.  Sentinel
+        sources use reserved paths such as ``"__terminate__"``.
+    :type source_state_path: str
+    :param domain: Optional domain used for eager validation, defaults to
+        ``None``.
+    :type domain: BmcDomain, optional
+
+    :ivar kind: Source kind.
+    :vartype kind: str
+    :ivar origin: Source origin.
+    :vartype origin: str
+    :ivar source_state_id: Domain state id.
+    :vartype source_state_id: int
+    :ivar source_state_path: Macro-case source path.
+    :vartype source_state_path: str
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.bmc.source import entry_source
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> entry_source(domain).allows_semantic_delta
+        True
+    """
+
+    kind: str
+    origin: str
+    source_state_id: int
+    source_state_path: str
+    domain: Optional[BmcDomain] = field(default=None, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        kind = _validate_choice(self.kind, _SOURCE_KINDS, "source kind")
+        origin = _validate_choice(self.origin, _SOURCE_ORIGINS, "source origin")
+        state_id = _validate_state_id(self.source_state_id, "source_state_id")
+        source_path = _require_non_empty_string(
+            self.source_state_path,
+            "source_state_path",
+        )
+        object.__setattr__(self, "kind", kind)
+        object.__setattr__(self, "origin", origin)
+        object.__setattr__(self, "source_state_id", state_id)
+        object.__setattr__(self, "source_state_path", source_path)
+        self._validate_intrinsic_shape()
+
+        if self.domain is not None:
+            if not isinstance(self.domain, BmcDomain):
+                raise InvalidBmcEncoding("domain must be BmcDomain.")
+            self._validate_against_domain(self.domain)
+
+    def _validate_intrinsic_shape(self) -> None:
+        if self.kind == "entry":
+            if self.origin != "initial":
+                raise InvalidBmcEncoding("entry source is initial-only.")
+            if self.source_state_id < 0:
+                raise InvalidBmcEncoding("entry source must use a model state id.")
+            if self.source_state_path in _RESERVED_CASE_PATHS:
+                raise InvalidBmcEncoding(
+                    "entry source must not use reserved macro-step paths."
+                )
+        elif self.kind == "stable_leaf":
+            if self.source_state_id < 0:
+                raise InvalidBmcEncoding(
+                    "stable_leaf source must use a model state id."
+                )
+            if self.source_state_path in _RESERVED_CASE_PATHS:
+                raise InvalidBmcEncoding(
+                    "stable_leaf source must not use reserved macro-step paths."
+                )
+        elif self.kind == "terminated":
+            if self.source_state_id != STATE_TERMINATE_ID:
+                raise InvalidBmcEncoding(
+                    "terminated source must use the fixed sentinel id."
+                )
+            if self.source_state_path != TERMINATE_CASE_PATH:
+                raise InvalidBmcEncoding(
+                    "terminated source must use the reserved macro-step path."
+                )
+        elif self.kind == "diagnostic":
+            if self.source_state_id != STATE_DIAGNOSTIC_ID:
+                raise InvalidBmcEncoding(
+                    "diagnostic source must use the fixed sentinel id."
+                )
+            if self.source_state_path != DIAGNOSTIC_CASE_PATH:
+                raise InvalidBmcEncoding(
+                    "diagnostic source must use the reserved macro-step path."
+                )
+
+    def _validate_against_domain(self, domain: BmcDomain) -> None:
+        if self.kind == "terminated":
+            self._validate_sentinel_source(
+                domain,
+                STATE_TERMINATE_ID,
+                TERMINATE_CASE_PATH,
+                "terminated",
+            )
+            return
+        if self.kind == "diagnostic":
+            self._validate_sentinel_source(
+                domain,
+                STATE_DIAGNOSTIC_ID,
+                DIAGNOSTIC_CASE_PATH,
+                "diagnostic",
+            )
+            return
+
+        try:
+            entry = domain.state_by_id(self.source_state_id)
+        except InvalidBmcDomain as err:
+            # InvalidBmcDomain: BmcDomain lookup rejects unknown source ids
+            # supplied through direct MacroStepSource construction.
+            raise InvalidBmcEncoding(str(err)) from err
+        if self.source_state_path != entry.path:
+            raise InvalidBmcEncoding("Source path does not match source state id.")
+        if entry.path in _RESERVED_CASE_PATHS:
+            raise InvalidBmcEncoding(
+                "Model source path must not use reserved macro-step paths."
+            )
+        if self.kind == "entry":
+            if entry.is_sentinel:
+                raise InvalidBmcEncoding(
+                    "Model source kind cannot use sentinel states."
+                )
+            if self.origin != "initial":
+                raise InvalidBmcEncoding("entry source is initial-only.")
+            if entry.is_stoppable and not entry.is_root:
+                raise InvalidBmcEncoding(
+                    "entry source must be root or non-stoppable model state."
+                )
+        elif self.kind == "stable_leaf":
+            if self.source_state_id not in domain.stable_state_ids:
+                raise InvalidBmcEncoding(
+                    "stable_leaf source must use a stable domain state id."
+                )
+            if entry.is_sentinel or entry.kind != "leaf" or not entry.is_stoppable:
+                raise InvalidBmcEncoding(
+                    "stable_leaf source must be a non-sentinel stoppable leaf."
+                )
+
+    def _validate_sentinel_source(
+        self,
+        domain: BmcDomain,
+        expected_id: int,
+        expected_path: str,
+        source_name: str,
+    ) -> None:
+        if self.source_state_id != expected_id:
+            raise InvalidBmcEncoding(
+                "%s source must use the fixed sentinel id." % source_name
+            )
+        try:
+            domain.state_by_id(expected_id)
+        except InvalidBmcDomain as err:
+            # InvalidBmcDomain: BmcDomain lookup rejects malformed sentinel
+            # metadata while validating an absorb source.
+            raise InvalidBmcEncoding(str(err)) from err
+        if self.source_state_path != expected_path:
+            raise InvalidBmcEncoding(
+                "%s source must use the reserved macro-step path." % source_name
+            )
+
+    @property
+    def allows_semantic_delta(self) -> bool:
+        """Return whether this source may emit semantic delta cases.
+
+        :return: ``True`` only for initial entry sources.
+        :rtype: bool
+
+        Example::
+
+            >>> MacroStepSource('entry', 'initial', 0, 'Root').allows_semantic_delta
+            True
+        """
+        return self.kind == "entry"
+
+    @property
+    def uses_stable_fallback(self) -> bool:
+        """Return whether this source must use stable leaf fallback.
+
+        :return: ``True`` for ``"stable_leaf"`` sources.
+        :rtype: bool
+
+        Example::
+
+            >>> MacroStepSource('stable_leaf', 'recurrence', 1, 'Root.A').uses_stable_fallback
+            True
+        """
+        return self.kind == "stable_leaf"
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable source dictionary.
+
+        :return: Canonical source profile.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> MacroStepSource('entry', 'initial', 0, 'Root').to_canonical()['kind']
+            'entry'
+        """
+        return {
+            "node": "macro_step_source",
+            "kind": self.kind,
+            "origin": self.origin,
+            "source_state_id": self.source_state_id,
+            "source_state_path": self.source_state_path,
+            "allows_semantic_delta": self.allows_semantic_delta,
+            "uses_stable_fallback": self.uses_stable_fallback,
+        }
+
+    def to_semantic_canonical(self, include_origin: bool = True) -> _CanonicalDict:
+        """Return canonical source semantics for equivalence checks.
+
+        :param include_origin: Whether to include the ``origin`` field,
+            defaults to ``True``.
+        :type include_origin: bool, optional
+        :return: Canonical semantic source profile.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> source = MacroStepSource('stable_leaf', 'initial', 1, 'Root.A')
+            >>> source.to_semantic_canonical(include_origin=False)['kind']
+            'stable_leaf'
+        """
+        result = self.to_canonical()
+        if not include_origin:
+            result = dict(result)
+            result.pop("origin", None)
+        return result
+
+
+def entry_source(
+    domain: BmcDomain,
+    state: Optional[_StateRef] = None,
+    origin: str = "initial",
+) -> MacroStepSource:
+    """Construct an initial-only entry source.
+
+    ``state`` defaults to the model root, which represents cold entry even when
+    the root is also a leaf.  Explicit non-root stoppable leaves should be
+    constructed through :func:`stable_leaf_source` instead.
+
+    :param domain: Domain snapshot that owns the source state.
+    :type domain: BmcDomain
+    :param state: Source state id, path, or entry, defaults to the root state.
+    :type state: int or str or StateDomainEntry, optional
+    :param origin: Source origin, defaults to ``"initial"``.
+    :type origin: str, optional
+    :return: Validated entry source.
+    :rtype: MacroStepSource
+    :raises InvalidBmcEncoding: If the source is not an initial entry source.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> entry_source(domain).kind
+        'entry'
+    """
+    entry = (
+        _root_state_entry(domain)
+        if state is None
+        else _resolve_state_entry(domain, state)
+    )
+    return MacroStepSource("entry", origin, entry.id, entry.path, domain=domain)
+
+
+def stable_leaf_source(
+    domain: BmcDomain,
+    state: _StateRef,
+    origin: str = "recurrence",
+) -> MacroStepSource:
+    """Construct a stable leaf source.
+
+    :param domain: Domain snapshot that owns the source state.
+    :type domain: BmcDomain
+    :param state: Stoppable leaf state id, path, or entry.
+    :type state: int or str or StateDomainEntry
+    :param origin: Source origin, defaults to ``"recurrence"``.
+    :type origin: str, optional
+    :return: Validated stable leaf source.
+    :rtype: MacroStepSource
+    :raises InvalidBmcEncoding: If ``state`` is not a non-sentinel stoppable
+        leaf in ``domain``.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> stable_leaf_source(domain, 'Root').uses_stable_fallback
+        True
+    """
+    entry = _resolve_state_entry(domain, state)
+    return MacroStepSource("stable_leaf", origin, entry.id, entry.path, domain=domain)
+
+
+def terminated_source(
+    domain: BmcDomain,
+    origin: str = "recurrence",
+) -> MacroStepSource:
+    """Construct a terminated sentinel absorb source.
+
+    :param domain: Domain snapshot containing the fixed terminate sentinel.
+    :type domain: BmcDomain
+    :param origin: Source origin, defaults to ``"recurrence"``.
+    :type origin: str, optional
+    :return: Validated terminated source.
+    :rtype: MacroStepSource
+    :raises InvalidBmcEncoding: If the domain sentinel metadata is missing.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain, STATE_TERMINATE_ID
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> terminated_source(domain).source_state_id == STATE_TERMINATE_ID
+        True
+    """
+    return MacroStepSource(
+        "terminated",
+        origin,
+        STATE_TERMINATE_ID,
+        TERMINATE_CASE_PATH,
+        domain=domain,
+    )
+
+
+def diagnostic_source(
+    domain: BmcDomain,
+    origin: str = "recurrence",
+) -> MacroStepSource:
+    """Construct a diagnostic sentinel absorb source.
+
+    This source starts at the diagnostic sentinel and is distinct from a
+    semantic ``delta`` case that targets the diagnostic sentinel from an entry
+    source.
+
+    :param domain: Domain snapshot containing the fixed diagnostic sentinel.
+    :type domain: BmcDomain
+    :param origin: Source origin, defaults to ``"recurrence"``.
+    :type origin: str, optional
+    :return: Validated diagnostic source.
+    :rtype: MacroStepSource
+    :raises InvalidBmcEncoding: If the domain sentinel metadata is missing.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain, STATE_DIAGNOSTIC_ID
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> diagnostic_source(domain).source_state_id == STATE_DIAGNOSTIC_ID
+        True
+    """
+    return MacroStepSource(
+        "diagnostic",
+        origin,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        domain=domain,
+    )
+
+
+def source_from_initial_spec(
+    domain: BmcDomain,
+    initial_spec: InitialSpec,
+) -> MacroStepSource:
+    """Build the initial macro-step source for an initial specification.
+
+    The optional ``InitialSpec.predicate`` is intentionally ignored here.  It
+    belongs to the initial-frame condition ``I_0`` and must not affect source
+    kind, fallback partition, or any future :class:`pyfcstm.bmc.macro.CycleCase`
+    condition.
+
+    :param domain: Domain snapshot used to resolve initial state paths.
+    :type domain: BmcDomain
+    :param initial_spec: Parser-independent initial specification.
+    :type initial_spec: InitialSpec
+    :return: Initial macro-step source.
+    :rtype: MacroStepSource
+    :raises InvalidBmcQuery: If ``initial_spec`` has an unsupported mode.
+    :raises InvalidBmcEncoding: If the referenced state cannot be used as a
+        source profile.
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.bmc.query import InitialSpec
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> source_from_initial_spec(
+        ...     domain, InitialSpec(mode='state', state_path='Root')
+        ... ).kind
+        'stable_leaf'
+    """
+    if not isinstance(initial_spec, InitialSpec):
+        raise InvalidBmcQuery("initial_spec must be InitialSpec.")
+    if initial_spec.mode == "cold":
+        return entry_source(domain, origin="initial")
+    if initial_spec.mode == "terminated":
+        return terminated_source(domain, origin="initial")
+    if initial_spec.mode == "state":
+        entry = _resolve_state_entry(domain, initial_spec.state_path or "")
+        if entry.is_stoppable and not entry.is_sentinel:
+            return stable_leaf_source(domain, entry, origin="initial")
+        return entry_source(domain, entry, origin="initial")
+    raise InvalidBmcQuery("unknown initial source mode: %r." % (initial_spec.mode,))
+
+
+__all__ = [
+    "TERMINATE_CASE_PATH",
+    "DIAGNOSTIC_CASE_PATH",
+    "MacroStepSource",
+    "entry_source",
+    "stable_leaf_source",
+    "terminated_source",
+    "diagnostic_source",
+    "source_from_initial_spec",
+]

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -59,13 +59,65 @@ def test_bmc_public_api_exports_exact_names():
         "EventInputRef",
         "BmcDomain",
         "build_bmc_domain",
+        "TERMINATE_CASE_PATH",
+        "DIAGNOSTIC_CASE_PATH",
+        "MacroStepSource",
+        "entry_source",
+        "stable_leaf_source",
+        "terminated_source",
+        "diagnostic_source",
+        "source_from_initial_spec",
+        "BoolTemplate",
+        "EventUse",
+        "VarUpdate",
+        "CycleCase",
+        "PartitionCheckResult",
+        "MacroStepFormal",
+        "carry_var_updates",
+        "var_update_for",
+        "build_var_updates",
+        "case_antecedent_condition",
+        "terminated_absorb_case",
+        "diagnostic_absorb_case",
+        "build_fallback_case",
+        "build_semantic_delta_case",
+        "verify_boolean_partition",
+        "verify_source_partition",
     }
 
     assert set(bmc.__all__) == expected
-    for name in expected - {"STATE_TERMINATE_ID", "STATE_DIAGNOSTIC_ID"}:
+    constant_names = {
+        "STATE_TERMINATE_ID",
+        "STATE_DIAGNOSTIC_ID",
+        "TERMINATE_CASE_PATH",
+        "DIAGNOSTIC_CASE_PATH",
+    }
+    function_names = {
+        "entry_source",
+        "stable_leaf_source",
+        "terminated_source",
+        "diagnostic_source",
+        "source_from_initial_spec",
+        "carry_var_updates",
+        "var_update_for",
+        "build_var_updates",
+        "case_antecedent_condition",
+        "terminated_absorb_case",
+        "diagnostic_absorb_case",
+        "build_fallback_case",
+        "build_semantic_delta_case",
+        "verify_boolean_partition",
+        "verify_source_partition",
+        "build_bmc_domain",
+    }
+    for name in expected - constant_names - function_names:
         assert getattr(bmc, name).__name__ == name
+    for name in function_names:
+        assert callable(getattr(bmc, name))
     assert bmc.STATE_TERMINATE_ID == -1
     assert bmc.STATE_DIAGNOSTIC_ID == -2
+    assert bmc.TERMINATE_CASE_PATH == "__terminate__"
+    assert bmc.DIAGNOSTIC_CASE_PATH == "__diagnostic__"
 
 
 @pytest.mark.unittest
@@ -75,6 +127,8 @@ def test_submodule_all_exports_are_exact():
     ast = importlib.import_module("pyfcstm.bmc.ast")
     query = importlib.import_module("pyfcstm.bmc.query")
     domain = importlib.import_module("pyfcstm.bmc.domain")
+    source = importlib.import_module("pyfcstm.bmc.source")
+    macro = importlib.import_module("pyfcstm.bmc.macro")
 
     assert set(errors.__all__) == {
         "BmcError",
@@ -130,6 +184,34 @@ def test_submodule_all_exports_are_exact():
         "BmcDomain",
         "build_bmc_domain",
     }
+    assert set(source.__all__) == {
+        "TERMINATE_CASE_PATH",
+        "DIAGNOSTIC_CASE_PATH",
+        "MacroStepSource",
+        "entry_source",
+        "stable_leaf_source",
+        "terminated_source",
+        "diagnostic_source",
+        "source_from_initial_spec",
+    }
+    assert set(macro.__all__) == {
+        "BoolTemplate",
+        "EventUse",
+        "VarUpdate",
+        "CycleCase",
+        "PartitionCheckResult",
+        "MacroStepFormal",
+        "carry_var_updates",
+        "var_update_for",
+        "build_var_updates",
+        "case_antecedent_condition",
+        "terminated_absorb_case",
+        "diagnostic_absorb_case",
+        "build_fallback_case",
+        "build_semantic_delta_case",
+        "verify_boolean_partition",
+        "verify_source_partition",
+    }
 
 
 @pytest.mark.unittest
@@ -149,7 +231,8 @@ def test_bmc_import_does_not_load_verify_modules():
     code = (
         "import sys; "
         "import pyfcstm.bmc; "
-        "print(any(name.startswith('pyfcstm.verify') for name in sys.modules))"
+        "print(any(name.startswith('pyfcstm.verify') for name in sys.modules)); "
+        "print('z3' in sys.modules)"
     )
 
     result = subprocess.run(
@@ -160,4 +243,4 @@ def test_bmc_import_does_not_load_verify_modules():
         universal_newlines=True,
     )
 
-    assert result.stdout.strip() == "False"
+    assert result.stdout.splitlines() == ["False", "False"]

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -393,6 +393,89 @@ def test_fallback_and_delta_helpers_accept_only_ordinary_success_cases(macro_dom
 
 
 @pytest.mark.unittest
+def test_macro_step_formal_revalidates_domainless_cases_against_source_domain(
+    macro_domain,
+):
+    """Domain-backed formals reject case target, event, and writeback bypasses."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    fallback = build_fallback_case(macro_domain, source, ())
+    carry = carry_var_updates(macro_domain)
+
+    bad_target = CycleCase(
+        "transition",
+        source.source_state_id,
+        source.source_state_path,
+        999,
+        "Missing.Target",
+        "%s::transition::Missing.Target::0" % source.source_state_path,
+        BoolTemplate.atom("bad_target"),
+        carry,
+    )
+    with pytest.raises(InvalidBmcEncoding, match="Unknown state id"):
+        MacroStepFormal(source, (bad_target, fallback))
+
+    bad_event = CycleCase(
+        "transition",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        "%s::transition::%s::1" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.atom("bad_event"),
+        carry,
+        used_events=(EventUse(999, "Missing.Event", "positive", "trigger"),),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="Unknown event id"):
+        MacroStepFormal(source, (bad_event, fallback))
+
+    missing_writeback = CycleCase(
+        "transition",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        "%s::transition::%s::2" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.atom("missing_writeback"),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="cover every persistent variable"):
+        MacroStepFormal(source, (missing_writeback, fallback))
+
+
+@pytest.mark.unittest
+def test_macro_step_formal_rejects_stable_leaf_diagnostic_success_case(
+    macro_domain,
+):
+    """Stable leaf formals cannot bypass entry-only delta/diagnostic buckets."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    diagnostic = CycleCase(
+        "diagnostic",
+        source.source_state_id,
+        source.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::diagnostic::%s::0" % (source.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.atom("diagnostic_success"),
+        carry_var_updates(macro_domain),
+        domain=macro_domain,
+    )
+    fallback = CycleCase(
+        "fallback",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        "%s::fallback::%s::0" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.not_(BoolTemplate.atom("diagnostic_success")),
+        carry_var_updates(macro_domain),
+        domain=macro_domain,
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="stable leaf success cases"):
+        MacroStepFormal(source, (diagnostic, fallback))
+
+
+@pytest.mark.unittest
 def test_macro_step_formal_rejects_illegal_delta_buckets_and_label_collisions(
     macro_domain,
 ):

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -1,0 +1,1000 @@
+"""Macro-step case contract tests for FCSTM BMC."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from pyfcstm.bmc import (
+    STATE_DIAGNOSTIC_ID,
+    STATE_TERMINATE_ID,
+    BmcBuildError,
+    InvalidBmcEncoding,
+    build_bmc_domain,
+)
+from pyfcstm.bmc.macro import (
+    BoolTemplate,
+    CycleCase,
+    EventUse,
+    MacroStepFormal,
+    VarUpdate,
+    build_fallback_case,
+    build_semantic_delta_case,
+    build_var_updates,
+    carry_var_updates,
+    case_antecedent_condition,
+    diagnostic_absorb_case,
+    terminated_absorb_case,
+    var_update_for,
+    verify_boolean_partition,
+    verify_source_partition,
+)
+from pyfcstm.bmc.source import (
+    DIAGNOSTIC_CASE_PATH,
+    TERMINATE_CASE_PATH,
+    diagnostic_source,
+    entry_source,
+    stable_leaf_source,
+    terminated_source,
+)
+from pyfcstm.model import load_state_machine_from_text
+
+
+@pytest.fixture()
+def macro_domain():
+    """Build a macro-contract fixture with variables and same-short-name events."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        def float y = 1.0;
+        state Root {
+            event Go;
+            state Plant {
+                event Ping;
+                state Idle;
+                state Busy;
+                [*] -> Idle;
+                Idle -> Busy :: Ping + Go;
+            }
+            state Backup {
+                event Ping;
+                state Idle;
+                [*] -> Idle;
+            }
+            [*] -> Plant;
+        }
+        """
+    )
+    return build_bmc_domain(model, bound=2)
+
+
+def make_case(
+    domain, source, label_kind="transition", condition=None, target_path=None, ordinal=0
+):
+    """Create a valid synthetic case for contract tests."""
+    if condition is None:
+        condition = BoolTemplate.atom("g%d" % ordinal)
+    if target_path is None:
+        target_path = source.source_state_path
+    target_id = domain.state_path_to_id(target_path)
+    return CycleCase(
+        label_kind,
+        source.source_state_id,
+        source.source_state_path,
+        target_id,
+        target_path,
+        "%s::%s::%s::%d" % (source.source_state_path, label_kind, target_path, ordinal),
+        condition,
+        carry_var_updates(domain),
+        domain=domain,
+    )
+
+
+@pytest.mark.unittest
+def test_cycle_case_condition_is_bare_gamma_and_source_guard_is_composed_later(
+    macro_domain,
+):
+    """CycleCase.condition excludes the pre-state source guard by contract."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    gamma = BoolTemplate.atom("trigger")
+    case = make_case(macro_domain, source, condition=gamma)
+
+    assert case.condition is gamma
+    assert case.condition.variables == ("trigger",)
+    assert (
+        case_antecedent_condition(case).to_canonical()
+        == BoolTemplate.and_(
+            BoolTemplate.atom("source_state:%d" % source.source_state_id),
+            gamma,
+        ).to_canonical()
+    )
+
+
+@pytest.mark.unittest
+def test_case_target_and_event_use_must_match_domain(macro_domain):
+    """Cases validate target ids and full event paths, including same short names."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    plant_ping = macro_domain.event_by_path("Root.Plant.Ping")
+    backup_ping = macro_domain.event_by_path("Root.Backup.Ping")
+
+    case = CycleCase(
+        "transition",
+        source.source_state_id,
+        source.source_state_path,
+        macro_domain.state_path_to_id("Root.Plant.Busy"),
+        "Root.Plant.Busy",
+        "%s::transition::Root.Plant.Busy::0" % source.source_state_path,
+        BoolTemplate.atom("ping"),
+        carry_var_updates(macro_domain),
+        used_events=(EventUse(plant_ping.id, plant_ping.path, "positive", "trigger"),),
+        domain=macro_domain,
+    )
+    assert case.used_events[0].event_id != backup_ping.id
+    assert case.used_events[0].path == "Root.Plant.Ping"
+
+    with pytest.raises(InvalidBmcEncoding, match="target path"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            macro_domain.state_path_to_id("Root.Plant.Busy"),
+            "Root.Backup.Idle",
+            "%s::transition::Root.Backup.Idle::0" % source.source_state_path,
+            BoolTemplate.atom("bad_target"),
+            carry_var_updates(macro_domain),
+            domain=macro_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="EventUse path"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::transition::%s::1"
+            % (source.source_state_path, source.source_state_path),
+            BoolTemplate.atom("bad_event"),
+            carry_var_updates(macro_domain),
+            used_events=(
+                EventUse(plant_ping.id, backup_ping.path, "positive", "trigger"),
+            ),
+            domain=macro_domain,
+        )
+
+
+@pytest.mark.unittest
+def test_var_update_requires_complete_explicit_persistent_var_coverage(macro_domain):
+    """Writeback recipes cover every persistent var and reject unknown or duplicate entries."""
+    complete = carry_var_updates(macro_domain)
+    assert [item.variable_name for item in complete] == ["x", "y"]
+    assert all(item.is_carry for item in complete)
+    assert build_var_updates(macro_domain, complete) == complete
+    assert var_update_for(macro_domain, "x", "x+1").to_canonical() == {
+        "node": "var_update",
+        "variable_id": macro_domain.variable_name_to_id("x"),
+        "variable_name": "x",
+        "expression": "x+1",
+        "is_carry": False,
+    }
+
+    with pytest.raises(InvalidBmcEncoding, match="cover every"):
+        build_var_updates(macro_domain, complete[:1])
+    with pytest.raises(InvalidBmcEncoding, match="Duplicate variable update id"):
+        build_var_updates(macro_domain, complete + (complete[0],))
+    with pytest.raises(InvalidBmcEncoding, match="Unknown variable id"):
+        build_var_updates(macro_domain, complete + (VarUpdate(999, "z", "0"),))
+    with pytest.raises(InvalidBmcEncoding, match="id/name mismatch"):
+        build_var_updates(
+            macro_domain,
+            (VarUpdate(complete[0].variable_id, "y", "pre:y"),) + complete[1:],
+        )
+
+
+@pytest.mark.unittest
+def test_absorb_cases_are_regular_cases_with_true_gamma_and_carry_all(macro_domain):
+    """Terminated and diagnostic absorbs are ordinary CycleCase objects."""
+    terminate = terminated_absorb_case(macro_domain)
+    diagnostic = diagnostic_absorb_case(macro_domain)
+
+    assert terminate.source_state_id == STATE_TERMINATE_ID
+    assert terminate.target_state_id == STATE_TERMINATE_ID
+    assert terminate.source_state_path == TERMINATE_CASE_PATH
+    assert terminate.label == "__terminate__::absorb::__terminate__::0"
+    assert terminate.condition.evaluate({}) is True
+    assert terminate.is_diagnostic is False
+    assert [item.variable_name for item in terminate.var_update] == ["x", "y"]
+
+    assert diagnostic.source_state_id == STATE_DIAGNOSTIC_ID
+    assert diagnostic.target_state_id == STATE_DIAGNOSTIC_ID
+    assert diagnostic.source_state_path == DIAGNOSTIC_CASE_PATH
+    assert diagnostic.label == "__diagnostic__::absorb::__diagnostic__::0"
+    assert diagnostic.condition.evaluate({}) is True
+    assert diagnostic.is_diagnostic is True
+
+
+@pytest.mark.unittest
+def test_fallback_condition_negates_only_accepted_gamma_not_failed_metadata(
+    macro_domain,
+):
+    """Failed raw candidates do not shrink stable leaf fallback uncovered space."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    accepted = make_case(
+        macro_domain,
+        source,
+        condition=BoolTemplate.atom("accepted"),
+        target_path="Root.Plant.Busy",
+    )
+    failed = BoolTemplate.atom("failed_raw")
+
+    fallback = build_fallback_case(macro_domain, source, (accepted,), (failed,))
+
+    assert fallback.kind == "fallback"
+    assert (
+        fallback.condition.to_canonical()
+        == BoolTemplate.not_(BoolTemplate.atom("accepted")).to_canonical()
+    )
+    assert fallback.failed_conditions == (failed,)
+    assert fallback.condition.evaluate({"accepted": False, "failed_raw": True}) is True
+    assert fallback.condition.evaluate({"accepted": True, "failed_raw": False}) is False
+
+
+@pytest.mark.unittest
+def test_semantic_delta_condition_excludes_success_and_build_diag_not_failed(
+    macro_domain,
+):
+    """Entry delta leaves failed candidate conditions as diagnostics only."""
+    source = entry_source(macro_domain, "Root.Plant")
+    accepted = make_case(
+        macro_domain,
+        source,
+        condition=BoolTemplate.atom("accepted"),
+        target_path="Root.Plant.Idle",
+    )
+    build_diag = BoolTemplate.atom("unsupported")
+    failed = BoolTemplate.atom("failed_raw")
+
+    delta = build_semantic_delta_case(
+        macro_domain, source, (accepted,), (build_diag,), (failed,)
+    )
+
+    expected = BoolTemplate.not_(
+        BoolTemplate.or_(BoolTemplate.atom("accepted"), build_diag)
+    )
+    assert delta.kind == "delta"
+    assert delta.target_state_id == STATE_DIAGNOSTIC_ID
+    assert delta.is_diagnostic is True
+    assert delta.condition.to_canonical() == expected.to_canonical()
+    assert delta.failed_conditions == (failed,)
+    assert (
+        delta.condition.evaluate(
+            {"accepted": False, "unsupported": False, "failed_raw": True}
+        )
+        is True
+    )
+
+
+@pytest.mark.unittest
+def test_macro_step_formal_rejects_illegal_delta_buckets_and_label_collisions(
+    macro_domain,
+):
+    """Formal buckets enforce source-local shape before runtime expansion is implemented."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    fallback = build_fallback_case(macro_domain, stable, ())
+    delta = CycleCase(
+        "delta",
+        stable.source_state_id,
+        stable.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::delta::%s::0" % (stable.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.atom("delta"),
+        carry_var_updates(macro_domain),
+        domain=macro_domain,
+    )
+
+    assert MacroStepFormal(stable, (fallback,)).cases == (fallback,)
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases require"):
+        MacroStepFormal(stable, (fallback,), (delta,))
+    with pytest.raises(InvalidBmcEncoding, match="Duplicate cycle case label"):
+        MacroStepFormal(stable, (fallback, fallback))
+    wrong_source = make_case(macro_domain, entry_source(macro_domain, "Root.Plant"))
+    with pytest.raises(InvalidBmcEncoding, match="case source id"):
+        MacroStepFormal(stable, (wrong_source,))
+
+
+@pytest.mark.unittest
+def test_macro_step_formal_accepts_entry_delta_and_sentinel_absorb_buckets(
+    macro_domain,
+):
+    """Entry formals may contain delta while sentinel formals absorb exactly once."""
+    entry = entry_source(macro_domain, "Root.Plant")
+    success = make_case(
+        macro_domain,
+        entry,
+        condition=BoolTemplate.atom("ok"),
+        target_path="Root.Plant.Idle",
+    )
+    delta = build_semantic_delta_case(macro_domain, entry, (success,))
+    formal = MacroStepFormal(entry, (success,), (delta,))
+    assert formal.cases == (success, delta)
+    assert [case.kind for case in formal.delta_cases] == ["delta"]
+
+    terminated_formal = MacroStepFormal(
+        terminated_source(macro_domain),
+        (terminated_absorb_case(macro_domain),),
+    )
+    diagnostic_formal = MacroStepFormal(
+        diagnostic_source(macro_domain),
+        (diagnostic_absorb_case(macro_domain),),
+    )
+    assert terminated_formal.success_cases[0].is_diagnostic is False
+    assert diagnostic_formal.success_cases[0].is_diagnostic is True
+
+    with pytest.raises(InvalidBmcEncoding, match="Duplicate cycle case label"):
+        MacroStepFormal(
+            terminated_source(macro_domain),
+            (
+                terminated_absorb_case(macro_domain),
+                terminated_absorb_case(macro_domain),
+            ),
+        )
+
+
+@pytest.mark.unittest
+def test_partition_verifier_accepts_complete_disjoint_stable_and_entry_universes(
+    macro_domain,
+):
+    """Synthetic truth-table partitions prove fallback and delta bucket contracts."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    accepted = make_case(
+        macro_domain,
+        stable,
+        condition=BoolTemplate.atom("accepted"),
+        target_path="Root.Plant.Busy",
+    )
+    fallback = build_fallback_case(macro_domain, stable, (accepted,))
+    result = MacroStepFormal(stable, (accepted, fallback)).verify_partition()
+    assert result.to_canonical() == {
+        "node": "partition_check_result",
+        "variables": ["accepted"],
+        "assignment_count": 2,
+        "bucket_count": 2,
+        "scope": "build-time-self-check",
+    }
+
+    entry = entry_source(macro_domain, "Root.Plant")
+    success = make_case(
+        macro_domain,
+        entry,
+        condition=BoolTemplate.atom("success"),
+        target_path="Root.Plant.Idle",
+    )
+    build_diag = BoolTemplate.and_(
+        BoolTemplate.atom("build_diag"),
+        BoolTemplate.not_(BoolTemplate.atom("success")),
+    )
+    delta = build_semantic_delta_case(macro_domain, entry, (success,), (build_diag,))
+    entry_result = MacroStepFormal(
+        entry, (success,), (delta,), (build_diag,)
+    ).verify_partition()
+    assert entry_result.variables == ("build_diag", "success")
+    assert entry_result.bucket_count == 3
+
+
+@pytest.mark.unittest
+def test_partition_verifier_fails_closed_on_gap_overlap_and_unknown_budget():
+    """Partition self-checks fail closed and never become Core_N clauses."""
+    a = BoolTemplate.atom("a")
+    with pytest.raises(BmcBuildError, match="overlap"):
+        verify_boolean_partition((a, a, BoolTemplate.not_(a)))
+    with pytest.raises(BmcBuildError, match="gap"):
+        verify_boolean_partition((a,))
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        verify_boolean_partition(
+            (a, BoolTemplate.not_(a)), variables=("a", "b"), max_assignments=2
+        )
+
+    result = verify_boolean_partition((a, BoolTemplate.not_(a)))
+    assert "clauses" not in result.to_canonical()
+    assert result.to_canonical()["scope"] == "build-time-self-check"
+
+
+@pytest.mark.unittest
+def test_case_validation_rejects_label_kind_and_primitive_mismatches(macro_domain):
+    """CycleCase and metadata constructors fail on malformed contract values."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    with pytest.raises(InvalidBmcEncoding, match="label case kind"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::fallback::%s::0"
+            % (source.source_state_path, source.source_state_path),
+            BoolTemplate.true(),
+            carry_var_updates(macro_domain),
+            domain=macro_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="event_id"):
+        EventUse(-1, "Root.Go", "positive", "trigger")
+    with pytest.raises(InvalidBmcEncoding, match="event polarity"):
+        EventUse(0, "Root.Go", "maybe", "trigger")
+    with pytest.raises(InvalidBmcEncoding, match="boolean template kind"):
+        BoolTemplate("xor")
+    with pytest.raises(InvalidBmcEncoding, match="Unknown state id"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            9999,
+            "Missing",
+            "%s::transition::Missing::0" % source.source_state_path,
+            BoolTemplate.true(),
+            carry_var_updates(macro_domain),
+            domain=macro_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="operands"):
+        BoolTemplate.or_(BoolTemplate.atom("ok"), object())
+
+
+@pytest.mark.unittest
+def test_macro_imports_do_not_load_z3_or_verify_modules():
+    """Macro contracts stay solver-independent and verify-registry independent."""
+    code = (
+        "import sys; "
+        "import pyfcstm.bmc.macro; "
+        "print('z3' in sys.modules); "
+        "print(any(name.startswith('pyfcstm.verify') for name in sys.modules))"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert result.stdout.splitlines() == ["False", "False"]
+
+
+@pytest.mark.unittest
+def test_bool_template_validation_and_evaluation_fail_closed():
+    """BoolTemplate rejects malformed recipes and evaluation unknowns."""
+    atom = BoolTemplate.atom("a")
+
+    with pytest.raises(InvalidBmcEncoding, match="operands"):
+        BoolTemplate("atom", name="a", operands=(atom,))
+    with pytest.raises(InvalidBmcEncoding, match="names"):
+        BoolTemplate("true", name="a")
+    with pytest.raises(InvalidBmcEncoding, match="operands"):
+        BoolTemplate("false", operands=(atom,))
+    with pytest.raises(InvalidBmcEncoding, match="names"):
+        BoolTemplate("not", name="a", operands=(atom,))
+    with pytest.raises(InvalidBmcEncoding, match="one operand"):
+        BoolTemplate("not")
+    with pytest.raises(InvalidBmcEncoding, match="names"):
+        BoolTemplate("and", name="a", operands=(atom,))
+    with pytest.raises(InvalidBmcEncoding, match="must have operands"):
+        BoolTemplate("or")
+    with pytest.raises(BmcBuildError, match="missing boolean assignment"):
+        atom.evaluate({})
+    with pytest.raises(BmcBuildError, match="must be bool"):
+        atom.evaluate({"a": 1})
+
+    forged = BoolTemplate.true()
+    object.__setattr__(forged, "kind", "xor")
+    with pytest.raises(BmcBuildError, match="unsupported boolean"):
+        forged.evaluate({})
+
+
+@pytest.mark.unittest
+def test_event_and_var_update_validation_rejects_malformed_metadata(macro_domain):
+    """EventUse and VarUpdate reject malformed primitive metadata."""
+    with pytest.raises(InvalidBmcEncoding, match="event_id"):
+        EventUse(True, "Root.Go", "positive", "trigger")
+    with pytest.raises(InvalidBmcEncoding, match="event_id"):
+        EventUse(-1, "Root.Go", "positive", "trigger")
+    with pytest.raises(InvalidBmcEncoding, match="event path"):
+        EventUse(0, "", "positive", "trigger")
+    with pytest.raises(InvalidBmcEncoding, match="event reason"):
+        EventUse(0, "Root.Go", "positive", "unknown")
+
+    with pytest.raises(InvalidBmcEncoding, match="variable_id"):
+        VarUpdate(True, "x", "pre:x")
+    with pytest.raises(InvalidBmcEncoding, match="non-negative"):
+        VarUpdate(-1, "x", "pre:x")
+    with pytest.raises(InvalidBmcEncoding, match="variable_name"):
+        VarUpdate(0, "", "pre:x")
+    with pytest.raises(InvalidBmcEncoding, match="expression"):
+        VarUpdate(0, "x", "")
+    with pytest.raises(InvalidBmcEncoding, match="is_carry"):
+        VarUpdate(0, "x", "pre:x", is_carry=object())
+    with pytest.raises(InvalidBmcEncoding, match="domain"):
+        carry_var_updates(object())
+    with pytest.raises(InvalidBmcEncoding, match="domain"):
+        var_update_for(object(), "x", "pre:x")
+    with pytest.raises(InvalidBmcEncoding, match="variable must"):
+        var_update_for(macro_domain, object(), "pre:x")
+    with pytest.raises(InvalidBmcEncoding, match="Unknown variable name"):
+        var_update_for(macro_domain, "missing", "0")
+    with pytest.raises(InvalidBmcEncoding, match="updates must be a sequence"):
+        build_var_updates(macro_domain, object())
+    with pytest.raises(InvalidBmcEncoding, match="VarUpdate"):
+        build_var_updates(macro_domain, (object(),))
+    duplicate_name = (
+        VarUpdate(macro_domain.variable_name_to_id("x"), "x", "pre:x"),
+        VarUpdate(macro_domain.variable_name_to_id("y"), "x", "pre:x"),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="Duplicate variable update name"):
+        build_var_updates(macro_domain, duplicate_name)
+
+
+@pytest.mark.unittest
+def test_cycle_case_validation_rejects_malformed_contract_fields(macro_domain):
+    """CycleCase rejects malformed labels, metadata, and kind-specific shapes."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    carry = carry_var_updates(macro_domain)
+    label = "%s::transition::%s::0" % (
+        source.source_state_path,
+        source.source_state_path,
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="condition"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            label,
+            object(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="used_events"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            label,
+            BoolTemplate.true(),
+            carry,
+            used_events=(object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            label,
+            BoolTemplate.true(),
+            carry,
+            failed_conditions=(object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="var_update"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            label,
+            BoolTemplate.true(),
+            (object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="source::kind"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "bad",
+            BoolTemplate.true(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="label source"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "Other::transition::%s::0" % source.source_state_path,
+            BoolTemplate.true(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="label target"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::transition::Other::0" % source.source_state_path,
+            BoolTemplate.true(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="ordinal"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::transition::%s::x"
+            % (source.source_state_path, source.source_state_path),
+            BoolTemplate.true(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="self-loop"):
+        CycleCase(
+            "absorb",
+            STATE_TERMINATE_ID,
+            TERMINATE_CASE_PATH,
+            STATE_DIAGNOSTIC_ID,
+            DIAGNOSTIC_CASE_PATH,
+            "%s::absorb::%s::0" % (TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH),
+            BoolTemplate.true(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel"):
+        CycleCase(
+            "absorb",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::absorb::%s::0" % (source.source_state_path, source.source_state_path),
+            BoolTemplate.true(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="target diagnostic"):
+        CycleCase(
+            "delta",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::delta::%s::0" % (source.source_state_path, source.source_state_path),
+            BoolTemplate.true(),
+            carry,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="domain"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            label,
+            BoolTemplate.true(),
+            carry,
+            domain=object(),
+        )
+
+
+@pytest.mark.unittest
+def test_macro_step_formal_validation_rejects_bucket_shape_errors(macro_domain):
+    """MacroStepFormal validates bucket types, source matches, and sentinel formals."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    entry = entry_source(macro_domain, "Root.Plant")
+    transition = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
+    stable_transition = make_case(macro_domain, stable)
+    fallback = build_fallback_case(macro_domain, stable, (stable_transition,))
+
+    with pytest.raises(InvalidBmcEncoding, match="source"):
+        MacroStepFormal(object(), (fallback,))
+    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
+        MacroStepFormal(stable, (object(),))
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
+        MacroStepFormal(entry, (transition,), object())
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
+        MacroStepFormal(entry, (transition,), (object(),))
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic"):
+        MacroStepFormal(entry, (transition,), (), (object(),))
+    with pytest.raises(InvalidBmcEncoding, match="at least one"):
+        MacroStepFormal(entry, ())
+    with pytest.raises(InvalidBmcEncoding, match="fallback"):
+        MacroStepFormal(stable, (stable_transition,))
+    with pytest.raises(InvalidBmcEncoding, match="build diagnostics"):
+        MacroStepFormal(stable, (fallback,), (), (BoolTemplate.atom("diag"),))
+    misplaced_delta = build_semantic_delta_case(macro_domain, entry, (transition,))
+    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
+        MacroStepFormal(entry, (misplaced_delta,))
+    non_delta = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases may only"):
+        MacroStepFormal(entry, (), (non_delta,))
+    with pytest.raises(InvalidBmcEncoding, match="case source id"):
+        MacroStepFormal(terminated_source(macro_domain), (transition,))
+    wrong_sentinel_case = CycleCase(
+        "absorb",
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "__diagnostic__::absorb::__diagnostic__::0",
+        BoolTemplate.true(),
+        carry_var_updates(macro_domain),
+        domain=macro_domain,
+    )
+    with pytest.raises(InvalidBmcEncoding, match="case source id"):
+        MacroStepFormal(terminated_source(macro_domain), (wrong_sentinel_case,))
+
+
+@pytest.mark.unittest
+def test_fallback_and_delta_helpers_reject_bad_inputs(macro_domain):
+    """Fallback and delta helper constructors validate source and metadata shape."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    other_stable = stable_leaf_source(macro_domain, "Root.Backup.Idle")
+    entry = entry_source(macro_domain, "Root.Plant")
+    other_entry = entry_source(macro_domain, "Root.Backup")
+    stable_case = make_case(macro_domain, stable)
+    other_stable_case = make_case(macro_domain, other_stable)
+    entry_case = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
+    other_entry_case = make_case(
+        macro_domain, other_entry, target_path="Root.Backup.Idle"
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="stable_leaf"):
+        build_fallback_case(macro_domain, entry, ())
+    with pytest.raises(InvalidBmcEncoding, match="ordinal"):
+        build_fallback_case(macro_domain, stable, (), ordinal=-1)
+    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
+        build_fallback_case(macro_domain, stable, (object(),))
+    with pytest.raises(InvalidBmcEncoding, match="fallback source"):
+        build_fallback_case(macro_domain, stable, (other_stable_case,))
+    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
+        build_fallback_case(macro_domain, stable, (stable_case,), (object(),))
+
+    with pytest.raises(InvalidBmcEncoding, match="entry source"):
+        build_semantic_delta_case(macro_domain, stable, ())
+    with pytest.raises(InvalidBmcEncoding, match="ordinal"):
+        build_semantic_delta_case(macro_domain, entry, (), ordinal=-1)
+    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
+        build_semantic_delta_case(macro_domain, entry, (object(),))
+    with pytest.raises(InvalidBmcEncoding, match="delta source"):
+        build_semantic_delta_case(macro_domain, entry, (other_entry_case,))
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic"):
+        build_semantic_delta_case(macro_domain, entry, (entry_case,), (object(),))
+    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
+        build_semantic_delta_case(macro_domain, entry, (entry_case,), (), (object(),))
+
+
+@pytest.mark.unittest
+def test_partition_helpers_reject_bad_inputs_and_source_mismatches(macro_domain):
+    """Partition self-check helpers reject malformed buckets and case ownership."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    entry = entry_source(macro_domain, "Root.Plant")
+    other_entry = entry_source(macro_domain, "Root.Backup")
+    delta = build_semantic_delta_case(macro_domain, entry, ())
+    other_delta = build_semantic_delta_case(macro_domain, other_entry, ())
+
+    with pytest.raises(BmcBuildError, match="at least one"):
+        verify_boolean_partition(())
+    with pytest.raises(BmcBuildError, match="BoolTemplate"):
+        verify_boolean_partition((object(),))
+    with pytest.raises(BmcBuildError, match="max_assignments"):
+        verify_boolean_partition((BoolTemplate.true(),), max_assignments=True)
+    with pytest.raises(BmcBuildError, match="max_assignments"):
+        verify_boolean_partition((BoolTemplate.true(),), max_assignments=0)
+    with pytest.raises(BmcBuildError, match="variables"):
+        verify_boolean_partition((BoolTemplate.true(),), variables=("",))
+    with pytest.raises(BmcBuildError, match="missing boolean assignment"):
+        verify_boolean_partition((BoolTemplate.atom("a"),), variables=())
+
+    with pytest.raises(InvalidBmcEncoding, match="source"):
+        verify_source_partition(object(), (), ())
+    with pytest.raises(InvalidBmcEncoding, match="entry source"):
+        verify_source_partition(stable, (), (delta,))
+    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
+        verify_source_partition(entry, (object(),), ())
+    with pytest.raises(InvalidBmcEncoding, match="source id"):
+        verify_source_partition(entry, (), (other_delta,))
+    non_delta = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases may only"):
+        verify_source_partition(entry, (), (non_delta,))
+    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
+        verify_source_partition(entry, (delta,), ())
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic"):
+        verify_source_partition(entry, (), (delta,), (object(),))
+
+
+@pytest.mark.unittest
+def test_additional_macro_contract_branches_are_hardened(macro_domain):
+    """Contract helpers cover no-domain, path-mismatch, and lookup-failure branches."""
+    assert BoolTemplate.true().evaluate({}) is True
+    assert BoolTemplate.false().evaluate({}) is False
+    assert BoolTemplate.and_().kind == "true"
+    assert BoolTemplate.and_(BoolTemplate.atom("a")) == BoolTemplate.atom("a")
+    assert BoolTemplate.or_(BoolTemplate.atom("a")) == BoolTemplate.atom("a")
+    with pytest.raises(InvalidBmcEncoding, match="operands"):
+        BoolTemplate("and", operands=(object(),))
+
+    with pytest.raises(InvalidBmcEncoding, match="Unknown variable id"):
+        var_update_for(macro_domain, 999, "0")
+    with pytest.raises(InvalidBmcEncoding, match="domain"):
+        build_var_updates(object(), ())
+
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    carry = carry_var_updates(macro_domain)
+    event = macro_domain.event_by_path("Root.Go")
+    with pytest.raises(InvalidBmcEncoding, match="Unknown event id"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::transition::%s::2"
+            % (source.source_state_path, source.source_state_path),
+            BoolTemplate.true(),
+            carry,
+            used_events=(EventUse(event.id + 1000, event.path, "positive", "trigger"),),
+            domain=macro_domain,
+        )
+    plain = CycleCase(
+        "transition",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        "%s::transition::%s::3" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.true(),
+        carry,
+    )
+    assert plain.to_canonical()["label"].endswith("::3")
+    with pytest.raises(InvalidBmcEncoding, match="case"):
+        case_antecedent_condition(object())
+
+    entry = entry_source(macro_domain, "Root.Plant")
+    wrong_path_case = CycleCase(
+        "delta",
+        entry.source_state_id,
+        "Other",
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "Other::delta::__diagnostic__::0",
+        BoolTemplate.true(),
+        carry,
+    )
+    with pytest.raises(InvalidBmcEncoding, match="case source path"):
+        MacroStepFormal(entry, (), (wrong_path_case,))
+    assert (
+        MacroStepFormal(
+            entry, (), (build_semantic_delta_case(macro_domain, entry, ()),)
+        ).to_canonical()["node"]
+        == "macro_step_formal"
+    )
+
+    diagnostic = diagnostic_source(macro_domain)
+    diagnostic_case = diagnostic_absorb_case(macro_domain)
+    with pytest.raises(InvalidBmcEncoding, match="case source id"):
+        MacroStepFormal(
+            diagnostic,
+            (diagnostic_case,),
+            (build_semantic_delta_case(macro_domain, entry, ()),),
+        )
+    non_absorb = CycleCase(
+        "diagnostic",
+        diagnostic.source_state_id,
+        diagnostic.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "__diagnostic__::diagnostic::__diagnostic__::0",
+        BoolTemplate.true(),
+        carry,
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel formal case"):
+        MacroStepFormal(diagnostic, (non_absorb,))
+    with pytest.raises(InvalidBmcEncoding, match="case source id"):
+        MacroStepFormal(diagnostic, (terminated_absorb_case(macro_domain),))
+
+    accepted_wrong_path = CycleCase(
+        "transition",
+        source.source_state_id,
+        "Other",
+        source.source_state_id,
+        source.source_state_path,
+        "Other::transition::%s::0" % source.source_state_path,
+        BoolTemplate.atom("wrong"),
+        carry,
+    )
+    with pytest.raises(InvalidBmcEncoding, match="fallback source"):
+        build_fallback_case(macro_domain, source, (accepted_wrong_path,))
+    entry_wrong_path = CycleCase(
+        "transition",
+        entry.source_state_id,
+        "Other",
+        macro_domain.state_path_to_id("Root.Plant.Idle"),
+        "Root.Plant.Idle",
+        "Other::transition::Root.Plant.Idle::0",
+        BoolTemplate.atom("wrong"),
+        carry,
+    )
+    with pytest.raises(InvalidBmcEncoding, match="delta source"):
+        build_semantic_delta_case(macro_domain, entry, (entry_wrong_path,))
+    with pytest.raises(InvalidBmcEncoding, match="source path"):
+        verify_source_partition(entry, (), (wrong_path_case,))
+
+
+@pytest.mark.unittest
+def test_macro_contract_sequence_type_guards_and_sentinel_absorb_branches(
+    macro_domain,
+):
+    """Sequence guards and sentinel absorb invariants fail closed."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    entry = entry_source(macro_domain, "Root.Plant")
+    diagnostic = diagnostic_source(macro_domain)
+    terminate = terminated_source(macro_domain)
+    carry = carry_var_updates(macro_domain)
+    success = make_case(macro_domain, source, condition=BoolTemplate.atom("ok"))
+    delta = build_semantic_delta_case(macro_domain, entry, ())
+
+    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
+        MacroStepFormal(source, object())
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
+        MacroStepFormal(entry, (), object())
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
+        MacroStepFormal(entry, (), (delta,), object())
+
+    with pytest.raises(InvalidBmcEncoding, match="case source id"):
+        MacroStepFormal(diagnostic, (diagnostic_absorb_case(macro_domain),), (delta,))
+    second_diagnostic_absorb = CycleCase(
+        "absorb",
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "__diagnostic__::absorb::__diagnostic__::1",
+        BoolTemplate.true(),
+        carry,
+    )
+    with pytest.raises(InvalidBmcEncoding, match="must contain one case"):
+        MacroStepFormal(
+            diagnostic,
+            (diagnostic_absorb_case(macro_domain), second_diagnostic_absorb),
+        )
+    wrong_sentinel_loop = CycleCase(
+        "absorb",
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "__diagnostic__::absorb::__diagnostic__::1",
+        BoolTemplate.true(),
+        carry,
+    )
+    object.__setattr__(wrong_sentinel_loop, "source_state_id", STATE_TERMINATE_ID)
+    object.__setattr__(wrong_sentinel_loop, "source_state_path", TERMINATE_CASE_PATH)
+    with pytest.raises(InvalidBmcEncoding, match="self-loop sentinel id"):
+        MacroStepFormal(terminate, (wrong_sentinel_loop,))
+
+    with pytest.raises(InvalidBmcEncoding, match="accepted_cases"):
+        build_fallback_case(macro_domain, source, object())
+    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
+        build_fallback_case(macro_domain, source, (success,), object())
+    with pytest.raises(InvalidBmcEncoding, match="accepted_cases"):
+        build_semantic_delta_case(macro_domain, entry, object())
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
+        build_semantic_delta_case(macro_domain, entry, (), object())
+    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
+        build_semantic_delta_case(macro_domain, entry, (), (), object())
+
+    with pytest.raises(BmcBuildError, match="partition buckets"):
+        verify_boolean_partition(object())
+    with pytest.raises(BmcBuildError, match="partition variables"):
+        verify_boolean_partition((BoolTemplate.true(),), variables=object())
+    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
+        verify_source_partition(source, object())
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
+        verify_source_partition(entry, (), object())
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
+        verify_source_partition(entry, (), (delta,), object())

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -302,7 +302,7 @@ def test_semantic_delta_condition_excludes_success_and_build_diag_not_failed(
 
 @pytest.mark.unittest
 def test_fallback_and_delta_helpers_accept_only_ordinary_success_cases(macro_domain):
-    """Fallback and delta uncovered regions ignore non-accepted bucket kinds."""
+    """Fallback and delta helpers apply their source-specific case policies."""
     stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
     entry = entry_source(macro_domain, "Root.Plant")
 
@@ -331,17 +331,12 @@ def test_fallback_and_delta_helpers_accept_only_ordinary_success_cases(macro_dom
         domain=macro_domain,
     )
 
-    fallback_with_initial = build_fallback_case(
-        macro_domain, stable, (stable_transition, stable_initial)
-    )
+    with pytest.raises(InvalidBmcEncoding, match="ordinary accepted cases"):
+        build_fallback_case(macro_domain, stable, (stable_transition, stable_initial))
+
     assert (
-        fallback_with_initial.condition.to_canonical()
-        == BoolTemplate.not_(
-            BoolTemplate.or_(
-                BoolTemplate.atom("stable_transition"),
-                BoolTemplate.atom("stable_initial"),
-            )
-        ).to_canonical()
+        fallback.condition.to_canonical()
+        == BoolTemplate.not_(BoolTemplate.atom("stable_transition")).to_canonical()
     )
 
     for rejected in (fallback, stable_diagnostic, diagnostic_absorb_case(macro_domain)):
@@ -953,6 +948,9 @@ def test_fallback_and_delta_helpers_reject_bad_inputs(macro_domain):
         build_fallback_case(macro_domain, stable, (object(),))
     with pytest.raises(InvalidBmcEncoding, match="fallback source"):
         build_fallback_case(macro_domain, stable, (other_stable_case,))
+    stable_initial_case = make_case(macro_domain, stable, label_kind="initial")
+    with pytest.raises(InvalidBmcEncoding, match="ordinary accepted"):
+        build_fallback_case(macro_domain, stable, (stable_initial_case,))
     with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
         build_fallback_case(macro_domain, stable, (stable_case,), (object(),))
 
@@ -964,6 +962,21 @@ def test_fallback_and_delta_helpers_reject_bad_inputs(macro_domain):
         build_semantic_delta_case(macro_domain, entry, (object(),))
     with pytest.raises(InvalidBmcEncoding, match="delta source"):
         build_semantic_delta_case(macro_domain, entry, (other_entry_case,))
+    entry_initial_case = make_case(
+        macro_domain,
+        entry,
+        label_kind="initial",
+        target_path="Root.Plant.Idle",
+    )
+    delta_with_initial = build_semantic_delta_case(
+        macro_domain,
+        entry,
+        (entry_initial_case,),
+    )
+    assert (
+        delta_with_initial.condition.to_canonical()
+        == BoolTemplate.not_(entry_initial_case.condition).to_canonical()
+    )
     with pytest.raises(InvalidBmcEncoding, match="build_diagnostic"):
         build_semantic_delta_case(macro_domain, entry, (entry_case,), (object(),))
     with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -301,6 +301,98 @@ def test_semantic_delta_condition_excludes_success_and_build_diag_not_failed(
 
 
 @pytest.mark.unittest
+def test_fallback_and_delta_helpers_accept_only_ordinary_success_cases(macro_domain):
+    """Fallback and delta uncovered regions ignore non-accepted bucket kinds."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    entry = entry_source(macro_domain, "Root.Plant")
+
+    stable_transition = make_case(
+        macro_domain,
+        stable,
+        condition=BoolTemplate.atom("stable_transition"),
+        target_path="Root.Plant.Busy",
+    )
+    stable_initial = make_case(
+        macro_domain,
+        stable,
+        label_kind="initial",
+        condition=BoolTemplate.atom("stable_initial"),
+    )
+    fallback = build_fallback_case(macro_domain, stable, (stable_transition,))
+    stable_diagnostic = CycleCase(
+        "diagnostic",
+        stable.source_state_id,
+        stable.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::diagnostic::%s::0" % (stable.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.atom("stable_diagnostic"),
+        carry_var_updates(macro_domain),
+        domain=macro_domain,
+    )
+
+    fallback_with_initial = build_fallback_case(
+        macro_domain, stable, (stable_transition, stable_initial)
+    )
+    assert (
+        fallback_with_initial.condition.to_canonical()
+        == BoolTemplate.not_(
+            BoolTemplate.or_(
+                BoolTemplate.atom("stable_transition"),
+                BoolTemplate.atom("stable_initial"),
+            )
+        ).to_canonical()
+    )
+
+    for rejected in (fallback, stable_diagnostic, diagnostic_absorb_case(macro_domain)):
+        with pytest.raises(InvalidBmcEncoding, match="ordinary accepted cases"):
+            build_fallback_case(macro_domain, stable, (rejected,))
+
+    entry_transition = make_case(
+        macro_domain,
+        entry,
+        condition=BoolTemplate.atom("entry_transition"),
+        target_path="Root.Plant.Idle",
+    )
+    entry_initial = make_case(
+        macro_domain,
+        entry,
+        label_kind="initial",
+        condition=BoolTemplate.atom("entry_initial"),
+        target_path="Root.Plant.Idle",
+    )
+    delta = build_semantic_delta_case(macro_domain, entry, (entry_transition,))
+    entry_diagnostic = CycleCase(
+        "diagnostic",
+        entry.source_state_id,
+        entry.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::diagnostic::%s::0" % (entry.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.atom("entry_diagnostic"),
+        carry_var_updates(macro_domain),
+        domain=macro_domain,
+    )
+
+    delta_with_initial = build_semantic_delta_case(
+        macro_domain, entry, (entry_transition, entry_initial)
+    )
+    assert (
+        delta_with_initial.condition.to_canonical()
+        == BoolTemplate.not_(
+            BoolTemplate.or_(
+                BoolTemplate.atom("entry_transition"),
+                BoolTemplate.atom("entry_initial"),
+            )
+        ).to_canonical()
+    )
+
+    for rejected in (delta, entry_diagnostic, diagnostic_absorb_case(macro_domain)):
+        with pytest.raises(InvalidBmcEncoding, match="ordinary accepted cases"):
+            build_semantic_delta_case(macro_domain, entry, (rejected,))
+
+
+@pytest.mark.unittest
 def test_macro_step_formal_rejects_illegal_delta_buckets_and_label_collisions(
     macro_domain,
 ):

--- a/test/bmc/test_macro_source.py
+++ b/test/bmc/test_macro_source.py
@@ -1,0 +1,278 @@
+"""Macro-step source contract tests for FCSTM BMC."""
+
+from __future__ import annotations
+
+import pytest
+
+from pyfcstm.bmc import (
+    STATE_DIAGNOSTIC_ID,
+    STATE_TERMINATE_ID,
+    BoolLiteral,
+    InitialSpec,
+    InvalidBmcEncoding,
+    InvalidBmcQuery,
+    build_bmc_domain,
+)
+from pyfcstm.bmc.source import (
+    DIAGNOSTIC_CASE_PATH,
+    TERMINATE_CASE_PATH,
+    MacroStepSource,
+    diagnostic_source,
+    entry_source,
+    source_from_initial_spec,
+    stable_leaf_source,
+    terminated_source,
+)
+from pyfcstm.model import load_state_machine_from_text
+
+
+@pytest.fixture()
+def source_domain():
+    """Build a source-domain fixture with leaf, composite, pseudo, and sentinel-like names."""
+    model = load_state_machine_from_text(
+        """
+        state Root {
+            state STATE_DIAGNOSTIC;
+            pseudo state Choice;
+            state Composite {
+                state Leaf;
+                [*] -> Leaf;
+            }
+            [*] -> Composite;
+        }
+        """
+    )
+    return build_bmc_domain(model, bound=2)
+
+
+@pytest.mark.unittest
+def test_cold_root_entry_source_uses_initial_entry_even_when_root_is_leaf():
+    """Cold starts always enter through an initial-only entry source."""
+    domain = build_bmc_domain(load_state_machine_from_text("state Root;"), bound=1)
+
+    source = source_from_initial_spec(domain, InitialSpec())
+
+    assert source == entry_source(domain)
+    assert source.to_canonical() == {
+        "node": "macro_step_source",
+        "kind": "entry",
+        "origin": "initial",
+        "source_state_id": domain.state_path_to_id("Root"),
+        "source_state_path": "Root",
+        "allows_semantic_delta": True,
+        "uses_stable_fallback": False,
+    }
+    assert source.allows_semantic_delta is True
+    assert source.uses_stable_fallback is False
+
+
+@pytest.mark.unittest
+def test_initial_hot_stable_leaf_matches_recurrence_stable_leaf_except_origin(
+    source_domain,
+):
+    """Hot leaf and recurrence leaf sources normalize to the same semantics."""
+    leaf_path = "Root.Composite.Leaf"
+
+    initial = source_from_initial_spec(
+        source_domain,
+        InitialSpec(mode="state", state_path=leaf_path, predicate=BoolLiteral("true")),
+    )
+    recurrence = stable_leaf_source(source_domain, leaf_path, origin="recurrence")
+
+    assert initial.kind == "stable_leaf"
+    assert initial.origin == "initial"
+    assert recurrence.origin == "recurrence"
+    assert initial.to_semantic_canonical(
+        include_origin=False
+    ) == recurrence.to_semantic_canonical(include_origin=False)
+
+
+@pytest.mark.unittest
+def test_hot_composite_and_pseudo_are_initial_only_entry_sources(source_domain):
+    """Initial state sources dispatch non-stoppable composite and pseudo states to entry."""
+    composite = source_from_initial_spec(
+        source_domain,
+        InitialSpec(mode="state", state_path="Root.Composite"),
+    )
+    pseudo = source_from_initial_spec(
+        source_domain,
+        InitialSpec(mode="state", state_path="Root.Choice"),
+    )
+
+    assert composite.kind == "entry"
+    assert composite.origin == "initial"
+    assert composite.source_state_path == "Root.Composite"
+    assert pseudo.kind == "entry"
+    assert pseudo.origin == "initial"
+    assert pseudo.source_state_path == "Root.Choice"
+
+    with pytest.raises(InvalidBmcEncoding, match="initial-only"):
+        entry_source(source_domain, "Root.Composite", origin="recurrence")
+
+
+@pytest.mark.unittest
+def test_non_stoppable_state_cannot_be_stable_leaf_source(source_domain):
+    """Stable leaf constructors reject composite, pseudo, root, and sentinel states."""
+    for state_path in ["Root", "Root.Composite", "Root.Choice"]:
+        with pytest.raises(InvalidBmcEncoding, match="stable_leaf"):
+            stable_leaf_source(source_domain, state_path)
+
+    with pytest.raises(InvalidBmcEncoding, match="stable_leaf"):
+        stable_leaf_source(source_domain, STATE_TERMINATE_ID)
+    with pytest.raises(InvalidBmcEncoding, match="stable_leaf"):
+        stable_leaf_source(source_domain, STATE_DIAGNOSTIC_ID)
+
+
+@pytest.mark.unittest
+def test_sentinel_sources_use_fixed_ids_and_reserved_paths(source_domain):
+    """Sentinel sources cannot be impersonated by model states with similar names."""
+    terminate = terminated_source(source_domain, origin="initial")
+    diagnostic = diagnostic_source(source_domain)
+
+    assert terminate.source_state_id == STATE_TERMINATE_ID
+    assert terminate.source_state_path == TERMINATE_CASE_PATH
+    assert terminate.kind == "terminated"
+    assert diagnostic.source_state_id == STATE_DIAGNOSTIC_ID
+    assert diagnostic.source_state_path == DIAGNOSTIC_CASE_PATH
+    assert diagnostic.kind == "diagnostic"
+
+    user_diagnostic = source_domain.state_path_to_id("Root.STATE_DIAGNOSTIC")
+    assert user_diagnostic >= 0
+    with pytest.raises(InvalidBmcEncoding, match="fixed sentinel id"):
+        MacroStepSource(
+            "diagnostic",
+            "recurrence",
+            user_diagnostic,
+            DIAGNOSTIC_CASE_PATH,
+            domain=source_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="reserved macro-step path"):
+        MacroStepSource(
+            "terminated",
+            "recurrence",
+            STATE_TERMINATE_ID,
+            "$STATE_TERMINATE",
+            domain=source_domain,
+        )
+
+
+@pytest.mark.unittest
+def test_source_from_initial_spec_ignores_where_predicate(source_domain):
+    """Initial predicates stay in I_0 and do not change source profile selection."""
+    without_predicate = source_from_initial_spec(
+        source_domain,
+        InitialSpec(mode="state", state_path="Root.Composite.Leaf"),
+    )
+    with_predicate = source_from_initial_spec(
+        source_domain,
+        InitialSpec(
+            mode="state",
+            state_path="Root.Composite.Leaf",
+            predicate=BoolLiteral("false"),
+        ),
+    )
+
+    assert with_predicate == without_predicate
+    assert "predicate" not in with_predicate.to_canonical()
+
+
+@pytest.mark.unittest
+def test_initial_terminated_source_is_absorb_source(source_domain):
+    """Initial terminated mode maps to a terminated absorb source."""
+    source = source_from_initial_spec(source_domain, InitialSpec(mode="terminated"))
+
+    assert source == terminated_source(source_domain, origin="initial")
+    assert source.to_canonical()["source_state_id"] == STATE_TERMINATE_ID
+
+
+@pytest.mark.unittest
+def test_source_constructors_reject_wrong_structural_values(source_domain):
+    """Source contract validates primitive fields and constructor arguments."""
+    with pytest.raises(InvalidBmcEncoding, match="source kind"):
+        MacroStepSource("unknown", "initial", 0, "Root")
+    with pytest.raises(InvalidBmcEncoding, match="source origin"):
+        MacroStepSource("entry", "later", 0, "Root")
+    with pytest.raises(InvalidBmcEncoding, match="initial-only"):
+        MacroStepSource("entry", "recurrence", 0, "Root")
+    with pytest.raises(InvalidBmcEncoding, match="model state id"):
+        MacroStepSource("entry", "initial", STATE_TERMINATE_ID, TERMINATE_CASE_PATH)
+    with pytest.raises(InvalidBmcEncoding, match="reserved macro-step paths"):
+        MacroStepSource("entry", "initial", 0, TERMINATE_CASE_PATH)
+    with pytest.raises(InvalidBmcEncoding, match="model state id"):
+        MacroStepSource(
+            "stable_leaf", "recurrence", STATE_DIAGNOSTIC_ID, DIAGNOSTIC_CASE_PATH
+        )
+    with pytest.raises(InvalidBmcEncoding, match="reserved macro-step paths"):
+        MacroStepSource("stable_leaf", "recurrence", 0, DIAGNOSTIC_CASE_PATH)
+    with pytest.raises(InvalidBmcEncoding, match="fixed sentinel id"):
+        MacroStepSource(
+            "terminated", "recurrence", STATE_DIAGNOSTIC_ID, TERMINATE_CASE_PATH
+        )
+    with pytest.raises(InvalidBmcEncoding, match="reserved macro-step path"):
+        MacroStepSource(
+            "diagnostic", "recurrence", STATE_DIAGNOSTIC_ID, TERMINATE_CASE_PATH
+        )
+    with pytest.raises(InvalidBmcEncoding, match="source_state_id"):
+        MacroStepSource("entry", "initial", True, "Root")
+    with pytest.raises(InvalidBmcEncoding, match="domain"):
+        entry_source(object())
+    with pytest.raises(InvalidBmcEncoding, match="state must"):
+        entry_source(source_domain, object())
+    with pytest.raises(InvalidBmcEncoding, match="Source path"):
+        MacroStepSource(
+            "entry",
+            "initial",
+            source_domain.state_path_to_id("Root.Composite"),
+            "Root",
+            domain=source_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="Unknown state id"):
+        MacroStepSource("entry", "initial", 9999, "Missing", domain=source_domain)
+    with pytest.raises(InvalidBmcEncoding, match="source_state_path"):
+        MacroStepSource("entry", "initial", 0, "")
+    with pytest.raises(InvalidBmcEncoding, match="domain"):
+        MacroStepSource("entry", "initial", 0, "Root", domain=object())
+
+
+@pytest.mark.unittest
+def test_source_validation_rejects_additional_adversarial_shapes(source_domain):
+    """Source validation covers hacked initial modes and lookup failures."""
+    with pytest.raises(InvalidBmcEncoding, match="domain"):
+        stable_leaf_source(object(), "Root")
+    with pytest.raises(InvalidBmcEncoding, match="Unknown state path"):
+        stable_leaf_source(source_domain, "Root.Missing")
+    with pytest.raises(InvalidBmcEncoding, match="entry source"):
+        entry_source(source_domain, "Root.Composite.Leaf")
+
+    direct = MacroStepSource("stable_leaf", "initial", 123, "Root.A")
+    assert direct.to_semantic_canonical()["origin"] == "initial"
+
+    with pytest.raises(InvalidBmcQuery, match="InitialSpec"):
+        source_from_initial_spec(source_domain, object())
+    hacked = InitialSpec()
+    object.__setattr__(hacked, "mode", "unknown")
+    with pytest.raises(InvalidBmcQuery, match="unknown initial"):
+        source_from_initial_spec(source_domain, hacked)
+
+
+@pytest.mark.unittest
+def test_source_validation_rejects_reserved_model_paths(
+    source_domain,
+):
+    """Source constructors fail closed for reserved macro-step paths."""
+    with pytest.raises(InvalidBmcEncoding, match="reserved macro-step paths"):
+        MacroStepSource(
+            "stable_leaf",
+            "recurrence",
+            0,
+            TERMINATE_CASE_PATH,
+            domain=source_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="reserved macro-step paths"):
+        MacroStepSource(
+            "entry",
+            "initial",
+            0,
+            DIAGNOSTIC_CASE_PATH,
+            domain=source_domain,
+        )


### PR DESCRIPTION
## 背景

本 PR 是 [PR #305](https://github.com/HansBug/pyfcstm/pull/305) 伞计划中的 **PR-8：宏步语义：定义 source 与 case 契约**，基于已合入伞分支的 PR-6 / [PR #324](https://github.com/HansBug/pyfcstm/pull/324) domain 层继续向 BMC 内核推进。

上游状态：

- PR-1 / [PR #315](https://github.com/HansBug/pyfcstm/pull/315) 已合入：`pyfcstm.bmc` query / expression 数据模型。
- PR-2 / [PR #323](https://github.com/HansBug/pyfcstm/pull/323) 已合入：独立 `.fbmcq` ANTLR grammar。
- PR-6 / [PR #324](https://github.com/HansBug/pyfcstm/pull/324) 已合入：`BmcDomain`、state/event/var/frame/step/event-input 编号与 sentinel。

本 PR 不切回 PR-3 / PR-4 query parser / binder 方向；它沿 PR-6 domain 内核方向继续，定义 `expand_macro_step_cases(...)` 与后续 Z3 relation 之间的 **macro-step semantic contract**。

## 正确公式边界（必须防止上下文污染）

本 PR 只定义 macro-step source / case 的语义契约，不构建正式 Z3 transition relation。但契约必须严格服务于 issue 设计中的核心公式：

```text
A_{σ,j}^i => R_{σ,j}^i
```

其中：

```text
A_{σ,j}^i = (s_i = id(src(σ))) ∧ γ_{σ,j}^i
```

```text
R_{σ,j}^i =
    (s_{i+1} = id(target(σ,j)))
    ∧ ∧_{v in Vars}(x_{v,i+1} = μ_{σ,j,v}^i)
```

实现含义：

- `CycleCase.condition` 表示裸 `γ_{σ,j}^i`，**不得包含** `pre.state == source_state_id`。
- PR-10 relation builder 才会统一组合：
  ```python
  enabled = z3.And(pre.state == case.source_state_id, case.condition(pre, step))
  successor = z3.And(post.state == case.target_state_id, *post_var_constraints)
  z3.Implies(enabled, successor)
  ```
- 不引入独立 `case_active` 布尔变量作为正式公式核心。
- 不在正式 `Core_N` / `Phi_N` 中用 `ExactlyOne`、额外 disjunction 或其它求解期补丁修补 case 分区。
- case 前件 `A` 的不重不漏是 `expand_macro_step_cases(...)` 的构造契约和 build-time / test-time 自检目标。

## 本 PR 范围

新增或更新：

- `pyfcstm.bmc.source`
  - `MacroStepSource`
  - source constructors / validators：cold entry（root/composite/pseudo/冷启动 root leaf）、initial state stable leaf、initial state non-stoppable entry、terminated、diagnostic、recurrence stable leaf。`source_from_initial_spec(...)` 忽略 `init where` predicate，只按 `InitialSpec.mode` 与 domain state kind 分派。
- `pyfcstm.bmc.macro`
  - `CycleCase`
  - `MacroStepFormal`
  - case condition / variable update / event-use / diagnostic bucket contract。
  - fallback / absorb / semantic-delta case construction helpers。
  - source-local case partition verification helpers or proof-ready contracts.
- `pyfcstm.bmc.__init__`
  - public API 和 module roadmap table 同步新增 source / macro 契约层。
- API RST
  - `docs/source/api_doc/bmc/source.rst`
  - `docs/source/api_doc/bmc/macro.rst`
- tests
  - `test/bmc/test_macro_source.py`
  - `test/bmc/test_macro_contract.py`
  - 继续维护 `test/bmc/test_bmc_public_api.py`。

## 本 PR 非目标

本 PR **不做**：

- `.fbmcq` parser / AST builder（PR-3）。
- `.fbmcq` semantic binder（PR-4）。
- 完整 `SimulationRuntime` 对齐的 macro-step 展开（PR-9）。
- 正式 Z3 relation / `T_N` / `Core_N` / `Phi_N` 构建（PR-10）。
- property objective 编译（PR-11）。
- witness replay（PR-12）。
- verify registry / adapter 接入（PR-13）。

允许在测试或 self-check helper 中使用 Z3 证明 partition，但这些证明只用于 build-time / test-time hardening，不得成为正式 trace formula 的约束补丁。

## 设计要点

### Source contract

`MacroStepSource` 需要表达：

| source kind | 语义 |
|---|---|
| `entry` | 只允许 `origin="initial"` 的 entry source；用于 cold root（即使 root 是 leaf，也表示运行时初始进入而非 hot stable fallback）以及 initial non-stoppable composite / pseudo source；uncovered branch 可进入 semantic diagnostic sentinel。 |
| `stable_leaf` | stable/stoppable leaf source；initial hot leaf 与 recurrence leaf 的 case 语义必须等价。 |
| `terminated` | terminate sentinel absorb source。 |
| `diagnostic` | diagnostic absorb source（source 已在 `STATE_DIAGNOSTIC_ID` sentinel 上；不同于 non-stoppable entry 产生的 `delta` case）。 |

硬约束：

- `entry` source 不允许出现在 recurrence。
- `source_from_initial_spec(InitialSpec(mode="state", state_path=...))` 对 stoppable leaf 必须分派到 `stable_leaf_source(..., origin="initial")`；对 composite / pseudo / non-stoppable source 分派到 `entry_source(..., origin="initial")`。
- `stable_leaf` source 必须引用 `domain.stable_state_ids` 中的非 sentinel stoppable leaf。
- `terminated` / `diagnostic` 必须引用固定 sentinel id，不能被普通 sentinel-like state name 冒充。
- `init where` predicate 不进入 `MacroStepSource`；它属于 `I_0`，不得改变 case partition。

### Case contract

`CycleCase` 必须携带后续 PR-10 lowering 所需的完整语义材料：

- stable `label`；规范形态沿 issue 约定：`state_path::case_kind::target_path::ordinal`，absorb 使用 reserved sentinel label。
- `source_state_id` / `source_state_path`。
- `target_state_id` / `target_state_path`。
- `kind`：`transition` / `fallback` / `initial` / `absorb` / `diagnostic` / `delta` 等本 PR 最小集合；label 中的 `case_kind` 必须来自同一集合并与字段一致。
- `is_diagnostic`：derived property，不作为可任意填写的独立语义事实；`kind in {"diagnostic", "delta"}` 或 `kind == "absorb" and target_state_id == STATE_DIAGNOSTIC_ID` 时为 true。`delta` case 属于 `MacroStepFormal.delta_cases`，diagnostic absorb 属于 `success_cases`。
- `used_events`：event id / path / polarity / reason，event id 必须来自 `BmcDomain`。
- `condition`：裸 `γ` recipe，不含 source-state guard。
- `var_update` 或等价 update recipe：采用显式完备覆盖（option A）；必须覆盖全部 persistent vars，未写变量也要以 carry-over 规则显式出现，不能留下 unconstrained post var。
- `failed_conditions` 仅允许作为 diagnostic metadata / explainability，不得参与 fallback uncovered 或 delta uncovered 的排除。

### Fallback / delta rules

- stable leaf 必须有 fallback self-cycle。
- stable leaf 禁止 semantic delta。
- fallback condition 必须是 `not(or(accepted transition γ))`，**不是** `not(or(raw triggers or failed_conditions))`；stable fallback 的 accepted set 只允许 `transition` case，不能把 initial-only `initial` case 扣入 stable fallback uncovered 区域。
- non-stoppable `entry` source 的 uncovered branch 进入 semantic diagnostic sentinel：`γ_delta = not(build_diag or or(accepted transition/initial γ))`；`initial` case 只在 entry semantic-delta accepted set 中有效。
- terminated / diagnostic absorb 必须作为普通 `CycleCase`，不得留给 relation builder 写特殊 if 分支。

## Hardened TDD 验收矩阵

本 PR 的测试要在 PR-8 阶段尽量抓住契约 bug，不能把基础设施错误留到 PR-9/PR-10。

### Source tests

- cold/root entry source canonical dump 稳定。
- hot stable leaf source 与 recurrence stable leaf source 除 `origin` 外语义字段可归一化等价。
- hot composite / hot pseudo source 归类为 initial-only `entry`。
- recurrence `entry` source 必须失败。
- non-stoppable state 不能构造成 `stable_leaf`。
- terminate / diagnostic sentinel source 使用固定 id。
- 普通 state 名接近 reserved sentinel label/path 时不能冒充 sentinel。

### Case contract tests

- `CycleCase.condition` 不包含 source-state guard；helper 组合出的 `A` 才是 `source_guard ∧ γ`。
- case target id 必须属于 `BmcDomain`。
- event use id/path 必须匹配 `BmcDomain`，同短名不同 owner event 不得混淆。
- `var_update` 必须覆盖全部 persistent vars；漏变量、未知变量、重复变量均失败。
- label collision 必须在 `MacroStepFormal` 聚合期即时失败；canonical dump 排序稳定。
- absorb case 恒 true `γ`、target same sentinel、vars carry all。
- fallback case 只否定 accepted `γ`，不扣除 failed raw conditions。
- `MacroStepFormal` bucket 结构不变量：stable leaf / terminated / diagnostic formal 不允许 delta cases；entry formal 才允许 delta cases；所有 cases 的 source id/path 必须等于 formal source；`cases == success_cases + delta_cases` 且排序稳定；至少要有 ordinary success 或 delta relation case。
- entry formal 允许 delta cases，但 delta / success / build diagnostic bucket 必须完备且互斥；`delta` 与 diagnostic absorb 的 `is_diagnostic` 语义必须可区分。
- `failed_conditions` 不得改变 fallback / delta uncovered 区域。

### Partition proof / self-check tests

- 用小型 synthetic boolean universe 证明 success / fallback 完备互斥。
- 用小型 entry universe 证明 success / delta / build diagnostic 完备互斥。
- 构造 overlap case，partition verifier 必须失败。
- 构造 gap case，partition verifier 必须失败。
- verifier unknown / timeout policy 必须无条件 fail closed；本 PR 若使用 truth-table/synthetic verifier，则缺少可判定 truth table 等价于 unknown 并抛 `BmcBuildError`，若接入 Z3 backend 则默认 timeout 建议为 5000ms 且 `unknown` / timeout 均失败。
- 明确测试这些 partition formula 只用于 self-check，不被暴露为正式 `Core_N` 约束。
- `condition` / `var_update` 的可比较性使用规范化摘要或 synthetic truth-table，而不是 Python callable identity；PR-8 的 `MacroStepFormal` 测试用人工构造 case 覆盖 contract，不要求等待 PR-9 的真实 `expand_macro_step_cases(...)`。

### Regression scope tests

- `pyfcstm.bmc.query` / `.grammar` import 不应因为本 PR 引入 macro contract 而导入 `z3`。
- root `pyfcstm.bmc` public API 是否 re-export source/macro 需显式测试；若 re-export 会导入 z3，则必须重新评估并避免 root import 变重。
- 不 import `pyfcstm.verify`。
- docstring / pydoc 满足 CLAUDE.md：module 清晰、public class/function 参数/返回/异常/Examples 完整，`__init__.py` list-table 更新。

## 本 PR 与后续 PR 的边界

- PR-8：冻结 macro-step source / case contract，harden case partition / fallback / delta / var-update / sentinel / label 不变量。
- PR-9：实现真实 `expand_macro_step_cases(source)`，对齐 `SimulationRuntime`，覆盖 exit/effect/enter、pseudo multi-hop、transition priority、validation-skip、rollback fallback、hot leaf vs recurrence 等价。
- PR-10：在 PR-7 提供的 bound query/model context、PR-4 binder-normalized query / ENV 输入与 PR-9 产出的 `CycleCase` 合流后，按 issue 设计 lower 成正式 Z3 relation：`A_{σ,j}^i => R_{σ,j}^i`，构建 `T_N` / `ENV_N` / `Core_N` / `Phi_N`。

## 初始本地检查计划

开发完成前至少运行：

```bash
make rst_auto RANGE_DIR=bmc
python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py
python -m doctest pyfcstm/bmc/*.py
ruff check pyfcstm/bmc test/bmc --exclude pyfcstm/bmc/grammar
ruff format --check pyfcstm/bmc test/bmc
SKIP_SLOW_TESTS=1 pytest test/bmc -q --cov=pyfcstm.bmc --cov-branch --cov-report=term-missing
make test_boundary_check
SKIP_SLOW_TESTS=1 make unittest
```

## 开工前 reviewer 检查点

请 reviewer 重点对抗性检查：

- 本 PR body 是否与 [PR #305](https://github.com/HansBug/pyfcstm/pull/305) / [issue #251](https://github.com/HansBug/pyfcstm/issues/251) 一致。
- 是否错误地把 PR-10 的 `A => R` 写成了 `case_active => And(A, R)` 或把 source guard 放错边界。
- PR-8 / PR-9 / PR-10 边界是否足够清晰。
- PR-8 测试矩阵是否足够 harden，能在基础设施层抓住 fallback / delta / partition / var_update / sentinel / label 错误。
- 是否存在把 partition 修补公式塞进正式 `Core_N` / `Phi_N` 的风险。


