### PR TITLE
查询语言：加入 .fbmcq 编辑器高亮与文档支持

### DIFF
--- a/.github/scripts/detect_ci_routes.py
+++ b/.github/scripts/detect_ci_routes.py
@@ -67,6 +67,7 @@ _JS_PATTERNS = (
     "editors/jsfcstm/**",
     "editors/vscode/**",
     "editors/fcstm.tmLanguage.json",
+    "editors/fcstm-bmc-query.tmLanguage.json",
     ".github/linguist/**",
 )
 _CLI_PATTERNS = (
@@ -604,6 +605,15 @@ def run_self_check() -> None:
     _check_case(
         "vscode source",
         ["editors/vscode/src/extension.ts"],
+        True,
+        False,
+        False,
+        True,
+        False,
+    )
+    _check_case(
+        "BMC query TextMate grammar",
+        ["editors/fcstm-bmc-query.tmLanguage.json"],
         True,
         False,
         False,

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -8,6 +8,7 @@ on:
       - 'editors/jsfcstm/**'
       - 'editors/vscode/**'
       - 'editors/fcstm.tmLanguage.json'
+      - 'editors/fcstm-bmc-query.tmLanguage.json'
       - 'templates/**'
       - 'tools/**'
       # Build & packaging manifests

--- a/docs/source/api_doc/highlight/bmc_query_lexer.rst
+++ b/docs/source/api_doc/highlight/bmc_query_lexer.rst
@@ -1,0 +1,19 @@
+pyfcstm.highlight.bmc\_query\_lexer
+========================================================
+
+.. currentmodule:: pyfcstm.highlight.bmc_query_lexer
+
+.. automodule:: pyfcstm.highlight.bmc_query_lexer
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+FcstmBmcQueryLexer
+-----------------------------------------------------
+
+.. autoclass:: FcstmBmcQueryLexer
+    :members: analyse_text,name,aliases,filenames,mimetypes,tokens

--- a/docs/source/api_doc/highlight/index.rst
+++ b/docs/source/api_doc/highlight/index.rst
@@ -9,6 +9,7 @@ pyfcstm.highlight
 .. toctree::
     :maxdepth: 3
 
+    bmc_query_lexer
     pygments_lexer
 
 \_\_all\_\_

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,12 +88,14 @@ from pyfcstm.config.meta import __TITLE__, __AUTHOR__, __VERSION__
 
 # Register FCSTM Pygments lexer for syntax highlighting
 from pygments.lexers import get_lexer_by_name
-from pyfcstm.highlight.pygments_lexer import FcstmLexer
+from pyfcstm.highlight import FcstmBmcQueryLexer, FcstmLexer
 from sphinx.highlighting import lexers
 
 # Register the lexer with Sphinx
 lexers['fcstm'] = FcstmLexer()
 lexers['fcsm'] = FcstmLexer()  # Alternative alias
+lexers['fbmcq'] = FcstmBmcQueryLexer()
+lexers['fcstm-bmc-query'] = FcstmBmcQueryLexer()
 
 print("✓ FCSTM Pygments lexer registered successfully")
 

--- a/editors/README.md
+++ b/editors/README.md
@@ -4,12 +4,12 @@ Syntax highlighting support for FCSTM (Finite State Machine) DSL.
 
 ## Overview
 
-Two implementations provide syntax highlighting for FCSTM code:
+Two implementations provide syntax highlighting for FCSTM-related code:
 
-1. **Pygments Lexer** - For Sphinx documentation and Python-based tools
-2. **TextMate Grammar** - For GitHub, GitLab, and other platforms supporting TextMate grammars
+1. **Pygments lexers** - For Sphinx documentation and Python-based tools
+2. **TextMate grammars** - For VSCode, GitHub, GitLab, and other platforms supporting TextMate grammars
 
-Both implementations are based on the ANTLR grammar (`pyfcstm/dsl/grammar/Grammar.g4`) and have been thoroughly tested.
+The main `*.fcstm` assets follow the FCSTM DSL grammar. The `*.fbmcq` assets follow the separate FCSTM BMC Query grammar under `pyfcstm/bmc/grammar/`. Both surfaces are syntax highlighters only; model-aware validation remains in the parser, binder, simulator, and verification layers.
 
 ## Quick Start
 
@@ -17,7 +17,7 @@ Both implementations are based on the ANTLR grammar (`pyfcstm/dsl/grammar/Gramma
 
 Pygments is included as a core dependency and is automatically available.
 
-Use in Sphinx RST files:
+Use FCSTM model code in Sphinx RST files:
 
 ```rst
 .. code-block:: fcstm
@@ -45,11 +45,11 @@ lexers['fcsm'] = FcstmLexer()  # Alternative alias
 print("✓ FCSTM Pygments lexer registered successfully")
 ```
 
-This registration should be placed after importing your project metadata and before the Sphinx configuration variables. The lexer will then be automatically available for all `.. code-block:: fcstm` directives in your documentation.
+This registration should be placed after importing your project metadata and before the Sphinx configuration variables. Register `FcstmBmcQueryLexer` in the same place when documentation uses `.. code-block:: fbmcq` or `.. code-block:: fcstm-bmc-query`.
 
 ### TextMate Grammar
 
-The TextMate grammar (`editors/fcstm.tmLanguage.json`) provides syntax highlighting for platforms that support TextMate grammars, including GitHub and GitLab.
+The TextMate grammar (`editors/fcstm.tmLanguage.json`) provides syntax highlighting for platforms that support TextMate grammars, including GitHub and GitLab. The BMC query grammar lives in `editors/fcstm-bmc-query.tmLanguage.json`; the VSCode extension ships copied assets under `editors/vscode/syntaxes/`.
 
 ## Supported Syntax
 
@@ -75,6 +75,23 @@ with the `xor` keyword; `->` remains transition syntax, so implication uses
 **Special Symbols:** `[*]` (pseudo-state), `//` (line comment), `/* */` (block comment), `#` (Python-style comment)
 
 **Import Mapping Forms:** `import "./worker.fcstm" as Worker { ... }`, `def sensor_* -> io_$1;`, `def * -> Worker_${1};`, `event /Start -> Start named "Mapped Start";`
+
+
+### FCSTM BMC Query (`*.fbmcq`)
+
+The BMC query language has its own highlighter so query files do not reuse the main FCSTM model scopes.
+
+**Frozen identifiers:**
+
+- File extension: `.fbmcq`
+- VSCode language id: `fcstm-bmc-query`
+- TextMate scope: `source.fcstm.bmc.query`
+- Pygments aliases: `fbmcq`, `fcstm-bmc-query`
+- MIME type: `text/x-fcstm-bmc-query`
+
+The highlighter covers query clauses (`init`, `assume`, `check`), property kinds (`reach`, `forbid`, `invariant`, `must_reach`, `exists_always`, `response`, `cover`), BMC atoms (`var`, `cycle`, `active`, `terminated`, `event`, `case`, `called`), event cardinality (`at_most_one`), FCSTM-compatible expression operators, literals, strings, and comments. It intentionally does not add `warm` or `hot` init targets because the current `.fbmcq` grammar only accepts `cold`, `terminated`, and `state("...")`.
+
+`^` is highlighted as a numeric bitwise operator. Boolean exclusive-or remains the `xor` keyword.
 
 ## Example
 
@@ -132,7 +149,9 @@ state TrafficLight {
 
 ### Pygments Lexer
 
-**Location:** `pyfcstm/highlight/pygments_lexer.py`
+**Locations:**
+- `pyfcstm/highlight/pygments_lexer.py` for `*.fcstm`
+- `pyfcstm/highlight/bmc_query_lexer.py` for `*.fbmcq`
 
 **Features:**
 - Token-based syntax highlighting
@@ -155,13 +174,16 @@ entry_points={
     ],
     'pygments.lexers': [
         'fcstm = pyfcstm.highlight.pygments_lexer:FcstmLexer',
+        'fbmcq = pyfcstm.highlight.bmc_query_lexer:FcstmBmcQueryLexer',
     ],
 }
 ```
 
 ### TextMate Grammar
 
-**Location:** `editors/fcstm.tmLanguage.json`
+**Locations:**
+- `editors/fcstm.tmLanguage.json` for `*.fcstm`
+- `editors/fcstm-bmc-query.tmLanguage.json` for `*.fbmcq`
 
 **Features:**
 - Scope-based syntax highlighting
@@ -180,11 +202,12 @@ entry_points={
 ### Validation Script
 
 **`editors/validate.py`** - Comprehensive validation:
-- Pygments lexer validation with 20+ checkpoints
-- TextMate grammar synchronization checks for the VSCode-packaged asset
-- Ordering-sensitive operator coverage checks
-- Terminal-based highlighting display
-- Token type verification
+- FCSTM Pygments lexer validation with 20+ checkpoints
+- FCSTM TextMate grammar synchronization checks for the VSCode-packaged asset
+- FBMCQ Pygments lexer metadata and token smoke checks
+- FBMCQ TextMate grammar synchronization and operator-order checks
+- VSCode `package.json` positive checks for `.fbmcq` language/grammar contributions
+- VSCode negative checks to ensure `.fbmcq` does not activate the `.fcstm` preview or language-server surfaces
 
 ### Running Tests
 
@@ -196,9 +219,10 @@ python editors/validate.py
 ### Test Results
 
 All tests pass successfully:
-- Pygments Lexer: PASSED (20/20 checkpoints)
-- Language detection score: 1.00
-- Token generation: 1861 tokens for comprehensive test code
+- FCSTM Pygments: PASSED
+- FCSTM TextMate: PASSED
+- FBMCQ Pygments: PASSED
+- FBMCQ TextMate and VSCode contribution checks: PASSED
 
 ## File Structure
 
@@ -206,12 +230,15 @@ All tests pass successfully:
 pyfcstm/
 ├── pyfcstm/
 │   └── highlight/
-│       ├── __init__.py              # Direct import of FcstmLexer
-│       └── pygments_lexer.py        # Pygments lexer implementation
+│       ├── __init__.py              # Direct import of public lexers
+│       ├── bmc_query_lexer.py       # FBMCQ Pygments lexer implementation
+│       └── pygments_lexer.py        # FCSTM Pygments lexer implementation
 ├── editors/
 │   ├── README.md                    # This file
-│   ├── fcstm.tmLanguage.json        # TextMate grammar
-│   └── validate.py                  # Validation script
+│   ├── fcstm.tmLanguage.json        # FCSTM TextMate grammar
+│   ├── fcstm-bmc-query.tmLanguage.json  # FBMCQ TextMate grammar
+│   ├── validate.py                  # Validation script
+│   └── vscode/syntaxes/             # VSCode-packaged grammar copies
 ├── requirements.txt                 # Includes pygments>=2.10.0
 └── setup.py                         # Updated with Pygments entry point
 ```
@@ -237,11 +264,12 @@ python -c "from pygments.lexers import get_lexer_by_name; print(get_lexer_by_nam
 
 When adding new keywords to the FCSTM grammar:
 
-1. Update `pyfcstm/dsl/grammar/Grammar.g4`
+1. Update the relevant ANTLR grammar: `pyfcstm/dsl/grammar/GrammarParser.g4` / `GrammarLexer.g4` for `*.fcstm`, or `pyfcstm/bmc/grammar/BmcQueryParser.g4` / `BmcQueryLexer.g4` for `*.fbmcq`.
 2. Regenerate parser: `make antlr_build`
 3. Update `pyfcstm/highlight/pygments_lexer.py`
-4. Update `editors/fcstm.tmLanguage.json`
-5. Update `editors/validate.py` to fit the new grammar (if necessary)
+4. Update `editors/fcstm.tmLanguage.json` for `*.fcstm`, or `editors/fcstm-bmc-query.tmLanguage.json` for `*.fbmcq`.
+5. Sync the VSCode grammar copy under `editors/vscode/syntaxes/`.
+6. Update `editors/validate.py` to fit the new grammar (if necessary).
 
 ### Consistency
 
@@ -250,7 +278,7 @@ Both implementations should be kept in sync. The Pygments lexer serves as the re
 ## Related Documentation
 
 - [FCSTM DSL Language Reference](../CLAUDE.md#dsl-language-reference)
-- [ANTLR Grammar](../pyfcstm/dsl/grammar/Grammar.g4)
+- [FCSTM Parser Grammar](../pyfcstm/dsl/grammar/GrammarParser.g4) and [FCSTM Lexer Grammar](../pyfcstm/dsl/grammar/GrammarLexer.g4)
 - [Pygments Documentation](https://pygments.org/)
 - [TextMate Grammar Documentation](https://macromates.com/manual/en/language_grammars)
 

--- a/editors/fcstm-bmc-query.tmLanguage.json
+++ b/editors/fcstm-bmc-query.tmLanguage.json
@@ -1,0 +1,220 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "FCSTM BMC Query",
+  "scopeName": "source.fcstm.bmc.query",
+  "fileTypes": [
+    "fbmcq"
+  ],
+  "patterns": [
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#atoms"
+    },
+    {
+      "include": "#clauses"
+    },
+    {
+      "include": "#keywords"
+    },
+    {
+      "include": "#constants"
+    },
+    {
+      "include": "#strings"
+    },
+    {
+      "include": "#numbers"
+    },
+    {
+      "include": "#operators"
+    },
+    {
+      "include": "#identifiers"
+    }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.block.fcstm.bmc.query",
+          "begin": "/\\*",
+          "end": "\\*/",
+          "patterns": [
+            {
+              "name": "comment.block.fcstm.bmc.query",
+              "match": "."
+            }
+          ]
+        },
+        {
+          "name": "comment.line.double-slash.fcstm.bmc.query",
+          "match": "//.*$"
+        },
+        {
+          "name": "comment.line.number-sign.fcstm.bmc.query",
+          "match": "#.*$"
+        }
+      ]
+    },
+    "clauses": {
+      "patterns": [
+        {
+          "name": "keyword.control.fcstm.bmc.query",
+          "match": "\\b(init|assume|check|state|event|events)\\b"
+        },
+        {
+          "name": "keyword.other.query-clause.fcstm.bmc.query",
+          "match": "\\b(cold|terminated|where|always|at|cardinality|any|reach|forbid|invariant|must_reach|exists_always|response|cover|trigger|within|current)\\b"
+        }
+      ]
+    },
+    "atoms": {
+      "patterns": [
+        {
+          "name": "support.function.bmc-atom.fcstm.bmc.query",
+          "match": "\\b(var|active|terminated|event|case|called)\\b(?=\\s*\\()"
+        },
+        {
+          "name": "support.function.bmc-atom.fcstm.bmc.query",
+          "match": "\\b(cycle|at_most_one)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "keyword.operator.word.fcstm.bmc.query",
+          "match": "\\b(and|or|not|implies|xor|iff)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.arithmetic.fcstm.bmc.query",
+          "match": "\\*\\*"
+        },
+        {
+          "name": "keyword.operator.bitshift.fcstm.bmc.query",
+          "match": ">>|<<"
+        },
+        {
+          "name": "keyword.operator.comparison.fcstm.bmc.query",
+          "match": "<=|>=|==|!="
+        },
+        {
+          "name": "keyword.operator.logical.fcstm.bmc.query",
+          "match": "&&|\\|\\|"
+        },
+        {
+          "name": "keyword.operator.logical.fcstm.bmc.query",
+          "match": "=>"
+        },
+        {
+          "name": "keyword.operator.response.fcstm.bmc.query",
+          "match": "->"
+        },
+        {
+          "name": "keyword.operator.range.fcstm.bmc.query",
+          "match": "\\.\\."
+        },
+        {
+          "name": "keyword.operator.logical.fcstm.bmc.query",
+          "match": "!"
+        },
+        {
+          "name": "keyword.operator.arithmetic.fcstm.bmc.query",
+          "match": "[+\\-*/%&|^~<>]"
+        },
+        {
+          "name": "keyword.operator.assignment.fcstm.bmc.query",
+          "match": "=|\\?"
+        },
+        {
+          "name": "punctuation.separator.fcstm.bmc.query",
+          "match": ",|;|:"
+        },
+        {
+          "name": "punctuation.section.fcstm.bmc.query",
+          "match": "\\{|\\}|\\(|\\)|\\[|\\]"
+        },
+        {
+          "name": "punctuation.accessor.fcstm.bmc.query",
+          "match": "\\."
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.boolean.fcstm.bmc.query",
+          "match": "\\b(True|true|TRUE|False|false|FALSE)\\b"
+        },
+        {
+          "name": "constant.language.math.fcstm.bmc.query",
+          "match": "\\b(pi|E|tau)\\b"
+        },
+        {
+          "name": "support.function.builtin.fcstm.bmc.query",
+          "match": "\\b(sin|cos|tan|asin|acos|atan|sinh|cosh|tanh|asinh|acosh|atanh|sqrt|cbrt|exp|log|log10|log2|log1p|abs|ceil|floor|round|trunc|sign)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.fcstm.bmc.query",
+          "begin": "\"",
+          "end": "\"",
+          "patterns": [
+            {
+              "name": "constant.character.escape.fcstm.bmc.query",
+              "match": "\\\\([btnfr\"'\\\\]|[0-7]{1,3}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2})"
+            }
+          ]
+        },
+        {
+          "name": "string.quoted.single.fcstm.bmc.query",
+          "begin": "'",
+          "end": "'",
+          "patterns": [
+            {
+              "name": "constant.character.escape.fcstm.bmc.query",
+              "match": "\\\\([btnfr\"'\\\\]|[0-7]{1,3}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2})"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.integer.fcstm.bmc.query",
+          "match": "\\b[0-9]+(?=\\.\\.)"
+        },
+        {
+          "name": "constant.numeric.hex.fcstm.bmc.query",
+          "match": "\\b0x[0-9a-fA-F]+\\b"
+        },
+        {
+          "name": "constant.numeric.float.fcstm.bmc.query",
+          "match": "(?<![\\w.])([0-9]+\\.(?!\\.)[0-9]*([eE][+-]?[0-9]+)?|\\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)(?![\\w.])"
+        },
+        {
+          "name": "constant.numeric.integer.fcstm.bmc.query",
+          "match": "\\b[0-9]+\\b"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.fcstm.bmc.query",
+          "match": "\\b[a-zA-Z_][a-zA-Z0-9_]*\\b"
+        }
+      ]
+    }
+  }
+}

--- a/editors/validate.py
+++ b/editors/validate.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# fmt: off
 """
 Comprehensive validation script for FCSTM syntax-highlighting assets.
 
@@ -21,11 +22,50 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from pygments.token import Token
 
-from pyfcstm.highlight.pygments_lexer import FcstmLexer
+from pyfcstm.highlight import FcstmBmcQueryLexer, FcstmLexer
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TEXTMATE_GRAMMAR_FILE = os.path.join(ROOT_DIR, 'editors', 'fcstm.tmLanguage.json')
 VSCODE_TEXTMATE_GRAMMAR_FILE = os.path.join(ROOT_DIR, 'editors', 'vscode', 'syntaxes', 'fcstm.tmLanguage.json')
+FBMCQ_TEXTMATE_GRAMMAR_FILE = os.path.join(ROOT_DIR, 'editors', 'fcstm-bmc-query.tmLanguage.json')
+VSCODE_FBMCQ_TEXTMATE_GRAMMAR_FILE = os.path.join(
+    ROOT_DIR, 'editors', 'vscode', 'syntaxes', 'fcstm-bmc-query.tmLanguage.json'
+)
+VSCODE_PACKAGE_FILE = os.path.join(ROOT_DIR, 'editors', 'vscode', 'package.json')
+
+
+FBMCQ_TEST_CODE = """
+// FCSTM BMC Query syntax-highlighting fixture.
+init state("Root.System.A") where x >= 0 and active("Root.System.A");
+
+assume always: terminated(current) or var("x") <= 1000 and cycle >= 0 or not called("Hook", current);
+assume at 0: sin(pi) + 0xFF + 3.5e-1 + .5 + 1. + (flags ** 2) + (flags >> 1) + (flags * 2 / 3 % 4) + (flags | 1) + (flags ^ 2) == var("x");
+assume event("Root.System.A.Tick", 0..3) != false;
+assume events cardinality at_most_one {
+    "Root.System.A.Tick",
+    "Root.System.A.Reset"
+};
+assume events cardinality any {
+    "Root.System.A.Tick",
+    "Root.System.A.Reset"
+};
+
+check reach <= 2: active("Root.Done");
+check forbid <= 2: terminated(current);
+check invariant <= 2: var("x") >= 0;
+check must_reach <= 4: active("Root.Recovering");
+check exists_always <= 4: active("Root.Safe");
+check response <= 10:
+    trigger event("Root.System.A.Tick", current) && active("Root.System.A")
+    -> within 3 active("Root.Recovering") iff true xor !false implies true;
+
+check cover <= 6:
+    ((~flags & 0xFF) == 0) || (cycle << 1) >= +2 && (-x <= 3.5e-1) => case("Root.System.A::transition::Root.System.B::1");
+
+# hash comment
+/* block comment */
+assume always: 'Root.System.A' == 'Root.System.A';
+"""
 
 COMPREHENSIVE_TEST_CODE = """
 // ============================================================================
@@ -384,6 +424,7 @@ class SharedExpectation:
     textmate_scope: str
     capture_group: Optional[int] = None
     mode: str = 'auto'
+    textmate_sample: Optional[str] = None
 
 
 SHARED_CHECKPOINT_SPECS: List[Dict[str, Any]] = [
@@ -628,6 +669,124 @@ SHARED_CHECKPOINT_SPECS: List[Dict[str, Any]] = [
     },
 ]
 
+
+FBMCQ_CHECKPOINT_SPECS: List[Dict[str, Any]] = [
+    {
+        'name': 'FBMCQ Query Clauses',
+        'description': 'init, assume, check, and query clause keywords',
+        'items': [
+            SharedExpectation('init', Token.Keyword.Declaration, 'clauses', 'keyword.control.fcstm.bmc.query'),
+            SharedExpectation('state', Token.Keyword.Declaration, 'clauses', 'keyword.control.fcstm.bmc.query'),
+            SharedExpectation('where', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('assume', Token.Keyword.Declaration, 'clauses', 'keyword.control.fcstm.bmc.query'),
+            SharedExpectation('always', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('at', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('events', Token.Keyword.Declaration, 'clauses', 'keyword.control.fcstm.bmc.query'),
+            SharedExpectation('cardinality', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('any', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('check', Token.Keyword.Declaration, 'clauses', 'keyword.control.fcstm.bmc.query'),
+            SharedExpectation('reach', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('forbid', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('invariant', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('must_reach', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('exists_always', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('response', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('cover', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('trigger', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('within', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+            SharedExpectation('current', Token.Keyword.Reserved, 'clauses', 'keyword.other.query-clause.fcstm.bmc.query'),
+        ],
+    },
+    {
+        'name': 'FBMCQ BMC Atoms',
+        'description': 'BMC atom names and helpers',
+        'items': [
+            SharedExpectation('var', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query', textmate_sample='var('),
+            SharedExpectation('cycle', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query'),
+            SharedExpectation('active', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query', textmate_sample='active('),
+            SharedExpectation('terminated', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query', textmate_sample='terminated('),
+            SharedExpectation('event', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query', textmate_sample='event('),
+            SharedExpectation('case', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query', textmate_sample='case('),
+            SharedExpectation('called', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query', textmate_sample='called('),
+            SharedExpectation('at_most_one', Token.Name.Builtin, 'atoms', 'support.function.bmc-atom.fcstm.bmc.query'),
+        ],
+    },
+    {
+        'name': 'FBMCQ Logical Operators',
+        'description': 'symbol and word logical operators',
+        'items': [
+            SharedExpectation('and', Token.Operator.Word, 'keywords', 'keyword.operator.word.fcstm.bmc.query'),
+            SharedExpectation('or', Token.Operator.Word, 'keywords', 'keyword.operator.word.fcstm.bmc.query'),
+            SharedExpectation('not', Token.Operator.Word, 'keywords', 'keyword.operator.word.fcstm.bmc.query'),
+            SharedExpectation('implies', Token.Operator.Word, 'keywords', 'keyword.operator.word.fcstm.bmc.query'),
+            SharedExpectation('xor', Token.Operator.Word, 'keywords', 'keyword.operator.word.fcstm.bmc.query'),
+            SharedExpectation('iff', Token.Operator.Word, 'keywords', 'keyword.operator.word.fcstm.bmc.query'),
+            SharedExpectation('&&', Token.Operator, 'operators', 'keyword.operator.logical.fcstm.bmc.query'),
+            SharedExpectation('||', Token.Operator, 'operators', 'keyword.operator.logical.fcstm.bmc.query'),
+            SharedExpectation('=>', Token.Operator, 'operators', 'keyword.operator.logical.fcstm.bmc.query'),
+            SharedExpectation('!', Token.Operator.Word, 'operators', 'keyword.operator.logical.fcstm.bmc.query'),
+        ],
+    },
+    {
+        'name': 'FBMCQ Response and Ranges',
+        'description': 'response arrow and event range operators',
+        'items': [
+            SharedExpectation('->', Token.Operator, 'operators', 'keyword.operator.response.fcstm.bmc.query'),
+            SharedExpectation('..', Token.Operator, 'operators', 'keyword.operator.range.fcstm.bmc.query'),
+        ],
+    },
+    {
+        'name': 'FBMCQ Numeric Operators',
+        'description': 'FCSTM-compatible arithmetic and bitwise operators',
+        'items': [
+            SharedExpectation('**', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('<<', Token.Operator, 'operators', 'keyword.operator.bitshift.fcstm.bmc.query'),
+            SharedExpectation('>>', Token.Operator, 'operators', 'keyword.operator.bitshift.fcstm.bmc.query'),
+            SharedExpectation('+', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('-', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('*', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('/', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('%', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('&', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('|', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('^', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('~', Token.Operator, 'operators', 'keyword.operator.arithmetic.fcstm.bmc.query'),
+            SharedExpectation('<=', Token.Operator, 'operators', 'keyword.operator.comparison.fcstm.bmc.query'),
+            SharedExpectation('>=', Token.Operator, 'operators', 'keyword.operator.comparison.fcstm.bmc.query'),
+            SharedExpectation('==', Token.Operator, 'operators', 'keyword.operator.comparison.fcstm.bmc.query'),
+            SharedExpectation('!=', Token.Operator, 'operators', 'keyword.operator.comparison.fcstm.bmc.query'),
+        ],
+    },
+    {
+        'name': 'FBMCQ Literals and Functions',
+        'description': 'numbers, strings, booleans, math constants, and ufuncs',
+        'items': [
+            SharedExpectation('0', Token.Number.Integer, 'numbers', 'constant.numeric.integer.fcstm.bmc.query'),
+            SharedExpectation('1000', Token.Number.Integer, 'numbers', 'constant.numeric.integer.fcstm.bmc.query'),
+            SharedExpectation('0xFF', Token.Number.Hex, 'numbers', 'constant.numeric.hex.fcstm.bmc.query'),
+            SharedExpectation('3.5e-1', Token.Number.Float, 'numbers', 'constant.numeric.float.fcstm.bmc.query'),
+            SharedExpectation('.5', Token.Number.Float, 'numbers', 'constant.numeric.float.fcstm.bmc.query'),
+            SharedExpectation('1.', Token.Number.Float, 'numbers', 'constant.numeric.float.fcstm.bmc.query'),
+            SharedExpectation('true', Token.Keyword.Constant, 'constants', 'constant.language.boolean.fcstm.bmc.query'),
+            SharedExpectation('false', Token.Keyword.Constant, 'constants', 'constant.language.boolean.fcstm.bmc.query'),
+            SharedExpectation('pi', Token.Name.Constant, 'constants', 'constant.language.math.fcstm.bmc.query'),
+            SharedExpectation('sin', Token.Name.Builtin, 'constants', 'support.function.builtin.fcstm.bmc.query'),
+            SharedExpectation('"Root.System.A"', Token.String.Double, 'strings', 'string.quoted.double.fcstm.bmc.query'),
+            SharedExpectation("'Root.System.A'", Token.String.Single, 'strings', 'string.quoted.single.fcstm.bmc.query'),
+        ],
+    },
+    {
+        'name': 'FBMCQ Comments',
+        'description': 'single-line, hash, and block comments',
+        'items': [
+            SharedExpectation('// FCSTM BMC Query syntax-highlighting fixture.', Token.Comment.Single, 'comments', 'comment.line.double-slash.fcstm.bmc.query'),
+            SharedExpectation('# hash comment', Token.Comment.Single, 'comments', 'comment.line.number-sign.fcstm.bmc.query'),
+            SharedExpectation('/*', Token.Comment.Multiline, 'comments', 'comment.block.fcstm.bmc.query', mode='begin'),
+            SharedExpectation('*/', Token.Comment.Multiline, 'comments', 'comment.block.fcstm.bmc.query', mode='end'),
+        ],
+    },
+]
+
 TEXTMATE_STRUCTURE_SPECS: List[Dict[str, Any]] = [
     {
         'name': 'Grammar Sync',
@@ -683,6 +842,7 @@ def _find_textmate_match(
 ) -> Tuple[bool, str]:
     repository = grammar.get('repository', {})
     patterns = repository.get(expectation.textmate_section, {}).get('patterns', [])
+    sample_text = expectation.textmate_sample or expectation.text
     candidate_details = []
 
     for pattern in patterns:
@@ -694,7 +854,7 @@ def _find_textmate_match(
         if expectation.capture_group is not None:
             if not regex:
                 continue
-            match = _compile_pattern(regex).search(expectation.text)
+            match = _compile_pattern(regex).search(sample_text)
             if not match:
                 continue
 
@@ -709,7 +869,7 @@ def _find_textmate_match(
             continue
 
         if regex:
-            if _compile_pattern(regex).search(expectation.text):
+            if _compile_pattern(regex).search(sample_text):
                 if scope_name == expectation.textmate_scope:
                     return True, ''
                 candidate_details.append(
@@ -718,7 +878,7 @@ def _find_textmate_match(
             continue
 
         if begin and end and expectation.mode == 'begin':
-            if _compile_pattern(begin).search(expectation.text):
+            if _compile_pattern(begin).search(sample_text):
                 if scope_name == expectation.textmate_scope:
                     return True, ''
                 candidate_details.append(
@@ -727,7 +887,7 @@ def _find_textmate_match(
             continue
 
         if begin and end and expectation.mode == 'end':
-            if _compile_pattern(end).search(expectation.text):
+            if _compile_pattern(end).search(sample_text):
                 if scope_name == expectation.textmate_scope:
                     return True, ''
                 candidate_details.append(
@@ -736,8 +896,8 @@ def _find_textmate_match(
             continue
 
         if begin and end:
-            begin_match = _compile_pattern(begin).search(expectation.text)
-            end_match = _compile_pattern(end).search(expectation.text)
+            begin_match = _compile_pattern(begin).search(sample_text)
+            end_match = _compile_pattern(end).search(sample_text)
             if begin_match and end_match and begin_match.start() <= end_match.start():
                 if scope_name == expectation.textmate_scope:
                     return True, ''
@@ -749,7 +909,7 @@ def _find_textmate_match(
         return False, '; '.join(candidate_details)
 
     return False, (
-        f"no pattern in repository section {expectation.textmate_section!r} matched {expectation.text!r} "
+        f"no pattern in repository section {expectation.textmate_section!r} matched {sample_text!r} "
         f"with expected scope {expectation.textmate_scope!r}"
     )
 
@@ -989,6 +1149,275 @@ def _validate_textmate_structure(grammar: Dict[str, Any], vscode_copy: Dict[str,
     return checkpoints
 
 
+
+def _validate_fbmcq_pygments(code: str) -> Tuple[List[ValidationCheckpoint], int, float]:
+    lexer = FcstmBmcQueryLexer()
+    tokens = list(lexer.get_tokens(code))
+    token_map = _token_map(tokens)
+    detection_score = FcstmBmcQueryLexer.analyse_text(code)
+
+    checkpoints: List[ValidationCheckpoint] = []
+
+    metadata_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Pygments Metadata',
+        description='the lexer exposes stable aliases, filenames, and MIME types',
+    )
+    metadata_expectations = [
+        ('name', FcstmBmcQueryLexer.name, 'FCSTM BMC Query'),
+        ('aliases', FcstmBmcQueryLexer.aliases, ['fbmcq', 'fcstm-bmc-query']),
+        ('filenames', FcstmBmcQueryLexer.filenames, ['*.fbmcq']),
+        ('mimetypes', FcstmBmcQueryLexer.mimetypes, ['text/x-fcstm-bmc-query']),
+    ]
+    for label, actual, expected in metadata_expectations:
+        if actual != expected:
+            metadata_checkpoint.failures.append(f'{label} expected {expected!r}, got {actual!r}')
+    metadata_checkpoint.passed = not metadata_checkpoint.failures
+    checkpoints.append(metadata_checkpoint)
+
+    tokenization_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Tokenization',
+        description='the lexer emits tokens for the shared BMC query test corpus',
+    )
+    if tokens:
+        tokenization_checkpoint.passed = True
+    else:
+        tokenization_checkpoint.failures.append('lexer returned zero tokens for the BMC query test corpus')
+    checkpoints.append(tokenization_checkpoint)
+
+    detection_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Language Detection',
+        description='analyse_text reports a confident BMC query detection score',
+    )
+    if detection_score >= 0.5:
+        detection_checkpoint.passed = True
+    else:
+        detection_checkpoint.failures.append(
+            f'detection score {detection_score:.2f} is below the required threshold 0.50'
+        )
+    checkpoints.append(detection_checkpoint)
+
+    for spec in FBMCQ_CHECKPOINT_SPECS:
+        checkpoint = ValidationCheckpoint(name=spec['name'], description=spec['description'])
+
+        for item in spec['items']:
+            actual_types = token_map.get(item.text)
+            if actual_types is None:
+                checkpoint.failures.append(f"token {item.text!r} was not found in the token stream")
+                continue
+            if item.pygments_token not in actual_types:
+                actual_text = ', '.join(str(token_type) for token_type in actual_types)
+                checkpoint.failures.append(
+                    f"token {item.text!r} expected {item.pygments_token}, got {actual_text}"
+                )
+
+        checkpoint.passed = not checkpoint.failures
+        checkpoints.append(checkpoint)
+
+    return checkpoints, len(tokens), detection_score
+
+
+def _validate_fbmcq_textmate_shared(grammar: Dict[str, Any]) -> List[ValidationCheckpoint]:
+    checkpoints: List[ValidationCheckpoint] = []
+
+    for spec in FBMCQ_CHECKPOINT_SPECS:
+        checkpoint = ValidationCheckpoint(name=spec['name'], description=spec['description'])
+
+        for item in spec['items']:
+            matched, failure_detail = _find_textmate_match(grammar, item)
+            if not matched:
+                checkpoint.failures.append(failure_detail)
+
+        checkpoint.passed = not checkpoint.failures
+        checkpoints.append(checkpoint)
+
+    return checkpoints
+
+
+
+def _match_textmate_root_token(grammar: Dict[str, Any], source: str, position: int = 0) -> Tuple[Optional[str], Optional[str]]:
+    repository = grammar.get('repository', {})
+    for include in grammar.get('patterns', []):
+        include_name = include.get('include')
+        if not include_name or not include_name.startswith('#'):
+            continue
+        section = repository.get(include_name[1:], {})
+        for pattern in section.get('patterns', []):
+            regex = pattern.get('match') or pattern.get('begin')
+            if not regex:
+                continue
+            match = _compile_pattern(regex).match(source, position)
+            if match:
+                return pattern.get('name'), match.group(0)
+    return None, None
+
+
+def _validate_fbmcq_textmate_structure(
+    grammar: Dict[str, Any],
+    vscode_copy: Dict[str, Any],
+    package_json: Dict[str, Any],
+) -> List[ValidationCheckpoint]:
+    checkpoints: List[ValidationCheckpoint] = []
+
+    sync_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Grammar Sync',
+        description='canonical and VSCode-packaged BMC query grammars are identical',
+    )
+    if grammar == vscode_copy:
+        sync_checkpoint.passed = True
+    else:
+        sync_checkpoint.failures.append('canonical BMC query grammar and VSCode-packaged grammar differ')
+    checkpoints.append(sync_checkpoint)
+
+    includes_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Top-Level Includes',
+        description='expected BMC query repository includes are present in pattern order',
+    )
+    expected_includes = [
+        '#comments',
+        '#atoms',
+        '#clauses',
+        '#keywords',
+        '#constants',
+        '#strings',
+        '#numbers',
+        '#operators',
+        '#identifiers',
+    ]
+    actual_includes = [item.get('include') for item in grammar.get('patterns', [])]
+    if actual_includes == expected_includes:
+        includes_checkpoint.passed = True
+    else:
+        includes_checkpoint.failures.append(
+            f'expected includes {expected_includes!r}, got {actual_includes!r}'
+        )
+    checkpoints.append(includes_checkpoint)
+
+    sections_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Repository Sections',
+        description='expected BMC query repository sections are present',
+    )
+    expected_sections = [
+        'comments', 'atoms', 'clauses', 'keywords', 'operators',
+        'constants', 'strings', 'numbers', 'identifiers',
+    ]
+    repository = grammar.get('repository', {})
+    for section in expected_sections:
+        if section not in repository:
+            sections_checkpoint.failures.append(f'missing repository section {section!r}')
+    sections_checkpoint.passed = not sections_checkpoint.failures
+    checkpoints.append(sections_checkpoint)
+
+    numeric_root_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Numeric Root Matching',
+        description='root include order lets BMC query numbers win over accessor punctuation when appropriate',
+    )
+    numeric_root_expectations = [
+        ('.5', 0, 'constant.numeric.float.fcstm.bmc.query', '.5'),
+        ('1.', 0, 'constant.numeric.float.fcstm.bmc.query', '1.'),
+        ('0..3', 0, 'constant.numeric.integer.fcstm.bmc.query', '0'),
+        ('0..3', 1, 'keyword.operator.range.fcstm.bmc.query', '..'),
+        ('0..3', 3, 'constant.numeric.integer.fcstm.bmc.query', '3'),
+    ]
+    for sample_text, position, expected_scope, expected_text in numeric_root_expectations:
+        actual_scope, actual_text = _match_textmate_root_token(grammar, sample_text, position)
+        if (actual_scope, actual_text) != (expected_scope, expected_text):
+            numeric_root_checkpoint.failures.append(
+                f"sample {sample_text!r} at {position} expected {(expected_scope, expected_text)!r}, "
+                f"got {(actual_scope, actual_text)!r}"
+            )
+    numeric_root_checkpoint.passed = not numeric_root_checkpoint.failures
+    checkpoints.append(numeric_root_checkpoint)
+
+    operator_checkpoint = ValidationCheckpoint(
+        name='FBMCQ Operator Order',
+        description='multi-character BMC query operators stay in safe matching order',
+    )
+    expected_operator_order = [
+        '\\*\\*',
+        '>>|<<',
+        '<=|>=|==|!=',
+        '&&|\\|\\|',
+        '=>',
+        '->',
+        '\\.\\.',
+        '!',
+        '[+\\-*/%&|^~<>]',
+        '=|\\?',
+        ',|;|:',
+        '\\{|\\}|\\(|\\)|\\[|\\]',
+        '\\.',
+    ]
+    operator_patterns = repository.get('operators', {}).get('patterns', [])
+    actual_operator_order = [item.get('match') for item in operator_patterns]
+    if actual_operator_order == expected_operator_order:
+        operator_checkpoint.passed = True
+    else:
+        operator_checkpoint.failures.append(
+            f'expected operator order {expected_operator_order!r}, got {actual_operator_order!r}'
+        )
+    checkpoints.append(operator_checkpoint)
+
+    contribution_checkpoint = ValidationCheckpoint(
+        name='FBMCQ VSCode Contribution',
+        description='package.json registers the BMC query language and grammar',
+    )
+    contributes = package_json.get('contributes', {})
+    languages = contributes.get('languages', [])
+    grammars = contributes.get('grammars', [])
+    language = next((item for item in languages if item.get('id') == 'fcstm-bmc-query'), None)
+    if language is None:
+        contribution_checkpoint.failures.append('missing language contribution id "fcstm-bmc-query"')
+    else:
+        if language.get('extensions') != ['.fbmcq']:
+            contribution_checkpoint.failures.append(
+                f'language extensions expected [\'.fbmcq\'], got {language.get("extensions")!r}'
+            )
+        expected_aliases = ['FCSTM BMC Query', 'fbmcq', 'fcstm-bmc-query']
+        if language.get('aliases') != expected_aliases:
+            contribution_checkpoint.failures.append(
+                f'language aliases expected {expected_aliases!r}, got {language.get("aliases")!r}'
+            )
+    grammar_entry = next((item for item in grammars if item.get('language') == 'fcstm-bmc-query'), None)
+    if grammar_entry is None:
+        contribution_checkpoint.failures.append('missing grammar contribution for language "fcstm-bmc-query"')
+    else:
+        if grammar_entry.get('scopeName') != 'source.fcstm.bmc.query':
+            contribution_checkpoint.failures.append(
+                f'grammar scope expected source.fcstm.bmc.query, got {grammar_entry.get("scopeName")!r}'
+            )
+        expected_path = './syntaxes/fcstm-bmc-query.tmLanguage.json'
+        if grammar_entry.get('path') != expected_path:
+            contribution_checkpoint.failures.append(
+                f'grammar path expected {expected_path!r}, got {grammar_entry.get("path")!r}'
+            )
+    contribution_checkpoint.passed = not contribution_checkpoint.failures
+    checkpoints.append(contribution_checkpoint)
+
+    negative_checkpoint = ValidationCheckpoint(
+        name='FBMCQ VSCode Negative Integration',
+        description='BMC query files do not activate FCSTM preview or language-server surfaces',
+    )
+    suspicious_needles = ('fcstm-bmc-query', '.fbmcq')
+    for activation in package_json.get('activationEvents', []):
+        if any(needle in activation for needle in suspicious_needles):
+            negative_checkpoint.failures.append(f'activation event must not target BMC query files: {activation!r}')
+    for menu_name, menu_items in contributes.get('menus', {}).items():
+        for item in menu_items:
+            when_clause = item.get('when', '')
+            if any(needle in when_clause for needle in suspicious_needles):
+                negative_checkpoint.failures.append(
+                    f'menu {menu_name!r} must not target BMC query files: {when_clause!r}'
+                )
+    for item in contributes.get('keybindings', []):
+        when_clause = item.get('when', '')
+        if any(needle in when_clause for needle in suspicious_needles):
+            negative_checkpoint.failures.append(f'keybinding must not target BMC query files: {when_clause!r}')
+    negative_checkpoint.passed = not negative_checkpoint.failures
+    checkpoints.append(negative_checkpoint)
+
+    return checkpoints
+
+
 def _print_section(title: str, checkpoints: List[ValidationCheckpoint]) -> None:
     print(f'\n🧪 {title}')
     for checkpoint in checkpoints:
@@ -1018,26 +1447,58 @@ def main() -> int:
     textmate_structure_checkpoints = _validate_textmate_structure(canonical_grammar, vscode_grammar)
     textmate_checkpoints = textmate_shared_checkpoints + textmate_structure_checkpoints
 
-    _print_section('Pygments Validation', pygments_checkpoints)
+    fbmcq_pygments_checkpoints, fbmcq_token_count, fbmcq_detection_score = _validate_fbmcq_pygments(FBMCQ_TEST_CODE)
+    fbmcq_canonical_grammar = _load_json(FBMCQ_TEXTMATE_GRAMMAR_FILE)
+    fbmcq_vscode_grammar = _load_json(VSCODE_FBMCQ_TEXTMATE_GRAMMAR_FILE)
+    vscode_package = _load_json(VSCODE_PACKAGE_FILE)
+    fbmcq_textmate_shared_checkpoints = _validate_fbmcq_textmate_shared(fbmcq_canonical_grammar)
+    fbmcq_textmate_structure_checkpoints = _validate_fbmcq_textmate_structure(
+        fbmcq_canonical_grammar,
+        fbmcq_vscode_grammar,
+        vscode_package,
+    )
+    fbmcq_textmate_checkpoints = fbmcq_textmate_shared_checkpoints + fbmcq_textmate_structure_checkpoints
+
+    _print_section('FCSTM Pygments Validation', pygments_checkpoints)
     print(
-        f'ℹ️ Pygments summary: {_count_passed(pygments_checkpoints)}/{len(pygments_checkpoints)} passed, '
+        f'ℹ️ FCSTM Pygments summary: {_count_passed(pygments_checkpoints)}/{len(pygments_checkpoints)} passed, '
         f'tokens={token_count}, detection={detection_score:.2f}'
     )
 
-    _print_section('TextMate Validation', textmate_checkpoints)
+    _print_section('FCSTM TextMate Validation', textmate_checkpoints)
     print(
-        f'ℹ️ TextMate summary: {_count_passed(textmate_checkpoints)}/{len(textmate_checkpoints)} passed'
+        f'ℹ️ FCSTM TextMate summary: {_count_passed(textmate_checkpoints)}/{len(textmate_checkpoints)} passed'
     )
 
-    all_checkpoints = pygments_checkpoints + textmate_checkpoints
+    _print_section('FBMCQ Pygments Validation', fbmcq_pygments_checkpoints)
+    print(
+        f'ℹ️ FBMCQ Pygments summary: '
+        f'{_count_passed(fbmcq_pygments_checkpoints)}/{len(fbmcq_pygments_checkpoints)} passed, '
+        f'tokens={fbmcq_token_count}, detection={fbmcq_detection_score:.2f}'
+    )
+
+    _print_section('FBMCQ TextMate and VSCode Validation', fbmcq_textmate_checkpoints)
+    print(
+        f'ℹ️ FBMCQ TextMate summary: '
+        f'{_count_passed(fbmcq_textmate_checkpoints)}/{len(fbmcq_textmate_checkpoints)} passed'
+    )
+
+    all_checkpoints = (
+        pygments_checkpoints
+        + textmate_checkpoints
+        + fbmcq_pygments_checkpoints
+        + fbmcq_textmate_checkpoints
+    )
     all_passed = all(checkpoint.passed for checkpoint in all_checkpoints)
 
     print('\n======================================================================')
     print('SUMMARY')
     print('======================================================================')
     print(
-        f'Pygments: {_count_passed(pygments_checkpoints)}/{len(pygments_checkpoints)} passed | '
-        f'TextMate: {_count_passed(textmate_checkpoints)}/{len(textmate_checkpoints)} passed'
+        f'FCSTM Pygments: {_count_passed(pygments_checkpoints)}/{len(pygments_checkpoints)} passed | '
+        f'FCSTM TextMate: {_count_passed(textmate_checkpoints)}/{len(textmate_checkpoints)} passed | '
+        f'FBMCQ Pygments: {_count_passed(fbmcq_pygments_checkpoints)}/{len(fbmcq_pygments_checkpoints)} passed | '
+        f'FBMCQ TextMate: {_count_passed(fbmcq_textmate_checkpoints)}/{len(fbmcq_textmate_checkpoints)} passed'
     )
 
     if all_passed:
@@ -1050,3 +1511,5 @@ def main() -> int:
 
 if __name__ == '__main__':
     sys.exit(main())
+
+# fmt: on

--- a/editors/vscode/Makefile
+++ b/editors/vscode/Makefile
@@ -14,6 +14,8 @@ PARSER_OUTPUT_DIR := ./parser
 SYNTAXES_DIR := ./syntaxes
 TEXTMATE_SRC := ../fcstm.tmLanguage.json
 TEXTMATE_DST := $(SYNTAXES_DIR)/fcstm.tmLanguage.json
+BMC_QUERY_TEXTMATE_SRC := ../fcstm-bmc-query.tmLanguage.json
+BMC_QUERY_TEXTMATE_DST := $(SYNTAXES_DIR)/fcstm-bmc-query.tmLanguage.json
 
 # Node/npm configuration
 NPM := npm
@@ -85,13 +87,19 @@ install: jsfcstm-install jsfcstm-build jsfcstm-pack
 	$(NPM) install --force --package-lock=false
 	$(NPM) install --force --package-lock=false ../jsfcstm/jsfcstm.tgz
 
-syntaxes: $(TEXTMATE_DST)
+syntaxes: $(TEXTMATE_DST) $(BMC_QUERY_TEXTMATE_DST)
 
 $(TEXTMATE_DST): $(TEXTMATE_SRC)
-	@echo "Copying TextMate grammar..."
+	@echo "Copying FCSTM TextMate grammar..."
 	@mkdir -p $(SYNTAXES_DIR)
 	cp $(TEXTMATE_SRC) $(TEXTMATE_DST)
-	@echo "TextMate grammar copied to $(TEXTMATE_DST)"
+	@echo "FCSTM TextMate grammar copied to $(TEXTMATE_DST)"
+
+$(BMC_QUERY_TEXTMATE_DST): $(BMC_QUERY_TEXTMATE_SRC)
+	@echo "Copying FCSTM BMC Query TextMate grammar..."
+	@mkdir -p $(SYNTAXES_DIR)
+	cp $(BMC_QUERY_TEXTMATE_SRC) $(BMC_QUERY_TEXTMATE_DST)
+	@echo "FCSTM BMC Query TextMate grammar copied to $(BMC_QUERY_TEXTMATE_DST)"
 
 parser: $(ANTLR_JAR) $(GRAMMAR_LEXER_FILE) $(GRAMMAR_PARSER_FILE)
 	@echo "Generating JavaScript parser from ANTLR grammar..."
@@ -226,6 +234,8 @@ package: all
 	@unzip -l ./build/*.vsix | grep -q "dist/extension.js" && echo "✓ Bundled extension.js included" || echo "✗ WARNING: extension.js not found in package!"
 	@unzip -l ./build/*.vsix | grep -q "dist/server.js" && echo "✓ Bundled server.js included" || (echo "✗ Bundled server.js missing from package!" && exit 1)
 	@unzip -l ./build/*.vsix | grep -q "resources/icon.png" && echo "✓ Extension icon included in package" || (echo "✗ Extension icon missing from package!" && exit 1)
+	@unzip -l ./build/*.vsix | grep -q "syntaxes/fcstm.tmLanguage.json" && echo "✓ FCSTM TextMate grammar included" || (echo "✗ FCSTM TextMate grammar missing from package!" && exit 1)
+	@unzip -l ./build/*.vsix | grep -q "syntaxes/fcstm-bmc-query.tmLanguage.json" && echo "✓ FCSTM BMC Query TextMate grammar included" || (echo "✗ FCSTM BMC Query TextMate grammar missing from package!" && exit 1)
 	@echo "Package size:"
 	@ls -lh ./build/*.vsix | awk '{print "  " $$9 ": " $$5}'
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -124,6 +124,18 @@
           ".fcstm"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "fcstm-bmc-query",
+        "aliases": [
+          "FCSTM BMC Query",
+          "fbmcq",
+          "fcstm-bmc-query"
+        ],
+        "extensions": [
+          ".fbmcq"
+        ],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -131,6 +143,11 @@
         "language": "fcstm",
         "scopeName": "source.fcstm",
         "path": "./syntaxes/fcstm.tmLanguage.json"
+      },
+      {
+        "language": "fcstm-bmc-query",
+        "scopeName": "source.fcstm.bmc.query",
+        "path": "./syntaxes/fcstm-bmc-query.tmLanguage.json"
       }
     ],
     "snippets": [

--- a/pyfcstm/highlight/__init__.py
+++ b/pyfcstm/highlight/__init__.py
@@ -1,23 +1,35 @@
-"""
-Syntax highlighting package for the FCSTM DSL.
+"""Syntax highlighting lexers for FCSTM languages.
 
-This package exposes Pygments lexer support for the FCSTM (Finite State
-Machine) domain-specific language. It provides a public entry point to the
-lexer implementation used by syntax highlighting tools and editors.
+The :mod:`pyfcstm.highlight` package exposes Pygments lexers used by Sphinx,
+editor integrations, and command-line highlighting tools.  The lexers are
+syntax highlighters only: they do not parse FCSTM models, bind BMC query paths,
+or run semantic validation.
 
-The package contains the following main components:
+Public lexer roadmap:
 
-* :class:`pyfcstm.highlight.pygments_lexer.FcstmLexer` - Pygments lexer for FCSTM
+.. list-table::
+   :header-rows: 1
+
+   * - Language surface
+     - Public lexer
+     - Purpose
+   * - FCSTM model DSL
+     - :class:`pyfcstm.highlight.pygments_lexer.FcstmLexer`
+     - Highlight ``*.fcstm`` state-machine model files.
+   * - FCSTM BMC Query
+     - :class:`pyfcstm.highlight.bmc_query_lexer.FcstmBmcQueryLexer`
+     - Highlight ``*.fbmcq`` bounded-model-checking query files.
 
 Example::
 
-    >>> from pyfcstm.highlight import FcstmLexer
-    >>> lexer = FcstmLexer()
-    >>> lexer.name
+    >>> from pyfcstm.highlight import FcstmBmcQueryLexer, FcstmLexer
+    >>> FcstmLexer().name
     'FCSTM'
-
+    >>> FcstmBmcQueryLexer().name
+    'FCSTM BMC Query'
 """
 
+from .bmc_query_lexer import FcstmBmcQueryLexer
 from .pygments_lexer import FcstmLexer
 
-__all__ = ['FcstmLexer']
+__all__ = ["FcstmLexer", "FcstmBmcQueryLexer"]

--- a/pyfcstm/highlight/bmc_query_lexer.py
+++ b/pyfcstm/highlight/bmc_query_lexer.py
@@ -1,0 +1,266 @@
+"""Pygments lexer for FCSTM BMC Query files.
+
+This module defines :class:`FcstmBmcQueryLexer`, a lightweight lexer for the
+``*.fbmcq`` query language used by the FCSTM bounded-model-checking workstream.
+The lexer mirrors the query grammar token surface closely enough for editor and
+Sphinx highlighting, but it deliberately does not parse or semantically validate
+queries.
+
+The module contains:
+
+* :class:`FcstmBmcQueryLexer` - Regex-based lexer for ``*.fbmcq`` query tokens.
+
+.. note::
+   :meth:`FcstmBmcQueryLexer.analyse_text` is a pure string heuristic.  It must
+   not import :mod:`pyfcstm.bmc.parse`, call the ANTLR parser, resolve model
+   paths, or run semantic binding.  Pygments may call language detection on
+   arbitrary text, including malformed snippets.
+
+Example::
+
+    >>> from pyfcstm.highlight import FcstmBmcQueryLexer
+    >>> lexer = FcstmBmcQueryLexer()
+    >>> lexer.name
+    'FCSTM BMC Query'
+    >>> query = 'init cold;\\ncheck reach <= 2: active("Root.Done");'
+    >>> FcstmBmcQueryLexer.analyse_text(query) >= 0.8
+    True
+"""
+
+import re
+
+from pygments.lexer import RegexLexer, include, words
+from pygments.token import (
+    Comment,
+    Keyword,
+    Name,
+    Number,
+    Operator,
+    Punctuation,
+    String,
+    Whitespace,
+)
+
+__all__ = ["FcstmBmcQueryLexer"]
+
+
+class FcstmBmcQueryLexer(RegexLexer):
+    """Lexer for FCSTM BMC Query files.
+
+    This lexer highlights the syntax-only ``*.fbmcq`` query surface used to
+    express bounded model checking objectives for FCSTM models.  It recognizes
+    query clauses, BMC-only atoms, FCSTM-compatible expression operators,
+    literals, strings, comments, and punctuation.  It does not validate whether
+    referenced states, events, variables, cases, or unsupported calls are
+    meaningful for a particular :class:`pyfcstm.model.StateMachine`.
+
+    :cvar name: Human-readable Pygments lexer name.
+    :type name: str
+    :cvar aliases: Pygments aliases for lookup by query-language name.
+    :type aliases: list
+    :cvar filenames: Filename globs recognized by Pygments.
+    :type filenames: list
+    :cvar mimetypes: MIME types recognized by Pygments.
+    :type mimetypes: list
+
+    Example::
+
+        >>> from pygments import lex
+        >>> from pyfcstm.highlight import FcstmBmcQueryLexer
+        >>> tokens = [(kind, text) for kind, text in lex('init cold;', FcstmBmcQueryLexer()) if text.strip()]
+        >>> tokens[0]
+        (Token.Keyword.Declaration, 'init')
+    """
+
+    name = "FCSTM BMC Query"
+    aliases = ["fbmcq", "fcstm-bmc-query"]
+    filenames = ["*.fbmcq"]
+    mimetypes = ["text/x-fcstm-bmc-query"]
+
+    _CLAUSE_KEYWORDS = (
+        "init",
+        "state",
+        "assume",
+        "event",
+        "events",
+        "check",
+    )
+    _RESERVED_KEYWORDS = (
+        "cold",
+        "terminated",
+        "where",
+        "always",
+        "at",
+        "cardinality",
+        "any",
+        "reach",
+        "forbid",
+        "invariant",
+        "must_reach",
+        "exists_always",
+        "response",
+        "cover",
+        "trigger",
+        "within",
+        "current",
+    )
+    _ATOM_NAMES = (
+        "var",
+        "active",
+        "terminated",
+        "event",
+        "case",
+        "called",
+    )
+    _BARE_ATOM_NAMES = ("cycle",)
+    _UFUNC_NAMES = (
+        "sin",
+        "cos",
+        "tan",
+        "asin",
+        "acos",
+        "atan",
+        "sinh",
+        "cosh",
+        "tanh",
+        "asinh",
+        "acosh",
+        "atanh",
+        "sqrt",
+        "cbrt",
+        "exp",
+        "log",
+        "log10",
+        "log2",
+        "log1p",
+        "abs",
+        "ceil",
+        "floor",
+        "round",
+        "trunc",
+        "sign",
+    )
+    _QUERY_HINT_RE = re.compile(
+        r"(?is)\b(?:init|assume|check)\b|\b(?:active|event|case|called|var|terminated)\s*\("
+    )
+    _CHECK_RE = re.compile(
+        r"(?is)\bcheck\s+(?:reach|forbid|invariant|must_reach|exists_always|response|cover)\s*<=\s*\d+\s*:"
+    )
+    _ASSUME_RE = re.compile(
+        r"(?is)\bassume\s+(?:always|at\s+\d+|event\s*\(|events\s+cardinality)\b"
+    )
+    _INIT_RE = re.compile(r"(?is)\binit\s+(?:cold|terminated|state\s*\()")
+
+    tokens = {
+        "root": [
+            include("whitespace"),
+            include("comments"),
+            include("strings"),
+            # Built-in atom/function names must come before generic keywords so
+            # dual-role words such as ``event(...)`` and ``terminated()`` are
+            # highlighted as calls while bare clause words stay as keywords.
+            # The suffix lookahead is the disambiguation boundary: atom names
+            # only match when a parenthesized call follows.
+            (words(_ATOM_NAMES, suffix=r"\b(?=\s*\()"), Name.Builtin),
+            (words(_BARE_ATOM_NAMES, suffix=r"\b"), Name.Builtin),
+            (words(("at_most_one",), suffix=r"\b"), Name.Builtin),
+            (words(_UFUNC_NAMES, suffix=r"\b(?=\s*\()"), Name.Builtin),
+            (words(_CLAUSE_KEYWORDS, suffix=r"\b"), Keyword.Declaration),
+            (words(_RESERVED_KEYWORDS, suffix=r"\b"), Keyword.Reserved),
+            (
+                words(("and", "or", "not", "implies", "xor", "iff"), suffix=r"\b"),
+                Operator.Word,
+            ),
+            (
+                words(
+                    ("True", "true", "TRUE", "False", "false", "FALSE"), suffix=r"\b"
+                ),
+                Keyword.Constant,
+            ),
+            (words(("pi", "E", "tau"), suffix=r"\b"), Name.Constant),
+            # Keep compact ranges such as ``0..3`` from being consumed as a
+            # floating-point prefix before the range operator is reached.
+            (r"[0-9]+(?=\.\.)", Number.Integer),
+            include("numbers"),
+            # Multi-character operators must precede shorter alternatives.
+            (r"\*\*", Operator),
+            (r">>|<<", Operator),
+            (r"<=|>=|==|!=", Operator),
+            (r"&&|\|\|", Operator),
+            (r"=>|->|\.\.", Operator),
+            (r"!", Operator.Word),
+            (r"[+\-*/%&|^~<>]", Operator),
+            (r"=|\?", Operator),
+            (r"[:;,{}()\[\]./]", Punctuation),
+            (r"[a-zA-Z_][a-zA-Z0-9_]*", Name),
+        ],
+        "whitespace": [
+            (r"\s+", Whitespace),
+        ],
+        "comments": [
+            (r"/\*", Comment.Multiline, "block-comment"),
+            (r"//.*?$", Comment.Single),
+            (r"#.*?$", Comment.Single),
+        ],
+        "block-comment": [
+            (r"\*/", Comment.Multiline, "#pop"),
+            (r"[^*]+", Comment.Multiline),
+            (r"\*", Comment.Multiline),
+        ],
+        "strings": [
+            (
+                r'"([^"\\\r\n]|\\[btnfr"\'\\]|\\[0-7]{1,3}|\\u[0-9a-fA-F]{4}|\\x[0-9a-fA-F]{2})*"',
+                String.Double,
+            ),
+            (
+                r"'([^'\\\r\n]|\\[btnfr\"'\\]|\\[0-7]{1,3}|\\u[0-9a-fA-F]{4}|\\x[0-9a-fA-F]{2})*'",
+                String.Single,
+            ),
+        ],
+        "numbers": [
+            (r"0x[0-9a-fA-F]+", Number.Hex),
+            (r"[0-9]+\.[0-9]*([eE][+-]?[0-9]+)?", Number.Float),
+            (r"\.[0-9]+([eE][+-]?[0-9]+)?", Number.Float),
+            (r"[0-9]+[eE][+-]?[0-9]+", Number.Float),
+            (r"[0-9]+", Number.Integer),
+        ],
+    }
+
+    # Do not decorate this with @staticmethod.  RegexLexerMeta wraps
+    # ``analyse_text`` through Pygments' ``make_analysator``; pre-wrapping it
+    # can make older supported Pygments releases swallow a TypeError and
+    # report ``0.0`` for valid query text.
+    def analyse_text(text: str) -> float:
+        """Return a heuristic confidence score for ``*.fbmcq`` text.
+
+        The score is intentionally based on lightweight regular expressions so
+        editor and Pygments discovery can run on incomplete or invalid query
+        snippets.  A complete query with ``init``/``assume``/``check`` clauses
+        receives a high score; unrelated text receives ``0.0``.
+
+        :param text: Candidate source text.
+        :type text: str
+        :return: Pygments confidence score between ``0.0`` and ``1.0``.
+        :rtype: float
+
+        Example::
+
+            >>> FcstmBmcQueryLexer.analyse_text('check cover <= 3: case("A::B");') >= 0.70
+            True
+        """
+        if not text or not FcstmBmcQueryLexer._QUERY_HINT_RE.search(text):
+            return 0.0
+
+        score = 0.0
+        if FcstmBmcQueryLexer._CHECK_RE.search(text):
+            score += 0.60
+        if FcstmBmcQueryLexer._ASSUME_RE.search(text):
+            score += 0.25
+        if FcstmBmcQueryLexer._INIT_RE.search(text):
+            score += 0.20
+        if re.search(r"(?is)\b(?:active|event|case|called|var|terminated)\s*\(", text):
+            score += 0.10
+        if re.search(r"(?is)\bstate\s+\w+\b|\[\s*\*\s*\]\s*->", text):
+            score -= 0.30
+
+        return max(0.0, min(score, 1.0))

--- a/setup.py
+++ b/setup.py
@@ -130,6 +130,7 @@ setup(
         "console_scripts": ["pyfcstm=pyfcstm.entry:pyfcstmcli"],
         "pygments.lexers": [
             "fcstm = pyfcstm.highlight.pygments_lexer:FcstmLexer",
+            "fbmcq = pyfcstm.highlight.bmc_query_lexer:FcstmBmcQueryLexer",
         ],
     },
     project_urls={

--- a/test/highlight/test_bmc_query_pygments_lexer.py
+++ b/test/highlight/test_bmc_query_pygments_lexer.py
@@ -1,0 +1,165 @@
+"""Tests for the FCSTM BMC Query Pygments lexer."""
+
+import sys
+import types
+from textwrap import dedent
+
+import pytest
+from pygments.token import Keyword, Name, Number, Operator, String
+
+from pyfcstm.highlight import FcstmBmcQueryLexer
+
+
+QUERY_SAMPLE = dedent(
+    """\
+    init state("Root.System.A") where x >= 0 and active("Root.System.A");
+
+    assume always: var("x") <= 1000;
+    assume at 0: x == var("x");
+    assume event("Root.System.A.Tick", 0..3) != false;
+    assume events cardinality at_most_one {
+        "Root.System.A.Tick",
+        "Root.System.A.Reset"
+    };
+
+    check response <= 10:
+        trigger event("Root.System.A.Tick", current) && active("Root.System.A")
+        -> within 3 active("Root.Recovering");
+    """
+)
+
+COVER_SAMPLE = dedent(
+    """\
+    init cold;
+
+    check cover <= 6:
+        case("Root.System.A::transition::Root.System.B::1");
+    """
+)
+
+
+def _token_pairs(source):
+    return [
+        (token_type, text)
+        for token_type, text in FcstmBmcQueryLexer().get_tokens(source)
+        if text.strip()
+    ]
+
+
+@pytest.mark.unittest
+def test_bmc_query_lexer_metadata_and_registry_aliases():
+    """Pygments metadata identifies ``*.fbmcq`` query files."""
+    assert FcstmBmcQueryLexer.name == "FCSTM BMC Query"
+    assert FcstmBmcQueryLexer.aliases == ["fbmcq", "fcstm-bmc-query"]
+    assert FcstmBmcQueryLexer.filenames == ["*.fbmcq"]
+    assert FcstmBmcQueryLexer.mimetypes == ["text/x-fcstm-bmc-query"]
+    setup_text = open("setup.py", encoding="utf-8").read()
+    assert "fbmcq = pyfcstm.highlight.bmc_query_lexer:FcstmBmcQueryLexer" in setup_text
+
+
+@pytest.mark.unittest
+def test_bmc_query_lexer_highlights_top_level_query_tokens():
+    """Representative query clauses receive stable Pygments token classes."""
+    tokens = _token_pairs(QUERY_SAMPLE)
+
+    assert (Keyword.Declaration, "init") in tokens
+    assert (Keyword.Declaration, "state") in tokens
+    assert (Keyword.Reserved, "where") in tokens
+    assert (Keyword.Declaration, "assume") in tokens
+    assert (Keyword.Reserved, "always") in tokens
+    assert (Keyword.Reserved, "at") in tokens
+    assert (Name.Builtin, "event") in tokens
+    assert (Keyword.Declaration, "events") in tokens
+    assert (Keyword.Reserved, "cardinality") in tokens
+    assert (Name.Builtin, "at_most_one") in tokens
+    assert (Keyword.Declaration, "check") in tokens
+    assert (Keyword.Reserved, "response") in tokens
+    assert (Keyword.Reserved, "trigger") in tokens
+    assert (Keyword.Reserved, "within") in tokens
+    assert (String.Double, '"Root.System.A"') in tokens
+    assert (Number.Integer, "1000") in tokens
+    assert (Operator.Word, "and") in tokens
+    assert (Operator, "&&") in tokens
+    assert (Operator, "->") in tokens
+    assert (Operator, "..") in tokens
+
+
+@pytest.mark.unittest
+def test_bmc_query_lexer_highlights_cover_case_tokens():
+    """Cover queries highlight ``cover`` and ``case`` without FCSTM state syntax."""
+    tokens = _token_pairs(COVER_SAMPLE)
+
+    assert (Keyword.Reserved, "cold") in tokens
+    assert (Keyword.Reserved, "cover") in tokens
+    assert (Name.Builtin, "case") in tokens
+    assert (String.Double, '"Root.System.A::transition::Root.System.B::1"') in tokens
+
+
+@pytest.mark.unittest
+def test_bmc_query_lexer_disambiguates_dual_role_keywords():
+    """Dual-role query words stay stable in clause and atom-call contexts."""
+    tokens = _token_pairs(
+        dedent(
+            """\
+            init terminated;
+
+            assume event("Root.Tick", current) != false;
+            assume events cardinality any {
+                "Root.Tick"
+            };
+
+            check reach <= 2: terminated(current);
+            """
+        )
+    )
+
+    assert (Keyword.Reserved, "terminated") in tokens
+    assert (Name.Builtin, "terminated") in tokens
+    assert (Name.Builtin, "event") in tokens
+    assert (Keyword.Declaration, "events") in tokens
+
+
+@pytest.mark.unittest
+def test_bmc_query_lexer_highlights_full_expression_surface():
+    """The lexer covers FCSTM-compatible expression operators used by queries."""
+    source = dedent(
+        """\
+        init cold;
+        assume always: ((~flags & 0xFF) == 0) or (cycle << 1) >= +2 and (-x <= 3.5e-1);
+        assume at 0: .5 + 1. + 1e2 >= var("x");
+        check reach <= 2: sin(pi) >= 0 xor false iff true;
+        """
+    )
+
+    tokens = _token_pairs(source)
+
+    for expected in ["~", "&", "<<", "+", "-", "<=", ">=", "xor", "iff"]:
+        assert any(token_text == expected for _, token_text in tokens), expected
+    assert (Number.Hex, "0xFF") in tokens
+    assert (Number.Float, "3.5e-1") in tokens
+    assert (Number.Float, ".5") in tokens
+    assert (Number.Float, "1.") in tokens
+    assert (Number.Float, "1e2") in tokens
+    assert (Name.Builtin, "cycle") in tokens
+    assert (Name.Builtin, "sin") in tokens
+    assert (Name.Constant, "pi") in tokens
+    assert (Keyword.Constant, "false") in tokens
+    assert (Keyword.Constant, "true") in tokens
+
+
+@pytest.mark.unittest
+def test_bmc_query_analyse_text_is_string_based(monkeypatch):
+    """Language detection must not import or call the parser layer."""
+    sentinel = types.ModuleType("pyfcstm.bmc.parse")
+
+    def fail_if_called(*_args, **_kwargs):
+        raise AssertionError("analyse_text must not call parse_bmc_query")
+
+    sentinel.parse_bmc_query = fail_if_called
+    monkeypatch.setitem(sys.modules, "pyfcstm.bmc.parse", sentinel)
+
+    score = FcstmBmcQueryLexer.analyse_text(QUERY_SAMPLE)
+
+    assert 0.0 <= score <= 1.0
+    assert score >= 0.80
+    assert sys.modules["pyfcstm.bmc.parse"] is sentinel


### PR DESCRIPTION
## 背景

本 PR 是 [伞 PR #305](https://github.com/HansBug/pyfcstm/pull/305) 的 **PR-5：查询语言：加入 `.fbmcq` 编辑器高亮与文档支持**。

当前上游已经合入：

- PR-1 / [#315](https://github.com/HansBug/pyfcstm/pull/315)：`pyfcstm.bmc` 查询数据模型与 canonical expression shape。
- PR-2 / [#323](https://github.com/HansBug/pyfcstm/pull/323)：独立 `.fbmcq` ANTLR grammar 与生成流程。
- PR-3 / [#326](https://github.com/HansBug/pyfcstm/pull/326)：`.fbmcq` parser、listener-based AST builder 与 expression parity tests。

本 PR 只补齐 `.fbmcq` 的编辑器与文档高亮支持，不进入 binder、solver、engine、witness 或 `verify.registry`。

## 当前阶段

这是空提交开出的执行 PR。当前先冻结计划并接受三路 review；review 的 C/I 问题清零后再开始 TDD 实现。

## 技术目标

| 目标 | 说明 | 验收信号 |
|---|---|---|
| TextMate canonical grammar | 新增 `.fbmcq` 独立 TextMate grammar。 | `editors/fcstm-bmc-query.tmLanguage.json` 存在，`scopeName` 为 `source.fcstm.bmc.query`。 |
| VSCode language contribution | 让 VSCode 识别 `.fbmcq` 文件并加载独立 grammar。 | `editors/vscode/package.json` 注册 `fcstm-bmc-query`、`.fbmcq`、`source.fcstm.bmc.query`。 |
| VSCode grammar copy | 将 canonical grammar 同步到扩展包 syntax 目录。 | `make -C editors/vscode syntaxes` 生成 `editors/vscode/syntaxes/fcstm-bmc-query.tmLanguage.json`，并与 canonical grammar 字节级一致。 |
| Pygments lexer | 新增 `.fbmcq` Pygments lexer，支持 Sphinx / CLI / 文档高亮。 | `FcstmBmcQueryLexer.aliases == ["fbmcq", "fcstm-bmc-query"]`，`filenames == ["*.fbmcq"]`，`mimetypes == ["text/x-fcstm-bmc-query"]`。 |
| validation checkpoint | 扩展 `python editors/validate.py`，独立校验 `.fbmcq` 资产。 | validator 检查 canonical / VSCode copy 同步、package contribution、Pygments metadata、token smoke。 |
| 文档与 API RST | 更新高亮文档和 generated API RST。 | `make rst_auto` 后 API docs 包含新增 lexer；文档说明 `.fbmcq` 资产与验证命令。 |

## 非目标

- 不修改 `pyfcstm/bmc/grammar/BmcQueryLexer.g4` 或 `BmcQueryParser.g4`。
- 不修改 `.fbmcq` parser / listener / AST 构建语义。
- 不实现 semantic binder、model path resolution、Z3 lowering、`BmcEngine` 或 witness replay。
- 不接入 `pyfcstm.verify.registry`。
- 不给 `.fbmcq` 接 VSCode LSP、diagnostics、completion、formatting 或 preview。
- 不让 `.fbmcq` 触发现有 `.fcstm` preview 菜单或语言服务器。

## 拟新增 / 修改文件

| 路径 | 操作 | 说明 |
|---|---|---|
| `editors/fcstm-bmc-query.tmLanguage.json` | 新增 | `.fbmcq` canonical TextMate grammar。 |
| `editors/vscode/syntaxes/fcstm-bmc-query.tmLanguage.json` | 生成 | 由 `make -C editors/vscode syntaxes` 从 canonical grammar 复制；该目录受忽略规则管理，不作为手写源文件提交。 |
| `editors/vscode/package.json` | 修改 | 注册 `fcstm-bmc-query` language 与 grammar。 |
| `pyfcstm/highlight/bmc_query_lexer.py` | 新增 | `.fbmcq` Pygments lexer。 |
| `pyfcstm/highlight/__init__.py` | 修改 | 导出 `FcstmBmcQueryLexer`，模块 docstring 更新为 roadmap 表格。 |
| `setup.py` | 修改 | 新增 `pygments.lexers` entry point：`fbmcq = pyfcstm.highlight.bmc_query_lexer:FcstmBmcQueryLexer`。 |
| `docs/source/conf.py` | 修改 | 注册 `fbmcq` / `fcstm-bmc-query` Sphinx lexer。 |
| `editors/validate.py` | 修改 | 增加 `.fbmcq` TextMate / VSCode / Pygments 校验。 |
| `test/highlight/test_bmc_query_pygments_lexer.py` | 新增 | `.fbmcq` Pygments lexer 单元测试。 |
| `editors/README.md` | 修改 | 说明 `.fbmcq` 高亮资产与验证流程。 |
| `docs/source/api_doc/highlight/*` | 生成更新 | `make rst_auto` 生成。 |

## `.fbmcq` 高亮契约

### 文件类型

| 项 | 冻结值 |
|---|---|
| 文件扩展名 | `.fbmcq` |
| VSCode language id | `fcstm-bmc-query` |
| TextMate scope | `source.fcstm.bmc.query` |
| Pygments aliases | `fbmcq`, `fcstm-bmc-query` |
| Pygments filename | `*.fbmcq` |
| MIME | `text/x-fcstm-bmc-query` |

### token 覆盖

| 分类 | 必须覆盖的文本 |
|---|---|
| 顶层结构 | `init`, `cold`, `terminated`, `state`, `where`, `assume`, `always`, `at`, `check` |
| event/cardinality | `event`, `events`, `cardinality`, `any`, `at_most_one` |
| property | `reach`, `forbid`, `invariant`, `must_reach`, `exists_always`, `response`, `cover`, `trigger`, `within` |
| BMC atom | `var`, `cycle`, `active`, `terminated`, `event`, `case`, `called`, `current` |
| FCSTM-compatible expression | decimal / hex / float、`true/True/TRUE/false/False/FALSE`、`pi/E/tau`、`+ - * / % ** << >> & ^ \|`、`< > <= >= == !=`、`&& \|\| ! and or not xor => implies iff`、`? :`、`UFUNC_NAME(...)` |
| trivia | `//`、`#`、`/* ... */`、single / double quoted strings 与 escape sequences |

说明：高亮器只负责 token 分类，不做模型语义校验。`^` 只作为 numeric bitwise operator 高亮；逻辑异或仍是 `xor`。

`.fbmcq` init target 以当前 grammar / 伞 PR 冻结语法为准，仅包含 `cold`、`terminated`、`state("...")`；本 PR 不新增 `warm` / `hot` 等未进入 grammar 的关键字高亮，以免编辑器暗示不存在的语法。

## TDD 执行方案

1. 先新增 `test/highlight/test_bmc_query_pygments_lexer.py`：锁定 alias / filename / mimetype、代表性 query token、`analyse_text` 纯字符串启发式、不会调用 `.fbmcq` parser。`analyse_text` 的测试必须具体化：在调用前用 monkeypatch / `sys.modules` sentinel 让 `pyfcstm.bmc.parse` 变成不可用或带副作用的伪模块，并断言 `FcstmBmcQueryLexer.analyse_text(sample)` 不导入、不调用 parser，同时返回 `0.0 <= score <= 1.0`。
2. 再新增 `editors/fcstm-bmc-query.tmLanguage.json`，并通过 `make -C editors/vscode syntaxes` 生成 VSCode copy；不要手写或强制提交 `editors/vscode/syntaxes/` 下的生成文件。
3. 扩展 `editors/validate.py`：先写 `.fbmcq` 校验目标，再实现校验逻辑。新增校验必须同时覆盖：canonical / VSCode grammar copy 字节级同步、`package.json` 正向 contribution、`activationEvents` / menus / keybindings 负向防误接入、Pygments metadata、`init` / `assume` / `check` / `response` / `cover` token smoke。
4. 更新 `pyfcstm/highlight/__init__.py`、`setup.py`、`docs/source/conf.py`。
5. 更新 `editors/README.md`。
6. 运行 `make rst_auto` 并纳入 generated RST。

## 本地验收命令

```bash
python -m py_compile pyfcstm/highlight/*.py editors/validate.py test/highlight/*.py
pytest test/highlight/test_bmc_query_pygments_lexer.py -q
pytest test/highlight/test_pygments_lexer.py -q
python editors/validate.py
python -m json.tool editors/fcstm-bmc-query.tmLanguage.json >/dev/null
make -C editors/vscode syntaxes
python -m json.tool editors/vscode/syntaxes/fcstm-bmc-query.tmLanguage.json >/dev/null
python -m json.tool editors/vscode/package.json >/dev/null
ruff check pyfcstm/highlight test/highlight editors/validate.py
ruff format --check pyfcstm/highlight/bmc_query_lexer.py pyfcstm/highlight/__init__.py test/highlight/test_bmc_query_pygments_lexer.py editors/validate.py
make rst_auto RANGE_DIR=highlight
SKIP_SLOW_TESTS=1 make unittest
```

如果本地 Node 环境可用，还应执行：

```bash
npm --prefix editors/vscode run compile:tsc
```

## PR 完成验收标准

- `.fbmcq` canonical TextMate grammar 与 `make -C editors/vscode syntaxes` 生成的 VSCode copy 字节级一致。
- VSCode `package.json` 注册 `fcstm-bmc-query` / `.fbmcq` / `source.fcstm.bmc.query`，但不把 `.fbmcq` 加进现有 `fcstm` LSP activation 或 preview 菜单。
- Pygments 可通过 `get_lexer_by_name("fbmcq")` 和 `get_lexer_by_name("fcstm-bmc-query")` 获取 lexer。
- `editors/validate.py` 能同时报告 FCSTM 主 DSL 与 `.fbmcq` 查询语言的高亮资产检查，并在任一侧失败时返回非零。
- token smoke 覆盖 `init` / `assume` / `check` / `response` / `cover`。
- 新增 public Python module / class 的 reST docstring 符合 `CLAUDE.md`：模块 docstring 清楚说明用途，class docstring 包含参数 / 示例；`__init__.py` 使用表格形态说明 module roadmap。
- `make rst_auto` 已运行，intentional RST 变更已提交。
- 本地 targeted checks 与 `SKIP_SLOW_TESTS=1 make unittest` 通过。
- GitHub CI 全绿；若 Codecov 出现评论，需要核对本 PR 覆盖率变化并补齐明显缺口。

## 计划 review 后修订

已按三路计划 review 修订以下 I 级验收缺口：

- 补齐 `editors/validate.py` 对 `editors/vscode/package.json` 的结构化正向检查，避免只检查 grammar copy 而漏掉 VSCode contribution。
- 补齐 `activationEvents` / menus / keybindings 的负向防误接入检查，确保 `.fbmcq` 不触发现有 `.fcstm` LSP、diagnostics 或 preview 面。
- 具体化 `analyse_text` 不调用 parser 的测试方式，要求通过 monkeypatch / `sys.modules` sentinel 证明它不 import / call `pyfcstm.bmc.parse`。
- 将 RST 生成命令收窄为 `make rst_auto RANGE_DIR=highlight`，减少无关 generated diff。
- 明确不新增 `warm` / `hot` 高亮；当前 `.fbmcq` grammar 只支持 `cold`、`terminated`、`state(...)` init target。

## Review 要求

三路 reviewer 需要强对抗检查：

- 本 PR 是否严格匹配伞 PR #305 的 PR-5 行。
- 是否误改 BMC grammar/parser/binder/engine 路径。
- `.fbmcq` 是否被错误接入 `.fcstm` LSP / preview / diagnostics。
- `editors/validate.py` 是否真的检查 canonical / VSCode copy 同步、VSCode contribution、VSCode 负向防误接入、Pygments metadata、关键 token smoke。
- Pygments lexer 是否保持纯字符串启发式，不调用 parser。
- pydoc / module roadmap / generated RST 是否符合仓库规范。




