### PR TITLE
查询语言：实现 .fbmcq 语义绑定与错误诊断

### DIFF
--- a/docs/source/api_doc/bmc/binding.rst
+++ b/docs/source/api_doc/bmc/binding.rst
@@ -1,0 +1,66 @@
+pyfcstm.bmc.binding
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.binding
+
+.. automodule:: pyfcstm.bmc.binding
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+BmcBindingDiagnostic
+-----------------------------------------------------
+
+.. autoclass:: BmcBindingDiagnostic
+    :members: __post_init__,to_canonical,__str__,code,path,message
+
+
+BoundReference
+-----------------------------------------------------
+
+.. autoclass:: BoundReference
+    :members: __post_init__,to_canonical,kind,name,path,spelling,resolved_id,declared_type
+
+
+BoundInitialSpec
+-----------------------------------------------------
+
+.. autoclass:: BoundInitialSpec
+    :members: __post_init__,mode,predicate,to_canonical,source,resolved_state_id
+
+
+BoundAssumption
+-----------------------------------------------------
+
+.. autoclass:: BoundAssumption
+    :members: __post_init__,to_canonical,source,kind,frame,cycles,resolved_event_ids
+
+
+BoundProperty
+-----------------------------------------------------
+
+.. autoclass:: BoundProperty
+    :members: __post_init__,kind,bound,to_canonical,source,case_label
+
+
+BoundBmcQuery
+-----------------------------------------------------
+
+.. autoclass:: BoundBmcQuery
+    :members: __post_init__,to_canonical,query,initial,assumptions,property,references
+
+
+bind\_bmc\_query\_structure
+-----------------------------------------------------
+
+.. autofunction:: bind_bmc_query_structure
+
+
+bind\_bmc\_query
+-----------------------------------------------------
+
+.. autofunction:: bind_bmc_query

--- a/docs/source/api_doc/bmc/binding.rst
+++ b/docs/source/api_doc/bmc/binding.rst
@@ -51,7 +51,7 @@ BoundBmcQuery
 -----------------------------------------------------
 
 .. autoclass:: BoundBmcQuery
-    :members: __post_init__,to_canonical,query,initial,assumptions,property,references
+    :members: __post_init__,to_ast_node,to_canonical,query,initial,assumptions,property,references
 
 
 bind\_bmc\_query\_structure

--- a/docs/source/api_doc/bmc/index.rst
+++ b/docs/source/api_doc/bmc/index.rst
@@ -10,6 +10,7 @@ pyfcstm.bmc
     :maxdepth: 3
 
     ast
+    binding
     domain
     errors
     grammar/index

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -41,6 +41,11 @@ Public module structure:
        :func:`build_bmc_ast_from_parse_tree`
      - Convert ``.fbmcq`` text or existing ANTLR parse trees into
        parser-independent AST/query nodes.
+   * - Query binding
+     - :class:`BmcBindingDiagnostic`, :class:`BoundBmcQuery`,
+       :func:`bind_bmc_query_structure`, :func:`bind_bmc_query`
+     - Validate query semantic contexts and optionally resolve model/domain
+       references without coupling parser-only imports to solver layers.
    * - Typed expression bases
      - :class:`BmcExpr`, :class:`BmcNumExpr`, :class:`BmcCondExpr`
      - Keep FCSTM numeric and condition expression categories explicit.
@@ -132,6 +137,17 @@ from pyfcstm.bmc.query import (
     InitialSpec,
 )
 
+_BINDING_EXPORTS = {
+    "BmcBindingDiagnostic",
+    "BoundReference",
+    "BoundInitialSpec",
+    "BoundAssumption",
+    "BoundProperty",
+    "BoundBmcQuery",
+    "bind_bmc_query_structure",
+    "bind_bmc_query",
+}
+
 _DOMAIN_EXPORTS = {
     "STATE_TERMINATE_ID",
     "STATE_DIAGNOSTIC_ID",
@@ -147,31 +163,36 @@ _DOMAIN_EXPORTS = {
 
 
 def __getattr__(name: str):
-    """Lazily resolve model-aware domain exports.
+    """Lazily resolve model-aware domain and binding exports.
 
     Domain numbering imports :mod:`pyfcstm.model`, while the query parser must
-    remain importable without loading model, verify, or solver layers.  Keeping
-    these top-level exports lazy preserves the public convenience API without
-    coupling parser-only callers to model-aware BMC preparation.
+    remain importable without loading model, verify, or solver layers.  Binding
+    exports are also lazy so the top-level package can list the public API
+    without importing the model-aware binding module on parser-only imports.
 
     :param name: Attribute name requested from :mod:`pyfcstm.bmc`.
     :type name: str
-    :return: The requested domain export.
+    :return: The requested lazy export.
     :rtype: object
-    :raises AttributeError: If ``name`` is not a public lazy domain export.
+    :raises AttributeError: If ``name`` is not a public lazy export.
 
     Example::
 
         >>> import pyfcstm.bmc as bmc
         >>> bmc.STATE_TERMINATE_ID
         -1
+        >>> callable(bmc.bind_bmc_query_structure)
+        True
     """
-    if name not in _DOMAIN_EXPORTS:
-        raise AttributeError("module 'pyfcstm.bmc' has no attribute %r" % name)
+    if name in _DOMAIN_EXPORTS:
+        from pyfcstm.bmc import domain
 
-    from pyfcstm.bmc import domain
+        return getattr(domain, name)
+    if name in _BINDING_EXPORTS:
+        from pyfcstm.bmc import binding
 
-    return getattr(domain, name)
+        return getattr(binding, name)
+    raise AttributeError("module 'pyfcstm.bmc' has no attribute %r" % name)
 
 
 def __dir__():
@@ -186,7 +207,7 @@ def __dir__():
         >>> 'BmcDomain' in dir(bmc)
         True
     """
-    return sorted(set(globals()) | _DOMAIN_EXPORTS)
+    return sorted(set(globals()) | _DOMAIN_EXPORTS | _BINDING_EXPORTS)
 
 
 __all__ = [
@@ -232,6 +253,14 @@ __all__ = [
     "EventCardinalityAssumption",
     "BmcProperty",
     "BmcQuery",
+    "BmcBindingDiagnostic",
+    "BoundReference",
+    "BoundInitialSpec",
+    "BoundAssumption",
+    "BoundProperty",
+    "BoundBmcQuery",
+    "bind_bmc_query_structure",
+    "bind_bmc_query",
     "STATE_TERMINATE_ID",
     "STATE_DIAGNOSTIC_ID",
     "StateDomainEntry",

--- a/pyfcstm/bmc/binding.py
+++ b/pyfcstm/bmc/binding.py
@@ -504,6 +504,29 @@ class BoundBmcQuery:
             )
         object.__setattr__(self, field_name, items)
 
+    def to_ast_node(self) -> BmcQuery:
+        """Return the parser-independent query AST bound by this snapshot.
+
+        Binding metadata such as resolved ids and declared variable types is
+        intentionally not represented in the returned query object.  Callers can
+        render the returned :class:`pyfcstm.bmc.query.BmcQuery` back to
+        canonical ``.fbmcq`` text, parse it again, and re-bind it with the same
+        model or domain when binding metadata must be reproduced.
+
+        :return: Original parser-independent BMC query object.
+        :rtype: pyfcstm.bmc.query.BmcQuery
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import BoolLiteral
+            >>> prop = BmcProperty('reach', 1, predicate=BoolLiteral('true'))
+            >>> query = BmcQuery(property=prop)
+            >>> bound = BoundBmcQuery(query, BoundInitialSpec(InitialSpec()), (), BoundProperty(prop))
+            >>> bound.to_ast_node() is query
+            True
+        """
+        return self.query
+
     def to_canonical(self) -> _CanonicalDict:
         """Return a JSON-stable bound query dictionary.
 

--- a/pyfcstm/bmc/binding.py
+++ b/pyfcstm/bmc/binding.py
@@ -79,7 +79,23 @@ from pyfcstm.bmc.query import (
 )
 
 _CanonicalDict = Dict[str, Any]
+_INITIAL_MODES = {"cold", "terminated", "state"}
+_FRAME_ASSUMPTION_KINDS = {"always", "at"}
+_EVENT_CARDINALITY_KINDS = {"any", "at_most_one"}
+_PROPERTY_KINDS = {
+    "reach",
+    "forbid",
+    "invariant",
+    "must_reach",
+    "exists_always",
+    "response",
+    "cover",
+}
 _RESERVED_STATE_PATHS = {"$STATE_TERMINATE", "$STATE_DIAGNOSTIC"}
+
+
+def _is_non_empty_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
 
 
 def _require_query(query: object) -> BmcQuery:
@@ -89,6 +105,7 @@ def _require_query(query: object) -> BmcQuery:
             "query",
             "query must be a BmcQuery object.",
         )
+    _validate_query_shape(query)
     return query
 
 
@@ -115,11 +132,11 @@ class BmcBindingDiagnostic:
     message: str
 
     def __post_init__(self) -> None:
-        if not isinstance(self.code, str) or not self.code:
+        if not _is_non_empty_text(self.code):
             raise InvalidBmcQuery("diagnostic code must be a non-empty string.")
-        if not isinstance(self.path, str) or not self.path:
+        if not _is_non_empty_text(self.path):
             raise InvalidBmcQuery("diagnostic path must be a non-empty string.")
-        if not isinstance(self.message, str) or not self.message:
+        if not _is_non_empty_text(self.message):
             raise InvalidBmcQuery("diagnostic message must be a non-empty string.")
 
     def to_canonical(self) -> _CanonicalDict:
@@ -186,7 +203,7 @@ class BoundReference:
     def __post_init__(self) -> None:
         for field_name in ("kind", "name", "path", "spelling"):
             value = getattr(self, field_name)
-            if not isinstance(value, str) or not value:
+            if not _is_non_empty_text(value):
                 raise InvalidBmcQuery(
                     f"BoundReference {field_name} must be a non-empty string."
                 )
@@ -196,7 +213,9 @@ class BoundReference:
             isinstance(self.resolved_id, bool) or not isinstance(self.resolved_id, int)
         ):
             raise InvalidBmcQuery("resolved_id must be an integer or None.")
-        if self.declared_type is not None and not isinstance(self.declared_type, str):
+        if self.declared_type is not None and not _is_non_empty_text(
+            self.declared_type
+        ):
             raise InvalidBmcQuery("declared_type must be a string or None.")
 
     def to_canonical(self) -> _CanonicalDict:
@@ -388,10 +407,14 @@ class BoundProperty:
     def __post_init__(self) -> None:
         if not isinstance(self.source, BmcProperty):
             raise InvalidBmcQuery("source must be BmcProperty.")
-        if self.case_label is not None and (
-            not isinstance(self.case_label, str) or not self.case_label
-        ):
+        if self.source.kind not in _PROPERTY_KINDS:
+            raise InvalidBmcQuery(
+                f"Unsupported bound property kind: {self.source.kind!r}."
+            )
+        if self.case_label is not None and not _is_non_empty_text(self.case_label):
             raise InvalidBmcQuery("case_label must be a non-empty string or None.")
+        if self.case_label is not None and self.source.kind != "cover":
+            raise InvalidBmcQuery("case_label is only valid for cover properties.")
 
     @property
     def kind(self) -> str:
@@ -510,6 +533,236 @@ def _raise_binding_error(code: str, path: str, message: str) -> None:
     error = InvalidBmcQuery(str(diagnostic))
     error.diagnostic = diagnostic
     raise error
+
+
+def _require_non_empty_field(value: object, path: str, field_name: str) -> None:
+    if not _is_non_empty_text(value):
+        _raise_binding_error(
+            "query_shape",
+            path,
+            f"{field_name} must be a non-empty string.",
+        )
+
+
+def _require_condition_field(value: object, path: str, field_name: str) -> None:
+    if not isinstance(value, BmcCondExpr):
+        _raise_binding_error(
+            "query_shape",
+            path,
+            f"{field_name} must be a BmcCondExpr object.",
+        )
+
+
+def _require_positive_integer_field(value: object, path: str, field_name: str) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        _raise_binding_error(
+            "query_shape",
+            path,
+            f"{field_name} must be a positive integer.",
+        )
+
+
+def _require_non_negative_integer_field(
+    value: object, path: str, field_name: str
+) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        _raise_binding_error(
+            "query_shape",
+            path,
+            f"{field_name} must be a non-negative integer.",
+        )
+
+
+def _validate_initial_shape(initial: object) -> None:
+    if not isinstance(initial, InitialSpec):
+        _raise_binding_error(
+            "query_shape",
+            "initial",
+            "initial must be an InitialSpec object.",
+        )
+    if initial.mode not in _INITIAL_MODES:
+        _raise_binding_error(
+            "query_shape",
+            "initial.mode",
+            f"Unsupported initial mode: {initial.mode!r}.",
+        )
+    if initial.mode == "state":
+        _require_non_empty_field(initial.state_path, "initial.state_path", "state_path")
+    elif initial.state_path is not None:
+        _raise_binding_error(
+            "query_shape",
+            "initial.state_path",
+            "state_path is only valid when initial mode is 'state'.",
+        )
+    if initial.predicate is not None:
+        _require_condition_field(
+            initial.predicate, "initial.predicate", "initial predicate"
+        )
+
+
+def _validate_frame_assumption_shape(assumption: FrameAssumption, path: str) -> None:
+    if assumption.kind not in _FRAME_ASSUMPTION_KINDS:
+        _raise_binding_error(
+            "query_shape",
+            path + ".kind",
+            f"Unsupported frame assumption kind: {assumption.kind!r}.",
+        )
+    _require_condition_field(assumption.predicate, path + ".predicate", "predicate")
+    if assumption.kind == "at":
+        _require_non_negative_integer_field(assumption.frame, path + ".frame", "frame")
+    elif assumption.frame is not None:
+        _raise_binding_error(
+            "query_shape",
+            path + ".frame",
+            "frame is only valid for 'at' frame assumptions.",
+        )
+
+
+def _validate_event_assumption_shape(assumption: EventAssumption, path: str) -> None:
+    _require_non_empty_field(assumption.event_path, path + ".event_path", "event_path")
+    selector = assumption.selector
+    if selector != "*" and not (
+        isinstance(selector, int) and not isinstance(selector, bool) and selector >= 0
+    ):
+        if not (
+            isinstance(selector, str)
+            and ".." in selector
+            and len(selector.split("..")) == 2
+            and all(_is_ascii_decimal(part) for part in selector.split(".."))
+        ):
+            _raise_binding_error(
+                "event_selector_invalid",
+                path + ".selector",
+                "event assumption selector must be '*', an integer, or an inclusive range.",
+            )
+    if not isinstance(assumption.expected, bool):
+        _raise_binding_error(
+            "query_shape",
+            path + ".expected",
+            "expected must be a boolean value.",
+        )
+
+
+def _validate_cardinality_assumption_shape(
+    assumption: EventCardinalityAssumption, path: str
+) -> None:
+    if assumption.kind not in _EVENT_CARDINALITY_KINDS:
+        _raise_binding_error(
+            "query_shape",
+            path + ".kind",
+            f"Unsupported event cardinality kind: {assumption.kind!r}.",
+        )
+    if isinstance(assumption.event_paths, str) or not isinstance(
+        assumption.event_paths, (list, tuple)
+    ):
+        _raise_binding_error(
+            "query_shape",
+            path + ".event_paths",
+            "event_paths must be a sequence of strings.",
+        )
+    event_paths = tuple(assumption.event_paths)
+    if assumption.kind == "at_most_one" and not event_paths:
+        _raise_binding_error(
+            "query_shape",
+            path + ".event_paths",
+            "event_paths must not be empty for at_most_one.",
+        )
+    if assumption.kind == "any" and event_paths:
+        _raise_binding_error(
+            "query_shape",
+            path + ".event_paths",
+            "event_paths is only valid for at_most_one.",
+        )
+    for event_index, event_path in enumerate(event_paths):
+        _require_non_empty_field(
+            event_path,
+            f"{path}.event_paths[{event_index}]",
+            "event path",
+        )
+    if len(set(event_paths)) != len(event_paths):
+        _raise_binding_error(
+            "query_shape",
+            path + ".event_paths",
+            "event_paths must not contain duplicate paths.",
+        )
+
+
+def _validate_assumption_shape(assumption: object, path: str) -> None:
+    if isinstance(assumption, FrameAssumption):
+        _validate_frame_assumption_shape(assumption, path)
+        return
+    if isinstance(assumption, EventAssumption):
+        _validate_event_assumption_shape(assumption, path)
+        return
+    if isinstance(assumption, EventCardinalityAssumption):
+        _validate_cardinality_assumption_shape(assumption, path)
+        return
+    _raise_binding_error(
+        "assumption_type",
+        path,
+        f"Unsupported assumption object: {type(assumption).__name__}.",
+    )
+
+
+def _validate_property_shape(property_node: object) -> None:
+    if not isinstance(property_node, BmcProperty):
+        _raise_binding_error(
+            "query_shape",
+            "property",
+            "property must be a BmcProperty object.",
+        )
+    if property_node.kind not in _PROPERTY_KINDS:
+        _raise_binding_error(
+            "query_shape",
+            "property.kind",
+            f"Unsupported property kind: {property_node.kind!r}.",
+        )
+    _require_positive_integer_field(property_node.bound, "property.bound", "bound")
+    if property_node.kind == "response":
+        _require_condition_field(
+            property_node.trigger, "property.trigger", "response trigger"
+        )
+        _require_condition_field(
+            property_node.response, "property.response", "response predicate"
+        )
+        _require_positive_integer_field(
+            property_node.within, "property.within", "response window"
+        )
+        if property_node.predicate is not None:
+            _raise_binding_error(
+                "query_shape",
+                "property.predicate",
+                "response properties only accept trigger, response predicate, and window.",
+            )
+        return
+    _require_condition_field(
+        property_node.predicate, "property.predicate", "property predicate"
+    )
+    if (
+        property_node.trigger is not None
+        or property_node.response is not None
+        or property_node.within is not None
+    ):
+        _raise_binding_error(
+            "query_shape",
+            "property",
+            "single-body properties only accept predicate.",
+        )
+
+
+def _validate_query_shape(query: BmcQuery) -> None:
+    _validate_initial_shape(query.initial)
+    if isinstance(query.assumptions, str) or not isinstance(
+        query.assumptions, (list, tuple)
+    ):
+        _raise_binding_error(
+            "query_shape",
+            "assumptions",
+            "assumptions must be a sequence of BmcAssumption objects.",
+        )
+    for index, assumption in enumerate(query.assumptions):
+        _validate_assumption_shape(assumption, f"assumptions[{index}]")
+    _validate_property_shape(query.property)
 
 
 class _BindingContext:

--- a/pyfcstm/bmc/binding.py
+++ b/pyfcstm/bmc/binding.py
@@ -1,0 +1,998 @@
+"""Semantic binding for parser-independent FCSTM BMC queries.
+
+The binding layer sits between the ``.fbmcq`` parser and later BMC engine or
+solver lowering code.  It validates query-context rules that are deliberately
+not encoded in the grammar, optionally resolves model paths through a
+:class:`pyfcstm.bmc.domain.BmcDomain`, and returns a stable, JSON-friendly
+binding snapshot.
+
+Design contracts:
+
+* Structure-only binding does not import :mod:`pyfcstm.model`,
+  :mod:`pyfcstm.solver`, :mod:`pyfcstm.verify`, or ``z3``.
+* Parser errors remain :class:`pyfcstm.bmc.errors.BmcQueryParseError`; semantic
+  binding errors use :class:`pyfcstm.bmc.errors.InvalidBmcQuery` with a
+  :class:`BmcBindingDiagnostic` attached.
+* Bound objects preserve the original parser AST and expose
+  :meth:`to_canonical` for golden tests and future engine handoff.
+* This binding layer keeps frame-local predicates conservative: omitted and
+  ``current`` frame selectors are accepted, while explicit integer frame
+  selectors are rejected outside event assumptions.
+
+The module contains:
+
+* :class:`BmcBindingDiagnostic` - Stable binding diagnostic.
+* :class:`BoundReference` - Model reference discovered during binding.
+* :class:`BoundInitialSpec`, :class:`BoundAssumption`,
+  :class:`BoundProperty`, and :class:`BoundBmcQuery` - Normalized bound query
+  snapshots.
+* :func:`bind_bmc_query_structure` - Query-only semantic binding.
+* :func:`bind_bmc_query` - Optional model/domain-aware binding.
+
+Example::
+
+    >>> from pyfcstm.bmc.parse import parse_bmc_query
+    >>> from pyfcstm.bmc.binding import bind_bmc_query_structure
+    >>> bound = bind_bmc_query_structure(parse_bmc_query('check reach <= 1: true;'))
+    >>> bound.property.kind
+    'reach'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from pyfcstm.bmc.ast import (
+    Active,
+    BmcCondExpr,
+    BmcNumExpr,
+    BoolLiteral,
+    Called,
+    Case,
+    CondBinaryOp,
+    CondConditionalOp,
+    CondUnaryOp,
+    Cycle,
+    Event,
+    FloatLiteral,
+    FrameVar,
+    IntLiteral,
+    MathConst,
+    NameRef,
+    NumBinaryOp,
+    NumConditionalOp,
+    NumUnaryOp,
+    NumericComparison,
+    Terminated,
+    UFuncCall,
+)
+from pyfcstm.bmc.errors import InvalidBmcDomain, InvalidBmcQuery
+from pyfcstm.bmc.query import (
+    BmcAssumption,
+    BmcProperty,
+    BmcQuery,
+    EventAssumption,
+    EventCardinalityAssumption,
+    FrameAssumption,
+    InitialSpec,
+)
+
+_CanonicalDict = Dict[str, Any]
+_RESERVED_STATE_PATHS = {"$STATE_TERMINATE", "$STATE_DIAGNOSTIC"}
+
+
+def _require_query(query: object) -> BmcQuery:
+    if not isinstance(query, BmcQuery):
+        _raise_binding_error(
+            "query_type",
+            "query",
+            "query must be a BmcQuery object.",
+        )
+    return query
+
+
+@dataclass(frozen=True)
+class BmcBindingDiagnostic:
+    """Stable diagnostic emitted by the BMC query binder.
+
+    :param code: Stable machine-readable diagnostic code.
+    :type code: str
+    :param path: Semantic node path such as ``"property.predicate"``.
+    :type path: str
+    :param message: Human-readable diagnostic message.
+    :type message: str
+
+    Example::
+
+        >>> diag = BmcBindingDiagnostic('bad_context', 'property', 'not allowed')
+        >>> diag.to_canonical()['code']
+        'bad_context'
+    """
+
+    code: str
+    path: str
+    message: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.code, str) or not self.code:
+            raise InvalidBmcQuery("diagnostic code must be a non-empty string.")
+        if not isinstance(self.path, str) or not self.path:
+            raise InvalidBmcQuery("diagnostic path must be a non-empty string.")
+        if not isinstance(self.message, str) or not self.message:
+            raise InvalidBmcQuery("diagnostic message must be a non-empty string.")
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable diagnostic dictionary.
+
+        :return: Canonical diagnostic dictionary.
+        :rtype: Dict[str, str]
+
+        Example::
+
+            >>> BmcBindingDiagnostic('code', 'path', 'message').to_canonical()['path']
+            'path'
+        """
+        return {"code": self.code, "path": self.path, "message": self.message}
+
+    def __str__(self) -> str:
+        """Return a compact diagnostic string.
+
+        :return: Human-readable diagnostic summary.
+        :rtype: str
+
+        Example::
+
+            >>> str(BmcBindingDiagnostic('code', 'path', 'message'))
+            'code at path: message'
+        """
+        return f"{self.code} at {self.path}: {self.message}"
+
+
+@dataclass(frozen=True)
+class BoundReference:
+    """Reference discovered and optionally resolved during query binding.
+
+    :param kind: Reference category: ``"state"``, ``"event"``, or
+        ``"variable"``.
+    :type kind: str
+    :param name: Query-visible name or path.
+    :type name: str
+    :param path: Semantic expression path where the reference was found.
+    :type path: str
+    :param spelling: Source spelling family such as ``"active"``,
+        ``"event"``, ``"bare"``, or ``"var_call"``.
+    :type spelling: str
+    :param resolved_id: Domain id when model/domain-aware binding is used,
+        defaults to ``None``.
+    :type resolved_id: int, optional
+    :param declared_type: Variable declared type for resolved variable refs,
+        defaults to ``None``.
+    :type declared_type: str, optional
+
+    Example::
+
+        >>> BoundReference('variable', 'x', 'property.predicate', 'bare').to_canonical()['name']
+        'x'
+    """
+
+    kind: str
+    name: str
+    path: str
+    spelling: str
+    resolved_id: Optional[int] = None
+    declared_type: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        for field_name in ("kind", "name", "path", "spelling"):
+            value = getattr(self, field_name)
+            if not isinstance(value, str) or not value:
+                raise InvalidBmcQuery(
+                    f"BoundReference {field_name} must be a non-empty string."
+                )
+        if self.kind not in {"state", "event", "variable"}:
+            raise InvalidBmcQuery(f"Unsupported bound reference kind: {self.kind!r}.")
+        if self.resolved_id is not None and (
+            isinstance(self.resolved_id, bool) or not isinstance(self.resolved_id, int)
+        ):
+            raise InvalidBmcQuery("resolved_id must be an integer or None.")
+        if self.declared_type is not None and not isinstance(self.declared_type, str):
+            raise InvalidBmcQuery("declared_type must be a string or None.")
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable reference dictionary.
+
+        :return: Canonical reference dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> BoundReference('state', 'Root', 'initial', 'state_path').to_canonical()['kind']
+            'state'
+        """
+        return {
+            "node": "bound_reference",
+            "kind": self.kind,
+            "name": self.name,
+            "path": self.path,
+            "spelling": self.spelling,
+            "resolved_id": self.resolved_id,
+            "declared_type": self.declared_type,
+        }
+
+
+@dataclass(frozen=True)
+class BoundInitialSpec:
+    """Bound initial-frame query specification.
+
+    :param source: Original parser-independent initial spec.
+    :type source: InitialSpec
+    :param resolved_state_id: Domain state id for ``mode="state"`` when
+        resolved, defaults to ``None``.
+    :type resolved_state_id: int, optional
+
+    Example::
+
+        >>> BoundInitialSpec(InitialSpec()).to_canonical()['mode']
+        'cold'
+    """
+
+    source: InitialSpec
+    resolved_state_id: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, InitialSpec):
+            raise InvalidBmcQuery("source must be InitialSpec.")
+        if self.resolved_state_id is not None and (
+            isinstance(self.resolved_state_id, bool)
+            or not isinstance(self.resolved_state_id, int)
+        ):
+            raise InvalidBmcQuery("resolved_state_id must be an integer or None.")
+
+    @property
+    def mode(self) -> str:
+        """Return the initial mode.
+
+        :return: Initial mode string.
+        :rtype: str
+        """
+        return self.source.mode
+
+    @property
+    def predicate(self) -> Optional[BmcCondExpr]:
+        """Return the optional initial predicate.
+
+        :return: Initial predicate or ``None``.
+        :rtype: Optional[BmcCondExpr]
+        """
+        return self.source.predicate
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable bound initial-spec dictionary.
+
+        :return: Canonical bound initial specification.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> BoundInitialSpec(InitialSpec()).to_canonical()['node']
+            'bound_initial_spec'
+        """
+        result = self.source.to_canonical()
+        result.update(
+            {
+                "node": "bound_initial_spec",
+                "resolved_state_id": self.resolved_state_id,
+            }
+        )
+        return result
+
+
+@dataclass(frozen=True)
+class BoundAssumption:
+    """Bound query assumption.
+
+    :param source: Original assumption object.
+    :type source: BmcAssumption
+    :param kind: Bound assumption category.
+    :type kind: str
+    :param frame: Frame index for frame assumptions, defaults to ``None``.
+    :type frame: int, optional
+    :param cycles: Event cycles selected by event assumptions.
+    :type cycles: Tuple[int, ...], optional
+    :param resolved_event_ids: Resolved event ids for event assumptions,
+        defaults to ``()``.
+    :type resolved_event_ids: Tuple[int, ...], optional
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import BoolLiteral
+        >>> src = FrameAssumption('always', BoolLiteral('true'))
+        >>> BoundAssumption(src, 'frame').to_canonical()['kind']
+        'frame'
+    """
+
+    source: BmcAssumption
+    kind: str
+    frame: Optional[int] = None
+    cycles: Tuple[int, ...] = ()
+    resolved_event_ids: Tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, BmcAssumption):
+            raise InvalidBmcQuery("source must be BmcAssumption.")
+        if self.kind not in {"frame", "event", "event_cardinality"}:
+            raise InvalidBmcQuery(f"Unsupported bound assumption kind: {self.kind!r}.")
+        if self.frame is not None and (
+            isinstance(self.frame, bool) or not isinstance(self.frame, int)
+        ):
+            raise InvalidBmcQuery("frame must be an integer or None.")
+        if self.frame is not None and self.frame < 0:
+            raise InvalidBmcQuery("frame must be non-negative or None.")
+        for field_name in ("cycles", "resolved_event_ids"):
+            value = getattr(self, field_name)
+            if not isinstance(value, (list, tuple)):
+                raise InvalidBmcQuery(f"{field_name} must be a sequence.")
+            normalized = tuple(value)
+            if not all(
+                not isinstance(item, bool) and isinstance(item, int)
+                for item in normalized
+            ):
+                raise InvalidBmcQuery(f"{field_name} must contain integers.")
+            object.__setattr__(self, field_name, normalized)
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable bound assumption dictionary.
+
+        :return: Canonical bound assumption.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import BoolLiteral
+            >>> src = FrameAssumption('always', BoolLiteral('true'))
+            >>> BoundAssumption(src, 'frame').to_canonical()['node']
+            'bound_assumption'
+        """
+        return {
+            "node": "bound_assumption",
+            "kind": self.kind,
+            "source": self.source.to_canonical(),
+            "frame": self.frame,
+            "cycles": list(self.cycles),
+            "resolved_event_ids": list(self.resolved_event_ids),
+        }
+
+
+@dataclass(frozen=True)
+class BoundProperty:
+    """Bound BMC query property.
+
+    :param source: Original property object.
+    :type source: BmcProperty
+    :param case_label: Cover case label when ``kind="cover"``, defaults to
+        ``None``.
+    :type case_label: str, optional
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import BoolLiteral
+        >>> prop = BmcProperty('reach', 1, predicate=BoolLiteral('true'))
+        >>> BoundProperty(prop).bound
+        1
+    """
+
+    source: BmcProperty
+    case_label: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.source, BmcProperty):
+            raise InvalidBmcQuery("source must be BmcProperty.")
+        if self.case_label is not None and (
+            not isinstance(self.case_label, str) or not self.case_label
+        ):
+            raise InvalidBmcQuery("case_label must be a non-empty string or None.")
+
+    @property
+    def kind(self) -> str:
+        """Return the property kind.
+
+        :return: Property kind.
+        :rtype: str
+        """
+        return self.source.kind
+
+    @property
+    def bound(self) -> int:
+        """Return the positive query bound.
+
+        :return: Query bound.
+        :rtype: int
+        """
+        return self.source.bound
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable bound property dictionary.
+
+        :return: Canonical bound property.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import BoolLiteral
+            >>> prop = BmcProperty('reach', 1, predicate=BoolLiteral('true'))
+            >>> BoundProperty(prop).to_canonical()['kind']
+            'reach'
+        """
+        result = self.source.to_canonical()
+        result.update({"node": "bound_property", "case_label": self.case_label})
+        return result
+
+
+@dataclass(frozen=True)
+class BoundBmcQuery:
+    """Complete semantically bound BMC query snapshot.
+
+    :param query: Original parser-independent query.
+    :type query: BmcQuery
+    :param initial: Bound initial specification.
+    :type initial: BoundInitialSpec
+    :param assumptions: Bound assumptions.
+    :type assumptions: Tuple[BoundAssumption, ...]
+    :param property: Bound property.
+    :type property: BoundProperty
+    :param references: References found while binding, defaults to ``()``.
+    :type references: Tuple[BoundReference, ...], optional
+
+    Example::
+
+        >>> from pyfcstm.bmc.ast import BoolLiteral
+        >>> prop = BmcProperty('reach', 1, predicate=BoolLiteral('true'))
+        >>> bound = BoundBmcQuery(BmcQuery(property=prop), BoundInitialSpec(InitialSpec()), (), BoundProperty(prop))
+        >>> bound.to_canonical()['node']
+        'bound_bmc_query'
+    """
+
+    query: BmcQuery
+    initial: BoundInitialSpec
+    assumptions: Tuple[BoundAssumption, ...]
+    property: BoundProperty
+    references: Tuple[BoundReference, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.query, BmcQuery):
+            raise InvalidBmcQuery("query must be BmcQuery.")
+        if not isinstance(self.initial, BoundInitialSpec):
+            raise InvalidBmcQuery("initial must be BoundInitialSpec.")
+        if not isinstance(self.property, BoundProperty):
+            raise InvalidBmcQuery("property must be BoundProperty.")
+        self._normalize_sequence("assumptions", self.assumptions, BoundAssumption)
+        self._normalize_sequence("references", self.references, BoundReference)
+
+    def _normalize_sequence(
+        self, field_name: str, value: Sequence[Any], item_type: type
+    ) -> None:
+        if not isinstance(value, (list, tuple)):
+            raise InvalidBmcQuery(f"{field_name} must be a sequence.")
+        items = tuple(value)
+        if not all(isinstance(item, item_type) for item in items):
+            raise InvalidBmcQuery(
+                f"{field_name} must contain {item_type.__name__} objects."
+            )
+        object.__setattr__(self, field_name, items)
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable bound query dictionary.
+
+        :return: Canonical bound query.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.ast import BoolLiteral
+            >>> prop = BmcProperty('reach', 1, predicate=BoolLiteral('true'))
+            >>> bound = BoundBmcQuery(BmcQuery(property=prop), BoundInitialSpec(InitialSpec()), (), BoundProperty(prop))
+            >>> bound.to_canonical()['property']['bound']
+            1
+        """
+        return {
+            "node": "bound_bmc_query",
+            "query": self.query.to_canonical(),
+            "initial": self.initial.to_canonical(),
+            "assumptions": [item.to_canonical() for item in self.assumptions],
+            "property": self.property.to_canonical(),
+            "references": [item.to_canonical() for item in self.references],
+        }
+
+
+def _raise_binding_error(code: str, path: str, message: str) -> None:
+    diagnostic = BmcBindingDiagnostic(code, path, message)
+    error = InvalidBmcQuery(str(diagnostic))
+    error.diagnostic = diagnostic
+    raise error
+
+
+class _BindingContext:
+    def __init__(self, bound: int, domain: object = None) -> None:
+        self.bound = bound
+        self.domain = domain
+        self.references: List[BoundReference] = []
+
+    @property
+    def has_domain(self) -> bool:
+        return self.domain is not None
+
+    def add_reference(
+        self,
+        kind: str,
+        name: str,
+        path: str,
+        spelling: str,
+        resolved_id: Optional[int] = None,
+        declared_type: Optional[str] = None,
+    ) -> None:
+        self.references.append(
+            BoundReference(kind, name, path, spelling, resolved_id, declared_type)
+        )
+
+
+def _resolve_state(
+    ctx: _BindingContext, state_path: str, path: str, spelling: str
+) -> Optional[int]:
+    if state_path in _RESERVED_STATE_PATHS:
+        _raise_binding_error(
+            "reserved_state_path",
+            path,
+            "Reserved BMC sentinel states are not user-addressable state paths.",
+        )
+    if not ctx.has_domain:
+        ctx.add_reference("state", state_path, path, spelling)
+        return None
+    try:
+        entry = ctx.domain.state_by_path(state_path)
+    except InvalidBmcDomain as err:
+        # InvalidBmcDomain: domain lookup fails when the query references an
+        # unknown state path; re-surface it as a query-binding diagnostic.
+        _raise_binding_error("unknown_state", path, str(err))
+    ctx.add_reference("state", state_path, path, spelling, entry.id)
+    return entry.id
+
+
+def _resolve_event(
+    ctx: _BindingContext, event_path: str, path: str, spelling: str
+) -> Optional[int]:
+    if not ctx.has_domain:
+        ctx.add_reference("event", event_path, path, spelling)
+        return None
+    try:
+        entry = ctx.domain.event_by_path(event_path)
+    except InvalidBmcDomain as err:
+        # InvalidBmcDomain: domain lookup fails when the query references an
+        # unknown event path; convert it into an InvalidBmcQuery diagnostic.
+        _raise_binding_error("unknown_event", path, str(err))
+    ctx.add_reference("event", event_path, path, spelling, entry.id)
+    return entry.id
+
+
+def _resolve_variable(
+    ctx: _BindingContext, name: str, path: str, spelling: str
+) -> Optional[int]:
+    if not ctx.has_domain:
+        ctx.add_reference("variable", name, path, spelling)
+        return None
+    try:
+        entry = ctx.domain.variable_by_name(name)
+    except InvalidBmcDomain as err:
+        # InvalidBmcDomain: domain lookup fails when the query references an
+        # unknown persistent variable; convert it into a binding diagnostic.
+        _raise_binding_error("unknown_variable", path, str(err))
+    ctx.add_reference("variable", name, path, spelling, entry.id, entry.declared_type)
+    return entry.id
+
+
+def _validate_current_frame(frame: object, path: str) -> None:
+    if frame != "current":
+        _raise_binding_error(
+            "explicit_frame_selector",
+            path,
+            "Frame-local predicates only allow omitted/current frame selectors.",
+        )
+
+
+def _is_ascii_decimal(value: str) -> bool:
+    return bool(value) and all("0" <= char <= "9" for char in value)
+
+
+def _validate_event_cycles(selector: object, bound: int, path: str) -> Tuple[int, ...]:
+    if selector == "*":
+        return tuple(range(bound))
+    if isinstance(selector, int) and not isinstance(selector, bool):
+        if 0 <= selector < bound:
+            return (selector,)
+        _raise_binding_error(
+            "event_selector_out_of_range",
+            path,
+            "event selector must satisfy 0 <= k < bound.",
+        )
+    if isinstance(selector, str) and ".." in selector:
+        start_text, end_text = selector.split("..", 1)
+        if not (_is_ascii_decimal(start_text) and _is_ascii_decimal(end_text)):
+            _raise_binding_error(
+                "event_selector_invalid",
+                path,
+                "event range endpoints must be ASCII decimal integers.",
+            )
+        start, end = int(start_text), int(end_text)
+        if 0 <= start <= end < bound:
+            return tuple(range(start, end + 1))
+        _raise_binding_error(
+            "event_range_out_of_range",
+            path,
+            "event range must satisfy 0 <= start <= end < bound.",
+        )
+    _raise_binding_error(
+        "event_selector_invalid",
+        path,
+        "event assumption selector must be '*', an integer, or an inclusive range.",
+    )
+
+
+def _bind_numeric_expr(
+    ctx: _BindingContext, expr: BmcNumExpr, path: str, allow_cycle: bool
+) -> None:
+    if isinstance(expr, NameRef):
+        _resolve_variable(ctx, expr.name, path, "bare")
+        return
+    if isinstance(expr, FrameVar):
+        _resolve_variable(ctx, expr.name, path, "var_call")
+        return
+    if isinstance(expr, Cycle):
+        if not allow_cycle:
+            _raise_binding_error(
+                "cycle_not_allowed",
+                path,
+                "bare cycle is not allowed in this binding context.",
+            )
+        return
+    if isinstance(expr, NumUnaryOp):
+        _bind_numeric_expr(ctx, expr.operand, path + ".operand", allow_cycle)
+        return
+    if isinstance(expr, NumBinaryOp):
+        _bind_numeric_expr(ctx, expr.left, path + ".left", allow_cycle)
+        _bind_numeric_expr(ctx, expr.right, path + ".right", allow_cycle)
+        return
+    if isinstance(expr, NumConditionalOp):
+        _bind_condition_expr(
+            ctx,
+            expr.condition,
+            path + ".condition",
+            _ConditionRules.frame_local(allow_cycle=allow_cycle),
+        )
+        _bind_numeric_expr(ctx, expr.if_true, path + ".if_true", allow_cycle)
+        _bind_numeric_expr(ctx, expr.if_false, path + ".if_false", allow_cycle)
+        return
+    if isinstance(expr, UFuncCall):
+        _bind_numeric_expr(ctx, expr.operand, path + ".operand", allow_cycle)
+        return
+    if isinstance(expr, (IntLiteral, FloatLiteral, MathConst)):
+        return
+    _raise_binding_error(
+        "unsupported_numeric_expr",
+        path,
+        f"Unsupported numeric expression object: {type(expr).__name__}.",
+    )
+
+
+@dataclass(frozen=True)
+class _ConditionRules:
+    allow_cycle: bool = True
+    allow_event_current: bool = False
+
+    @classmethod
+    def frame_local(cls, allow_cycle: bool = True) -> "_ConditionRules":
+        return cls(allow_cycle=allow_cycle)
+
+
+def _bind_condition_expr(
+    ctx: _BindingContext, expr: BmcCondExpr, path: str, rules: _ConditionRules
+) -> None:
+    if isinstance(expr, NumericComparison):
+        _bind_numeric_expr(ctx, expr.left, path + ".left", rules.allow_cycle)
+        _bind_numeric_expr(ctx, expr.right, path + ".right", rules.allow_cycle)
+        return
+    if isinstance(expr, CondUnaryOp):
+        _bind_condition_expr(ctx, expr.operand, path + ".operand", rules)
+        return
+    if isinstance(expr, CondBinaryOp):
+        _bind_condition_expr(ctx, expr.left, path + ".left", rules)
+        _bind_condition_expr(ctx, expr.right, path + ".right", rules)
+        return
+    if isinstance(expr, CondConditionalOp):
+        _bind_condition_expr(ctx, expr.condition, path + ".condition", rules)
+        _bind_condition_expr(ctx, expr.if_true, path + ".if_true", rules)
+        _bind_condition_expr(ctx, expr.if_false, path + ".if_false", rules)
+        return
+    if isinstance(expr, Active):
+        _validate_current_frame(expr.frame, path + ".frame")
+        _resolve_state(ctx, expr.state_path, path, "active")
+        return
+    if isinstance(expr, Terminated):
+        _validate_current_frame(expr.frame, path + ".frame")
+        return
+    if isinstance(expr, Event):
+        if rules.allow_event_current and expr.selector == "current":
+            _resolve_event(ctx, expr.event_path, path, "event")
+            return
+        _raise_binding_error(
+            "event_not_allowed",
+            path,
+            "event atoms are not allowed in this binding context.",
+        )
+    if isinstance(expr, Case):
+        _raise_binding_error(
+            "case_not_allowed",
+            path,
+            "case atoms are only allowed as the naked cover predicate.",
+        )
+    if isinstance(expr, Called):
+        _raise_binding_error(
+            "unsupported_called_atom",
+            path,
+            "called() atoms are parsed but unsupported by this semantic binding layer.",
+        )
+    if isinstance(expr, BoolLiteral):
+        return
+    _raise_binding_error(
+        "unsupported_condition_expr",
+        path,
+        f"Unsupported condition expression object: {type(expr).__name__}.",
+    )
+
+
+def _bind_initial(ctx: _BindingContext, initial: InitialSpec) -> BoundInitialSpec:
+    resolved_state_id = None
+    if initial.mode == "state":
+        resolved_state_id = _resolve_state(
+            ctx, initial.state_path or "", "initial.state_path", "state_path"
+        )
+    if initial.predicate is not None:
+        _bind_condition_expr(
+            ctx,
+            initial.predicate,
+            "initial.predicate",
+            _ConditionRules.frame_local(allow_cycle=False),
+        )
+    return BoundInitialSpec(initial, resolved_state_id)
+
+
+def _bind_frame_assumption(
+    ctx: _BindingContext, assumption: FrameAssumption, index: int
+) -> BoundAssumption:
+    path = f"assumptions[{index}]"
+    if assumption.kind == "at" and (
+        assumption.frame is None
+        or isinstance(assumption.frame, bool)
+        or not isinstance(assumption.frame, int)
+        or assumption.frame < 0
+        or assumption.frame > ctx.bound
+    ):
+        _raise_binding_error(
+            "frame_selector_out_of_range",
+            path + ".frame",
+            "assume at frame must satisfy 0 <= k <= bound.",
+        )
+    _bind_condition_expr(
+        ctx,
+        assumption.predicate,
+        path + ".predicate",
+        _ConditionRules.frame_local(allow_cycle=True),
+    )
+    return BoundAssumption(assumption, "frame", frame=assumption.frame)
+
+
+def _bind_event_assumption(
+    ctx: _BindingContext, assumption: EventAssumption, index: int
+) -> BoundAssumption:
+    path = f"assumptions[{index}]"
+    cycles = _validate_event_cycles(assumption.selector, ctx.bound, path + ".selector")
+    resolved_id = _resolve_event(
+        ctx, assumption.event_path, path + ".event_path", "event_assumption"
+    )
+    resolved_ids = () if resolved_id is None else (resolved_id,)
+    return BoundAssumption(
+        assumption, "event", cycles=cycles, resolved_event_ids=resolved_ids
+    )
+
+
+def _bind_cardinality_assumption(
+    ctx: _BindingContext, assumption: EventCardinalityAssumption, index: int
+) -> BoundAssumption:
+    resolved_ids = []
+    for event_index, event_path in enumerate(assumption.event_paths):
+        resolved_id = _resolve_event(
+            ctx,
+            event_path,
+            f"assumptions[{index}].event_paths[{event_index}]",
+            "cardinality_event",
+        )
+        if resolved_id is not None:
+            resolved_ids.append(resolved_id)
+    return BoundAssumption(
+        assumption,
+        "event_cardinality",
+        resolved_event_ids=tuple(resolved_ids),
+    )
+
+
+def _bind_assumptions(
+    ctx: _BindingContext, assumptions: Sequence[BmcAssumption]
+) -> Tuple[BoundAssumption, ...]:
+    bound_assumptions = []
+    for index, assumption in enumerate(assumptions):
+        if isinstance(assumption, FrameAssumption):
+            bound_assumptions.append(_bind_frame_assumption(ctx, assumption, index))
+        elif isinstance(assumption, EventAssumption):
+            bound_assumptions.append(_bind_event_assumption(ctx, assumption, index))
+        elif isinstance(assumption, EventCardinalityAssumption):
+            bound_assumptions.append(
+                _bind_cardinality_assumption(ctx, assumption, index)
+            )
+        else:
+            _raise_binding_error(
+                "assumption_type",
+                f"assumptions[{index}]",
+                f"Unsupported assumption object: {type(assumption).__name__}.",
+            )
+    return tuple(bound_assumptions)
+
+
+def _bind_property(ctx: _BindingContext, property_node: BmcProperty) -> BoundProperty:
+    kind = property_node.kind
+    if kind == "response":
+        _bind_condition_expr(
+            ctx,
+            property_node.trigger,
+            "property.trigger",
+            _ConditionRules(allow_cycle=True, allow_event_current=True),
+        )
+        _bind_condition_expr(
+            ctx,
+            property_node.response,
+            "property.response",
+            _ConditionRules.frame_local(allow_cycle=True),
+        )
+        return BoundProperty(property_node)
+    if kind == "cover":
+        predicate = property_node.predicate
+        if isinstance(predicate, Called):
+            _bind_condition_expr(
+                ctx,
+                predicate,
+                "property.predicate",
+                _ConditionRules.frame_local(allow_cycle=True),
+            )
+        if not isinstance(predicate, Case) or predicate.frame != "current":
+            _raise_binding_error(
+                "cover_predicate",
+                "property.predicate",
+                'cover properties require a naked case("label") predicate.',
+            )
+        return BoundProperty(property_node, case_label=predicate.label)
+    _bind_condition_expr(
+        ctx,
+        property_node.predicate,
+        "property.predicate",
+        _ConditionRules.frame_local(allow_cycle=True),
+    )
+    return BoundProperty(property_node)
+
+
+def _bind_query_with_domain(query: BmcQuery, domain: object = None) -> BoundBmcQuery:
+    ctx = _BindingContext(query.property.bound, domain=domain)
+    initial = _bind_initial(ctx, query.initial)
+    assumptions = _bind_assumptions(ctx, query.assumptions)
+    property_node = _bind_property(ctx, query.property)
+    return BoundBmcQuery(
+        query=query,
+        initial=initial,
+        assumptions=assumptions,
+        property=property_node,
+        references=tuple(ctx.references),
+    )
+
+
+def bind_bmc_query_structure(query: BmcQuery) -> BoundBmcQuery:
+    """Bind a BMC query without loading or resolving a model domain.
+
+    :param query: Parser-independent BMC query object.
+    :type query: BmcQuery
+    :return: Query-only bound snapshot.
+    :rtype: BoundBmcQuery
+    :raises pyfcstm.bmc.errors.InvalidBmcQuery: If the query violates semantic
+        context rules.
+
+    Example::
+
+        >>> from pyfcstm.bmc.parse import parse_bmc_query
+        >>> bound = bind_bmc_query_structure(parse_bmc_query('check reach <= 1: true;'))
+        >>> bound.property.bound
+        1
+    """
+    return _bind_query_with_domain(_require_query(query), domain=None)
+
+
+def _domain_from_model(model: object, bound: int) -> object:
+    from pyfcstm.bmc.domain import build_bmc_domain
+
+    try:
+        return build_bmc_domain(model, bound)
+    except InvalidBmcDomain as err:
+        # InvalidBmcDomain: build_bmc_domain rejects non-StateMachine values or
+        # inconsistent models; expose it as a stable binding diagnostic.
+        _raise_binding_error("invalid_model", "model", str(err))
+
+
+def _validate_domain_bound(domain: object, query_bound: int) -> None:
+    from pyfcstm.bmc.domain import BmcDomain
+
+    if not isinstance(domain, BmcDomain):
+        _raise_binding_error("domain_type", "domain", "domain must be BmcDomain.")
+    if domain.bound != query_bound:
+        _raise_binding_error(
+            "domain_bound_mismatch",
+            "domain.bound",
+            f"domain bound {domain.bound} does not match query bound {query_bound}.",
+        )
+
+
+def bind_bmc_query(
+    query: BmcQuery, model: object = None, domain: object = None
+) -> BoundBmcQuery:
+    """Bind a BMC query with optional model/domain resolution.
+
+    :param query: Parser-independent BMC query object.
+    :type query: BmcQuery
+    :param model: Optional state machine.  When supplied without ``domain``, a
+        :class:`pyfcstm.bmc.domain.BmcDomain` is built from ``query``'s bound.
+    :type model: object, optional
+    :param domain: Optional pre-built domain.  Its bound must match
+        ``query.property.bound``.
+    :type domain: object, optional
+    :return: Bound query snapshot.
+    :rtype: BoundBmcQuery
+    :raises pyfcstm.bmc.errors.InvalidBmcQuery: If query binding fails, both
+        ``model`` and ``domain`` are supplied, or the supplied domain bound does
+        not match the query bound.
+
+    Example::
+
+        >>> from pyfcstm.bmc.parse import parse_bmc_query
+        >>> bind_bmc_query(parse_bmc_query('check reach <= 1: true;')).property.kind
+        'reach'
+    """
+    query = _require_query(query)
+    if model is not None and domain is not None:
+        _raise_binding_error(
+            "model_domain_conflict",
+            "model",
+            "bind_bmc_query accepts either model or domain, not both.",
+        )
+    if domain is not None:
+        _validate_domain_bound(domain, query.property.bound)
+        return _bind_query_with_domain(query, domain=domain)
+    if model is not None:
+        resolved_domain = _domain_from_model(model, query.property.bound)
+        return _bind_query_with_domain(query, domain=resolved_domain)
+    return bind_bmc_query_structure(query)
+
+
+__all__ = [
+    "BmcBindingDiagnostic",
+    "BoundReference",
+    "BoundInitialSpec",
+    "BoundAssumption",
+    "BoundProperty",
+    "BoundBmcQuery",
+    "bind_bmc_query_structure",
+    "bind_bmc_query",
+]

--- a/pyfcstm/bmc/binding.py
+++ b/pyfcstm/bmc/binding.py
@@ -792,6 +792,7 @@ class _BindingContext:
 def _resolve_state(
     ctx: _BindingContext, state_path: str, path: str, spelling: str
 ) -> Optional[int]:
+    _require_non_empty_field(state_path, path, "state path")
     if state_path in _RESERVED_STATE_PATHS:
         _raise_binding_error(
             "reserved_state_path",
@@ -814,6 +815,7 @@ def _resolve_state(
 def _resolve_event(
     ctx: _BindingContext, event_path: str, path: str, spelling: str
 ) -> Optional[int]:
+    _require_non_empty_field(event_path, path, "event path")
     if not ctx.has_domain:
         ctx.add_reference("event", event_path, path, spelling)
         return None
@@ -830,6 +832,7 @@ def _resolve_event(
 def _resolve_variable(
     ctx: _BindingContext, name: str, path: str, spelling: str
 ) -> Optional[int]:
+    _require_non_empty_field(name, path, "variable name")
     if not ctx.has_domain:
         ctx.add_reference("variable", name, path, spelling)
         return None
@@ -1130,6 +1133,9 @@ def _bind_property(ctx: _BindingContext, property_node: BmcProperty) -> BoundPro
                 "property.predicate",
                 'cover properties require a naked case("label") predicate.',
             )
+        _require_non_empty_field(
+            predicate.label, "property.predicate.label", "case label"
+        )
         return BoundProperty(property_node, case_label=predicate.label)
     _bind_condition_expr(
         ctx,

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -55,6 +55,14 @@ def test_bmc_public_api_exports_exact_names():
         "EventCardinalityAssumption",
         "BmcProperty",
         "BmcQuery",
+        "BmcBindingDiagnostic",
+        "BoundReference",
+        "BoundInitialSpec",
+        "BoundAssumption",
+        "BoundProperty",
+        "BoundBmcQuery",
+        "bind_bmc_query_structure",
+        "bind_bmc_query",
         "STATE_TERMINATE_ID",
         "STATE_DIAGNOSTIC_ID",
         "StateDomainEntry",
@@ -86,6 +94,7 @@ def test_submodule_all_exports_are_exact():
     query = importlib.import_module("pyfcstm.bmc.query")
     parse = importlib.import_module("pyfcstm.bmc.parse")
     domain = importlib.import_module("pyfcstm.bmc.domain")
+    binding = importlib.import_module("pyfcstm.bmc.binding")
 
     assert set(errors.__all__) == {
         "BmcError",
@@ -148,6 +157,16 @@ def test_submodule_all_exports_are_exact():
         "EventInputRef",
         "BmcDomain",
         "build_bmc_domain",
+    }
+    assert set(binding.__all__) == {
+        "BmcBindingDiagnostic",
+        "BoundReference",
+        "BoundInitialSpec",
+        "BoundAssumption",
+        "BoundProperty",
+        "BoundBmcQuery",
+        "bind_bmc_query_structure",
+        "bind_bmc_query",
     }
 
 

--- a/test/bmc/test_query_binding.py
+++ b/test/bmc/test_query_binding.py
@@ -1,0 +1,768 @@
+"""Semantic binding tests for FCSTM BMC queries."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import pytest
+
+from pyfcstm.bmc.binding import (
+    BmcBindingDiagnostic,
+    BoundAssumption,
+    BoundBmcQuery,
+    BoundInitialSpec,
+    BoundProperty,
+    BoundReference,
+    bind_bmc_query,
+    bind_bmc_query_structure,
+)
+from pyfcstm.bmc.domain import build_bmc_domain
+from pyfcstm.bmc.errors import BmcQueryParseError, InvalidBmcQuery
+from pyfcstm.bmc.ast import (
+    BmcCondExpr,
+    BmcNumExpr,
+    BoolLiteral,
+    Case,
+    IntLiteral,
+    NumericComparison,
+)
+from pyfcstm.bmc.parse import parse_bmc_cond_expression, parse_bmc_query
+from pyfcstm.bmc.query import (
+    BmcAssumption,
+    BmcProperty,
+    BmcQuery,
+    EventAssumption,
+    FrameAssumption,
+    InitialSpec,
+)
+from pyfcstm.model import load_state_machine_from_text
+
+
+def _query(text: str):
+    return parse_bmc_query(text)
+
+
+def _bind(text: str) -> BoundBmcQuery:
+    return bind_bmc_query_structure(_query(text))
+
+
+def _diagnostic(excinfo) -> BmcBindingDiagnostic:
+    diag = getattr(excinfo.value, "diagnostic", None)
+    assert isinstance(diag, BmcBindingDiagnostic)
+    return diag
+
+
+@pytest.fixture()
+def binding_model():
+    """Return a compact model with variables, states, and events for binding."""
+    return load_state_machine_from_text(
+        """
+        def int x = 0;
+        def int cycle = 1;
+        def float pressure = 0.0;
+        state Root {
+            event Tick;
+            event Reset;
+            state Idle;
+            state Done;
+            [*] -> Idle;
+            Idle -> Done :: Tick;
+        }
+        """
+    )
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source, expected",
+    [
+        pytest.param(
+            "check reach <= 1: true;",
+            {"mode": "cold", "kind": "reach", "assumptions": 0},
+            id="default-cold-reach",
+        ),
+        pytest.param(
+            'init cold where active("Root.Idle"); check forbid <= 2: false;',
+            {"mode": "cold", "kind": "forbid", "assumptions": 0},
+            id="cold-where",
+        ),
+        pytest.param(
+            'init state("Root.Idle") where x >= 0; check invariant <= 3: x >= 0;',
+            {"mode": "state", "kind": "invariant", "assumptions": 0},
+            id="state-where-bare-var",
+        ),
+        pytest.param(
+            'init terminated where var("cycle") == 1; check must_reach <= 4: terminated();',
+            {"mode": "terminated", "kind": "must_reach", "assumptions": 0},
+            id="terminated-where-model-cycle-var",
+        ),
+        pytest.param(
+            'assume always: cycle <= 5; assume at 2: active("Root.Idle"); '
+            'check exists_always <= 5: !active("Root.Bad");',
+            {"mode": "cold", "kind": "exists_always", "assumptions": 2},
+            id="frame-assumptions",
+        ),
+        pytest.param(
+            'assume event("Root.Tick", *) == true; '
+            'assume event("Root.Reset", 1..2) == false; '
+            "assume events cardinality any; "
+            'assume events cardinality at_most_one {"Root.Tick"}; '
+            'check response <= 3: trigger event("Root.Tick", current) '
+            '-> within 1 active("Root.Done");',
+            {"mode": "cold", "kind": "response", "assumptions": 4},
+            id="event-and-response",
+        ),
+        pytest.param(
+            'check cover <= 2: case("Root.Idle::transition::Root.Done::1", current);',
+            {"mode": "cold", "kind": "cover", "assumptions": 0},
+            id="cover-current-canonical",
+        ),
+    ],
+)
+def test_bind_bmc_query_structure_accepts_positive_queries(source, expected):
+    """Structure binding accepts conservative positive query shapes."""
+    bound = _bind(source)
+    canonical = bound.to_canonical()
+
+    assert isinstance(bound, BoundBmcQuery)
+    assert bound.initial.mode == expected["mode"]
+    assert bound.property.kind == expected["kind"]
+    assert len(bound.assumptions) == expected["assumptions"]
+    assert canonical["node"] == "bound_bmc_query"
+    assert canonical["initial"]["mode"] == expected["mode"]
+    assert canonical["property"]["kind"] == expected["kind"]
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source, code_fragment, path_fragment",
+    [
+        pytest.param(
+            'check reach <= 5: event("Root.Tick", current);',
+            "event_not_allowed",
+            "property.predicate",
+            id="ordinary-property-event-current",
+        ),
+        pytest.param(
+            'assume always: event("Root.Tick", 0); check reach <= 1: true;',
+            "event_not_allowed",
+            "assumptions[0].predicate",
+            id="frame-assumption-event",
+        ),
+        pytest.param(
+            'check reach <= 5: active("Root.Idle", 2);',
+            "explicit_frame_selector",
+            "property.predicate.frame",
+            id="ordinary-property-explicit-frame",
+        ),
+        pytest.param(
+            'check response <= 5: trigger active("Root.Idle", 1) '
+            '-> within 2 active("Root.Done");',
+            "explicit_frame_selector",
+            "property.trigger.frame",
+            id="response-trigger-explicit-frame",
+        ),
+        pytest.param(
+            'check response <= 5: trigger active("Root.Idle") '
+            '-> within 2 active("Root.Done", 3);',
+            "explicit_frame_selector",
+            "property.response.frame",
+            id="response-target-explicit-frame",
+        ),
+        pytest.param(
+            'check response <= 5: trigger active("Root.Idle") '
+            '-> within 2 event("Root.Tick", current);',
+            "event_not_allowed",
+            "property.response",
+            id="response-target-event-current",
+        ),
+        pytest.param(
+            'check response <= 5: trigger event("Root.Tick", 3) '
+            '-> within 2 active("Root.Done");',
+            "event_not_allowed",
+            "property.trigger",
+            id="response-trigger-event-index",
+        ),
+        pytest.param(
+            'check cover <= 3: active("Root.Idle") && case("label");',
+            "cover_predicate",
+            "property.predicate",
+            id="cover-composite-symbolic-and",
+        ),
+        pytest.param(
+            'check cover <= 3: active("Root.Idle") and case("label");',
+            "cover_predicate",
+            "property.predicate",
+            id="cover-composite-keyword-and",
+        ),
+        pytest.param(
+            'check cover <= 3: case("label", 2);',
+            "cover_predicate",
+            "property.predicate",
+            id="cover-fixed-step-case",
+        ),
+        pytest.param(
+            "init cold where cycle == 0; check reach <= 1: true;",
+            "cycle_not_allowed",
+            "initial.predicate.left",
+            id="init-where-bare-cycle",
+        ),
+        pytest.param(
+            'init cold where event("Root.Tick", current); check reach <= 1: true;',
+            "event_not_allowed",
+            "initial.predicate",
+            id="init-where-event",
+        ),
+        pytest.param(
+            'check reach <= 3: called("Hook");',
+            "unsupported_called_atom",
+            "property.predicate",
+            id="called-ordinary-property",
+        ),
+        pytest.param(
+            'check cover <= 3: called("Hook");',
+            "unsupported_called_atom",
+            "property.predicate",
+            id="called-cover-property",
+        ),
+        pytest.param(
+            'check reach <= 3: (cycle <= 1) ? active("A") : case("L");',
+            "case_not_allowed",
+            "property.predicate.if_false",
+            id="nested-conditional-case",
+        ),
+    ],
+)
+def test_bind_bmc_query_structure_rejects_context_errors(
+    source, code_fragment, path_fragment
+):
+    """Binder rejects grammar-valid query shapes that violate semantic context."""
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        _bind(source)
+
+    diagnostic = _diagnostic(excinfo)
+    assert diagnostic.code == code_fragment
+    assert path_fragment in diagnostic.path
+    assert code_fragment in str(excinfo.value)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source, code",
+    [
+        pytest.param(
+            'assume event("Root.Tick", 3) == true; check reach <= 3: true;',
+            "event_selector_out_of_range",
+            id="event-selector-equals-bound",
+        ),
+        pytest.param(
+            'assume event("Root.Tick", 4..5) == true; check reach <= 5: true;',
+            "event_range_out_of_range",
+            id="event-range-end-equals-bound",
+        ),
+        pytest.param(
+            "assume at 4: true; check reach <= 3: true;",
+            "frame_selector_out_of_range",
+            id="assume-at-greater-than-bound",
+        ),
+    ],
+)
+def test_bind_bmc_query_structure_rejects_selector_boundaries(source, code):
+    """Binder checks frame and event selector ranges against query bound."""
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        _bind(source)
+
+    assert _diagnostic(excinfo).code == code
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source",
+    [
+        "check reach <= 0: true;",
+        "assume at -1: true; check reach <= 1: true;",
+        'check reach <= 5: event("Root.Tick", *);',
+        'check reach <= 5: event("Root.Tick", 0..2);',
+        'active("A") + 1',
+        "cycle and true",
+        "cycle && true",
+        'var("x") and active("A")',
+    ],
+)
+def test_parse_layer_rejects_non_ast_semantic_boundaries(source):
+    """Parser-invalid boundaries remain part of the binding guardrail matrix."""
+    with pytest.raises((BmcQueryParseError, InvalidBmcQuery)):
+        if source.startswith("check") or source.startswith("assume"):
+            parse_bmc_query(source)
+        else:
+            parse_bmc_cond_expression(source)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source, expected_cycles",
+    [
+        ('assume event("Root.Tick", 0) == true; check reach <= 3: true;', (0,)),
+        ('assume event("Root.Tick", 2) == true; check reach <= 3: true;', (2,)),
+        (
+            'assume event("Root.Tick", 0..2) == true; check reach <= 3: true;',
+            (0, 1, 2),
+        ),
+        (
+            'assume event("Root.Tick", *) == true; check reach <= 3: true;',
+            (0, 1, 2),
+        ),
+    ],
+)
+def test_event_assumption_selectors_expand_to_cycle_tuples(source, expected_cycles):
+    """Event assumptions normalize point, range, and wildcard selectors."""
+    bound = _bind(source)
+
+    assert bound.assumptions[0].cycles == expected_cycles
+
+
+@pytest.mark.unittest
+def test_bind_bmc_query_model_resolution_records_references(binding_model):
+    """Model-aware binding resolves state, event, and variable references."""
+    query = _query(
+        'init state("Root.Idle") where x == var("x"); '
+        'assume event("Root.Tick", 0) == true; '
+        'assume events cardinality at_most_one {"Root.Tick", "Root.Reset"}; '
+        'check reach <= 2: active("Root.Done") && var("cycle") >= cycle;'
+    )
+
+    bound = bind_bmc_query(query, model=binding_model)
+    references = bound.to_canonical()["references"]
+    by_key = {
+        (item["kind"], item["name"], item["spelling"]): item for item in references
+    }
+
+    assert bound.initial.resolved_state_id is not None
+    assert by_key[("state", "Root.Idle", "state_path")]["resolved_id"] is not None
+    assert by_key[("state", "Root.Done", "active")]["resolved_id"] is not None
+    assert by_key[("event", "Root.Tick", "event_assumption")]["resolved_id"] is not None
+    assert (
+        by_key[("event", "Root.Reset", "cardinality_event")]["resolved_id"] is not None
+    )
+    assert by_key[("variable", "x", "bare")]["declared_type"] == "int"
+    assert by_key[("variable", "x", "var_call")]["declared_type"] == "int"
+    assert by_key[("variable", "cycle", "var_call")]["declared_type"] == "int"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source, code",
+    [
+        ('check reach <= 1: active("Root.Missing");', "unknown_state"),
+        ('check reach <= 1: active("$STATE_TERMINATE");', "reserved_state_path"),
+        (
+            'init state("$STATE_DIAGNOSTIC"); check reach <= 1: true;',
+            "reserved_state_path",
+        ),
+        (
+            'assume event("Root.Missing", 0) == true; check reach <= 1: true;',
+            "unknown_event",
+        ),
+        ("check reach <= 1: missing >= 0;", "unknown_variable"),
+    ],
+)
+def test_bind_bmc_query_model_resolution_rejects_unknown_references(
+    binding_model, source, code
+):
+    """Model-aware binding rejects unresolved state, event, and variable names."""
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query(_query(source), model=binding_model)
+
+    assert _diagnostic(excinfo).code == code
+
+
+@pytest.mark.unittest
+def test_bind_bmc_query_domain_contracts(binding_model):
+    """The public binding entry freezes model/domain combinations."""
+    query = _query('check reach <= 2: active("Root.Done");')
+    matching_domain = build_bmc_domain(binding_model, 2)
+    mismatched_domain = build_bmc_domain(binding_model, 3)
+
+    assert bind_bmc_query(query).to_canonical()["node"] == "bound_bmc_query"
+    assert bind_bmc_query(query, domain=matching_domain).property.bound == 2
+
+    with pytest.raises(InvalidBmcQuery) as mismatch:
+        bind_bmc_query(query, domain=mismatched_domain)
+    assert _diagnostic(mismatch).code == "domain_bound_mismatch"
+
+    with pytest.raises(InvalidBmcQuery) as conflict:
+        bind_bmc_query(query, model=binding_model, domain=matching_domain)
+    assert _diagnostic(conflict).code == "model_domain_conflict"
+
+    with pytest.raises(InvalidBmcQuery) as wrong_domain:
+        bind_bmc_query(query, domain=object())
+    assert _diagnostic(wrong_domain).code == "domain_type"
+
+
+@pytest.mark.unittest
+def test_binding_diagnostic_is_stable_and_validated():
+    """Binding diagnostics expose stable canonical output and validation."""
+    diagnostic = BmcBindingDiagnostic("code", "path", "message")
+
+    assert str(diagnostic) == "code at path: message"
+    assert diagnostic.to_canonical() == {
+        "code": "code",
+        "path": "path",
+        "message": "message",
+    }
+
+    for args in [
+        ("", "path", "message"),
+        ("code", "", "message"),
+        ("code", "path", ""),
+    ]:
+        with pytest.raises(InvalidBmcQuery):
+            BmcBindingDiagnostic(*args)
+
+
+@pytest.mark.unittest
+def test_binding_imports_remain_layered():
+    """Structure binding imports do not load model, solver, z3, or verify."""
+    code = (
+        "import sys; "
+        "import pyfcstm.bmc.binding; "
+        "bad = [name for name in sys.modules "
+        "if name == 'z3' "
+        "or name.startswith('pyfcstm.model') "
+        "or name.startswith('pyfcstm.verify') "
+        "or name.startswith('pyfcstm.solver')]; "
+        "print(bad)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert result.stdout.strip() == "[]"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "factory",
+    [
+        pytest.param(
+            lambda: BmcBindingDiagnostic(1, "path", "message"), id="diag-code-type"
+        ),
+        pytest.param(
+            lambda: BmcBindingDiagnostic("code", 1, "message"), id="diag-path-type"
+        ),
+        pytest.param(
+            lambda: BmcBindingDiagnostic("code", "path", 1), id="diag-message-type"
+        ),
+        pytest.param(
+            lambda: BoundReference("state", "", "path", "active"),
+            id="reference-empty-name",
+        ),
+        pytest.param(
+            lambda: BoundReference("hook", "A", "path", "active"), id="reference-kind"
+        ),
+        pytest.param(
+            lambda: BoundReference("state", "A", "path", "active", resolved_id=True),
+            id="reference-resolved-bool",
+        ),
+        pytest.param(
+            lambda: BoundReference("variable", "x", "path", "bare", declared_type=1),
+            id="reference-declared-type",
+        ),
+        pytest.param(lambda: BoundInitialSpec(object()), id="initial-source"),
+        pytest.param(
+            lambda: BoundInitialSpec(InitialSpec(), resolved_state_id=True),
+            id="initial-resolved-bool",
+        ),
+        pytest.param(
+            lambda: BoundAssumption(object(), "frame"), id="assumption-source"
+        ),
+        pytest.param(
+            lambda: BoundAssumption(
+                FrameAssumption("always", BoolLiteral("true")), "bad"
+            ),
+            id="assumption-kind",
+        ),
+        pytest.param(
+            lambda: BoundAssumption(
+                FrameAssumption("always", BoolLiteral("true")), "frame", frame=True
+            ),
+            id="assumption-frame-bool",
+        ),
+        pytest.param(
+            lambda: BoundAssumption(
+                FrameAssumption("always", BoolLiteral("true")), "frame", frame=-1
+            ),
+            id="assumption-frame-negative",
+        ),
+        pytest.param(
+            lambda: BoundAssumption(
+                FrameAssumption("always", BoolLiteral("true")), "frame", cycles="bad"
+            ),
+            id="assumption-cycles-string",
+        ),
+        pytest.param(
+            lambda: BoundAssumption(
+                FrameAssumption("always", BoolLiteral("true")), "frame", cycles=(True,)
+            ),
+            id="assumption-cycles-bool",
+        ),
+        pytest.param(lambda: BoundProperty(object()), id="property-source"),
+        pytest.param(
+            lambda: BoundProperty(
+                BmcProperty("cover", 1, predicate=Case("case")), case_label=""
+            ),
+            id="property-label-empty",
+        ),
+        pytest.param(
+            lambda: BoundBmcQuery(
+                object(),
+                BoundInitialSpec(InitialSpec()),
+                (),
+                BoundProperty(BmcProperty("reach", 1, predicate=BoolLiteral("true"))),
+            ),
+            id="bound-query-source",
+        ),
+        pytest.param(
+            lambda: BoundBmcQuery(
+                BmcQuery(
+                    property=BmcProperty("reach", 1, predicate=BoolLiteral("true"))
+                ),
+                object(),
+                (),
+                BoundProperty(BmcProperty("reach", 1, predicate=BoolLiteral("true"))),
+            ),
+            id="bound-query-initial",
+        ),
+        pytest.param(
+            lambda: BoundBmcQuery(
+                BmcQuery(
+                    property=BmcProperty("reach", 1, predicate=BoolLiteral("true"))
+                ),
+                BoundInitialSpec(InitialSpec()),
+                (),
+                object(),
+            ),
+            id="bound-query-property",
+        ),
+        pytest.param(
+            lambda: BoundBmcQuery(
+                BmcQuery(
+                    property=BmcProperty("reach", 1, predicate=BoolLiteral("true"))
+                ),
+                BoundInitialSpec(InitialSpec()),
+                "bad",
+                BoundProperty(BmcProperty("reach", 1, predicate=BoolLiteral("true"))),
+            ),
+            id="bound-query-assumptions-string",
+        ),
+        pytest.param(
+            lambda: BoundBmcQuery(
+                BmcQuery(
+                    property=BmcProperty("reach", 1, predicate=BoolLiteral("true"))
+                ),
+                BoundInitialSpec(InitialSpec()),
+                (object(),),
+                BoundProperty(BmcProperty("reach", 1, predicate=BoolLiteral("true"))),
+            ),
+            id="bound-query-assumption-item",
+        ),
+    ],
+)
+def test_bound_binding_objects_reject_invalid_constructor_inputs(factory):
+    """Bound dataclasses reject malformed direct construction inputs."""
+    with pytest.raises(InvalidBmcQuery):
+        factory()
+
+
+@pytest.mark.unittest
+def test_bound_initial_properties_and_sequence_normalization():
+    """Bound snapshots expose convenience properties and normalize sequences."""
+    initial = BoundInitialSpec(
+        InitialSpec(predicate=BoolLiteral("true")), resolved_state_id=1
+    )
+    assumption = BoundAssumption(
+        FrameAssumption("always", BoolLiteral("true")),
+        "frame",
+        cycles=[0, 1],
+        resolved_event_ids=[2],
+    )
+    prop = BoundProperty(BmcProperty("reach", 2, predicate=BoolLiteral("true")))
+    bound = BoundBmcQuery(
+        BmcQuery(property=prop.source),
+        initial,
+        [assumption],
+        prop,
+        [BoundReference("event", "Root.Tick", "path", "event", 3)],
+    )
+
+    assert initial.mode == "cold"
+    assert initial.predicate == BoolLiteral("true")
+    assert assumption.cycles == (0, 1)
+    assert assumption.resolved_event_ids == (2,)
+    assert isinstance(bound.assumptions, tuple)
+    assert isinstance(bound.references, tuple)
+
+
+@pytest.mark.unittest
+def test_bind_bmc_query_rejects_non_query_input():
+    """Public binding entries reject non-query values with structured errors."""
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(object())
+
+    assert _diagnostic(excinfo).code == "query_type"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "source, expected_names",
+    [
+        pytest.param(
+            "check reach <= 2: -(x + 1) <= sqrt(y);",
+            {"x", "y"},
+            id="unary-binary-and-ufunc",
+        ),
+        pytest.param(
+            'check reach <= 2: ((active("Root.Idle")) ? (x + 1) : sqrt(y)) >= 0;',
+            {"Root.Idle", "x", "y"},
+            id="numeric-conditional",
+        ),
+        pytest.param(
+            'check reach <= 2: (active("Root.Idle")) ? active("Root.Done") : terminated();',
+            {"Root.Idle", "Root.Done"},
+            id="condition-conditional",
+        ),
+        pytest.param(
+            "check reach <= 2: x <= 1.5 && y >= pi;",
+            {"x", "y"},
+            id="float-literal-and-math-constant",
+        ),
+    ],
+)
+def test_binding_walks_nested_numeric_and_condition_expression_shapes(
+    source, expected_names
+):
+    """Binder traverses expression nodes that are not query-specific atoms."""
+    bound = _bind(source)
+
+    assert {reference.name for reference in bound.references} == expected_names
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "selector",
+    [
+        pytest.param(object(), id="opaque-object"),
+        pytest.param("0..x", id="bad-range-endpoint"),
+    ],
+)
+def test_internal_event_cycle_guard_rejects_unexpected_selector_shape(selector):
+    """The event selector helper fails closed for non-parser selector shapes."""
+    malformed = EventAssumption("Root.Tick", 0)
+    object.__setattr__(malformed, "selector", selector)
+    query = BmcQuery(
+        property=BmcProperty("reach", 2, predicate=BoolLiteral("true")),
+        assumptions=(malformed,),
+    )
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    assert _diagnostic(excinfo).code == "event_selector_invalid"
+
+
+@pytest.mark.unittest
+def test_internal_assumption_guard_rejects_unknown_assumption_subclass():
+    """The binder fails closed if future assumption subclasses reach it."""
+
+    class FutureAssumption(BmcAssumption):
+        def _canonical_payload(self):
+            return {}
+
+        def _to_dsl(self):
+            return "assume future;"
+
+    query = BmcQuery(
+        property=BmcProperty("reach", 1, predicate=BoolLiteral("true")),
+        assumptions=(FutureAssumption(),),
+    )
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    assert _diagnostic(excinfo).code == "assumption_type"
+
+
+@pytest.mark.unittest
+def test_bind_bmc_query_converts_invalid_model_to_query_diagnostic():
+    """Model/domain entry converts invalid model objects into binding errors."""
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query(_query("check reach <= 1: true;"), model=object())
+
+    assert _diagnostic(excinfo).code == "invalid_model"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "forged_frame",
+    [
+        pytest.param(None, id="missing-at-frame"),
+        pytest.param(True, id="boolean-at-frame"),
+        pytest.param("1", id="string-at-frame"),
+        pytest.param(-1, id="negative-at-frame"),
+    ],
+)
+def test_internal_frame_assumption_guard_rejects_forged_frame_values(forged_frame):
+    """The binder fails closed if a frame assumption is forged after parsing."""
+    assumption = FrameAssumption("at", BoolLiteral("true"), frame=0)
+    object.__setattr__(assumption, "frame", forged_frame)
+    query = BmcQuery(
+        property=BmcProperty("reach", 1, predicate=BoolLiteral("true")),
+        assumptions=(assumption,),
+    )
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    assert _diagnostic(excinfo).code == "frame_selector_out_of_range"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "predicate, code",
+    [
+        pytest.param("future_condition", "unsupported_condition_expr", id="condition"),
+        pytest.param("future_numeric", "unsupported_numeric_expr", id="numeric"),
+    ],
+)
+def test_binding_rejects_unknown_expression_subclasses(predicate, code):
+    """Binder fails closed when future expression subclasses reach it."""
+
+    class FutureCond(BmcCondExpr):
+        def _canonical_payload(self):
+            return {"name": "p"}
+
+        def _to_dsl(self):
+            return "future_cond()"
+
+    class FutureNum(BmcNumExpr):
+        def _canonical_payload(self):
+            return {"name": "x"}
+
+        def _to_dsl(self):
+            return "future_num()"
+
+    if predicate == "future_condition":
+        query_predicate = FutureCond()
+    else:
+        query_predicate = NumericComparison(FutureNum(), "==", IntLiteral("0"))
+    query = BmcQuery(property=BmcProperty("reach", 1, predicate=query_predicate))
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    assert _diagnostic(excinfo).code == code

--- a/test/bmc/test_query_binding.py
+++ b/test/bmc/test_query_binding.py
@@ -144,6 +144,117 @@ def test_bind_bmc_query_structure_accepts_positive_queries(source, expected):
 
 @pytest.mark.unittest
 @pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("check reach <= 1: true;", id="default-cold-reach"),
+        pytest.param(
+            'init cold where active("Root.Idle"); check forbid <= 2: false;',
+            id="cold-active-where",
+        ),
+        pytest.param(
+            'init state("Root.Idle") where x >= 0; check invariant <= 3: x >= 0;',
+            id="hot-state-bare-variable",
+        ),
+        pytest.param(
+            'init terminated where var("cycle") == 1; '
+            "check must_reach <= 4: terminated();",
+            id="terminated-explicit-cycle-var",
+        ),
+        pytest.param(
+            'assume always: cycle <= 5; assume at 2: active("Root.Idle"); '
+            'check exists_always <= 5: !active("Root.Bad");',
+            id="frame-assumptions",
+        ),
+        pytest.param(
+            'assume event("Root.Tick", *) == true; '
+            'assume event("Root.Reset", 1..2) == false; '
+            "assume events cardinality any; "
+            'assume events cardinality at_most_one {"Root.Tick"}; '
+            'check response <= 3: trigger event("Root.Tick", current) '
+            '-> within 1 active("Root.Done");',
+            id="event-assumptions-response",
+        ),
+        pytest.param(
+            'check cover <= 2: case("Root.Idle::transition::Root.Done::1", current);',
+            id="cover-current-canonicalizes-to-omitted-frame",
+        ),
+        pytest.param(
+            "check reach <= 2: -(x + 1) <= sqrt(y);",
+            id="numeric-unary-binary-ufunc",
+        ),
+        pytest.param(
+            'check reach <= 2: ((active("Root.Idle")) ? (x + 1) : sqrt(y)) >= 0;',
+            id="numeric-conditional",
+        ),
+        pytest.param(
+            'check reach <= 2: (active("Root.Idle")) ? active("Root.Done") : terminated();',
+            id="condition-conditional",
+        ),
+        pytest.param(
+            "check reach <= 2: x <= 1.5 && y >= pi;",
+            id="float-and-math-constant",
+        ),
+        pytest.param(
+            "check reach <= 3: (x << 1) >= (y >> 2);",
+            id="bit-shift-comparison",
+        ),
+        pytest.param(
+            "check reach <= 3: (x & 3) == 1 || (y | 4) != 0;",
+            id="bitwise-and-condition-or",
+        ),
+        pytest.param(
+            "check reach <= 3: !((x == 1) iff (y == 2));",
+            id="iff-under-negation",
+        ),
+        pytest.param(
+            "check reach <= 3: (x == 1) => (y == 2);",
+            id="implication",
+        ),
+        pytest.param(
+            "check reach <= 3: (x == 1) xor (y == 2);",
+            id="condition-xor",
+        ),
+    ],
+)
+def test_bound_bmc_query_to_ast_node_round_trips_structure_binding(source):
+    """Bound query snapshots round-trip through their BMC query AST object."""
+    bound = _bind(source)
+    ast_node = bound.to_ast_node()
+    reparsed_ast_node = parse_bmc_query(str(ast_node))
+    rebound = bind_bmc_query_structure(reparsed_ast_node)
+
+    assert isinstance(ast_node, BmcQuery)
+    assert ast_node is bound.query
+    assert reparsed_ast_node.to_canonical() == ast_node.to_canonical()
+    assert rebound.to_ast_node().to_canonical() == ast_node.to_canonical()
+    assert rebound.to_canonical() == bound.to_canonical()
+
+
+@pytest.mark.unittest
+def test_bound_bmc_query_to_ast_node_round_trips_domain_binding(binding_model):
+    """A bound AST node can be parsed again and re-bound with the same domain."""
+    source = (
+        'init state("Root.Idle") where x == var("x"); '
+        'assume event("Root.Tick", 0) == true; '
+        'assume events cardinality at_most_one {"Root.Tick", "Root.Reset"}; '
+        'check reach <= 2: active("Root.Done") && var("cycle") >= cycle;'
+    )
+    query = parse_bmc_query(source)
+    domain = build_bmc_domain(binding_model, 2)
+    bound = bind_bmc_query(query, domain=domain)
+
+    ast_node = bound.to_ast_node()
+    reparsed_ast_node = parse_bmc_query(str(ast_node))
+    rebound = bind_bmc_query(reparsed_ast_node, domain=domain)
+
+    assert ast_node is query
+    assert reparsed_ast_node.to_canonical() == ast_node.to_canonical()
+    assert rebound.to_ast_node().to_canonical() == ast_node.to_canonical()
+    assert rebound.to_canonical() == bound.to_canonical()
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
     "source, code_fragment, path_fragment",
     [
         pytest.param(

--- a/test/bmc/test_query_binding.py
+++ b/test/bmc/test_query_binding.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import pytest
 
+import pyfcstm.bmc.binding as binding_module
 from pyfcstm.bmc.binding import (
     BmcBindingDiagnostic,
     BoundAssumption,
@@ -19,6 +20,7 @@ from pyfcstm.bmc.binding import (
 from pyfcstm.bmc.domain import build_bmc_domain
 from pyfcstm.bmc.errors import BmcQueryParseError, InvalidBmcQuery
 from pyfcstm.bmc.ast import (
+    Active,
     BmcCondExpr,
     BmcNumExpr,
     BoolLiteral,
@@ -32,6 +34,7 @@ from pyfcstm.bmc.query import (
     BmcProperty,
     BmcQuery,
     EventAssumption,
+    EventCardinalityAssumption,
     FrameAssumption,
     InitialSpec,
 )
@@ -50,6 +53,12 @@ def _diagnostic(excinfo) -> BmcBindingDiagnostic:
     diag = getattr(excinfo.value, "diagnostic", None)
     assert isinstance(diag, BmcBindingDiagnostic)
     return diag
+
+
+def _forged_bound_property_with_kind(kind: str) -> BoundProperty:
+    prop = BmcProperty("reach", 1, predicate=BoolLiteral("true"))
+    object.__setattr__(prop, "kind", kind)
+    return BoundProperty(prop)
 
 
 @pytest.fixture()
@@ -459,8 +468,36 @@ def test_binding_imports_remain_layered():
             lambda: BmcBindingDiagnostic("code", "path", 1), id="diag-message-type"
         ),
         pytest.param(
+            lambda: BmcBindingDiagnostic("   ", "path", "message"),
+            id="diag-code-whitespace",
+        ),
+        pytest.param(
+            lambda: BmcBindingDiagnostic("code", "\t", "message"),
+            id="diag-path-whitespace",
+        ),
+        pytest.param(
+            lambda: BmcBindingDiagnostic("code", "path", "\n"),
+            id="diag-message-whitespace",
+        ),
+        pytest.param(
             lambda: BoundReference("state", "", "path", "active"),
             id="reference-empty-name",
+        ),
+        pytest.param(
+            lambda: BoundReference(" ", "A", "path", "active"),
+            id="reference-whitespace-kind",
+        ),
+        pytest.param(
+            lambda: BoundReference("state", " ", "path", "active"),
+            id="reference-whitespace-name",
+        ),
+        pytest.param(
+            lambda: BoundReference("state", "A", " ", "active"),
+            id="reference-whitespace-path",
+        ),
+        pytest.param(
+            lambda: BoundReference("state", "A", "path", " "),
+            id="reference-whitespace-spelling",
         ),
         pytest.param(
             lambda: BoundReference("hook", "A", "path", "active"), id="reference-kind"
@@ -472,6 +509,14 @@ def test_binding_imports_remain_layered():
         pytest.param(
             lambda: BoundReference("variable", "x", "path", "bare", declared_type=1),
             id="reference-declared-type",
+        ),
+        pytest.param(
+            lambda: BoundReference("variable", "x", "path", "bare", declared_type=""),
+            id="reference-declared-type-empty",
+        ),
+        pytest.param(
+            lambda: BoundReference("variable", "x", "path", "bare", declared_type=" "),
+            id="reference-declared-type-whitespace",
         ),
         pytest.param(lambda: BoundInitialSpec(object()), id="initial-source"),
         pytest.param(
@@ -513,10 +558,27 @@ def test_binding_imports_remain_layered():
         ),
         pytest.param(lambda: BoundProperty(object()), id="property-source"),
         pytest.param(
+            lambda: _forged_bound_property_with_kind("future"),
+            id="property-source-unknown-kind",
+        ),
+        pytest.param(
             lambda: BoundProperty(
                 BmcProperty("cover", 1, predicate=Case("case")), case_label=""
             ),
             id="property-label-empty",
+        ),
+        pytest.param(
+            lambda: BoundProperty(
+                BmcProperty("cover", 1, predicate=Case("case")), case_label=" "
+            ),
+            id="property-label-whitespace",
+        ),
+        pytest.param(
+            lambda: BoundProperty(
+                BmcProperty("reach", 1, predicate=BoolLiteral("true")),
+                case_label="case",
+            ),
+            id="property-label-non-cover",
         ),
         pytest.param(
             lambda: BoundBmcQuery(
@@ -676,6 +738,32 @@ def test_internal_event_cycle_guard_rejects_unexpected_selector_shape(selector):
 
 
 @pytest.mark.unittest
+@pytest.mark.parametrize(
+    "selector",
+    [
+        pytest.param(object(), id="opaque-object"),
+        pytest.param("0..x", id="bad-range-endpoint"),
+    ],
+)
+def test_internal_event_cycle_guard_remains_defensive_when_shape_check_is_bypassed(
+    monkeypatch, selector
+):
+    """The event cycle helper independently rejects malformed selector values."""
+    monkeypatch.setattr(binding_module, "_validate_query_shape", lambda query: None)
+    malformed = EventAssumption("Root.Tick", 0)
+    object.__setattr__(malformed, "selector", selector)
+    query = BmcQuery(
+        property=BmcProperty("reach", 2, predicate=BoolLiteral("true")),
+        assumptions=(malformed,),
+    )
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    assert _diagnostic(excinfo).code == "event_selector_invalid"
+
+
+@pytest.mark.unittest
 def test_internal_assumption_guard_rejects_unknown_assumption_subclass():
     """The binder fails closed if future assumption subclasses reach it."""
 
@@ -686,6 +774,31 @@ def test_internal_assumption_guard_rejects_unknown_assumption_subclass():
         def _to_dsl(self):
             return "assume future;"
 
+    query = BmcQuery(
+        property=BmcProperty("reach", 1, predicate=BoolLiteral("true")),
+        assumptions=(FutureAssumption(),),
+    )
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    assert _diagnostic(excinfo).code == "assumption_type"
+
+
+@pytest.mark.unittest
+def test_internal_assumption_dispatch_remains_defensive_when_shape_check_is_bypassed(
+    monkeypatch,
+):
+    """The binding dispatcher still rejects unknown assumptions after prechecks."""
+
+    class FutureAssumption(BmcAssumption):
+        def _canonical_payload(self):
+            return {}
+
+        def _to_dsl(self):
+            return "assume future;"
+
+    monkeypatch.setattr(binding_module, "_validate_query_shape", lambda query: None)
     query = BmcQuery(
         property=BmcProperty("reach", 1, predicate=BoolLiteral("true")),
         assumptions=(FutureAssumption(),),
@@ -728,7 +841,280 @@ def test_internal_frame_assumption_guard_rejects_forged_frame_values(forged_fram
     with pytest.raises(InvalidBmcQuery) as excinfo:
         bind_bmc_query_structure(query)
 
-    assert _diagnostic(excinfo).code == "frame_selector_out_of_range"
+    assert _diagnostic(excinfo).code == "query_shape"
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "mutator, expected_path, expected_code",
+    [
+        pytest.param(
+            lambda query: object.__setattr__(query.property, "bound", 0),
+            "property.bound",
+            "query_shape",
+            id="property-bound-zero",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query.property, "bound", True),
+            "property.bound",
+            "query_shape",
+            id="property-bound-bool",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query.property, "kind", "future"),
+            "property.kind",
+            "query_shape",
+            id="property-unknown-kind",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query.property, "predicate", None),
+            "property.predicate",
+            "query_shape",
+            id="single-property-missing-predicate",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(
+                query.property, "trigger", BoolLiteral("true")
+            ),
+            "property",
+            "query_shape",
+            id="single-property-extra-trigger",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query, "initial", object()),
+            "initial",
+            "query_shape",
+            id="initial-wrong-type",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query.initial, "mode", "warm"),
+            "initial.mode",
+            "query_shape",
+            id="initial-unknown-mode",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query.initial, "state_path", "Root.Idle"),
+            "initial.state_path",
+            "query_shape",
+            id="initial-cold-extra-state-path",
+        ),
+        pytest.param(
+            lambda query: (
+                object.__setattr__(query.initial, "mode", "state"),
+                object.__setattr__(query.initial, "state_path", " "),
+            ),
+            "initial.state_path",
+            "query_shape",
+            id="initial-state-whitespace-path",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query.initial, "predicate", object()),
+            "initial.predicate",
+            "query_shape",
+            id="initial-predicate-wrong-type",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query, "assumptions", "bad"),
+            "assumptions",
+            "query_shape",
+            id="assumptions-string",
+        ),
+        pytest.param(
+            lambda query: object.__setattr__(query, "property", object()),
+            "property",
+            "query_shape",
+            id="property-wrong-type",
+        ),
+    ],
+)
+def test_binding_revalidates_forged_query_root_and_property_shapes(
+    mutator, expected_path, expected_code
+):
+    """The binder fails closed if frozen query-root invariants are bypassed."""
+    query = BmcQuery(property=BmcProperty("reach", 1, predicate=BoolLiteral("true")))
+    mutator(query)
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    diagnostic = _diagnostic(excinfo)
+    assert diagnostic.code == expected_code
+    assert expected_path in diagnostic.path
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "mutator, expected_path",
+    [
+        pytest.param(
+            lambda prop: object.__setattr__(prop, "within", 0),
+            "property.within",
+            id="response-window-zero",
+        ),
+        pytest.param(
+            lambda prop: object.__setattr__(prop, "within", True),
+            "property.within",
+            id="response-window-bool",
+        ),
+        pytest.param(
+            lambda prop: object.__setattr__(prop, "trigger", object()),
+            "property.trigger",
+            id="response-trigger-wrong-type",
+        ),
+        pytest.param(
+            lambda prop: object.__setattr__(prop, "response", object()),
+            "property.response",
+            id="response-target-wrong-type",
+        ),
+        pytest.param(
+            lambda prop: object.__setattr__(prop, "predicate", BoolLiteral("true")),
+            "property.predicate",
+            id="response-extra-predicate",
+        ),
+    ],
+)
+def test_binding_revalidates_forged_response_property_shape(mutator, expected_path):
+    """The binder rechecks response-specific fields before semantic traversal."""
+    prop = BmcProperty(
+        "response",
+        2,
+        trigger=Active("Root.Idle"),
+        response=Active("Root.Done"),
+        within=1,
+    )
+    query = BmcQuery(property=prop)
+    mutator(prop)
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    diagnostic = _diagnostic(excinfo)
+    assert diagnostic.code == "query_shape"
+    assert expected_path in diagnostic.path
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    "assumption, mutator, expected_code, expected_path",
+    [
+        pytest.param(
+            FrameAssumption("always", BoolLiteral("true")),
+            lambda item: object.__setattr__(item, "kind", "future"),
+            "query_shape",
+            "assumptions[0].kind",
+            id="frame-unknown-kind",
+        ),
+        pytest.param(
+            FrameAssumption("always", BoolLiteral("true")),
+            lambda item: object.__setattr__(item, "predicate", object()),
+            "query_shape",
+            "assumptions[0].predicate",
+            id="frame-predicate-wrong-type",
+        ),
+        pytest.param(
+            FrameAssumption("always", BoolLiteral("true")),
+            lambda item: object.__setattr__(item, "frame", 0),
+            "query_shape",
+            "assumptions[0].frame",
+            id="always-extra-frame",
+        ),
+        pytest.param(
+            FrameAssumption("at", BoolLiteral("true"), frame=0),
+            lambda item: object.__setattr__(item, "frame", True),
+            "query_shape",
+            "assumptions[0].frame",
+            id="at-bool-frame",
+        ),
+        pytest.param(
+            EventAssumption("Root.Tick", 0),
+            lambda item: object.__setattr__(item, "event_path", " "),
+            "query_shape",
+            "assumptions[0].event_path",
+            id="event-whitespace-path",
+        ),
+        pytest.param(
+            EventAssumption("Root.Tick", 0),
+            lambda item: object.__setattr__(item, "selector", True),
+            "event_selector_invalid",
+            "assumptions[0].selector",
+            id="event-bool-selector",
+        ),
+        pytest.param(
+            EventAssumption("Root.Tick", 0),
+            lambda item: object.__setattr__(item, "selector", -1),
+            "event_selector_invalid",
+            "assumptions[0].selector",
+            id="event-negative-selector",
+        ),
+        pytest.param(
+            EventAssumption("Root.Tick", 0),
+            lambda item: object.__setattr__(item, "expected", 1),
+            "query_shape",
+            "assumptions[0].expected",
+            id="event-expected-non-bool",
+        ),
+        pytest.param(
+            EventCardinalityAssumption("any"),
+            lambda item: object.__setattr__(item, "kind", "future"),
+            "query_shape",
+            "assumptions[0].kind",
+            id="cardinality-unknown-kind",
+        ),
+        pytest.param(
+            EventCardinalityAssumption("any"),
+            lambda item: object.__setattr__(item, "event_paths", "Root.Tick"),
+            "query_shape",
+            "assumptions[0].event_paths",
+            id="cardinality-string-paths",
+        ),
+        pytest.param(
+            EventCardinalityAssumption("any"),
+            lambda item: object.__setattr__(item, "event_paths", ("Root.Tick",)),
+            "query_shape",
+            "assumptions[0].event_paths",
+            id="cardinality-any-extra-path",
+        ),
+        pytest.param(
+            EventCardinalityAssumption("at_most_one", ("Root.Tick",)),
+            lambda item: object.__setattr__(item, "event_paths", ()),
+            "query_shape",
+            "assumptions[0].event_paths",
+            id="cardinality-at-most-one-empty",
+        ),
+        pytest.param(
+            EventCardinalityAssumption("at_most_one", ("Root.Tick",)),
+            lambda item: object.__setattr__(item, "event_paths", ("Root.Tick", " ")),
+            "query_shape",
+            "assumptions[0].event_paths[1]",
+            id="cardinality-whitespace-event",
+        ),
+        pytest.param(
+            EventCardinalityAssumption("at_most_one", ("Root.Tick",)),
+            lambda item: object.__setattr__(
+                item, "event_paths", ("Root.Tick", "Root.Tick")
+            ),
+            "query_shape",
+            "assumptions[0].event_paths",
+            id="cardinality-duplicate-event",
+        ),
+    ],
+)
+def test_binding_revalidates_forged_assumption_shapes(
+    assumption, mutator, expected_code, expected_path
+):
+    """The binder rechecks assumption invariants bypassed by direct mutation."""
+    mutator(assumption)
+    query = BmcQuery(
+        property=BmcProperty("reach", 2, predicate=BoolLiteral("true")),
+        assumptions=(assumption,),
+    )
+
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        bind_bmc_query_structure(query)
+
+    diagnostic = _diagnostic(excinfo)
+    assert diagnostic.code == expected_code
+    assert expected_path in diagnostic.path
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_query_binding.py
+++ b/test/bmc/test_query_binding.py
@@ -257,6 +257,44 @@ def test_bind_bmc_query_structure_rejects_context_errors(
 
 @pytest.mark.unittest
 @pytest.mark.parametrize(
+    "source, expected_path",
+    [
+        pytest.param(
+            'check reach <= 1: active(" ");',
+            "property.predicate",
+            id="active-whitespace-path",
+        ),
+        pytest.param(
+            'check reach <= 1: var(" ") == 0;',
+            "property.predicate.left",
+            id="frame-var-whitespace-name",
+        ),
+        pytest.param(
+            'check response <= 1: trigger event(" ", current) -> within 1 true;',
+            "property.trigger",
+            id="response-event-whitespace-path",
+        ),
+        pytest.param(
+            'check cover <= 1: case(" ");',
+            "property.predicate.label",
+            id="cover-case-whitespace-label",
+        ),
+    ],
+)
+def test_bind_bmc_query_structure_reports_diagnostics_for_whitespace_query_atoms(
+    source, expected_path
+):
+    """Binder reports structured diagnostics for whitespace-only quoted atoms."""
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        _bind(source)
+
+    diagnostic = _diagnostic(excinfo)
+    assert diagnostic.code == "query_shape"
+    assert expected_path in diagnostic.path
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
     "source, code",
     [
         pytest.param(


### PR DESCRIPTION
## 背景

本 PR 是 BMC 伞 PR [#305](https://github.com/HansBug/pyfcstm/pull/305) 的 PR-4：**查询语言：实现 `.fbmcq` 语义绑定与错误诊断**。

前置链路已经完成：

| 前置 | 状态 | 说明 |
|---|---|---|
| PR-1 / [#315](https://github.com/HansBug/pyfcstm/pull/315) | 🟢 已合入 | `.fbmcq` parser-independent AST / query dataclass / canonical `__str__` / `to_canonical()` |
| PR-2 / [#323](https://github.com/HansBug/pyfcstm/pull/323) | 🟢 已合入 | 独立 `.fbmcq` ANTLR grammar、generated parser、grammar parity |
| PR-3 / [#326](https://github.com/HansBug/pyfcstm/pull/326) | 🟢 已合入 | listener-based parser、public parse API、query/expression AST round-trip |
| PR-6 / [#324](https://github.com/HansBug/pyfcstm/pull/324) | 🟢 已合入 | `BmcDomain`、state/event/variable/frame/step/event-input 编号与 lookup helper；PR-4 只在显式传入 model/domain 时使用这些 domain API |

PR-3 以后，`.fbmcq` 已经能从文本解析成 `BmcQuery` / expression AST；但 parser 只能判断语法形状，不能回答“这个 atom 放在这个上下文里语义是否合理”“这个变量/状态/事件是否能绑定到模型”“这个 query 是否能被后续 engine/compiler 安全消费”。本 PR 补上的就是 parser 和后续 BMC engine/compiler 之间的 **semantic binder / diagnostics 闸门**。

## 与伞 PR / 讨论的一致性

本 PR 遵守 #305 中 PR-4 的边界：

- 继续使用独立根模块 `pyfcstm.bmc`，不把 BMC 内核放进 `pyfcstm.verify`。
- 不接 `verify.registry`；registry realignment 仍保留到后置 PR。
- 不实现 solver lowering、macro-step expansion、witness replay 或 CLI。
- 不扩大 parser 职责；grammar 能 parse 但语义上下文非法的内容，应在 binder 层给出结构化错误。
- 保持 FCSTM numeric / condition expression 分层：numeric expression 不能直接当 predicate，BMC boolean atom 不能进入 numeric operator。
- 保持 PR-3 的 round-trip 与 canonical text 契约；binder 输出新增绑定结果，不改写 parser AST 的基本职责。
- 保守收敛用户讨论中的 frame-local / step-local 边界：PR-4 先禁止显式整数 frame selector 和普通 property 中的 event/case/called，后续若要支持 cross-frame / cross-step predicate 必须在 compiler/lowering 阶段另行定义。

## 技术目标

| 目标 | 说明 | 验收信号 |
|---|---|---|
| 建立 binder public API | 提供 query-only 与 model/domain-aware 两层绑定入口。 | 可从 `pyfcstm.bmc.binding` 导入；若从 `pyfcstm.bmc` 顶层导出则必须保持 lazy，不让 parser-only import 加载 `pyfcstm.model` / `pyfcstm.solver` / `z3` / `pyfcstm.verify`。 |
| 固化 query 上下文规则 | 把 frame-local predicate、step-local event/case、`init where`、response trigger/target、cover body 的语义边界钉死。 | parser-valid / binder-invalid 矩阵测试覆盖。 |
| 结构化诊断 | 给 invalid query 提供稳定 error code / semantic node path / message，方便后续 CLI/JSON 输出。 | golden diagnostics 测试稳定，不依赖 ANTLR 内部文本。PR-4 不承诺 line/column source span，因为 PR-3 AST 尚不保存 token span；如后续 CLI 需要源码坐标，单独补 parser span propagation。 |
| model/domain-aware resolution | 在提供 `StateMachine` 或 `BmcDomain` 时解析 state/event/var path。 | known path/name valid；unknown state/event/var invalid；bare `x` 与 `var("x")` 同绑；domain bound mismatch invalid。 |
| 保守语义策略 | PR-4 先禁止容易混淆的 cross-frame / cross-step predicate。 | 普通 property 不接受 `event(...)` / `case(...)` / `called(...)`；`response trigger` 只接受 `event("E", current)` 这一种 event atom；`cover` 只接受裸 `case("...")`。 |

## 设计方案

### 新增模块与入口

计划新增 `pyfcstm/bmc/binding.py`，核心 API：

| API / 类型 | 作用 |
|---|---|
| `bind_bmc_query_structure(query)` | 不依赖模型，只用 `query.property.bound` 检查 query 自身的上下文合法性并返回 normalized binding。 |
| `bind_bmc_query(query, model=None, domain=None)` | 在 structure binding 基础上，如提供 model 或 domain，则解析 state/event/variable。 |
| `BoundBmcQuery` | 绑定后的 query root；保留原 `BmcQuery` 引用，同时提供 `to_canonical()` golden dump。 |
| `BoundInitialSpec`、`BoundAssumption`、`BoundProperty` | 对 init / assumption / property 的 normalized binding 子结构。 |
| `BmcBindingDiagnostic` | 稳定诊断对象，至少含 `code`、`path`、`message`；`path` 是 semantic node path，不是源码 line/column。 |

### `bind_bmc_query` 的 model/domain 契约

为避免 query bound、domain bound、model snapshot 之间出现隐式优先级，本 PR 明确冻结入口契约：

| 调用形态 | 行为 |
|---|---|
| `bind_bmc_query(query)` | 等价 `bind_bmc_query_structure(query)`，只做 query-only semantic binding。 |
| `bind_bmc_query(query, model=model)` | 使用 `query.property.bound` 构造 `BmcDomain`，再做 model/domain-aware resolution。 |
| `bind_bmc_query(query, domain=domain)` | 要求 `domain.bound == query.property.bound`；不一致时抛 `InvalidBmcQuery` 并给出 `domain_bound_mismatch` diagnostic。 |
| `bind_bmc_query(query, model=model, domain=domain)` | PR-4 直接拒绝，要求调用者二选一，避免 model/domain 不一致时出现静默优先级。 |
| `bind_bmc_query_structure(query)` | 永远不导入 `pyfcstm.model`、`pyfcstm.solver`、`z3`、`pyfcstm.verify`。 |

### 错误策略

- parser / syntax 错误仍使用 `BmcQueryParseError`。
- query semantic invalid 使用 `InvalidBmcQuery`，并携带或可取回 `BmcBindingDiagnostic`。
- `UnsupportedBmcQuery` 不在 PR-4 主动抛出；它保留给后续 compiler/lowering 对未来允许的 unsupported marker 或 forged bound object 做后端能力诊断。
- 当前 PR-4 中，任何用户 query 上下文出现 `called(...)` 都产生 `InvalidBmcQuery` + diagnostic（例如 `unsupported_called_atom`），不得对 `called(...)` 做任何求值、归约或常量替换。

### 保守语义规则

本 PR 采用用户讨论后认可的保守策略：先把 **frame-local predicate** 与 **step-local event/case predicate** 分清楚，避免早期 query 语义过宽。设 query bound 为 `N`，frame 编号是 `F_0..F_N`，event/case step 编号是 `0..N-1`。

| 上下文 | 允许 | 禁止 / 说明 |
|---|---|---|
| 跨上下文类型规则 | `active(...)`、`terminated()`、`event(...)`、`case(...)`、`called(...)` 是 boolean atom，只能出现在 condition expression 内；`cycle`、`var(...)`、bare `ID`、numeric literal 是 numeric expression，必须通过 comparison 进入 condition expression。 | `active("A") + 1`、`cycle and true` / `cycle && true`、`var("x") and active("A")` invalid。 |
| frame-local selector | PR-4 中 frame-local predicate 只允许 omitted/current frame selector；`active("A")` 与 `active("A", current)` 等价，`terminated()` 与 `terminated(current)` 等价。 | 显式整数 frame selector 默认拒绝，例如 `active("A", 0)`、`active("A", 2)`、`terminated(3)`；未来如需支持 absolute frame selector 必须另行定义 compiler/lowering 语义。 |
| `init where` | `where` 对所有 init mode 都合法，包括 `init cold where ...`、`init state("...") where ...`、`init terminated where ...`；predicate 只进入 `$I_0$`，可使用 frame-local `active(...)` / `terminated()`、`var("x")`、bare `x`、numeric comparison / boolean connective。 | 禁止 `event(...)`、`case(...)`、`called(...)`、裸 `cycle`、显式整数 frame selector；`init where` 不得偷看未来 frame，也不得进入 source/profile/case partition。模型变量 `cycle` 必须写 `var("cycle")`。 |
| `assume always` | frame-local predicate，允许 omitted/current frame selector、`cycle`、`var(...)`、bare `ID`、numeric literal / comparison / boolean connective；语义是约束 `F_0..F_N`。 | 禁止显式整数 frame selector、`event(...)`、`case(...)`、`called(...)`。 |
| `assume at k` | frame-local predicate，允许 omitted/current frame selector、`cycle`、`var(...)`、bare `ID`、numeric literal / comparison / boolean connective；要求 `0 <= k <= N`，语义是约束 `F_k`。 | 禁止 predicate 内显式指向其他 frame；禁止 `event(...)`、`case(...)`、`called(...)`；`assume at -1` 与 `assume at N+1` invalid。 |
| `assume event("E", selector)` | selector 为 `*`、`k`、`a..b`；`k` 必须满足 `0 <= k < N`，range 必须满足 `0 <= a <= b < N`；range / `*` 是逐点全称约束。 | `event("E", N)`、负数 selector、反向 range（如 `3..1`）invalid；不在 binder 阶段 OR / exists 解释 range。 |
| `assume events cardinality any` | 等价 no-op。 | 不强制 event 互斥。 |
| `assume events cardinality at_most_one {...}` | 非空、无重复；model-aware 时 resolve event path；单元素合法但语义上 no-op。 | 空列表、重复 event、unknown event path invalid。 |
| 普通 frame property：`reach` / `forbid` / `invariant` / `must_reach` / `exists_always` | frame-local predicate，允许 omitted/current frame selector、`cycle`、`var(...)`、bare `ID`、numeric comparison / boolean connective。 | 禁止 `event(...)`、`case(...)`、`called(...)`、显式整数 frame selector；例如 `check reach <= 5: event("E", current)`、`check reach <= 5: event("E", *)`、`check reach <= 5: event("E", 0..2)`、`check reach <= 5: active("A", 2)` invalid。 |
| `response trigger` | frame-local predicate；额外允许 `event("E", current)` 表示当前 step trigger。 | 禁止 explicit integer event selector（如 `event("E", 3)`）、`*`、range、`case(...)`、`called(...)`、显式整数 frame selector。 |
| `response target` | frame-local predicate。 | 禁止任意 `event(...)`，尤其 `event("E", current)`；禁止 `case(...)`、`called(...)`、显式整数 frame selector。 |
| `cover` | body 必须是裸 `case("label")`；`case("label", current)` parse 后 canonical 等价裸 case，可接受为同一语义。 | 禁止 `case("label", 2)`、`active(...) && case(...)` / `active(...) and case(...)`、`event(...)`、`called(...)`；label 是否存在留给 macro case table 阶段。 |

### 变量与内建名绑定

| 表达 | 行为 |
|---|---|
| `x` | model-aware binder 中解析为 persistent variable `x`。 |
| `var("x")` | 解析为同一个 persistent variable `x`。 |
| `cycle` | 永远是 BMC 内建 numeric `int`，表示当前绑定上下文 cycle index；在 frame assumption 和 ordinary frame property 中合法，在 `init where` 中作为裸内建量非法。 |
| `var("cycle")` | 如模型中存在名为 `cycle` 的 persistent variable，则绑定到该模型变量。 |
| bare name 与保留字冲突 | 用户必须用 `var("...")`。 |

## 执行方案

1. **PR body 审查阶段**
   - 创建 empty PR。
   - 使用 codex / claude / codex-deepseek 三路 reviewer 检查：与 #305 是否一致、计划是否可执行、验收是否可测。
   - 若出现 C/I 级问题，先修 PR body，再继续。
2. **TDD：binder 数据结构与诊断**
   - 先写 `BmcBindingDiagnostic`、`BoundBmcQuery.to_canonical()` golden tests。
   - 再实现最小绑定结果。
3. **TDD：query-only semantic matrix**
   - 覆盖 init / assumptions / properties / response / cover 的合法与非法上下文。
   - 特别覆盖 grammar-accepted but binder-invalid 样例，包括嵌套表达式中隐藏的非法 atom。
4. **TDD：model/domain-aware resolution**
   - 使用小型 FCSTM fixtures 验证 state/event/var resolve。
   - 验证 bare `x` 与 `var("x")` 同绑，`cycle` 内建不被模型变量 shadow。
   - 验证 `model` / `domain` 入参互斥、domain bound mismatch、unknown path/name diagnostics。
5. **Public API / docs**
   - 更新 `pyfcstm.bmc.__init__` roadmap list-table 与 `__all__`；若顶层导出 binder API，必须采用 lazy export 保持 parser-only import 隔离。
   - 新增 RST 自动文档。
6. **本地验证与推送**
   - 使用 slow-skip 本地迭代。
   - push 后 watch CI。
7. **强对抗代码 review**
   - 三路 reviewer 必须构造真实错误例子，检查 binder 是否可被上下文混淆绕过。
   - C/I 必修；M 尽量修但不因 M 卡住。

## 验收标准

### 功能验收

- `bind_bmc_query_structure(parse_bmc_query(...))` 可用于不加载 model/domain 的 query semantic 检查。
- `bind_bmc_query(parse_bmc_query(...), model=...)` 可用 `query.property.bound` 构造 domain 并解析 state/event/var。
- `bind_bmc_query(parse_bmc_query(...), domain=...)` 要求 `domain.bound == query.property.bound`；不一致时稳定 diagnostic。
- 同时传入 `model` 和 `domain` 必须拒绝，避免优先级歧义。
- 省略 `init` 仍等价 `init cold`，绑定结果显式携带 cold initial spec。
- `init cold where ...`、`init state("...") where ...`、`init terminated where ...` 均在结构层合法，但 `init where` 只保存为 initial predicate，不进入 source/profile/case partition，也不允许引用未来 frame / event / case / called / bare `cycle`。
- `assume at k` 检查 `0 <= k <= N`；event selector 检查 `0 <= k < N`、`0 <= a <= b < N`。
- 普通 frame property 禁止 `event(...)` / `case(...)` / `called(...)` / 显式整数 frame selector。
- `response trigger` 只允许 `event("E", current)` 这一种 event atom；`response target` 禁止任意 event atom。
- `cover` 只允许裸 `case("label")` / canonical-current case，禁止 fixed-step case 和复合 predicate。
- `called(...)` 在 PR-4 的任何用户 query 上下文中都必须作为 semantic invalid diagnostic 处理，不对其求值、归约或常量替换。
- `active("A") + 1`、`cycle and true` / `cycle && true`、`var("x") and active("A")` 等 numeric/boolean 类型混用必须 invalid。
- 不 import `pyfcstm.verify`、不 import `z3`、不接 registry；structure binding 不加载 model/domain。

### 测试验收

新增或更新测试至少覆盖：

| 测试方向 | 必须覆盖 |
|---|---|
| structure binding positives | cold/state/terminated init、`init cold/state/terminated where`、always、at、event assumption、cardinality、reach/forbid/invariant/must_reach/exists_always/response/cover。 |
| grammar-accepted binder-invalid | `check reach <= 0`、`assume at -1`、`assume at N+1`、`assume always: event("E", 0)`、`check cover <= 3: active("A") && case("L")`、`check cover <= 3: active("A") and case("L")`、`check reach <= 5: event("E", current)`、`check reach <= 5: event("E", *)`、`check reach <= 5: event("E", 0..2)`、`check reach <= 5: active("A", 2)`、`check response <= 5: trigger active("A", 1) -> within 2 active("B")`、`check response <= 5: trigger active("A") -> within 2 active("B", 3)`、`check response <= 5: trigger active("A") -> within 2 event("E", current)`、`init cold where cycle == 0`、`active("A") + 1`、`cycle and true` / `cycle && true`、`var("x") and active("A")`。 |
| selector boundary | `assume at 0/N/N+1`；`event` selector `0/N-1/N`；range `0..0`、`0..N-1`、反向 range `3..1`；negative tests assert stable diagnostics。 |
| context atom traversal | nested ternary / unary / binary 中藏 `event` / `case` / `called` / explicit frame selector 仍能被发现。 |
| variable binding | bare `x`、`var("x")`、模型变量名 `cycle`、unknown variable、bare reserved/internal name。 |
| path resolution | known/unknown state；known/unknown event；known/unknown variable；cardinality duplicate / empty / unknown event。 |
| model/domain contract | no model/domain structure binding；model-only builds domain from query bound；domain-only bound match succeeds；domain-only bound mismatch invalid；model+domain together invalid。 |
| diagnostics | error code、semantic path、message 稳定；line/column source span 不作为 PR-4 验收项。 |
| public API/import isolation | `pyfcstm.bmc.__all__`、lazy domain exports 不被破坏；`import pyfcstm.bmc.binding` 与 parser-only import 不加载 `z3` / `pyfcstm.verify` / `pyfcstm.solver`，structure binding 不加载 `pyfcstm.model`。 |
| alias coverage | `and` / `&&`、`or` / `||`、`not` / `!` 等 operator alias 至少各有 binder-context traversal 覆盖，避免 alias 绕过。 |

### 必跑命令

本地开发使用 slow-skip：

```bash
python -m doctest pyfcstm/bmc/*.py
pytest test/bmc -q
SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=bmc
ruff check pyfcstm/bmc test/bmc
ruff format --check pyfcstm/bmc test/bmc
make rst_auto RANGE_DIR=bmc
```

推送后需要 watch GitHub CI 直到全部 required checks 通过。若 Codecov 对本 PR 新增文件给出覆盖率反馈，需要拉取并纳入最终 review。

## 非目标

- 不实现 Z3 formula lowering。
- 不实现 macro-step source / case table。
- 不验证 `case("label")` 是否存在于实际 case table。
- 不实现 witness decode / replay。
- 不新增 CLI。
- 不新增 `.fbmcq` TextMate / VSCode / Pygments 高亮；这属于 PR-5。
- 不修改 `pyfcstm.verify.registry`。
- 不为 PR-4 AST retrofitting line/column source span；diagnostic 使用 semantic path，源码坐标如有需要后续单独补 parser span propagation。

## 当前状态

- [x] Empty PR 创建。
- [x] 三路 PR body review 完成。
- [x] PR body 首轮 C/I 问题已修订。
- [x] PR body 复审 ready。
- [ ] TDD 实现完成。
- [ ] 本地验证完成。
- [ ] CI 全绿。
- [ ] 三路强对抗代码 review 完成。
- [ ] ready to merge（等待人工指示，不在本流程自动 merge）。

