### PR TITLE
宏步语义：输出 runtime-aligned control path plan

### DIFF
--- a/docs/source/api_doc/bmc/domain.rst
+++ b/docs/source/api_doc/bmc/domain.rst
@@ -70,7 +70,7 @@ BmcDomain
 -----------------------------------------------------
 
 .. autoclass:: BmcDomain
-    :members: __post_init__,frame0_state_ids,recurrence_state_ids,state_by_id,state_by_path,state_path_to_id,state_id_to_path,event_by_id,event_by_path,event_path_to_id,event_id_to_path,variable_by_id,variable_by_name,variable_name_to_id,variable_id_to_name,event_input,to_canonical,bound,states,events,variables,frames,steps,event_inputs,initial_state_ids,stable_state_ids
+    :members: __post_init__,frame0_state_ids,recurrence_state_ids,state_by_id,state_by_path,state_path_to_id,state_id_to_path,event_by_id,event_by_path,event_path_to_id,event_id_to_path,variable_by_id,variable_by_name,variable_name_to_id,variable_id_to_name,event_input,to_canonical,bound,states,events,variables,frames,steps,event_inputs,initial_state_ids,stable_state_ids,model
 
 
 build\_bmc\_domain

--- a/docs/source/api_doc/bmc/expand.rst
+++ b/docs/source/api_doc/bmc/expand.rst
@@ -1,0 +1,25 @@
+pyfcstm.bmc.expand
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.expand
+
+.. automodule:: pyfcstm.bmc.expand
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+MacroExpansionOptions
+-----------------------------------------------------
+
+.. autoclass:: MacroExpansionOptions
+    :members: __post_init__,max_micro_steps,max_stack_depth,verify_partition,partition_max_assignments
+
+
+expand\_macro\_step\_cases
+-----------------------------------------------------
+
+.. autofunction:: expand_macro_step_cases

--- a/docs/source/api_doc/bmc/index.rst
+++ b/docs/source/api_doc/bmc/index.rst
@@ -12,6 +12,7 @@ pyfcstm.bmc
     ast
     domain
     errors
+    expand
     grammar/index
     listener
     macro

--- a/docs/source/api_doc/bmc/macro.rst
+++ b/docs/source/api_doc/bmc/macro.rst
@@ -26,18 +26,32 @@ EventUse
     :members: __post_init__,to_canonical,event_id,path,polarity,reason
 
 
-VarUpdate
+GuardRequirement
 -----------------------------------------------------
 
-.. autoclass:: VarUpdate
-    :members: __post_init__,to_canonical,variable_id,variable_name,expression,is_carry
+.. autoclass:: GuardRequirement
+    :members: __post_init__,atom_name,to_canonical,requirement_id,owner_state_id,owner_state_path,transition_label,expr,polarity,reason,after_action_block_index
+
+
+PriorityExclusion
+-----------------------------------------------------
+
+.. autoclass:: PriorityExclusion
+    :members: __post_init__,to_canonical,decision_id,reason,excluded_case_labels,excluded_condition,event_paths,guard_requirement_ids
+
+
+ActionBlock
+-----------------------------------------------------
+
+.. autoclass:: ActionBlock
+    :members: __post_init__,to_canonical,block_kind,runtime_role,owner_state_id,owner_state_path,operations,action_name,transition_label,is_abstract
 
 
 CycleCase
 -----------------------------------------------------
 
 .. autoclass:: CycleCase
-    :members: __post_init__,to_canonical,kind,source_state_id,source_state_path,target_state_id,target_state_path,label,condition,var_update,used_events,failed_conditions,domain,is_diagnostic
+    :members: __post_init__,to_canonical,kind,source_state_id,source_state_path,target_state_id,target_state_path,label,condition,action_blocks,used_events,guard_requirements,priority_exclusions,failed_conditions,domain,is_diagnostic
 
 
 PartitionCheckResult
@@ -54,28 +68,10 @@ MacroStepFormal
     :members: __post_init__,cases,verify_partition,to_canonical,source,success_cases,delta_cases,build_diagnostic_conditions
 
 
-carry\_var\_updates
+case\_path\_condition
 -----------------------------------------------------
 
-.. autofunction:: carry_var_updates
-
-
-var\_update\_for
------------------------------------------------------
-
-.. autofunction:: var_update_for
-
-
-build\_var\_updates
------------------------------------------------------
-
-.. autofunction:: build_var_updates
-
-
-case\_antecedent\_condition
------------------------------------------------------
-
-.. autofunction:: case_antecedent_condition
+.. autofunction:: case_path_condition
 
 
 terminated\_absorb\_case

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -13,8 +13,8 @@ Package contracts:
   separate from model-aware binding or solver lowering.
 * Domain-numbering and macro-step exports are resolved lazily so parser-only
   imports do not load ``pyfcstm.model``.
-* Macro-step contracts are solver-independent and do not import ``z3`` from the
-  root package.
+* Macro-step contracts and expansion are solver-independent and do not import
+  ``z3`` from the root package.
 * The root package must not depend on ``pyfcstm.verify`` or its registry.
 * :func:`str` on exported query and expression dataclasses is reserved for the
   canonical ``.fbmcq`` query DSL spelling.
@@ -88,6 +88,10 @@ Public module structure:
        :func:`verify_boolean_partition`, :func:`verify_source_partition`
      - Construct carry, absorb, fallback, and semantic-delta cases while keeping
        partition self-checks outside formal trace formulas.
+   * - Macro-step expansion
+     - :class:`MacroExpansionOptions`, :func:`expand_macro_step_cases`
+     - Expand source profiles into runtime-aligned, solver-independent macro-step
+       cases consumed by later relation builders.
    * - Query root model
      - :class:`InitialSpec`, :class:`BmcAssumption`,
        :class:`FrameAssumption`, :class:`EventAssumption`,
@@ -179,6 +183,11 @@ _SOURCE_EXPORTS = {
     "source_from_initial_spec",
 }
 
+_EXPAND_EXPORTS = {
+    "MacroExpansionOptions",
+    "expand_macro_step_cases",
+}
+
 _MACRO_EXPORTS = {
     "BoolTemplate",
     "EventUse",
@@ -202,6 +211,7 @@ _LAZY_EXPORT_MODULES = {
     "pyfcstm.bmc.domain": _DOMAIN_EXPORTS,
     "pyfcstm.bmc.source": _SOURCE_EXPORTS,
     "pyfcstm.bmc.macro": _MACRO_EXPORTS,
+    "pyfcstm.bmc.expand": _EXPAND_EXPORTS,
 }
 
 
@@ -247,7 +257,13 @@ def __dir__():
         >>> 'BmcDomain' in dir(bmc)
         True
     """
-    return sorted(set(globals()) | _DOMAIN_EXPORTS | _SOURCE_EXPORTS | _MACRO_EXPORTS)
+    return sorted(
+        set(globals())
+        | _DOMAIN_EXPORTS
+        | _SOURCE_EXPORTS
+        | _MACRO_EXPORTS
+        | _EXPAND_EXPORTS
+    )
 
 
 __all__ = [
@@ -311,6 +327,8 @@ __all__ = [
     "terminated_source",
     "diagnostic_source",
     "source_from_initial_spec",
+    "MacroExpansionOptions",
+    "expand_macro_step_cases",
     "BoolTemplate",
     "EventUse",
     "VarUpdate",

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -80,18 +80,19 @@ Public module structure:
      - Describe initial and recurrence source profiles without reading
        initial ``where`` predicates or building solver relations.
    * - Macro-step case data
-     - :class:`BoolTemplate`, :class:`EventUse`, :class:`VarUpdate`,
-       :class:`CycleCase`, :class:`MacroStepFormal`,
-       :class:`PartitionCheckResult`
-     - Freeze case labels, bare conditions, explicit variable writeback,
-       source-local buckets, and build-time partition summaries.
+     - :class:`BoolTemplate`, :class:`EventUse`,
+       :class:`GuardRequirement`, :class:`PriorityExclusion`,
+       :class:`ActionBlock`, :class:`CycleCase`,
+       :class:`MacroStepFormal`, :class:`PartitionCheckResult`
+     - Freeze case labels, control-path conditions, anchored guards,
+       runtime action blocks, source-local buckets, and build-time partition
+       summaries.
    * - Macro-step case helpers
-     - :func:`carry_var_updates`, :func:`var_update_for`,
-       :func:`build_var_updates`, :func:`case_antecedent_condition`,
-       :func:`terminated_absorb_case`, :func:`diagnostic_absorb_case`,
+     - :func:`case_path_condition`, :func:`terminated_absorb_case`,
+       :func:`diagnostic_absorb_case`,
        :func:`build_fallback_case`, :func:`build_semantic_delta_case`,
        :func:`verify_boolean_partition`, :func:`verify_source_partition`
-     - Construct carry, absorb, fallback, and semantic-delta cases while keeping
+     - Construct absorb, fallback, and semantic-delta cases while keeping
        partition self-checks outside formal trace formulas.
    * - Macro-step expansion
      - :class:`MacroExpansionOptions`, :func:`expand_macro_step_cases`
@@ -207,14 +208,13 @@ _EXPAND_EXPORTS = {
 _MACRO_EXPORTS = {
     "BoolTemplate",
     "EventUse",
-    "VarUpdate",
+    "GuardRequirement",
+    "PriorityExclusion",
+    "ActionBlock",
     "CycleCase",
     "PartitionCheckResult",
     "MacroStepFormal",
-    "carry_var_updates",
-    "var_update_for",
-    "build_var_updates",
-    "case_antecedent_condition",
+    "case_path_condition",
     "terminated_absorb_case",
     "diagnostic_absorb_case",
     "build_fallback_case",
@@ -360,14 +360,13 @@ __all__ = [
     "expand_macro_step_cases",
     "BoolTemplate",
     "EventUse",
-    "VarUpdate",
+    "GuardRequirement",
+    "PriorityExclusion",
+    "ActionBlock",
     "CycleCase",
     "PartitionCheckResult",
     "MacroStepFormal",
-    "carry_var_updates",
-    "var_update_for",
-    "build_var_updates",
-    "case_antecedent_condition",
+    "case_path_condition",
     "terminated_absorb_case",
     "diagnostic_absorb_case",
     "build_fallback_case",

--- a/pyfcstm/bmc/domain.py
+++ b/pyfcstm/bmc/domain.py
@@ -45,7 +45,7 @@ Example::
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, Optional, Sequence, Tuple
 
 from pyfcstm.bmc.errors import InvalidBmcDomain
@@ -654,6 +654,10 @@ class BmcDomain:
     :type initial_state_ids: Tuple[int, ...]
     :param stable_state_ids: State ids allowed at recurrence frame boundaries.
     :type stable_state_ids: Tuple[int, ...]
+    :param model: Optional source model back-reference used by model-aware BMC
+        layers, defaults to ``None``.  It is intentionally excluded from
+        equality and canonical snapshots.
+    :type model: StateMachine, optional
 
     Example::
 
@@ -672,6 +676,7 @@ class BmcDomain:
     event_inputs: Tuple[EventInputRef, ...]
     initial_state_ids: Tuple[int, ...]
     stable_state_ids: Tuple[int, ...]
+    model: Optional[StateMachine] = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         _validate_positive_bound(self.bound)
@@ -692,6 +697,8 @@ class BmcDomain:
         self._validate_event_owners()
         self._validate_event_inputs()
         self._validate_allowed_state_ids()
+        if self.model is not None and not isinstance(self.model, StateMachine):
+            raise InvalidBmcDomain("model must be StateMachine when provided.")
 
     @property
     def frame0_state_ids(self) -> Tuple[int, ...]:
@@ -1417,6 +1424,7 @@ def build_bmc_domain(model: StateMachine, bound: int) -> BmcDomain:
         event_inputs=event_inputs,
         initial_state_ids=initial_state_ids,
         stable_state_ids=stable_state_ids,
+        model=model,
     )
 
 

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -549,8 +549,18 @@ class _Expander:
                 )
             failed.extend(candidate_failed)
             previous_accepted.append(accepted)
-            previous_event_uses.extend(
-                _event_uses_from_condition(accepted, self.domain)
+            accepted_event_uses = tuple(
+                item
+                for outcome in candidate_outcomes
+                for item in outcome.used_events
+                if item.polarity == "positive"
+            )
+            previous_event_uses = list(
+                _merge_event_uses(
+                    previous_event_uses,
+                    accepted_event_uses,
+                    _event_uses_from_condition(accepted, self.domain),
+                )
             )
         return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
 
@@ -752,6 +762,9 @@ class _Expander:
         if not frame.plain_before_pending:
             return (frontier,)
         branches = (frontier,)
+        # Plain boundary ``during before`` actions live in ``on_durings``.
+        # Descendant aspect actions (``>> during before``) are intentionally
+        # executed later by ``_run_leaf_during``, matching SimulationRuntime.
         for on_during_before in frame.state.list_on_durings(aspect="before"):
             branches = self._flat_map(
                 branches,
@@ -1232,7 +1245,17 @@ def expand_macro_step_cases(
         options = MacroExpansionOptions()
     if not isinstance(options, MacroExpansionOptions):
         raise InvalidBmcEncoding("options must be MacroExpansionOptions.")
-    return _Expander(source, options).expand()
+    try:
+        return _Expander(source, options).expand()
+    except RecursionError as err:
+        # RecursionError: hostile macro graphs may create structurally new
+        # recursive frontiers faster than Python's call stack can represent.
+        # Surface that as a build failure rather than leaking an interpreter
+        # implementation limit to BMC callers.
+        raise BmcBuildError(
+            "macro expansion exceeded the Python recursion limit before "
+            "reaching a runtime-aligned safety cap."
+        ) from err
 
 
 __all__ = ["MacroExpansionOptions", "expand_macro_step_cases"]

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -668,9 +668,7 @@ class _MacroExpander:
 
     def _finalize_exit_to_parent(self, frontier: _MacroFrontier) -> _MacroFrontier:
         if not frontier.stack:
-            raise _internal_expansion_error(  # pragma: no cover
-                "exit-to-parent finalization received an empty runtime stack."
-            )
+            return frontier
         parent = frontier.stack[-1].state
         current = frontier
         for on_during_after in parent.list_on_durings(aspect="after"):

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -5,7 +5,9 @@ solver-independent :class:`pyfcstm.bmc.macro.MacroStepFormal`.  It mirrors the
 cycle-level control flow of :class:`pyfcstm.simulate.SimulationRuntime` without
 creating Z3 symbols or verify-registry entries.  The output conditions remain
 bare case predicates; later relation builders compose the source-state guard and
-lower each case as an implication.
+lower each case as an implication.  Ordered transitions use accepted
+continuations for priority masks, and event reads used only by those masks are
+kept in :class:`pyfcstm.bmc.macro.EventUse` metadata for witness explanations.
 
 The module contains:
 
@@ -532,12 +534,12 @@ class _Expander:
             loop_transition = first
             exit_transition = second
             loop_has_priority = True
-            variable_name, threshold = first_loop
+            variable_name, increment, threshold = first_loop
         elif second_loop is not None and first_loop is None:
             loop_transition = second
             exit_transition = first
             loop_has_priority = False
-            variable_name, threshold = second_loop
+            variable_name, increment, threshold = second_loop
         else:
             return None
         if not self._is_complementary_threshold_exit(
@@ -561,7 +563,11 @@ class _Expander:
             exit_condition = exit_trigger
 
         loop_store = dict(frontier.store.values)
-        loop_store[variable_name] = _ValueTemplate.const_value(threshold)
+        loop_store[variable_name] = _threshold_reached_value(
+            frontier.store.values[variable_name],
+            threshold,
+            increment,
+        )
         accelerated_loop = self._replace_frontier(
             frontier,
             condition=BoolTemplate.and_(frontier.condition, loop_condition),
@@ -629,16 +635,16 @@ class _Expander:
 
     def _accelerable_pseudo_loop(
         self, transition: Transition, state: State
-    ) -> Optional[Tuple[str, int]]:
+    ) -> Optional[Tuple[str, int, int]]:
         """Extract the integer threshold pattern from a pseudo self-loop.
 
         :param transition: Candidate self-loop transition.
         :type transition: pyfcstm.model.Transition
         :param state: Pseudo state that owns the transition.
         :type state: pyfcstm.model.State
-        :return: ``(variable_name, threshold)`` for ``x < K`` plus
-            ``x = x + 1`` loops, or ``None`` for unsupported shapes.
-        :rtype: Optional[Tuple[str, int]]
+        :return: ``(variable_name, increment, threshold)`` for ``x < K`` plus
+            ``x = x + step`` loops, or ``None`` for unsupported shapes.
+        :rtype: Optional[Tuple[str, int, int]]
         """
         if transition.from_state != state.name or transition.to_state != state.name:
             return None
@@ -658,9 +664,10 @@ class _Expander:
         if len(transition.effects) != 1:
             return None
         effect = transition.effects[0]
-        if not _is_unit_increment_effect(effect, variable_name):
+        increment = _positive_integer_increment_effect(effect, variable_name)
+        if increment is None:
             return None
-        return variable_name, threshold
+        return variable_name, increment, threshold
 
     def _is_complementary_threshold_exit(
         self,
@@ -765,6 +772,15 @@ class _Expander:
                 )
             failed.extend(candidate_failed)
             previous_accepted.append(accepted)
+            previous_event_uses = list(
+                _merge_event_uses(
+                    previous_event_uses,
+                    tuple(
+                        EventUse(item.event_id, item.path, "negative", "priority")
+                        for item in raw_events
+                    ),
+                )
+            )
             accepted_event_uses = tuple(
                 item
                 for outcome in candidate_outcomes
@@ -807,6 +823,8 @@ class _Expander:
         transition: Transition,
     ) -> Tuple[_MacroFrontier, ...]:
         top = frontier.stack[-1]
+        if not isinstance(transition.to_state, str):
+            raise BmcBuildError("initial transition target must be a child state.")
         target = top.state.substates[transition.to_state]
         branches = self._execute_operation_block(frontier, transition.effects)
         result = []
@@ -843,6 +861,10 @@ class _Expander:
                     )
                 result.extend(self._finalize_exit_to_parent(popped))
                 continue
+            if not isinstance(transition.to_state, str):
+                raise BmcBuildError("transition target must be a sibling state.")
+            if current_state.parent is None:
+                raise BmcBuildError("root transition cannot target a sibling state.")
             target_state = current_state.parent.substates[transition.to_state]
             current = popped
             if (
@@ -975,7 +997,8 @@ class _Expander:
         self, frontier: _MacroFrontier, state: State
     ) -> Tuple[_MacroFrontier, ...]:
         branches = (frontier,)
-        for _, func in state.iter_on_during_aspect_recursively():
+        for item in state.iter_on_during_aspect_recursively():
+            func = item[-1]
             branches = self._flat_map(
                 branches, lambda item, action=func: self._execute_func(item, action)
             )
@@ -1338,30 +1361,66 @@ def _literal_int(expr: Expr) -> Optional[int]:
     return None
 
 
-def _is_unit_increment_effect(
+def _positive_integer_increment_effect(
     statement: OperationStatement, variable_name: str
-) -> bool:
-    """Return whether a statement writes ``variable_name = variable_name + 1``.
+) -> Optional[int]:
+    """Return the positive integer step for ``variable_name = variable_name + N``.
 
     :param statement: Operation statement to inspect.
     :type statement: pyfcstm.model.OperationStatement
     :param variable_name: Persistent variable that should be incremented.
     :type variable_name: str
-    :return: Whether the statement is the supported unit increment.
-    :rtype: bool
+    :return: Positive integer increment, or ``None`` for unsupported shapes.
+    :rtype: Optional[int]
     """
     if not isinstance(statement, Operation):
-        return False
+        return None
     if statement.var_name != variable_name:
-        return False
+        return None
     expr = statement.expr
     if not isinstance(expr, BinaryOp) or expr.op != "+":
-        return False
+        return None
     if isinstance(expr.x, Variable) and expr.x.name == variable_name:
-        return _literal_int(expr.y) == 1
+        value = _literal_int(expr.y)
+        return value if value is not None and value > 0 else None
     if isinstance(expr.y, Variable) and expr.y.name == variable_name:
-        return _literal_int(expr.x) == 1
-    return False
+        value = _literal_int(expr.x)
+        return value if value is not None and value > 0 else None
+    return None
+
+
+def _threshold_reached_value(
+    value: _ValueTemplate,
+    threshold: int,
+    increment: int,
+) -> _ValueTemplate:
+    """Return the first loop value that satisfies ``x >= threshold``.
+
+    :param value: Current symbolic value before the accelerated loop.
+    :type value: _ValueTemplate
+    :param threshold: Exit threshold.
+    :type threshold: int
+    :param increment: Positive loop increment.
+    :type increment: int
+    :return: First value reached by repeated increments that exits the loop.
+    :rtype: _ValueTemplate
+    :raises BmcBuildError: If the loop input is not a linear expression over
+        pre-state variables or the increment is invalid.
+    """
+    if increment <= 0:
+        raise BmcBuildError("pseudo loop increment must be positive.")
+    if value.linear is None:
+        raise BmcBuildError("pseudo loop acceleration requires a linear integer value.")
+    if any(not name.startswith(_PRE_VAR_PREFIX) for name in value.linear.coeffs):
+        raise BmcBuildError("pseudo loop acceleration requires pre-state variables.")
+    if increment == 1:
+        return _ValueTemplate.const_value(threshold)
+    threshold_text = _format_number(threshold)
+    increment_text = _format_number(increment)
+    return _ValueTemplate(
+        "%s + (((%s) - %s) %% %s)"
+        % (threshold_text, value.text, threshold_text, increment_text)
+    )
 
 
 def _has_direct_atom_contradiction(condition: BoolTemplate) -> bool:

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -873,6 +873,9 @@ class _MacroExpander:
                     }
                 )
             )
+            # These ids describe guards read by the excluded accepted paths.
+            # They are witness/debug metadata only; the fallback truth source
+            # remains ``condition`` plus ``not(accepted_condition)`` above.
             priority = PriorityExclusion(
                 "fallback%d" % self._decision_counter,
                 "fallback",

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -67,8 +67,9 @@ _ACCEPTED_ATOM_PREFIX = "accepted:"
 def _internal_expansion_error(detail: str) -> BmcBuildError:
     return BmcBuildError(
         "internal error: %s This indicates a pyfcstm BMC bug or a corrupted "
-        "internal object; please report this issue with the FCSTM input, query, "
-        "and traceback at https://github.com/HansBug/pyfcstm/issues." % detail
+        "internal object; please report this issue with the FCSTM input, BMC "
+        "query or expansion source, and traceback at "
+        "https://github.com/HansBug/pyfcstm/issues." % detail
     )
 
 

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -1387,6 +1387,10 @@ class _Expander:
 def _literal_int(expr: Expr) -> Optional[int]:
     """Return an integer literal value if ``expr`` is integral syntax.
 
+    Pure integer constant expressions such as ``4 - 1`` and ``2 * (1 + 1)``
+    are folded so threshold normalization can recognize natural guard forms
+    without evaluating expressions that depend on model variables.
+
     :param expr: Model expression to inspect.
     :type expr: pyfcstm.model.Expr
     :return: Integer literal value, or ``None`` for non-integer syntax.
@@ -1394,10 +1398,28 @@ def _literal_int(expr: Expr) -> Optional[int]:
     """
     if isinstance(expr, Integer):
         return expr.value
-    if isinstance(expr, UnaryOp) and expr.op == "-" and isinstance(expr.x, Integer):
-        return -expr.x.value
-    if isinstance(expr, UnaryOp) and expr.op == "+" and isinstance(expr.x, Integer):
-        return expr.x.value
+    if isinstance(expr, UnaryOp) and expr.op in ("+", "-"):
+        value = _literal_int(expr.x)
+        if value is None:
+            return None
+        return value if expr.op == "+" else -value
+    if isinstance(expr, BinaryOp) and expr.op in ("+", "-", "*", "%", "/"):
+        left = _literal_int(expr.x)
+        right = _literal_int(expr.y)
+        if left is None or right is None:
+            return None
+        if expr.op == "+":
+            return left + right
+        if expr.op == "-":
+            return left - right
+        if expr.op == "*":
+            return left * right
+        if right == 0:
+            return None
+        if expr.op == "%":
+            return left % right
+        if left % right == 0:
+            return left // right
     return None
 
 

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -64,6 +64,14 @@ _GUARD_ATOM_PREFIX = "guard:"
 _ACCEPTED_ATOM_PREFIX = "accepted:"
 
 
+def _internal_expansion_error(detail: str) -> BmcBuildError:
+    return BmcBuildError(
+        "internal error: %s This indicates a pyfcstm BMC bug or a corrupted "
+        "internal object; please report this issue with the FCSTM input, query, "
+        "and traceback at https://github.com/HansBug/pyfcstm/issues." % detail
+    )
+
+
 def _validate_positive_int(value: object, field_name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         raise InvalidBmcEncoding("%s must be a positive integer." % field_name)
@@ -209,7 +217,9 @@ class _MacroExpander:
                 "macro-step expansion requires a domain-backed source."
             )
         if not isinstance(domain, BmcDomain):
-            raise InvalidBmcEncoding("source domain must be BmcDomain.")
+            raise _internal_expansion_error(  # pragma: no cover
+                "macro-step source domain is not a BmcDomain after source validation."
+            )
         model = domain.model
         if model is None:
             raise InvalidBmcEncoding(
@@ -259,8 +269,9 @@ class _MacroExpander:
                 ),
             )
         elif diagnostics:
-            raise BmcBuildError(
-                "stable macro-step source produced unsupported build diagnostic conditions."
+            raise _internal_expansion_error(  # pragma: no cover
+                "stable macro-step source produced unsupported build diagnostic "
+                "conditions."
             )
         formal = MacroStepFormal(self.source, success_cases, delta_cases, diagnostics)
         if self.options.verify_partition:
@@ -299,7 +310,10 @@ class _MacroExpander:
             )
 
         if self.source.kind != "entry":
-            raise InvalidBmcEncoding("unsupported source kind: %r." % self.source.kind)
+            raise _internal_expansion_error(  # pragma: no cover
+                "unsupported source kind reached macro expansion: %r."
+                % self.source.kind
+            )
         if state.is_root_state:
             base = _MacroFrontier(
                 (),
@@ -386,7 +400,9 @@ class _MacroExpander:
             return self._expand_initial_transitions(frontier)
         if top.mode == "post_child_exit":
             return self._expand_parent_continuation(frontier)
-        return _Expansion((), (), (frontier.condition,))
+        raise _internal_expansion_error(  # pragma: no cover
+            "unsupported macro frontier stack frame mode: %r." % top.mode
+        )
 
     def _expand_leaf_active(self, frontier: _MacroFrontier) -> _Expansion:
         transitions = frontier.stack[-1].state.transitions_from
@@ -594,7 +610,9 @@ class _MacroExpander:
         current = self._record_transition_effect(frontier, state, transition)
         target_name = transition.to_state
         if not isinstance(target_name, str):
-            raise BmcBuildError("initial transition target must be a child state.")
+            raise _internal_expansion_error(  # pragma: no cover
+                "initial transition target is not a child state name."
+            )
         target_state = state.substates[target_name]
         if not target_state.is_pseudo:
             current = self._consume_plain_before_if_pending(current)
@@ -630,10 +648,14 @@ class _MacroExpander:
 
         parent = current_state.parent
         if parent is None:
-            raise BmcBuildError("non-exit transition from root has no parent.")
+            raise _internal_expansion_error(  # pragma: no cover
+                "non-exit transition source has no parent state."
+            )
         target_name = transition.to_state
         if not isinstance(target_name, str):
-            raise BmcBuildError("transition target must be a sibling state.")
+            raise _internal_expansion_error(  # pragma: no cover
+                "transition target is not a sibling state name."
+            )
         target_state = parent.substates[target_name]
         if (
             current_state.is_pseudo
@@ -646,7 +668,9 @@ class _MacroExpander:
 
     def _finalize_exit_to_parent(self, frontier: _MacroFrontier) -> _MacroFrontier:
         if not frontier.stack:
-            return frontier
+            raise _internal_expansion_error(  # pragma: no cover
+                "exit-to-parent finalization received an empty runtime stack."
+            )
         parent = frontier.stack[-1].state
         current = frontier
         for on_during_after in parent.list_on_durings(aspect="after"):
@@ -695,14 +719,16 @@ class _MacroExpander:
         current = frontier
         for item in state.iter_on_during_aspect_recursively():
             owner, func = cast(Tuple[State, Union[OnAspect, OnStage]], item)
-            assert isinstance(owner, State), (
-                "State.iter_on_during_aspect_recursively() must yield owner states "
-                "when called without with_ids."
-            )
-            assert isinstance(func, (OnAspect, OnStage)), (
-                "State.iter_on_during_aspect_recursively() must yield lifecycle "
-                "actions when called without with_ids."
-            )
+            if not isinstance(owner, State):
+                raise _internal_expansion_error(  # pragma: no cover
+                    "State.iter_on_during_aspect_recursively() yielded a non-State "
+                    "owner when called without with_ids."
+                )
+            if not isinstance(func, (OnAspect, OnStage)):
+                raise _internal_expansion_error(  # pragma: no cover
+                    "State.iter_on_during_aspect_recursively() yielded a non-lifecycle "
+                    "action when called without with_ids."
+                )
             if isinstance(func, OnAspect):
                 role = (
                     "aspect_during_before"
@@ -720,7 +746,9 @@ class _MacroExpander:
         self, frontier: _MacroFrontier
     ) -> _MacroFrontier:
         if not frontier.stack:
-            return frontier
+            raise _internal_expansion_error(  # pragma: no cover
+                "plain during-before consumption received an empty runtime stack."
+            )
         frame = frontier.stack[-1]
         if not frame.plain_before_pending:
             return frontier
@@ -787,13 +815,17 @@ class _MacroExpander:
     ) -> _MacroFrontier:
         if isinstance(func, (OnStage, OnAspect)) and func.is_ref:
             if func.ref is None:
-                raise BmcBuildError("action reference is missing a target.")
+                raise _internal_expansion_error(  # pragma: no cover
+                    "action reference is missing its resolved target."
+                )
             ref_owner = func.ref.parent if func.ref.parent is not None else owner
             return self._record_func(
                 frontier, ref_owner, func.ref, block_kind, runtime_role
             )
         if not isinstance(func, (OnStage, OnAspect)):
-            raise BmcBuildError("unsupported lifecycle action type.")
+            raise _internal_expansion_error(  # pragma: no cover
+                "unsupported lifecycle action object reached macro expansion."
+            )
         operations = () if func.is_abstract else tuple(func.operations)
         if not operations and not func.is_abstract:
             return frontier
@@ -913,7 +945,9 @@ class _MacroExpander:
         )
         expansion = self._expand_frontier(active)
         if not expansion.outcomes:
-            raise BmcBuildError("stable fallback did not produce an outcome.")
+            raise _internal_expansion_error(  # pragma: no cover
+                "stable fallback did not produce a stable or terminal outcome."
+            )
         failed_guard_requirements = self._guard_requirements_for_conditions(failed)
         return tuple(
             _MacroOutcome(
@@ -1040,7 +1074,9 @@ class _MacroExpander:
             for index, item in enumerate(transitions):
                 if item is transition:
                     return index
-        raise BmcBuildError("transition not found on owner state.")
+        raise _internal_expansion_error(  # pragma: no cover
+            "transition object was not found on its owner state."
+        )
 
     def _event_uses_for_paths(
         self, paths: Sequence[str], polarity: str, reason: str

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -29,7 +29,7 @@ Example::
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union, cast
 
 from pyfcstm.bmc.domain import STATE_TERMINATE_ID, BmcDomain
 from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcDomain, InvalidBmcEncoding
@@ -694,16 +694,15 @@ class _MacroExpander:
     ) -> _MacroFrontier:
         current = frontier
         for item in state.iter_on_during_aspect_recursively():
-            if len(item) == 3:
-                owner = item[1]
-                func = item[2]
-            else:
-                owner = item[0]
-                func = item[1]
-            if not isinstance(owner, State) or not isinstance(
-                func, (OnAspect, OnStage)
-            ):
-                raise BmcBuildError("invalid during action traversal item.")
+            owner, func = cast(Tuple[State, Union[OnAspect, OnStage]], item)
+            assert isinstance(owner, State), (
+                "State.iter_on_during_aspect_recursively() must yield owner states "
+                "when called without with_ids."
+            )
+            assert isinstance(func, (OnAspect, OnStage)), (
+                "State.iter_on_during_aspect_recursively() must yield lifecycle "
+                "actions when called without with_ids."
+            )
             if isinstance(func, OnAspect):
                 role = (
                     "aspect_during_before"

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 from pyfcstm.bmc.domain import STATE_TERMINATE_ID, BmcDomain
-from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcEncoding
+from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcDomain, InvalidBmcEncoding
 from pyfcstm.bmc.macro import (
     BoolTemplate,
     CycleCase,
@@ -448,6 +448,10 @@ class _Expander:
         return _Expansion((), (), (frontier.condition,))
 
     def _expand_leaf_active(self, frontier: _MacroFrontier) -> _Expansion:
+        accelerated = self._try_expand_pseudo_threshold_loop(frontier)
+        if accelerated is not None:
+            return accelerated
+
         transitions = frontier.stack[-1].state.transitions_from
         expanded = self._expand_ordered_candidates(
             frontier, transitions, is_initial=False
@@ -491,6 +495,218 @@ class _Expander:
         return _Expansion(
             (), (frontier.condition,) + expanded.failed, expanded.diagnostics
         )
+
+    def _try_expand_pseudo_threshold_loop(
+        self, frontier: _MacroFrontier
+    ) -> Optional[_Expansion]:
+        """Return an accelerated expansion for simple monotone pseudo loops.
+
+        The runtime validation worklist can accept a pseudo self-loop that
+        monotonically increments an integer variable until a complementary exit
+        guard becomes true.  Symbolic recursion cannot prove that convergence
+        by path-signature repetition alone because each loop iteration changes
+        the symbolic store.  This helper recognizes that narrow runtime-safe
+        pattern and summarizes the finite loop as a threshold writeback before
+        executing the ordinary exit transition.
+
+        :param frontier: Current macro frontier whose stack top may be a pseudo
+            state.
+        :type frontier: _MacroFrontier
+        :return: Accelerated expansion, or ``None`` if the frontier does not
+            match the supported monotone pseudo-loop shape.
+        :rtype: Optional[_Expansion]
+        """
+        top = frontier.stack[-1]
+        state = top.state
+        if not state.is_pseudo:
+            return None
+        if not self._pseudo_state_is_accelerable(state):
+            return None
+        transitions = tuple(state.transitions_from)
+        if len(transitions) != 2:
+            return None
+        first, second = transitions
+        first_loop = self._accelerable_pseudo_loop(first, state)
+        second_loop = self._accelerable_pseudo_loop(second, state)
+        if first_loop is not None and second_loop is None:
+            loop_transition = first
+            exit_transition = second
+            loop_has_priority = True
+            variable_name, threshold = first_loop
+        elif second_loop is not None and first_loop is None:
+            loop_transition = second
+            exit_transition = first
+            loop_has_priority = False
+            variable_name, threshold = second_loop
+        else:
+            return None
+        if not self._is_complementary_threshold_exit(
+            exit_transition, state, variable_name, threshold
+        ):
+            return None
+
+        loop_trigger = self._transition_trigger(
+            loop_transition, frontier.store, is_initial=False
+        )[0]
+        exit_trigger = self._transition_trigger(
+            exit_transition, frontier.store, is_initial=False
+        )[0]
+        if loop_has_priority:
+            loop_condition = loop_trigger
+            exit_condition = BoolTemplate.not_(loop_trigger)
+        else:
+            loop_condition = BoolTemplate.and_(
+                BoolTemplate.not_(exit_trigger), loop_trigger
+            )
+            exit_condition = exit_trigger
+
+        loop_store = dict(frontier.store.values)
+        loop_store[variable_name] = _ValueTemplate.const_value(threshold)
+        accelerated_loop = self._replace_frontier(
+            frontier,
+            condition=BoolTemplate.and_(frontier.condition, loop_condition),
+            store=_Store(loop_store),
+        )
+        loop_expansion = (
+            _Expansion((), (), ())
+            if _has_direct_atom_contradiction(accelerated_loop.condition)
+            else self._expand_triggered_transition(accelerated_loop, exit_transition)
+        )
+
+        direct_exit = self._replace_frontier(
+            frontier,
+            condition=BoolTemplate.and_(frontier.condition, exit_condition),
+        )
+        if _has_direct_atom_contradiction(direct_exit.condition):
+            exit_expansion = _Expansion((), (), ())
+        else:
+            exit_expansion = self._expand_triggered_transition(
+                direct_exit, exit_transition
+            )
+
+        return self._merge_expansions((loop_expansion, exit_expansion))
+
+    def _expand_triggered_transition(
+        self, frontier: _MacroFrontier, transition: Transition
+    ) -> _Expansion:
+        """Execute a transition whose trigger is already part of ``frontier``.
+
+        :param frontier: Frontier with the selected transition condition already
+            included.
+        :type frontier: _MacroFrontier
+        :param transition: Transition to execute.
+        :type transition: pyfcstm.model.Transition
+        :return: Expansion produced by executing the transition and continuing
+            to a stable boundary.
+        :rtype: _Expansion
+        """
+        outcomes: List[_MacroOutcome] = []
+        failed: List[BoolTemplate] = []
+        diagnostics: List[BoolTemplate] = []
+        for branch in self._execute_transition(frontier, transition):
+            branch_expansion = self._expand_frontier(branch)
+            outcomes.extend(branch_expansion.outcomes)
+            failed.extend(branch_expansion.failed)
+            diagnostics.extend(branch_expansion.diagnostics)
+        return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
+
+    @staticmethod
+    def _pseudo_state_is_accelerable(state: State) -> bool:
+        """Return whether a pseudo state has no lifecycle side effects.
+
+        :param state: Pseudo state candidate.
+        :type state: pyfcstm.model.State
+        :return: Whether the state can be summarized without losing lifecycle
+            behavior.
+        :rtype: bool
+        """
+        return not (
+            state.on_enters
+            or state.on_exits
+            or state.on_durings
+            or state.on_during_aspects
+        )
+
+    def _accelerable_pseudo_loop(
+        self, transition: Transition, state: State
+    ) -> Optional[Tuple[str, int]]:
+        """Extract the integer threshold pattern from a pseudo self-loop.
+
+        :param transition: Candidate self-loop transition.
+        :type transition: pyfcstm.model.Transition
+        :param state: Pseudo state that owns the transition.
+        :type state: pyfcstm.model.State
+        :return: ``(variable_name, threshold)`` for ``x < K`` plus
+            ``x = x + 1`` loops, or ``None`` for unsupported shapes.
+        :rtype: Optional[Tuple[str, int]]
+        """
+        if transition.from_state != state.name or transition.to_state != state.name:
+            return None
+        if transition.event is not None:
+            return None
+        guard = transition.guard
+        if not isinstance(guard, BinaryOp) or guard.op != "<":
+            return None
+        if not isinstance(guard.x, Variable):
+            return None
+        variable_name = guard.x.name
+        if not self._is_int_variable(variable_name):
+            return None
+        threshold = _literal_int(guard.y)
+        if threshold is None:
+            return None
+        if len(transition.effects) != 1:
+            return None
+        effect = transition.effects[0]
+        if not _is_unit_increment_effect(effect, variable_name):
+            return None
+        return variable_name, threshold
+
+    def _is_complementary_threshold_exit(
+        self,
+        transition: Transition,
+        state: State,
+        variable_name: str,
+        threshold: int,
+    ) -> bool:
+        """Return whether ``transition`` exits once the loop threshold is met.
+
+        :param transition: Candidate exit transition.
+        :type transition: pyfcstm.model.Transition
+        :param state: Pseudo state that owns the transition.
+        :type state: pyfcstm.model.State
+        :param variable_name: Integer variable advanced by the loop.
+        :type variable_name: str
+        :param threshold: Loop threshold.
+        :type threshold: int
+        :return: Whether the transition has guard ``x >= K`` and leaves the
+            pseudo state.
+        :rtype: bool
+        """
+        if transition.from_state != state.name or transition.to_state == state.name:
+            return False
+        if transition.event is not None:
+            return False
+        guard = transition.guard
+        if not isinstance(guard, BinaryOp) or guard.op != ">=":
+            return False
+        if not isinstance(guard.x, Variable) or guard.x.name != variable_name:
+            return False
+        return _literal_int(guard.y) == threshold
+
+    def _is_int_variable(self, variable_name: str) -> bool:
+        """Return whether ``variable_name`` is a persistent integer variable.
+
+        :param variable_name: Candidate persistent variable name.
+        :type variable_name: str
+        :return: Whether the BMC domain declares it as ``int``.
+        :rtype: bool
+        """
+        try:
+            entry = self.domain.variable_by_name(variable_name)
+        except InvalidBmcDomain:
+            return False
+        return entry.declared_type == "int"
 
     def _expand_ordered_candidates(
         self,
@@ -717,6 +933,12 @@ class _Expander:
             )
         else:
             condition = frontier.condition
+        failed_events = _event_uses_from_condition(
+            BoolTemplate.or_(*failed),
+            self.domain,
+            polarity="negative",
+            reason="fallback",
+        )
         fallback_frontier = self._replace_frontier(
             frontier,
             condition=condition,
@@ -738,7 +960,11 @@ class _Expander:
                 outcome.target_state_path,
                 outcome.condition,
                 outcome.store,
-                _merge_event_uses(outcome.used_events, fallback_events),
+                _merge_event_uses(
+                    outcome.used_events,
+                    fallback_events,
+                    failed_events,
+                ),
                 _CASE_KIND_FALLBACK,
                 tuple(failed),
             )
@@ -1097,6 +1323,79 @@ class _Expander:
         frontiers: Iterable[_MacroFrontier], func
     ) -> Tuple[_MacroFrontier, ...]:
         return tuple(item for frontier in frontiers for item in func(frontier))
+
+
+def _literal_int(expr: Expr) -> Optional[int]:
+    """Return an integer literal value if ``expr`` is exactly integral syntax.
+
+    :param expr: Model expression to inspect.
+    :type expr: pyfcstm.model.Expr
+    :return: Integer literal value, or ``None`` for non-integer syntax.
+    :rtype: Optional[int]
+    """
+    if isinstance(expr, Integer):
+        return expr.value
+    return None
+
+
+def _is_unit_increment_effect(
+    statement: OperationStatement, variable_name: str
+) -> bool:
+    """Return whether a statement writes ``variable_name = variable_name + 1``.
+
+    :param statement: Operation statement to inspect.
+    :type statement: pyfcstm.model.OperationStatement
+    :param variable_name: Persistent variable that should be incremented.
+    :type variable_name: str
+    :return: Whether the statement is the supported unit increment.
+    :rtype: bool
+    """
+    if not isinstance(statement, Operation):
+        return False
+    if statement.var_name != variable_name:
+        return False
+    expr = statement.expr
+    if not isinstance(expr, BinaryOp) or expr.op != "+":
+        return False
+    if isinstance(expr.x, Variable) and expr.x.name == variable_name:
+        return _literal_int(expr.y) == 1
+    if isinstance(expr.y, Variable) and expr.y.name == variable_name:
+        return _literal_int(expr.x) == 1
+    return False
+
+
+def _has_direct_atom_contradiction(condition: BoolTemplate) -> bool:
+    """Return whether a conjunction contains both ``a`` and ``not a``.
+
+    :param condition: Boolean recipe to inspect.
+    :type condition: pyfcstm.bmc.macro.BoolTemplate
+    :return: Whether a direct atom contradiction is present.
+    :rtype: bool
+    """
+    positive = set()
+    negative = set()
+    for item in _conjunctive_literals(condition):
+        if item.kind == "atom":
+            positive.add(item._atom_name())
+        elif item.kind == "not" and item.operands[0].kind == "atom":
+            negative.add(item.operands[0]._atom_name())
+    return bool(positive.intersection(negative))
+
+
+def _conjunctive_literals(condition: BoolTemplate) -> Tuple[BoolTemplate, ...]:
+    """Flatten conjunction operands for direct literal inspection.
+
+    :param condition: Boolean recipe to flatten.
+    :type condition: pyfcstm.bmc.macro.BoolTemplate
+    :return: Tuple of conjunction leaves.
+    :rtype: Tuple[pyfcstm.bmc.macro.BoolTemplate, ...]
+    """
+    if condition.kind == "and":
+        result = []
+        for operand in condition.operands:
+            result.extend(_conjunctive_literals(operand))
+        return tuple(result)
+    return (condition,)
 
 
 def _comparison_condition(

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -1,13 +1,13 @@
-"""Macro-step expansion aligned with the FCSTM simulation runtime.
+"""Runtime-aligned macro-step expansion for FCSTM BMC.
 
 The expansion layer turns a :class:`pyfcstm.bmc.source.MacroStepSource` into a
 solver-independent :class:`pyfcstm.bmc.macro.MacroStepFormal`.  It mirrors the
-cycle-level control flow of :class:`pyfcstm.simulate.SimulationRuntime` without
-creating Z3 symbols or verify-registry entries.  The output conditions remain
-bare case predicates; later relation builders compose the source-state guard and
-lower each case as an implication.  Ordered transitions use accepted
-continuations for priority masks, and event reads used only by those masks are
-kept in :class:`pyfcstm.bmc.macro.EventUse` metadata for witness explanations.
+cycle-level control flow of :class:`pyfcstm.simulate.SimulationRuntime` while
+staying strictly below solver lowering: the output is a flat control-path plan
+with event atoms, anchored guard requirements, accepted-path priority masks, and
+ordered model action blocks.  The expander does not build Z3 expressions, does
+not turn operations into writeback strings, and does not split action-local
+``if`` blocks into separate cases.
 
 The module contains:
 
@@ -28,17 +28,20 @@ Example::
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Iterable, Optional, Sequence, Tuple
 
 from pyfcstm.bmc.domain import STATE_TERMINATE_ID, BmcDomain
 from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcDomain, InvalidBmcEncoding
 from pyfcstm.bmc.macro import (
+    ActionBlock,
     BoolTemplate,
     CycleCase,
     EventUse,
+    GuardRequirement,
     MacroStepFormal,
-    VarUpdate,
+    PriorityExclusion,
     build_semantic_delta_case,
     diagnostic_absorb_case,
     terminated_absorb_case,
@@ -46,23 +49,12 @@ from pyfcstm.bmc.macro import (
 from pyfcstm.bmc.source import TERMINATE_CASE_PATH, MacroStepSource
 from pyfcstm.dsl import EXIT_STATE
 from pyfcstm.model import (
-    BinaryOp,
     Boolean,
-    ConditionalOp,
-    Expr,
-    Float,
-    IfBlock,
-    Integer,
     OnAspect,
     OnStage,
-    Operation,
     OperationStatement,
     State,
-    StateMachine,
     Transition,
-    UFunc,
-    UnaryOp,
-    Variable,
 )
 
 _CASE_KIND_FALLBACK = "fallback"
@@ -70,7 +62,7 @@ _CASE_KIND_INITIAL = "initial"
 _CASE_KIND_TRANSITION = "transition"
 _EVENT_ATOM_PREFIX = "event:"
 _GUARD_ATOM_PREFIX = "guard:"
-_PRE_VAR_PREFIX = "pre:"
+_ACCEPTED_ATOM_PREFIX = "accepted:"
 
 
 def _validate_positive_int(value: object, field_name: str) -> int:
@@ -123,131 +115,11 @@ class MacroExpansionOptions:
             self,
             "partition_max_assignments",
             _validate_positive_int(
-                self.partition_max_assignments,
-                "partition_max_assignments",
+                self.partition_max_assignments, "partition_max_assignments"
             ),
         )
         if not isinstance(self.verify_partition, bool):
             raise InvalidBmcEncoding("verify_partition must be a boolean.")
-
-
-@dataclass(frozen=True)
-class _LinearExpr:
-    coeffs: Mapping[str, float]
-    const: float = 0.0
-
-    @classmethod
-    def variable(cls, name: str) -> "_LinearExpr":
-        return cls({name: 1.0}, 0.0)
-
-    @classmethod
-    def const_value(cls, value: float) -> "_LinearExpr":
-        return cls({}, float(value))
-
-    def add(self, other: "_LinearExpr") -> "_LinearExpr":
-        coeffs = dict(self.coeffs)
-        for name, coeff in other.coeffs.items():
-            coeffs[name] = coeffs.get(name, 0.0) + coeff
-            if coeffs[name] == 0:
-                del coeffs[name]
-        return _LinearExpr(coeffs, self.const + other.const)
-
-    def mul_const(self, value: float) -> "_LinearExpr":
-        return _LinearExpr(
-            {name: coeff * value for name, coeff in self.coeffs.items()},
-            self.const * value,
-        )
-
-    def to_text(self) -> str:
-        parts = []
-        for name in sorted(self.coeffs):
-            coeff = self.coeffs[name]
-            if coeff == 1:
-                part = name
-            elif coeff == -1:
-                part = "-%s" % name
-            else:
-                part = "%s * %s" % (_format_number(coeff), name)
-            parts.append(part)
-        const = self.const
-        if const:
-            const_text = _format_number(abs(const))
-            if parts:
-                parts.append(("+ " if const > 0 else "- ") + const_text)
-            else:
-                parts.append(_format_number(const))
-        if not parts:
-            return "0"
-        text = parts[0]
-        for part in parts[1:]:
-            if part.startswith("+ ") or part.startswith("- "):
-                text = "%s %s" % (text, part)
-            elif part.startswith("-"):
-                text = "%s - %s" % (text, part[1:])
-            else:
-                text = "%s + %s" % (text, part)
-        return text
-
-
-@dataclass(frozen=True)
-class _ValueTemplate:
-    text: str
-    linear: Optional[_LinearExpr] = None
-
-    @classmethod
-    def variable(cls, name: str) -> "_ValueTemplate":
-        text = "%s%s" % (_PRE_VAR_PREFIX, name)
-        return cls(text, _LinearExpr.variable(text))
-
-    @classmethod
-    def const_value(cls, value: float) -> "_ValueTemplate":
-        text = _format_number(value)
-        return cls(text, _LinearExpr.const_value(value))
-
-    def binary(self, op: str, other: "_ValueTemplate") -> "_ValueTemplate":
-        if op == "+" and self.linear is not None and other.linear is not None:
-            return _value_from_linear(self.linear.add(other.linear))
-        if op == "-" and self.linear is not None and other.linear is not None:
-            return _value_from_linear(self.linear.add(other.linear.mul_const(-1)))
-        if op == "*":
-            if self.linear is not None and not self.linear.coeffs:
-                return (
-                    _value_from_linear(other.linear.mul_const(self.linear.const))
-                    if other.linear is not None
-                    else _ValueTemplate("%s * %s" % (self.text, other.text))
-                )
-            if other.linear is not None and not other.linear.coeffs:
-                return (
-                    _value_from_linear(self.linear.mul_const(other.linear.const))
-                    if self.linear is not None
-                    else _ValueTemplate("%s * %s" % (self.text, other.text))
-                )
-        if (
-            op == "/"
-            and other.linear is not None
-            and not other.linear.coeffs
-            and other.linear.const != 0
-            and self.linear is not None
-        ):
-            return _value_from_linear(self.linear.mul_const(1.0 / other.linear.const))
-        return _ValueTemplate("%s %s %s" % (self.text, op, other.text))
-
-    def unary(self, op: str) -> "_ValueTemplate":
-        if op == "+":
-            return self
-        if op == "-" and self.linear is not None:
-            return _value_from_linear(self.linear.mul_const(-1))
-        return _ValueTemplate("%s%s" % (op, self.text))
-
-
-def _format_number(value: float) -> str:
-    if int(value) == value:
-        return str(int(value))
-    return repr(float(value))
-
-
-def _value_from_linear(linear: _LinearExpr) -> _ValueTemplate:
-    return _ValueTemplate(linear.to_text(), linear)
 
 
 @dataclass(frozen=True)
@@ -258,16 +130,13 @@ class _FormalStackFrame:
 
 
 @dataclass(frozen=True)
-class _Store:
-    values: Mapping[str, _ValueTemplate]
-
-
-@dataclass(frozen=True)
 class _MacroFrontier:
     stack: Tuple[_FormalStackFrame, ...]
-    store: _Store
     condition: BoolTemplate
     used_events: Tuple[EventUse, ...]
+    action_blocks: Tuple[ActionBlock, ...]
+    guard_requirements: Tuple[GuardRequirement, ...]
+    priority_exclusions: Tuple[PriorityExclusion, ...]
     case_kind: str
     path_signatures: Tuple[Tuple[object, ...], ...] = ()
     depth: int = 0
@@ -275,11 +144,14 @@ class _MacroFrontier:
 
 @dataclass(frozen=True)
 class _MacroOutcome:
+    label: str
     target_state_id: int
     target_state_path: str
     condition: BoolTemplate
-    store: _Store
     used_events: Tuple[EventUse, ...]
+    action_blocks: Tuple[ActionBlock, ...]
+    guard_requirements: Tuple[GuardRequirement, ...]
+    priority_exclusions: Tuple[PriorityExclusion, ...]
     case_kind: str
     failed_conditions: Tuple[BoolTemplate, ...] = ()
 
@@ -291,65 +163,100 @@ class _Expansion:
     diagnostics: Tuple[BoolTemplate, ...]
 
 
-@dataclass(frozen=True)
-class _Branch:
-    condition: BoolTemplate
-    store: _Store
+def expand_macro_step_cases(
+    source: MacroStepSource,
+    options: Optional[MacroExpansionOptions] = None,
+) -> MacroStepFormal:
+    """Expand one macro-step source into runtime-aligned flat cases.
+
+    :param source: Macro-step source profile to expand.
+    :type source: MacroStepSource
+    :param options: Expansion safety options, defaults to ``None``.
+    :type options: MacroExpansionOptions, optional
+    :return: Source-local macro-step formal.
+    :rtype: pyfcstm.bmc.macro.MacroStepFormal
+    :raises InvalidBmcEncoding: If the source is malformed or lacks a domain
+        model reference.
+    :raises BmcBuildError: If expansion cannot safely summarize a bounded
+        runtime path.
+
+    Example::
+
+        >>> from pyfcstm.bmc import build_bmc_domain, stable_leaf_source
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> model = load_state_machine_from_text('state Root;')
+        >>> domain = build_bmc_domain(model, 1)
+        >>> expand_macro_step_cases(stable_leaf_source(domain, 'Root')).success_cases[0].kind
+        'fallback'
+    """
+    if not isinstance(source, MacroStepSource):
+        raise InvalidBmcEncoding("source must be MacroStepSource.")
+    if options is None:
+        options = MacroExpansionOptions()
+    elif not isinstance(options, MacroExpansionOptions):
+        raise InvalidBmcEncoding("options must be MacroExpansionOptions.")
+    return _MacroExpander(source, options).expand()
 
 
-class _Expander:
-    def __init__(self, source: MacroStepSource, options: MacroExpansionOptions):
-        if source.domain is None:
-            raise InvalidBmcEncoding("macro-step source must be domain-backed.")
-        if not isinstance(source.domain, BmcDomain):
-            raise InvalidBmcEncoding("source.domain must be BmcDomain.")
+class _MacroExpander:
+    """Internal runtime-aligned macro-step expander."""
+
+    def __init__(self, source: MacroStepSource, options: MacroExpansionOptions) -> None:
         self.source = source
         self.domain = source.domain
-        self.options = options
-        model = getattr(self.domain, "model", None)
-        if not isinstance(model, StateMachine):
+        if self.domain is None:
             raise InvalidBmcEncoding(
-                "source domain must preserve the state machine model for expansion."
+                "macro-step expansion requires a domain-backed source."
             )
-        self.model = model
+        if not isinstance(self.domain, BmcDomain):
+            raise InvalidBmcEncoding("source domain must be BmcDomain.")
+        self.model = self.domain.model
+        if self.model is None:
+            raise InvalidBmcEncoding(
+                "macro-step expansion requires a domain with model back-reference."
+            )
+        self.options = options
         self.states_by_path = {
-            ".".join(state.path): state for state in model.walk_states()
+            ".".join(state.path): state for state in self.model.walk_states()
         }
-        self.event_entries = {entry.path: entry for entry in self.domain.events}
-        self.state_ids = {entry.path: entry.id for entry in self.domain.states}
+        self.state_ids = {
+            entry.path: entry.id
+            for entry in self.domain.states
+            if not entry.is_sentinel
+        }
+        self._case_counters = {}  # type: Dict[str, int]
+        self._guard_counter = 0
+        self._decision_counter = 0
 
     def expand(self) -> MacroStepFormal:
+        """Return the expanded macro-step formal."""
         if self.source.kind == "terminated":
             return MacroStepFormal(self.source, (terminated_absorb_case(self.domain),))
         if self.source.kind == "diagnostic":
             return MacroStepFormal(self.source, (diagnostic_absorb_case(self.domain),))
 
-        initial_frontiers = self._frontiers_from_source()
         expansion = self._merge_expansions(
-            self._expand_frontier(frontier) for frontier in initial_frontiers
+            self._expand_frontier(frontier)
+            for frontier in self._frontiers_from_source()
         )
-        if self.source.kind == "stable_leaf" and expansion.diagnostics:
-            raise BmcBuildError("stable macro expansion produced build diagnostics.")
-
         success_cases = self._cases_from_outcomes(expansion.outcomes)
         delta_cases = ()
         diagnostics = expansion.diagnostics
-        if self.source.kind == "entry":
-            delta = build_semantic_delta_case(
-                self.domain,
-                self.source,
-                success_cases,
-                diagnostics,
-                expansion.failed,
+        if self.source.allows_semantic_delta:
+            delta_cases = (
+                build_semantic_delta_case(
+                    self.domain,
+                    self.source,
+                    success_cases,
+                    diagnostics,
+                    expansion.failed,
+                ),
             )
-            delta_cases = (delta,)
-
-        formal = MacroStepFormal(
-            self.source,
-            success_cases,
-            delta_cases,
-            diagnostics,
-        )
+        elif diagnostics:
+            raise BmcBuildError(
+                "stable macro-step source produced unsupported build diagnostic conditions."
+            )
+        formal = MacroStepFormal(self.source, success_cases, delta_cases, diagnostics)
         if self.options.verify_partition:
             formal.verify_partition(
                 max_assignments=self.options.partition_max_assignments
@@ -368,12 +275,6 @@ class _Expander:
         return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
 
     def _frontiers_from_source(self) -> Tuple[_MacroFrontier, ...]:
-        store = _Store(
-            {
-                entry.name: _ValueTemplate.variable(entry.name)
-                for entry in self.domain.variables
-            }
-        )
         state = self._source_state()
         if self.source.kind == "stable_leaf":
             stack = tuple(
@@ -381,7 +282,13 @@ class _Expander:
             )
             return (
                 _MacroFrontier(
-                    stack, store, BoolTemplate.true(), (), _CASE_KIND_TRANSITION
+                    stack,
+                    BoolTemplate.true(),
+                    (),
+                    (),
+                    (),
+                    (),
+                    _CASE_KIND_TRANSITION,
                 ),
             )
 
@@ -389,7 +296,13 @@ class _Expander:
             raise InvalidBmcEncoding("unsupported source kind: %r." % self.source.kind)
         if state.is_root_state:
             base = _MacroFrontier(
-                (), store, BoolTemplate.true(), (), _CASE_KIND_INITIAL
+                (),
+                BoolTemplate.true(),
+                (),
+                (),
+                (),
+                (),
+                _CASE_KIND_INITIAL,
             )
             return self._enter_state(base, state)
         stack = []
@@ -406,7 +319,13 @@ class _Expander:
                 stack.append(_FormalStackFrame(item, "active"))
         return (
             _MacroFrontier(
-                tuple(stack), store, BoolTemplate.true(), (), _CASE_KIND_INITIAL
+                tuple(stack),
+                BoolTemplate.true(),
+                (),
+                (),
+                (),
+                (),
+                _CASE_KIND_INITIAL,
             ),
         )
 
@@ -418,9 +337,15 @@ class _Expander:
 
     def _expand_frontier(self, frontier: _MacroFrontier) -> _Expansion:
         if frontier.depth >= self.options.max_micro_steps:
-            return _Expansion((), (), (frontier.condition,))
+            raise BmcBuildError(
+                "macro-step expansion exceeded the micro-step safety limit."
+            )
         if len(frontier.stack) > self.options.max_stack_depth:
-            return _Expansion((), (), (frontier.condition,))
+            raise BmcBuildError(
+                "macro-step expansion exceeded the stack-depth safety limit."
+            )
+        if frontier.condition.kind == "false":
+            return _Expansion((), (), ())
         signature = self._frontier_signature(frontier)
         if signature in frontier.path_signatures:
             return _Expansion((), (frontier.condition,), ())
@@ -450,10 +375,6 @@ class _Expander:
         return _Expansion((), (), (frontier.condition,))
 
     def _expand_leaf_active(self, frontier: _MacroFrontier) -> _Expansion:
-        accelerated = self._try_expand_pseudo_threshold_loop(frontier)
-        if accelerated is not None:
-            return accelerated
-
         transitions = frontier.stack[-1].state.transitions_from
         expanded = self._expand_ordered_candidates(
             frontier, transitions, is_initial=False
@@ -498,378 +419,174 @@ class _Expander:
             (), (frontier.condition,) + expanded.failed, expanded.diagnostics
         )
 
-    def _try_expand_pseudo_threshold_loop(
-        self, frontier: _MacroFrontier
-    ) -> Optional[_Expansion]:
-        """Return an accelerated expansion for simple monotone pseudo loops.
-
-        The runtime validation worklist can accept a pseudo self-loop that
-        monotonically increments an integer variable until a complementary exit
-        guard becomes true.  Symbolic recursion cannot prove that convergence
-        by path-signature repetition alone because each loop iteration changes
-        the symbolic store.  This helper recognizes that narrow runtime-safe
-        pattern and summarizes the finite loop as a threshold writeback before
-        executing the ordinary exit transition.
-
-        :param frontier: Current macro frontier whose stack top may be a pseudo
-            state.
-        :type frontier: _MacroFrontier
-        :return: Accelerated expansion, or ``None`` if the frontier does not
-            match the supported monotone pseudo-loop shape.
-        :rtype: Optional[_Expansion]
-        """
-        top = frontier.stack[-1]
-        state = top.state
-        if not state.is_pseudo:
-            return None
-        if not self._pseudo_state_is_accelerable(state):
-            return None
-        transitions = tuple(state.transitions_from)
-        if len(transitions) != 2:
-            return None
-        first, second = transitions
-        first_loop = self._accelerable_pseudo_loop(first, state)
-        second_loop = self._accelerable_pseudo_loop(second, state)
-        if first_loop is not None and second_loop is None:
-            exit_transition = second
-            loop_has_priority = True
-            variable_name, increment, threshold = first_loop
-        elif second_loop is not None and first_loop is None:
-            exit_transition = first
-            loop_has_priority = False
-            variable_name, increment, threshold = second_loop
-        else:
-            return None
-        if not self._is_complementary_threshold_exit(
-            exit_transition, state, variable_name, threshold
-        ):
-            return None
-
-        loop_trigger = self._threshold_store_condition(
-            frontier.store, variable_name, "lt", threshold
-        )
-        exit_trigger = self._threshold_store_condition(
-            frontier.store, variable_name, "ge", threshold
-        )
-        if loop_has_priority:
-            loop_condition = loop_trigger
-            exit_condition = BoolTemplate.not_(loop_trigger)
-        else:
-            loop_condition = BoolTemplate.not_(exit_trigger)
-            exit_condition = exit_trigger
-
-        loop_store = dict(frontier.store.values)
-        loop_store[variable_name] = _threshold_reached_value(
-            frontier.store.values[variable_name],
-            threshold,
-            increment,
-        )
-        accelerated_loop = self._replace_frontier(
-            frontier,
-            condition=BoolTemplate.and_(frontier.condition, loop_condition),
-            store=_Store(loop_store),
-        )
-        loop_expansion = (
-            _Expansion((), (), ())
-            if _has_direct_atom_contradiction(accelerated_loop.condition)
-            else self._expand_triggered_transition(accelerated_loop, exit_transition)
-        )
-
-        direct_exit = self._replace_frontier(
-            frontier,
-            condition=BoolTemplate.and_(frontier.condition, exit_condition),
-        )
-        if _has_direct_atom_contradiction(direct_exit.condition):
-            exit_expansion = _Expansion((), (), ())
-        else:
-            exit_expansion = self._expand_triggered_transition(
-                direct_exit, exit_transition
+    def _expand_ordered_candidates(
+        self,
+        frontier: _MacroFrontier,
+        transitions: Sequence[Transition],
+        is_initial: bool,
+    ) -> _Expansion:
+        outcomes = []  # type: List[_MacroOutcome]
+        failed = []  # type: List[BoolTemplate]
+        diagnostics = []  # type: List[BoolTemplate]
+        for index, transition in enumerate(transitions):
+            candidate = self._apply_priority_exclusion(frontier, outcomes, is_initial)
+            candidate = self._apply_transition_trigger(
+                candidate, transition, index, is_initial
             )
+            if candidate.condition.kind == "false":
+                continue
+            branch_expansion = self._expand_triggered_transition(
+                candidate, transition, is_initial
+            )
+            if branch_expansion.outcomes:
+                outcomes.extend(branch_expansion.outcomes)
+            else:
+                failed.append(candidate.condition)
+            failed.extend(branch_expansion.failed)
+            diagnostics.extend(branch_expansion.diagnostics)
+        return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
 
-        return self._merge_expansions((loop_expansion, exit_expansion))
+    def _apply_priority_exclusion(
+        self,
+        frontier: _MacroFrontier,
+        accepted: Sequence[_MacroOutcome],
+        is_initial: bool,
+    ) -> _MacroFrontier:
+        if not accepted:
+            return frontier
+        labels = tuple(outcome.label for outcome in accepted)
+        accepted_condition = BoolTemplate.or_(
+            *[
+                BoolTemplate.atom("%s%s" % (_ACCEPTED_ATOM_PREFIX, label))
+                for label in labels
+            ]
+        )
+        event_paths = tuple(
+            sorted(
+                {event.path for outcome in accepted for event in outcome.used_events}
+            )
+        )
+        guard_ids = tuple(
+            sorted(
+                {
+                    guard.requirement_id
+                    for outcome in accepted
+                    for guard in outcome.guard_requirements
+                }
+            )
+        )
+        decision_id = "d%d" % self._decision_counter
+        self._decision_counter += 1
+        priority = PriorityExclusion(
+            decision_id,
+            "initial_priority" if is_initial else "transition_priority",
+            labels,
+            accepted_condition,
+            event_paths,
+            guard_ids,
+        )
+        return self._replace_frontier(
+            frontier,
+            condition=BoolTemplate.and_(
+                frontier.condition, BoolTemplate.not_(accepted_condition)
+            ),
+            used_events=_merge_event_uses(
+                frontier.used_events,
+                self._event_uses_for_paths(event_paths, "negative", "priority"),
+            ),
+            priority_exclusions=frontier.priority_exclusions + (priority,),
+        )
+
+    def _apply_transition_trigger(
+        self,
+        frontier: _MacroFrontier,
+        transition: Transition,
+        transition_index: int,
+        is_initial: bool,
+    ) -> _MacroFrontier:
+        conditions = [frontier.condition]
+        used_events = frontier.used_events
+        guard_requirements = frontier.guard_requirements
+        owner = frontier.stack[-1].state
+        transition_label = self._transition_label(owner, transition, transition_index)
+        if transition.event is not None:
+            path = transition.event.path_name
+            conditions.append(BoolTemplate.atom("%s%s" % (_EVENT_ATOM_PREFIX, path)))
+            used_events = _merge_event_uses(
+                used_events,
+                self._event_uses_for_paths((path,), "positive", "trigger"),
+            )
+        if transition.guard is not None:
+            if isinstance(transition.guard, Boolean):
+                if transition.guard.value:
+                    pass
+                else:
+                    conditions.append(BoolTemplate.false())
+            else:
+                requirement_id = "g%d" % self._guard_counter
+                self._guard_counter += 1
+                owner_path = ".".join(owner.path)
+                guard = GuardRequirement(
+                    requirement_id,
+                    self._state_id(owner_path),
+                    owner_path,
+                    transition_label,
+                    transition.guard,
+                    "positive",
+                    "initial_guard" if is_initial else "transition_guard",
+                    len(frontier.action_blocks),
+                )
+                guard_requirements = guard_requirements + (guard,)
+                conditions.append(BoolTemplate.atom(guard.atom_name))
+        return self._replace_frontier(
+            frontier,
+            condition=BoolTemplate.and_(*conditions),
+            used_events=used_events,
+            guard_requirements=guard_requirements,
+        )
 
     def _expand_triggered_transition(
-        self, frontier: _MacroFrontier, transition: Transition
+        self,
+        frontier: _MacroFrontier,
+        transition: Transition,
+        is_initial: bool,
     ) -> _Expansion:
-        """Execute a transition whose trigger is already part of ``frontier``.
-
-        :param frontier: Frontier with the selected transition condition already
-            included.
-        :type frontier: _MacroFrontier
-        :param transition: Transition to execute.
-        :type transition: pyfcstm.model.Transition
-        :return: Expansion produced by executing the transition and continuing
-            to a stable boundary.
-        :rtype: _Expansion
-        """
-        outcomes: List[_MacroOutcome] = []
-        failed: List[BoolTemplate] = []
-        diagnostics: List[BoolTemplate] = []
-        for branch in self._execute_transition(frontier, transition):
+        branches = (
+            self._execute_initial_transition(frontier, transition)
+            if is_initial
+            else self._execute_transition(frontier, transition)
+        )
+        outcomes = []
+        failed = []
+        diagnostics = []
+        for branch in branches:
             branch_expansion = self._expand_frontier(branch)
             outcomes.extend(branch_expansion.outcomes)
             failed.extend(branch_expansion.failed)
             diagnostics.extend(branch_expansion.diagnostics)
         return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
 
-    @staticmethod
-    def _pseudo_state_is_accelerable(state: State) -> bool:
-        """Return whether a pseudo state has no lifecycle side effects.
-
-        :param state: Pseudo state candidate.
-        :type state: pyfcstm.model.State
-        :return: Whether the state can be summarized without losing lifecycle
-            behavior.
-        :rtype: bool
-        """
-        return not (
-            state.on_enters
-            or state.on_exits
-            or state.on_durings
-            or state.on_during_aspects
-        )
-
-    def _accelerable_pseudo_loop(
-        self, transition: Transition, state: State
-    ) -> Optional[Tuple[str, int, int]]:
-        """Extract the integer threshold pattern from a pseudo self-loop.
-
-        :param transition: Candidate self-loop transition.
-        :type transition: pyfcstm.model.Transition
-        :param state: Pseudo state that owns the transition.
-        :type state: pyfcstm.model.State
-        :return: ``(variable_name, increment, threshold)`` for integer forms
-            equivalent to ``x < K`` plus ``x = x + step`` loops, or ``None``
-            for unsupported shapes.
-        :rtype: Optional[Tuple[str, int, int]]
-        """
-        if transition.from_state != state.name or transition.to_state != state.name:
-            return None
-        if transition.event is not None:
-            return None
-        guard = _integer_threshold_guard(transition.guard)
-        if guard is None:
-            return None
-        variable_name, relation, threshold = guard
-        if relation != "lt":
-            return None
-        if not self._is_int_variable(variable_name):
-            return None
-        if len(transition.effects) != 1:
-            return None
-        effect = transition.effects[0]
-        increment = _positive_integer_increment_effect(effect, variable_name)
-        if increment is None:
-            return None
-        return variable_name, increment, threshold
-
-    def _is_complementary_threshold_exit(
-        self,
-        transition: Transition,
-        state: State,
-        variable_name: str,
-        threshold: int,
-    ) -> bool:
-        """Return whether ``transition`` exits once the loop threshold is met.
-
-        :param transition: Candidate exit transition.
-        :type transition: pyfcstm.model.Transition
-        :param state: Pseudo state that owns the transition.
-        :type state: pyfcstm.model.State
-        :param variable_name: Integer variable advanced by the loop.
-        :type variable_name: str
-        :param threshold: Loop threshold.
-        :type threshold: int
-        :return: Whether the transition has an integer guard equivalent to
-            ``x >= K`` and leaves the pseudo state.
-        :rtype: bool
-        """
-        if transition.from_state != state.name or transition.to_state == state.name:
-            return False
-        if transition.event is not None:
-            return False
-        guard = _integer_threshold_guard(transition.guard)
-        if guard is None:
-            return False
-        exit_variable_name, relation, exit_threshold = guard
-        return (
-            exit_variable_name == variable_name
-            and relation == "ge"
-            and exit_threshold == threshold
-        )
-
-    def _threshold_store_condition(
-        self,
-        store: _Store,
-        variable_name: str,
-        relation: str,
-        threshold: int,
-    ) -> BoolTemplate:
-        """Build a normalized threshold condition over the symbolic store.
-
-        :param store: Current symbolic variable store.
-        :type store: _Store
-        :param variable_name: Persistent integer variable to compare.
-        :type variable_name: str
-        :param relation: ``"lt"`` for ``x < threshold`` or ``"ge"`` for
-            ``x >= threshold``.
-        :type relation: str
-        :param threshold: Integer threshold.
-        :type threshold: int
-        :return: Boolean recipe for the normalized comparison.
-        :rtype: pyfcstm.bmc.macro.BoolTemplate
-        :raises BmcBuildError: If the variable is missing or ``relation`` is
-            unsupported.
-        """
-        if variable_name not in store.values:
-            raise BmcBuildError("unknown threshold variable %r." % variable_name)
-        if relation == "lt":
-            return _comparison_condition(
-                store.values[variable_name],
-                "<",
-                _ValueTemplate.const_value(threshold),
-            )
-        if relation == "ge":
-            return _comparison_condition(
-                store.values[variable_name],
-                ">=",
-                _ValueTemplate.const_value(threshold),
-            )
-        raise BmcBuildError("unsupported threshold relation %r." % relation)
-
-    def _is_int_variable(self, variable_name: str) -> bool:
-        """Return whether ``variable_name`` is a persistent integer variable.
-
-        :param variable_name: Candidate persistent variable name.
-        :type variable_name: str
-        :return: Whether the BMC domain declares it as ``int``.
-        :rtype: bool
-        """
-        try:
-            entry = self.domain.variable_by_name(variable_name)
-        except InvalidBmcDomain:
-            return False
-        return entry.declared_type == "int"
-
-    def _expand_ordered_candidates(
-        self,
-        frontier: _MacroFrontier,
-        transitions: Sequence[Transition],
-        *,
-        is_initial: bool,
-    ) -> _Expansion:
-        outcomes: List[_MacroOutcome] = []
-        failed: List[BoolTemplate] = []
-        diagnostics: List[BoolTemplate] = []
-        previous_accepted: List[BoolTemplate] = []
-        previous_event_uses: List[EventUse] = []
-        for transition in transitions:
-            raw, raw_events = self._transition_trigger(
-                transition, frontier.store, is_initial=is_initial
-            )
-            candidate = self._replace_frontier(
-                frontier,
-                condition=BoolTemplate.and_(frontier.condition, raw),
-                used_events=_merge_event_uses(frontier.used_events, raw_events),
-            )
-            branches = (
-                self._execute_initial_transition(candidate, transition)
-                if is_initial
-                else self._execute_transition(candidate, transition)
-            )
-            candidate_outcomes: List[_MacroOutcome] = []
-            candidate_failed: List[BoolTemplate] = []
-            for branch in branches:
-                branch_expansion = self._expand_frontier(branch)
-                candidate_outcomes.extend(branch_expansion.outcomes)
-                candidate_failed.extend(branch_expansion.failed)
-                diagnostics.extend(branch_expansion.diagnostics)
-            accepted = BoolTemplate.or_(
-                *[item.condition for item in candidate_outcomes]
-            )
-            priority = BoolTemplate.and_(
-                *[BoolTemplate.not_(item) for item in previous_accepted]
-            )
-            priority_events = tuple(
-                EventUse(item.event_id, item.path, "negative", "priority")
-                for item in previous_event_uses
-            )
-            for outcome in candidate_outcomes:
-                outcomes.append(
-                    _MacroOutcome(
-                        outcome.target_state_id,
-                        outcome.target_state_path,
-                        BoolTemplate.and_(priority, outcome.condition),
-                        outcome.store,
-                        _merge_event_uses(outcome.used_events, priority_events),
-                        outcome.case_kind,
-                        outcome.failed_conditions,
-                    )
-                )
-            failed.extend(candidate_failed)
-            previous_accepted.append(accepted)
-            previous_event_uses = list(
-                _merge_event_uses(
-                    previous_event_uses,
-                    tuple(
-                        EventUse(item.event_id, item.path, "negative", "priority")
-                        for item in raw_events
-                    ),
-                )
-            )
-            accepted_event_uses = tuple(
-                item
-                for outcome in candidate_outcomes
-                for item in outcome.used_events
-                if item.polarity == "positive"
-            )
-            previous_event_uses = list(
-                _merge_event_uses(
-                    previous_event_uses,
-                    accepted_event_uses,
-                    _event_uses_from_condition(accepted, self.domain),
-                )
-            )
-        return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
-
-    def _transition_trigger(
-        self,
-        transition: Transition,
-        store: _Store,
-        *,
-        is_initial: bool,
-    ) -> Tuple[BoolTemplate, Tuple[EventUse, ...]]:
-        conditions = []
-        event_uses = []
-        if transition.event is not None:
-            atom = BoolTemplate.atom(_event_atom(transition.event.path_name))
-            conditions.append(atom)
-            entry = self.event_entries.get(transition.event.path_name)
-            if entry is None:
-                raise InvalidBmcEncoding("transition event is missing from BMC domain.")
-            reason = "descent" if is_initial else "trigger"
-            event_uses.append(EventUse(entry.id, entry.path, "positive", reason))
-        if transition.guard is not None:
-            conditions.append(self._condition_from_expr(transition.guard, store))
-        return BoolTemplate.and_(*conditions), tuple(event_uses)
-
     def _execute_initial_transition(
         self,
         frontier: _MacroFrontier,
         transition: Transition,
     ) -> Tuple[_MacroFrontier, ...]:
-        top = frontier.stack[-1]
-        if not isinstance(transition.to_state, str):
-            raise BmcBuildError("initial transition target must be a child state.")
-        target = top.state.substates[transition.to_state]
-        branches = self._execute_operation_block(frontier, transition.effects)
+        composite_frame = frontier.stack[-1]
+        state = composite_frame.state
+        current = self._record_transition_effect(
+            frontier, state, transition, "initial_effect"
+        )
+        target_state = state.substates[transition.to_state]
+        if not target_state.is_pseudo:
+            current = self._consume_plain_before_if_pending(current)
+        entered = self._enter_state(current, target_state)
         result = []
-        for branch in branches:
-            current_items = (branch,)
-            if not target.is_pseudo:
-                current_items = self._consume_plain_before_if_pending(branch)
-            for current in current_items:
-                result.extend(self._enter_state(current, target))
+        for item in entered:
+            if any(frame.state is composite_frame.state for frame in item.stack):
+                item = self._replace_frame(
+                    item, composite_frame.state, "active", plain_before_pending=False
+                )
+            result.append(item)
         return tuple(result)
 
     def _execute_transition(
@@ -878,189 +595,109 @@ class _Expander:
         transition: Transition,
     ) -> Tuple[_MacroFrontier, ...]:
         current_state = frontier.stack[-1].state
-        branches = (frontier,)
+        current = frontier
         for on_exit in current_state.on_exits:
-            branches = self._flat_map(
-                branches, lambda item, func=on_exit: self._execute_func(item, func)
+            current = self._record_func(
+                current, current_state, on_exit, "exit", "state_exit"
             )
-        branches = self._flat_map(
-            branches,
-            lambda item: self._execute_operation_block(item, transition.effects),
+        current = self._record_transition_effect(
+            current, current_state, transition, "transition_effect"
         )
-        result = []
-        for branch in branches:
-            popped = self._replace_frontier(branch, stack=branch.stack[:-1])
-            if transition.to_state == EXIT_STATE:
-                if current_state.is_pseudo:
-                    popped = self._clear_parent_plain_before_pending_after_pseudo_exit(
-                        popped, current_state
-                    )
-                result.extend(self._finalize_exit_to_parent(popped))
-                continue
-            if not isinstance(transition.to_state, str):
-                raise BmcBuildError("transition target must be a sibling state.")
-            if current_state.parent is None:
-                raise BmcBuildError("root transition cannot target a sibling state.")
-            target_state = current_state.parent.substates[transition.to_state]
-            current = popped
-            if (
-                current_state.is_pseudo
-                and current.stack
-                and current.stack[-1].state is current_state.parent
-                and not target_state.is_pseudo
-            ):
-                for consumed in self._consume_plain_before_if_pending(current):
-                    result.extend(self._enter_state(consumed, target_state))
-                continue
-            result.extend(self._enter_state(current, target_state))
-        return tuple(result)
+        current = self._replace_frontier(current, stack=current.stack[:-1])
+
+        if transition.to_state == EXIT_STATE:
+            current = self._clear_parent_plain_before_pending_after_pseudo_exit(
+                current, current_state
+            )
+            return (self._finalize_exit_to_parent(current),)
+
+        parent = current_state.parent
+        if parent is None:
+            raise BmcBuildError("non-exit transition from root has no parent.")
+        target_state = parent.substates[transition.to_state]
+        if (
+            current_state.is_pseudo
+            and current.stack
+            and current.stack[-1].state is parent
+            and not target_state.is_pseudo
+        ):
+            current = self._consume_plain_before_if_pending(current)
+        return self._enter_state(current, target_state)
+
+    def _finalize_exit_to_parent(self, frontier: _MacroFrontier) -> _MacroFrontier:
+        if not frontier.stack:
+            return frontier
+        parent = frontier.stack[-1].state
+        current = frontier
+        for on_during_after in parent.list_on_durings(aspect="after"):
+            current = self._record_func(
+                current,
+                parent,
+                on_during_after,
+                "during",
+                "plain_during_after",
+            )
+        if parent.is_root_state:
+            for on_exit in parent.on_exits:
+                current = self._record_func(
+                    current, parent, on_exit, "exit", "state_exit"
+                )
+            return self._replace_frontier(current, stack=())
+        return self._replace_top(current, _FormalStackFrame(parent, "post_child_exit"))
 
     def _enter_state(
         self, frontier: _MacroFrontier, state: State
     ) -> Tuple[_MacroFrontier, ...]:
-        entered = self._replace_frontier(
-            frontier, stack=frontier.stack + (_FormalStackFrame(state, "active"),)
-        )
-        branches = (entered,)
-        for on_enter in state.on_enters:
-            branches = self._flat_map(
-                branches, lambda item, func=on_enter: self._execute_func(item, func)
-            )
-        result = []
-        for branch in branches:
-            if state.is_leaf_state:
-                during_branches = self._run_leaf_during(branch, state)
-                result.extend(
-                    self._replace_top(item, _FormalStackFrame(state, "after_entry"))
-                    for item in during_branches
-                )
-            else:
-                result.append(
-                    self._replace_top(
-                        branch,
-                        _FormalStackFrame(
-                            state, "init_wait", plain_before_pending=True
-                        ),
-                    )
-                )
-        return tuple(result)
-
-    def _finalize_exit_to_parent(
-        self, frontier: _MacroFrontier
-    ) -> Tuple[_MacroFrontier, ...]:
-        if not frontier.stack:
-            return (frontier,)
-        parent = frontier.stack[-1].state
-        branches = (frontier,)
-        for on_during_after in parent.list_on_durings(aspect="after"):
-            branches = self._flat_map(
-                branches,
-                lambda item, func=on_during_after: self._execute_func(item, func),
-            )
-        if parent.is_root_state:
-            for on_exit in parent.on_exits:
-                branches = self._flat_map(
-                    branches, lambda item, func=on_exit: self._execute_func(item, func)
-                )
-            return tuple(self._replace_frontier(item, stack=()) for item in branches)
-        return tuple(
-            self._replace_top(item, _FormalStackFrame(parent, "post_child_exit"))
-            for item in branches
-        )
-
-    def _leaf_fallback_outcomes(
-        self,
-        frontier: _MacroFrontier,
-        accepted: Sequence[_MacroOutcome],
-        failed: Sequence[BoolTemplate],
-    ) -> Tuple[_MacroOutcome, ...]:
-        fallback_events: Tuple[EventUse, ...] = ()
-        if accepted:
-            accepted_condition = BoolTemplate.or_(
-                *[item.condition for item in accepted]
-            )
-            condition = BoolTemplate.and_(
-                frontier.condition,
-                BoolTemplate.not_(accepted_condition),
-            )
-            fallback_events = _event_uses_from_condition(
-                accepted_condition,
-                self.domain,
-                polarity="negative",
-                reason="fallback",
-            )
-        else:
-            condition = frontier.condition
-        failed_events = _event_uses_from_condition(
-            BoolTemplate.or_(*failed),
-            self.domain,
-            polarity="negative",
-            reason="fallback",
-        )
-        fallback_frontier = self._replace_frontier(
+        current = self._replace_frontier(
             frontier,
-            condition=condition,
-            case_kind=_CASE_KIND_FALLBACK,
+            stack=frontier.stack + (_FormalStackFrame(state, "active"),),
         )
-        branches = self._run_leaf_during(fallback_frontier, frontier.stack[-1].state)
-        outcomes = []
-        for branch in branches:
-            active = self._replace_top(
-                branch, _FormalStackFrame(branch.stack[-1].state, "after_entry")
+        for on_enter in state.on_enters:
+            current = self._record_func(
+                current, state, on_enter, "enter", "state_enter"
             )
-            expansion = self._expand_frontier(active)
-            outcomes.extend(expansion.outcomes)
-        if not outcomes:
-            raise BmcBuildError("stable fallback did not produce an outcome.")
-        return tuple(
-            _MacroOutcome(
-                outcome.target_state_id,
-                outcome.target_state_path,
-                outcome.condition,
-                outcome.store,
-                _merge_event_uses(
-                    outcome.used_events,
-                    fallback_events,
-                    failed_events,
-                ),
-                _CASE_KIND_FALLBACK,
-                tuple(failed),
+
+        if state.is_leaf_state:
+            current = self._run_leaf_during(current, state)
+            return (
+                self._replace_top(current, _FormalStackFrame(state, "after_entry")),
             )
-            for outcome in outcomes
+        return (
+            self._replace_top(
+                current,
+                _FormalStackFrame(state, "init_wait", plain_before_pending=True),
+            ),
         )
 
     def _run_leaf_during(
         self, frontier: _MacroFrontier, state: State
-    ) -> Tuple[_MacroFrontier, ...]:
-        branches = (frontier,)
-        for item in state.iter_on_during_aspect_recursively():
-            func = item[-1]
-            branches = self._flat_map(
-                branches, lambda item, action=func: self._execute_func(item, action)
-            )
-        return tuple(branches)
+    ) -> _MacroFrontier:
+        current = frontier
+        for owner, func in state.iter_on_during_aspect_recursively():
+            block_kind = "during_aspect" if isinstance(func, OnAspect) else "during"
+            current = self._record_func(current, owner, func, block_kind, "leaf_during")
+        return current
 
     def _consume_plain_before_if_pending(
         self, frontier: _MacroFrontier
-    ) -> Tuple[_MacroFrontier, ...]:
+    ) -> _MacroFrontier:
+        if not frontier.stack:
+            return frontier
         frame = frontier.stack[-1]
         if not frame.plain_before_pending:
-            return (frontier,)
-        branches = (frontier,)
-        # Plain boundary ``during before`` actions live in ``on_durings``.
-        # Descendant aspect actions (``>> during before``) are intentionally
-        # executed later by ``_run_leaf_during``, matching SimulationRuntime.
+            return frontier
+        current = frontier
         for on_during_before in frame.state.list_on_durings(aspect="before"):
-            branches = self._flat_map(
-                branches,
-                lambda item, func=on_during_before: self._execute_func(item, func),
-            )
-        return tuple(
-            self._replace_top(
+            current = self._record_func(
                 current,
-                _FormalStackFrame(frame.state, frame.mode, plain_before_pending=False),
+                frame.state,
+                on_during_before,
+                "during",
+                "plain_during_before",
             )
-            for current in branches
+        return self._replace_top(
+            current,
+            _FormalStackFrame(frame.state, frame.mode, plain_before_pending=False),
         )
 
     def _clear_parent_plain_before_pending_after_pseudo_exit(
@@ -1069,274 +706,291 @@ class _Expander:
         current_state: State,
     ) -> _MacroFrontier:
         if (
-            frontier.stack
+            current_state.is_pseudo
+            and frontier.stack
             and frontier.stack[-1].state is current_state.parent
             and frontier.stack[-1].plain_before_pending
         ):
             parent = frontier.stack[-1]
             return self._replace_top(
-                frontier, _FormalStackFrame(parent.state, parent.mode, False)
+                frontier,
+                _FormalStackFrame(parent.state, parent.mode, False),
             )
         return frontier
 
-    def _execute_func(
-        self, frontier: _MacroFrontier, func: object
-    ) -> Tuple[_MacroFrontier, ...]:
+    def _record_transition_effect(
+        self,
+        frontier: _MacroFrontier,
+        owner: State,
+        transition: Transition,
+        runtime_role: str,
+    ) -> _MacroFrontier:
+        if not transition.effects:
+            return frontier
+        return self._append_action_block(
+            frontier,
+            owner,
+            "transition_effect",
+            runtime_role,
+            tuple(transition.effects),
+            None,
+            self._transition_label(
+                owner, transition, self._transition_index(owner, transition)
+            ),
+            False,
+        )
+
+    def _record_func(
+        self,
+        frontier: _MacroFrontier,
+        owner: State,
+        func: object,
+        block_kind: str,
+        runtime_role: str,
+    ) -> _MacroFrontier:
         if isinstance(func, (OnStage, OnAspect)) and func.is_ref:
             if func.ref is None:
                 raise BmcBuildError("action reference is missing a target.")
-            return self._execute_func(frontier, func.ref)
+            ref_owner = func.ref.parent if func.ref.parent is not None else owner
+            return self._record_func(
+                frontier, ref_owner, func.ref, block_kind, runtime_role
+            )
         if not isinstance(func, (OnStage, OnAspect)):
             raise BmcBuildError("unsupported lifecycle action type.")
-        if func.is_abstract:
-            return (frontier,)
-        return self._execute_operation_block(frontier, func.operations)
+        operations = () if func.is_abstract else tuple(func.operations)
+        if not operations and not func.is_abstract:
+            return frontier
+        return self._append_action_block(
+            frontier,
+            owner,
+            block_kind,
+            runtime_role,
+            operations,
+            func.func_name,
+            None,
+            func.is_abstract,
+        )
 
-    def _execute_operation_block(
+    def _append_action_block(
         self,
         frontier: _MacroFrontier,
-        operations: Sequence[OperationStatement],
-    ) -> Tuple[_MacroFrontier, ...]:
-        if not operations:
-            return (frontier,)
-        branches = (_Branch(frontier.condition, frontier.store),)
-        for statement in operations:
-            next_branches = []
-            for branch in branches:
-                next_branches.extend(self._execute_statement(branch, statement))
-            branches = tuple(next_branches)
-        persistent_names = tuple(entry.name for entry in self.domain.variables)
-        return tuple(
-            self._replace_frontier(
-                frontier,
-                condition=branch.condition,
-                store=_Store(
-                    {name: branch.store.values[name] for name in persistent_names}
-                ),
-            )
-            for branch in branches
+        owner: State,
+        block_kind: str,
+        runtime_role: str,
+        operations: Tuple[OperationStatement, ...],
+        action_name: Optional[str],
+        transition_label: Optional[str],
+        is_abstract: bool,
+    ) -> _MacroFrontier:
+        owner_path = ".".join(owner.path)
+        block = ActionBlock(
+            block_kind,
+            runtime_role,
+            self._state_id(owner_path),
+            owner_path,
+            operations,
+            action_name=action_name,
+            transition_label=transition_label,
+            is_abstract=is_abstract,
+        )
+        return self._replace_frontier(
+            frontier,
+            action_blocks=frontier.action_blocks + (block,),
         )
 
-    def _execute_statement(
-        self, branch: _Branch, statement: OperationStatement
-    ) -> Tuple[_Branch, ...]:
-        if isinstance(statement, Operation):
-            scope = dict(branch.store.values)
-            value = self._value_from_expr(statement.expr, scope)
-            scope[statement.var_name] = value
-            return (_Branch(branch.condition, _Store(scope)),)
-        if isinstance(statement, IfBlock):
-            result = []
-            previous = []
-            has_else = False
-            for block_index, block_branch in enumerate(statement.branches):
-                if block_branch.condition is None:
-                    selector = BoolTemplate.true()
-                    has_else = True
-                else:
-                    selector = self._condition_from_expr(
-                        block_branch.condition, branch.store
-                    )
-                active = BoolTemplate.and_(
-                    branch.condition,
-                    *[BoolTemplate.not_(item) for item in previous],
-                    selector,
-                )
-                visible = tuple(branch.store.values)
-                nested = (_Branch(active, branch.store),)
-                for nested_statement in block_branch.statements:
-                    nested = tuple(
-                        item
-                        for nested_branch in nested
-                        for item in self._execute_statement(
-                            nested_branch, nested_statement
-                        )
-                    )
-                for nested_branch in nested:
-                    writeback = {
-                        name: nested_branch.store.values[name] for name in visible
+    def _leaf_fallback_outcomes(
+        self,
+        frontier: _MacroFrontier,
+        accepted: Sequence[_MacroOutcome],
+        failed: Sequence[BoolTemplate],
+    ) -> Tuple[_MacroOutcome, ...]:
+        condition = frontier.condition
+        used_events = frontier.used_events
+        priority_exclusions = frontier.priority_exclusions
+        if accepted:
+            labels = tuple(outcome.label for outcome in accepted)
+            accepted_condition = BoolTemplate.or_(
+                *[
+                    BoolTemplate.atom("%s%s" % (_ACCEPTED_ATOM_PREFIX, label))
+                    for label in labels
+                ]
+            )
+            condition = BoolTemplate.and_(
+                condition, BoolTemplate.not_(accepted_condition)
+            )
+            event_paths = tuple(
+                sorted(
+                    {
+                        event.path
+                        for outcome in accepted
+                        for event in outcome.used_events
                     }
-                    result.append(_Branch(nested_branch.condition, _Store(writeback)))
-                previous.append(selector)
-                if (
-                    block_branch.condition is None
-                    and block_index == len(statement.branches) - 1
-                ):
-                    break
-            if not has_else:
-                result.append(
-                    _Branch(
-                        BoolTemplate.and_(
-                            branch.condition,
-                            *[BoolTemplate.not_(item) for item in previous],
-                        ),
-                        branch.store,
-                    )
                 )
-            return tuple(result)
-        raise BmcBuildError(
-            "unsupported operation statement type: %r." % (type(statement),)
+            )
+            guard_ids = tuple(
+                sorted(
+                    {
+                        guard.requirement_id
+                        for outcome in accepted
+                        for guard in outcome.guard_requirements
+                    }
+                )
+            )
+            priority = PriorityExclusion(
+                "fallback%d" % self._decision_counter,
+                "fallback",
+                labels,
+                accepted_condition,
+                event_paths,
+                guard_ids,
+            )
+            self._decision_counter += 1
+            priority_exclusions = priority_exclusions + (priority,)
+            used_events = _merge_event_uses(
+                used_events,
+                self._event_uses_for_paths(event_paths, "negative", "fallback"),
+            )
+        failed_condition = BoolTemplate.or_(*failed)
+        used_events = _merge_event_uses(
+            used_events,
+            self._event_uses_for_paths(
+                _event_paths_from_condition(failed_condition), "negative", "fallback"
+            ),
         )
-
-    def _value_from_expr(
-        self, expr: Expr, scope: Mapping[str, _ValueTemplate]
-    ) -> _ValueTemplate:
-        if isinstance(expr, Integer):
-            return _ValueTemplate.const_value(expr.value)
-        if isinstance(expr, Float):
-            return _ValueTemplate.const_value(expr.value)
-        if isinstance(expr, Variable):
-            if expr.name not in scope:
-                raise BmcBuildError("unknown symbolic variable %r." % expr.name)
-            return scope[expr.name]
-        if isinstance(expr, UnaryOp):
-            return self._value_from_expr(expr.x, scope).unary(expr.op)
-        if isinstance(expr, BinaryOp):
-            left = self._value_from_expr(expr.x, scope)
-            right = self._value_from_expr(expr.y, scope)
-            return left.binary(expr.op, right)
-        if isinstance(expr, UFunc):
-            value = self._value_from_expr(expr.x, scope)
-            return _ValueTemplate("%s(%s)" % (expr.func, value.text))
-        if isinstance(expr, ConditionalOp):
-            condition = self._condition_from_expr(expr.cond, _Store(scope))
-            if_true = self._value_from_expr(expr.if_true, scope)
-            if_false = self._value_from_expr(expr.if_false, scope)
-            return _ValueTemplate(
-                "if(%s, %s, %s)"
-                % (_condition_text(condition), if_true.text, if_false.text)
+        fallback_frontier = self._replace_frontier(
+            frontier,
+            condition=condition,
+            used_events=used_events,
+            priority_exclusions=priority_exclusions,
+            case_kind=_CASE_KIND_FALLBACK,
+        )
+        fallback_frontier = self._run_leaf_during(
+            fallback_frontier, frontier.stack[-1].state
+        )
+        active = self._replace_top(
+            fallback_frontier,
+            _FormalStackFrame(fallback_frontier.stack[-1].state, "after_entry"),
+        )
+        expansion = self._expand_frontier(active)
+        if not expansion.outcomes:
+            raise BmcBuildError("stable fallback did not produce an outcome.")
+        return tuple(
+            _MacroOutcome(
+                outcome.label,
+                outcome.target_state_id,
+                outcome.target_state_path,
+                outcome.condition,
+                outcome.used_events,
+                outcome.action_blocks,
+                outcome.guard_requirements,
+                outcome.priority_exclusions,
+                _CASE_KIND_FALLBACK,
+                tuple(failed),
             )
-        if isinstance(expr, Boolean):
-            return _ValueTemplate("true" if expr.value else "false")
-        raise BmcBuildError("unsupported expression type: %r." % (type(expr),))
-
-    def _condition_from_expr(self, expr: Expr, store: _Store) -> BoolTemplate:
-        if isinstance(expr, Boolean):
-            return BoolTemplate.true() if expr.value else BoolTemplate.false()
-        if isinstance(expr, UnaryOp) and expr.op == "!":
-            return BoolTemplate.not_(self._condition_from_expr(expr.x, store))
-        if isinstance(expr, BinaryOp) and expr.op in ("&&", "and"):
-            return BoolTemplate.and_(
-                self._condition_from_expr(expr.x, store),
-                self._condition_from_expr(expr.y, store),
-            )
-        if isinstance(expr, BinaryOp) and expr.op in ("||", "or"):
-            return BoolTemplate.or_(
-                self._condition_from_expr(expr.x, store),
-                self._condition_from_expr(expr.y, store),
-            )
-        if isinstance(expr, BinaryOp) and expr.op == "xor":
-            left = self._condition_from_expr(expr.x, store)
-            right = self._condition_from_expr(expr.y, store)
-            return BoolTemplate.or_(
-                BoolTemplate.and_(left, BoolTemplate.not_(right)),
-                BoolTemplate.and_(BoolTemplate.not_(left), right),
-            )
-        if isinstance(expr, BinaryOp) and expr.op == "=>":
-            return BoolTemplate.or_(
-                BoolTemplate.not_(self._condition_from_expr(expr.x, store)),
-                self._condition_from_expr(expr.y, store),
-            )
-        if isinstance(expr, BinaryOp) and expr.op == "iff":
-            left = self._condition_from_expr(expr.x, store)
-            right = self._condition_from_expr(expr.y, store)
-            return BoolTemplate.or_(
-                BoolTemplate.and_(left, right),
-                BoolTemplate.and_(BoolTemplate.not_(left), BoolTemplate.not_(right)),
-            )
-        if (
-            isinstance(expr, BinaryOp)
-            and expr.op in ("==", "!=")
-            and (_is_condition_expr(expr.x) or _is_condition_expr(expr.y))
-        ):
-            left = self._condition_from_expr(expr.x, store)
-            right = self._condition_from_expr(expr.y, store)
-            equal = BoolTemplate.or_(
-                BoolTemplate.and_(left, right),
-                BoolTemplate.and_(BoolTemplate.not_(left), BoolTemplate.not_(right)),
-            )
-            return BoolTemplate.not_(equal) if expr.op == "!=" else equal
-        if isinstance(expr, BinaryOp) and expr.op in ("<", "<=", ">", ">=", "==", "!="):
-            left = self._value_from_expr(expr.x, store.values)
-            right = self._value_from_expr(expr.y, store.values)
-            return _comparison_condition(left, expr.op, right)
-        if isinstance(expr, ConditionalOp):
-            selector = self._condition_from_expr(expr.cond, store)
-            if_true = self._condition_from_expr(expr.if_true, store)
-            if_false = self._condition_from_expr(expr.if_false, store)
-            return BoolTemplate.or_(
-                BoolTemplate.and_(selector, if_true),
-                BoolTemplate.and_(BoolTemplate.not_(selector), if_false),
-            )
-        value = self._value_from_expr(expr, store.values)
-        return BoolTemplate.atom("%s%s" % (_GUARD_ATOM_PREFIX, value.text))
+            for outcome in expansion.outcomes
+        )
 
     def _stable_outcome(self, frontier: _MacroFrontier, state: State) -> _MacroOutcome:
         path = ".".join(state.path)
         return _MacroOutcome(
-            self.state_ids[path],
+            self._allocate_case_label(frontier.case_kind, path),
+            self._state_id(path),
             path,
             frontier.condition,
-            frontier.store,
             frontier.used_events,
+            frontier.action_blocks,
+            frontier.guard_requirements,
+            frontier.priority_exclusions,
             frontier.case_kind,
         )
 
     def _terminate_outcome(self, frontier: _MacroFrontier) -> _MacroOutcome:
         return _MacroOutcome(
+            self._allocate_case_label(frontier.case_kind, TERMINATE_CASE_PATH),
             STATE_TERMINATE_ID,
             TERMINATE_CASE_PATH,
             frontier.condition,
-            frontier.store,
             frontier.used_events,
+            frontier.action_blocks,
+            frontier.guard_requirements,
+            frontier.priority_exclusions,
             frontier.case_kind,
         )
 
     def _cases_from_outcomes(
         self, outcomes: Sequence[_MacroOutcome]
     ) -> Tuple[CycleCase, ...]:
-        counters: Dict[str, int] = {}
-        cases = []
-        for outcome in outcomes:
-            ordinal = counters.get(outcome.case_kind, 0)
-            counters[outcome.case_kind] = ordinal + 1
-            cases.append(
-                CycleCase(
-                    outcome.case_kind,
-                    self.source.source_state_id,
-                    self.source.source_state_path,
-                    outcome.target_state_id,
-                    outcome.target_state_path,
-                    "%s::%s::%s::%d"
-                    % (
-                        self.source.source_state_path,
-                        outcome.case_kind,
-                        outcome.target_state_path,
-                        ordinal,
-                    ),
-                    outcome.condition,
-                    self._var_updates(outcome.store),
-                    used_events=outcome.used_events,
-                    failed_conditions=outcome.failed_conditions,
-                    domain=self.domain,
-                )
+        return tuple(
+            CycleCase(
+                outcome.case_kind,
+                self.source.source_state_id,
+                self.source.source_state_path,
+                outcome.target_state_id,
+                outcome.target_state_path,
+                outcome.label,
+                outcome.condition,
+                outcome.action_blocks,
+                used_events=outcome.used_events,
+                guard_requirements=outcome.guard_requirements,
+                priority_exclusions=outcome.priority_exclusions,
+                failed_conditions=outcome.failed_conditions,
+                domain=self.domain,
             )
-        return tuple(cases)
+            for outcome in outcomes
+        )
 
-    def _var_updates(self, store: _Store) -> Tuple[VarUpdate, ...]:
-        updates = []
-        for entry in self.domain.variables:
-            value = store.values[entry.name]
-            carry_text = "%s%s" % (_PRE_VAR_PREFIX, entry.name)
-            updates.append(
-                VarUpdate(
-                    entry.id,
-                    entry.name,
-                    value.text,
-                    is_carry=value.text == carry_text,
-                )
-            )
-        return tuple(updates)
+    def _allocate_case_label(self, case_kind: str, target_path: str) -> str:
+        ordinal = self._case_counters.get(case_kind, 0)
+        self._case_counters[case_kind] = ordinal + 1
+        return "%s::%s::%s::%d" % (
+            self.source.source_state_path,
+            case_kind,
+            target_path,
+            ordinal,
+        )
+
+    def _transition_label(
+        self, owner: State, transition: Transition, index: int
+    ) -> str:
+        target = (
+            "[*]" if transition.to_state == EXIT_STATE else str(transition.to_state)
+        )
+        return "%s::%d::%s->%s" % (
+            ".".join(owner.path),
+            index,
+            transition.from_state,
+            target,
+        )
+
+    @staticmethod
+    def _transition_index(owner: State, transition: Transition) -> int:
+        for transitions in (owner.init_transitions, owner.transitions_from):
+            for index, item in enumerate(transitions):
+                if item is transition:
+                    return index
+        return 0
+
+    def _event_uses_for_paths(
+        self, paths: Sequence[str], polarity: str, reason: str
+    ) -> Tuple[EventUse, ...]:
+        result = []
+        for path in sorted(set(paths)):
+            try:
+                entry = self.domain.event_by_path(path)
+            except InvalidBmcDomain as err:
+                # InvalidBmcDomain: event paths in transition triggers or priority
+                # masks must exist in the domain snapshot.
+                raise InvalidBmcEncoding(str(err)) from err
+            result.append(EventUse(entry.id, entry.path, polarity, reason))
+        return tuple(result)
+
+    def _state_id(self, path: str) -> int:
+        try:
+            return self.domain.state_path_to_id(path)
+        except InvalidBmcDomain as err:
+            # InvalidBmcDomain: model state paths encountered by the expander
+            # must exist in the domain snapshot built from the same model.
+            raise InvalidBmcEncoding(str(err)) from err
 
     def _frontier_signature(self, frontier: _MacroFrontier) -> Tuple[object, ...]:
         return (
@@ -1344,16 +998,14 @@ class _Expander:
                 (frame.state.path, frame.mode, frame.plain_before_pending)
                 for frame in frontier.stack
             ),
-            tuple(
-                sorted(
-                    (name, value.text) for name, value in frontier.store.values.items()
-                )
+            json.dumps(
+                frontier.condition.to_canonical(), sort_keys=True, separators=(",", ":")
             ),
-            _condition_text(frontier.condition),
             tuple(
-                item.to_canonical()["path"] + ":" + item.to_canonical()["polarity"]
-                for item in frontier.used_events
+                json.dumps(block.to_canonical(), sort_keys=True, separators=(",", ":"))
+                for block in frontier.action_blocks
             ),
+            tuple(item.requirement_id for item in frontier.guard_requirements),
             frontier.case_kind,
         )
 
@@ -1362,9 +1014,11 @@ class _Expander:
     ) -> _MacroFrontier:
         values = {
             "stack": frontier.stack,
-            "store": frontier.store,
             "condition": frontier.condition,
             "used_events": frontier.used_events,
+            "action_blocks": frontier.action_blocks,
+            "guard_requirements": frontier.guard_requirements,
+            "priority_exclusions": frontier.priority_exclusions,
             "case_kind": frontier.case_kind,
             "path_signatures": frontier.path_signatures,
             "depth": frontier.depth,
@@ -1377,298 +1031,31 @@ class _Expander:
     ) -> _MacroFrontier:
         return self._replace_frontier(frontier, stack=frontier.stack[:-1] + (frame,))
 
-    @staticmethod
-    def _flat_map(
-        frontiers: Iterable[_MacroFrontier], func
-    ) -> Tuple[_MacroFrontier, ...]:
-        return tuple(item for frontier in frontiers for item in func(frontier))
+    def _replace_frame(
+        self,
+        frontier: _MacroFrontier,
+        state: State,
+        mode: str,
+        plain_before_pending: bool,
+    ) -> _MacroFrontier:
+        frames = []
+        replaced = False
+        for frame in frontier.stack:
+            if frame.state is state and not replaced:
+                frames.append(_FormalStackFrame(state, mode, plain_before_pending))
+                replaced = True
+            else:
+                frames.append(frame)
+        return self._replace_frontier(frontier, stack=tuple(frames))
 
 
-def _literal_int(expr: Expr) -> Optional[int]:
-    """Return an integer literal value if ``expr`` is integral syntax.
-
-    Pure integer constant expressions such as ``4 - 1`` and ``2 * (1 + 1)``
-    are folded so threshold normalization can recognize natural guard forms
-    without evaluating expressions that depend on model variables.
-
-    :param expr: Model expression to inspect.
-    :type expr: pyfcstm.model.Expr
-    :return: Integer literal value, or ``None`` for non-integer syntax.
-    :rtype: Optional[int]
-    """
-    if isinstance(expr, Integer):
-        return expr.value
-    if isinstance(expr, UnaryOp) and expr.op in ("+", "-"):
-        value = _literal_int(expr.x)
-        if value is None:
-            return None
-        return value if expr.op == "+" else -value
-    if isinstance(expr, BinaryOp) and expr.op in ("+", "-", "*", "%", "/"):
-        left = _literal_int(expr.x)
-        right = _literal_int(expr.y)
-        if left is None or right is None:
-            return None
-        if expr.op == "+":
-            return left + right
-        if expr.op == "-":
-            return left - right
-        if expr.op == "*":
-            return left * right
-        if right == 0:
-            return None
-        if expr.op == "%":
-            return left % right
-        if left % right == 0:
-            return left // right
-    return None
-
-
-def _integer_threshold_guard(expr: Optional[Expr]) -> Optional[Tuple[str, str, int]]:
-    """Normalize simple integer threshold guards.
-
-    The pseudo-loop accelerator needs to recognize syntactic variants that are
-    equivalent over integer variables.  This helper converts comparisons such
-    as ``x <= K - 1``, ``K > x``, and negated comparisons into a half-line
-    predicate represented as ``(variable_name, relation, threshold)`` where
-    ``relation`` is ``"lt"`` for ``x < threshold`` or ``"ge"`` for
-    ``x >= threshold``.
-
-    :param expr: Candidate guard expression.
-    :type expr: Optional[pyfcstm.model.Expr]
-    :return: Normalized integer threshold predicate, or ``None`` for
-        unsupported syntax.
-    :rtype: Optional[Tuple[str, str, int]]
-
-    Example::
-
-        >>> _integer_threshold_guard(BinaryOp(Variable('x'), '<=', Integer(3)))
-        ('x', 'lt', 4)
-        >>> _integer_threshold_guard(UnaryOp('!', BinaryOp(Variable('x'), '<', Integer(4))))
-        ('x', 'ge', 4)
-    """
-    if isinstance(expr, UnaryOp) and expr.op == "!":
-        inner = _integer_threshold_guard(expr.x)
-        if inner is None:
-            return None
-        variable_name, relation, threshold = inner
-        return variable_name, "ge" if relation == "lt" else "lt", threshold
-    if not isinstance(expr, BinaryOp) or expr.op not in ("<", "<=", ">", ">="):
-        return None
-
-    op = expr.op
-    if isinstance(expr.x, Variable):
-        variable_name = expr.x.name
-        value = _literal_int(expr.y)
-    elif isinstance(expr.y, Variable):
-        variable_name = expr.y.name
-        value = _literal_int(expr.x)
-        op = {"<": ">", "<=": ">=", ">": "<", ">=": "<="}[op]
-    else:
-        return None
-
-    if value is None:
-        return None
-    if op == "<":
-        return variable_name, "lt", value
-    if op == "<=":
-        return variable_name, "lt", value + 1
-    if op == ">":
-        return variable_name, "ge", value + 1
-    if op == ">=":
-        return variable_name, "ge", value
-    return None
-
-
-def _positive_integer_increment_effect(
-    statement: OperationStatement, variable_name: str
-) -> Optional[int]:
-    """Return the positive integer step for ``variable_name = variable_name + N``.
-
-    :param statement: Operation statement to inspect.
-    :type statement: pyfcstm.model.OperationStatement
-    :param variable_name: Persistent variable that should be incremented.
-    :type variable_name: str
-    :return: Positive integer increment, or ``None`` for unsupported shapes.
-    :rtype: Optional[int]
-    """
-    if not isinstance(statement, Operation):
-        return None
-    if statement.var_name != variable_name:
-        return None
-    expr = statement.expr
-    if not isinstance(expr, BinaryOp) or expr.op != "+":
-        return None
-    if isinstance(expr.x, Variable) and expr.x.name == variable_name:
-        value = _literal_int(expr.y)
-        return value if value is not None and value > 0 else None
-    if isinstance(expr.y, Variable) and expr.y.name == variable_name:
-        value = _literal_int(expr.x)
-        return value if value is not None and value > 0 else None
-    return None
-
-
-def _threshold_reached_value(
-    value: _ValueTemplate,
-    threshold: int,
-    increment: int,
-) -> _ValueTemplate:
-    """Return the first loop value that satisfies ``x >= threshold``.
-
-    :param value: Current symbolic value before the accelerated loop.
-    :type value: _ValueTemplate
-    :param threshold: Exit threshold.
-    :type threshold: int
-    :param increment: Positive loop increment.
-    :type increment: int
-    :return: First value reached by repeated increments that exits the loop.
-    :rtype: _ValueTemplate
-    :raises BmcBuildError: If the loop input is not a linear expression over
-        pre-state variables or the increment is invalid.
-    """
-    if increment <= 0:
-        raise BmcBuildError("pseudo loop increment must be positive.")
-    if value.linear is None:
-        raise BmcBuildError("pseudo loop acceleration requires a linear integer value.")
-    if any(not name.startswith(_PRE_VAR_PREFIX) for name in value.linear.coeffs):
-        raise BmcBuildError("pseudo loop acceleration requires pre-state variables.")
-    if increment == 1:
-        return _ValueTemplate.const_value(threshold)
-    threshold_text = _format_number(threshold)
-    increment_text = _format_number(increment)
-    # The generated recipe intentionally uses Python/Z3 Euclidean modulo
-    # semantics.  PR-10 relation lowering must preserve that meaning for
-    # negative pre-state values instead of adopting target-language remainder
-    # semantics such as C's truncated ``%``.
-    return _ValueTemplate(
-        "%s + (((%s) - %s) %% %s)"
-        % (threshold_text, value.text, threshold_text, increment_text)
-    )
-
-
-def _has_direct_atom_contradiction(condition: BoolTemplate) -> bool:
-    """Return whether a conjunction contains both ``a`` and ``not a``.
-
-    :param condition: Boolean recipe to inspect.
-    :type condition: pyfcstm.bmc.macro.BoolTemplate
-    :return: Whether a direct atom contradiction is present.
-    :rtype: bool
-    """
-    positive = set()
-    negative = set()
-    for item in _conjunctive_literals(condition):
-        if item.kind == "atom":
-            positive.add(item._atom_name())
-        elif item.kind == "not" and item.operands[0].kind == "atom":
-            negative.add(item.operands[0]._atom_name())
-    return bool(positive.intersection(negative))
-
-
-def _conjunctive_literals(condition: BoolTemplate) -> Tuple[BoolTemplate, ...]:
-    """Flatten conjunction operands for direct literal inspection.
-
-    :param condition: Boolean recipe to flatten.
-    :type condition: pyfcstm.bmc.macro.BoolTemplate
-    :return: Tuple of conjunction leaves.
-    :rtype: Tuple[pyfcstm.bmc.macro.BoolTemplate, ...]
-    """
-    if condition.kind == "and":
-        result = []
-        for operand in condition.operands:
-            result.extend(_conjunctive_literals(operand))
-        return tuple(result)
-    return (condition,)
-
-
-def _comparison_condition(
-    left: _ValueTemplate, op: str, right: _ValueTemplate
-) -> BoolTemplate:
-    if left.linear is not None and right.linear is not None:
-        diff = left.linear.add(right.linear.mul_const(-1))
-        normalized = _single_var_threshold(diff, op)
-        if normalized is not None:
-            atom_text, negated = normalized
-            atom = BoolTemplate.atom("%s%s" % (_GUARD_ATOM_PREFIX, atom_text))
-            return BoolTemplate.not_(atom) if negated else atom
-    return BoolTemplate.atom(
-        "%s%s %s %s" % (_GUARD_ATOM_PREFIX, left.text, op, right.text)
-    )
-
-
-def _single_var_threshold(diff: _LinearExpr, op: str) -> Optional[Tuple[str, bool]]:
-    if len(diff.coeffs) != 1:
-        return None
-    ((name, coeff),) = diff.coeffs.items()
-    if coeff == 0:
-        return None
-    threshold = -diff.const / coeff
-    if coeff < 0:
-        reverse = {"<": ">", "<=": ">=", ">": "<", ">=": "<=", "==": "==", "!=": "!="}
-        op = reverse[op]
-    value = _format_number(threshold)
-    if op == "<":
-        return "%s < %s" % (name, value), False
-    if op == ">=":
-        return "%s < %s" % (name, value), True
-    if op == "<=":
-        return "%s <= %s" % (name, value), False
-    if op == ">":
-        return "%s <= %s" % (name, value), True
-    if op == "==":
-        return "%s == %s" % (name, value), False
-    if op == "!=":
-        return "%s == %s" % (name, value), True
-    return None
-
-
-def _condition_text(condition: BoolTemplate) -> str:
-    return repr(condition.to_canonical())
-
-
-def _is_condition_expr(expr: Expr) -> bool:
-    if isinstance(expr, Boolean):
-        return True
-    if isinstance(expr, UnaryOp) and expr.op in ("!", "not"):
-        return True
-    if isinstance(expr, BinaryOp) and expr.op in (
-        "&&",
-        "and",
-        "||",
-        "or",
-        "xor",
-        "=>",
-        "implies",
-        "iff",
-    ):
-        return True
-    if isinstance(expr, BinaryOp) and expr.op in ("<", "<=", ">", ">="):
-        return True
-    if isinstance(expr, BinaryOp) and expr.op in ("==", "!="):
-        return _is_condition_expr(expr.x) or _is_condition_expr(expr.y)
-    if isinstance(expr, ConditionalOp):
-        return _is_condition_expr(expr.if_true) or _is_condition_expr(expr.if_false)
-    return False
-
-
-def _event_atom(path: str) -> str:
-    return "%s%s" % (_EVENT_ATOM_PREFIX, path)
-
-
-def _event_uses_from_condition(
-    condition: BoolTemplate,
-    domain: BmcDomain,
-    polarity: str = "positive",
-    reason: str = "trigger",
-) -> Tuple[EventUse, ...]:
-    entries = {entry.path: entry for entry in domain.events}
+def _path_to_root(state: State) -> Tuple[State, ...]:
     result = []
-    for variable in condition.variables:
-        if not variable.startswith(_EVENT_ATOM_PREFIX):
-            continue
-        path = variable[len(_EVENT_ATOM_PREFIX) :]
-        entry = entries.get(path)
-        if entry is not None:
-            result.append(EventUse(entry.id, entry.path, polarity, reason))
-    return tuple(result)
+    current = state
+    while current is not None:
+        result.append(current)
+        current = current.parent
+    return tuple(reversed(result))
 
 
 def _merge_event_uses(*groups: Sequence[EventUse]) -> Tuple[EventUse, ...]:
@@ -1676,66 +1063,20 @@ def _merge_event_uses(*groups: Sequence[EventUse]) -> Tuple[EventUse, ...]:
     for group in groups:
         for item in group:
             by_key[(item.event_id, item.path, item.polarity, item.reason)] = item
+    return tuple(by_key[key] for key in sorted(by_key))
+
+
+def _event_paths_from_condition(condition: BoolTemplate) -> Tuple[str, ...]:
     return tuple(
         sorted(
-            by_key.values(),
-            key=lambda item: (item.event_id, item.polarity, item.reason),
+            atom[len(_EVENT_ATOM_PREFIX) :]
+            for atom in condition.variables
+            if atom.startswith(_EVENT_ATOM_PREFIX)
         )
     )
 
 
-def _path_to_root(state: State) -> Tuple[State, ...]:
-    path = []
-    current = state
-    while current is not None:
-        path.insert(0, current)
-        current = current.parent
-    return tuple(path)
-
-
-def expand_macro_step_cases(
-    source: MacroStepSource,
-    options: Optional[MacroExpansionOptions] = None,
-) -> MacroStepFormal:
-    """Expand one macro-step source into source-local cycle cases.
-
-    :param source: Domain-backed macro-step source profile.
-    :type source: MacroStepSource
-    :param options: Optional expansion options, defaults to ``None``.
-    :type options: MacroExpansionOptions, optional
-    :return: Source-local macro-step formal buckets.
-    :rtype: pyfcstm.bmc.macro.MacroStepFormal
-    :raises InvalidBmcEncoding: If ``source`` is not a supported domain-backed
-        source or its domain lacks a model snapshot.
-    :raises BmcBuildError: If expansion cannot prove a local partition or hits
-        runtime-aligned safety limits.
-
-    Example::
-
-        >>> from pyfcstm.bmc import build_bmc_domain, stable_leaf_source
-        >>> from pyfcstm.model import load_state_machine_from_text
-        >>> model = load_state_machine_from_text('state Root;')
-        >>> domain = build_bmc_domain(model, 1)
-        >>> expand_macro_step_cases(stable_leaf_source(domain, 'Root')).source.kind
-        'stable_leaf'
-    """
-    if not isinstance(source, MacroStepSource):
-        raise InvalidBmcEncoding("source must be MacroStepSource.")
-    if options is None:
-        options = MacroExpansionOptions()
-    if not isinstance(options, MacroExpansionOptions):
-        raise InvalidBmcEncoding("options must be MacroExpansionOptions.")
-    try:
-        return _Expander(source, options).expand()
-    except RecursionError as err:
-        # RecursionError: hostile macro graphs may create structurally new
-        # recursive frontiers faster than Python's call stack can represent.
-        # Surface that as a build failure rather than leaking an interpreter
-        # implementation limit to BMC callers.
-        raise BmcBuildError(
-            "macro expansion exceeded the Python recursion limit before "
-            "reaching a runtime-aligned safety cap."
-        ) from err
-
-
-__all__ = ["MacroExpansionOptions", "expand_macro_step_cases"]
+__all__ = [
+    "MacroExpansionOptions",
+    "expand_macro_step_cases",
+]

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -531,12 +531,10 @@ class _Expander:
         first_loop = self._accelerable_pseudo_loop(first, state)
         second_loop = self._accelerable_pseudo_loop(second, state)
         if first_loop is not None and second_loop is None:
-            loop_transition = first
             exit_transition = second
             loop_has_priority = True
             variable_name, increment, threshold = first_loop
         elif second_loop is not None and first_loop is None:
-            loop_transition = second
             exit_transition = first
             loop_has_priority = False
             variable_name, increment, threshold = second_loop
@@ -547,19 +545,17 @@ class _Expander:
         ):
             return None
 
-        loop_trigger = self._transition_trigger(
-            loop_transition, frontier.store, is_initial=False
-        )[0]
-        exit_trigger = self._transition_trigger(
-            exit_transition, frontier.store, is_initial=False
-        )[0]
+        loop_trigger = self._threshold_store_condition(
+            frontier.store, variable_name, "lt", threshold
+        )
+        exit_trigger = self._threshold_store_condition(
+            frontier.store, variable_name, "ge", threshold
+        )
         if loop_has_priority:
             loop_condition = loop_trigger
             exit_condition = BoolTemplate.not_(loop_trigger)
         else:
-            loop_condition = BoolTemplate.and_(
-                BoolTemplate.not_(exit_trigger), loop_trigger
-            )
+            loop_condition = BoolTemplate.not_(exit_trigger)
             exit_condition = exit_trigger
 
         loop_store = dict(frontier.store.values)
@@ -642,24 +638,22 @@ class _Expander:
         :type transition: pyfcstm.model.Transition
         :param state: Pseudo state that owns the transition.
         :type state: pyfcstm.model.State
-        :return: ``(variable_name, increment, threshold)`` for ``x < K`` plus
-            ``x = x + step`` loops, or ``None`` for unsupported shapes.
+        :return: ``(variable_name, increment, threshold)`` for integer forms
+            equivalent to ``x < K`` plus ``x = x + step`` loops, or ``None``
+            for unsupported shapes.
         :rtype: Optional[Tuple[str, int, int]]
         """
         if transition.from_state != state.name or transition.to_state != state.name:
             return None
         if transition.event is not None:
             return None
-        guard = transition.guard
-        if not isinstance(guard, BinaryOp) or guard.op != "<":
+        guard = _integer_threshold_guard(transition.guard)
+        if guard is None:
             return None
-        if not isinstance(guard.x, Variable):
+        variable_name, relation, threshold = guard
+        if relation != "lt":
             return None
-        variable_name = guard.x.name
         if not self._is_int_variable(variable_name):
-            return None
-        threshold = _literal_int(guard.y)
-        if threshold is None:
             return None
         if len(transition.effects) != 1:
             return None
@@ -686,20 +680,62 @@ class _Expander:
         :type variable_name: str
         :param threshold: Loop threshold.
         :type threshold: int
-        :return: Whether the transition has guard ``x >= K`` and leaves the
-            pseudo state.
+        :return: Whether the transition has an integer guard equivalent to
+            ``x >= K`` and leaves the pseudo state.
         :rtype: bool
         """
         if transition.from_state != state.name or transition.to_state == state.name:
             return False
         if transition.event is not None:
             return False
-        guard = transition.guard
-        if not isinstance(guard, BinaryOp) or guard.op != ">=":
+        guard = _integer_threshold_guard(transition.guard)
+        if guard is None:
             return False
-        if not isinstance(guard.x, Variable) or guard.x.name != variable_name:
-            return False
-        return _literal_int(guard.y) == threshold
+        exit_variable_name, relation, exit_threshold = guard
+        return (
+            exit_variable_name == variable_name
+            and relation == "ge"
+            and exit_threshold == threshold
+        )
+
+    def _threshold_store_condition(
+        self,
+        store: _Store,
+        variable_name: str,
+        relation: str,
+        threshold: int,
+    ) -> BoolTemplate:
+        """Build a normalized threshold condition over the symbolic store.
+
+        :param store: Current symbolic variable store.
+        :type store: _Store
+        :param variable_name: Persistent integer variable to compare.
+        :type variable_name: str
+        :param relation: ``"lt"`` for ``x < threshold`` or ``"ge"`` for
+            ``x >= threshold``.
+        :type relation: str
+        :param threshold: Integer threshold.
+        :type threshold: int
+        :return: Boolean recipe for the normalized comparison.
+        :rtype: pyfcstm.bmc.macro.BoolTemplate
+        :raises BmcBuildError: If the variable is missing or ``relation`` is
+            unsupported.
+        """
+        if variable_name not in store.values:
+            raise BmcBuildError("unknown threshold variable %r." % variable_name)
+        if relation == "lt":
+            return _comparison_condition(
+                store.values[variable_name],
+                "<",
+                _ValueTemplate.const_value(threshold),
+            )
+        if relation == "ge":
+            return _comparison_condition(
+                store.values[variable_name],
+                ">=",
+                _ValueTemplate.const_value(threshold),
+            )
+        raise BmcBuildError("unsupported threshold relation %r." % relation)
 
     def _is_int_variable(self, variable_name: str) -> bool:
         """Return whether ``variable_name`` is a persistent integer variable.
@@ -1349,7 +1385,7 @@ class _Expander:
 
 
 def _literal_int(expr: Expr) -> Optional[int]:
-    """Return an integer literal value if ``expr`` is exactly integral syntax.
+    """Return an integer literal value if ``expr`` is integral syntax.
 
     :param expr: Model expression to inspect.
     :type expr: pyfcstm.model.Expr
@@ -1358,6 +1394,66 @@ def _literal_int(expr: Expr) -> Optional[int]:
     """
     if isinstance(expr, Integer):
         return expr.value
+    if isinstance(expr, UnaryOp) and expr.op == "-" and isinstance(expr.x, Integer):
+        return -expr.x.value
+    if isinstance(expr, UnaryOp) and expr.op == "+" and isinstance(expr.x, Integer):
+        return expr.x.value
+    return None
+
+
+def _integer_threshold_guard(expr: Optional[Expr]) -> Optional[Tuple[str, str, int]]:
+    """Normalize simple integer threshold guards.
+
+    The pseudo-loop accelerator needs to recognize syntactic variants that are
+    equivalent over integer variables.  This helper converts comparisons such
+    as ``x <= K - 1``, ``K > x``, and negated comparisons into a half-line
+    predicate represented as ``(variable_name, relation, threshold)`` where
+    ``relation`` is ``"lt"`` for ``x < threshold`` or ``"ge"`` for
+    ``x >= threshold``.
+
+    :param expr: Candidate guard expression.
+    :type expr: Optional[pyfcstm.model.Expr]
+    :return: Normalized integer threshold predicate, or ``None`` for
+        unsupported syntax.
+    :rtype: Optional[Tuple[str, str, int]]
+
+    Example::
+
+        >>> _integer_threshold_guard(BinaryOp(Variable('x'), '<=', Integer(3)))
+        ('x', 'lt', 4)
+        >>> _integer_threshold_guard(UnaryOp('!', BinaryOp(Variable('x'), '<', Integer(4))))
+        ('x', 'ge', 4)
+    """
+    if isinstance(expr, UnaryOp) and expr.op == "!":
+        inner = _integer_threshold_guard(expr.x)
+        if inner is None:
+            return None
+        variable_name, relation, threshold = inner
+        return variable_name, "ge" if relation == "lt" else "lt", threshold
+    if not isinstance(expr, BinaryOp) or expr.op not in ("<", "<=", ">", ">="):
+        return None
+
+    op = expr.op
+    if isinstance(expr.x, Variable):
+        variable_name = expr.x.name
+        value = _literal_int(expr.y)
+    elif isinstance(expr.y, Variable):
+        variable_name = expr.y.name
+        value = _literal_int(expr.x)
+        op = {"<": ">", "<=": ">=", ">": "<", ">=": "<="}[op]
+    else:
+        return None
+
+    if value is None:
+        return None
+    if op == "<":
+        return variable_name, "lt", value
+    if op == "<=":
+        return variable_name, "lt", value + 1
+    if op == ">":
+        return variable_name, "ge", value + 1
+    if op == ">=":
+        return variable_name, "ge", value
     return None
 
 
@@ -1417,6 +1513,10 @@ def _threshold_reached_value(
         return _ValueTemplate.const_value(threshold)
     threshold_text = _format_number(threshold)
     increment_text = _format_number(increment)
+    # The generated recipe intentionally uses Python/Z3 Euclidean modulo
+    # semantics.  PR-10 relation lowering must preserve that meaning for
+    # negative pre-state values instead of adopting target-language remainder
+    # semantics such as C's truncated ``%``.
     return _ValueTemplate(
         "%s + (((%s) - %s) %% %s)"
         % (threshold_text, value.text, threshold_text, increment_text)

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -28,9 +28,8 @@ Example::
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from typing import Iterable, Optional, Sequence, Tuple
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 from pyfcstm.bmc.domain import STATE_TERMINATE_ID, BmcDomain
 from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcDomain, InvalidBmcEncoding
@@ -85,8 +84,9 @@ class MacroExpansionOptions:
     :param verify_partition: Whether to run the source-local partition
         self-check after building cases, defaults to ``True``.
     :type verify_partition: bool, optional
-    :param partition_max_assignments: Truth-table assignment budget for the
-        current solver-independent checker, defaults to ``4096``.
+    :param partition_max_assignments: Assignment budget for the fallback
+        truth-table checker, defaults to ``4096``.  Structurally recognized
+        accepted/fallback masks can validate without enumerating this budget.
     :type partition_max_assignments: int, optional
 
     Example::
@@ -138,7 +138,7 @@ class _MacroFrontier:
     guard_requirements: Tuple[GuardRequirement, ...]
     priority_exclusions: Tuple[PriorityExclusion, ...]
     case_kind: str
-    path_signatures: Tuple[Tuple[object, ...], ...] = ()
+    path_signatures: Tuple[Tuple[Tuple[object, ...], int], ...] = ()
     depth: int = 0
 
 
@@ -203,28 +203,31 @@ class _MacroExpander:
 
     def __init__(self, source: MacroStepSource, options: MacroExpansionOptions) -> None:
         self.source = source
-        self.domain = source.domain
-        if self.domain is None:
+        domain = source.domain
+        if domain is None:
             raise InvalidBmcEncoding(
                 "macro-step expansion requires a domain-backed source."
             )
-        if not isinstance(self.domain, BmcDomain):
+        if not isinstance(domain, BmcDomain):
             raise InvalidBmcEncoding("source domain must be BmcDomain.")
-        self.model = self.domain.model
-        if self.model is None:
+        model = domain.model
+        if model is None:
             raise InvalidBmcEncoding(
                 "macro-step expansion requires a domain with model back-reference."
             )
+        self.domain = domain
+        self.model = model
         self.options = options
-        self.states_by_path = {
+        self.states_by_path: Dict[str, State] = {
             ".".join(state.path): state for state in self.model.walk_states()
         }
-        self.state_ids = {
+        self.state_ids: Dict[str, int] = {
             entry.path: entry.id
             for entry in self.domain.states
             if not entry.is_sentinel
         }
-        self._case_counters = {}  # type: Dict[str, int]
+        self._case_counters: Dict[str, int] = {}
+        self._failed_guard_requirements: Dict[str, GuardRequirement] = {}
         self._guard_counter = 0
         self._decision_counter = 0
 
@@ -250,6 +253,9 @@ class _MacroExpander:
                     success_cases,
                     diagnostics,
                     expansion.failed,
+                    guard_requirements=self._guard_requirements_for_conditions(
+                        expansion.failed
+                    ),
                 ),
             )
         elif diagnostics:
@@ -265,9 +271,9 @@ class _MacroExpander:
 
     @staticmethod
     def _merge_expansions(expansions: Iterable[_Expansion]) -> _Expansion:
-        outcomes = []
-        failed = []
-        diagnostics = []
+        outcomes: List[_MacroOutcome] = []
+        failed: List[BoolTemplate] = []
+        diagnostics: List[BoolTemplate] = []
         for expansion in expansions:
             outcomes.extend(expansion.outcomes)
             failed.extend(expansion.failed)
@@ -347,11 +353,19 @@ class _MacroExpander:
         if frontier.condition.kind == "false":
             return _Expansion((), (), ())
         signature = self._frontier_signature(frontier)
-        if signature in frontier.path_signatures:
+        for previous_signature, previous_action_count in frontier.path_signatures:
+            if previous_signature != signature:
+                continue
+            if len(frontier.action_blocks) > previous_action_count:
+                raise BmcBuildError(
+                    "macro-step expansion encountered an action-dependent pseudo loop."
+                )
+            self._remember_failed_guard_requirements(frontier)
             return _Expansion((), (frontier.condition,), ())
         frontier = self._replace_frontier(
             frontier,
-            path_signatures=frontier.path_signatures + (signature,),
+            path_signatures=frontier.path_signatures
+            + ((signature, len(frontier.action_blocks)),),
             depth=frontier.depth + 1,
         )
 
@@ -391,6 +405,7 @@ class _MacroExpander:
                 )
             return expanded
         if not frontier.stack[-1].state.is_stoppable:
+            self._remember_failed_guard_requirements(frontier)
             return _Expansion(
                 (), (frontier.condition,) + expanded.failed, expanded.diagnostics
             )
@@ -404,6 +419,7 @@ class _MacroExpander:
         )
         if expanded.outcomes:
             return expanded
+        self._remember_failed_guard_requirements(frontier)
         return _Expansion(
             (), (frontier.condition,) + expanded.failed, expanded.diagnostics
         )
@@ -415,6 +431,7 @@ class _MacroExpander:
         )
         if expanded.outcomes:
             return expanded
+        self._remember_failed_guard_requirements(frontier)
         return _Expansion(
             (), (frontier.condition,) + expanded.failed, expanded.diagnostics
         )
@@ -425,9 +442,9 @@ class _MacroExpander:
         transitions: Sequence[Transition],
         is_initial: bool,
     ) -> _Expansion:
-        outcomes = []  # type: List[_MacroOutcome]
-        failed = []  # type: List[BoolTemplate]
-        diagnostics = []  # type: List[BoolTemplate]
+        outcomes: List[_MacroOutcome] = []
+        failed: List[BoolTemplate] = []
+        diagnostics: List[BoolTemplate] = []
         for index, transition in enumerate(transitions):
             candidate = self._apply_priority_exclusion(frontier, outcomes, is_initial)
             candidate = self._apply_transition_trigger(
@@ -441,6 +458,7 @@ class _MacroExpander:
             if branch_expansion.outcomes:
                 outcomes.extend(branch_expansion.outcomes)
             else:
+                self._remember_failed_guard_requirements(candidate)
                 failed.append(candidate.condition)
             failed.extend(branch_expansion.failed)
             diagnostics.extend(branch_expansion.diagnostics)
@@ -533,7 +551,7 @@ class _MacroExpander:
                     transition_label,
                     transition.guard,
                     "positive",
-                    "initial_guard" if is_initial else "transition_guard",
+                    self._guard_reason(frontier, is_initial),
                     len(frontier.action_blocks),
                 )
                 guard_requirements = guard_requirements + (guard,)
@@ -556,9 +574,9 @@ class _MacroExpander:
             if is_initial
             else self._execute_transition(frontier, transition)
         )
-        outcomes = []
-        failed = []
-        diagnostics = []
+        outcomes: List[_MacroOutcome] = []
+        failed: List[BoolTemplate] = []
+        diagnostics: List[BoolTemplate] = []
         for branch in branches:
             branch_expansion = self._expand_frontier(branch)
             outcomes.extend(branch_expansion.outcomes)
@@ -573,10 +591,11 @@ class _MacroExpander:
     ) -> Tuple[_MacroFrontier, ...]:
         composite_frame = frontier.stack[-1]
         state = composite_frame.state
-        current = self._record_transition_effect(
-            frontier, state, transition, "initial_effect"
-        )
-        target_state = state.substates[transition.to_state]
+        current = self._record_transition_effect(frontier, state, transition)
+        target_name = transition.to_state
+        if not isinstance(target_name, str):
+            raise BmcBuildError("initial transition target must be a child state.")
+        target_state = state.substates[target_name]
         if not target_state.is_pseudo:
             current = self._consume_plain_before_if_pending(current)
         entered = self._enter_state(current, target_state)
@@ -598,11 +617,9 @@ class _MacroExpander:
         current = frontier
         for on_exit in current_state.on_exits:
             current = self._record_func(
-                current, current_state, on_exit, "exit", "state_exit"
+                current, current_state, on_exit, "state_action", "state_exit"
             )
-        current = self._record_transition_effect(
-            current, current_state, transition, "transition_effect"
-        )
+        current = self._record_transition_effect(current, current_state, transition)
         current = self._replace_frontier(current, stack=current.stack[:-1])
 
         if transition.to_state == EXIT_STATE:
@@ -614,7 +631,10 @@ class _MacroExpander:
         parent = current_state.parent
         if parent is None:
             raise BmcBuildError("non-exit transition from root has no parent.")
-        target_state = parent.substates[transition.to_state]
+        target_name = transition.to_state
+        if not isinstance(target_name, str):
+            raise BmcBuildError("transition target must be a sibling state.")
+        target_state = parent.substates[target_name]
         if (
             current_state.is_pseudo
             and current.stack
@@ -634,13 +654,13 @@ class _MacroExpander:
                 current,
                 parent,
                 on_during_after,
-                "during",
+                "state_action",
                 "plain_during_after",
             )
         if parent.is_root_state:
             for on_exit in parent.on_exits:
                 current = self._record_func(
-                    current, parent, on_exit, "exit", "state_exit"
+                    current, parent, on_exit, "state_action", "state_exit"
                 )
             return self._replace_frontier(current, stack=())
         return self._replace_top(current, _FormalStackFrame(parent, "post_child_exit"))
@@ -654,7 +674,7 @@ class _MacroExpander:
         )
         for on_enter in state.on_enters:
             current = self._record_func(
-                current, state, on_enter, "enter", "state_enter"
+                current, state, on_enter, "state_action", "state_enter"
             )
 
         if state.is_leaf_state:
@@ -673,9 +693,28 @@ class _MacroExpander:
         self, frontier: _MacroFrontier, state: State
     ) -> _MacroFrontier:
         current = frontier
-        for owner, func in state.iter_on_during_aspect_recursively():
-            block_kind = "during_aspect" if isinstance(func, OnAspect) else "during"
-            current = self._record_func(current, owner, func, block_kind, "leaf_during")
+        for item in state.iter_on_during_aspect_recursively():
+            if len(item) == 3:
+                owner = item[1]
+                func = item[2]
+            else:
+                owner = item[0]
+                func = item[1]
+            if not isinstance(owner, State) or not isinstance(
+                func, (OnAspect, OnStage)
+            ):
+                raise BmcBuildError("invalid during action traversal item.")
+            if isinstance(func, OnAspect):
+                role = (
+                    "aspect_during_before"
+                    if func.aspect == "before"
+                    else "aspect_during_after"
+                )
+                current = self._record_func(current, owner, func, "aspect_action", role)
+            else:
+                current = self._record_func(
+                    current, owner, func, "state_action", "leaf_during"
+                )
         return current
 
     def _consume_plain_before_if_pending(
@@ -692,7 +731,7 @@ class _MacroExpander:
                 current,
                 frame.state,
                 on_during_before,
-                "during",
+                "state_action",
                 "plain_during_before",
             )
         return self._replace_top(
@@ -723,7 +762,6 @@ class _MacroExpander:
         frontier: _MacroFrontier,
         owner: State,
         transition: Transition,
-        runtime_role: str,
     ) -> _MacroFrontier:
         if not transition.effects:
             return frontier
@@ -731,7 +769,7 @@ class _MacroExpander:
             frontier,
             owner,
             "transition_effect",
-            runtime_role,
+            "transition_effect",
             tuple(transition.effects),
             None,
             self._transition_label(
@@ -874,6 +912,7 @@ class _MacroExpander:
         expansion = self._expand_frontier(active)
         if not expansion.outcomes:
             raise BmcBuildError("stable fallback did not produce an outcome.")
+        failed_guard_requirements = self._guard_requirements_for_conditions(failed)
         return tuple(
             _MacroOutcome(
                 outcome.label,
@@ -882,7 +921,9 @@ class _MacroExpander:
                 outcome.condition,
                 outcome.used_events,
                 outcome.action_blocks,
-                outcome.guard_requirements,
+                _merge_guard_requirements(
+                    outcome.guard_requirements, failed_guard_requirements
+                ),
                 outcome.priority_exclusions,
                 _CASE_KIND_FALLBACK,
                 tuple(failed),
@@ -939,6 +980,35 @@ class _MacroExpander:
             for outcome in outcomes
         )
 
+    def _guard_reason(self, frontier: _MacroFrontier, is_initial: bool) -> str:
+        if is_initial:
+            return "initial_guard"
+        frame = frontier.stack[-1]
+        if frame.mode == "post_child_exit":
+            return "parent_continuation_guard"
+        if frame.state.is_pseudo:
+            return "pseudo_guard"
+        return "transition_guard"
+
+    def _remember_failed_guard_requirements(self, frontier: _MacroFrontier) -> None:
+        for guard in frontier.guard_requirements:
+            self._failed_guard_requirements[guard.requirement_id] = guard
+
+    def _guard_requirements_for_conditions(
+        self, conditions: Sequence[BoolTemplate]
+    ) -> Tuple[GuardRequirement, ...]:
+        ids = {
+            atom[len(_GUARD_ATOM_PREFIX) :]
+            for condition in conditions
+            for atom in condition.variables
+            if atom.startswith(_GUARD_ATOM_PREFIX)
+        }
+        return tuple(
+            self._failed_guard_requirements[item]
+            for item in sorted(ids)
+            if item in self._failed_guard_requirements
+        )
+
     def _allocate_case_label(self, case_kind: str, target_path: str) -> str:
         ordinal = self._case_counters.get(case_kind, 0)
         self._case_counters[case_kind] = ordinal + 1
@@ -968,7 +1038,7 @@ class _MacroExpander:
             for index, item in enumerate(transitions):
                 if item is transition:
                     return index
-        return 0
+        raise BmcBuildError("transition not found on owner state.")
 
     def _event_uses_for_paths(
         self, paths: Sequence[str], polarity: str, reason: str
@@ -998,14 +1068,6 @@ class _MacroExpander:
                 (frame.state.path, frame.mode, frame.plain_before_pending)
                 for frame in frontier.stack
             ),
-            json.dumps(
-                frontier.condition.to_canonical(), sort_keys=True, separators=(",", ":")
-            ),
-            tuple(
-                json.dumps(block.to_canonical(), sort_keys=True, separators=(",", ":"))
-                for block in frontier.action_blocks
-            ),
-            tuple(item.requirement_id for item in frontier.guard_requirements),
             frontier.case_kind,
         )
 
@@ -1064,6 +1126,16 @@ def _merge_event_uses(*groups: Sequence[EventUse]) -> Tuple[EventUse, ...]:
         for item in group:
             by_key[(item.event_id, item.path, item.polarity, item.reason)] = item
     return tuple(by_key[key] for key in sorted(by_key))
+
+
+def _merge_guard_requirements(
+    *groups: Sequence[GuardRequirement],
+) -> Tuple[GuardRequirement, ...]:
+    by_id = {}
+    for group in groups:
+        for item in group:
+            by_id[item.requirement_id] = item
+    return tuple(by_id[key] for key in sorted(by_id))
 
 
 def _event_paths_from_condition(condition: BoolTemplate) -> Tuple[str, ...]:

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -1,0 +1,1238 @@
+"""Macro-step expansion aligned with the FCSTM simulation runtime.
+
+The expansion layer turns a :class:`pyfcstm.bmc.source.MacroStepSource` into a
+solver-independent :class:`pyfcstm.bmc.macro.MacroStepFormal`.  It mirrors the
+cycle-level control flow of :class:`pyfcstm.simulate.SimulationRuntime` without
+creating Z3 symbols or verify-registry entries.  The output conditions remain
+bare case predicates; later relation builders compose the source-state guard and
+lower each case as an implication.
+
+The module contains:
+
+* :class:`MacroExpansionOptions` - Runtime-aligned safety and self-check limits.
+* :func:`expand_macro_step_cases` - Public source-only macro-step expander.
+
+Example::
+
+    >>> from pyfcstm.bmc import build_bmc_domain, stable_leaf_source
+    >>> from pyfcstm.bmc.expand import expand_macro_step_cases
+    >>> from pyfcstm.model import load_state_machine_from_text
+    >>> model = load_state_machine_from_text('def int x = 0; state Root { during { x = x + 1; } }')
+    >>> domain = build_bmc_domain(model, 1)
+    >>> formal = expand_macro_step_cases(stable_leaf_source(domain, 'Root'))
+    >>> formal.success_cases[0].kind
+    'fallback'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from pyfcstm.bmc.domain import STATE_TERMINATE_ID, BmcDomain
+from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcEncoding
+from pyfcstm.bmc.macro import (
+    BoolTemplate,
+    CycleCase,
+    EventUse,
+    MacroStepFormal,
+    VarUpdate,
+    build_semantic_delta_case,
+    diagnostic_absorb_case,
+    terminated_absorb_case,
+)
+from pyfcstm.bmc.source import TERMINATE_CASE_PATH, MacroStepSource
+from pyfcstm.dsl import EXIT_STATE
+from pyfcstm.model import (
+    BinaryOp,
+    Boolean,
+    ConditionalOp,
+    Expr,
+    Float,
+    IfBlock,
+    Integer,
+    OnAspect,
+    OnStage,
+    Operation,
+    OperationStatement,
+    State,
+    StateMachine,
+    Transition,
+    UFunc,
+    UnaryOp,
+    Variable,
+)
+
+_CASE_KIND_FALLBACK = "fallback"
+_CASE_KIND_INITIAL = "initial"
+_CASE_KIND_TRANSITION = "transition"
+_EVENT_ATOM_PREFIX = "event:"
+_GUARD_ATOM_PREFIX = "guard:"
+_PRE_VAR_PREFIX = "pre:"
+
+
+def _validate_positive_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise InvalidBmcEncoding("%s must be a positive integer." % field_name)
+    if value <= 0:
+        raise InvalidBmcEncoding("%s must be a positive integer." % field_name)
+    return value
+
+
+@dataclass(frozen=True)
+class MacroExpansionOptions:
+    """Options controlling macro-step expansion safety checks.
+
+    :param max_micro_steps: Maximum symbolic micro-steps explored before the
+        build fails, defaults to ``1000``.
+    :type max_micro_steps: int, optional
+    :param max_stack_depth: Maximum runtime stack depth, defaults to ``64``.
+    :type max_stack_depth: int, optional
+    :param verify_partition: Whether to run the source-local partition
+        self-check after building cases, defaults to ``True``.
+    :type verify_partition: bool, optional
+    :param partition_max_assignments: Truth-table assignment budget for the
+        current solver-independent checker, defaults to ``4096``.
+    :type partition_max_assignments: int, optional
+
+    Example::
+
+        >>> MacroExpansionOptions(max_micro_steps=10).max_stack_depth
+        64
+    """
+
+    max_micro_steps: int = 1000
+    max_stack_depth: int = 64
+    verify_partition: bool = True
+    partition_max_assignments: int = 4096
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "max_micro_steps",
+            _validate_positive_int(self.max_micro_steps, "max_micro_steps"),
+        )
+        object.__setattr__(
+            self,
+            "max_stack_depth",
+            _validate_positive_int(self.max_stack_depth, "max_stack_depth"),
+        )
+        object.__setattr__(
+            self,
+            "partition_max_assignments",
+            _validate_positive_int(
+                self.partition_max_assignments,
+                "partition_max_assignments",
+            ),
+        )
+        if not isinstance(self.verify_partition, bool):
+            raise InvalidBmcEncoding("verify_partition must be a boolean.")
+
+
+@dataclass(frozen=True)
+class _LinearExpr:
+    coeffs: Mapping[str, float]
+    const: float = 0.0
+
+    @classmethod
+    def variable(cls, name: str) -> "_LinearExpr":
+        return cls({name: 1.0}, 0.0)
+
+    @classmethod
+    def const_value(cls, value: float) -> "_LinearExpr":
+        return cls({}, float(value))
+
+    def add(self, other: "_LinearExpr") -> "_LinearExpr":
+        coeffs = dict(self.coeffs)
+        for name, coeff in other.coeffs.items():
+            coeffs[name] = coeffs.get(name, 0.0) + coeff
+            if coeffs[name] == 0:
+                del coeffs[name]
+        return _LinearExpr(coeffs, self.const + other.const)
+
+    def mul_const(self, value: float) -> "_LinearExpr":
+        return _LinearExpr(
+            {name: coeff * value for name, coeff in self.coeffs.items()},
+            self.const * value,
+        )
+
+    def to_text(self) -> str:
+        parts = []
+        for name in sorted(self.coeffs):
+            coeff = self.coeffs[name]
+            if coeff == 1:
+                part = name
+            elif coeff == -1:
+                part = "-%s" % name
+            else:
+                part = "%s * %s" % (_format_number(coeff), name)
+            parts.append(part)
+        const = self.const
+        if const:
+            const_text = _format_number(abs(const))
+            if parts:
+                parts.append(("+ " if const > 0 else "- ") + const_text)
+            else:
+                parts.append(_format_number(const))
+        if not parts:
+            return "0"
+        text = parts[0]
+        for part in parts[1:]:
+            if part.startswith("+ ") or part.startswith("- "):
+                text = "%s %s" % (text, part)
+            elif part.startswith("-"):
+                text = "%s - %s" % (text, part[1:])
+            else:
+                text = "%s + %s" % (text, part)
+        return text
+
+
+@dataclass(frozen=True)
+class _ValueTemplate:
+    text: str
+    linear: Optional[_LinearExpr] = None
+
+    @classmethod
+    def variable(cls, name: str) -> "_ValueTemplate":
+        text = "%s%s" % (_PRE_VAR_PREFIX, name)
+        return cls(text, _LinearExpr.variable(text))
+
+    @classmethod
+    def const_value(cls, value: float) -> "_ValueTemplate":
+        text = _format_number(value)
+        return cls(text, _LinearExpr.const_value(value))
+
+    def binary(self, op: str, other: "_ValueTemplate") -> "_ValueTemplate":
+        if op == "+" and self.linear is not None and other.linear is not None:
+            return _value_from_linear(self.linear.add(other.linear))
+        if op == "-" and self.linear is not None and other.linear is not None:
+            return _value_from_linear(self.linear.add(other.linear.mul_const(-1)))
+        if op == "*":
+            if self.linear is not None and not self.linear.coeffs:
+                return (
+                    _value_from_linear(other.linear.mul_const(self.linear.const))
+                    if other.linear is not None
+                    else _ValueTemplate("%s * %s" % (self.text, other.text))
+                )
+            if other.linear is not None and not other.linear.coeffs:
+                return (
+                    _value_from_linear(self.linear.mul_const(other.linear.const))
+                    if self.linear is not None
+                    else _ValueTemplate("%s * %s" % (self.text, other.text))
+                )
+        if (
+            op == "/"
+            and other.linear is not None
+            and not other.linear.coeffs
+            and other.linear.const != 0
+            and self.linear is not None
+        ):
+            return _value_from_linear(self.linear.mul_const(1.0 / other.linear.const))
+        return _ValueTemplate("%s %s %s" % (self.text, op, other.text))
+
+    def unary(self, op: str) -> "_ValueTemplate":
+        if op == "+":
+            return self
+        if op == "-" and self.linear is not None:
+            return _value_from_linear(self.linear.mul_const(-1))
+        return _ValueTemplate("%s%s" % (op, self.text))
+
+
+def _format_number(value: float) -> str:
+    if int(value) == value:
+        return str(int(value))
+    return repr(float(value))
+
+
+def _value_from_linear(linear: _LinearExpr) -> _ValueTemplate:
+    return _ValueTemplate(linear.to_text(), linear)
+
+
+@dataclass(frozen=True)
+class _FormalStackFrame:
+    state: State
+    mode: str
+    plain_before_pending: bool = False
+
+
+@dataclass(frozen=True)
+class _Store:
+    values: Mapping[str, _ValueTemplate]
+
+
+@dataclass(frozen=True)
+class _MacroFrontier:
+    stack: Tuple[_FormalStackFrame, ...]
+    store: _Store
+    condition: BoolTemplate
+    used_events: Tuple[EventUse, ...]
+    case_kind: str
+    path_signatures: Tuple[Tuple[object, ...], ...] = ()
+    depth: int = 0
+
+
+@dataclass(frozen=True)
+class _MacroOutcome:
+    target_state_id: int
+    target_state_path: str
+    condition: BoolTemplate
+    store: _Store
+    used_events: Tuple[EventUse, ...]
+    case_kind: str
+    failed_conditions: Tuple[BoolTemplate, ...] = ()
+
+
+@dataclass(frozen=True)
+class _Expansion:
+    outcomes: Tuple[_MacroOutcome, ...]
+    failed: Tuple[BoolTemplate, ...]
+    diagnostics: Tuple[BoolTemplate, ...]
+
+
+@dataclass(frozen=True)
+class _Branch:
+    condition: BoolTemplate
+    store: _Store
+
+
+class _Expander:
+    def __init__(self, source: MacroStepSource, options: MacroExpansionOptions):
+        if source.domain is None:
+            raise InvalidBmcEncoding("macro-step source must be domain-backed.")
+        if not isinstance(source.domain, BmcDomain):
+            raise InvalidBmcEncoding("source.domain must be BmcDomain.")
+        self.source = source
+        self.domain = source.domain
+        self.options = options
+        model = getattr(self.domain, "model", None)
+        if not isinstance(model, StateMachine):
+            raise InvalidBmcEncoding(
+                "source domain must preserve the state machine model for expansion."
+            )
+        self.model = model
+        self.states_by_path = {
+            ".".join(state.path): state for state in model.walk_states()
+        }
+        self.event_entries = {entry.path: entry for entry in self.domain.events}
+        self.state_ids = {entry.path: entry.id for entry in self.domain.states}
+
+    def expand(self) -> MacroStepFormal:
+        if self.source.kind == "terminated":
+            return MacroStepFormal(self.source, (terminated_absorb_case(self.domain),))
+        if self.source.kind == "diagnostic":
+            return MacroStepFormal(self.source, (diagnostic_absorb_case(self.domain),))
+
+        initial_frontiers = self._frontiers_from_source()
+        expansion = self._merge_expansions(
+            self._expand_frontier(frontier) for frontier in initial_frontiers
+        )
+        if self.source.kind == "stable_leaf" and expansion.diagnostics:
+            raise BmcBuildError("stable macro expansion produced build diagnostics.")
+
+        success_cases = self._cases_from_outcomes(expansion.outcomes)
+        delta_cases = ()
+        diagnostics = expansion.diagnostics
+        if self.source.kind == "entry":
+            delta = build_semantic_delta_case(
+                self.domain,
+                self.source,
+                success_cases,
+                diagnostics,
+                expansion.failed,
+            )
+            delta_cases = (delta,)
+
+        formal = MacroStepFormal(
+            self.source,
+            success_cases,
+            delta_cases,
+            diagnostics,
+        )
+        if self.options.verify_partition:
+            formal.verify_partition(
+                max_assignments=self.options.partition_max_assignments
+            )
+        return formal
+
+    @staticmethod
+    def _merge_expansions(expansions: Iterable[_Expansion]) -> _Expansion:
+        outcomes = []
+        failed = []
+        diagnostics = []
+        for expansion in expansions:
+            outcomes.extend(expansion.outcomes)
+            failed.extend(expansion.failed)
+            diagnostics.extend(expansion.diagnostics)
+        return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
+
+    def _frontiers_from_source(self) -> Tuple[_MacroFrontier, ...]:
+        store = _Store(
+            {
+                entry.name: _ValueTemplate.variable(entry.name)
+                for entry in self.domain.variables
+            }
+        )
+        state = self._source_state()
+        if self.source.kind == "stable_leaf":
+            stack = tuple(
+                _FormalStackFrame(item, "active") for item in _path_to_root(state)
+            )
+            return (
+                _MacroFrontier(
+                    stack, store, BoolTemplate.true(), (), _CASE_KIND_TRANSITION
+                ),
+            )
+
+        if self.source.kind != "entry":
+            raise InvalidBmcEncoding("unsupported source kind: %r." % self.source.kind)
+        if state.is_root_state:
+            base = _MacroFrontier(
+                (), store, BoolTemplate.true(), (), _CASE_KIND_INITIAL
+            )
+            return self._enter_state(base, state)
+        stack = []
+        path = _path_to_root(state)
+        for index, item in enumerate(path):
+            is_target = index == len(path) - 1
+            if item.is_leaf_state:
+                stack.append(_FormalStackFrame(item, "active"))
+            elif is_target:
+                stack.append(
+                    _FormalStackFrame(item, "init_wait", plain_before_pending=False)
+                )
+            else:
+                stack.append(_FormalStackFrame(item, "active"))
+        return (
+            _MacroFrontier(
+                tuple(stack), store, BoolTemplate.true(), (), _CASE_KIND_INITIAL
+            ),
+        )
+
+    def _source_state(self) -> State:
+        state = self.states_by_path.get(self.source.source_state_path)
+        if state is None:
+            raise InvalidBmcEncoding("source state is not present in the model.")
+        return state
+
+    def _expand_frontier(self, frontier: _MacroFrontier) -> _Expansion:
+        if frontier.depth >= self.options.max_micro_steps:
+            return _Expansion((), (), (frontier.condition,))
+        if len(frontier.stack) > self.options.max_stack_depth:
+            return _Expansion((), (), (frontier.condition,))
+        signature = self._frontier_signature(frontier)
+        if signature in frontier.path_signatures:
+            return _Expansion((), (frontier.condition,), ())
+        frontier = self._replace_frontier(
+            frontier,
+            path_signatures=frontier.path_signatures + (signature,),
+            depth=frontier.depth + 1,
+        )
+
+        if not frontier.stack:
+            return _Expansion((self._terminate_outcome(frontier),), (), ())
+
+        top = frontier.stack[-1]
+        state = top.state
+        if state.is_leaf_state and top.mode == "after_entry":
+            active = self._replace_top(frontier, _FormalStackFrame(state, "active"))
+            if state.is_stoppable:
+                return _Expansion((self._stable_outcome(active, state),), (), ())
+            return self._expand_frontier(active)
+
+        if state.is_leaf_state:
+            return self._expand_leaf_active(frontier)
+        if top.mode == "init_wait":
+            return self._expand_initial_transitions(frontier)
+        if top.mode == "post_child_exit":
+            return self._expand_parent_continuation(frontier)
+        return _Expansion((), (), (frontier.condition,))
+
+    def _expand_leaf_active(self, frontier: _MacroFrontier) -> _Expansion:
+        transitions = frontier.stack[-1].state.transitions_from
+        expanded = self._expand_ordered_candidates(
+            frontier, transitions, is_initial=False
+        )
+        if expanded.outcomes:
+            if frontier.stack[-1].state.is_stoppable:
+                fallback = self._leaf_fallback_outcomes(
+                    frontier, expanded.outcomes, expanded.failed
+                )
+                return _Expansion(
+                    expanded.outcomes + fallback,
+                    expanded.failed,
+                    expanded.diagnostics,
+                )
+            return expanded
+        if not frontier.stack[-1].state.is_stoppable:
+            return _Expansion(
+                (), (frontier.condition,) + expanded.failed, expanded.diagnostics
+            )
+        fallback = self._leaf_fallback_outcomes(frontier, (), expanded.failed)
+        return _Expansion(fallback, expanded.failed, expanded.diagnostics)
+
+    def _expand_initial_transitions(self, frontier: _MacroFrontier) -> _Expansion:
+        transitions = frontier.stack[-1].state.init_transitions
+        expanded = self._expand_ordered_candidates(
+            frontier, transitions, is_initial=True
+        )
+        if expanded.outcomes:
+            return expanded
+        return _Expansion(
+            (), (frontier.condition,) + expanded.failed, expanded.diagnostics
+        )
+
+    def _expand_parent_continuation(self, frontier: _MacroFrontier) -> _Expansion:
+        transitions = frontier.stack[-1].state.transitions_from
+        expanded = self._expand_ordered_candidates(
+            frontier, transitions, is_initial=False
+        )
+        if expanded.outcomes:
+            return expanded
+        return _Expansion(
+            (), (frontier.condition,) + expanded.failed, expanded.diagnostics
+        )
+
+    def _expand_ordered_candidates(
+        self,
+        frontier: _MacroFrontier,
+        transitions: Sequence[Transition],
+        *,
+        is_initial: bool,
+    ) -> _Expansion:
+        outcomes: List[_MacroOutcome] = []
+        failed: List[BoolTemplate] = []
+        diagnostics: List[BoolTemplate] = []
+        previous_accepted: List[BoolTemplate] = []
+        previous_event_uses: List[EventUse] = []
+        for transition in transitions:
+            raw, raw_events = self._transition_trigger(
+                transition, frontier.store, is_initial=is_initial
+            )
+            candidate = self._replace_frontier(
+                frontier,
+                condition=BoolTemplate.and_(frontier.condition, raw),
+                used_events=_merge_event_uses(frontier.used_events, raw_events),
+            )
+            branches = (
+                self._execute_initial_transition(candidate, transition)
+                if is_initial
+                else self._execute_transition(candidate, transition)
+            )
+            candidate_outcomes: List[_MacroOutcome] = []
+            candidate_failed: List[BoolTemplate] = []
+            for branch in branches:
+                branch_expansion = self._expand_frontier(branch)
+                candidate_outcomes.extend(branch_expansion.outcomes)
+                candidate_failed.extend(branch_expansion.failed)
+                diagnostics.extend(branch_expansion.diagnostics)
+            accepted = BoolTemplate.or_(
+                *[item.condition for item in candidate_outcomes]
+            )
+            priority = BoolTemplate.and_(
+                *[BoolTemplate.not_(item) for item in previous_accepted]
+            )
+            priority_events = tuple(
+                EventUse(item.event_id, item.path, "negative", "priority")
+                for item in previous_event_uses
+            )
+            for outcome in candidate_outcomes:
+                outcomes.append(
+                    _MacroOutcome(
+                        outcome.target_state_id,
+                        outcome.target_state_path,
+                        BoolTemplate.and_(priority, outcome.condition),
+                        outcome.store,
+                        _merge_event_uses(outcome.used_events, priority_events),
+                        outcome.case_kind,
+                        outcome.failed_conditions,
+                    )
+                )
+            failed.extend(candidate_failed)
+            previous_accepted.append(accepted)
+            previous_event_uses.extend(
+                _event_uses_from_condition(accepted, self.domain)
+            )
+        return _Expansion(tuple(outcomes), tuple(failed), tuple(diagnostics))
+
+    def _transition_trigger(
+        self,
+        transition: Transition,
+        store: _Store,
+        *,
+        is_initial: bool,
+    ) -> Tuple[BoolTemplate, Tuple[EventUse, ...]]:
+        conditions = []
+        event_uses = []
+        if transition.event is not None:
+            atom = BoolTemplate.atom(_event_atom(transition.event.path_name))
+            conditions.append(atom)
+            entry = self.event_entries.get(transition.event.path_name)
+            if entry is None:
+                raise InvalidBmcEncoding("transition event is missing from BMC domain.")
+            reason = "descent" if is_initial else "trigger"
+            event_uses.append(EventUse(entry.id, entry.path, "positive", reason))
+        if transition.guard is not None:
+            conditions.append(self._condition_from_expr(transition.guard, store))
+        return BoolTemplate.and_(*conditions), tuple(event_uses)
+
+    def _execute_initial_transition(
+        self,
+        frontier: _MacroFrontier,
+        transition: Transition,
+    ) -> Tuple[_MacroFrontier, ...]:
+        top = frontier.stack[-1]
+        target = top.state.substates[transition.to_state]
+        branches = self._execute_operation_block(frontier, transition.effects)
+        result = []
+        for branch in branches:
+            current_items = (branch,)
+            if not target.is_pseudo:
+                current_items = self._consume_plain_before_if_pending(branch)
+            for current in current_items:
+                result.extend(self._enter_state(current, target))
+        return tuple(result)
+
+    def _execute_transition(
+        self,
+        frontier: _MacroFrontier,
+        transition: Transition,
+    ) -> Tuple[_MacroFrontier, ...]:
+        current_state = frontier.stack[-1].state
+        branches = (frontier,)
+        for on_exit in current_state.on_exits:
+            branches = self._flat_map(
+                branches, lambda item, func=on_exit: self._execute_func(item, func)
+            )
+        branches = self._flat_map(
+            branches,
+            lambda item: self._execute_operation_block(item, transition.effects),
+        )
+        result = []
+        for branch in branches:
+            popped = self._replace_frontier(branch, stack=branch.stack[:-1])
+            if transition.to_state == EXIT_STATE:
+                if current_state.is_pseudo:
+                    popped = self._clear_parent_plain_before_pending_after_pseudo_exit(
+                        popped, current_state
+                    )
+                result.extend(self._finalize_exit_to_parent(popped))
+                continue
+            target_state = current_state.parent.substates[transition.to_state]
+            current = popped
+            if (
+                current_state.is_pseudo
+                and current.stack
+                and current.stack[-1].state is current_state.parent
+                and not target_state.is_pseudo
+            ):
+                for consumed in self._consume_plain_before_if_pending(current):
+                    result.extend(self._enter_state(consumed, target_state))
+                continue
+            result.extend(self._enter_state(current, target_state))
+        return tuple(result)
+
+    def _enter_state(
+        self, frontier: _MacroFrontier, state: State
+    ) -> Tuple[_MacroFrontier, ...]:
+        entered = self._replace_frontier(
+            frontier, stack=frontier.stack + (_FormalStackFrame(state, "active"),)
+        )
+        branches = (entered,)
+        for on_enter in state.on_enters:
+            branches = self._flat_map(
+                branches, lambda item, func=on_enter: self._execute_func(item, func)
+            )
+        result = []
+        for branch in branches:
+            if state.is_leaf_state:
+                during_branches = self._run_leaf_during(branch, state)
+                result.extend(
+                    self._replace_top(item, _FormalStackFrame(state, "after_entry"))
+                    for item in during_branches
+                )
+            else:
+                result.append(
+                    self._replace_top(
+                        branch,
+                        _FormalStackFrame(
+                            state, "init_wait", plain_before_pending=True
+                        ),
+                    )
+                )
+        return tuple(result)
+
+    def _finalize_exit_to_parent(
+        self, frontier: _MacroFrontier
+    ) -> Tuple[_MacroFrontier, ...]:
+        if not frontier.stack:
+            return (frontier,)
+        parent = frontier.stack[-1].state
+        branches = (frontier,)
+        for on_during_after in parent.list_on_durings(aspect="after"):
+            branches = self._flat_map(
+                branches,
+                lambda item, func=on_during_after: self._execute_func(item, func),
+            )
+        if parent.is_root_state:
+            for on_exit in parent.on_exits:
+                branches = self._flat_map(
+                    branches, lambda item, func=on_exit: self._execute_func(item, func)
+                )
+            return tuple(self._replace_frontier(item, stack=()) for item in branches)
+        return tuple(
+            self._replace_top(item, _FormalStackFrame(parent, "post_child_exit"))
+            for item in branches
+        )
+
+    def _leaf_fallback_outcomes(
+        self,
+        frontier: _MacroFrontier,
+        accepted: Sequence[_MacroOutcome],
+        failed: Sequence[BoolTemplate],
+    ) -> Tuple[_MacroOutcome, ...]:
+        fallback_events: Tuple[EventUse, ...] = ()
+        if accepted:
+            accepted_condition = BoolTemplate.or_(
+                *[item.condition for item in accepted]
+            )
+            condition = BoolTemplate.and_(
+                frontier.condition,
+                BoolTemplate.not_(accepted_condition),
+            )
+            fallback_events = _event_uses_from_condition(
+                accepted_condition,
+                self.domain,
+                polarity="negative",
+                reason="fallback",
+            )
+        else:
+            condition = frontier.condition
+        fallback_frontier = self._replace_frontier(
+            frontier,
+            condition=condition,
+            case_kind=_CASE_KIND_FALLBACK,
+        )
+        branches = self._run_leaf_during(fallback_frontier, frontier.stack[-1].state)
+        outcomes = []
+        for branch in branches:
+            active = self._replace_top(
+                branch, _FormalStackFrame(branch.stack[-1].state, "after_entry")
+            )
+            expansion = self._expand_frontier(active)
+            outcomes.extend(expansion.outcomes)
+        if not outcomes:
+            raise BmcBuildError("stable fallback did not produce an outcome.")
+        return tuple(
+            _MacroOutcome(
+                outcome.target_state_id,
+                outcome.target_state_path,
+                outcome.condition,
+                outcome.store,
+                _merge_event_uses(outcome.used_events, fallback_events),
+                _CASE_KIND_FALLBACK,
+                tuple(failed),
+            )
+            for outcome in outcomes
+        )
+
+    def _run_leaf_during(
+        self, frontier: _MacroFrontier, state: State
+    ) -> Tuple[_MacroFrontier, ...]:
+        branches = (frontier,)
+        for _, func in state.iter_on_during_aspect_recursively():
+            branches = self._flat_map(
+                branches, lambda item, action=func: self._execute_func(item, action)
+            )
+        return tuple(branches)
+
+    def _consume_plain_before_if_pending(
+        self, frontier: _MacroFrontier
+    ) -> Tuple[_MacroFrontier, ...]:
+        frame = frontier.stack[-1]
+        if not frame.plain_before_pending:
+            return (frontier,)
+        branches = (frontier,)
+        for on_during_before in frame.state.list_on_durings(aspect="before"):
+            branches = self._flat_map(
+                branches,
+                lambda item, func=on_during_before: self._execute_func(item, func),
+            )
+        return tuple(
+            self._replace_top(
+                current,
+                _FormalStackFrame(frame.state, frame.mode, plain_before_pending=False),
+            )
+            for current in branches
+        )
+
+    def _clear_parent_plain_before_pending_after_pseudo_exit(
+        self,
+        frontier: _MacroFrontier,
+        current_state: State,
+    ) -> _MacroFrontier:
+        if (
+            frontier.stack
+            and frontier.stack[-1].state is current_state.parent
+            and frontier.stack[-1].plain_before_pending
+        ):
+            parent = frontier.stack[-1]
+            return self._replace_top(
+                frontier, _FormalStackFrame(parent.state, parent.mode, False)
+            )
+        return frontier
+
+    def _execute_func(
+        self, frontier: _MacroFrontier, func: object
+    ) -> Tuple[_MacroFrontier, ...]:
+        if isinstance(func, (OnStage, OnAspect)) and func.is_ref:
+            if func.ref is None:
+                raise BmcBuildError("action reference is missing a target.")
+            return self._execute_func(frontier, func.ref)
+        if not isinstance(func, (OnStage, OnAspect)):
+            raise BmcBuildError("unsupported lifecycle action type.")
+        if func.is_abstract:
+            return (frontier,)
+        return self._execute_operation_block(frontier, func.operations)
+
+    def _execute_operation_block(
+        self,
+        frontier: _MacroFrontier,
+        operations: Sequence[OperationStatement],
+    ) -> Tuple[_MacroFrontier, ...]:
+        if not operations:
+            return (frontier,)
+        branches = (_Branch(frontier.condition, frontier.store),)
+        for statement in operations:
+            next_branches = []
+            for branch in branches:
+                next_branches.extend(self._execute_statement(branch, statement))
+            branches = tuple(next_branches)
+        persistent_names = tuple(entry.name for entry in self.domain.variables)
+        return tuple(
+            self._replace_frontier(
+                frontier,
+                condition=branch.condition,
+                store=_Store(
+                    {name: branch.store.values[name] for name in persistent_names}
+                ),
+            )
+            for branch in branches
+        )
+
+    def _execute_statement(
+        self, branch: _Branch, statement: OperationStatement
+    ) -> Tuple[_Branch, ...]:
+        if isinstance(statement, Operation):
+            scope = dict(branch.store.values)
+            value = self._value_from_expr(statement.expr, scope)
+            scope[statement.var_name] = value
+            return (_Branch(branch.condition, _Store(scope)),)
+        if isinstance(statement, IfBlock):
+            result = []
+            previous = []
+            has_else = False
+            for block_index, block_branch in enumerate(statement.branches):
+                if block_branch.condition is None:
+                    selector = BoolTemplate.true()
+                    has_else = True
+                else:
+                    selector = self._condition_from_expr(
+                        block_branch.condition, branch.store
+                    )
+                active = BoolTemplate.and_(
+                    branch.condition,
+                    *[BoolTemplate.not_(item) for item in previous],
+                    selector,
+                )
+                visible = tuple(branch.store.values)
+                nested = (_Branch(active, branch.store),)
+                for nested_statement in block_branch.statements:
+                    nested = tuple(
+                        item
+                        for nested_branch in nested
+                        for item in self._execute_statement(
+                            nested_branch, nested_statement
+                        )
+                    )
+                for nested_branch in nested:
+                    writeback = {
+                        name: nested_branch.store.values[name] for name in visible
+                    }
+                    result.append(_Branch(nested_branch.condition, _Store(writeback)))
+                previous.append(selector)
+                if (
+                    block_branch.condition is None
+                    and block_index == len(statement.branches) - 1
+                ):
+                    break
+            if not has_else:
+                result.append(
+                    _Branch(
+                        BoolTemplate.and_(
+                            branch.condition,
+                            *[BoolTemplate.not_(item) for item in previous],
+                        ),
+                        branch.store,
+                    )
+                )
+            return tuple(result)
+        raise BmcBuildError(
+            "unsupported operation statement type: %r." % (type(statement),)
+        )
+
+    def _value_from_expr(
+        self, expr: Expr, scope: Mapping[str, _ValueTemplate]
+    ) -> _ValueTemplate:
+        if isinstance(expr, Integer):
+            return _ValueTemplate.const_value(expr.value)
+        if isinstance(expr, Float):
+            return _ValueTemplate.const_value(expr.value)
+        if isinstance(expr, Variable):
+            if expr.name not in scope:
+                raise BmcBuildError("unknown symbolic variable %r." % expr.name)
+            return scope[expr.name]
+        if isinstance(expr, UnaryOp):
+            return self._value_from_expr(expr.x, scope).unary(expr.op)
+        if isinstance(expr, BinaryOp):
+            left = self._value_from_expr(expr.x, scope)
+            right = self._value_from_expr(expr.y, scope)
+            return left.binary(expr.op, right)
+        if isinstance(expr, UFunc):
+            value = self._value_from_expr(expr.x, scope)
+            return _ValueTemplate("%s(%s)" % (expr.func, value.text))
+        if isinstance(expr, ConditionalOp):
+            condition = self._condition_from_expr(expr.cond, _Store(scope))
+            if_true = self._value_from_expr(expr.if_true, scope)
+            if_false = self._value_from_expr(expr.if_false, scope)
+            return _ValueTemplate(
+                "if(%s, %s, %s)"
+                % (_condition_text(condition), if_true.text, if_false.text)
+            )
+        if isinstance(expr, Boolean):
+            return _ValueTemplate("true" if expr.value else "false")
+        raise BmcBuildError("unsupported expression type: %r." % (type(expr),))
+
+    def _condition_from_expr(self, expr: Expr, store: _Store) -> BoolTemplate:
+        if isinstance(expr, Boolean):
+            return BoolTemplate.true() if expr.value else BoolTemplate.false()
+        if isinstance(expr, UnaryOp) and expr.op == "!":
+            return BoolTemplate.not_(self._condition_from_expr(expr.x, store))
+        if isinstance(expr, BinaryOp) and expr.op in ("&&", "and"):
+            return BoolTemplate.and_(
+                self._condition_from_expr(expr.x, store),
+                self._condition_from_expr(expr.y, store),
+            )
+        if isinstance(expr, BinaryOp) and expr.op in ("||", "or"):
+            return BoolTemplate.or_(
+                self._condition_from_expr(expr.x, store),
+                self._condition_from_expr(expr.y, store),
+            )
+        if isinstance(expr, BinaryOp) and expr.op == "xor":
+            left = self._condition_from_expr(expr.x, store)
+            right = self._condition_from_expr(expr.y, store)
+            return BoolTemplate.or_(
+                BoolTemplate.and_(left, BoolTemplate.not_(right)),
+                BoolTemplate.and_(BoolTemplate.not_(left), right),
+            )
+        if isinstance(expr, BinaryOp) and expr.op == "=>":
+            return BoolTemplate.or_(
+                BoolTemplate.not_(self._condition_from_expr(expr.x, store)),
+                self._condition_from_expr(expr.y, store),
+            )
+        if isinstance(expr, BinaryOp) and expr.op == "iff":
+            left = self._condition_from_expr(expr.x, store)
+            right = self._condition_from_expr(expr.y, store)
+            return BoolTemplate.or_(
+                BoolTemplate.and_(left, right),
+                BoolTemplate.and_(BoolTemplate.not_(left), BoolTemplate.not_(right)),
+            )
+        if (
+            isinstance(expr, BinaryOp)
+            and expr.op in ("==", "!=")
+            and (_is_condition_expr(expr.x) or _is_condition_expr(expr.y))
+        ):
+            left = self._condition_from_expr(expr.x, store)
+            right = self._condition_from_expr(expr.y, store)
+            equal = BoolTemplate.or_(
+                BoolTemplate.and_(left, right),
+                BoolTemplate.and_(BoolTemplate.not_(left), BoolTemplate.not_(right)),
+            )
+            return BoolTemplate.not_(equal) if expr.op == "!=" else equal
+        if isinstance(expr, BinaryOp) and expr.op in ("<", "<=", ">", ">=", "==", "!="):
+            left = self._value_from_expr(expr.x, store.values)
+            right = self._value_from_expr(expr.y, store.values)
+            return _comparison_condition(left, expr.op, right)
+        if isinstance(expr, ConditionalOp):
+            selector = self._condition_from_expr(expr.cond, store)
+            if_true = self._condition_from_expr(expr.if_true, store)
+            if_false = self._condition_from_expr(expr.if_false, store)
+            return BoolTemplate.or_(
+                BoolTemplate.and_(selector, if_true),
+                BoolTemplate.and_(BoolTemplate.not_(selector), if_false),
+            )
+        value = self._value_from_expr(expr, store.values)
+        return BoolTemplate.atom("%s%s" % (_GUARD_ATOM_PREFIX, value.text))
+
+    def _stable_outcome(self, frontier: _MacroFrontier, state: State) -> _MacroOutcome:
+        path = ".".join(state.path)
+        return _MacroOutcome(
+            self.state_ids[path],
+            path,
+            frontier.condition,
+            frontier.store,
+            frontier.used_events,
+            frontier.case_kind,
+        )
+
+    def _terminate_outcome(self, frontier: _MacroFrontier) -> _MacroOutcome:
+        return _MacroOutcome(
+            STATE_TERMINATE_ID,
+            TERMINATE_CASE_PATH,
+            frontier.condition,
+            frontier.store,
+            frontier.used_events,
+            frontier.case_kind,
+        )
+
+    def _cases_from_outcomes(
+        self, outcomes: Sequence[_MacroOutcome]
+    ) -> Tuple[CycleCase, ...]:
+        counters: Dict[str, int] = {}
+        cases = []
+        for outcome in outcomes:
+            ordinal = counters.get(outcome.case_kind, 0)
+            counters[outcome.case_kind] = ordinal + 1
+            cases.append(
+                CycleCase(
+                    outcome.case_kind,
+                    self.source.source_state_id,
+                    self.source.source_state_path,
+                    outcome.target_state_id,
+                    outcome.target_state_path,
+                    "%s::%s::%s::%d"
+                    % (
+                        self.source.source_state_path,
+                        outcome.case_kind,
+                        outcome.target_state_path,
+                        ordinal,
+                    ),
+                    outcome.condition,
+                    self._var_updates(outcome.store),
+                    used_events=outcome.used_events,
+                    failed_conditions=outcome.failed_conditions,
+                    domain=self.domain,
+                )
+            )
+        return tuple(cases)
+
+    def _var_updates(self, store: _Store) -> Tuple[VarUpdate, ...]:
+        updates = []
+        for entry in self.domain.variables:
+            value = store.values[entry.name]
+            carry_text = "%s%s" % (_PRE_VAR_PREFIX, entry.name)
+            updates.append(
+                VarUpdate(
+                    entry.id,
+                    entry.name,
+                    value.text,
+                    is_carry=value.text == carry_text,
+                )
+            )
+        return tuple(updates)
+
+    def _frontier_signature(self, frontier: _MacroFrontier) -> Tuple[object, ...]:
+        return (
+            tuple(
+                (frame.state.path, frame.mode, frame.plain_before_pending)
+                for frame in frontier.stack
+            ),
+            tuple(
+                sorted(
+                    (name, value.text) for name, value in frontier.store.values.items()
+                )
+            ),
+            _condition_text(frontier.condition),
+            tuple(
+                item.to_canonical()["path"] + ":" + item.to_canonical()["polarity"]
+                for item in frontier.used_events
+            ),
+            frontier.case_kind,
+        )
+
+    def _replace_frontier(
+        self, frontier: _MacroFrontier, **updates: object
+    ) -> _MacroFrontier:
+        values = {
+            "stack": frontier.stack,
+            "store": frontier.store,
+            "condition": frontier.condition,
+            "used_events": frontier.used_events,
+            "case_kind": frontier.case_kind,
+            "path_signatures": frontier.path_signatures,
+            "depth": frontier.depth,
+        }
+        values.update(updates)
+        return _MacroFrontier(**values)
+
+    def _replace_top(
+        self, frontier: _MacroFrontier, frame: _FormalStackFrame
+    ) -> _MacroFrontier:
+        return self._replace_frontier(frontier, stack=frontier.stack[:-1] + (frame,))
+
+    @staticmethod
+    def _flat_map(
+        frontiers: Iterable[_MacroFrontier], func
+    ) -> Tuple[_MacroFrontier, ...]:
+        return tuple(item for frontier in frontiers for item in func(frontier))
+
+
+def _comparison_condition(
+    left: _ValueTemplate, op: str, right: _ValueTemplate
+) -> BoolTemplate:
+    if left.linear is not None and right.linear is not None:
+        diff = left.linear.add(right.linear.mul_const(-1))
+        normalized = _single_var_threshold(diff, op)
+        if normalized is not None:
+            atom_text, negated = normalized
+            atom = BoolTemplate.atom("%s%s" % (_GUARD_ATOM_PREFIX, atom_text))
+            return BoolTemplate.not_(atom) if negated else atom
+    return BoolTemplate.atom(
+        "%s%s %s %s" % (_GUARD_ATOM_PREFIX, left.text, op, right.text)
+    )
+
+
+def _single_var_threshold(diff: _LinearExpr, op: str) -> Optional[Tuple[str, bool]]:
+    if len(diff.coeffs) != 1:
+        return None
+    ((name, coeff),) = diff.coeffs.items()
+    if coeff == 0:
+        return None
+    threshold = -diff.const / coeff
+    if coeff < 0:
+        reverse = {"<": ">", "<=": ">=", ">": "<", ">=": "<=", "==": "==", "!=": "!="}
+        op = reverse[op]
+    value = _format_number(threshold)
+    if op == "<":
+        return "%s < %s" % (name, value), False
+    if op == ">=":
+        return "%s < %s" % (name, value), True
+    if op == "<=":
+        return "%s <= %s" % (name, value), False
+    if op == ">":
+        return "%s <= %s" % (name, value), True
+    if op == "==":
+        return "%s == %s" % (name, value), False
+    if op == "!=":
+        return "%s == %s" % (name, value), True
+    return None
+
+
+def _condition_text(condition: BoolTemplate) -> str:
+    return repr(condition.to_canonical())
+
+
+def _is_condition_expr(expr: Expr) -> bool:
+    if isinstance(expr, Boolean):
+        return True
+    if isinstance(expr, UnaryOp) and expr.op in ("!", "not"):
+        return True
+    if isinstance(expr, BinaryOp) and expr.op in (
+        "&&",
+        "and",
+        "||",
+        "or",
+        "xor",
+        "=>",
+        "implies",
+        "iff",
+    ):
+        return True
+    if isinstance(expr, BinaryOp) and expr.op in ("<", "<=", ">", ">="):
+        return True
+    if isinstance(expr, BinaryOp) and expr.op in ("==", "!="):
+        return _is_condition_expr(expr.x) or _is_condition_expr(expr.y)
+    if isinstance(expr, ConditionalOp):
+        return _is_condition_expr(expr.if_true) or _is_condition_expr(expr.if_false)
+    return False
+
+
+def _event_atom(path: str) -> str:
+    return "%s%s" % (_EVENT_ATOM_PREFIX, path)
+
+
+def _event_uses_from_condition(
+    condition: BoolTemplate,
+    domain: BmcDomain,
+    polarity: str = "positive",
+    reason: str = "trigger",
+) -> Tuple[EventUse, ...]:
+    entries = {entry.path: entry for entry in domain.events}
+    result = []
+    for variable in condition.variables:
+        if not variable.startswith(_EVENT_ATOM_PREFIX):
+            continue
+        path = variable[len(_EVENT_ATOM_PREFIX) :]
+        entry = entries.get(path)
+        if entry is not None:
+            result.append(EventUse(entry.id, entry.path, polarity, reason))
+    return tuple(result)
+
+
+def _merge_event_uses(*groups: Sequence[EventUse]) -> Tuple[EventUse, ...]:
+    by_key = {}
+    for group in groups:
+        for item in group:
+            by_key[(item.event_id, item.path, item.polarity, item.reason)] = item
+    return tuple(
+        sorted(
+            by_key.values(),
+            key=lambda item: (item.event_id, item.polarity, item.reason),
+        )
+    )
+
+
+def _path_to_root(state: State) -> Tuple[State, ...]:
+    path = []
+    current = state
+    while current is not None:
+        path.insert(0, current)
+        current = current.parent
+    return tuple(path)
+
+
+def expand_macro_step_cases(
+    source: MacroStepSource,
+    options: Optional[MacroExpansionOptions] = None,
+) -> MacroStepFormal:
+    """Expand one macro-step source into source-local cycle cases.
+
+    :param source: Domain-backed macro-step source profile.
+    :type source: MacroStepSource
+    :param options: Optional expansion options, defaults to ``None``.
+    :type options: MacroExpansionOptions, optional
+    :return: Source-local macro-step formal buckets.
+    :rtype: pyfcstm.bmc.macro.MacroStepFormal
+    :raises InvalidBmcEncoding: If ``source`` is not a supported domain-backed
+        source or its domain lacks a model snapshot.
+    :raises BmcBuildError: If expansion cannot prove a local partition or hits
+        runtime-aligned safety limits.
+
+    Example::
+
+        >>> from pyfcstm.bmc import build_bmc_domain, stable_leaf_source
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> model = load_state_machine_from_text('state Root;')
+        >>> domain = build_bmc_domain(model, 1)
+        >>> expand_macro_step_cases(stable_leaf_source(domain, 'Root')).source.kind
+        'stable_leaf'
+    """
+    if not isinstance(source, MacroStepSource):
+        raise InvalidBmcEncoding("source must be MacroStepSource.")
+    if options is None:
+        options = MacroExpansionOptions()
+    if not isinstance(options, MacroExpansionOptions):
+        raise InvalidBmcEncoding("options must be MacroExpansionOptions.")
+    return _Expander(source, options).expand()
+
+
+__all__ = ["MacroExpansionOptions", "expand_macro_step_cases"]

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -2180,6 +2180,13 @@ def verify_source_partition(
     success = tuple(success_cases)
     delta = tuple(delta_cases)
     diagnostics = tuple(build_diagnostic_conditions)
+    if source.kind in {"terminated", "diagnostic"}:
+        if delta:
+            raise InvalidBmcEncoding("sentinel absorb formal cannot have delta cases.")
+        if diagnostics:
+            raise InvalidBmcEncoding(
+                "sentinel absorb formal cannot have build diagnostics."
+            )
     if delta and not source.allows_semantic_delta:
         raise InvalidBmcEncoding("delta cases require an entry source.")
     for case in success + delta:

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -1,36 +1,38 @@
 """Macro-step case contracts for FCSTM bounded model checking.
 
-The macro contract layer defines the data objects exchanged between future
-macro-step expansion and solver-relation lowering.  It does not traverse a
-runtime state machine, build Z3 transition relations, or append partition
-repair constraints to user formulas.  Instead, it makes the shape of each case
-explicit: source and target ids, stable labels, event uses, a bare case
-condition ``gamma``, and an explicit writeback recipe for every persistent
-variable.
+The macro contract layer defines the solver-independent data objects exchanged
+between runtime-aligned macro-step expansion and later relation lowering.  It
+records **which flat control path** a macro-step can take: source/target state
+ids, event/guard control atoms, priority exclusions expressed through accepted
+case labels, and the ordered model action blocks that would execute on that
+path.  It deliberately does not lower operations into variable writeback
+expressions, split action-local ``if`` blocks, or construct Z3 implications.
 
 Design contracts:
 
-* :class:`CycleCase.condition` is the bare case condition.  It never includes
-  the pre-state source guard; later relation builders form ``source_guard and
-  gamma`` before emitting ``A => R``.
-* :class:`VarUpdate` entries are explicit and complete.  Carry-over variables
-  are represented as writeback entries rather than left unconstrained.
-* Fallback and semantic-delta helpers subtract only their source-appropriate
-  ordinary accepted success-case conditions: stable fallback accepts transition
-  cases only, while entry semantic delta accepts transition or initial cases.
-  Build-diagnostic conditions are excluded only where the issue design requires
-  them.  Failed candidate metadata is kept for diagnostics and never removes
-  uncovered regions.
-* Partition verification is a build-time/test-time self-check.  It returns a
-  diagnostic summary or raises :class:`pyfcstm.bmc.errors.BmcBuildError`; it
-  never produces clauses for ``Core_N`` or ``Phi_N``.
+* :class:`CycleCase.condition` contains only control-path atoms.  Valid atom
+  prefixes are ``event:``, ``guard:``, and ``accepted:``; action-local control
+  flow and variable writeback constraints belong to later lowering.
+* :class:`GuardRequirement` stores the raw model guard plus the action-block
+  anchor at which that guard is checked.  Later lowering interleaves action
+  lowering and guard lowering instead of substituting guards in this layer.
+* :class:`ActionBlock` preserves runtime action block boundaries and operation
+  statement objects.  A block may contain an :class:`pyfcstm.model.IfBlock`, but
+  that nested branch is not part of the case condition.
+* :class:`PriorityExclusion` records declaration-order masks through
+  ``accepted:<case_label>`` atoms.  The accepted atom denotes the already lowered
+  antecedent of a prior accepted path, not a raw event or guard trigger.
+* Partition verification is a build-time/test-time self-check.  It resolves
+  accepted atoms through the source-local case registry before running the small
+  truth-table checker and never produces clauses for ``Core_N`` or ``Phi_N``.
 
 The module contains:
 
-* :class:`BoolTemplate` - Small solver-independent boolean recipe for contract
-  tests and partition self-checks.
-* :class:`EventUse` and :class:`VarUpdate` - Event-use and writeback metadata.
-* :class:`CycleCase` - One macro-step relation case.
+* :class:`BoolTemplate` - A small boolean recipe used by contract tests and
+  partition self-checks.
+* :class:`EventUse`, :class:`GuardRequirement`, :class:`ActionBlock`, and
+  :class:`PriorityExclusion` - Metadata for the flat macro-step path plan.
+* :class:`CycleCase` - One macro-step relation case before solver lowering.
 * :class:`MacroStepFormal` - Source-local buckets of success, delta, and build
   diagnostic conditions.
 * Helper constructors for absorb, fallback, semantic-delta, and partition
@@ -51,7 +53,7 @@ from __future__ import annotations
 import itertools
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Mapping, Optional, Sequence, Set, Tuple
 
 from pyfcstm.bmc.domain import STATE_DIAGNOSTIC_ID, STATE_TERMINATE_ID, BmcDomain
 from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcDomain, InvalidBmcEncoding
@@ -60,6 +62,7 @@ from pyfcstm.bmc.source import (
     TERMINATE_CASE_PATH,
     MacroStepSource,
 )
+from pyfcstm.model import Expr, IfBlock, Operation, OperationStatement
 
 _CanonicalDict = Dict[str, Any]
 _BOOL_KINDS = {"true", "false", "atom", "not", "and", "or"}
@@ -67,8 +70,19 @@ _CASE_KINDS = {"transition", "fallback", "initial", "absorb", "diagnostic", "del
 _ACCEPTED_CASE_KINDS = {"transition", "initial"}
 _EVENT_POLARITIES = {"positive", "negative"}
 _EVENT_REASONS = {"trigger", "priority", "fallback", "descent", "assumption"}
+_GUARD_POLARITIES = {"positive", "negative"}
+_GUARD_REASONS = {"transition_guard", "initial_guard", "priority", "fallback"}
+_PRIORITY_REASONS = {"transition_priority", "initial_priority", "fallback", "delta"}
 _RESERVED_CASE_PATHS = {TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH}
 _SOURCE_STATE_ATOM_PREFIX = "__source_state__:"
+_EVENT_ATOM_PREFIX = "event:"
+_GUARD_ATOM_PREFIX = "guard:"
+_ACCEPTED_ATOM_PREFIX = "accepted:"
+_VALID_CONDITION_PREFIXES = (
+    _EVENT_ATOM_PREFIX,
+    _GUARD_ATOM_PREFIX,
+    _ACCEPTED_ATOM_PREFIX,
+)
 
 
 def _require_non_empty_string(value: object, field_name: str) -> str:
@@ -83,7 +97,7 @@ def _validate_index(value: object, field_name: str) -> int:
     return value
 
 
-def _validate_choice(value: object, choices: set, field_name: str) -> str:
+def _validate_choice(value: object, choices: Set[str], field_name: str) -> str:
     if not isinstance(value, str) or value not in choices:
         raise InvalidBmcEncoding("Unsupported %s: %r." % (field_name, value))
     return value
@@ -101,9 +115,10 @@ def _canonical_key(item: Any) -> str:
 class BoolTemplate:
     """Solver-independent boolean condition recipe.
 
-    ``BoolTemplate`` is intentionally small.  It is sufficient for macro contract
-    tests and partition proofs, while later solver lowering can map
-    richer case recipes into Z3 without changing the surrounding case contract.
+    ``BoolTemplate`` intentionally supports only constants, atoms, ``not``,
+    ``and``, and ``or``.  That is enough for macro contract checks while later
+    solver lowering can map the recorded event, guard, and accepted atoms into
+    Z3 formulas.
 
     :param kind: ``"true"``, ``"false"``, ``"atom"``, ``"not"``,
         ``"and"``, or ``"or"``.
@@ -116,8 +131,8 @@ class BoolTemplate:
 
     Example::
 
-        >>> gamma = BoolTemplate.atom('gamma')
-        >>> BoolTemplate.not_(gamma).evaluate({'gamma': False})
+        >>> gamma = BoolTemplate.atom('event:Root.Go')
+        >>> BoolTemplate.not_(gamma).evaluate({'event:Root.Go': False})
         True
     """
 
@@ -196,8 +211,8 @@ class BoolTemplate:
 
         Example::
 
-            >>> BoolTemplate.atom('go').variables
-            ('go',)
+            >>> BoolTemplate.atom('guard:g0').variables
+            ('guard:g0',)
         """
         return cls("atom", name=name)
 
@@ -207,16 +222,13 @@ class BoolTemplate:
 
         :param operand: Operand condition.
         :type operand: BoolTemplate
-        :return: Negated condition with constant and double-negation identities
-            reduced.
+        :return: Negated condition with simple identities reduced.
         :rtype: BoolTemplate
 
         Example::
 
             >>> BoolTemplate.not_(BoolTemplate.false()).evaluate({})
             True
-            >>> BoolTemplate.not_(BoolTemplate.not_(BoolTemplate.atom('go'))).to_canonical()['name']
-            'go'
         """
         if not isinstance(operand, BoolTemplate):
             raise InvalidBmcEncoding("operand must be BoolTemplate.")
@@ -234,16 +246,13 @@ class BoolTemplate:
 
         :param operands: Operand conditions.
         :type operands: BoolTemplate
-        :return: Conjunction with identity, absorbing, and idempotent operands
-            reduced, or constant true for an empty input.
+        :return: Reduced conjunction, or constant true for an empty input.
         :rtype: BoolTemplate
 
         Example::
 
             >>> BoolTemplate.and_().evaluate({})
             True
-            >>> BoolTemplate.and_(BoolTemplate.true(), BoolTemplate.atom('go')).to_canonical()['name']
-            'go'
         """
         if not operands:
             return cls.true()
@@ -275,16 +284,13 @@ class BoolTemplate:
 
         :param operands: Operand conditions.
         :type operands: BoolTemplate
-        :return: Disjunction with identity, absorbing, and idempotent operands
-            reduced, or constant false for an empty input.
+        :return: Reduced disjunction, or constant false for an empty input.
         :rtype: BoolTemplate
 
         Example::
 
             >>> BoolTemplate.or_().evaluate({})
             False
-            >>> BoolTemplate.or_(BoolTemplate.false(), BoolTemplate.atom('go')).to_canonical()['name']
-            'go'
         """
         if not operands:
             return cls.false()
@@ -378,10 +384,10 @@ class BoolTemplate:
 
         Example::
 
-            >>> BoolTemplate.atom('gamma').to_canonical()['name']
-            'gamma'
+            >>> BoolTemplate.atom('guard:g0').to_canonical()['name']
+            'guard:g0'
         """
-        result: _CanonicalDict = {"node": "bool_template", "kind": self.kind}
+        result = {"node": "bool_template", "kind": self.kind}
         if self.kind == "atom":
             result["name"] = self._atom_name()
         if self.operands:
@@ -419,9 +425,7 @@ class EventUse:
             raise InvalidBmcEncoding("event_id must be non-negative.")
         object.__setattr__(self, "event_id", event_id)
         object.__setattr__(
-            self,
-            "path",
-            _require_non_empty_string(self.path, "event path"),
+            self, "path", _require_non_empty_string(self.path, "event path")
         )
         object.__setattr__(
             self,
@@ -455,199 +459,339 @@ class EventUse:
 
 
 @dataclass(frozen=True)
-class VarUpdate:
-    """Persistent-variable writeback recipe for one macro-step case.
+class GuardRequirement:
+    """Raw transition guard requirement anchored to an action-block prefix.
 
-    :param variable_id: Domain variable id.
-    :type variable_id: int
-    :param variable_name: Persistent variable name.
-    :type variable_name: str
-    :param expression: Stable expression digest or recipe key used by later
-        lowering.
-    :type expression: str
-    :param is_carry: Whether this update is explicit carry-over, defaults to
-        ``False``.
-    :type is_carry: bool, optional
+    :param requirement_id: Stable per-formal guard requirement id.
+    :type requirement_id: str
+    :param owner_state_id: Domain id of the state whose chooser owns the guard.
+    :type owner_state_id: int
+    :param owner_state_path: Dot-separated owner state path.
+    :type owner_state_path: str
+    :param transition_label: Human-readable transition label.
+    :type transition_label: str
+    :param expr: Raw model expression evaluated by the runtime guard check.
+    :type expr: pyfcstm.model.Expr
+    :param polarity: Guard polarity, normally ``"positive"``.
+    :type polarity: str
+    :param reason: Guard-use reason such as ``"transition_guard"``.
+    :type reason: str
+    :param after_action_block_index: Number of action blocks that have executed
+        before the guard is checked.
+    :type after_action_block_index: int
 
     Example::
 
-        >>> VarUpdate(0, 'x', 'pre:x', is_carry=True).is_carry
-        True
+        >>> from pyfcstm.model.expr import Boolean
+        >>> GuardRequirement('g0', 0, 'Root', 'Root -> A', Boolean(True), 'positive', 'transition_guard', 0).atom_name
+        'guard:g0'
     """
 
-    variable_id: int
-    variable_name: str
-    expression: str
-    is_carry: bool = False
+    requirement_id: str
+    owner_state_id: int
+    owner_state_path: str
+    transition_label: str
+    expr: Expr
+    polarity: str
+    reason: str
+    after_action_block_index: int
 
     def __post_init__(self) -> None:
+        owner_state_id = _validate_index(self.owner_state_id, "owner_state_id")
+        if owner_state_id < 0:
+            raise InvalidBmcEncoding("owner_state_id must be non-negative.")
+        if not isinstance(self.expr, Expr):
+            raise InvalidBmcEncoding("guard requirement expr must be Expr.")
+        anchor = _validate_index(
+            self.after_action_block_index, "after_action_block_index"
+        )
+        if anchor < 0:
+            raise InvalidBmcEncoding("after_action_block_index must be non-negative.")
         object.__setattr__(
             self,
-            "variable_id",
-            _validate_index(self.variable_id, "variable_id"),
+            "requirement_id",
+            _require_non_empty_string(self.requirement_id, "requirement_id"),
         )
-        if self.variable_id < 0:
-            raise InvalidBmcEncoding("variable_id must be non-negative.")
+        object.__setattr__(self, "owner_state_id", owner_state_id)
         object.__setattr__(
             self,
-            "variable_name",
-            _require_non_empty_string(self.variable_name, "variable_name"),
+            "owner_state_path",
+            _require_non_empty_string(self.owner_state_path, "owner_state_path"),
         )
         object.__setattr__(
             self,
-            "expression",
-            _require_non_empty_string(self.expression, "expression"),
+            "transition_label",
+            _require_non_empty_string(self.transition_label, "transition_label"),
         )
-        if not isinstance(self.is_carry, bool):
-            raise InvalidBmcEncoding("is_carry must be a boolean.")
+        object.__setattr__(
+            self,
+            "polarity",
+            _validate_choice(self.polarity, _GUARD_POLARITIES, "guard polarity"),
+        )
+        object.__setattr__(
+            self,
+            "reason",
+            _validate_choice(self.reason, _GUARD_REASONS, "guard reason"),
+        )
+        object.__setattr__(self, "after_action_block_index", anchor)
+
+    @property
+    def atom_name(self) -> str:
+        """Return the boolean atom name for this guard.
+
+        :return: Atom name in the ``guard:<id>`` namespace.
+        :rtype: str
+
+        Example::
+
+            >>> from pyfcstm.model.expr import Boolean
+            >>> GuardRequirement('g0', 0, 'Root', 't', Boolean(True), 'positive', 'transition_guard', 0).atom_name
+            'guard:g0'
+        """
+        return "%s%s" % (_GUARD_ATOM_PREFIX, self.requirement_id)
 
     def to_canonical(self) -> _CanonicalDict:
-        """Return a JSON-stable variable update dictionary.
+        """Return a JSON-stable guard requirement dictionary.
 
-        :return: Canonical variable update.
+        :return: Canonical guard requirement metadata.
         :rtype: Dict[str, object]
 
         Example::
 
-            >>> VarUpdate(0, 'x', 'pre:x').to_canonical()['variable_name']
-            'x'
+            >>> from pyfcstm.model.expr import Boolean
+            >>> GuardRequirement('g0', 0, 'Root', 't', Boolean(True), 'positive', 'transition_guard', 0).to_canonical()['atom']
+            'guard:g0'
         """
         return {
-            "node": "var_update",
-            "variable_id": self.variable_id,
-            "variable_name": self.variable_name,
-            "expression": self.expression,
-            "is_carry": self.is_carry,
+            "node": "guard_requirement",
+            "requirement_id": self.requirement_id,
+            "atom": self.atom_name,
+            "owner_state_id": self.owner_state_id,
+            "owner_state_path": self.owner_state_path,
+            "transition_label": self.transition_label,
+            "expr": _expr_to_text(self.expr),
+            "polarity": self.polarity,
+            "reason": self.reason,
+            "after_action_block_index": self.after_action_block_index,
         }
 
 
-def carry_var_updates(domain: BmcDomain) -> Tuple[VarUpdate, ...]:
-    """Return explicit carry-over updates for every persistent variable.
+@dataclass(frozen=True)
+class PriorityExclusion:
+    """Priority mask that excludes previously accepted control paths.
 
-    :param domain: Domain snapshot whose variables should be carried.
-    :type domain: BmcDomain
-    :return: Complete carry-over update tuple sorted by variable id.
-    :rtype: Tuple[VarUpdate, ...]
-    :raises InvalidBmcEncoding: If ``domain`` is not a BMC domain.
-
-    Example::
-
-        >>> from pyfcstm.bmc.domain import build_bmc_domain
-        >>> from pyfcstm.model import load_state_machine_from_text
-        >>> domain = build_bmc_domain(load_state_machine_from_text('def int x = 0; state Root;'), 1)
-        >>> carry_var_updates(domain)[0].expression
-        'pre:x'
-    """
-    if not isinstance(domain, BmcDomain):
-        raise InvalidBmcEncoding("domain must be BmcDomain.")
-    return tuple(
-        VarUpdate(entry.id, entry.name, "pre:%s" % entry.name, is_carry=True)
-        for entry in domain.variables
-    )
-
-
-def var_update_for(
-    domain: BmcDomain,
-    variable: object,
-    expression: str,
-    is_carry: bool = False,
-) -> VarUpdate:
-    """Build one variable update from a domain variable id or name.
-
-    :param domain: Domain snapshot that owns the variable.
-    :type domain: BmcDomain
-    :param variable: Variable id or name.
-    :type variable: int or str
-    :param expression: Stable expression digest or recipe key.
-    :type expression: str
-    :param is_carry: Whether this update is carry-over, defaults to ``False``.
-    :type is_carry: bool, optional
-    :return: Variable update entry.
-    :rtype: VarUpdate
-    :raises InvalidBmcEncoding: If ``variable`` cannot be resolved.
+    :param decision_id: Stable id for the chooser decision point.
+    :type decision_id: str
+    :param reason: Exclusion reason such as ``"transition_priority"``.
+    :type reason: str
+    :param excluded_case_labels: Case labels excluded by this mask.
+    :type excluded_case_labels: Tuple[str, ...]
+    :param excluded_condition: Boolean template over ``accepted:`` atoms.
+    :type excluded_condition: BoolTemplate
+    :param event_paths: Event paths read by excluded cases, defaults to ``()``.
+    :type event_paths: Tuple[str, ...], optional
+    :param guard_requirement_ids: Guard ids read by excluded cases, defaults to
+        ``()``.
+    :type guard_requirement_ids: Tuple[str, ...], optional
 
     Example::
 
-        >>> from pyfcstm.bmc.domain import build_bmc_domain
-        >>> from pyfcstm.model import load_state_machine_from_text
-        >>> domain = build_bmc_domain(load_state_machine_from_text('def int x = 0; state Root;'), 1)
-        >>> var_update_for(domain, 'x', 'x+1').variable_id
-        0
+        >>> mask = PriorityExclusion('d0', 'transition_priority', ('c0',), BoolTemplate.atom('accepted:c0'))
+        >>> mask.excluded_case_labels
+        ('c0',)
     """
-    if not isinstance(domain, BmcDomain):
-        raise InvalidBmcEncoding("domain must be BmcDomain.")
-    try:
-        if isinstance(variable, str):
-            entry = domain.variable_by_name(variable)
-        elif isinstance(variable, bool) or not isinstance(variable, int):
-            raise InvalidBmcEncoding("variable must be a variable id or name.")
-        else:
-            entry = domain.variable_by_id(variable)
-    except InvalidBmcDomain as err:
-        # InvalidBmcDomain: BmcDomain lookup rejects unknown variable ids or
-        # names supplied by this writeback recipe constructor.
-        raise InvalidBmcEncoding(str(err)) from err
-    return VarUpdate(entry.id, entry.name, expression, is_carry=is_carry)
 
+    decision_id: str
+    reason: str
+    excluded_case_labels: Tuple[str, ...]
+    excluded_condition: BoolTemplate
+    event_paths: Tuple[str, ...] = ()
+    guard_requirement_ids: Tuple[str, ...] = ()
 
-def build_var_updates(
-    domain: BmcDomain,
-    updates: Sequence[VarUpdate],
-) -> Tuple[VarUpdate, ...]:
-    """Validate and normalize a complete writeback tuple.
-
-    :param domain: Domain snapshot whose persistent variables must be covered.
-    :type domain: BmcDomain
-    :param updates: Candidate variable updates.
-    :type updates: Sequence[VarUpdate]
-    :return: Updates sorted by variable id.
-    :rtype: Tuple[VarUpdate, ...]
-    :raises InvalidBmcEncoding: If an update is missing, duplicated, or
-        references an unknown variable.
-
-    Example::
-
-        >>> from pyfcstm.bmc.domain import build_bmc_domain
-        >>> from pyfcstm.model import load_state_machine_from_text
-        >>> domain = build_bmc_domain(load_state_machine_from_text('def int x = 0; state Root;'), 1)
-        >>> build_var_updates(domain, carry_var_updates(domain))[0].variable_name
-        'x'
-    """
-    if not isinstance(domain, BmcDomain):
-        raise InvalidBmcEncoding("domain must be BmcDomain.")
-    if not isinstance(updates, (list, tuple)):
-        raise InvalidBmcEncoding("updates must be a sequence.")
-    items = tuple(updates)
-    if not all(isinstance(item, VarUpdate) for item in items):
-        raise InvalidBmcEncoding("updates must contain VarUpdate objects.")
-
-    by_id = {}
-    by_name = {}
-    for item in items:
-        if item.variable_id in by_id:
+    def __post_init__(self) -> None:
+        labels = tuple(self.excluded_case_labels)
+        if not labels:
+            raise InvalidBmcEncoding("excluded_case_labels must not be empty.")
+        if not all(isinstance(item, str) and item for item in labels):
             raise InvalidBmcEncoding(
-                "Duplicate variable update id: %r." % item.variable_id
+                "excluded_case_labels must contain non-empty strings."
             )
-        if item.variable_name in by_name:
-            raise InvalidBmcEncoding(
-                "Duplicate variable update name: %r." % item.variable_name
-            )
-        try:
-            entry = domain.variable_by_id(item.variable_id)
-        except InvalidBmcDomain as err:
-            # InvalidBmcDomain: domain.variable_by_id rejects unknown variable ids
-            # supplied by this macro-step writeback recipe.
-            raise InvalidBmcEncoding(str(err)) from err
-        if entry.name != item.variable_name:
-            raise InvalidBmcEncoding("Variable update id/name mismatch.")
-        by_id[item.variable_id] = item
-        by_name[item.variable_name] = item
+        if not isinstance(self.excluded_condition, BoolTemplate):
+            raise InvalidBmcEncoding("excluded_condition must be BoolTemplate.")
+        for atom in self.excluded_condition.variables:
+            if not atom.startswith(_ACCEPTED_ATOM_PREFIX):
+                raise InvalidBmcEncoding(
+                    "priority excluded_condition must use accepted atoms."
+                )
+        object.__setattr__(
+            self,
+            "decision_id",
+            _require_non_empty_string(self.decision_id, "decision_id"),
+        )
+        object.__setattr__(
+            self,
+            "reason",
+            _validate_choice(self.reason, _PRIORITY_REASONS, "priority reason"),
+        )
+        object.__setattr__(self, "excluded_case_labels", tuple(sorted(labels)))
+        object.__setattr__(self, "event_paths", tuple(sorted(set(self.event_paths))))
+        object.__setattr__(
+            self,
+            "guard_requirement_ids",
+            tuple(sorted(set(self.guard_requirement_ids))),
+        )
 
-    expected_ids = tuple(entry.id for entry in domain.variables)
-    actual_ids = tuple(sorted(by_id))
-    if actual_ids != expected_ids:
-        raise InvalidBmcEncoding("var_update must cover every persistent variable.")
-    return tuple(by_id[index] for index in expected_ids)
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable priority-exclusion dictionary.
+
+        :return: Canonical priority metadata.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> PriorityExclusion('d0', 'transition_priority', ('c0',), BoolTemplate.atom('accepted:c0')).to_canonical()['reason']
+            'transition_priority'
+        """
+        return {
+            "node": "priority_exclusion",
+            "decision_id": self.decision_id,
+            "reason": self.reason,
+            "excluded_case_labels": list(self.excluded_case_labels),
+            "excluded_condition": self.excluded_condition.to_canonical(),
+            "event_paths": list(self.event_paths),
+            "guard_requirement_ids": list(self.guard_requirement_ids),
+        }
+
+
+@dataclass(frozen=True)
+class ActionBlock:
+    """Runtime action block recorded for a macro-step path.
+
+    :param block_kind: Domain block kind such as ``"enter"``, ``"exit"``,
+        ``"during"``, ``"during_aspect"``, or ``"transition_effect"``.
+    :type block_kind: str
+    :param runtime_role: Runtime role explaining why the block executes.
+    :type runtime_role: str
+    :param owner_state_id: Domain id of the state that owns the block.
+    :type owner_state_id: int
+    :param owner_state_path: Dot-separated owner state path.
+    :type owner_state_path: str
+    :param operations: Ordered model statements in the block.
+    :type operations: Tuple[pyfcstm.model.OperationStatement, ...]
+    :param action_name: Optional model action function name, defaults to
+        ``None``.
+    :type action_name: str, optional
+    :param transition_label: Optional transition label for effect blocks,
+        defaults to ``None``.
+    :type transition_label: str, optional
+    :param is_abstract: Whether this block represents an abstract hook, defaults
+        to ``False``.
+    :type is_abstract: bool, optional
+
+    Example::
+
+        >>> ActionBlock('during', 'leaf_during', 0, 'Root', ()).operations
+        ()
+    """
+
+    block_kind: str
+    runtime_role: str
+    owner_state_id: int
+    owner_state_path: str
+    operations: Tuple[OperationStatement, ...]
+    action_name: Optional[str] = None
+    transition_label: Optional[str] = None
+    is_abstract: bool = False
+
+    def __post_init__(self) -> None:
+        owner_state_id = _validate_index(self.owner_state_id, "owner_state_id")
+        if owner_state_id < 0:
+            raise InvalidBmcEncoding("owner_state_id must be non-negative.")
+        operations = tuple(self.operations)
+        if not all(isinstance(item, OperationStatement) for item in operations):
+            raise InvalidBmcEncoding(
+                "operations must contain OperationStatement objects."
+            )
+        if not isinstance(self.is_abstract, bool):
+            raise InvalidBmcEncoding("is_abstract must be a boolean.")
+        object.__setattr__(
+            self, "block_kind", _require_non_empty_string(self.block_kind, "block_kind")
+        )
+        object.__setattr__(
+            self,
+            "runtime_role",
+            _require_non_empty_string(self.runtime_role, "runtime_role"),
+        )
+        object.__setattr__(self, "owner_state_id", owner_state_id)
+        object.__setattr__(
+            self,
+            "owner_state_path",
+            _require_non_empty_string(self.owner_state_path, "owner_state_path"),
+        )
+        object.__setattr__(self, "operations", operations)
+        if self.action_name is not None:
+            object.__setattr__(
+                self,
+                "action_name",
+                _require_non_empty_string(self.action_name, "action_name"),
+            )
+        if self.transition_label is not None:
+            object.__setattr__(
+                self,
+                "transition_label",
+                _require_non_empty_string(self.transition_label, "transition_label"),
+            )
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable action-block dictionary.
+
+        :return: Canonical action-block metadata.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> ActionBlock('during', 'leaf_during', 0, 'Root', ()).to_canonical()['block_kind']
+            'during'
+        """
+        return {
+            "node": "action_block",
+            "block_kind": self.block_kind,
+            "runtime_role": self.runtime_role,
+            "owner_state_id": self.owner_state_id,
+            "owner_state_path": self.owner_state_path,
+            "action_name": self.action_name,
+            "transition_label": self.transition_label,
+            "is_abstract": self.is_abstract,
+            "operations": [_statement_to_canonical(item) for item in self.operations],
+        }
+
+
+def _expr_to_text(expr: Expr) -> str:
+    return str(expr.to_ast_node())
+
+
+def _statement_to_canonical(statement: OperationStatement) -> _CanonicalDict:
+    if isinstance(statement, Operation):
+        return {
+            "node": "operation",
+            "var_name": statement.var_name,
+            "expr": _expr_to_text(statement.expr),
+        }
+    if isinstance(statement, IfBlock):
+        branches = []
+        for branch in statement.branches:
+            branches.append(
+                {
+                    "condition": _expr_to_text(branch.condition)
+                    if branch.condition is not None
+                    else None,
+                    "statements": [
+                        _statement_to_canonical(item) for item in branch.statements
+                    ],
+                }
+            )
+        return {"node": "if_block", "branches": branches}
+    return {"node": type(statement).__name__}
 
 
 def _expected_case_path(domain: BmcDomain, state_id: int) -> str:
@@ -678,52 +822,80 @@ def _validate_case_state(
         raise InvalidBmcEncoding("%s path does not match %s id." % (role, role))
 
 
-def _event_atom_paths_in_case(case: "CycleCase") -> Tuple[str, ...]:
-    paths = set()
-    for condition in (case.condition,) + case.failed_conditions:
-        for variable in condition.variables:
-            if variable.startswith("event:"):
-                paths.add(variable[len("event:") :])
-    return tuple(sorted(paths))
-
-
-def _event_uses_from_condition(
-    condition: BoolTemplate,
-    domain: BmcDomain,
-    polarity: str,
-    reason: str,
-) -> Tuple[EventUse, ...]:
-    result = []
-    for variable in condition.variables:
-        if not variable.startswith("event:"):
-            continue
-        path = variable[len("event:") :]
-        try:
-            entry = domain.event_by_path(path)
-        except InvalidBmcDomain as err:
-            # InvalidBmcDomain: domain.event_by_path rejects event atoms that
-            # helper-built fallback/delta conditions pulled from malformed input.
-            raise InvalidBmcEncoding(str(err)) from err
-        result.append(EventUse(entry.id, entry.path, polarity, reason))
-    return tuple(sorted(result, key=_canonical_key))
-
-
 def _derive_is_diagnostic(kind: str, target_state_id: int) -> bool:
     return kind in {"diagnostic", "delta"} or (
         kind == "absorb" and target_state_id == STATE_DIAGNOSTIC_ID
     )
 
 
-def _validate_non_reserved_condition_atoms(
-    condition: BoolTemplate,
-    field_name: str,
-) -> None:
-    for variable in condition.variables:
-        if variable.startswith(_SOURCE_STATE_ATOM_PREFIX):
+def _condition_atoms(condition: BoolTemplate) -> Tuple[str, ...]:
+    return condition.variables
+
+
+def _validate_condition_atom_prefixes(condition: BoolTemplate, field_name: str) -> None:
+    for atom in _condition_atoms(condition):
+        if atom.startswith(_SOURCE_STATE_ATOM_PREFIX):
             raise InvalidBmcEncoding(
-                "%s uses reserved source-state atom namespace: %r."
-                % (field_name, variable)
+                "%s uses reserved source-state atom namespace: %r." % (field_name, atom)
             )
+        if not atom.startswith(_VALID_CONDITION_PREFIXES):
+            raise InvalidBmcEncoding(
+                "%s uses unsupported macro condition atom namespace: %r."
+                % (field_name, atom)
+            )
+
+
+def _event_atom_paths(condition: BoolTemplate) -> Tuple[str, ...]:
+    return tuple(
+        sorted(
+            atom[len(_EVENT_ATOM_PREFIX) :]
+            for atom in condition.variables
+            if atom.startswith(_EVENT_ATOM_PREFIX)
+        )
+    )
+
+
+def _guard_atom_ids(condition: BoolTemplate) -> Tuple[str, ...]:
+    return tuple(
+        sorted(
+            atom[len(_GUARD_ATOM_PREFIX) :]
+            for atom in condition.variables
+            if atom.startswith(_GUARD_ATOM_PREFIX)
+        )
+    )
+
+
+def _accepted_atom_labels(condition: BoolTemplate) -> Tuple[str, ...]:
+    return tuple(
+        sorted(
+            atom[len(_ACCEPTED_ATOM_PREFIX) :]
+            for atom in condition.variables
+            if atom.startswith(_ACCEPTED_ATOM_PREFIX)
+        )
+    )
+
+
+def _event_uses_from_paths(
+    domain: BmcDomain, paths: Sequence[str], polarity: str, reason: str
+) -> Tuple[EventUse, ...]:
+    result = []
+    for path in sorted(set(paths)):
+        try:
+            entry = domain.event_by_path(path)
+        except InvalidBmcDomain as err:
+            # InvalidBmcDomain: domain.event_by_path rejects event paths copied
+            # from malformed macro control atoms.
+            raise InvalidBmcEncoding(str(err)) from err
+        result.append(EventUse(entry.id, entry.path, polarity, reason))
+    return tuple(result)
+
+
+def _event_uses_from_condition(
+    condition: BoolTemplate, domain: BmcDomain, polarity: str, reason: str
+) -> Tuple[EventUse, ...]:
+    return _event_uses_from_paths(
+        domain, _event_atom_paths(condition), polarity, reason
+    )
 
 
 def _normalize_accepted_cases(
@@ -743,8 +915,8 @@ def _normalize_accepted_cases(
     for case in accepted:
         if case.kind not in allowed:
             raise InvalidBmcEncoding(
-                "accepted_cases for %s may only contain ordinary accepted "
-                "cases with kinds %r." % (helper_name, allowed)
+                "accepted_cases for %s may only contain ordinary accepted cases with kinds %r."
+                % (helper_name, allowed)
             )
         if case.is_diagnostic:
             raise InvalidBmcEncoding(
@@ -781,25 +953,27 @@ class CycleCase:
     :type target_state_id: int
     :param target_state_path: Target path used by the case label.
     :type target_state_path: str
-    :param label: Stable label in
-        ``source_path::case_kind::target_path::ordinal`` form.
+    :param label: Stable label in ``source_path::case_kind::target_path::ordinal``
+        form.
     :type label: str
-    :param condition: Bare case condition ``gamma`` without a source guard.
+    :param condition: Bare control-path condition without a source-state guard.
     :type condition: BoolTemplate
-    :param var_update: Explicit updates for every persistent variable.
-    :type var_update: Tuple[VarUpdate, ...]
+    :param action_blocks: Runtime action blocks executed by this path.
+    :type action_blocks: Tuple[ActionBlock, ...]
     :param used_events: Event inputs read by this case, defaults to ``()``.
     :type used_events: Tuple[EventUse, ...], optional
+    :param guard_requirements: Guard requirements read by this case, defaults to
+        ``()``.
+    :type guard_requirements: Tuple[GuardRequirement, ...], optional
+    :param priority_exclusions: Priority masks applied by this case, defaults to
+        ``()``.
+    :type priority_exclusions: Tuple[PriorityExclusion, ...], optional
     :param failed_conditions: Diagnostic-only failed candidate conditions,
         defaults to ``()``.
     :type failed_conditions: Tuple[BoolTemplate, ...], optional
     :param domain: Optional domain used for eager validation, defaults to
         ``None``.
     :type domain: BmcDomain, optional
-
-    :ivar is_diagnostic: Derived diagnostic classification.  It is true for
-        ``delta`` cases and diagnostic absorb cases.
-    :vartype is_diagnostic: bool
 
     Example::
 
@@ -815,8 +989,10 @@ class CycleCase:
     target_state_path: str
     label: str
     condition: BoolTemplate
-    var_update: Tuple[VarUpdate, ...]
+    action_blocks: Tuple[ActionBlock, ...]
     used_events: Tuple[EventUse, ...] = ()
+    guard_requirements: Tuple[GuardRequirement, ...] = ()
+    priority_exclusions: Tuple[PriorityExclusion, ...] = ()
     failed_conditions: Tuple[BoolTemplate, ...] = ()
     domain: Optional[BmcDomain] = field(default=None, repr=False, compare=False)
     is_diagnostic: bool = field(init=False)
@@ -826,28 +1002,38 @@ class CycleCase:
         source_id = _validate_index(self.source_state_id, "source_state_id")
         target_id = _validate_index(self.target_state_id, "target_state_id")
         source_path = _require_non_empty_string(
-            self.source_state_path,
-            "source_state_path",
+            self.source_state_path, "source_state_path"
         )
         target_path = _require_non_empty_string(
-            self.target_state_path,
-            "target_state_path",
+            self.target_state_path, "target_state_path"
         )
         label = _require_non_empty_string(self.label, "label")
         if not isinstance(self.condition, BoolTemplate):
             raise InvalidBmcEncoding("condition must be BoolTemplate.")
-        _validate_non_reserved_condition_atoms(self.condition, "condition")
+        _validate_condition_atom_prefixes(self.condition, "condition")
+        action_blocks = tuple(self.action_blocks)
+        if not all(isinstance(item, ActionBlock) for item in action_blocks):
+            raise InvalidBmcEncoding("action_blocks must contain ActionBlock objects.")
         used_events = tuple(self.used_events)
         if not all(isinstance(item, EventUse) for item in used_events):
             raise InvalidBmcEncoding("used_events must contain EventUse objects.")
+        guard_requirements = tuple(self.guard_requirements)
+        if not all(isinstance(item, GuardRequirement) for item in guard_requirements):
+            raise InvalidBmcEncoding(
+                "guard_requirements must contain GuardRequirement objects."
+            )
+        priority_exclusions = tuple(self.priority_exclusions)
+        if not all(isinstance(item, PriorityExclusion) for item in priority_exclusions):
+            raise InvalidBmcEncoding(
+                "priority_exclusions must contain PriorityExclusion objects."
+            )
         failed_conditions = tuple(self.failed_conditions)
         if not all(isinstance(item, BoolTemplate) for item in failed_conditions):
             raise InvalidBmcEncoding(
                 "failed_conditions must contain BoolTemplate objects."
             )
-        var_update = tuple(self.var_update)
-        if not all(isinstance(item, VarUpdate) for item in var_update):
-            raise InvalidBmcEncoding("var_update must contain VarUpdate objects.")
+        for item in failed_conditions:
+            _validate_condition_atom_prefixes(item, "failed_conditions")
 
         object.__setattr__(self, "kind", kind)
         object.__setattr__(self, "source_state_id", source_id)
@@ -855,10 +1041,22 @@ class CycleCase:
         object.__setattr__(self, "source_state_path", source_path)
         object.__setattr__(self, "target_state_path", target_path)
         object.__setattr__(self, "label", label)
+        object.__setattr__(self, "action_blocks", action_blocks)
+        event_by_key = {_canonical_key(item): item for item in used_events}
         object.__setattr__(
             self,
             "used_events",
-            tuple(sorted(used_events, key=_canonical_key)),
+            tuple(event_by_key[key] for key in sorted(event_by_key)),
+        )
+        object.__setattr__(
+            self,
+            "guard_requirements",
+            tuple(sorted(guard_requirements, key=lambda item: item.requirement_id)),
+        )
+        object.__setattr__(
+            self,
+            "priority_exclusions",
+            tuple(sorted(priority_exclusions, key=lambda item: item.decision_id)),
         )
         object.__setattr__(
             self,
@@ -866,16 +1064,12 @@ class CycleCase:
             tuple(sorted(failed_conditions, key=_canonical_key)),
         )
         object.__setattr__(
-            self,
-            "var_update",
-            tuple(sorted(var_update, key=lambda item: item.variable_id)),
-        )
-        object.__setattr__(
             self, "is_diagnostic", _derive_is_diagnostic(kind, target_id)
         )
 
         self._validate_label()
         self._validate_kind_shape()
+        self._validate_local_atom_links()
         if self.domain is not None:
             if not isinstance(self.domain, BmcDomain):
                 raise InvalidBmcEncoding("domain must be BmcDomain.")
@@ -901,24 +1095,36 @@ class CycleCase:
                 raise InvalidBmcEncoding("absorb cases must self-loop.")
             if self.source_state_id not in {STATE_TERMINATE_ID, STATE_DIAGNOSTIC_ID}:
                 raise InvalidBmcEncoding("absorb cases must use sentinel states.")
-        if self.kind in {"delta", "diagnostic"}:
-            if self.target_state_id != STATE_DIAGNOSTIC_ID:
-                raise InvalidBmcEncoding(
-                    "diagnostic and delta cases target diagnostic."
-                )
+        if (
+            self.kind in {"delta", "diagnostic"}
+            and self.target_state_id != STATE_DIAGNOSTIC_ID
+        ):
+            raise InvalidBmcEncoding("diagnostic and delta cases target diagnostic.")
+
+    def _validate_local_atom_links(self) -> None:
+        condition_guard_ids = set(_guard_atom_ids(self.condition))
+        for failed in self.failed_conditions:
+            condition_guard_ids.update(_guard_atom_ids(failed))
+        declared_guard_ids = {item.requirement_id for item in self.guard_requirements}
+        missing = sorted(condition_guard_ids - declared_guard_ids)
+        if missing:
+            raise InvalidBmcEncoding(
+                "guard atoms must have matching GuardRequirement: %r." % missing[0]
+            )
+        if len(declared_guard_ids) != len(self.guard_requirements):
+            raise InvalidBmcEncoding("Duplicate guard requirement id.")
+        if any(
+            item.after_action_block_index > len(self.action_blocks)
+            for item in self.guard_requirements
+        ):
+            raise InvalidBmcEncoding("guard anchor exceeds action block count.")
 
     def _validate_against_domain(self, domain: BmcDomain) -> None:
         _validate_case_state(
-            domain,
-            self.source_state_id,
-            self.source_state_path,
-            "source",
+            domain, self.source_state_id, self.source_state_path, "source"
         )
         _validate_case_state(
-            domain,
-            self.target_state_id,
-            self.target_state_path,
-            "target",
+            domain, self.target_state_id, self.target_state_path, "target"
         )
         used_event_paths = set()
         for event_use in self.used_events:
@@ -931,7 +1137,9 @@ class CycleCase:
             if event.path != event_use.path:
                 raise InvalidBmcEncoding("EventUse path does not match event id.")
             used_event_paths.add(event.path)
-        for event_path in _event_atom_paths_in_case(self):
+        for event_path in _event_atom_paths(self.condition) + tuple(
+            path for item in self.failed_conditions for path in _event_atom_paths(item)
+        ):
             try:
                 domain.event_by_path(event_path)
             except InvalidBmcDomain as err:
@@ -942,11 +1150,14 @@ class CycleCase:
                 raise InvalidBmcEncoding(
                     "event atoms in case conditions must be listed in used_events."
                 )
-        object.__setattr__(
-            self,
-            "var_update",
-            build_var_updates(domain, self.var_update),
-        )
+        for guard in self.guard_requirements:
+            _validate_case_state(
+                domain, guard.owner_state_id, guard.owner_state_path, "guard owner"
+            )
+        for block in self.action_blocks:
+            _validate_case_state(
+                domain, block.owner_state_id, block.owner_state_path, "action owner"
+            )
 
     def to_canonical(self) -> _CanonicalDict:
         """Return a JSON-stable case dictionary.
@@ -970,8 +1181,14 @@ class CycleCase:
             "label": self.label,
             "is_diagnostic": self.is_diagnostic,
             "used_events": [item.to_canonical() for item in self.used_events],
+            "guard_requirements": [
+                item.to_canonical() for item in self.guard_requirements
+            ],
+            "priority_exclusions": [
+                item.to_canonical() for item in self.priority_exclusions
+            ],
+            "action_blocks": [item.to_canonical() for item in self.action_blocks],
             "condition": self.condition.to_canonical(),
-            "var_update": [item.to_canonical() for item in self.var_update],
             "failed_conditions": [
                 item.to_canonical() for item in self.failed_conditions
             ],
@@ -1097,10 +1314,9 @@ class MacroStepFormal:
         Example::
 
             >>> source = MacroStepSource('entry', 'initial', 0, 'Root')
-            >>> MacroStepFormal(source, (), ()).cases
-            Traceback (most recent call last):
-            ...
-            pyfcstm.bmc.errors.InvalidBmcEncoding: MacroStepFormal must contain at least one relation case.
+            >>> case = CycleCase('delta', 0, 'Root', -2, '__diagnostic__', 'Root::delta::__diagnostic__::0', BoolTemplate.true(), ())
+            >>> MacroStepFormal(source, (), (case,)).cases[0].kind
+            'delta'
         """
         return self.success_cases + self.delta_cases
 
@@ -1119,6 +1335,7 @@ class MacroStepFormal:
             if case.source_state_path != self.source.source_state_path:
                 raise InvalidBmcEncoding("case source path must match formal source.")
             self._validate_case_domain_contract(case)
+        self._validate_accepted_atom_registry(labels)
         for case in self.success_cases:
             if case.kind == "delta":
                 raise InvalidBmcEncoding("success_cases must not contain delta cases.")
@@ -1143,6 +1360,22 @@ class MacroStepFormal:
     def _validate_case_domain_contract(self, case: CycleCase) -> None:
         if self.source.domain is not None:
             case._validate_against_domain(self.source.domain)
+
+    def _validate_accepted_atom_registry(self, labels: Set[str]) -> None:
+        for case in self.cases:
+            for condition in (case.condition,) + case.failed_conditions:
+                for label in _accepted_atom_labels(condition):
+                    if label not in labels:
+                        raise InvalidBmcEncoding(
+                            "accepted atom references unknown case label: %r." % label
+                        )
+            for priority in case.priority_exclusions:
+                for label in priority.excluded_case_labels:
+                    if label not in labels:
+                        raise InvalidBmcEncoding(
+                            "priority exclusion references unknown case label: %r."
+                            % label
+                        )
 
     def _validate_success_case_shape(self, case: CycleCase) -> None:
         if self.source.kind == "stable_leaf":
@@ -1183,10 +1416,7 @@ class MacroStepFormal:
         if case.source_state_id != sentinel_id or case.target_state_id != sentinel_id:
             raise InvalidBmcEncoding("sentinel absorb case must self-loop sentinel id.")
 
-    def verify_partition(
-        self,
-        max_assignments: int = 4096,
-    ) -> PartitionCheckResult:
+    def verify_partition(self, max_assignments: int = 4096) -> PartitionCheckResult:
         """Verify local case buckets with the truth-table self-checker.
 
         :param max_assignments: Maximum assignments to enumerate, defaults to
@@ -1194,8 +1424,8 @@ class MacroStepFormal:
         :type max_assignments: int, optional
         :return: Partition self-check summary.
         :rtype: PartitionCheckResult
-        :raises BmcBuildError: If the buckets overlap, leave a gap, or cannot
-            be checked within the assignment budget.
+        :raises BmcBuildError: If the buckets overlap, leave a gap, or exceed
+            the assignment budget.
 
         Example::
 
@@ -1236,42 +1466,34 @@ class MacroStepFormal:
         }
 
 
-def case_antecedent_condition(case: CycleCase) -> BoolTemplate:
-    """Return ``source_guard and gamma`` for diagnostic comparison.
+def case_path_condition(case: CycleCase) -> BoolTemplate:
+    """Return the solver-independent control-path condition for ``case``.
 
-    The returned recipe mirrors the later relation-builder boundary but
-    is still solver-independent.  It proves that the source guard is composed
-    outside :attr:`CycleCase.condition`.  Source guards use the reserved
-    ``"__source_state__:"`` atom namespace so synthetic case conditions cannot
-    collide with the helper's guard atom.
+    The helper intentionally returns :attr:`CycleCase.condition` without adding
+    a source-state guard.  Later relation builders are responsible for building
+    the final antecedent and emitting ``Implies(A, R)``.
 
-    :param case: Case whose antecedent should be represented.
+    :param case: Case whose control-path condition should be returned.
     :type case: CycleCase
-    :return: Source-guarded antecedent recipe.
+    :return: Bare case condition.
     :rtype: BoolTemplate
     :raises InvalidBmcEncoding: If ``case`` is not a cycle case.
 
     Example::
 
-        >>> case = CycleCase(
-        ...     'transition', 0, 'Root', 0, 'Root',
-        ...     'Root::transition::Root::0', BoolTemplate.atom('g'), ()
-        ... )
-        >>> case_antecedent_condition(case).variables
-        ('__source_state__:0', 'g')
+        >>> case = CycleCase('transition', 0, 'Root', 0, 'Root', 'Root::transition::Root::0', BoolTemplate.true(), ())
+        >>> case_path_condition(case).evaluate({})
+        True
     """
     if not isinstance(case, CycleCase):
         raise InvalidBmcEncoding("case must be CycleCase.")
-    return BoolTemplate.and_(
-        BoolTemplate.atom("%s%d" % (_SOURCE_STATE_ATOM_PREFIX, case.source_state_id)),
-        case.condition,
-    )
+    return case.condition
 
 
 def terminated_absorb_case(domain: BmcDomain) -> CycleCase:
     """Build the terminate sentinel absorb case.
 
-    :param domain: Domain snapshot whose sentinel and variables are used.
+    :param domain: Domain snapshot whose sentinel entries are used.
     :type domain: BmcDomain
     :return: Terminated self-loop absorb case.
     :rtype: CycleCase
@@ -1292,7 +1514,7 @@ def terminated_absorb_case(domain: BmcDomain) -> CycleCase:
         TERMINATE_CASE_PATH,
         "%s::absorb::%s::0" % (TERMINATE_CASE_PATH, TERMINATE_CASE_PATH),
         BoolTemplate.true(),
-        carry_var_updates(domain),
+        (),
         domain=domain,
     )
 
@@ -1300,7 +1522,7 @@ def terminated_absorb_case(domain: BmcDomain) -> CycleCase:
 def diagnostic_absorb_case(domain: BmcDomain) -> CycleCase:
     """Build the diagnostic sentinel absorb case.
 
-    :param domain: Domain snapshot whose sentinel and variables are used.
+    :param domain: Domain snapshot whose sentinel entries are used.
     :type domain: BmcDomain
     :return: Diagnostic self-loop absorb case.
     :rtype: CycleCase
@@ -1321,13 +1543,47 @@ def diagnostic_absorb_case(domain: BmcDomain) -> CycleCase:
         DIAGNOSTIC_CASE_PATH,
         "%s::absorb::%s::0" % (DIAGNOSTIC_CASE_PATH, DIAGNOSTIC_CASE_PATH),
         BoolTemplate.true(),
-        carry_var_updates(domain),
+        (),
         domain=domain,
     )
 
 
 def _case_label(source_path: str, kind: str, target_path: str, ordinal: int) -> str:
     return "%s::%s::%s::%d" % (source_path, kind, target_path, ordinal)
+
+
+def _accepted_condition(accepted: Sequence[CycleCase]) -> BoolTemplate:
+    if not accepted:
+        return BoolTemplate.false()
+    return BoolTemplate.or_(
+        *[
+            BoolTemplate.atom("%s%s" % (_ACCEPTED_ATOM_PREFIX, case.label))
+            for case in accepted
+        ]
+    )
+
+
+def _priority_exclusion_for_accepted(
+    decision_id: str,
+    reason: str,
+    accepted: Sequence[CycleCase],
+) -> Optional[PriorityExclusion]:
+    if not accepted:
+        return None
+    event_paths = sorted(
+        {event.path for case in accepted for event in case.used_events}
+    )
+    guard_ids = sorted(
+        {guard.requirement_id for case in accepted for guard in case.guard_requirements}
+    )
+    return PriorityExclusion(
+        decision_id,
+        reason,
+        tuple(case.label for case in accepted),
+        _accepted_condition(accepted),
+        tuple(event_paths),
+        tuple(guard_ids),
+    )
 
 
 def build_fallback_case(
@@ -1339,11 +1595,11 @@ def build_fallback_case(
 ) -> CycleCase:
     """Build a stable leaf fallback self-cycle.
 
-    The fallback condition negates only accepted case conditions.  Failed
-    candidate conditions are copied as metadata and do not shrink the fallback
-    region.
+    The fallback condition negates accepted case labels rather than reusing raw
+    trigger/guard predicates.  Failed candidate conditions remain diagnostic
+    metadata and do not shrink the fallback region.
 
-    :param domain: Domain snapshot whose variables are carried.
+    :param domain: Domain snapshot whose event ids are used.
     :type domain: BmcDomain
     :param source: Stable leaf source.
     :type source: MacroStepSource
@@ -1375,33 +1631,27 @@ def build_fallback_case(
     if ordinal < 0:
         raise InvalidBmcEncoding("ordinal must be non-negative.")
     accepted = _normalize_accepted_cases(
-        accepted_cases,
-        source,
-        "fallback",
-        ("transition",),
+        accepted_cases, source, "fallback", ("transition",)
     )
     if not isinstance(failed_conditions, (list, tuple)):
         raise InvalidBmcEncoding("failed_conditions must be a sequence.")
     failed = tuple(failed_conditions)
     if not all(isinstance(item, BoolTemplate) for item in failed):
         raise InvalidBmcEncoding("failed_conditions must contain BoolTemplate objects.")
-    if accepted:
-        condition = BoolTemplate.not_(
-            BoolTemplate.or_(*[case.condition for case in accepted])
-        )
-    else:
-        condition = BoolTemplate.true()
-    used_events = _event_uses_from_condition(
-        condition,
+    excluded = _accepted_condition(accepted)
+    condition = BoolTemplate.not_(excluded) if accepted else BoolTemplate.true()
+    used_events = _event_uses_from_paths(
         domain,
-        polarity="negative",
-        reason="fallback",
+        [event.path for case in accepted for event in case.used_events],
+        "negative",
+        "fallback",
     )
+    used_events += _event_uses_from_condition(condition, domain, "negative", "fallback")
     used_events += _event_uses_from_condition(
-        BoolTemplate.or_(*failed),
-        domain,
-        polarity="negative",
-        reason="fallback",
+        BoolTemplate.or_(*failed), domain, "negative", "fallback"
+    )
+    priority = _priority_exclusion_for_accepted(
+        "fallback:%s:%d" % (source.source_state_path, ordinal), "fallback", accepted
     )
     return CycleCase(
         "fallback",
@@ -1410,14 +1660,12 @@ def build_fallback_case(
         source.source_state_id,
         source.source_state_path,
         _case_label(
-            source.source_state_path,
-            "fallback",
-            source.source_state_path,
-            ordinal,
+            source.source_state_path, "fallback", source.source_state_path, ordinal
         ),
         condition,
-        carry_var_updates(domain),
+        (),
         used_events=used_events,
+        priority_exclusions=(priority,) if priority is not None else (),
         failed_conditions=failed,
         domain=domain,
     )
@@ -1433,15 +1681,14 @@ def build_semantic_delta_case(
 ) -> CycleCase:
     """Build a non-stoppable entry uncovered-region delta case.
 
-    The delta condition negates accepted case conditions and build-diagnostic
-    conditions.  Failed candidate conditions are copied as metadata only.
+    The delta condition negates accepted case labels and build-diagnostic
+    conditions.  Failed candidate conditions remain diagnostic metadata only.
 
-    :param domain: Domain snapshot whose variables are carried.
+    :param domain: Domain snapshot whose event ids are used.
     :type domain: BmcDomain
     :param source: Initial entry source.
     :type source: MacroStepSource
-    :param accepted_cases: Accepted transition or initial success cases for the
-        same entry source.
+    :param accepted_cases: Accepted transition or initial success cases.
     :type accepted_cases: Sequence[CycleCase]
     :param build_diagnostic_conditions: Build diagnostic conditions excluded
         from semantic delta, defaults to ``()``.
@@ -1471,10 +1718,7 @@ def build_semantic_delta_case(
     if ordinal < 0:
         raise InvalidBmcEncoding("ordinal must be non-negative.")
     accepted = _normalize_accepted_cases(
-        accepted_cases,
-        source,
-        "delta",
-        ("transition", "initial"),
+        accepted_cases, source, "delta", ("transition", "initial")
     )
     if not isinstance(build_diagnostic_conditions, (list, tuple)):
         raise InvalidBmcEncoding("build_diagnostic_conditions must be a sequence.")
@@ -1488,23 +1732,27 @@ def build_semantic_delta_case(
     failed = tuple(failed_conditions)
     if not all(isinstance(item, BoolTemplate) for item in failed):
         raise InvalidBmcEncoding("failed_conditions must contain BoolTemplate objects.")
-    excluded = [case.condition for case in accepted]
+    excluded = []
+    if accepted:
+        excluded.append(_accepted_condition(accepted))
     excluded.extend(diagnostics)
-    if excluded:
-        condition = BoolTemplate.not_(BoolTemplate.or_(*excluded))
-    else:
-        condition = BoolTemplate.true()
-    used_events = _event_uses_from_condition(
-        condition,
-        domain,
-        polarity="negative",
-        reason="fallback",
+    condition = (
+        BoolTemplate.not_(BoolTemplate.or_(*excluded))
+        if excluded
+        else BoolTemplate.true()
     )
-    used_events += _event_uses_from_condition(
-        BoolTemplate.or_(*failed),
+    used_events = _event_uses_from_paths(
         domain,
-        polarity="negative",
-        reason="fallback",
+        [event.path for case in accepted for event in case.used_events],
+        "negative",
+        "fallback",
+    )
+    used_events += _event_uses_from_condition(condition, domain, "negative", "fallback")
+    used_events += _event_uses_from_condition(
+        BoolTemplate.or_(*failed), domain, "negative", "fallback"
+    )
+    priority = _priority_exclusion_for_accepted(
+        "delta:%s:%d" % (source.source_state_path, ordinal), "delta", accepted
     )
     return CycleCase(
         "delta",
@@ -1512,18 +1760,61 @@ def build_semantic_delta_case(
         source.source_state_path,
         STATE_DIAGNOSTIC_ID,
         DIAGNOSTIC_CASE_PATH,
-        _case_label(
-            source.source_state_path,
-            "delta",
-            DIAGNOSTIC_CASE_PATH,
-            ordinal,
-        ),
+        _case_label(source.source_state_path, "delta", DIAGNOSTIC_CASE_PATH, ordinal),
         condition,
-        carry_var_updates(domain),
+        (),
         used_events=used_events,
+        priority_exclusions=(priority,) if priority is not None else (),
         failed_conditions=failed,
         domain=domain,
     )
+
+
+def _resolve_accepted_atoms(
+    condition: BoolTemplate,
+    registry: Mapping[str, BoolTemplate],
+    active: Optional[Set[str]] = None,
+) -> BoolTemplate:
+    if active is None:
+        active = set()
+    if condition.kind == "atom":
+        atom = condition._atom_name()
+        if not atom.startswith(_ACCEPTED_ATOM_PREFIX):
+            return condition
+        label = atom[len(_ACCEPTED_ATOM_PREFIX) :]
+        if label not in registry:
+            raise BmcBuildError(
+                "accepted atom references unknown case label: %r." % label
+            )
+        if label in active:
+            raise BmcBuildError(
+                "accepted atom cycle detected for case label: %r." % label
+            )
+        active.add(label)
+        resolved = _resolve_accepted_atoms(registry[label], registry, active)
+        active.remove(label)
+        return resolved
+    if condition.kind in {"true", "false"}:
+        return condition
+    if condition.kind == "not":
+        return BoolTemplate.not_(
+            _resolve_accepted_atoms(condition.operands[0], registry, active)
+        )
+    if condition.kind == "and":
+        return BoolTemplate.and_(
+            *[
+                _resolve_accepted_atoms(item, registry, active)
+                for item in condition.operands
+            ]
+        )
+    if condition.kind == "or":
+        return BoolTemplate.or_(
+            *[
+                _resolve_accepted_atoms(item, registry, active)
+                for item in condition.operands
+            ]
+        )
+    raise BmcBuildError("unsupported boolean template kind: %r." % condition.kind)
 
 
 def verify_boolean_partition(
@@ -1532,11 +1823,6 @@ def verify_boolean_partition(
     max_assignments: int = 4096,
 ) -> PartitionCheckResult:
     """Verify that boolean buckets are complete and pairwise disjoint.
-
-    This helper is deliberately a self-check.  It enumerates a small synthetic
-    boolean universe and raises :class:`BmcBuildError` on gaps, overlaps, or an
-    assignment budget overflow.  It returns only a summary and never returns
-    solver clauses.
 
     :param buckets: Boolean bucket conditions.
     :type buckets: Sequence[BoolTemplate]
@@ -1548,7 +1834,7 @@ def verify_boolean_partition(
     :type max_assignments: int, optional
     :return: Partition self-check summary.
     :rtype: PartitionCheckResult
-    :raises BmcBuildError: If the partition is not exactly-one or cannot be
+    :raises BmcBuildError: If the partition is not exactly one or cannot be
         checked.
 
     Example::
@@ -1616,9 +1902,10 @@ def verify_source_partition(
 ) -> PartitionCheckResult:
     """Verify one source's local case partition.
 
-    Build-diagnostic conditions form one extra local bucket.  That bucket must
-    be disjoint from every success and delta case, and the combined buckets must
-    still cover the whole synthetic boolean universe.
+    ``accepted:<case_label>`` atoms are resolved through the source-local case
+    registry before truth-table enumeration, so declaration-priority masks are
+    checked against the same accepted-path meaning that later relation lowering
+    will use.
 
     :param source: Macro-step source profile.
     :type source: MacroStepSource
@@ -1641,11 +1928,8 @@ def verify_source_partition(
     Example::
 
         >>> source = MacroStepSource('entry', 'initial', 0, 'Root')
-        >>> delta = CycleCase(
-        ...     'delta', 0, 'Root', -2, '__diagnostic__',
-        ...     'Root::delta::__diagnostic__::0', BoolTemplate.true(), ()
-        ... )
-        >>> verify_source_partition(source, (), (delta,)).bucket_count
+        >>> case = CycleCase('delta', 0, 'Root', -2, '__diagnostic__', 'Root::delta::__diagnostic__::0', BoolTemplate.true(), ())
+        >>> verify_source_partition(source, (), (case,)).bucket_count
         1
     """
     if not isinstance(source, MacroStepSource):
@@ -1678,8 +1962,10 @@ def verify_source_partition(
         raise InvalidBmcEncoding(
             "build_diagnostic_conditions must contain BoolTemplate objects."
         )
-    buckets = [case.condition for case in success]
-    buckets.extend(case.condition for case in delta)
+
+    registry = {case.label: case.condition for case in success + delta}
+    buckets = [_resolve_accepted_atoms(case.condition, registry) for case in success]
+    buckets.extend(_resolve_accepted_atoms(case.condition, registry) for case in delta)
     if diagnostics:
         buckets.append(BoolTemplate.or_(*diagnostics))
     return verify_boolean_partition(buckets, max_assignments=max_assignments)
@@ -1688,14 +1974,13 @@ def verify_source_partition(
 __all__ = [
     "BoolTemplate",
     "EventUse",
-    "VarUpdate",
+    "GuardRequirement",
+    "PriorityExclusion",
+    "ActionBlock",
     "CycleCase",
     "PartitionCheckResult",
     "MacroStepFormal",
-    "carry_var_updates",
-    "var_update_for",
-    "build_var_updates",
-    "case_antecedent_condition",
+    "case_path_condition",
     "terminated_absorb_case",
     "diagnostic_absorb_case",
     "build_fallback_case",

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -600,6 +600,12 @@ class GuardRequirement:
 class PriorityExclusion:
     """Priority mask that excludes previously accepted control paths.
 
+    The event and guard-id fields are explanation metadata for the excluded
+    accepted cases. They do not add conjuncts to the case condition. Lowering
+    code must treat ``excluded_condition`` and ``CycleCase.condition`` as the
+    truth sources and use the metadata only
+    for witness/debug completeness.
+
     :param decision_id: Stable id for the chooser decision point.
     :type decision_id: str
     :param reason: Exclusion reason such as ``"transition_priority"``.
@@ -1502,8 +1508,6 @@ class MacroStepFormal:
         )
         _validate_sentinel_absorb_partition(
             self.success_cases,
-            self.delta_cases,
-            self.build_diagnostic_conditions,
             sentinel_id,
             expected_path,
         )
@@ -1931,17 +1935,27 @@ def _resolve_accepted_atoms(
 
 def _validate_sentinel_absorb_partition(
     success: Sequence[CycleCase],
-    delta: Sequence[CycleCase],
-    diagnostics: Sequence[BoolTemplate],
     sentinel_id: int,
     sentinel_path: str,
 ) -> None:
-    if delta:
-        raise InvalidBmcEncoding("sentinel absorb formal cannot have delta cases.")
-    if diagnostics:
-        raise InvalidBmcEncoding(
-            "sentinel absorb formal cannot have build diagnostics."
-        )
+    """Validate the exact shape of a sentinel self-absorb partition.
+
+    The validator is intentionally fail-fast: if one malformed bucket violates
+    several constraints, the first constraint in this function's structural
+    order determines the reported message. Tests should construct one target
+    violation per case when asserting specific diagnostics.
+
+    :param success: Success bucket under validation.
+    :type success: Sequence[CycleCase]
+    :param sentinel_id: Fixed sentinel state id expected for the source.
+    :type sentinel_id: int
+    :param sentinel_path: Fixed sentinel state path expected for the source.
+    :type sentinel_path: str
+    :return: ``None``.
+    :rtype: None
+    :raises InvalidBmcEncoding: If the buckets are not a single pure sentinel
+        absorb self-loop.
+    """
     if len(success) != 1:
         raise InvalidBmcEncoding("sentinel absorb formal must contain one case.")
     case = success[0]
@@ -1989,9 +2003,10 @@ def _structural_partition_result(
         sentinel_path = (
             TERMINATE_CASE_PATH if source.kind == "terminated" else DIAGNOSTIC_CASE_PATH
         )
-        _validate_sentinel_absorb_partition(
-            success, delta, diagnostics, sentinel_id, sentinel_path
+        assert not delta and not diagnostics, (
+            "sentinel delta and diagnostics are rejected by public preflight"
         )
+        _validate_sentinel_absorb_partition(success, sentinel_id, sentinel_path)
         return PartitionCheckResult(tuple(variables), 0, 1)
 
     cases = tuple(success) + tuple(delta)

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -920,25 +920,6 @@ def _accepted_atom_labels(condition: BoolTemplate) -> Tuple[str, ...]:
     )
 
 
-def _accepted_union_labels(condition: BoolTemplate) -> Optional[Tuple[str, ...]]:
-    if condition.kind == "false":
-        return ()
-    if condition.kind == "atom":
-        atom = condition._atom_name()
-        if atom.startswith(_ACCEPTED_ATOM_PREFIX):
-            return (atom[len(_ACCEPTED_ATOM_PREFIX) :],)
-        return None
-    if condition.kind != "or":
-        return None
-    labels = []
-    for operand in condition.operands:
-        item = _accepted_union_labels(operand)
-        if item is None or len(item) != 1:
-            return None
-        labels.extend(item)
-    return tuple(sorted(set(labels)))
-
-
 def _condition_uses_expected_accepted_prefix(
     condition: BoolTemplate, labels: Sequence[str]
 ) -> bool:
@@ -1019,8 +1000,9 @@ def _normalize_accepted_cases(
         raise InvalidBmcEncoding("accepted_cases must be a sequence.")
     accepted = tuple(accepted_cases)
     allowed = tuple(allowed_kinds)
-    if not allowed or any(kind not in _ACCEPTED_CASE_KINDS for kind in allowed):
-        raise InvalidBmcEncoding("accepted case kind policy is invalid.")
+    assert allowed and all(kind in _ACCEPTED_CASE_KINDS for kind in allowed), (
+        "_normalize_accepted_cases only accepts ordinary macro case kind policies."
+    )
     if not all(isinstance(item, CycleCase) for item in accepted):
         raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
     for case in accepted:
@@ -1028,10 +1010,6 @@ def _normalize_accepted_cases(
             raise InvalidBmcEncoding(
                 "accepted_cases for %s may only contain ordinary accepted cases with kinds %r."
                 % (helper_name, allowed)
-            )
-        if case.is_diagnostic:
-            raise InvalidBmcEncoding(
-                "accepted_cases for %s must not contain diagnostic cases." % helper_name
             )
         if not _is_model_or_terminate_target(case):
             raise InvalidBmcEncoding(
@@ -1517,15 +1495,13 @@ class MacroStepFormal:
                 )
 
     def _validate_sentinel_absorb(self, sentinel_id: int) -> None:
-        if self.delta_cases:
-            raise InvalidBmcEncoding("sentinel absorb formals cannot have delta cases.")
         if len(self.success_cases) != 1:
             raise InvalidBmcEncoding("sentinel absorb formal must contain one case.")
         case = self.success_cases[0]
         if case.kind != "absorb":
             raise InvalidBmcEncoding("sentinel formal case must be absorb.")
-        if case.source_state_id != sentinel_id or case.target_state_id != sentinel_id:
-            raise InvalidBmcEncoding("sentinel absorb case must self-loop sentinel id.")
+        assert case.source_state_id == sentinel_id
+        assert case.target_state_id == sentinel_id
 
     def verify_partition(self, max_assignments: int = 4096) -> PartitionCheckResult:
         """Verify local case buckets with structural and truth-table self-checks.
@@ -2040,8 +2016,6 @@ def verify_boolean_partition(
         raise BmcBuildError("max_assignments must be a positive integer.")
     if max_assignments <= 0:
         raise BmcBuildError("max_assignments must be a positive integer.")
-    _validate_partition_atom_prefixes(items, variables)
-
     if variables is None:
         names = sorted(
             set(itertools.chain.from_iterable(item.variables for item in items))
@@ -2053,6 +2027,7 @@ def verify_boolean_partition(
         if not all(isinstance(name, str) and name for name in raw_names):
             raise BmcBuildError("partition variables must be non-empty strings.")
         names = sorted(set(raw_names))
+    _validate_partition_atom_prefixes(items, names)
     assignment_count = 2 ** len(names)
     if assignment_count > max_assignments:
         raise BmcBuildError("partition check exceeded assignment budget.")
@@ -2150,6 +2125,13 @@ def verify_source_partition(
         raise InvalidBmcEncoding(
             "build_diagnostic_conditions must contain BoolTemplate objects."
         )
+
+    if source.kind in {"terminated", "diagnostic"}:
+        structural = _structural_partition_result(
+            source, success, delta, diagnostics, ()
+        )
+        if structural is not None:
+            return structural
 
     _validate_partition_atom_prefixes(
         [case.condition for case in success + delta] + list(diagnostics)

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -1956,8 +1956,23 @@ def _validate_sentinel_absorb_partition(
         raise InvalidBmcEncoding(
             "sentinel absorb case must self-loop the source sentinel."
         )
+    expected_label = "%s::absorb::%s::0" % (sentinel_path, sentinel_path)
+    if case.label != expected_label:
+        raise InvalidBmcEncoding("sentinel absorb label must be canonical.")
     if case.condition.kind != "true":
         raise InvalidBmcEncoding("sentinel absorb condition must be true.")
+    if case.action_blocks:
+        raise InvalidBmcEncoding("sentinel absorb case cannot have action blocks.")
+    if case.used_events:
+        raise InvalidBmcEncoding("sentinel absorb case cannot use events.")
+    if case.guard_requirements:
+        raise InvalidBmcEncoding("sentinel absorb case cannot have guard requirements.")
+    if case.priority_exclusions:
+        raise InvalidBmcEncoding(
+            "sentinel absorb case cannot have priority exclusions."
+        )
+    if case.failed_conditions:
+        raise InvalidBmcEncoding("sentinel absorb case cannot have failed conditions.")
 
 
 def _structural_partition_result(

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -1495,13 +1495,18 @@ class MacroStepFormal:
                 )
 
     def _validate_sentinel_absorb(self, sentinel_id: int) -> None:
-        if len(self.success_cases) != 1:
-            raise InvalidBmcEncoding("sentinel absorb formal must contain one case.")
-        case = self.success_cases[0]
-        if case.kind != "absorb":
-            raise InvalidBmcEncoding("sentinel formal case must be absorb.")
-        assert case.source_state_id == sentinel_id
-        assert case.target_state_id == sentinel_id
+        expected_path = (
+            TERMINATE_CASE_PATH
+            if sentinel_id == STATE_TERMINATE_ID
+            else DIAGNOSTIC_CASE_PATH
+        )
+        _validate_sentinel_absorb_partition(
+            self.success_cases,
+            self.delta_cases,
+            self.build_diagnostic_conditions,
+            sentinel_id,
+            expected_path,
+        )
 
     def verify_partition(self, max_assignments: int = 4096) -> PartitionCheckResult:
         """Verify local case buckets with structural and truth-table self-checks.
@@ -1924,6 +1929,37 @@ def _resolve_accepted_atoms(
     raise BmcBuildError("unsupported boolean template kind: %r." % condition.kind)
 
 
+def _validate_sentinel_absorb_partition(
+    success: Sequence[CycleCase],
+    delta: Sequence[CycleCase],
+    diagnostics: Sequence[BoolTemplate],
+    sentinel_id: int,
+    sentinel_path: str,
+) -> None:
+    if delta:
+        raise InvalidBmcEncoding("sentinel absorb formal cannot have delta cases.")
+    if diagnostics:
+        raise InvalidBmcEncoding(
+            "sentinel absorb formal cannot have build diagnostics."
+        )
+    if len(success) != 1:
+        raise InvalidBmcEncoding("sentinel absorb formal must contain one case.")
+    case = success[0]
+    if case.kind != "absorb":
+        raise InvalidBmcEncoding("sentinel formal case must be absorb.")
+    if (
+        case.source_state_id != sentinel_id
+        or case.target_state_id != sentinel_id
+        or case.source_state_path != sentinel_path
+        or case.target_state_path != sentinel_path
+    ):
+        raise InvalidBmcEncoding(
+            "sentinel absorb case must self-loop the source sentinel."
+        )
+    if case.condition.kind != "true":
+        raise InvalidBmcEncoding("sentinel absorb condition must be true.")
+
+
 def _structural_partition_result(
     source: MacroStepSource,
     success: Sequence[CycleCase],
@@ -1932,9 +1968,16 @@ def _structural_partition_result(
     variables: Sequence[str],
 ) -> Optional[PartitionCheckResult]:
     if source.kind in {"terminated", "diagnostic"}:
-        if len(success) == 1 and not delta and not diagnostics:
-            return PartitionCheckResult(tuple(variables), 0, 1)
-        return None
+        sentinel_id = (
+            STATE_TERMINATE_ID if source.kind == "terminated" else STATE_DIAGNOSTIC_ID
+        )
+        sentinel_path = (
+            TERMINATE_CASE_PATH if source.kind == "terminated" else DIAGNOSTIC_CASE_PATH
+        )
+        _validate_sentinel_absorb_partition(
+            success, delta, diagnostics, sentinel_id, sentinel_path
+        )
+        return PartitionCheckResult(tuple(variables), 0, 1)
 
     cases = tuple(success) + tuple(delta)
     accepted_cases = [case for case in cases if case.kind in _ACCEPTED_CASE_KINDS]
@@ -2085,8 +2128,9 @@ def verify_source_partition(
     :return: Partition self-check summary.
     :rtype: PartitionCheckResult
     :raises BmcBuildError: If the buckets are not complete and disjoint.
-    :raises InvalidBmcEncoding: If delta cases are used for a source that does
-        not allow semantic delta.
+    :raises InvalidBmcEncoding: If the source/case buckets have an invalid
+        shape, including unsupported delta buckets or malformed sentinel absorb
+        partitions.
 
     Example::
 

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -678,6 +678,36 @@ def _validate_case_state(
         raise InvalidBmcEncoding("%s path does not match %s id." % (role, role))
 
 
+def _event_atom_paths_in_case(case: "CycleCase") -> Tuple[str, ...]:
+    paths = set()
+    for condition in (case.condition,) + case.failed_conditions:
+        for variable in condition.variables:
+            if variable.startswith("event:"):
+                paths.add(variable[len("event:") :])
+    return tuple(sorted(paths))
+
+
+def _event_uses_from_condition(
+    condition: BoolTemplate,
+    domain: BmcDomain,
+    polarity: str,
+    reason: str,
+) -> Tuple[EventUse, ...]:
+    result = []
+    for variable in condition.variables:
+        if not variable.startswith("event:"):
+            continue
+        path = variable[len("event:") :]
+        try:
+            entry = domain.event_by_path(path)
+        except InvalidBmcDomain as err:
+            # InvalidBmcDomain: domain.event_by_path rejects event atoms that
+            # helper-built fallback/delta conditions pulled from malformed input.
+            raise InvalidBmcEncoding(str(err)) from err
+        result.append(EventUse(entry.id, entry.path, polarity, reason))
+    return tuple(sorted(result, key=_canonical_key))
+
+
 def _derive_is_diagnostic(kind: str, target_state_id: int) -> bool:
     return kind in {"diagnostic", "delta"} or (
         kind == "absorb" and target_state_id == STATE_DIAGNOSTIC_ID
@@ -890,6 +920,7 @@ class CycleCase:
             self.target_state_path,
             "target",
         )
+        used_event_paths = set()
         for event_use in self.used_events:
             try:
                 event = domain.event_by_id(event_use.event_id)
@@ -899,6 +930,18 @@ class CycleCase:
                 raise InvalidBmcEncoding(str(err)) from err
             if event.path != event_use.path:
                 raise InvalidBmcEncoding("EventUse path does not match event id.")
+            used_event_paths.add(event.path)
+        for event_path in _event_atom_paths_in_case(self):
+            try:
+                domain.event_by_path(event_path)
+            except InvalidBmcDomain as err:
+                # InvalidBmcDomain: BmcDomain lookup rejects event atoms that
+                # reference paths outside the case's domain snapshot.
+                raise InvalidBmcEncoding(str(err)) from err
+            if event_path not in used_event_paths:
+                raise InvalidBmcEncoding(
+                    "event atoms in case conditions must be listed in used_events."
+                )
         object.__setattr__(
             self,
             "var_update",
@@ -1348,6 +1391,18 @@ def build_fallback_case(
         )
     else:
         condition = BoolTemplate.true()
+    used_events = _event_uses_from_condition(
+        condition,
+        domain,
+        polarity="negative",
+        reason="fallback",
+    )
+    used_events += _event_uses_from_condition(
+        BoolTemplate.or_(*failed),
+        domain,
+        polarity="negative",
+        reason="fallback",
+    )
     return CycleCase(
         "fallback",
         source.source_state_id,
@@ -1362,6 +1417,7 @@ def build_fallback_case(
         ),
         condition,
         carry_var_updates(domain),
+        used_events=used_events,
         failed_conditions=failed,
         domain=domain,
     )
@@ -1438,6 +1494,18 @@ def build_semantic_delta_case(
         condition = BoolTemplate.not_(BoolTemplate.or_(*excluded))
     else:
         condition = BoolTemplate.true()
+    used_events = _event_uses_from_condition(
+        condition,
+        domain,
+        polarity="negative",
+        reason="fallback",
+    )
+    used_events += _event_uses_from_condition(
+        BoolTemplate.or_(*failed),
+        domain,
+        polarity="negative",
+        reason="fallback",
+    )
     return CycleCase(
         "delta",
         source.source_state_id,
@@ -1452,6 +1520,7 @@ def build_semantic_delta_case(
         ),
         condition,
         carry_var_updates(domain),
+        used_events=used_events,
         failed_conditions=failed,
         domain=domain,
     )

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -22,9 +22,10 @@ Design contracts:
 * :class:`PriorityExclusion` records declaration-order masks through
   ``accepted:<case_label>`` atoms.  The accepted atom denotes the already lowered
   antecedent of a prior accepted path, not a raw event or guard trigger.
-* Partition verification is a build-time/test-time self-check.  It resolves
-  accepted atoms through the source-local case registry before running the small
-  truth-table checker and never produces clauses for ``Core_N`` or ``Phi_N``.
+* Partition verification is a build-time/test-time self-check.  It first accepts
+  structural accepted/fallback masks that are disjoint by construction, then
+  falls back to a bounded truth-table checker for small non-canonical shapes. It
+  never produces clauses for ``Core_N`` or ``Phi_N``.
 
 The module contains:
 
@@ -53,7 +54,7 @@ from __future__ import annotations
 import itertools
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, Mapping, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 
 from pyfcstm.bmc.domain import STATE_DIAGNOSTIC_ID, STATE_TERMINATE_ID, BmcDomain
 from pyfcstm.bmc.errors import BmcBuildError, InvalidBmcDomain, InvalidBmcEncoding
@@ -71,8 +72,27 @@ _ACCEPTED_CASE_KINDS = {"transition", "initial"}
 _EVENT_POLARITIES = {"positive", "negative"}
 _EVENT_REASONS = {"trigger", "priority", "fallback", "descent", "assumption"}
 _GUARD_POLARITIES = {"positive", "negative"}
-_GUARD_REASONS = {"transition_guard", "initial_guard", "priority", "fallback"}
+_GUARD_REASONS = {
+    "transition_guard",
+    "initial_guard",
+    "pseudo_guard",
+    "parent_continuation_guard",
+    "priority",
+    "fallback",
+    "delta_exclusion",
+}
 _PRIORITY_REASONS = {"transition_priority", "initial_priority", "fallback", "delta"}
+_ACTION_BLOCK_KINDS = {"state_action", "aspect_action", "transition_effect"}
+_ACTION_RUNTIME_ROLES = {
+    "state_enter",
+    "state_exit",
+    "leaf_during",
+    "plain_during_before",
+    "plain_during_after",
+    "aspect_during_before",
+    "aspect_during_after",
+    "transition_effect",
+}
 _RESERVED_CASE_PATHS = {TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH}
 _SOURCE_STATE_ATOM_PREFIX = "__source_state__:"
 _EVENT_ATOM_PREFIX = "event:"
@@ -387,7 +407,7 @@ class BoolTemplate:
             >>> BoolTemplate.atom('guard:g0').to_canonical()['name']
             'guard:g0'
         """
-        result = {"node": "bool_template", "kind": self.kind}
+        result = {"node": "bool_template", "kind": self.kind}  # type: _CanonicalDict
         if self.kind == "atom":
             result["name"] = self._atom_name()
         if self.operands:
@@ -667,10 +687,12 @@ class PriorityExclusion:
 class ActionBlock:
     """Runtime action block recorded for a macro-step path.
 
-    :param block_kind: Domain block kind such as ``"enter"``, ``"exit"``,
-        ``"during"``, ``"during_aspect"``, or ``"transition_effect"``.
+    :param block_kind: Public block kind: ``"state_action"``,
+        ``"aspect_action"``, or ``"transition_effect"``.
     :type block_kind: str
-    :param runtime_role: Runtime role explaining why the block executes.
+    :param runtime_role: Runtime role explaining why the block executes, such as
+        ``"state_enter"``, ``"leaf_during"``, ``"aspect_during_before"``, or
+        ``"transition_effect"``.
     :type runtime_role: str
     :param owner_state_id: Domain id of the state that owns the block.
     :type owner_state_id: int
@@ -690,7 +712,7 @@ class ActionBlock:
 
     Example::
 
-        >>> ActionBlock('during', 'leaf_during', 0, 'Root', ()).operations
+        >>> ActionBlock('state_action', 'leaf_during', 0, 'Root', ()).operations
         ()
     """
 
@@ -715,12 +737,14 @@ class ActionBlock:
         if not isinstance(self.is_abstract, bool):
             raise InvalidBmcEncoding("is_abstract must be a boolean.")
         object.__setattr__(
-            self, "block_kind", _require_non_empty_string(self.block_kind, "block_kind")
+            self,
+            "block_kind",
+            _validate_choice(self.block_kind, _ACTION_BLOCK_KINDS, "block_kind"),
         )
         object.__setattr__(
             self,
             "runtime_role",
-            _require_non_empty_string(self.runtime_role, "runtime_role"),
+            _validate_choice(self.runtime_role, _ACTION_RUNTIME_ROLES, "runtime_role"),
         )
         object.__setattr__(self, "owner_state_id", owner_state_id)
         object.__setattr__(
@@ -750,8 +774,8 @@ class ActionBlock:
 
         Example::
 
-            >>> ActionBlock('during', 'leaf_during', 0, 'Root', ()).to_canonical()['block_kind']
-            'during'
+            >>> ActionBlock('state_action', 'leaf_during', 0, 'Root', ()).to_canonical()['block_kind']
+            'state_action'
         """
         return {
             "node": "action_block",
@@ -845,6 +869,27 @@ def _validate_condition_atom_prefixes(condition: BoolTemplate, field_name: str) 
             )
 
 
+def _validate_partition_atom_prefixes(
+    conditions: Sequence[BoolTemplate],
+    variables: Optional[Sequence[str]] = None,
+) -> None:
+    for condition in conditions:
+        _validate_condition_atom_prefixes(condition, "partition bucket")
+    if variables is None:
+        return
+    for atom in variables:
+        if atom.startswith(_SOURCE_STATE_ATOM_PREFIX):
+            raise BmcBuildError(
+                "partition variables use reserved source-state atom namespace: %r."
+                % atom
+            )
+        if not atom.startswith(_VALID_CONDITION_PREFIXES):
+            raise BmcBuildError(
+                "partition variables use unsupported macro condition atom namespace: %r."
+                % atom
+            )
+
+
 def _event_atom_paths(condition: BoolTemplate) -> Tuple[str, ...]:
     return tuple(
         sorted(
@@ -873,6 +918,72 @@ def _accepted_atom_labels(condition: BoolTemplate) -> Tuple[str, ...]:
             if atom.startswith(_ACCEPTED_ATOM_PREFIX)
         )
     )
+
+
+def _accepted_union_labels(condition: BoolTemplate) -> Optional[Tuple[str, ...]]:
+    if condition.kind == "false":
+        return ()
+    if condition.kind == "atom":
+        atom = condition._atom_name()
+        if atom.startswith(_ACCEPTED_ATOM_PREFIX):
+            return (atom[len(_ACCEPTED_ATOM_PREFIX) :],)
+        return None
+    if condition.kind != "or":
+        return None
+    labels = []
+    for operand in condition.operands:
+        item = _accepted_union_labels(operand)
+        if item is None or len(item) != 1:
+            return None
+        labels.extend(item)
+    return tuple(sorted(set(labels)))
+
+
+def _condition_uses_expected_accepted_prefix(
+    condition: BoolTemplate, labels: Sequence[str]
+) -> bool:
+    """Return whether ``condition`` has exactly the expected accepted mask."""
+    expected = tuple(labels)
+    if not expected:
+        return not _accepted_atom_labels(condition)
+    expected_mask = BoolTemplate.not_(
+        BoolTemplate.or_(
+            *[
+                BoolTemplate.atom("%s%s" % (_ACCEPTED_ATOM_PREFIX, label))
+                for label in expected
+            ]
+        )
+    )
+    expected_mask_key = _canonical_key(expected_mask)
+    if _canonical_key(condition) == expected_mask_key:
+        return True
+    if condition.kind != "and":
+        return False
+    mask_count = 0
+    for operand in condition.operands:
+        if _canonical_key(operand) == expected_mask_key:
+            mask_count += 1
+            continue
+        if _accepted_atom_labels(operand):
+            return False
+    return mask_count == 1
+
+
+def _condition_uses_exact_accepted_complement(
+    condition: BoolTemplate,
+    labels: Sequence[str],
+    extra_exclusions: Sequence[BoolTemplate] = (),
+) -> bool:
+    exclusions = [
+        BoolTemplate.atom("%s%s" % (_ACCEPTED_ATOM_PREFIX, label)) for label in labels
+    ]
+    exclusions.extend(extra_exclusions)
+    expected = (
+        BoolTemplate.not_(BoolTemplate.or_(*exclusions))
+        if exclusions
+        else BoolTemplate.true()
+    )
+    return _canonical_key(condition) == _canonical_key(expected)
 
 
 def _event_uses_from_paths(
@@ -1208,7 +1319,7 @@ class PartitionCheckResult:
 
     Example::
 
-        >>> PartitionCheckResult(('a',), 2, 2).to_canonical()['assignment_count']
+        >>> PartitionCheckResult(('event:Root.Go',), 2, 2).to_canonical()['assignment_count']
         2
     """
 
@@ -1417,7 +1528,7 @@ class MacroStepFormal:
             raise InvalidBmcEncoding("sentinel absorb case must self-loop sentinel id.")
 
     def verify_partition(self, max_assignments: int = 4096) -> PartitionCheckResult:
-        """Verify local case buckets with the truth-table self-checker.
+        """Verify local case buckets with structural and truth-table self-checks.
 
         :param max_assignments: Maximum assignments to enumerate, defaults to
             ``4096``.
@@ -1425,7 +1536,7 @@ class MacroStepFormal:
         :return: Partition self-check summary.
         :rtype: PartitionCheckResult
         :raises BmcBuildError: If the buckets overlap, leave a gap, or exceed
-            the assignment budget.
+            the assignment budget for a non-structural shape.
 
         Example::
 
@@ -1592,6 +1703,7 @@ def build_fallback_case(
     accepted_cases: Sequence[CycleCase],
     failed_conditions: Sequence[BoolTemplate] = (),
     ordinal: int = 0,
+    guard_requirements: Sequence[GuardRequirement] = (),
 ) -> CycleCase:
     """Build a stable leaf fallback self-cycle.
 
@@ -1611,6 +1723,9 @@ def build_fallback_case(
     :type failed_conditions: Sequence[BoolTemplate], optional
     :param ordinal: Label ordinal, defaults to ``0``.
     :type ordinal: int, optional
+    :param guard_requirements: Guard metadata for atoms referenced by failed
+        diagnostic conditions, defaults to ``()``.
+    :type guard_requirements: Sequence[GuardRequirement], optional
     :return: Fallback case.
     :rtype: CycleCase
     :raises InvalidBmcEncoding: If ``source`` is not a stable leaf source.
@@ -1638,6 +1753,11 @@ def build_fallback_case(
     failed = tuple(failed_conditions)
     if not all(isinstance(item, BoolTemplate) for item in failed):
         raise InvalidBmcEncoding("failed_conditions must contain BoolTemplate objects.")
+    guards = tuple(guard_requirements)
+    if not all(isinstance(item, GuardRequirement) for item in guards):
+        raise InvalidBmcEncoding(
+            "guard_requirements must contain GuardRequirement objects."
+        )
     excluded = _accepted_condition(accepted)
     condition = BoolTemplate.not_(excluded) if accepted else BoolTemplate.true()
     used_events = _event_uses_from_paths(
@@ -1665,6 +1785,7 @@ def build_fallback_case(
         condition,
         (),
         used_events=used_events,
+        guard_requirements=guards,
         priority_exclusions=(priority,) if priority is not None else (),
         failed_conditions=failed,
         domain=domain,
@@ -1678,6 +1799,7 @@ def build_semantic_delta_case(
     build_diagnostic_conditions: Sequence[BoolTemplate] = (),
     failed_conditions: Sequence[BoolTemplate] = (),
     ordinal: int = 0,
+    guard_requirements: Sequence[GuardRequirement] = (),
 ) -> CycleCase:
     """Build a non-stoppable entry uncovered-region delta case.
 
@@ -1698,6 +1820,9 @@ def build_semantic_delta_case(
     :type failed_conditions: Sequence[BoolTemplate], optional
     :param ordinal: Label ordinal, defaults to ``0``.
     :type ordinal: int, optional
+    :param guard_requirements: Guard metadata for atoms referenced by failed
+        diagnostic conditions, defaults to ``()``.
+    :type guard_requirements: Sequence[GuardRequirement], optional
     :return: Semantic delta case targeting the diagnostic sentinel.
     :rtype: CycleCase
     :raises InvalidBmcEncoding: If ``source`` does not allow semantic delta.
@@ -1732,6 +1857,11 @@ def build_semantic_delta_case(
     failed = tuple(failed_conditions)
     if not all(isinstance(item, BoolTemplate) for item in failed):
         raise InvalidBmcEncoding("failed_conditions must contain BoolTemplate objects.")
+    guards = tuple(guard_requirements)
+    if not all(isinstance(item, GuardRequirement) for item in guards):
+        raise InvalidBmcEncoding(
+            "guard_requirements must contain GuardRequirement objects."
+        )
     excluded = []
     if accepted:
         excluded.append(_accepted_condition(accepted))
@@ -1764,6 +1894,7 @@ def build_semantic_delta_case(
         condition,
         (),
         used_events=used_events,
+        guard_requirements=guards,
         priority_exclusions=(priority,) if priority is not None else (),
         failed_conditions=failed,
         domain=domain,
@@ -1817,6 +1948,61 @@ def _resolve_accepted_atoms(
     raise BmcBuildError("unsupported boolean template kind: %r." % condition.kind)
 
 
+def _structural_partition_result(
+    source: MacroStepSource,
+    success: Sequence[CycleCase],
+    delta: Sequence[CycleCase],
+    diagnostics: Sequence[BoolTemplate],
+    variables: Sequence[str],
+) -> Optional[PartitionCheckResult]:
+    if source.kind in {"terminated", "diagnostic"}:
+        if len(success) == 1 and not delta and not diagnostics:
+            return PartitionCheckResult(tuple(variables), 0, 1)
+        return None
+
+    cases = tuple(success) + tuple(delta)
+    accepted_cases = [case for case in cases if case.kind in _ACCEPTED_CASE_KINDS]
+    terminal_cases = [case for case in cases if case.kind not in _ACCEPTED_CASE_KINDS]
+    accepted_labels: List[str] = []
+    remaining: List[CycleCase] = list(accepted_cases)
+    while remaining:
+        candidates = [
+            case
+            for case in remaining
+            if _condition_uses_expected_accepted_prefix(case.condition, accepted_labels)
+        ]
+        if len(candidates) != 1:
+            return None
+        selected = candidates[0]
+        accepted_labels.append(selected.label)
+        remaining.remove(selected)
+
+    if len(terminal_cases) != 1:
+        return None
+    terminal = terminal_cases[0]
+    if terminal.kind == "fallback":
+        if source.kind != "stable_leaf" or delta or diagnostics:
+            return None
+        if not _condition_uses_exact_accepted_complement(
+            terminal.condition, accepted_labels
+        ):
+            return None
+    elif terminal.kind == "delta":
+        if source.kind != "entry":
+            return None
+        if not _condition_uses_exact_accepted_complement(
+            terminal.condition, accepted_labels, diagnostics
+        ):
+            return None
+    else:
+        return None
+
+    if diagnostics and (source.kind != "entry" or not delta):
+        return None
+    bucket_count = len(cases) + (1 if diagnostics else 0)
+    return PartitionCheckResult(tuple(variables), 0, bucket_count)
+
+
 def verify_boolean_partition(
     buckets: Sequence[BoolTemplate],
     variables: Optional[Sequence[str]] = None,
@@ -1839,7 +2025,7 @@ def verify_boolean_partition(
 
     Example::
 
-        >>> a = BoolTemplate.atom('a')
+        >>> a = BoolTemplate.atom('event:Root.Go')
         >>> verify_boolean_partition((a, BoolTemplate.not_(a))).assignment_count
         2
     """
@@ -1854,6 +2040,7 @@ def verify_boolean_partition(
         raise BmcBuildError("max_assignments must be a positive integer.")
     if max_assignments <= 0:
         raise BmcBuildError("max_assignments must be a positive integer.")
+    _validate_partition_atom_prefixes(items, variables)
 
     if variables is None:
         names = sorted(
@@ -1902,10 +2089,11 @@ def verify_source_partition(
 ) -> PartitionCheckResult:
     """Verify one source's local case partition.
 
-    ``accepted:<case_label>`` atoms are resolved through the source-local case
-    registry before truth-table enumeration, so declaration-priority masks are
-    checked against the same accepted-path meaning that later relation lowering
-    will use.
+    Canonical accepted/fallback masks are verified structurally to avoid
+    rejecting large declaration-priority partitions merely because their event
+    or guard atom count exceeds the fallback truth-table budget.  Non-canonical
+    shapes are resolved through the source-local accepted-case registry and then
+    checked by bounded truth-table enumeration.
 
     :param source: Macro-step source profile.
     :type source: MacroStepSource
@@ -1963,11 +2151,23 @@ def verify_source_partition(
             "build_diagnostic_conditions must contain BoolTemplate objects."
         )
 
+    _validate_partition_atom_prefixes(
+        [case.condition for case in success + delta] + list(diagnostics)
+    )
     registry = {case.label: case.condition for case in success + delta}
     buckets = [_resolve_accepted_atoms(case.condition, registry) for case in success]
     buckets.extend(_resolve_accepted_atoms(case.condition, registry) for case in delta)
     if diagnostics:
         buckets.append(BoolTemplate.or_(*diagnostics))
+    variables = sorted(
+        set(itertools.chain.from_iterable(bucket.variables for bucket in buckets))
+    )
+    if 2 ** len(variables) > max_assignments:
+        structural = _structural_partition_result(
+            source, success, delta, diagnostics, variables
+        )
+        if structural is not None:
+            return structural
     return verify_boolean_partition(buckets, max_assignments=max_assignments)
 
 

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -207,14 +207,25 @@ class BoolTemplate:
 
         :param operand: Operand condition.
         :type operand: BoolTemplate
-        :return: Negated condition.
+        :return: Negated condition with constant and double-negation identities
+            reduced.
         :rtype: BoolTemplate
 
         Example::
 
             >>> BoolTemplate.not_(BoolTemplate.false()).evaluate({})
             True
+            >>> BoolTemplate.not_(BoolTemplate.not_(BoolTemplate.atom('go'))).to_canonical()['name']
+            'go'
         """
+        if not isinstance(operand, BoolTemplate):
+            raise InvalidBmcEncoding("operand must be BoolTemplate.")
+        if operand.kind == "true":
+            return cls.false()
+        if operand.kind == "false":
+            return cls.true()
+        if operand.kind == "not":
+            return operand.operands[0]
         return cls("not", operands=(operand,))
 
     @classmethod
@@ -223,21 +234,40 @@ class BoolTemplate:
 
         :param operands: Operand conditions.
         :type operands: BoolTemplate
-        :return: Conjunction, or constant true for an empty input.
+        :return: Conjunction with identity, absorbing, and idempotent operands
+            reduced, or constant true for an empty input.
         :rtype: BoolTemplate
 
         Example::
 
             >>> BoolTemplate.and_().evaluate({})
             True
+            >>> BoolTemplate.and_(BoolTemplate.true(), BoolTemplate.atom('go')).to_canonical()['name']
+            'go'
         """
         if not operands:
             return cls.true()
         if not all(isinstance(item, BoolTemplate) for item in operands):
             raise InvalidBmcEncoding("operands must contain BoolTemplate objects.")
-        if len(operands) == 1:
-            return operands[0]
-        return cls("and", operands=tuple(operands))
+        flattened = []
+        pending = list(operands)
+        while pending:
+            operand = pending.pop(0)
+            if operand.kind == "false":
+                return cls.false()
+            if operand.kind == "true":
+                continue
+            if operand.kind == "and":
+                pending[:0] = operand.operands
+            else:
+                flattened.append(operand)
+        by_key = {_canonical_key(item): item for item in flattened}
+        reduced = tuple(by_key[key] for key in sorted(by_key))
+        if not reduced:
+            return cls.true()
+        if len(reduced) == 1:
+            return reduced[0]
+        return cls("and", operands=reduced)
 
     @classmethod
     def or_(cls, *operands: "BoolTemplate") -> "BoolTemplate":
@@ -245,21 +275,40 @@ class BoolTemplate:
 
         :param operands: Operand conditions.
         :type operands: BoolTemplate
-        :return: Disjunction, or constant false for an empty input.
+        :return: Disjunction with identity, absorbing, and idempotent operands
+            reduced, or constant false for an empty input.
         :rtype: BoolTemplate
 
         Example::
 
             >>> BoolTemplate.or_().evaluate({})
             False
+            >>> BoolTemplate.or_(BoolTemplate.false(), BoolTemplate.atom('go')).to_canonical()['name']
+            'go'
         """
         if not operands:
             return cls.false()
         if not all(isinstance(item, BoolTemplate) for item in operands):
             raise InvalidBmcEncoding("operands must contain BoolTemplate objects.")
-        if len(operands) == 1:
-            return operands[0]
-        return cls("or", operands=tuple(operands))
+        flattened = []
+        pending = list(operands)
+        while pending:
+            operand = pending.pop(0)
+            if operand.kind == "true":
+                return cls.true()
+            if operand.kind == "false":
+                continue
+            if operand.kind == "or":
+                pending[:0] = operand.operands
+            else:
+                flattened.append(operand)
+        by_key = {_canonical_key(item): item for item in flattened}
+        reduced = tuple(by_key[key] for key in sorted(by_key))
+        if not reduced:
+            return cls.false()
+        if len(reduced) == 1:
+            return reduced[0]
+        return cls("or", operands=reduced)
 
     @property
     def variables(self) -> Tuple[str, ...]:

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -671,9 +671,10 @@ def _normalize_accepted_cases(
             raise InvalidBmcEncoding(
                 "accepted_cases for %s must not contain diagnostic cases." % helper_name
             )
-        if case.target_state_id < 0 or case.target_state_path in _RESERVED_CASE_PATHS:
+        if not _is_model_or_terminate_target(case):
             raise InvalidBmcEncoding(
-                "accepted_cases for %s must target model states." % helper_name
+                "accepted_cases for %s must target model states or terminate."
+                % helper_name
             )
         if case.source_state_id != source.source_state_id:
             raise InvalidBmcEncoding(
@@ -926,6 +927,14 @@ class PartitionCheckResult:
         }
 
 
+def _is_model_or_terminate_target(case: CycleCase) -> bool:
+    if case.target_state_id == STATE_TERMINATE_ID:
+        return case.target_state_path == TERMINATE_CASE_PATH
+    return (
+        case.target_state_id >= 0 and case.target_state_path not in _RESERVED_CASE_PATHS
+    )
+
+
 @dataclass(frozen=True)
 class MacroStepFormal:
     """Source-local macro-step case buckets.
@@ -1049,29 +1058,26 @@ class MacroStepFormal:
                 raise InvalidBmcEncoding(
                     "stable leaf success cases may only be transition or fallback."
                 )
-            if (
-                case.target_state_id < 0
-                or case.target_state_path in _RESERVED_CASE_PATHS
-            ):
-                raise InvalidBmcEncoding(
-                    "stable leaf success cases must target model states."
-                )
             if case.kind == "fallback" and (
                 case.target_state_id != self.source.source_state_id
                 or case.target_state_path != self.source.source_state_path
             ):
                 raise InvalidBmcEncoding("fallback cases must self-loop source.")
+            if case.kind == "transition" and not _is_model_or_terminate_target(case):
+                raise InvalidBmcEncoding(
+                    "stable leaf transitions must target model states or terminate."
+                )
         elif self.source.kind == "entry":
             if case.kind not in {"transition", "initial", "diagnostic"}:
                 raise InvalidBmcEncoding(
                     "entry success cases may only be transition, initial, or diagnostic."
                 )
-            if case.kind in {"transition", "initial"} and (
-                case.target_state_id < 0
-                or case.target_state_path in _RESERVED_CASE_PATHS
-            ):
+            if case.kind in {
+                "transition",
+                "initial",
+            } and not _is_model_or_terminate_target(case):
                 raise InvalidBmcEncoding(
-                    "entry transition and initial cases must target model states."
+                    "entry transition and initial cases must target model states or terminate."
                 )
 
     def _validate_sentinel_absorb(self, sentinel_id: int) -> None:

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -108,8 +108,9 @@ _VALID_CONDITION_PREFIXES = (
 def _internal_bmc_error(detail: str) -> BmcBuildError:
     return BmcBuildError(
         "internal error: %s This indicates a pyfcstm BMC bug or a corrupted "
-        "internal object; please report this issue with the FCSTM input, query, "
-        "and traceback at https://github.com/HansBug/pyfcstm/issues." % detail
+        "internal object; please report this issue with the FCSTM input, BMC "
+        "query or expansion source, and traceback at "
+        "https://github.com/HansBug/pyfcstm/issues." % detail
     )
 
 

--- a/pyfcstm/bmc/macro.py
+++ b/pyfcstm/bmc/macro.py
@@ -105,6 +105,14 @@ _VALID_CONDITION_PREFIXES = (
 )
 
 
+def _internal_bmc_error(detail: str) -> BmcBuildError:
+    return BmcBuildError(
+        "internal error: %s This indicates a pyfcstm BMC bug or a corrupted "
+        "internal object; please report this issue with the FCSTM input, query, "
+        "and traceback at https://github.com/HansBug/pyfcstm/issues." % detail
+    )
+
+
 def _require_non_empty_string(value: object, field_name: str) -> str:
     if not isinstance(value, str) or not value:
         raise InvalidBmcEncoding("%s must be a non-empty string." % field_name)
@@ -358,7 +366,9 @@ class BoolTemplate:
     def _atom_name(self) -> str:
         name = self.name
         if name is None:
-            raise BmcBuildError("atom template is missing a name.")
+            raise _internal_bmc_error(
+                "atom template is missing a name."
+            )  # pragma: no cover
         return name
 
     def evaluate(self, values: Mapping[str, bool]) -> bool:
@@ -394,7 +404,9 @@ class BoolTemplate:
             return all(operand.evaluate(values) for operand in self.operands)
         if self.kind == "or":
             return any(operand.evaluate(values) for operand in self.operands)
-        raise BmcBuildError("unsupported boolean template kind: %r." % self.kind)
+        raise _internal_bmc_error(  # pragma: no cover
+            "unsupported boolean template kind while evaluating: %r." % self.kind
+        )
 
     def to_canonical(self) -> _CanonicalDict:
         """Return a JSON-stable condition recipe.
@@ -1006,9 +1018,10 @@ def _normalize_accepted_cases(
         raise InvalidBmcEncoding("accepted_cases must be a sequence.")
     accepted = tuple(accepted_cases)
     allowed = tuple(allowed_kinds)
-    assert allowed and all(kind in _ACCEPTED_CASE_KINDS for kind in allowed), (
-        "_normalize_accepted_cases only accepts ordinary macro case kind policies."
-    )
+    if not allowed or not all(kind in _ACCEPTED_CASE_KINDS for kind in allowed):
+        raise _internal_bmc_error(  # pragma: no cover
+            "_normalize_accepted_cases only accepts ordinary macro case kind policies."
+        )
     if not all(isinstance(item, CycleCase) for item in accepted):
         raise InvalidBmcEncoding("accepted_cases must contain CycleCase objects.")
     for case in accepted:
@@ -1930,7 +1943,10 @@ def _resolve_accepted_atoms(
                 for item in condition.operands
             ]
         )
-    raise BmcBuildError("unsupported boolean template kind: %r." % condition.kind)
+    raise _internal_bmc_error(  # pragma: no cover
+        "unsupported boolean template kind while resolving accepted atoms: %r."
+        % condition.kind
+    )
 
 
 def _validate_sentinel_absorb_partition(
@@ -2003,9 +2019,11 @@ def _structural_partition_result(
         sentinel_path = (
             TERMINATE_CASE_PATH if source.kind == "terminated" else DIAGNOSTIC_CASE_PATH
         )
-        assert not delta and not diagnostics, (
-            "sentinel delta and diagnostics are rejected by public preflight"
-        )
+        if delta or diagnostics:
+            raise _internal_bmc_error(  # pragma: no cover
+                "sentinel structural partition received delta or diagnostic buckets "
+                "after public preflight."
+            )
         _validate_sentinel_absorb_partition(success, sentinel_id, sentinel_path)
         return PartitionCheckResult(tuple(variables), 0, 1)
 
@@ -2038,7 +2056,13 @@ def _structural_partition_result(
             return None
     elif terminal.kind == "delta":
         if source.kind != "entry":
-            return None
+            # Public verify_source_partition() rejects non-entry delta buckets
+            # before structural recognition; reaching this branch means an
+            # internal caller bypassed that preflight.
+            raise _internal_bmc_error(  # pragma: no cover
+                "delta structural partition reached a non-entry source after "
+                "public preflight."
+            )
         if not _condition_uses_exact_accepted_complement(
             terminal.condition, accepted_labels, diagnostics
         ):
@@ -2047,7 +2071,14 @@ def _structural_partition_result(
         return None
 
     if diagnostics and (source.kind != "entry" or not delta):
-        return None
+        # The fallback branch rejects diagnostics above, public preflight rejects
+        # non-entry delta buckets, and the only accepted diagnostic shape has a
+        # delta bucket.  Keep this as a loud structural guard for corrupted
+        # internal callers.
+        raise _internal_bmc_error(  # pragma: no cover
+            "diagnostic structural partition reached an unsupported source or "
+            "missing delta bucket after public preflight."
+        )
     bucket_count = len(cases) + (1 if diagnostics else 0)
     return PartitionCheckResult(tuple(variables), 0, bucket_count)
 

--- a/test/bmc/fixtures/macro_runtime_alignment.fcstm
+++ b/test/bmc/fixtures/macro_runtime_alignment.fcstm
@@ -1,0 +1,46 @@
+def int x = 0;
+def int y = 0;
+
+state Root {
+    >> during before { x = x + 1000; }
+    >> during after { y = y + 1000; }
+
+    state System {
+        during before { y = y + 1; }
+        during after { y = y + 2; }
+        exit { y = y + 4; }
+
+        state A {
+            exit { y = y + 10; }
+            during { x = x + 1; }
+        }
+
+        state Trap {
+            state TrapLeaf {
+                during { x = x + 400; }
+            }
+            [*] -> TrapLeaf :: Arm;
+        }
+
+        pseudo state Route;
+
+        state B {
+            enter { y = y + 1; }
+            during { x = x + 3; }
+        }
+
+        [*] -> A effect { x = x + 10; }
+        A -> Trap :: Tick effect { x = x + 20; }
+        A -> Route :: Tick effect { x = x + 2; }
+        Route -> B : if [x < 13] effect { x = x * 2; }
+        Route -> [*] : if [x >= 13] effect { y = y + 20; }
+    }
+
+    state Done {
+        enter { y = y + 10000; }
+        during { x = x + 10000; }
+    }
+
+    [*] -> System;
+    System -> Done : if [y >= 30] effect { x = x + 100; }
+}

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -83,14 +83,13 @@ def test_bmc_public_api_exports_exact_names():
         "source_from_initial_spec",
         "BoolTemplate",
         "EventUse",
-        "VarUpdate",
+        "GuardRequirement",
+        "PriorityExclusion",
+        "ActionBlock",
         "CycleCase",
         "PartitionCheckResult",
         "MacroStepFormal",
-        "carry_var_updates",
-        "var_update_for",
-        "build_var_updates",
-        "case_antecedent_condition",
+        "case_path_condition",
         "terminated_absorb_case",
         "diagnostic_absorb_case",
         "build_fallback_case",
@@ -123,14 +122,13 @@ def test_bmc_public_api_exports_exact_names():
         "source_from_initial_spec",
         "BoolTemplate",
         "EventUse",
-        "VarUpdate",
+        "GuardRequirement",
+        "PriorityExclusion",
+        "ActionBlock",
         "CycleCase",
         "PartitionCheckResult",
         "MacroStepFormal",
-        "carry_var_updates",
-        "var_update_for",
-        "build_var_updates",
-        "case_antecedent_condition",
+        "case_path_condition",
         "terminated_absorb_case",
         "diagnostic_absorb_case",
         "build_fallback_case",
@@ -151,10 +149,7 @@ def test_bmc_public_api_exports_exact_names():
         "terminated_source",
         "diagnostic_source",
         "source_from_initial_spec",
-        "carry_var_updates",
-        "var_update_for",
-        "build_var_updates",
-        "case_antecedent_condition",
+        "case_path_condition",
         "terminated_absorb_case",
         "diagnostic_absorb_case",
         "build_fallback_case",
@@ -170,8 +165,8 @@ def test_bmc_public_api_exports_exact_names():
         assert callable(getattr(bmc, name))
     assert bmc.STATE_TERMINATE_ID == -1
     assert bmc.STATE_DIAGNOSTIC_ID == -2
-    assert bmc.TERMINATE_CASE_PATH == "__terminate__"
     assert bmc.DIAGNOSTIC_CASE_PATH == "__diagnostic__"
+    assert bmc.TERMINATE_CASE_PATH == "__terminate__"
     assert "BmcDomain" in dir(bmc)
 
     with pytest.raises(AttributeError, match="NoSuchBmcExport"):
@@ -276,14 +271,13 @@ def test_submodule_all_exports_are_exact():
     assert set(macro.__all__) == {
         "BoolTemplate",
         "EventUse",
-        "VarUpdate",
+        "GuardRequirement",
+        "PriorityExclusion",
+        "ActionBlock",
         "CycleCase",
         "PartitionCheckResult",
         "MacroStepFormal",
-        "carry_var_updates",
-        "var_update_for",
-        "build_var_updates",
-        "case_antecedent_condition",
+        "case_path_condition",
         "terminated_absorb_case",
         "diagnostic_absorb_case",
         "build_fallback_case",
@@ -310,7 +304,7 @@ def test_bmc_does_not_import_verify_registry():
 
 @pytest.mark.unittest
 def test_bmc_import_does_not_load_verify_modules():
-    """Importing BMC in a fresh process keeps verify internals unloaded."""
+    """Importing BMC in a fresh process keeps model and verify internals unloaded."""
     code = (
         "import sys; "
         "import pyfcstm.bmc; "

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -89,6 +89,8 @@ def test_bmc_public_api_exports_exact_names():
         "build_semantic_delta_case",
         "verify_boolean_partition",
         "verify_source_partition",
+        "MacroExpansionOptions",
+        "expand_macro_step_cases",
     }
 
     assert set(bmc.__all__) == expected
@@ -127,6 +129,8 @@ def test_bmc_public_api_exports_exact_names():
         "build_semantic_delta_case",
         "verify_boolean_partition",
         "verify_source_partition",
+        "MacroExpansionOptions",
+        "expand_macro_step_cases",
     }
     function_names = {
         "parse_bmc_query",
@@ -150,6 +154,7 @@ def test_bmc_public_api_exports_exact_names():
         "verify_boolean_partition",
         "verify_source_partition",
         "build_bmc_domain",
+        "expand_macro_step_cases",
     }
     for name in expected - lazy_names - function_names:
         assert getattr(bmc, name).__name__ == name
@@ -175,6 +180,7 @@ def test_submodule_all_exports_are_exact():
     domain = importlib.import_module("pyfcstm.bmc.domain")
     source = importlib.import_module("pyfcstm.bmc.source")
     macro = importlib.import_module("pyfcstm.bmc.macro")
+    expand = importlib.import_module("pyfcstm.bmc.expand")
 
     assert set(errors.__all__) == {
         "BmcError",
@@ -265,6 +271,10 @@ def test_submodule_all_exports_are_exact():
         "build_semantic_delta_case",
         "verify_boolean_partition",
         "verify_source_partition",
+    }
+    assert set(expand.__all__) == {
+        "MacroExpansionOptions",
+        "expand_macro_step_cases",
     }
 
 

--- a/test/bmc/test_domain.py
+++ b/test/bmc/test_domain.py
@@ -351,6 +351,21 @@ def test_build_domain_rejects_invalid_model_or_bound(adversarial_model):
     with pytest.raises(InvalidBmcDomain):
         build_bmc_domain(object(), bound=1)
 
+    domain = build_bmc_domain(adversarial_model, bound=1)
+    with pytest.raises(InvalidBmcDomain, match="model must be StateMachine"):
+        BmcDomain(
+            domain.bound,
+            domain.states,
+            domain.events,
+            domain.variables,
+            domain.frames,
+            domain.steps,
+            domain.event_inputs,
+            domain.initial_state_ids,
+            domain.stable_state_ids,
+            model=object(),
+        )
+
 
 @pytest.mark.unittest
 def test_domain_entry_validation_rejects_malformed_values():

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -15,19 +15,17 @@ from pyfcstm.bmc import (
     build_bmc_domain,
 )
 from pyfcstm.bmc.macro import (
+    ActionBlock,
     BoolTemplate,
     CycleCase,
     EventUse,
+    GuardRequirement,
     MacroStepFormal,
-    VarUpdate,
     build_fallback_case,
     build_semantic_delta_case,
-    build_var_updates,
-    carry_var_updates,
-    case_antecedent_condition,
+    case_path_condition,
     diagnostic_absorb_case,
     terminated_absorb_case,
-    var_update_for,
     verify_boolean_partition,
     verify_source_partition,
 )
@@ -40,12 +38,13 @@ from pyfcstm.bmc.source import (
     terminated_source,
 )
 from pyfcstm.model import load_state_machine_from_text
+from pyfcstm.model.expr import Boolean, Variable
 
 
 @pytest.fixture()
-def macro_domain():
-    """Build a macro-contract fixture with variables and same-short-name events."""
-    model = load_state_machine_from_text(
+def macro_model():
+    """Build a macro-contract fixture model."""
+    return load_state_machine_from_text(
         """
         def int x = 0;
         def float y = 1.0;
@@ -53,7 +52,7 @@ def macro_domain():
             event Go;
             state Plant {
                 event Ping;
-                state Idle;
+                state Idle { during { if [x > 0] { y = y + 1; } else { y = 0; } } }
                 state Busy;
                 [*] -> Idle;
                 Idle -> Busy :: Ping + Go;
@@ -67,15 +66,33 @@ def macro_domain():
         }
         """
     )
-    return build_bmc_domain(model, bound=2)
+
+
+@pytest.fixture()
+def macro_domain(macro_model):
+    """Build a macro-contract fixture with variables and same-short-name events."""
+    return build_bmc_domain(macro_model, bound=2)
+
+
+@pytest.fixture()
+def sample_operation(macro_model):
+    """Return one concrete operation statement from the fixture model."""
+    state = macro_model.root_state.substates["Plant"].substates["Idle"]
+    return state.on_durings[0].operations[0]
 
 
 def make_case(
-    domain, source, label_kind="transition", condition=None, target_path=None, ordinal=0
+    domain,
+    source,
+    label_kind="transition",
+    condition=None,
+    target_path=None,
+    ordinal=0,
+    **kwargs,
 ):
     """Create a valid synthetic case for contract tests."""
     if condition is None:
-        condition = BoolTemplate.atom("g%d" % ordinal)
+        condition = BoolTemplate.true()
     if target_path is None:
         target_path = source.source_state_path
     target_id = domain.state_path_to_id(target_path)
@@ -85,193 +102,152 @@ def make_case(
         source.source_state_path,
         target_id,
         target_path,
-        "%s::%s::%s::%d" % (source.source_state_path, label_kind, target_path, ordinal),
+        "%s::%s::%s::%d"
+        % (
+            source.source_state_path,
+            label_kind,
+            target_path,
+            ordinal,
+        ),
         condition,
-        carry_var_updates(domain),
+        kwargs.pop("action_blocks", ()),
         domain=domain,
+        **kwargs,
     )
 
 
 @pytest.mark.unittest
-def test_cycle_case_condition_is_bare_gamma_and_source_guard_is_composed_later(
-    macro_domain,
-):
-    """CycleCase.condition excludes the pre-state source guard by contract."""
+def test_cycle_case_condition_is_control_path_only(macro_domain):
+    """CycleCase.condition excludes source guards and writeback formulas."""
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    gamma = BoolTemplate.atom("trigger")
-    case = make_case(macro_domain, source, condition=gamma)
+    gamma = BoolTemplate.atom("event:Root.Plant.Ping")
+    event = macro_domain.event_by_path("Root.Plant.Ping")
+    case = make_case(
+        macro_domain,
+        source,
+        condition=gamma,
+        used_events=(EventUse(event.id, event.path, "positive", "trigger"),),
+    )
 
     assert case.condition is gamma
-    assert case.condition.variables == ("trigger",)
-    assert (
-        case_antecedent_condition(case).to_canonical()
-        == BoolTemplate.and_(
-            BoolTemplate.atom("__source_state__:%d" % source.source_state_id),
-            gamma,
-        ).to_canonical()
-    )
+    assert case_path_condition(case) is gamma
+    assert case.to_canonical()["condition"]["name"] == "event:Root.Plant.Ping"
+    assert "var_update" not in case.to_canonical()
 
 
 @pytest.mark.unittest
-def test_reserved_source_guard_atom_namespace_is_rejected(macro_domain):
-    """Synthetic gamma atoms cannot collide with composed source-state guards."""
+def test_unknown_condition_atom_namespaces_are_rejected(macro_domain):
+    """Case conditions fail closed unless atoms use event/guard/accepted namespaces."""
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    with pytest.raises(InvalidBmcEncoding, match="reserved source-state atom"):
-        make_case(
-            macro_domain,
-            source,
-            condition=BoolTemplate.atom("__source_state__:%d" % source.source_state_id),
-        )
+
+    for atom in ("plain", "pre:x", "__source_state__:%d" % source.source_state_id):
+        with pytest.raises(InvalidBmcEncoding, match="atom namespace"):
+            make_case(macro_domain, source, condition=BoolTemplate.atom(atom))
 
 
 @pytest.mark.unittest
 def test_event_atoms_require_domain_events_and_metadata(macro_domain):
     """Domain eager validation covers event atoms in all case conditions."""
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    ping_id = macro_domain.event_path_to_id("Root.Plant.Ping")
-    carry = carry_var_updates(macro_domain)
-    label = "%s::transition::%s::0" % (
-        source.source_state_path,
-        source.source_state_path,
-    )
+    ping = macro_domain.event_by_path("Root.Plant.Ping")
 
-    valid = CycleCase(
-        "transition",
-        source.source_state_id,
-        source.source_state_path,
-        source.source_state_id,
-        source.source_state_path,
-        label,
-        BoolTemplate.atom("event:Root.Plant.Ping"),
-        carry,
-        used_events=(EventUse(ping_id, "Root.Plant.Ping", "positive", "trigger"),),
-        domain=macro_domain,
+    valid = make_case(
+        macro_domain,
+        source,
+        condition=BoolTemplate.atom("event:Root.Plant.Ping"),
+        used_events=(EventUse(ping.id, ping.path, "positive", "trigger"),),
     )
     assert valid.used_events[0].path == "Root.Plant.Ping"
 
     with pytest.raises(InvalidBmcEncoding, match="used_events"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            label,
-            BoolTemplate.atom("event:Root.Plant.Ping"),
-            carry,
-            domain=macro_domain,
+        make_case(
+            macro_domain,
+            source,
+            condition=BoolTemplate.atom("event:Root.Plant.Ping"),
         )
 
     with pytest.raises(InvalidBmcEncoding, match="Unknown event path"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            label,
-            BoolTemplate.true(),
-            carry,
+        make_case(
+            macro_domain,
+            source,
             failed_conditions=(BoolTemplate.atom("event:Root.Plant.NoSuch"),),
-            domain=macro_domain,
         )
 
 
 @pytest.mark.unittest
-def test_empty_fallback_and_delta_conditions_canonicalize_to_true(macro_domain):
-    """Uncovered-region helpers use the canonical true template when nothing is excluded."""
-    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    entry = entry_source(macro_domain, "Root.Plant")
-
-    fallback = build_fallback_case(macro_domain, stable, ())
-    delta = build_semantic_delta_case(macro_domain, entry, ())
-
-    assert fallback.condition.to_canonical() == BoolTemplate.true().to_canonical()
-    assert delta.condition.to_canonical() == BoolTemplate.true().to_canonical()
-
-
-@pytest.mark.unittest
-def test_case_target_and_event_use_must_match_domain(macro_domain):
-    """Cases validate target ids and full event paths, including same short names."""
+def test_guard_atoms_require_matching_requirement_and_anchor(macro_domain):
+    """Guard atoms point to raw expressions with action-block prefix anchors."""
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    plant_ping = macro_domain.event_by_path("Root.Plant.Ping")
-    backup_ping = macro_domain.event_by_path("Root.Backup.Ping")
-
-    case = CycleCase(
-        "transition",
+    guard = GuardRequirement(
+        "g0",
         source.source_state_id,
         source.source_state_path,
-        macro_domain.state_path_to_id("Root.Plant.Busy"),
-        "Root.Plant.Busy",
-        "%s::transition::Root.Plant.Busy::0" % source.source_state_path,
-        BoolTemplate.atom("ping"),
-        carry_var_updates(macro_domain),
-        used_events=(EventUse(plant_ping.id, plant_ping.path, "positive", "trigger"),),
-        domain=macro_domain,
+        "Idle -> Busy",
+        Variable("x") > 0,
+        "positive",
+        "transition_guard",
+        0,
     )
-    assert case.used_events[0].event_id != backup_ping.id
-    assert case.used_events[0].path == "Root.Plant.Ping"
+    case = make_case(
+        macro_domain,
+        source,
+        condition=BoolTemplate.atom("guard:g0"),
+        guard_requirements=(guard,),
+    )
 
-    with pytest.raises(InvalidBmcEncoding, match="target path"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            macro_domain.state_path_to_id("Root.Plant.Busy"),
-            "Root.Backup.Idle",
-            "%s::transition::Root.Backup.Idle::0" % source.source_state_path,
-            BoolTemplate.atom("bad_target"),
-            carry_var_updates(macro_domain),
-            domain=macro_domain,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="EventUse path"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "%s::transition::%s::1"
-            % (source.source_state_path, source.source_state_path),
-            BoolTemplate.atom("bad_event"),
-            carry_var_updates(macro_domain),
-            used_events=(
-                EventUse(plant_ping.id, backup_ping.path, "positive", "trigger"),
-            ),
-            domain=macro_domain,
-        )
+    assert case.guard_requirements[0].atom_name == "guard:g0"
+    assert case.guard_requirements[0].after_action_block_index == 0
+    assert case.to_canonical()["guard_requirements"][0]["expr"] == "x > 0"
 
+    with pytest.raises(InvalidBmcEncoding, match="matching GuardRequirement"):
+        make_case(macro_domain, source, condition=BoolTemplate.atom("guard:g_missing"))
 
-@pytest.mark.unittest
-def test_var_update_requires_complete_explicit_persistent_var_coverage(macro_domain):
-    """Writeback recipes cover every persistent var and reject unknown or duplicate entries."""
-    complete = carry_var_updates(macro_domain)
-    assert [item.variable_name for item in complete] == ["x", "y"]
-    assert all(item.is_carry for item in complete)
-    assert build_var_updates(macro_domain, complete) == complete
-    assert var_update_for(macro_domain, "x", "x+1").to_canonical() == {
-        "node": "var_update",
-        "variable_id": macro_domain.variable_name_to_id("x"),
-        "variable_name": "x",
-        "expression": "x+1",
-        "is_carry": False,
-    }
-
-    with pytest.raises(InvalidBmcEncoding, match="cover every"):
-        build_var_updates(macro_domain, complete[:1])
-    with pytest.raises(InvalidBmcEncoding, match="Duplicate variable update id"):
-        build_var_updates(macro_domain, complete + (complete[0],))
-    with pytest.raises(InvalidBmcEncoding, match="Unknown variable id"):
-        build_var_updates(macro_domain, complete + (VarUpdate(999, "z", "0"),))
-    with pytest.raises(InvalidBmcEncoding, match="id/name mismatch"):
-        build_var_updates(
+    with pytest.raises(InvalidBmcEncoding, match="guard anchor"):
+        make_case(
             macro_domain,
-            (VarUpdate(complete[0].variable_id, "y", "pre:y"),) + complete[1:],
+            source,
+            condition=BoolTemplate.atom("guard:g1"),
+            guard_requirements=(
+                GuardRequirement(
+                    "g1",
+                    source.source_state_id,
+                    source.source_state_path,
+                    "Idle -> Busy",
+                    Boolean(True),
+                    "positive",
+                    "transition_guard",
+                    1,
+                ),
+            ),
         )
 
 
 @pytest.mark.unittest
-def test_absorb_cases_are_regular_cases_with_true_gamma_and_carry_all(macro_domain):
+def test_action_block_preserves_if_block_without_condition_split(
+    macro_domain,
+    sample_operation,
+):
+    """ActionBlock stores model statements, including nested IfBlock objects."""
+    block = ActionBlock(
+        "during",
+        "leaf_during",
+        macro_domain.state_path_to_id("Root.Plant.Idle"),
+        "Root.Plant.Idle",
+        (sample_operation,),
+        action_name="Root.Plant.Idle.<unnamed>",
+    )
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    case = make_case(macro_domain, source, action_blocks=(block,))
+
+    assert case.action_blocks[0].operations == (sample_operation,)
+    assert (
+        case.to_canonical()["action_blocks"][0]["operations"][0]["node"] == "if_block"
+    )
+    assert case.condition.variables == ()
+
+
+@pytest.mark.unittest
+def test_absorb_cases_are_regular_cases_with_true_condition(macro_domain):
     """Terminated and diagnostic absorbs are ordinary CycleCase objects."""
     terminate = terminated_absorb_case(macro_domain)
     diagnostic = diagnostic_absorb_case(macro_domain)
@@ -281,45 +257,44 @@ def test_absorb_cases_are_regular_cases_with_true_gamma_and_carry_all(macro_doma
     assert terminate.source_state_path == TERMINATE_CASE_PATH
     assert terminate.label == "__terminate__::absorb::__terminate__::0"
     assert terminate.condition.evaluate({}) is True
+    assert terminate.action_blocks == ()
     assert terminate.is_diagnostic is False
-    assert [item.variable_name for item in terminate.var_update] == ["x", "y"]
 
     assert diagnostic.source_state_id == STATE_DIAGNOSTIC_ID
     assert diagnostic.target_state_id == STATE_DIAGNOSTIC_ID
     assert diagnostic.source_state_path == DIAGNOSTIC_CASE_PATH
     assert diagnostic.label == "__diagnostic__::absorb::__diagnostic__::0"
     assert diagnostic.condition.evaluate({}) is True
+    assert diagnostic.action_blocks == ()
     assert diagnostic.is_diagnostic is True
 
 
 @pytest.mark.unittest
-def test_fallback_condition_negates_only_accepted_gamma_not_failed_metadata(
-    macro_domain,
-):
-    """Failed raw candidates do not shrink stable leaf fallback uncovered space."""
+def test_fallback_condition_negates_accepted_labels_not_raw_conditions(macro_domain):
+    """Fallback masks use accepted:<label> instead of copying trigger atoms."""
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    ping = macro_domain.event_by_path("Root.Plant.Ping")
     accepted = make_case(
         macro_domain,
         source,
-        condition=BoolTemplate.atom("accepted"),
+        condition=BoolTemplate.atom("event:Root.Plant.Ping"),
         target_path="Root.Plant.Busy",
+        used_events=(EventUse(ping.id, ping.path, "positive", "trigger"),),
     )
-    failed = BoolTemplate.atom("failed_raw")
+    failed = BoolTemplate.atom("event:Root.Go")
+    root_go = macro_domain.event_by_path("Root.Go")
 
     fallback = build_fallback_case(macro_domain, source, (accepted,), (failed,))
 
     assert fallback.kind == "fallback"
-    assert (
-        fallback.condition.to_canonical()
-        == BoolTemplate.not_(BoolTemplate.atom("accepted")).to_canonical()
-    )
+    assert fallback.condition.variables == ("accepted:%s" % accepted.label,)
+    assert fallback.priority_exclusions[0].excluded_case_labels == (accepted.label,)
+    assert {item.path for item in fallback.used_events} == {ping.path, root_go.path}
     assert fallback.failed_conditions == (failed,)
-    assert fallback.condition.evaluate({"accepted": False, "failed_raw": True}) is True
-    assert fallback.condition.evaluate({"accepted": True, "failed_raw": False}) is False
 
 
 @pytest.mark.unittest
-def test_semantic_delta_condition_excludes_success_and_build_diag_not_failed(
+def test_semantic_delta_condition_excludes_success_labels_and_build_diag(
     macro_domain,
 ):
     """Entry delta leaves failed candidate conditions as diagnostics only."""
@@ -327,127 +302,72 @@ def test_semantic_delta_condition_excludes_success_and_build_diag_not_failed(
     accepted = make_case(
         macro_domain,
         source,
-        condition=BoolTemplate.atom("accepted"),
+        label_kind="initial",
         target_path="Root.Plant.Idle",
+        condition=BoolTemplate.atom("guard:g0"),
+        guard_requirements=(
+            GuardRequirement(
+                "g0",
+                source.source_state_id,
+                source.source_state_path,
+                "[*] -> Idle",
+                Boolean(True),
+                "positive",
+                "initial_guard",
+                0,
+            ),
+        ),
     )
-    build_diag = BoolTemplate.atom("unsupported")
-    failed = BoolTemplate.atom("failed_raw")
+    build_diag = BoolTemplate.atom("event:Root.Go")
+    root_go = macro_domain.event_by_path("Root.Go")
+    failed = BoolTemplate.atom("event:Root.Plant.Ping")
 
     delta = build_semantic_delta_case(
-        macro_domain, source, (accepted,), (build_diag,), (failed,)
+        macro_domain,
+        source,
+        (accepted,),
+        (build_diag,),
+        (failed,),
     )
 
-    expected = BoolTemplate.not_(
-        BoolTemplate.or_(BoolTemplate.atom("accepted"), build_diag)
-    )
     assert delta.kind == "delta"
     assert delta.target_state_id == STATE_DIAGNOSTIC_ID
-    assert delta.is_diagnostic is True
-    assert delta.condition.to_canonical() == expected.to_canonical()
+    assert delta.condition.variables == (
+        "accepted:%s" % accepted.label,
+        "event:Root.Go",
+    )
+    assert delta.priority_exclusions[0].excluded_case_labels == (accepted.label,)
+    assert root_go.path in {item.path for item in delta.used_events}
     assert delta.failed_conditions == (failed,)
-    assert (
-        delta.condition.evaluate(
-            {"accepted": False, "unsupported": False, "failed_raw": True}
-        )
-        is True
-    )
 
 
 @pytest.mark.unittest
-def test_fallback_and_delta_helpers_accept_only_ordinary_success_cases(macro_domain):
-    """Fallback and delta helpers apply their source-specific case policies."""
-    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    entry = entry_source(macro_domain, "Root.Plant")
-
-    stable_transition = make_case(
+def test_partition_resolves_accepted_atoms_through_case_registry(macro_domain):
+    """Source partition checks use accepted-path semantics, not free atoms."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    ping = macro_domain.event_by_path("Root.Plant.Ping")
+    transition = make_case(
         macro_domain,
-        stable,
-        condition=BoolTemplate.atom("stable_transition"),
+        source,
+        condition=BoolTemplate.atom("event:Root.Plant.Ping"),
         target_path="Root.Plant.Busy",
+        used_events=(EventUse(ping.id, ping.path, "positive", "trigger"),),
     )
-    stable_initial = make_case(
-        macro_domain,
-        stable,
-        label_kind="initial",
-        condition=BoolTemplate.atom("stable_initial"),
-    )
-    fallback = build_fallback_case(macro_domain, stable, (stable_transition,))
-    stable_diagnostic = CycleCase(
-        "diagnostic",
-        stable.source_state_id,
-        stable.source_state_path,
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "%s::diagnostic::%s::0" % (stable.source_state_path, DIAGNOSTIC_CASE_PATH),
-        BoolTemplate.atom("stable_diagnostic"),
-        carry_var_updates(macro_domain),
-        domain=macro_domain,
-    )
+    fallback = build_fallback_case(macro_domain, source, (transition,))
 
-    with pytest.raises(InvalidBmcEncoding, match="ordinary accepted cases"):
-        build_fallback_case(macro_domain, stable, (stable_transition, stable_initial))
+    result = verify_source_partition(source, (transition, fallback))
 
-    assert (
-        fallback.condition.to_canonical()
-        == BoolTemplate.not_(BoolTemplate.atom("stable_transition")).to_canonical()
-    )
-
-    for rejected in (fallback, stable_diagnostic, diagnostic_absorb_case(macro_domain)):
-        with pytest.raises(InvalidBmcEncoding, match="ordinary accepted cases"):
-            build_fallback_case(macro_domain, stable, (rejected,))
-
-    entry_transition = make_case(
-        macro_domain,
-        entry,
-        condition=BoolTemplate.atom("entry_transition"),
-        target_path="Root.Plant.Idle",
-    )
-    entry_initial = make_case(
-        macro_domain,
-        entry,
-        label_kind="initial",
-        condition=BoolTemplate.atom("entry_initial"),
-        target_path="Root.Plant.Idle",
-    )
-    delta = build_semantic_delta_case(macro_domain, entry, (entry_transition,))
-    entry_diagnostic = CycleCase(
-        "diagnostic",
-        entry.source_state_id,
-        entry.source_state_path,
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "%s::diagnostic::%s::0" % (entry.source_state_path, DIAGNOSTIC_CASE_PATH),
-        BoolTemplate.atom("entry_diagnostic"),
-        carry_var_updates(macro_domain),
-        domain=macro_domain,
-    )
-
-    delta_with_initial = build_semantic_delta_case(
-        macro_domain, entry, (entry_transition, entry_initial)
-    )
-    assert (
-        delta_with_initial.condition.to_canonical()
-        == BoolTemplate.not_(
-            BoolTemplate.or_(
-                BoolTemplate.atom("entry_transition"),
-                BoolTemplate.atom("entry_initial"),
-            )
-        ).to_canonical()
-    )
-
-    for rejected in (delta, entry_diagnostic, diagnostic_absorb_case(macro_domain)):
-        with pytest.raises(InvalidBmcEncoding, match="ordinary accepted cases"):
-            build_semantic_delta_case(macro_domain, entry, (rejected,))
+    assert result.variables == ("event:Root.Plant.Ping",)
+    assert result.assignment_count == 2
 
 
 @pytest.mark.unittest
-def test_macro_step_formal_revalidates_domainless_cases_against_source_domain(
+def test_macro_step_formal_revalidates_domainless_cases_and_accepted_atoms(
     macro_domain,
 ):
-    """Domain-backed formals reject case target, event, and writeback bypasses."""
+    """Domain-backed formals reject target, event, guard, and label bypasses."""
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
     fallback = build_fallback_case(macro_domain, source, ())
-    carry = carry_var_updates(macro_domain)
 
     bad_target = CycleCase(
         "transition",
@@ -456,8 +376,8 @@ def test_macro_step_formal_revalidates_domainless_cases_against_source_domain(
         999,
         "Missing.Target",
         "%s::transition::Missing.Target::0" % source.source_state_path,
-        BoolTemplate.atom("bad_target"),
-        carry,
+        BoolTemplate.true(),
+        (),
     )
     with pytest.raises(InvalidBmcEncoding, match="Unknown state id"):
         MacroStepFormal(source, (bad_target, fallback))
@@ -469,65 +389,32 @@ def test_macro_step_formal_revalidates_domainless_cases_against_source_domain(
         source.source_state_id,
         source.source_state_path,
         "%s::transition::%s::1" % (source.source_state_path, source.source_state_path),
-        BoolTemplate.atom("bad_event"),
-        carry,
+        BoolTemplate.true(),
+        (),
         used_events=(EventUse(999, "Missing.Event", "positive", "trigger"),),
     )
     with pytest.raises(InvalidBmcEncoding, match="Unknown event id"):
         MacroStepFormal(source, (bad_event, fallback))
 
-    missing_writeback = CycleCase(
-        "transition",
-        source.source_state_id,
-        source.source_state_path,
-        source.source_state_id,
-        source.source_state_path,
-        "%s::transition::%s::2" % (source.source_state_path, source.source_state_path),
-        BoolTemplate.atom("missing_writeback"),
-        (),
-    )
-    with pytest.raises(InvalidBmcEncoding, match="cover every persistent variable"):
-        MacroStepFormal(source, (missing_writeback, fallback))
-
-
-@pytest.mark.unittest
-def test_macro_step_formal_rejects_stable_leaf_diagnostic_success_case(
-    macro_domain,
-):
-    """Stable leaf formals cannot bypass entry-only delta/diagnostic buckets."""
-    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    diagnostic = CycleCase(
-        "diagnostic",
-        source.source_state_id,
-        source.source_state_path,
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "%s::diagnostic::%s::0" % (source.source_state_path, DIAGNOSTIC_CASE_PATH),
-        BoolTemplate.atom("diagnostic_success"),
-        carry_var_updates(macro_domain),
-        domain=macro_domain,
-    )
-    fallback = CycleCase(
+    unknown_accepted = CycleCase(
         "fallback",
         source.source_state_id,
         source.source_state_path,
         source.source_state_id,
         source.source_state_path,
-        "%s::fallback::%s::0" % (source.source_state_path, source.source_state_path),
-        BoolTemplate.not_(BoolTemplate.atom("diagnostic_success")),
-        carry_var_updates(macro_domain),
-        domain=macro_domain,
+        "%s::fallback::%s::1" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.atom("accepted:no-such-label"),
+        (),
     )
-
-    with pytest.raises(InvalidBmcEncoding, match="stable leaf success cases"):
-        MacroStepFormal(source, (diagnostic, fallback))
+    with pytest.raises(InvalidBmcEncoding, match="unknown case label"):
+        MacroStepFormal(source, (unknown_accepted,))
 
 
 @pytest.mark.unittest
 def test_macro_step_formal_rejects_illegal_delta_buckets_and_label_collisions(
     macro_domain,
 ):
-    """Formal buckets enforce source-local shape before runtime expansion is implemented."""
+    """Formal buckets enforce source-local shape before solver lowering."""
     stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
     fallback = build_fallback_case(macro_domain, stable, ())
     delta = CycleCase(
@@ -537,8 +424,8 @@ def test_macro_step_formal_rejects_illegal_delta_buckets_and_label_collisions(
         STATE_DIAGNOSTIC_ID,
         DIAGNOSTIC_CASE_PATH,
         "%s::delta::%s::0" % (stable.source_state_path, DIAGNOSTIC_CASE_PATH),
-        BoolTemplate.atom("delta"),
-        carry_var_updates(macro_domain),
+        BoolTemplate.true(),
+        (),
         domain=macro_domain,
     )
 
@@ -556,148 +443,50 @@ def test_macro_step_formal_rejects_illegal_delta_buckets_and_label_collisions(
 def test_macro_step_formal_accepts_entry_delta_and_sentinel_absorb_buckets(
     macro_domain,
 ):
-    """Entry formals may contain delta while sentinel formals absorb exactly once."""
+    """Entry formals and sentinel formals accept their dedicated bucket shapes."""
     entry = entry_source(macro_domain, "Root.Plant")
-    success = make_case(
-        macro_domain,
-        entry,
-        condition=BoolTemplate.atom("ok"),
-        target_path="Root.Plant.Idle",
-    )
-    delta = build_semantic_delta_case(macro_domain, entry, (success,))
-    formal = MacroStepFormal(entry, (success,), (delta,))
-    assert formal.cases == (success, delta)
-    assert [case.kind for case in formal.delta_cases] == ["delta"]
+    delta = build_semantic_delta_case(macro_domain, entry, ())
+    assert MacroStepFormal(entry, (), (delta,)).delta_cases == (delta,)
 
-    terminated_formal = MacroStepFormal(
+    terminate = MacroStepFormal(
         terminated_source(macro_domain),
         (terminated_absorb_case(macro_domain),),
     )
-    diagnostic_formal = MacroStepFormal(
+    diagnostic = MacroStepFormal(
         diagnostic_source(macro_domain),
         (diagnostic_absorb_case(macro_domain),),
     )
-    assert terminated_formal.success_cases[0].is_diagnostic is False
-    assert diagnostic_formal.success_cases[0].is_diagnostic is True
-
-    with pytest.raises(InvalidBmcEncoding, match="Duplicate cycle case label"):
-        MacroStepFormal(
-            terminated_source(macro_domain),
-            (
-                terminated_absorb_case(macro_domain),
-                terminated_absorb_case(macro_domain),
-            ),
-        )
+    assert terminate.cases[0].target_state_id == STATE_TERMINATE_ID
+    assert diagnostic.cases[0].target_state_id == STATE_DIAGNOSTIC_ID
 
 
 @pytest.mark.unittest
-def test_partition_verifier_accepts_complete_disjoint_stable_and_entry_universes(
-    macro_domain,
-):
-    """Synthetic truth-table partitions prove fallback and delta bucket contracts."""
-    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    accepted = make_case(
-        macro_domain,
-        stable,
-        condition=BoolTemplate.atom("accepted"),
-        target_path="Root.Plant.Busy",
-    )
-    fallback = build_fallback_case(macro_domain, stable, (accepted,))
-    result = MacroStepFormal(stable, (accepted, fallback)).verify_partition()
-    assert result.to_canonical() == {
-        "node": "partition_check_result",
-        "variables": ["accepted"],
-        "assignment_count": 2,
-        "bucket_count": 2,
-        "scope": "build-time-self-check",
-    }
-
-    entry = entry_source(macro_domain, "Root.Plant")
-    success = make_case(
-        macro_domain,
-        entry,
-        condition=BoolTemplate.atom("success"),
-        target_path="Root.Plant.Idle",
-    )
-    build_diag = BoolTemplate.and_(
-        BoolTemplate.atom("build_diag"),
-        BoolTemplate.not_(BoolTemplate.atom("success")),
-    )
-    delta = build_semantic_delta_case(macro_domain, entry, (success,), (build_diag,))
-    entry_result = MacroStepFormal(
-        entry, (success,), (delta,), (build_diag,)
-    ).verify_partition()
-    assert entry_result.variables == ("build_diag", "success")
-    assert entry_result.bucket_count == 3
-
-
-@pytest.mark.unittest
-def test_partition_verifier_fails_closed_on_gap_overlap_and_unknown_budget():
-    """Partition self-checks fail closed and never become Core_N clauses."""
+def test_verify_boolean_partition_reports_gaps_overlaps_and_budget():
+    """Truth-table checker stays build-time only and reports hard failures."""
     a = BoolTemplate.atom("a")
+
+    assert verify_boolean_partition((a, BoolTemplate.not_(a))).bucket_count == 2
     with pytest.raises(BmcBuildError, match="overlap"):
-        verify_boolean_partition((a, a, BoolTemplate.not_(a)))
+        verify_boolean_partition((a, BoolTemplate.true()))
     with pytest.raises(BmcBuildError, match="gap"):
-        verify_boolean_partition((a,))
-    with pytest.raises(BmcBuildError, match="overlap.*gap"):
-        verify_boolean_partition((a, a))
+        verify_boolean_partition((a, BoolTemplate.false()))
     with pytest.raises(BmcBuildError, match="assignment budget"):
         verify_boolean_partition(
-            (a, BoolTemplate.not_(a)), variables=("a", "b"), max_assignments=2
+            (BoolTemplate.true(),), variables=("a", "b"), max_assignments=2
         )
-
-    result = verify_boolean_partition((a, BoolTemplate.not_(a)))
-    assert "clauses" not in result.to_canonical()
-    assert result.to_canonical()["scope"] == "build-time-self-check"
 
 
 @pytest.mark.unittest
-def test_case_validation_rejects_label_kind_and_primitive_mismatches(macro_domain):
-    """CycleCase and metadata constructors fail on malformed contract values."""
-    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    with pytest.raises(InvalidBmcEncoding, match="label case kind"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "%s::fallback::%s::0"
-            % (source.source_state_path, source.source_state_path),
-            BoolTemplate.true(),
-            carry_var_updates(macro_domain),
-            domain=macro_domain,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="event_id"):
-        EventUse(-1, "Root.Go", "positive", "trigger")
-    with pytest.raises(InvalidBmcEncoding, match="event polarity"):
-        EventUse(0, "Root.Go", "maybe", "trigger")
-    with pytest.raises(InvalidBmcEncoding, match="boolean template kind"):
-        BoolTemplate("xor")
-    with pytest.raises(InvalidBmcEncoding, match="Unknown state id"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            9999,
-            "Missing",
-            "%s::transition::Missing::0" % source.source_state_path,
-            BoolTemplate.true(),
-            carry_var_updates(macro_domain),
-            domain=macro_domain,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="operands"):
-        BoolTemplate.or_(BoolTemplate.atom("ok"), object())
-
-
-@pytest.mark.unittest
-def test_macro_imports_do_not_load_z3_or_verify_modules():
-    """Macro contracts stay solver-independent and verify-registry independent."""
+def test_bmc_macro_import_does_not_load_z3_or_verify_modules():
+    """Importing macro contracts remains independent from solver and verify."""
     code = (
         "import sys; "
         "import pyfcstm.bmc.macro; "
-        "print('z3' in sys.modules); "
-        "print(any(name.startswith('pyfcstm.verify') for name in sys.modules))"
+        "bad = ["
+        "name for name in sys.modules "
+        "if name == 'z3' or name.startswith('pyfcstm.verify')"
+        "]; "
+        "print(bad)"
     )
 
     result = subprocess.run(
@@ -708,594 +497,4 @@ def test_macro_imports_do_not_load_z3_or_verify_modules():
         universal_newlines=True,
     )
 
-    assert result.stdout.splitlines() == ["False", "False"]
-
-
-@pytest.mark.unittest
-def test_bool_template_reduces_identity_absorbing_and_duplicate_operands():
-    """Boolean recipes normalize local identities before canonical comparison."""
-    atom = BoolTemplate.atom("a")
-    other = BoolTemplate.atom("b")
-
-    assert (
-        BoolTemplate.and_(BoolTemplate.true(), atom).to_canonical()
-        == atom.to_canonical()
-    )
-    assert BoolTemplate.and_(atom, atom).to_canonical() == atom.to_canonical()
-    assert BoolTemplate.and_(atom, BoolTemplate.false()).to_canonical() == (
-        BoolTemplate.false().to_canonical()
-    )
-    assert (
-        BoolTemplate.or_(BoolTemplate.false(), atom).to_canonical()
-        == atom.to_canonical()
-    )
-    assert BoolTemplate.or_(atom, atom).to_canonical() == atom.to_canonical()
-    assert BoolTemplate.or_(atom, BoolTemplate.true()).to_canonical() == (
-        BoolTemplate.true().to_canonical()
-    )
-    assert (
-        BoolTemplate.not_(BoolTemplate.not_(atom)).to_canonical() == atom.to_canonical()
-    )
-
-    nested = BoolTemplate.and_(
-        atom, BoolTemplate.and_(BoolTemplate.true(), other, atom)
-    )
-    assert nested.kind == "and"
-    assert nested.variables == ("a", "b")
-
-
-@pytest.mark.unittest
-def test_bool_template_validation_and_evaluation_fail_closed():
-    """BoolTemplate rejects malformed recipes and evaluation unknowns."""
-    atom = BoolTemplate.atom("a")
-
-    with pytest.raises(InvalidBmcEncoding, match="operands"):
-        BoolTemplate("atom", name="a", operands=(atom,))
-    with pytest.raises(InvalidBmcEncoding, match="names"):
-        BoolTemplate("true", name="a")
-    with pytest.raises(InvalidBmcEncoding, match="operands"):
-        BoolTemplate("false", operands=(atom,))
-    with pytest.raises(InvalidBmcEncoding, match="names"):
-        BoolTemplate("not", name="a", operands=(atom,))
-    with pytest.raises(InvalidBmcEncoding, match="one operand"):
-        BoolTemplate("not")
-    with pytest.raises(InvalidBmcEncoding, match="names"):
-        BoolTemplate("and", name="a", operands=(atom,))
-    with pytest.raises(InvalidBmcEncoding, match="must have operands"):
-        BoolTemplate("or")
-    with pytest.raises(BmcBuildError, match="missing boolean assignment"):
-        atom.evaluate({})
-    with pytest.raises(BmcBuildError, match="must be bool"):
-        atom.evaluate({"a": 1})
-
-    forged = BoolTemplate.true()
-    object.__setattr__(forged, "kind", "xor")
-    with pytest.raises(BmcBuildError, match="unsupported boolean"):
-        forged.evaluate({})
-
-
-@pytest.mark.unittest
-def test_event_and_var_update_validation_rejects_malformed_metadata(macro_domain):
-    """EventUse and VarUpdate reject malformed primitive metadata."""
-    with pytest.raises(InvalidBmcEncoding, match="event_id"):
-        EventUse(True, "Root.Go", "positive", "trigger")
-    with pytest.raises(InvalidBmcEncoding, match="event_id"):
-        EventUse(-1, "Root.Go", "positive", "trigger")
-    with pytest.raises(InvalidBmcEncoding, match="event path"):
-        EventUse(0, "", "positive", "trigger")
-    with pytest.raises(InvalidBmcEncoding, match="event reason"):
-        EventUse(0, "Root.Go", "positive", "unknown")
-
-    with pytest.raises(InvalidBmcEncoding, match="variable_id"):
-        VarUpdate(True, "x", "pre:x")
-    with pytest.raises(InvalidBmcEncoding, match="non-negative"):
-        VarUpdate(-1, "x", "pre:x")
-    with pytest.raises(InvalidBmcEncoding, match="variable_name"):
-        VarUpdate(0, "", "pre:x")
-    with pytest.raises(InvalidBmcEncoding, match="expression"):
-        VarUpdate(0, "x", "")
-    with pytest.raises(InvalidBmcEncoding, match="is_carry"):
-        VarUpdate(0, "x", "pre:x", is_carry=object())
-    with pytest.raises(InvalidBmcEncoding, match="domain"):
-        carry_var_updates(object())
-    with pytest.raises(InvalidBmcEncoding, match="domain"):
-        var_update_for(object(), "x", "pre:x")
-    with pytest.raises(InvalidBmcEncoding, match="variable must"):
-        var_update_for(macro_domain, object(), "pre:x")
-    with pytest.raises(InvalidBmcEncoding, match="Unknown variable name"):
-        var_update_for(macro_domain, "missing", "0")
-    with pytest.raises(InvalidBmcEncoding, match="updates must be a sequence"):
-        build_var_updates(macro_domain, object())
-    with pytest.raises(InvalidBmcEncoding, match="VarUpdate"):
-        build_var_updates(macro_domain, (object(),))
-    duplicate_name = (
-        VarUpdate(macro_domain.variable_name_to_id("x"), "x", "pre:x"),
-        VarUpdate(macro_domain.variable_name_to_id("y"), "x", "pre:x"),
-    )
-    with pytest.raises(InvalidBmcEncoding, match="Duplicate variable update name"):
-        build_var_updates(macro_domain, duplicate_name)
-
-
-@pytest.mark.unittest
-def test_cycle_case_validation_rejects_malformed_contract_fields(macro_domain):
-    """CycleCase rejects malformed labels, metadata, and kind-specific shapes."""
-    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    carry = carry_var_updates(macro_domain)
-    label = "%s::transition::%s::0" % (
-        source.source_state_path,
-        source.source_state_path,
-    )
-
-    with pytest.raises(InvalidBmcEncoding, match="condition"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            label,
-            object(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="used_events"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            label,
-            BoolTemplate.true(),
-            carry,
-            used_events=(object(),),
-        )
-    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            label,
-            BoolTemplate.true(),
-            carry,
-            failed_conditions=(object(),),
-        )
-    with pytest.raises(InvalidBmcEncoding, match="var_update"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            label,
-            BoolTemplate.true(),
-            (object(),),
-        )
-    with pytest.raises(InvalidBmcEncoding, match="source::kind"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "bad",
-            BoolTemplate.true(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="label source"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "Other::transition::%s::0" % source.source_state_path,
-            BoolTemplate.true(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="label target"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "%s::transition::Other::0" % source.source_state_path,
-            BoolTemplate.true(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="ordinal"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "%s::transition::%s::x"
-            % (source.source_state_path, source.source_state_path),
-            BoolTemplate.true(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="self-loop"):
-        CycleCase(
-            "absorb",
-            STATE_TERMINATE_ID,
-            TERMINATE_CASE_PATH,
-            STATE_DIAGNOSTIC_ID,
-            DIAGNOSTIC_CASE_PATH,
-            "%s::absorb::%s::0" % (TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH),
-            BoolTemplate.true(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="sentinel"):
-        CycleCase(
-            "absorb",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "%s::absorb::%s::0" % (source.source_state_path, source.source_state_path),
-            BoolTemplate.true(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="target diagnostic"):
-        CycleCase(
-            "delta",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "%s::delta::%s::0" % (source.source_state_path, source.source_state_path),
-            BoolTemplate.true(),
-            carry,
-        )
-    with pytest.raises(InvalidBmcEncoding, match="domain"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            label,
-            BoolTemplate.true(),
-            carry,
-            domain=object(),
-        )
-
-
-@pytest.mark.unittest
-def test_macro_step_formal_validation_rejects_bucket_shape_errors(macro_domain):
-    """MacroStepFormal validates bucket types, source matches, and sentinel formals."""
-    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    entry = entry_source(macro_domain, "Root.Plant")
-    transition = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
-    stable_transition = make_case(macro_domain, stable)
-    fallback = build_fallback_case(macro_domain, stable, (stable_transition,))
-
-    with pytest.raises(InvalidBmcEncoding, match="source"):
-        MacroStepFormal(object(), (fallback,))
-    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
-        MacroStepFormal(stable, (object(),))
-    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
-        MacroStepFormal(entry, (transition,), object())
-    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
-        MacroStepFormal(entry, (transition,), (object(),))
-    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic"):
-        MacroStepFormal(entry, (transition,), (), (object(),))
-    with pytest.raises(InvalidBmcEncoding, match="at least one"):
-        MacroStepFormal(entry, ())
-    with pytest.raises(InvalidBmcEncoding, match="fallback"):
-        MacroStepFormal(stable, (stable_transition,))
-    with pytest.raises(InvalidBmcEncoding, match="build diagnostics"):
-        MacroStepFormal(stable, (fallback,), (), (BoolTemplate.atom("diag"),))
-    misplaced_delta = build_semantic_delta_case(macro_domain, entry, (transition,))
-    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
-        MacroStepFormal(entry, (misplaced_delta,))
-    non_delta = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
-    with pytest.raises(InvalidBmcEncoding, match="delta_cases may only"):
-        MacroStepFormal(entry, (), (non_delta,))
-    with pytest.raises(InvalidBmcEncoding, match="case source id"):
-        MacroStepFormal(terminated_source(macro_domain), (transition,))
-    wrong_sentinel_case = CycleCase(
-        "absorb",
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "__diagnostic__::absorb::__diagnostic__::0",
-        BoolTemplate.true(),
-        carry_var_updates(macro_domain),
-        domain=macro_domain,
-    )
-    with pytest.raises(InvalidBmcEncoding, match="case source id"):
-        MacroStepFormal(terminated_source(macro_domain), (wrong_sentinel_case,))
-
-
-@pytest.mark.unittest
-def test_fallback_and_delta_helpers_reject_bad_inputs(macro_domain):
-    """Fallback and delta helper constructors validate source and metadata shape."""
-    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    other_stable = stable_leaf_source(macro_domain, "Root.Backup.Idle")
-    entry = entry_source(macro_domain, "Root.Plant")
-    other_entry = entry_source(macro_domain, "Root.Backup")
-    stable_case = make_case(macro_domain, stable)
-    other_stable_case = make_case(macro_domain, other_stable)
-    entry_case = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
-    other_entry_case = make_case(
-        macro_domain, other_entry, target_path="Root.Backup.Idle"
-    )
-
-    with pytest.raises(InvalidBmcEncoding, match="stable_leaf"):
-        build_fallback_case(macro_domain, entry, ())
-    with pytest.raises(InvalidBmcEncoding, match="ordinal"):
-        build_fallback_case(macro_domain, stable, (), ordinal=-1)
-    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
-        build_fallback_case(macro_domain, stable, (object(),))
-    with pytest.raises(InvalidBmcEncoding, match="fallback source"):
-        build_fallback_case(macro_domain, stable, (other_stable_case,))
-    stable_initial_case = make_case(macro_domain, stable, label_kind="initial")
-    with pytest.raises(InvalidBmcEncoding, match="ordinary accepted"):
-        build_fallback_case(macro_domain, stable, (stable_initial_case,))
-    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
-        build_fallback_case(macro_domain, stable, (stable_case,), (object(),))
-
-    with pytest.raises(InvalidBmcEncoding, match="entry source"):
-        build_semantic_delta_case(macro_domain, stable, ())
-    with pytest.raises(InvalidBmcEncoding, match="ordinal"):
-        build_semantic_delta_case(macro_domain, entry, (), ordinal=-1)
-    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
-        build_semantic_delta_case(macro_domain, entry, (object(),))
-    with pytest.raises(InvalidBmcEncoding, match="delta source"):
-        build_semantic_delta_case(macro_domain, entry, (other_entry_case,))
-    entry_initial_case = make_case(
-        macro_domain,
-        entry,
-        label_kind="initial",
-        target_path="Root.Plant.Idle",
-    )
-    delta_with_initial = build_semantic_delta_case(
-        macro_domain,
-        entry,
-        (entry_initial_case,),
-    )
-    assert (
-        delta_with_initial.condition.to_canonical()
-        == BoolTemplate.not_(entry_initial_case.condition).to_canonical()
-    )
-    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic"):
-        build_semantic_delta_case(macro_domain, entry, (entry_case,), (object(),))
-    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
-        build_semantic_delta_case(macro_domain, entry, (entry_case,), (), (object(),))
-
-
-@pytest.mark.unittest
-def test_partition_helpers_reject_bad_inputs_and_source_mismatches(macro_domain):
-    """Partition self-check helpers reject malformed buckets and case ownership."""
-    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    entry = entry_source(macro_domain, "Root.Plant")
-    other_entry = entry_source(macro_domain, "Root.Backup")
-    delta = build_semantic_delta_case(macro_domain, entry, ())
-    other_delta = build_semantic_delta_case(macro_domain, other_entry, ())
-
-    with pytest.raises(BmcBuildError, match="at least one"):
-        verify_boolean_partition(())
-    with pytest.raises(BmcBuildError, match="BoolTemplate"):
-        verify_boolean_partition((object(),))
-    with pytest.raises(BmcBuildError, match="max_assignments"):
-        verify_boolean_partition((BoolTemplate.true(),), max_assignments=True)
-    with pytest.raises(BmcBuildError, match="max_assignments"):
-        verify_boolean_partition((BoolTemplate.true(),), max_assignments=0)
-    with pytest.raises(BmcBuildError, match="variables"):
-        verify_boolean_partition((BoolTemplate.true(),), variables=("",))
-    with pytest.raises(BmcBuildError, match="missing boolean assignment"):
-        verify_boolean_partition((BoolTemplate.atom("a"),), variables=())
-
-    with pytest.raises(InvalidBmcEncoding, match="source"):
-        verify_source_partition(object(), (), ())
-    with pytest.raises(InvalidBmcEncoding, match="entry source"):
-        verify_source_partition(stable, (), (delta,))
-    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
-        verify_source_partition(entry, (object(),), ())
-    with pytest.raises(InvalidBmcEncoding, match="source id"):
-        verify_source_partition(entry, (), (other_delta,))
-    non_delta = make_case(macro_domain, entry, target_path="Root.Plant.Idle")
-    with pytest.raises(InvalidBmcEncoding, match="delta_cases may only"):
-        verify_source_partition(entry, (), (non_delta,))
-    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
-        verify_source_partition(entry, (delta,), ())
-    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic"):
-        verify_source_partition(entry, (), (delta,), (object(),))
-
-
-@pytest.mark.unittest
-def test_additional_macro_contract_branches_are_hardened(macro_domain):
-    """Contract helpers cover no-domain, path-mismatch, and lookup-failure branches."""
-    assert BoolTemplate.true().evaluate({}) is True
-    assert BoolTemplate.false().evaluate({}) is False
-    assert BoolTemplate.and_().kind == "true"
-    assert BoolTemplate.and_(BoolTemplate.atom("a")) == BoolTemplate.atom("a")
-    assert BoolTemplate.or_(BoolTemplate.atom("a")) == BoolTemplate.atom("a")
-    with pytest.raises(InvalidBmcEncoding, match="operands"):
-        BoolTemplate("and", operands=(object(),))
-
-    with pytest.raises(InvalidBmcEncoding, match="Unknown variable id"):
-        var_update_for(macro_domain, 999, "0")
-    with pytest.raises(InvalidBmcEncoding, match="domain"):
-        build_var_updates(object(), ())
-
-    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    carry = carry_var_updates(macro_domain)
-    event = macro_domain.event_by_path("Root.Go")
-    with pytest.raises(InvalidBmcEncoding, match="Unknown event id"):
-        CycleCase(
-            "transition",
-            source.source_state_id,
-            source.source_state_path,
-            source.source_state_id,
-            source.source_state_path,
-            "%s::transition::%s::2"
-            % (source.source_state_path, source.source_state_path),
-            BoolTemplate.true(),
-            carry,
-            used_events=(EventUse(event.id + 1000, event.path, "positive", "trigger"),),
-            domain=macro_domain,
-        )
-    plain = CycleCase(
-        "transition",
-        source.source_state_id,
-        source.source_state_path,
-        source.source_state_id,
-        source.source_state_path,
-        "%s::transition::%s::3" % (source.source_state_path, source.source_state_path),
-        BoolTemplate.true(),
-        carry,
-    )
-    assert plain.to_canonical()["label"].endswith("::3")
-    with pytest.raises(InvalidBmcEncoding, match="case"):
-        case_antecedent_condition(object())
-
-    entry = entry_source(macro_domain, "Root.Plant")
-    wrong_path_case = CycleCase(
-        "delta",
-        entry.source_state_id,
-        "Other",
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "Other::delta::__diagnostic__::0",
-        BoolTemplate.true(),
-        carry,
-    )
-    with pytest.raises(InvalidBmcEncoding, match="case source path"):
-        MacroStepFormal(entry, (), (wrong_path_case,))
-    assert (
-        MacroStepFormal(
-            entry, (), (build_semantic_delta_case(macro_domain, entry, ()),)
-        ).to_canonical()["node"]
-        == "macro_step_formal"
-    )
-
-    diagnostic = diagnostic_source(macro_domain)
-    diagnostic_case = diagnostic_absorb_case(macro_domain)
-    with pytest.raises(InvalidBmcEncoding, match="case source id"):
-        MacroStepFormal(
-            diagnostic,
-            (diagnostic_case,),
-            (build_semantic_delta_case(macro_domain, entry, ()),),
-        )
-    non_absorb = CycleCase(
-        "diagnostic",
-        diagnostic.source_state_id,
-        diagnostic.source_state_path,
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "__diagnostic__::diagnostic::__diagnostic__::0",
-        BoolTemplate.true(),
-        carry,
-    )
-    with pytest.raises(InvalidBmcEncoding, match="sentinel formal case"):
-        MacroStepFormal(diagnostic, (non_absorb,))
-    with pytest.raises(InvalidBmcEncoding, match="case source id"):
-        MacroStepFormal(diagnostic, (terminated_absorb_case(macro_domain),))
-
-    accepted_wrong_path = CycleCase(
-        "transition",
-        source.source_state_id,
-        "Other",
-        source.source_state_id,
-        source.source_state_path,
-        "Other::transition::%s::0" % source.source_state_path,
-        BoolTemplate.atom("wrong"),
-        carry,
-    )
-    with pytest.raises(InvalidBmcEncoding, match="fallback source"):
-        build_fallback_case(macro_domain, source, (accepted_wrong_path,))
-    entry_wrong_path = CycleCase(
-        "transition",
-        entry.source_state_id,
-        "Other",
-        macro_domain.state_path_to_id("Root.Plant.Idle"),
-        "Root.Plant.Idle",
-        "Other::transition::Root.Plant.Idle::0",
-        BoolTemplate.atom("wrong"),
-        carry,
-    )
-    with pytest.raises(InvalidBmcEncoding, match="delta source"):
-        build_semantic_delta_case(macro_domain, entry, (entry_wrong_path,))
-    with pytest.raises(InvalidBmcEncoding, match="source path"):
-        verify_source_partition(entry, (), (wrong_path_case,))
-
-
-@pytest.mark.unittest
-def test_macro_contract_sequence_type_guards_and_sentinel_absorb_branches(
-    macro_domain,
-):
-    """Sequence guards and sentinel absorb invariants fail closed."""
-    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
-    entry = entry_source(macro_domain, "Root.Plant")
-    diagnostic = diagnostic_source(macro_domain)
-    terminate = terminated_source(macro_domain)
-    carry = carry_var_updates(macro_domain)
-    success = make_case(macro_domain, source, condition=BoolTemplate.atom("ok"))
-    delta = build_semantic_delta_case(macro_domain, entry, ())
-
-    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
-        MacroStepFormal(source, object())
-    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
-        MacroStepFormal(entry, (), object())
-    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
-        MacroStepFormal(entry, (), (delta,), object())
-
-    with pytest.raises(InvalidBmcEncoding, match="case source id"):
-        MacroStepFormal(diagnostic, (diagnostic_absorb_case(macro_domain),), (delta,))
-    second_diagnostic_absorb = CycleCase(
-        "absorb",
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "__diagnostic__::absorb::__diagnostic__::1",
-        BoolTemplate.true(),
-        carry,
-    )
-    with pytest.raises(InvalidBmcEncoding, match="must contain one case"):
-        MacroStepFormal(
-            diagnostic,
-            (diagnostic_absorb_case(macro_domain), second_diagnostic_absorb),
-        )
-    wrong_sentinel_loop = CycleCase(
-        "absorb",
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        STATE_DIAGNOSTIC_ID,
-        DIAGNOSTIC_CASE_PATH,
-        "__diagnostic__::absorb::__diagnostic__::1",
-        BoolTemplate.true(),
-        carry,
-    )
-    object.__setattr__(wrong_sentinel_loop, "source_state_id", STATE_TERMINATE_ID)
-    object.__setattr__(wrong_sentinel_loop, "source_state_path", TERMINATE_CASE_PATH)
-    with pytest.raises(InvalidBmcEncoding, match="self-loop sentinel id"):
-        MacroStepFormal(terminate, (wrong_sentinel_loop,))
-
-    with pytest.raises(InvalidBmcEncoding, match="accepted_cases"):
-        build_fallback_case(macro_domain, source, object())
-    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
-        build_fallback_case(macro_domain, source, (success,), object())
-    with pytest.raises(InvalidBmcEncoding, match="accepted_cases"):
-        build_semantic_delta_case(macro_domain, entry, object())
-    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
-        build_semantic_delta_case(macro_domain, entry, (), object())
-    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
-        build_semantic_delta_case(macro_domain, entry, (), (), object())
-
-    with pytest.raises(BmcBuildError, match="partition buckets"):
-        verify_boolean_partition(object())
-    with pytest.raises(BmcBuildError, match="partition variables"):
-        verify_boolean_partition((BoolTemplate.true(),), variables=object())
-    with pytest.raises(InvalidBmcEncoding, match="success_cases"):
-        verify_source_partition(source, object())
-    with pytest.raises(InvalidBmcEncoding, match="delta_cases"):
-        verify_source_partition(entry, (), object())
-    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
-        verify_source_partition(entry, (), (delta,), object())
+    assert result.stdout.strip() == "[]"

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -718,13 +718,48 @@ def test_macro_step_formal_public_validation_rejects_invalid_bucket_shapes(
         terminate.source_state_path,
         terminate.source_state_id,
         terminate.source_state_path,
-        "%s::absorb::%s::2"
+        "%s::absorb::%s::0"
         % (terminate.source_state_path, terminate.source_state_path),
         BoolTemplate.false(),
         (),
     )
     with pytest.raises(InvalidBmcEncoding, match="sentinel absorb condition"):
         MacroStepFormal(terminate, (false_absorb,))
+    absorb_with_action = CycleCase(
+        "absorb",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::absorb::%s::0"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.true(),
+        (
+            ActionBlock(
+                "state_action",
+                "leaf_during",
+                macro_domain.state_path_to_id("Root.Plant.Idle"),
+                "Root.Plant.Idle",
+                (),
+                is_abstract=True,
+            ),
+        ),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel absorb case cannot"):
+        MacroStepFormal(terminate, (absorb_with_action,))
+    noncanonical_absorb = CycleCase(
+        "absorb",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::absorb::%s::3"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel absorb label"):
+        MacroStepFormal(terminate, (noncanonical_absorb,))
 
     assert (
         MacroStepFormal(stable, (fallback,)).to_canonical()["node"]
@@ -1106,13 +1141,36 @@ def test_partition_handles_sentinel_delta_and_accepted_atom_failures(macro_domai
         terminate.source_state_path,
         terminate.source_state_id,
         terminate.source_state_path,
-        "%s::absorb::%s::1"
+        "%s::absorb::%s::0"
         % (terminate.source_state_path, terminate.source_state_path),
         BoolTemplate.false(),
         (),
     )
     with pytest.raises(InvalidBmcEncoding, match="sentinel absorb condition"):
         verify_source_partition(terminate, (false_absorb,), max_assignments=1)
+
+    absorb_with_action = CycleCase(
+        "absorb",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::absorb::%s::0"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.true(),
+        (
+            ActionBlock(
+                "state_action",
+                "leaf_during",
+                macro_domain.state_path_to_id("Root.Plant.Idle"),
+                "Root.Plant.Idle",
+                (),
+                is_abstract=True,
+            ),
+        ),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel absorb case cannot"):
+        verify_source_partition(terminate, (absorb_with_action,), max_assignments=1)
 
     sentinel_fallback = CycleCase(
         "fallback",

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -116,6 +116,57 @@ def make_case(
     )
 
 
+def make_large_priority_partition(source, condition_hook=None):
+    """Create a synthetic large accepted/fallback partition."""
+    accepted = []
+    for index in range(13):
+        prefix = (
+            BoolTemplate.not_(
+                BoolTemplate.or_(
+                    *[
+                        BoolTemplate.atom("accepted:%s" % case.label)
+                        for case in accepted
+                    ]
+                )
+            )
+            if accepted
+            else BoolTemplate.true()
+        )
+        condition = BoolTemplate.and_(
+            prefix, BoolTemplate.atom("event:Root.Event%d" % index)
+        )
+        if condition_hook is not None:
+            condition = condition_hook(index, accepted, condition)
+        accepted.append(
+            CycleCase(
+                "transition",
+                source.source_state_id,
+                source.source_state_path,
+                source.source_state_id,
+                source.source_state_path,
+                "%s::transition::%s::%d"
+                % (source.source_state_path, source.source_state_path, index),
+                condition,
+                (),
+            )
+        )
+    fallback = CycleCase(
+        "fallback",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        "%s::fallback::%s::0" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.not_(
+            BoolTemplate.or_(
+                *[BoolTemplate.atom("accepted:%s" % case.label) for case in accepted]
+            )
+        ),
+        (),
+    )
+    return tuple(accepted) + (fallback,)
+
+
 @pytest.mark.unittest
 def test_cycle_case_condition_is_control_path_only(macro_domain):
     """CycleCase.condition excludes source guards and writeback formulas."""
@@ -229,7 +280,7 @@ def test_action_block_preserves_if_block_without_condition_split(
 ):
     """ActionBlock stores model statements, including nested IfBlock objects."""
     block = ActionBlock(
-        "during",
+        "state_action",
         "leaf_during",
         macro_domain.state_path_to_id("Root.Plant.Idle"),
         "Root.Plant.Idle",
@@ -463,7 +514,7 @@ def test_macro_step_formal_accepts_entry_delta_and_sentinel_absorb_buckets(
 @pytest.mark.unittest
 def test_verify_boolean_partition_reports_gaps_overlaps_and_budget():
     """Truth-table checker stays build-time only and reports hard failures."""
-    a = BoolTemplate.atom("a")
+    a = BoolTemplate.atom("event:Root.Go")
 
     assert verify_boolean_partition((a, BoolTemplate.not_(a))).bucket_count == 2
     with pytest.raises(BmcBuildError, match="overlap"):
@@ -472,7 +523,53 @@ def test_verify_boolean_partition_reports_gaps_overlaps_and_budget():
         verify_boolean_partition((a, BoolTemplate.false()))
     with pytest.raises(BmcBuildError, match="assignment budget"):
         verify_boolean_partition(
-            (BoolTemplate.true(),), variables=("a", "b"), max_assignments=2
+            (BoolTemplate.true(),),
+            variables=("event:Root.A", "event:Root.B"),
+            max_assignments=2,
+        )
+
+
+@pytest.mark.unittest
+def test_verify_boolean_partition_rejects_unknown_atom_namespace():
+    """Public partition checks fail closed on non-canonical atom prefixes."""
+    atom = BoolTemplate.atom("opaque:bad")
+
+    with pytest.raises(InvalidBmcEncoding, match="atom namespace"):
+        verify_boolean_partition((atom, BoolTemplate.not_(atom)), max_assignments=4)
+
+
+@pytest.mark.unittest
+def test_structural_partition_checker_handles_large_priority_masks():
+    """Large canonical accepted/fallback masks avoid truth-table budget failures."""
+    source = stable_leaf_source(
+        build_bmc_domain(load_state_machine_from_text("state Root;"), 1), "Root"
+    )
+
+    result = verify_source_partition(source, make_large_priority_partition(source))
+
+    assert result.bucket_count == 14
+    assert len(result.variables) == 13
+    assert result.assignment_count == 0
+
+
+@pytest.mark.unittest
+def test_structural_partition_checker_rejects_extra_accepted_atoms():
+    """Structural budget bypass applies only to exact canonical accepted masks."""
+    source = stable_leaf_source(
+        build_bmc_domain(load_state_machine_from_text("state Root;"), 1), "Root"
+    )
+
+    def inject_positive_accepted(index, accepted, condition):
+        if index != 1:
+            return condition
+        return BoolTemplate.and_(
+            condition, BoolTemplate.atom("accepted:%s" % accepted[0].label)
+        )
+
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        verify_source_partition(
+            source,
+            make_large_priority_partition(source, inject_positive_accepted),
         )
 
 

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -61,7 +61,7 @@ def _assert_internal_bug_message(error: BmcBuildError) -> None:
     message = str(error)
     assert "internal error" in message
     assert "pyfcstm BMC bug" in message
-    assert "FCSTM input, query, and traceback" in message
+    assert "FCSTM input, BMC query or expansion source, and traceback" in message
     assert "https://github.com/HansBug/pyfcstm/issues" in message
 
 

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -125,6 +125,59 @@ def test_reserved_source_guard_atom_namespace_is_rejected(macro_domain):
 
 
 @pytest.mark.unittest
+def test_event_atoms_require_domain_events_and_metadata(macro_domain):
+    """Domain eager validation covers event atoms in all case conditions."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    ping_id = macro_domain.event_path_to_id("Root.Plant.Ping")
+    carry = carry_var_updates(macro_domain)
+    label = "%s::transition::%s::0" % (
+        source.source_state_path,
+        source.source_state_path,
+    )
+
+    valid = CycleCase(
+        "transition",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        label,
+        BoolTemplate.atom("event:Root.Plant.Ping"),
+        carry,
+        used_events=(EventUse(ping_id, "Root.Plant.Ping", "positive", "trigger"),),
+        domain=macro_domain,
+    )
+    assert valid.used_events[0].path == "Root.Plant.Ping"
+
+    with pytest.raises(InvalidBmcEncoding, match="used_events"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            label,
+            BoolTemplate.atom("event:Root.Plant.Ping"),
+            carry,
+            domain=macro_domain,
+        )
+
+    with pytest.raises(InvalidBmcEncoding, match="Unknown event path"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            label,
+            BoolTemplate.true(),
+            carry,
+            failed_conditions=(BoolTemplate.atom("event:Root.Plant.NoSuch"),),
+            domain=macro_domain,
+        )
+
+
+@pytest.mark.unittest
 def test_empty_fallback_and_delta_conditions_canonicalize_to_true(macro_domain):
     """Uncovered-region helpers use the canonical true template when nothing is excluded."""
     stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -8,6 +8,8 @@ from typing import Any, cast
 
 import pytest
 
+import pyfcstm.bmc.expand as expand_module
+import pyfcstm.bmc.macro as macro_module
 from pyfcstm.bmc import (
     STATE_DIAGNOSTIC_ID,
     STATE_TERMINATE_ID,
@@ -41,13 +43,26 @@ from pyfcstm.bmc.source import (
     stable_leaf_source,
     terminated_source,
 )
-from pyfcstm.model import load_state_machine_from_text
+from pyfcstm.model import OperationStatement, load_state_machine_from_text
 from pyfcstm.model.expr import Boolean, Variable
+
+
+class _UnknownOperationStatement(OperationStatement):
+    """Operation statement subtype used to exercise canonical fallback logic."""
 
 
 def _bad_object() -> Any:
     """Return an intentionally bad value without tripping static type checks."""
     return cast(Any, object())
+
+
+def _assert_internal_bug_message(error: BmcBuildError) -> None:
+    """Assert that internal bug diagnostics route users to the issue tracker."""
+    message = str(error)
+    assert "internal error" in message
+    assert "pyfcstm BMC bug" in message
+    assert "FCSTM input, query, and traceback" in message
+    assert "https://github.com/HansBug/pyfcstm/issues" in message
 
 
 @pytest.fixture()
@@ -81,6 +96,15 @@ def macro_model():
 def macro_domain(macro_model):
     """Build a macro-contract fixture with variables and same-short-name events."""
     return build_bmc_domain(macro_model, bound=2)
+
+
+@pytest.mark.unittest
+def test_internal_bug_messages_link_issue_tracker():
+    """Internal BMC bug diagnostics include actionable reporting guidance."""
+    _assert_internal_bug_message(macro_module._internal_bmc_error("synthetic bug."))
+    _assert_internal_bug_message(
+        expand_module._internal_expansion_error("synthetic expansion bug.")
+    )
 
 
 @pytest.fixture()
@@ -228,14 +252,38 @@ def test_bool_template_public_validation_and_identity_reductions():
         InvalidBmcEncoding, match="compound templates cannot have names"
     ):
         BoolTemplate("and", "a", (atom,))
+    with pytest.raises(InvalidBmcEncoding, match="operands must contain"):
+        BoolTemplate("and", operands=(atom, _bad_object()))
     with pytest.raises(
         InvalidBmcEncoding, match="compound templates must have operands"
     ):
         BoolTemplate("or", operands=())
     with pytest.raises(InvalidBmcEncoding, match="operands must contain"):
         BoolTemplate.and_(atom, _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="operands must contain"):
+        BoolTemplate.or_(atom, _bad_object())
     with pytest.raises(InvalidBmcEncoding, match="operand must be BoolTemplate"):
         BoolTemplate.not_(_bad_object())
+
+
+@pytest.mark.unittest
+def test_bool_template_canonical_helpers_cover_raw_values():
+    """Canonical key helpers also support raw JSON-compatible values."""
+    raw = {"b": [2, 1], "a": {"z": True}}
+
+    assert macro_module._canonical_key(raw) == '{"a":{"z":true},"b":[2,1]}'
+
+
+@pytest.mark.unittest
+def test_structural_accepted_prefix_helper_recognizes_exact_masks():
+    """Accepted-mask recognition covers exact and clearly non-canonical shapes."""
+    mask = BoolTemplate.not_(BoolTemplate.atom("accepted:first"))
+
+    assert macro_module._condition_uses_expected_accepted_prefix(mask, ("first",))
+    assert not macro_module._condition_uses_expected_accepted_prefix(
+        BoolTemplate.atom("event:Root.Go"),
+        ("first",),
+    )
 
 
 @pytest.mark.unittest
@@ -261,6 +309,8 @@ def test_public_contract_dataclasses_reject_invalid_shapes(
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
     expr = Variable("x") > 0
 
+    with pytest.raises(InvalidBmcEncoding, match="event_id must be an integer"):
+        EventUse(True, "Root.Go", "positive", "trigger")
     with pytest.raises(InvalidBmcEncoding, match="event_id must be non-negative"):
         EventUse(-1, "Root.Go", "positive", "trigger")
     with pytest.raises(InvalidBmcEncoding, match="event polarity"):
@@ -327,6 +377,16 @@ def test_public_contract_dataclasses_reject_invalid_shapes(
             (sample_operation,),
             is_abstract=_bad_object(),
         )
+    block = ActionBlock(
+        "state_action",
+        "leaf_during",
+        source.source_state_id,
+        source.source_state_path,
+        (_UnknownOperationStatement(),),
+    )
+    assert block.to_canonical()["operations"] == [
+        {"node": "_UnknownOperationStatement"}
+    ]
 
     priority = PriorityExclusion(
         "d0",
@@ -570,6 +630,35 @@ def test_cycle_case_public_validation_rejects_invalid_local_shapes(macro_domain)
             ),
             domain=macro_domain,
         )
+    reserved_domain = build_bmc_domain(
+        load_state_machine_from_text("state __terminate__;"), bound=1
+    )
+    with pytest.raises(InvalidBmcEncoding, match="reserved macro-step paths"):
+        CycleCase(
+            "transition",
+            reserved_domain.state_path_to_id("__terminate__"),
+            "__terminate__",
+            reserved_domain.state_path_to_id("__terminate__"),
+            "__terminate__",
+            "__terminate__::transition::__terminate__::0",
+            BoolTemplate.true(),
+            (),
+            domain=reserved_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="source path does not match"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            "Other",
+            target_id,
+            target_path,
+            "Other::transition::%s::0" % target_path,
+            BoolTemplate.true(),
+            (),
+            domain=macro_domain,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="case must be CycleCase"):
+        case_path_condition(_bad_object())
 
 
 @pytest.mark.unittest
@@ -686,6 +775,32 @@ def test_macro_step_formal_public_validation_rejects_invalid_bucket_shapes(
     )
     with pytest.raises(InvalidBmcEncoding, match="entry transition and initial cases"):
         MacroStepFormal(entry, (bad_entry_case,))
+    bad_entry_fallback = CycleCase(
+        "fallback",
+        entry.source_state_id,
+        entry.source_state_path,
+        entry.source_state_id,
+        entry.source_state_path,
+        "%s::fallback::%s::0" % (entry.source_state_path, entry.source_state_path),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="entry success cases"):
+        MacroStepFormal(entry, (bad_entry_fallback,))
+    bad_delta_bucket = make_case(
+        macro_domain,
+        entry,
+        label_kind="transition",
+        target_path="Root.Plant.Idle",
+    )
+    valid_entry_case = make_case(
+        macro_domain,
+        entry,
+        label_kind="initial",
+        target_path="Root.Plant.Idle",
+    )
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases may only contain delta"):
+        MacroStepFormal(entry, (valid_entry_case,), (bad_delta_bucket,))
 
     terminate = terminated_source(macro_domain)
     good_absorb = terminated_absorb_case(macro_domain)
@@ -1443,6 +1558,8 @@ def test_structural_partition_negative_shapes_fall_back_to_truth_table_budget(
         BoolTemplate.true(),
         (),
     )
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        verify_source_partition(source, (accepted, bad_fallback), max_assignments=1)
     with pytest.raises(BmcBuildError, match="overlap"):
         verify_source_partition(source, (accepted, bad_fallback), max_assignments=8)
 
@@ -1462,6 +1579,20 @@ def test_structural_partition_negative_shapes_fall_back_to_truth_table_budget(
             ),
         ),
     )
+    entry_fallback = CycleCase(
+        "fallback",
+        entry.source_state_id,
+        entry.source_state_path,
+        entry.source_state_id,
+        entry.source_state_path,
+        "%s::fallback::%s::21" % (entry.source_state_path, entry.source_state_path),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        verify_source_partition(
+            entry, (accepted_entry, entry_fallback), max_assignments=1
+        )
     bad_delta = CycleCase(
         "delta",
         entry.source_state_id,
@@ -1472,9 +1603,27 @@ def test_structural_partition_negative_shapes_fall_back_to_truth_table_budget(
         BoolTemplate.true(),
         (),
     )
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        verify_source_partition(
+            entry, (accepted_entry,), (bad_delta,), max_assignments=1
+        )
     with pytest.raises(BmcBuildError, match="overlap"):
         verify_source_partition(
             entry, (accepted_entry,), (bad_delta,), max_assignments=8
+        )
+    diagnostic_terminal = CycleCase(
+        "diagnostic",
+        entry.source_state_id,
+        entry.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::diagnostic::%s::22" % (entry.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        verify_source_partition(
+            entry, (accepted_entry, diagnostic_terminal), max_assignments=1
         )
 
 
@@ -1498,6 +1647,13 @@ def test_verify_partition_public_validation_rejects_bad_arguments(macro_domain):
         verify_boolean_partition((BoolTemplate.true(),), variables=_bad_object())
     with pytest.raises(BmcBuildError, match="non-empty strings"):
         verify_boolean_partition((BoolTemplate.true(),), variables=("",))
+    with pytest.raises(BmcBuildError, match="reserved source-state atom"):
+        verify_boolean_partition(
+            (BoolTemplate.true(),),
+            variables=("__source_state__:Root",),
+        )
+    with pytest.raises(BmcBuildError, match="unsupported macro condition atom"):
+        verify_boolean_partition((BoolTemplate.true(),), variables=("opaque:bad",))
 
     with pytest.raises(InvalidBmcEncoding, match="source must be MacroStepSource"):
         verify_source_partition(_bad_object(), (fallback,))

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from typing import Any, cast
 
 import pytest
 
@@ -21,6 +22,8 @@ from pyfcstm.bmc.macro import (
     EventUse,
     GuardRequirement,
     MacroStepFormal,
+    PartitionCheckResult,
+    PriorityExclusion,
     build_fallback_case,
     build_semantic_delta_case,
     case_path_condition,
@@ -31,6 +34,7 @@ from pyfcstm.bmc.macro import (
 )
 from pyfcstm.bmc.source import (
     DIAGNOSTIC_CASE_PATH,
+    MacroStepSource,
     TERMINATE_CASE_PATH,
     diagnostic_source,
     entry_source,
@@ -39,6 +43,11 @@ from pyfcstm.bmc.source import (
 )
 from pyfcstm.model import load_state_machine_from_text
 from pyfcstm.model.expr import Boolean, Variable
+
+
+def _bad_object() -> Any:
+    """Return an intentionally bad value without tripping static type checks."""
+    return cast(Any, object())
 
 
 @pytest.fixture()
@@ -165,6 +174,553 @@ def make_large_priority_partition(source, condition_hook=None):
         (),
     )
     return tuple(accepted) + (fallback,)
+
+
+@pytest.mark.unittest
+def test_bool_template_public_validation_and_identity_reductions():
+    """BoolTemplate validates public shape and folds simple boolean identities."""
+    atom = BoolTemplate.atom("event:Root.Go")
+
+    assert BoolTemplate.not_(BoolTemplate.true()).kind == "false"
+    assert BoolTemplate.not_(BoolTemplate.false()).kind == "true"
+    assert BoolTemplate.not_(BoolTemplate.not_(atom)) is atom
+    assert BoolTemplate.and_().kind == "true"
+    assert BoolTemplate.and_(BoolTemplate.true()).kind == "true"
+    assert BoolTemplate.and_(atom, BoolTemplate.false()).kind == "false"
+    assert BoolTemplate.or_().kind == "false"
+    assert BoolTemplate.or_(BoolTemplate.false()).kind == "false"
+    assert BoolTemplate.or_(atom, BoolTemplate.true()).kind == "true"
+
+    with pytest.raises(InvalidBmcEncoding, match="Unsupported boolean template kind"):
+        BoolTemplate("xor")
+    with pytest.raises(InvalidBmcEncoding, match="atom name"):
+        BoolTemplate("atom")
+    with pytest.raises(InvalidBmcEncoding, match="atom templates cannot have operands"):
+        BoolTemplate("atom", "a", (atom,))
+    with pytest.raises(
+        InvalidBmcEncoding, match="constant templates cannot have names"
+    ):
+        BoolTemplate("true", "a")
+    with pytest.raises(
+        InvalidBmcEncoding, match="constant templates cannot have operands"
+    ):
+        BoolTemplate("false", operands=(atom,))
+    with pytest.raises(InvalidBmcEncoding, match="not templates cannot have names"):
+        BoolTemplate("not", "a", (atom,))
+    with pytest.raises(InvalidBmcEncoding, match="not templates must have one operand"):
+        BoolTemplate("not", operands=())
+    with pytest.raises(
+        InvalidBmcEncoding, match="compound templates cannot have names"
+    ):
+        BoolTemplate("and", "a", (atom,))
+    with pytest.raises(
+        InvalidBmcEncoding, match="compound templates must have operands"
+    ):
+        BoolTemplate("or", operands=())
+    with pytest.raises(InvalidBmcEncoding, match="operands must contain"):
+        BoolTemplate.and_(atom, _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="operand must be BoolTemplate"):
+        BoolTemplate.not_(_bad_object())
+
+
+@pytest.mark.unittest
+def test_bool_template_evaluate_rejects_missing_and_non_boolean_assignments():
+    """BoolTemplate public evaluator fails loudly on malformed assignments."""
+    atom = BoolTemplate.atom("event:Root.Go")
+
+    assert BoolTemplate.and_(
+        atom, BoolTemplate.not_(BoolTemplate.atom("event:Root.Stop"))
+    ).evaluate({"event:Root.Go": True, "event:Root.Stop": False})
+    with pytest.raises(BmcBuildError, match="missing boolean assignment"):
+        atom.evaluate({})
+    with pytest.raises(BmcBuildError, match="must be bool"):
+        atom.evaluate({"event:Root.Go": _bad_object()})
+
+
+@pytest.mark.unittest
+def test_public_contract_dataclasses_reject_invalid_shapes(
+    macro_domain,
+    sample_operation,
+):
+    """Public macro contract objects validate their constructor boundaries."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    expr = Variable("x") > 0
+
+    with pytest.raises(InvalidBmcEncoding, match="event_id must be non-negative"):
+        EventUse(-1, "Root.Go", "positive", "trigger")
+    with pytest.raises(InvalidBmcEncoding, match="event polarity"):
+        EventUse(0, "Root.Go", "maybe", "trigger")
+    with pytest.raises(InvalidBmcEncoding, match="owner_state_id must be non-negative"):
+        GuardRequirement(
+            "g0",
+            -1,
+            source.source_state_path,
+            "t",
+            expr,
+            "positive",
+            "transition_guard",
+            0,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="guard requirement expr"):
+        GuardRequirement(
+            "g0",
+            source.source_state_id,
+            source.source_state_path,
+            "t",
+            _bad_object(),
+            "positive",
+            "transition_guard",
+            0,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="after_action_block_index"):
+        GuardRequirement(
+            "g0",
+            source.source_state_id,
+            source.source_state_path,
+            "t",
+            expr,
+            "positive",
+            "transition_guard",
+            -1,
+        )
+    with pytest.raises(InvalidBmcEncoding, match="excluded_case_labels"):
+        PriorityExclusion("d0", "fallback", (), BoolTemplate.true())
+    with pytest.raises(InvalidBmcEncoding, match="non-empty strings"):
+        PriorityExclusion("d0", "fallback", ("",), BoolTemplate.true())
+    with pytest.raises(
+        InvalidBmcEncoding, match="excluded_condition must be BoolTemplate"
+    ):
+        PriorityExclusion("d0", "fallback", ("c0",), _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="accepted atoms"):
+        PriorityExclusion("d0", "fallback", ("c0",), BoolTemplate.atom("event:Root.Go"))
+    with pytest.raises(InvalidBmcEncoding, match="owner_state_id must be non-negative"):
+        ActionBlock("state_action", "leaf_during", -1, "Root.Plant.Idle", ())
+    with pytest.raises(InvalidBmcEncoding, match="OperationStatement"):
+        ActionBlock(
+            "state_action",
+            "leaf_during",
+            source.source_state_id,
+            source.source_state_path,
+            (_bad_object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="is_abstract"):
+        ActionBlock(
+            "state_action",
+            "leaf_during",
+            source.source_state_id,
+            source.source_state_path,
+            (sample_operation,),
+            is_abstract=_bad_object(),
+        )
+
+    priority = PriorityExclusion(
+        "d0",
+        "fallback",
+        ("c0",),
+        BoolTemplate.atom("accepted:c0"),
+    )
+    assert priority.to_canonical()["node"] == "priority_exclusion"
+
+
+@pytest.mark.unittest
+def test_cycle_case_public_validation_rejects_invalid_local_shapes(macro_domain):
+    """CycleCase rejects malformed labels, links, and local metadata."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    target_id = source.source_state_id
+    target_path = source.source_state_path
+    label = "%s::transition::%s::0" % (source.source_state_path, target_path)
+
+    with pytest.raises(InvalidBmcEncoding, match="condition must be BoolTemplate"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            _bad_object(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="action_blocks"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.true(),
+            (_bad_object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="used_events"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.true(),
+            (),
+            used_events=(_bad_object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="GuardRequirement"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.true(),
+            (),
+            guard_requirements=(_bad_object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="PriorityExclusion"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.true(),
+            (),
+            priority_exclusions=(_bad_object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.true(),
+            (),
+            failed_conditions=(_bad_object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="label must use"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            "bad",
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="label source path"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            "Other::transition::%s::0" % target_path,
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="label case kind"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            "%s::fallback::%s::0" % (source.source_state_path, target_path),
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="label target path"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            "%s::transition::Other::0" % source.source_state_path,
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="label ordinal"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            "%s::transition::%s::x" % (source.source_state_path, target_path),
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="absorb cases must self-loop"):
+        CycleCase(
+            "absorb",
+            STATE_TERMINATE_ID,
+            TERMINATE_CASE_PATH,
+            STATE_DIAGNOSTIC_ID,
+            DIAGNOSTIC_CASE_PATH,
+            "%s::absorb::%s::0" % (TERMINATE_CASE_PATH, DIAGNOSTIC_CASE_PATH),
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="absorb cases must use sentinel"):
+        CycleCase(
+            "absorb",
+            source.source_state_id,
+            source.source_state_path,
+            source.source_state_id,
+            source.source_state_path,
+            "%s::absorb::%s::0" % (source.source_state_path, source.source_state_path),
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(
+        InvalidBmcEncoding, match="diagnostic and delta cases target diagnostic"
+    ):
+        CycleCase(
+            "diagnostic",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            "%s::diagnostic::%s::0" % (source.source_state_path, target_path),
+            BoolTemplate.true(),
+            (),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="Duplicate guard requirement id"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.atom("guard:g0"),
+            (),
+            guard_requirements=(
+                GuardRequirement(
+                    "g0",
+                    source.source_state_id,
+                    source.source_state_path,
+                    "t0",
+                    Boolean(True),
+                    "positive",
+                    "transition_guard",
+                    0,
+                ),
+                GuardRequirement(
+                    "g0",
+                    source.source_state_id,
+                    source.source_state_path,
+                    "t1",
+                    Boolean(True),
+                    "positive",
+                    "transition_guard",
+                    0,
+                ),
+            ),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="domain must be BmcDomain"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.true(),
+            (),
+            domain=_bad_object(),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="EventUse path"):
+        CycleCase(
+            "transition",
+            source.source_state_id,
+            source.source_state_path,
+            target_id,
+            target_path,
+            label,
+            BoolTemplate.true(),
+            (),
+            used_events=(
+                EventUse(
+                    macro_domain.event_by_path("Root.Go").id,
+                    "Root.Plant.Ping",
+                    "positive",
+                    "trigger",
+                ),
+            ),
+            domain=macro_domain,
+        )
+
+
+@pytest.mark.unittest
+def test_macro_step_formal_public_validation_rejects_invalid_bucket_shapes(
+    macro_domain,
+):
+    """MacroStepFormal validates public source, bucket, and sentinel contracts."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    fallback = build_fallback_case(macro_domain, stable, ())
+    transition = make_case(macro_domain, stable, target_path="Root.Plant.Busy")
+    delta = CycleCase(
+        "delta",
+        stable.source_state_id,
+        stable.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::delta::%s::0" % (stable.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="source must be MacroStepSource"):
+        MacroStepFormal(_bad_object(), (fallback,))
+    with pytest.raises(InvalidBmcEncoding, match="success_cases must be a sequence"):
+        MacroStepFormal(stable, _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases must be a sequence"):
+        MacroStepFormal(stable, (fallback,), _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
+        MacroStepFormal(stable, (fallback,), (), _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
+        MacroStepFormal(stable, (_bad_object(),))
+    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
+        MacroStepFormal(stable, (fallback,), (_bad_object(),))
+    with pytest.raises(InvalidBmcEncoding, match="BoolTemplate"):
+        MacroStepFormal(stable, (fallback,), (), (_bad_object(),))
+    with pytest.raises(InvalidBmcEncoding, match="at least one relation case"):
+        MacroStepFormal(stable, ())
+    with pytest.raises(InvalidBmcEncoding, match="case source path"):
+        MacroStepFormal(
+            MacroStepSource(
+                "stable_leaf", "recurrence", stable.source_state_id, "Other"
+            ),
+            (fallback,),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="build diagnostics"):
+        MacroStepFormal(stable, (fallback,), (), (BoolTemplate.true(),))
+    with pytest.raises(
+        InvalidBmcEncoding, match="success_cases must not contain delta"
+    ):
+        MacroStepFormal(stable, (delta,))
+    with pytest.raises(
+        InvalidBmcEncoding, match="stable leaf formal requires a fallback"
+    ):
+        MacroStepFormal(stable, (transition,))
+    with pytest.raises(InvalidBmcEncoding, match="stable leaf success cases"):
+        MacroStepFormal(
+            stable, (make_case(macro_domain, stable, label_kind="initial"), fallback)
+        )
+    bad_fallback_target = CycleCase(
+        "fallback",
+        stable.source_state_id,
+        stable.source_state_path,
+        macro_domain.state_path_to_id("Root.Plant.Busy"),
+        "Root.Plant.Busy",
+        "%s::fallback::Root.Plant.Busy::0" % stable.source_state_path,
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="fallback cases must self-loop"):
+        MacroStepFormal(stable, (bad_fallback_target,))
+    bad_transition_target = CycleCase(
+        "transition",
+        stable.source_state_id,
+        stable.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::transition::%s::0" % (stable.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="stable leaf transitions"):
+        MacroStepFormal(stable, (bad_transition_target, fallback))
+    bad_priority = CycleCase(
+        "fallback",
+        stable.source_state_id,
+        stable.source_state_path,
+        stable.source_state_id,
+        stable.source_state_path,
+        "%s::fallback::%s::2" % (stable.source_state_path, stable.source_state_path),
+        BoolTemplate.true(),
+        (),
+        priority_exclusions=(
+            PriorityExclusion(
+                "d0",
+                "fallback",
+                ("missing",),
+                BoolTemplate.atom("accepted:missing"),
+            ),
+        ),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="priority exclusion"):
+        MacroStepFormal(stable, (bad_priority,))
+
+    entry = entry_source(macro_domain, "Root.Plant")
+    bad_entry_case = CycleCase(
+        "initial",
+        entry.source_state_id,
+        entry.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::initial::%s::0" % (entry.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="entry transition and initial cases"):
+        MacroStepFormal(entry, (bad_entry_case,))
+
+    terminate = terminated_source(macro_domain)
+    good_absorb = terminated_absorb_case(macro_domain)
+    sentinel_delta = CycleCase(
+        "delta",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::delta::%s::0" % (terminate.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases require"):
+        MacroStepFormal(terminate, (good_absorb,), (sentinel_delta,))
+    second_absorb = CycleCase(
+        "absorb",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::absorb::%s::1"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="must contain one case"):
+        MacroStepFormal(terminate, (good_absorb, second_absorb))
+    wrong_sentinel_case = CycleCase(
+        "transition",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::transition::%s::0"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel formal case"):
+        MacroStepFormal(terminate, (wrong_sentinel_case,))
+
+    assert (
+        MacroStepFormal(stable, (fallback,)).to_canonical()["node"]
+        == "macro_step_formal"
+    )
+    assert (
+        PartitionCheckResult((), 0, 1).to_canonical()["node"]
+        == "partition_check_result"
+    )
 
 
 @pytest.mark.unittest
@@ -393,6 +949,113 @@ def test_semantic_delta_condition_excludes_success_labels_and_build_diag(
 
 
 @pytest.mark.unittest
+def test_build_case_helpers_reject_invalid_public_arguments(macro_domain):
+    """Public fallback and delta builders fail closed on malformed inputs."""
+    stable = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    entry = entry_source(macro_domain, "Root.Plant")
+
+    with pytest.raises(InvalidBmcEncoding, match="fallback case requires"):
+        build_fallback_case(macro_domain, entry, ())
+    with pytest.raises(InvalidBmcEncoding, match="ordinal must be non-negative"):
+        build_fallback_case(macro_domain, stable, (), ordinal=-1)
+    with pytest.raises(InvalidBmcEncoding, match="accepted_cases must be a sequence"):
+        build_fallback_case(macro_domain, stable, _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
+        build_fallback_case(macro_domain, stable, (_bad_object(),))
+    with pytest.raises(
+        InvalidBmcEncoding, match="failed_conditions must be a sequence"
+    ):
+        build_fallback_case(macro_domain, stable, (), failed_conditions=_bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="BoolTemplate"):
+        build_fallback_case(
+            macro_domain, stable, (), failed_conditions=(_bad_object(),)
+        )
+    with pytest.raises(InvalidBmcEncoding, match="GuardRequirement"):
+        build_fallback_case(
+            macro_domain, stable, (), guard_requirements=(_bad_object(),)
+        )
+
+    bad_kind = make_case(macro_domain, stable, label_kind="fallback")
+    with pytest.raises(InvalidBmcEncoding, match="ordinary accepted cases"):
+        build_fallback_case(macro_domain, stable, (bad_kind,))
+    bad_source = make_case(
+        macro_domain,
+        entry,
+        label_kind="transition",
+        target_path="Root.Plant.Idle",
+    )
+    with pytest.raises(InvalidBmcEncoding, match="accepted case source id"):
+        build_fallback_case(macro_domain, stable, (bad_source,))
+    bad_path = CycleCase(
+        "transition",
+        stable.source_state_id,
+        "Other",
+        stable.source_state_id,
+        stable.source_state_path,
+        "Other::transition::%s::0" % stable.source_state_path,
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="accepted case source path"):
+        build_fallback_case(macro_domain, stable, (bad_path,))
+    diagnostic = CycleCase(
+        "transition",
+        stable.source_state_id,
+        stable.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::transition::%s::0" % (stable.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="target model states or terminate"):
+        build_fallback_case(macro_domain, stable, (diagnostic,))
+    with pytest.raises(InvalidBmcEncoding, match="Unknown event path"):
+        build_fallback_case(
+            macro_domain,
+            stable,
+            (),
+            failed_conditions=(BoolTemplate.atom("event:Root.NoSuch"),),
+        )
+
+    with pytest.raises(InvalidBmcEncoding, match="semantic delta case requires"):
+        build_semantic_delta_case(macro_domain, stable, ())
+    with pytest.raises(InvalidBmcEncoding, match="ordinal must be non-negative"):
+        build_semantic_delta_case(macro_domain, entry, (), ordinal=-1)
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
+        build_semantic_delta_case(
+            macro_domain,
+            entry,
+            (),
+            build_diagnostic_conditions=_bad_object(),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="BoolTemplate"):
+        build_semantic_delta_case(
+            macro_domain,
+            entry,
+            (),
+            build_diagnostic_conditions=(_bad_object(),),
+        )
+    with pytest.raises(InvalidBmcEncoding, match="failed_conditions"):
+        build_semantic_delta_case(
+            macro_domain, entry, (), failed_conditions=_bad_object()
+        )
+    with pytest.raises(InvalidBmcEncoding, match="GuardRequirement"):
+        build_semantic_delta_case(
+            macro_domain, entry, (), guard_requirements=(_bad_object(),)
+        )
+    with pytest.raises(
+        InvalidBmcEncoding, match="failed_conditions must contain BoolTemplate"
+    ):
+        build_semantic_delta_case(
+            macro_domain,
+            entry,
+            (),
+            failed_conditions=(_bad_object(),),
+        )
+
+
+@pytest.mark.unittest
 def test_partition_resolves_accepted_atoms_through_case_registry(macro_domain):
     """Source partition checks use accepted-path semantics, not free atoms."""
     source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
@@ -410,6 +1073,223 @@ def test_partition_resolves_accepted_atoms_through_case_registry(macro_domain):
 
     assert result.variables == ("event:Root.Plant.Ping",)
     assert result.assignment_count == 2
+
+
+@pytest.mark.unittest
+def test_partition_handles_sentinel_delta_and_accepted_atom_failures(macro_domain):
+    """Source partition checks cover sentinel, delta, diagnostic, and atom cycles."""
+    terminated = verify_source_partition(
+        terminated_source(macro_domain),
+        (terminated_absorb_case(macro_domain),),
+        max_assignments=1,
+    )
+    assert terminated.assignment_count == 0
+    assert terminated.bucket_count == 1
+
+    entry = entry_source(macro_domain, "Root.Plant")
+    accepted = make_case(
+        macro_domain,
+        entry,
+        label_kind="initial",
+        target_path="Root.Plant.Idle",
+        condition=BoolTemplate.atom("event:Root.Go"),
+        used_events=(
+            EventUse(
+                macro_domain.event_by_path("Root.Go").id,
+                "Root.Go",
+                "positive",
+                "trigger",
+            ),
+        ),
+    )
+    diagnostic_condition = BoolTemplate.atom("event:Root.Plant.Ping")
+    delta = build_semantic_delta_case(
+        macro_domain,
+        entry,
+        (accepted,),
+        build_diagnostic_conditions=(diagnostic_condition,),
+    )
+    result = verify_source_partition(
+        entry,
+        (accepted,),
+        (delta,),
+        (diagnostic_condition,),
+        max_assignments=1,
+    )
+    assert result.assignment_count == 0
+    assert result.bucket_count == 3
+
+    first = CycleCase(
+        "transition",
+        entry.source_state_id,
+        entry.source_state_path,
+        entry.source_state_id,
+        entry.source_state_path,
+        "%s::transition::%s::10" % (entry.source_state_path, entry.source_state_path),
+        BoolTemplate.atom(
+            "accepted:%s::transition::%s::11"
+            % (entry.source_state_path, entry.source_state_path)
+        ),
+        (),
+    )
+    second = CycleCase(
+        "transition",
+        entry.source_state_id,
+        entry.source_state_path,
+        entry.source_state_id,
+        entry.source_state_path,
+        "%s::transition::%s::11" % (entry.source_state_path, entry.source_state_path),
+        BoolTemplate.atom("accepted:%s" % first.label),
+        (),
+    )
+    with pytest.raises(BmcBuildError, match="cycle detected"):
+        verify_source_partition(entry, (first, second), max_assignments=8)
+
+    unknown = CycleCase(
+        "transition",
+        entry.source_state_id,
+        entry.source_state_path,
+        entry.source_state_id,
+        entry.source_state_path,
+        "%s::transition::%s::12" % (entry.source_state_path, entry.source_state_path),
+        BoolTemplate.atom("accepted:missing-label"),
+        (),
+    )
+    with pytest.raises(BmcBuildError, match="unknown case label"):
+        verify_source_partition(entry, (unknown,), max_assignments=8)
+
+
+@pytest.mark.unittest
+def test_structural_partition_negative_shapes_fall_back_to_truth_table_budget(
+    macro_domain,
+):
+    """Structural recognizer refuses malformed accepted/fallback/delta shapes."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+
+    accepted_only = make_large_priority_partition(source)[:-1]
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        verify_source_partition(source, accepted_only, max_assignments=1)
+
+    accepted = make_case(
+        macro_domain,
+        source,
+        condition=BoolTemplate.atom("event:Root.Plant.Ping"),
+        target_path="Root.Plant.Busy",
+        used_events=(
+            EventUse(
+                macro_domain.event_by_path("Root.Plant.Ping").id,
+                "Root.Plant.Ping",
+                "positive",
+                "trigger",
+            ),
+        ),
+    )
+    bad_fallback = CycleCase(
+        "fallback",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        "%s::fallback::%s::20" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(BmcBuildError, match="overlap"):
+        verify_source_partition(source, (accepted, bad_fallback), max_assignments=8)
+
+    entry = entry_source(macro_domain, "Root.Plant")
+    accepted_entry = make_case(
+        macro_domain,
+        entry,
+        label_kind="initial",
+        target_path="Root.Plant.Idle",
+        condition=BoolTemplate.atom("event:Root.Go"),
+        used_events=(
+            EventUse(
+                macro_domain.event_by_path("Root.Go").id,
+                "Root.Go",
+                "positive",
+                "trigger",
+            ),
+        ),
+    )
+    bad_delta = CycleCase(
+        "delta",
+        entry.source_state_id,
+        entry.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::delta::%s::20" % (entry.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(BmcBuildError, match="overlap"):
+        verify_source_partition(
+            entry, (accepted_entry,), (bad_delta,), max_assignments=8
+        )
+
+
+@pytest.mark.unittest
+def test_verify_partition_public_validation_rejects_bad_arguments(macro_domain):
+    """Public partition helpers validate their documented argument boundary."""
+    source = stable_leaf_source(macro_domain, "Root.Plant.Idle")
+    fallback = build_fallback_case(macro_domain, source, ())
+
+    with pytest.raises(BmcBuildError, match="partition buckets"):
+        verify_boolean_partition(_bad_object())
+    with pytest.raises(BmcBuildError, match="at least one bucket"):
+        verify_boolean_partition(())
+    with pytest.raises(BmcBuildError, match="BoolTemplate"):
+        verify_boolean_partition((_bad_object(),))
+    with pytest.raises(BmcBuildError, match="max_assignments"):
+        verify_boolean_partition((BoolTemplate.true(),), max_assignments=True)
+    with pytest.raises(BmcBuildError, match="max_assignments"):
+        verify_boolean_partition((BoolTemplate.true(),), max_assignments=0)
+    with pytest.raises(BmcBuildError, match="partition variables"):
+        verify_boolean_partition((BoolTemplate.true(),), variables=_bad_object())
+    with pytest.raises(BmcBuildError, match="non-empty strings"):
+        verify_boolean_partition((BoolTemplate.true(),), variables=("",))
+
+    with pytest.raises(InvalidBmcEncoding, match="source must be MacroStepSource"):
+        verify_source_partition(_bad_object(), (fallback,))
+    with pytest.raises(InvalidBmcEncoding, match="success_cases must be a sequence"):
+        verify_source_partition(source, _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases must be a sequence"):
+        verify_source_partition(source, (fallback,), _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="build_diagnostic_conditions"):
+        verify_source_partition(source, (fallback,), (), _bad_object())
+    with pytest.raises(InvalidBmcEncoding, match="CycleCase"):
+        verify_source_partition(source, (_bad_object(),))
+    with pytest.raises(InvalidBmcEncoding, match="source id mismatch"):
+        verify_source_partition(
+            source, (make_case(macro_domain, entry_source(macro_domain, "Root.Plant")),)
+        )
+    wrong_path = CycleCase(
+        "fallback",
+        source.source_state_id,
+        "Other",
+        source.source_state_id,
+        source.source_state_path,
+        "Other::fallback::%s::0" % source.source_state_path,
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="source path mismatch"):
+        verify_source_partition(source, (wrong_path,))
+    delta = build_semantic_delta_case(
+        macro_domain, entry_source(macro_domain, "Root.Plant"), ()
+    )
+    with pytest.raises(
+        InvalidBmcEncoding, match="success_cases must not contain delta"
+    ):
+        verify_source_partition(entry_source(macro_domain, "Root.Plant"), (delta,))
+    with pytest.raises(InvalidBmcEncoding, match="delta_cases may only contain delta"):
+        entry = entry_source(macro_domain, "Root.Plant")
+        verify_source_partition(entry, (), (make_case(macro_domain, entry),))
+    with pytest.raises(InvalidBmcEncoding, match="BoolTemplate"):
+        verify_source_partition(source, (fallback,), (), (_bad_object(),))
+    with pytest.raises(InvalidBmcEncoding, match="delta cases require"):
+        verify_source_partition(source, (fallback,), (delta,))
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -712,6 +712,19 @@ def test_macro_step_formal_public_validation_rejects_invalid_bucket_shapes(
     )
     with pytest.raises(InvalidBmcEncoding, match="sentinel formal case"):
         MacroStepFormal(terminate, (wrong_sentinel_case,))
+    false_absorb = CycleCase(
+        "absorb",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::absorb::%s::2"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.false(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel absorb condition"):
+        MacroStepFormal(terminate, (false_absorb,))
 
     assert (
         MacroStepFormal(stable, (fallback,)).to_canonical()["node"]
@@ -1078,13 +1091,42 @@ def test_partition_resolves_accepted_atoms_through_case_registry(macro_domain):
 @pytest.mark.unittest
 def test_partition_handles_sentinel_delta_and_accepted_atom_failures(macro_domain):
     """Source partition checks cover sentinel, delta, diagnostic, and atom cycles."""
+    terminate = terminated_source(macro_domain)
     terminated = verify_source_partition(
-        terminated_source(macro_domain),
+        terminate,
         (terminated_absorb_case(macro_domain),),
         max_assignments=1,
     )
     assert terminated.assignment_count == 0
     assert terminated.bucket_count == 1
+
+    false_absorb = CycleCase(
+        "absorb",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::absorb::%s::1"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.false(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel absorb condition"):
+        verify_source_partition(terminate, (false_absorb,), max_assignments=1)
+
+    sentinel_fallback = CycleCase(
+        "fallback",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        terminate.source_state_id,
+        terminate.source_state_path,
+        "%s::fallback::%s::0"
+        % (terminate.source_state_path, terminate.source_state_path),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="sentinel formal case"):
+        verify_source_partition(terminate, (sentinel_fallback,), max_assignments=1)
 
     entry = entry_source(macro_domain, "Root.Plant")
     accepted = make_case(

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -125,6 +125,21 @@ def make_case(
     )
 
 
+def make_sentinel_absorb_case(source, **kwargs):
+    """Create a synthetic sentinel absorb case for validation tests."""
+    return CycleCase(
+        "absorb",
+        source.source_state_id,
+        source.source_state_path,
+        source.source_state_id,
+        source.source_state_path,
+        "%s::absorb::%s::0" % (source.source_state_path, source.source_state_path),
+        BoolTemplate.true(),
+        kwargs.pop("action_blocks", ()),
+        **kwargs,
+    )
+
+
 def make_large_priority_partition(source, condition_hook=None):
     """Create a synthetic large accepted/fallback partition."""
     accepted = []
@@ -725,6 +740,21 @@ def test_macro_step_formal_public_validation_rejects_invalid_bucket_shapes(
     )
     with pytest.raises(InvalidBmcEncoding, match="sentinel absorb condition"):
         MacroStepFormal(terminate, (false_absorb,))
+    raw_terminate = MacroStepSource(
+        "terminated", "recurrence", STATE_TERMINATE_ID, TERMINATE_CASE_PATH
+    )
+    absorb_to_diagnostic = CycleCase(
+        "absorb",
+        raw_terminate.source_state_id,
+        raw_terminate.source_state_path,
+        raw_terminate.source_state_id,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::absorb::%s::0" % (raw_terminate.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="self-loop"):
+        MacroStepFormal(raw_terminate, (absorb_to_diagnostic,))
     absorb_with_action = CycleCase(
         "absorb",
         terminate.source_state_id,
@@ -769,6 +799,74 @@ def test_macro_step_formal_public_validation_rejects_invalid_bucket_shapes(
         PartitionCheckResult((), 0, 1).to_canonical()["node"]
         == "partition_check_result"
     )
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    ("field_name", "payload_key", "message"),
+    [
+        ("used_events", "used_events", "sentinel absorb case cannot use events"),
+        (
+            "guard_requirements",
+            "guard_requirements",
+            "sentinel absorb case cannot have guard requirements",
+        ),
+        (
+            "priority_exclusions",
+            "priority_exclusions",
+            "sentinel absorb case cannot have priority exclusions",
+        ),
+        (
+            "failed_conditions",
+            "failed_conditions",
+            "sentinel absorb case cannot have failed conditions",
+        ),
+    ],
+)
+def test_sentinel_absorb_rejects_runtime_metadata_on_public_paths(
+    macro_domain, field_name, payload_key, message
+):
+    """Sentinel absorb buckets stay pure through both public validation paths."""
+    terminate = terminated_source(macro_domain)
+    event = macro_domain.event_by_path("Root.Go")
+    payloads = {
+        "used_events": (EventUse(event.id, event.path, "positive", "trigger"),),
+        "guard_requirements": (
+            GuardRequirement(
+                "g0",
+                macro_domain.state_path_to_id("Root.Plant.Idle"),
+                "Root.Plant.Idle",
+                "Root.Plant.Idle -> Root.Plant.Busy",
+                Boolean(True),
+                "positive",
+                "transition_guard",
+                0,
+            ),
+        ),
+        "priority_exclusions": (
+            PriorityExclusion(
+                "d0",
+                "fallback",
+                (
+                    "%s::absorb::%s::0"
+                    % (terminate.source_state_path, terminate.source_state_path),
+                ),
+                BoolTemplate.atom(
+                    "accepted:%s::absorb::%s::0"
+                    % (terminate.source_state_path, terminate.source_state_path)
+                ),
+            ),
+        ),
+        "failed_conditions": (BoolTemplate.true(),),
+    }
+    malformed = make_sentinel_absorb_case(
+        terminate, **{payload_key: payloads[field_name]}
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match=message):
+        MacroStepFormal(terminate, (malformed,))
+    with pytest.raises(InvalidBmcEncoding, match=message):
+        verify_source_partition(terminate, (malformed,), max_assignments=1)
 
 
 @pytest.mark.unittest
@@ -1148,6 +1246,24 @@ def test_partition_handles_sentinel_delta_and_accepted_atom_failures(macro_domai
     )
     with pytest.raises(InvalidBmcEncoding, match="sentinel absorb condition"):
         verify_source_partition(terminate, (false_absorb,), max_assignments=1)
+
+    raw_terminate = MacroStepSource(
+        "terminated", "recurrence", STATE_TERMINATE_ID, TERMINATE_CASE_PATH
+    )
+    absorb_to_diagnostic = CycleCase(
+        "absorb",
+        raw_terminate.source_state_id,
+        raw_terminate.source_state_path,
+        raw_terminate.source_state_id,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::absorb::%s::0" % (raw_terminate.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="self-loop"):
+        verify_source_partition(
+            raw_terminate, (absorb_to_diagnostic,), max_assignments=1
+        )
 
     absorb_with_action = CycleCase(
         "absorb",

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -659,6 +659,39 @@ def test_macro_imports_do_not_load_z3_or_verify_modules():
 
 
 @pytest.mark.unittest
+def test_bool_template_reduces_identity_absorbing_and_duplicate_operands():
+    """Boolean recipes normalize local identities before canonical comparison."""
+    atom = BoolTemplate.atom("a")
+    other = BoolTemplate.atom("b")
+
+    assert (
+        BoolTemplate.and_(BoolTemplate.true(), atom).to_canonical()
+        == atom.to_canonical()
+    )
+    assert BoolTemplate.and_(atom, atom).to_canonical() == atom.to_canonical()
+    assert BoolTemplate.and_(atom, BoolTemplate.false()).to_canonical() == (
+        BoolTemplate.false().to_canonical()
+    )
+    assert (
+        BoolTemplate.or_(BoolTemplate.false(), atom).to_canonical()
+        == atom.to_canonical()
+    )
+    assert BoolTemplate.or_(atom, atom).to_canonical() == atom.to_canonical()
+    assert BoolTemplate.or_(atom, BoolTemplate.true()).to_canonical() == (
+        BoolTemplate.true().to_canonical()
+    )
+    assert (
+        BoolTemplate.not_(BoolTemplate.not_(atom)).to_canonical() == atom.to_canonical()
+    )
+
+    nested = BoolTemplate.and_(
+        atom, BoolTemplate.and_(BoolTemplate.true(), other, atom)
+    )
+    assert nested.kind == "and"
+    assert nested.variables == ("a", "b")
+
+
+@pytest.mark.unittest
 def test_bool_template_validation_and_evaluation_fail_closed():
     """BoolTemplate rejects malformed recipes and evaluation unknowns."""
     atom = BoolTemplate.atom("a")

--- a/test/bmc/test_macro_contract.py
+++ b/test/bmc/test_macro_contract.py
@@ -1233,6 +1233,39 @@ def test_partition_handles_sentinel_delta_and_accepted_atom_failures(macro_domai
     assert terminated.assignment_count == 0
     assert terminated.bucket_count == 1
 
+    with pytest.raises(InvalidBmcEncoding, match="cannot have build diagnostics"):
+        verify_source_partition(
+            terminate,
+            (terminated_absorb_case(macro_domain),),
+            build_diagnostic_conditions=(BoolTemplate.true(),),
+            max_assignments=1,
+        )
+    diagnostic = diagnostic_source(macro_domain)
+    with pytest.raises(InvalidBmcEncoding, match="cannot have build diagnostics"):
+        verify_source_partition(
+            diagnostic,
+            (diagnostic_absorb_case(macro_domain),),
+            build_diagnostic_conditions=(BoolTemplate.true(),),
+            max_assignments=1,
+        )
+    sentinel_delta = CycleCase(
+        "delta",
+        terminate.source_state_id,
+        terminate.source_state_path,
+        STATE_DIAGNOSTIC_ID,
+        DIAGNOSTIC_CASE_PATH,
+        "%s::delta::%s::0" % (terminate.source_state_path, DIAGNOSTIC_CASE_PATH),
+        BoolTemplate.true(),
+        (),
+    )
+    with pytest.raises(InvalidBmcEncoding, match="cannot have delta cases"):
+        verify_source_partition(
+            terminate,
+            (terminated_absorb_case(macro_domain),),
+            delta_cases=(sentinel_delta,),
+            max_assignments=1,
+        )
+
     false_absorb = CycleCase(
         "absorb",
         terminate.source_state_id,
@@ -1667,6 +1700,43 @@ def test_structural_partition_checker_rejects_extra_accepted_atoms():
             source,
             make_large_priority_partition(source, inject_positive_accepted),
         )
+
+
+@pytest.mark.unittest
+def test_sentinel_diagnostics_fail_closed_under_optimized_python():
+    """Sentinel partition validation must not depend on assert statements."""
+    code = """
+from pyfcstm.bmc import build_bmc_domain, terminated_source
+from pyfcstm.bmc.errors import InvalidBmcEncoding
+from pyfcstm.bmc.macro import BoolTemplate, terminated_absorb_case, verify_source_partition
+from pyfcstm.model import load_state_machine_from_text
+
+domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+source = terminated_source(domain)
+try:
+    verify_source_partition(
+        source,
+        (terminated_absorb_case(domain),),
+        build_diagnostic_conditions=(BoolTemplate.true(),),
+        max_assignments=1,
+    )
+except InvalidBmcEncoding as err:
+    print(type(err).__name__, str(err))
+else:
+    raise SystemExit('sentinel diagnostics were accepted')
+"""
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert (
+        "InvalidBmcEncoding sentinel absorb formal cannot have build diagnostics"
+        in (result.stdout.strip())
+    )
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -3,17 +3,30 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
 from pyfcstm.bmc import (
     BmcBuildError,
+    BmcDomain,
+    MacroExpansionOptions,
+    diagnostic_source,
     build_bmc_domain,
     entry_source,
+    terminated_source,
+    InvalidBmcEncoding,
+    MacroStepSource,
     stable_leaf_source,
 )
 from pyfcstm.bmc.expand import expand_macro_step_cases
 from pyfcstm.model import IfBlock, load_state_machine_from_text
+
+
+def _bad_object() -> Any:
+    """Return an intentionally bad value without tripping static type checks."""
+    return cast(Any, object())
+
 
 _FIXTURE = Path(__file__).with_name("fixtures") / "macro_runtime_alignment.fcstm"
 
@@ -27,6 +40,388 @@ def _case_by_kind_target(formal, kind, target_path):
 
 def _conditions(case):
     return set(case.condition.variables)
+
+
+@pytest.mark.unittest
+def test_expand_public_api_rejects_bad_source_and_options():
+    """Public expansion entry validates only its public boundary arguments."""
+    model = load_state_machine_from_text("state Root;")
+    domain = build_bmc_domain(model, bound=1)
+
+    with pytest.raises(InvalidBmcEncoding, match="source must be MacroStepSource"):
+        expand_macro_step_cases(_bad_object())
+    with pytest.raises(
+        InvalidBmcEncoding, match="options must be MacroExpansionOptions"
+    ):
+        expand_macro_step_cases(
+            stable_leaf_source(domain, "Root"), options=_bad_object()
+        )
+    with pytest.raises(InvalidBmcEncoding, match="max_micro_steps"):
+        MacroExpansionOptions(max_micro_steps=0)
+    with pytest.raises(InvalidBmcEncoding, match="max_stack_depth"):
+        MacroExpansionOptions(max_stack_depth=True)
+    with pytest.raises(InvalidBmcEncoding, match="partition_max_assignments"):
+        MacroExpansionOptions(partition_max_assignments=0)
+    with pytest.raises(InvalidBmcEncoding, match="verify_partition"):
+        MacroExpansionOptions(verify_partition="yes")
+
+
+@pytest.mark.unittest
+def test_expand_rejects_domainless_and_modeless_sources():
+    """Expansion requires a source carrying a domain with a model back-reference."""
+    model = load_state_machine_from_text("state Root;")
+    domain = build_bmc_domain(model, bound=1)
+    source = stable_leaf_source(domain, "Root")
+    modeless = BmcDomain(
+        domain.bound,
+        domain.states,
+        domain.events,
+        domain.variables,
+        domain.frames,
+        domain.steps,
+        domain.event_inputs,
+        domain.initial_state_ids,
+        domain.stable_state_ids,
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="domain-backed source"):
+        expand_macro_step_cases(MacroStepSource("stable_leaf", "recurrence", 0, "Root"))
+    with pytest.raises(InvalidBmcEncoding, match="model back-reference"):
+        expand_macro_step_cases(
+            MacroStepSource(
+                source.kind,
+                source.origin,
+                source.source_state_id,
+                source.source_state_path,
+                domain=modeless,
+            )
+        )
+
+
+@pytest.mark.unittest
+def test_expansion_safety_limits_fail_closed():
+    """Micro-step and stack-depth caps are loud build-time failures."""
+    model = load_state_machine_from_text(
+        """
+        state Root {
+            state Parent {
+                state Child;
+                [*] -> Child;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+
+    with pytest.raises(BmcBuildError, match="micro-step"):
+        expand_macro_step_cases(
+            entry_source(domain),
+            MacroExpansionOptions(max_micro_steps=1),
+        )
+    with pytest.raises(BmcBuildError, match="stack-depth"):
+        expand_macro_step_cases(
+            stable_leaf_source(domain, "Root.Parent.Child"),
+            MacroExpansionOptions(max_stack_depth=1),
+        )
+
+
+@pytest.mark.unittest
+def test_sentinel_sources_expand_to_absorb_cases():
+    """Terminated and diagnostic macro sources are explicit absorb formals."""
+    model = load_state_machine_from_text("state Root;")
+    domain = build_bmc_domain(model, bound=1)
+
+    terminated = expand_macro_step_cases(terminated_source(domain))
+    diagnostic = expand_macro_step_cases(diagnostic_source(domain))
+
+    assert [
+        (case.kind, case.source_state_path, case.target_state_path)
+        for case in terminated.cases
+    ] == [("absorb", "__terminate__", "__terminate__")]
+    assert [
+        (case.kind, case.source_state_path, case.target_state_path)
+        for case in diagnostic.cases
+    ] == [("absorb", "__diagnostic__", "__diagnostic__")]
+    assert terminated.cases[0].condition.evaluate({}) is True
+    assert diagnostic.cases[0].condition.evaluate({}) is True
+
+
+@pytest.mark.unittest
+def test_root_entry_expands_initial_descent_actions():
+    """Root entry starts from an empty stack and records cold-entry actions."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            enter { x = x + 1; }
+            state A { during { x = x + 2; } }
+            [*] -> A effect { x = x + 4; }
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain))
+    initial = _case_by_kind_target(formal, "initial", "Root.A")
+
+    assert initial.condition.evaluate({}) is True
+    assert [
+        (block.runtime_role, block.owner_state_path, block.transition_label)
+        for block in initial.action_blocks
+    ] == [
+        ("state_enter", "Root", None),
+        ("transition_effect", "Root", "Root::0::INIT_STATE->A"),
+        ("leaf_during", "Root.A", None),
+    ]
+
+
+@pytest.mark.unittest
+def test_nested_composite_entry_continues_through_initial_child():
+    """Hot entry into a composite target expands its own initial transition."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state Parent {
+                enter { x = x + 1; }
+                state Child { during { x = x + 2; } }
+                [*] -> Child effect { x = x + 3; }
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain, "Root.Parent"))
+    initial = _case_by_kind_target(formal, "initial", "Root.Parent.Child")
+
+    assert [
+        (block.runtime_role, block.owner_state_path, block.transition_label)
+        for block in initial.action_blocks
+    ] == [
+        ("transition_effect", "Root.Parent", "Root.Parent::0::INIT_STATE->Child"),
+        ("leaf_during", "Root.Parent.Child", None),
+    ]
+
+
+@pytest.mark.unittest
+def test_non_pseudo_initial_transition_consumes_plain_before_actions():
+    """Composite plain during-before runs before non-pseudo initial children."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state Parent {
+                during before { x = x + 10; }
+                state Child { during { x = x + 1; } }
+                [*] -> Child;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain))
+    initial = _case_by_kind_target(formal, "initial", "Root.Parent.Child")
+
+    assert [block.runtime_role for block in initial.action_blocks] == [
+        "plain_during_before",
+        "leaf_during",
+    ]
+
+
+@pytest.mark.unittest
+def test_literal_boolean_guards_are_folded_before_case_expansion():
+    """Literal true guards add no atom; literal false guards are pruned."""
+    model = load_state_machine_from_text(
+        """
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B : if [false];
+            A -> C : if [true];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    to_c = _case_by_kind_target(formal, "transition", "Root.C")
+    fallback = _case_by_kind_target(formal, "fallback", "Root.A")
+    assert to_c.condition.evaluate({}) is True
+    assert _conditions(to_c) == set()
+    assert all(case.target_state_path != "Root.B" for case in formal.cases)
+    assert _conditions(fallback) == {"accepted:%s" % to_c.label}
+
+
+@pytest.mark.unittest
+def test_failed_initial_candidate_becomes_entry_delta_with_initial_guard_metadata():
+    """Unstable guarded initial descent is reported as entry semantic delta."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state Parent {
+                pseudo state Route;
+                state Child;
+                [*] -> Route : if [x > 0];
+                Route -> Route;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain, "Root.Parent"))
+    delta = _case_by_kind_target(formal, "delta", "__diagnostic__")
+
+    assert delta.condition.evaluate({}) is True
+    assert {item.name for item in delta.failed_conditions if item.kind == "atom"} == {
+        "guard:g0"
+    }
+    assert [
+        (guard.requirement_id, str(guard.expr.to_ast_node()), guard.reason)
+        for guard in delta.guard_requirements
+    ] == [("g0", "x > 0", "initial_guard")]
+
+
+@pytest.mark.unittest
+def test_failed_parent_continuation_falls_back_with_parent_guard_metadata():
+    """Rejected parent continuation is carried into stable fallback diagnostics."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state Parent {
+                state Child;
+                [*] -> Child;
+                Child -> [*];
+            }
+            pseudo state Route;
+            [*] -> Parent;
+            Parent -> Route : if [x > 0];
+            Route -> Route;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.Parent.Child"))
+    fallback = _case_by_kind_target(formal, "fallback", "Root.Parent.Child")
+
+    assert fallback.condition.evaluate({}) is True
+    assert {
+        item.name for item in fallback.failed_conditions if item.kind == "atom"
+    } == {"guard:g0"}
+    assert [
+        (guard.requirement_id, str(guard.expr.to_ast_node()), guard.reason)
+        for guard in fallback.guard_requirements
+    ] == [("g0", "x > 0", "parent_continuation_guard")]
+
+
+@pytest.mark.unittest
+def test_exit_to_root_records_root_exit_and_targets_terminate():
+    """Exit transitions unwind to the terminate sentinel with exit actions."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            exit { x = x + 10; }
+            state A { exit { x = x + 1; } }
+            [*] -> A;
+            A -> [*];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    transition = _case_by_kind_target(formal, "transition", "__terminate__")
+
+    assert transition.condition.evaluate({}) is True
+    assert [
+        (block.runtime_role, block.owner_state_path)
+        for block in transition.action_blocks
+    ] == [
+        ("state_exit", "Root.A"),
+        ("state_exit", "Root"),
+    ]
+
+
+@pytest.mark.unittest
+def test_pseudo_exit_clears_pending_plain_before_without_running_it():
+    """Pseudo exit from a just-entered composite clears pending plain-before work."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state Parent {
+                during before { x = x + 100; }
+                pseudo state Route;
+                [*] -> Route;
+                Route -> [*];
+            }
+            state Done;
+            [*] -> Parent;
+            Parent -> Done;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain, "Root.Parent"))
+    selected = _case_by_kind_target(formal, "initial", "Root.Done")
+
+    assert [block.runtime_role for block in selected.action_blocks] == []
+
+
+@pytest.mark.unittest
+def test_lifecycle_ref_actions_record_referenced_action_owner_and_name():
+    """Lifecycle refs are resolved to the referenced action block."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            enter Shared { x = x + 1; }
+            state A {
+                enter ref /Shared;
+                during { }
+            }
+            [*] -> A;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain))
+    selected = _case_by_kind_target(formal, "initial", "Root.A")
+
+    assert [
+        (block.runtime_role, block.owner_state_path, block.action_name)
+        for block in selected.action_blocks
+    ] == [
+        ("state_enter", "Root", "Root.Shared"),
+        ("state_enter", "Root", "Root.Shared"),
+    ]
+
+
+@pytest.mark.unittest
+def test_empty_concrete_actions_do_not_create_action_blocks():
+    """Empty concrete lifecycle actions are no-ops in the action-block plan."""
+    model = load_state_machine_from_text(
+        """
+        state Root {
+            state A {
+                enter { }
+                during { }
+            }
+            [*] -> A;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain))
+    selected = _case_by_kind_target(formal, "initial", "Root.A")
+
+    assert selected.action_blocks == ()
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -204,6 +204,45 @@ def test_failed_event_candidate_metadata_is_reported_on_fallback():
 
 
 @pytest.mark.unittest
+def test_rejected_event_candidate_metadata_is_reported_on_later_transitions():
+    """Accepted later cases keep event reads used by priority masks."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            state C;
+            pseudo state P;
+            [*] -> A;
+            A -> P :: Go;
+            P -> P;
+            A -> B :: Fire;
+            A -> C;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    by_target = {case.target_state_path: case for case in formal.success_cases}
+
+    assert sorted(
+        (event.path, event.polarity, event.reason)
+        for event in by_target["Root.B"].used_events
+    ) == [
+        ("Root.A.Fire", "positive", "trigger"),
+        ("Root.A.Go", "negative", "priority"),
+    ]
+    assert sorted(
+        (event.path, event.polarity, event.reason)
+        for event in by_target["Root.C"].used_events
+    ) == [
+        ("Root.A.Fire", "negative", "priority"),
+        ("Root.A.Go", "negative", "priority"),
+    ]
+
+
+@pytest.mark.unittest
 def test_verify_partition_option_raises_for_budget_too_small():
     """Partition self-check failures surface as build errors, not silent deltas."""
     model = load_state_machine_from_text(

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -19,7 +19,13 @@ from pyfcstm.bmc import (
     MacroStepSource,
     stable_leaf_source,
 )
-from pyfcstm.bmc.expand import expand_macro_step_cases
+from pyfcstm.bmc.expand import (
+    _FormalStackFrame,
+    _MacroExpander,
+    _MacroFrontier,
+    expand_macro_step_cases,
+)
+from pyfcstm.bmc.macro import BoolTemplate
 from pyfcstm.model import IfBlock, load_state_machine_from_text
 
 
@@ -96,6 +102,157 @@ def test_expand_rejects_domainless_and_modeless_sources():
                 domain=modeless,
             )
         )
+
+
+@pytest.mark.unittest
+def test_expand_rejects_inconsistent_domain_model_snapshots():
+    """Expansion fails loudly when a domain back-reference no longer matches ids."""
+    source_model = load_state_machine_from_text(
+        """
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    source_domain = build_bmc_domain(source_model, bound=1)
+    missing_source_domain = BmcDomain(
+        source_domain.bound,
+        source_domain.states,
+        source_domain.events,
+        source_domain.variables,
+        source_domain.frames,
+        source_domain.steps,
+        source_domain.event_inputs,
+        source_domain.initial_state_ids,
+        source_domain.stable_state_ids,
+        model=load_state_machine_from_text("state Root;"),
+    )
+    source = MacroStepSource(
+        "stable_leaf",
+        "recurrence",
+        source_domain.state_path_to_id("Root.A"),
+        "Root.A",
+        domain=missing_source_domain,
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="source state is not present"):
+        expand_macro_step_cases(source)
+
+    target_model = load_state_machine_from_text(
+        """
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    target_domain = build_bmc_domain(load_state_machine_from_text("state Root;"), 1)
+    missing_target_domain = BmcDomain(
+        target_domain.bound,
+        target_domain.states,
+        target_domain.events,
+        target_domain.variables,
+        target_domain.frames,
+        target_domain.steps,
+        target_domain.event_inputs,
+        target_domain.initial_state_ids,
+        target_domain.stable_state_ids,
+        model=target_model,
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="Unknown state path"):
+        expand_macro_step_cases(entry_source(missing_target_domain))
+
+
+@pytest.mark.unittest
+def test_expand_rejects_event_paths_missing_from_domain_snapshot():
+    """Event atoms discovered in model transitions must be present in the domain."""
+    model = load_state_machine_from_text(
+        """
+        state Root {
+            state A { event Go; }
+            state B;
+            [*] -> A;
+            A -> B :: Go;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    eventless_domain = BmcDomain(
+        domain.bound,
+        domain.states,
+        (),
+        domain.variables,
+        domain.frames,
+        domain.steps,
+        (),
+        domain.initial_state_ids,
+        domain.stable_state_ids,
+        model=model,
+    )
+    source = MacroStepSource(
+        "stable_leaf",
+        "recurrence",
+        domain.state_path_to_id("Root.A"),
+        "Root.A",
+        domain=eventless_domain,
+    )
+
+    with pytest.raises(InvalidBmcEncoding, match="Unknown event path"):
+        expand_macro_step_cases(source)
+
+
+@pytest.mark.unittest
+def test_internal_frontier_helpers_prune_false_and_clear_pending_pseudo_exit():
+    """Internal frontier helpers keep false paths empty and clear pseudo-exit state."""
+    model = load_state_machine_from_text(
+        """
+        state Root {
+            state Parent {
+                pseudo state Route;
+                [*] -> Route;
+                Route -> [*];
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    expander = _MacroExpander(entry_source(domain), MacroExpansionOptions())
+    root = model.root_state
+    parent = root.substates["Parent"]
+    route = parent.substates["Route"]
+
+    false_frontier = _MacroFrontier(
+        (_FormalStackFrame(root, "active"),),
+        BoolTemplate.false(),
+        (),
+        (),
+        (),
+        (),
+        "initial",
+    )
+    false_expansion = expander._expand_frontier(false_frontier)
+    assert false_expansion.outcomes == ()
+    assert false_expansion.failed == ()
+    assert false_expansion.diagnostics == ()
+
+    pending_frontier = _MacroFrontier(
+        (_FormalStackFrame(parent, "init_wait", plain_before_pending=True),),
+        BoolTemplate.true(),
+        (),
+        (),
+        (),
+        (),
+        "initial",
+    )
+    cleared = expander._clear_parent_plain_before_pending_after_pseudo_exit(
+        pending_frontier,
+        route,
+    )
+    assert cleared.stack[-1].state is parent
+    assert not cleared.stack[-1].plain_before_pending
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -177,6 +177,33 @@ def test_event_used_by_fallback_condition_is_reported_as_negative_fallback_use()
 
 
 @pytest.mark.unittest
+def test_failed_event_candidate_metadata_is_reported_on_fallback():
+    """Fallback metadata includes event reads from rejected candidates."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            pseudo state P;
+            [*] -> A;
+            A -> P :: Go;
+            A -> B;
+            P -> P;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
+
+    assert fallback.failed_conditions
+    assert [event.path for event in fallback.used_events] == ["Root.A.Go"]
+    assert [event.polarity for event in fallback.used_events] == ["negative"]
+    assert [event.reason for event in fallback.used_events] == ["fallback"]
+
+
+@pytest.mark.unittest
 def test_verify_partition_option_raises_for_budget_too_small():
     """Partition self-check failures surface as build errors, not silent deltas."""
     model = load_state_machine_from_text(

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -1,0 +1,384 @@
+"""Macro-step expansion contract tests for FCSTM BMC."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from typing import Any
+
+import pytest
+
+from pyfcstm.bmc import (
+    STATE_DIAGNOSTIC_ID,
+    STATE_TERMINATE_ID,
+    BmcBuildError,
+    InvalidBmcEncoding,
+    MacroExpansionOptions,
+    build_bmc_domain,
+    diagnostic_source,
+    expand_macro_step_cases,
+    stable_leaf_source,
+    terminated_source,
+)
+from pyfcstm.bmc.macro import BoolTemplate, MacroStepFormal
+from pyfcstm.bmc.source import MacroStepSource, source_from_initial_spec
+from pyfcstm.bmc.query import InitialSpec
+from pyfcstm.model import load_state_machine_from_text
+
+
+@pytest.fixture()
+def simple_domain():
+    """Build a minimal model domain used by expansion API tests."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A { during { x = x + 1; } }
+            [*] -> A;
+        }
+        """
+    )
+    return build_bmc_domain(model, bound=1)
+
+
+@pytest.mark.unittest
+def test_public_expand_api_exports_exact_names():
+    """The BMC root and expand module expose only the macro expansion API."""
+    import pyfcstm.bmc as bmc
+    import pyfcstm.bmc.expand as expand
+
+    assert "MacroExpansionOptions" in bmc.__all__
+    assert "expand_macro_step_cases" in bmc.__all__
+    assert set(expand.__all__) == {"MacroExpansionOptions", "expand_macro_step_cases"}
+    assert bmc.MacroExpansionOptions is MacroExpansionOptions
+    assert bmc.expand_macro_step_cases is expand_macro_step_cases
+
+
+@pytest.mark.unittest
+def test_expand_imports_do_not_load_z3_or_verify_registry():
+    """Macro expansion remains solver-independent and verify-registry independent."""
+    code = """
+import sys
+import pyfcstm.bmc.expand
+import pyfcstm.bmc as bmc
+_ = bmc.expand_macro_step_cases
+blocked = [name for name in sys.modules if name == 'z3' or name.startswith('z3.') or name == 'pyfcstm.verify.registry']
+if blocked:
+    raise SystemExit('blocked imports: ' + ','.join(sorted(blocked)))
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)
+
+
+@pytest.mark.unittest
+def test_sentinel_sources_expand_to_absorb_formals(simple_domain):
+    """Terminated and diagnostic source expansion delegates to sentinel absorbs."""
+    terminated = expand_macro_step_cases(terminated_source(simple_domain))
+    diagnostic = expand_macro_step_cases(diagnostic_source(simple_domain))
+
+    assert isinstance(terminated, MacroStepFormal)
+    assert [case.kind for case in terminated.success_cases] == ["absorb"]
+    assert terminated.success_cases[0].source_state_id == STATE_TERMINATE_ID
+    assert terminated.success_cases[0].target_state_id == STATE_TERMINATE_ID
+    assert terminated.delta_cases == ()
+    assert [case.kind for case in diagnostic.success_cases] == ["absorb"]
+    assert diagnostic.success_cases[0].source_state_id == STATE_DIAGNOSTIC_ID
+    assert diagnostic.success_cases[0].target_state_id == STATE_DIAGNOSTIC_ID
+    assert diagnostic.success_cases[0].is_diagnostic is True
+
+
+@pytest.mark.unittest
+def test_expand_requires_domain_backed_source(simple_domain):
+    """Direct sources without a domain fail closed instead of using side channels."""
+    direct = MacroStepSource("stable_leaf", "recurrence", 0, "Root.A")
+
+    with pytest.raises(InvalidBmcEncoding, match="domain-backed"):
+        expand_macro_step_cases(direct)
+
+    source = stable_leaf_source(simple_domain, "Root.A")
+    formal = expand_macro_step_cases(source)
+    assert formal.source is source
+
+
+@pytest.mark.unittest
+def test_macro_expansion_options_validate_runtime_caps():
+    """Expansion options reject non-positive caps and invalid partition budgets."""
+    assert MacroExpansionOptions().max_micro_steps == 1000
+    assert MacroExpansionOptions().max_stack_depth == 64
+    assert MacroExpansionOptions(verify_partition=False).verify_partition is False
+
+    invalid_options = [
+        {"max_micro_steps": 0},
+        {"max_stack_depth": 0},
+        {"partition_max_assignments": 0},
+        {"verify_partition": "yes"},
+    ]
+    for kwargs in invalid_options:
+        with pytest.raises(InvalidBmcEncoding):
+            MacroExpansionOptions(**kwargs)
+
+
+@pytest.mark.unittest
+def test_hot_stable_leaf_initial_and_recurrence_have_same_cases(simple_domain):
+    """Hot leaf initial sources reuse recurrence stable-leaf macro semantics."""
+    initial = source_from_initial_spec(
+        simple_domain,
+        InitialSpec(mode="state", state_path="Root.A"),
+    )
+    recurrence = stable_leaf_source(simple_domain, "Root.A", origin="recurrence")
+
+    initial_formal = expand_macro_step_cases(initial)
+    recurrence_formal = expand_macro_step_cases(recurrence)
+
+    def normalized(formal):
+        return [
+            (
+                case.kind,
+                case.target_state_path,
+                case.condition.to_canonical(),
+                [item.expression for item in case.var_update],
+            )
+            for case in formal.cases
+        ]
+
+    assert initial.origin == "initial"
+    assert recurrence.origin == "recurrence"
+    assert normalized(initial_formal) == normalized(recurrence_formal)
+
+
+@pytest.mark.unittest
+def test_stable_leaf_fallback_executes_during_chain_not_carry_only(simple_domain):
+    """Fallback writeback records lifecycle effects rather than no-op carry."""
+    source = stable_leaf_source(simple_domain, "Root.A")
+    formal = expand_macro_step_cases(source)
+    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
+
+    assert fallback.condition.to_canonical() == BoolTemplate.true().to_canonical()
+    assert fallback.var_update[0].variable_name == "x"
+    assert fallback.var_update[0].is_carry is False
+    assert fallback.var_update[0].expression != "pre:x"
+
+
+@pytest.mark.unittest
+def test_event_used_by_fallback_condition_is_reported_as_negative_fallback_use():
+    """Fallback metadata includes event reads from negated accepted transitions."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            state A;
+            state B;
+            [*] -> A;
+            A -> B :: Go;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
+
+    assert [event.path for event in fallback.used_events] == ["Root.A.Go"]
+    assert [event.polarity for event in fallback.used_events] == ["negative"]
+    assert [event.reason for event in fallback.used_events] == ["fallback"]
+
+
+@pytest.mark.unittest
+def test_verify_partition_option_raises_for_budget_too_small():
+    """Partition self-check failures surface as build errors, not silent deltas."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            state A { during { x = x + 1; } }
+            state B;
+            [*] -> A;
+            A -> B :: Go;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    source = stable_leaf_source(domain, "Root.A")
+
+    with pytest.raises(BmcBuildError, match="assignment budget"):
+        expand_macro_step_cases(
+            source,
+            MacroExpansionOptions(partition_max_assignments=1),
+        )
+
+
+@pytest.mark.unittest
+def test_source_domain_must_preserve_model_back_reference(simple_domain):
+    """Expansion fails closed if a hand-built domain has no model snapshot."""
+    cloned = type(simple_domain)(
+        bound=simple_domain.bound,
+        states=simple_domain.states,
+        events=simple_domain.events,
+        variables=simple_domain.variables,
+        frames=simple_domain.frames,
+        steps=simple_domain.steps,
+        event_inputs=simple_domain.event_inputs,
+        initial_state_ids=simple_domain.initial_state_ids,
+        stable_state_ids=simple_domain.stable_state_ids,
+    )
+    source = stable_leaf_source(cloned, "Root.A")
+
+    with pytest.raises(InvalidBmcEncoding, match="state machine model"):
+        expand_macro_step_cases(source)
+
+
+@pytest.mark.unittest
+def test_guarded_if_without_else_keeps_fallback_partition():
+    """Runtime no-op branch paths remain explicit fallback cases."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A {
+                during {
+                    if [x > 0] { x = x + 1; }
+                }
+            }
+            [*] -> A;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    fallback_cases = [case for case in formal.success_cases if case.kind == "fallback"]
+
+    assert len(fallback_cases) == 2
+    by_update = {case.var_update[0].expression: case for case in fallback_cases}
+    assert sorted(by_update) == ["pre:x", "pre:x + 1"]
+    assert _evaluate_x_only(by_update["pre:x + 1"], x=1) is True
+    assert _evaluate_x_only(by_update["pre:x"], x=0) is True
+
+
+@pytest.mark.unittest
+def test_operation_block_temporaries_are_visible_to_later_statements():
+    """Block-local temporaries follow runtime scope inside one operation block."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A {
+                during {
+                    tmp = x + 2;
+                    x = tmp * 3;
+                }
+            }
+            [*] -> A;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
+
+    assert fallback.var_update[0].expression == "3 * pre:x + 6"
+
+
+@pytest.mark.unittest
+def test_boolean_connectives_are_expanded_in_case_partition():
+    """Boolean equality and implication are expanded into guard atom formulas."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : if [(x < 0) == (x <= -1)];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    selected = [case for case in formal.cases if _evaluate_x_only(case, x=0)]
+
+    assert len(selected) == 1
+    assert selected[0].kind == "transition"
+    assert selected[0].target_state_path == "Root.B"
+
+
+@pytest.mark.unittest
+def test_plain_during_before_can_branch_before_child_entry():
+    """Composite plain during-before if paths feed child entry semantics."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        def int y = 0;
+        state Root {
+            state Parent {
+                during before {
+                    if [x > 0] { y = y + 10; }
+                }
+                state A { enter { y = y + 1; } }
+                [*] -> A;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(source_from_initial_spec(domain, InitialSpec()))
+    cases = [case for case in formal.success_cases if case.kind == "initial"]
+
+    assert len(cases) == 2
+    by_update = {case.var_update[1].expression: case for case in cases}
+    assert sorted(by_update) == ["pre:y + 1", "pre:y + 11"]
+    assert _evaluate_x_only(by_update["pre:y + 11"], x=1) is True
+    assert _evaluate_x_only(by_update["pre:y + 1"], x=0) is True
+
+
+@pytest.mark.unittest
+def test_constant_zero_divisor_does_not_crash_expansion():
+    """Constant zero divisors remain symbolic instead of crashing expansion."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : if [x / 0 > 1];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    assert any(case.kind == "fallback" for case in formal.success_cases)
+    assert any(case.kind == "transition" for case in formal.success_cases)
+
+
+def _evaluate_x_only(case: Any, x: int) -> bool:
+    """Evaluate a test case condition with one integer variable.
+
+    :param case: Macro-step case whose condition should be evaluated.
+    :type case: pyfcstm.bmc.macro.CycleCase
+    :param x: Runtime value for the ``x`` variable.
+    :type x: int
+    :return: Whether the case condition holds under the test assignment.
+    :rtype: bool
+
+    Example::
+
+        >>> from pyfcstm.bmc.macro import BoolTemplate, CycleCase
+        >>> case = CycleCase("transition", 0, "Root", 0, "Root", "Root::transition::Root::0", BoolTemplate.true(), ())
+        >>> _evaluate_x_only(case, 0)
+        True
+    """
+    values = {}
+    for variable in case.condition.variables:
+        if variable.startswith("guard:"):
+            expr = variable[len("guard:") :].replace("pre:x", "x")
+            try:
+                values[variable] = bool(eval(expr, {"__builtins__": {}}, {"x": x}))
+            except ZeroDivisionError:
+                # ZeroDivisionError: this helper may emulate guard atoms that
+                # intentionally keep a constant zero divisor symbolic.
+                values[variable] = False
+        elif variable.startswith("event:"):
+            values[variable] = False
+    return case.condition.evaluate(values)

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -12,7 +12,7 @@ from pyfcstm.bmc import (
     entry_source,
     stable_leaf_source,
 )
-from pyfcstm.bmc.expand import MacroExpansionOptions, expand_macro_step_cases
+from pyfcstm.bmc.expand import expand_macro_step_cases
 from pyfcstm.model import IfBlock, load_state_machine_from_text
 
 _FIXTURE = Path(__file__).with_name("fixtures") / "macro_runtime_alignment.fcstm"
@@ -48,7 +48,7 @@ def test_stable_leaf_fallback_records_during_action_blocks_not_var_updates():
 
     assert fallback.condition.variables == ()
     assert [block.runtime_role for block in fallback.action_blocks] == [
-        "leaf_during",
+        "aspect_during_before",
         "leaf_during",
     ]
     assert "var_update" not in fallback.to_canonical()
@@ -138,12 +138,19 @@ def test_runtime_fixture_records_guard_anchors_after_prefix_actions():
         ("x >= 13", 2),
         ("y >= 30", 4),
     ]
-    assert [block.runtime_role for block in to_done.action_blocks[:5]] == [
-        "state_exit",
-        "transition_effect",
-        "transition_effect",
-        "plain_during_after",
-        "state_exit",
+    assert [
+        (block.block_kind, block.runtime_role) for block in to_done.action_blocks[:5]
+    ] == [
+        ("state_action", "state_exit"),
+        ("transition_effect", "transition_effect"),
+        ("transition_effect", "transition_effect"),
+        ("state_action", "plain_during_after"),
+        ("state_action", "state_exit"),
+    ]
+    assert [guard.reason for guard in to_b.guard_requirements] == ["pseudo_guard"]
+    assert [guard.reason for guard in to_done.guard_requirements] == [
+        "pseudo_guard",
+        "parent_continuation_guard",
     ]
 
 
@@ -159,15 +166,15 @@ def test_hot_pseudo_entry_uses_guard_anchor_zero_for_first_route_guard():
     delta = _case_by_kind_target(formal, "delta", "__diagnostic__")
 
     assert [
-        (str(g.expr.to_ast_node()), g.after_action_block_index)
+        (str(g.expr.to_ast_node()), g.after_action_block_index, g.reason)
         for g in to_b.guard_requirements
-    ] == [("x < 13", 0)]
+    ] == [("x < 13", 0, "pseudo_guard")]
     assert [
-        (str(g.expr.to_ast_node()), g.after_action_block_index)
+        (str(g.expr.to_ast_node()), g.after_action_block_index, g.reason)
         for g in to_done.guard_requirements
     ] == [
-        ("x >= 13", 0),
-        ("y >= 30", 2),
+        ("x >= 13", 0, "pseudo_guard"),
+        ("y >= 30", 2, "parent_continuation_guard"),
     ]
     assert _conditions(delta) == {
         "accepted:%s" % to_b.label,
@@ -206,7 +213,7 @@ def test_rejected_pseudo_loop_allows_later_transition_and_fallback():
 
 @pytest.mark.unittest
 def test_variable_progressing_pseudo_loop_fails_closed():
-    """PR-9 refuses to summarize pseudo loops whose convergence depends on effects."""
+    """Macro expansion refuses to summarize pseudo loops that depend on effects."""
     model = load_state_machine_from_text(
         """
         def int x = 0;
@@ -223,8 +230,36 @@ def test_variable_progressing_pseudo_loop_fails_closed():
     )
     domain = build_bmc_domain(model, bound=1)
 
-    with pytest.raises(BmcBuildError, match="micro-step safety limit"):
-        expand_macro_step_cases(
-            stable_leaf_source(domain, "Root.A"),
-            MacroExpansionOptions(max_micro_steps=20),
-        )
+    with pytest.raises(BmcBuildError, match="action-dependent pseudo loop"):
+        expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+
+@pytest.mark.unittest
+def test_failed_guarded_pseudo_candidate_keeps_failed_guard_metadata():
+    """Fallback failed conditions keep matching guard requirements."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            pseudo state Route;
+            state B;
+            A -> Route : if [x > 5];
+            Route -> Route;
+            Route -> B;
+            [*] -> A;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    fallback = _case_by_kind_target(formal, "fallback", "Root.A")
+
+    assert fallback.failed_conditions
+    assert {atom for item in fallback.failed_conditions for atom in item.variables} == {
+        "guard:g0"
+    }
+    assert [
+        (guard.requirement_id, guard.reason) for guard in fallback.guard_requirements
+    ] == [("g0", "transition_guard")]

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -1,211 +1,62 @@
-"""Macro-step expansion contract tests for FCSTM BMC."""
+"""Macro-step expansion tests for FCSTM BMC."""
 
 from __future__ import annotations
 
-import subprocess
-import sys
-from typing import Any
+from pathlib import Path
 
 import pytest
 
 from pyfcstm.bmc import (
-    STATE_DIAGNOSTIC_ID,
-    STATE_TERMINATE_ID,
     BmcBuildError,
-    InvalidBmcEncoding,
-    MacroExpansionOptions,
     build_bmc_domain,
-    diagnostic_source,
-    expand_macro_step_cases,
+    entry_source,
     stable_leaf_source,
-    terminated_source,
 )
-from pyfcstm.bmc.macro import BoolTemplate, MacroStepFormal
-from pyfcstm.bmc.source import MacroStepSource, source_from_initial_spec
-from pyfcstm.bmc.query import InitialSpec
-from pyfcstm.model import load_state_machine_from_text
+from pyfcstm.bmc.expand import MacroExpansionOptions, expand_macro_step_cases
+from pyfcstm.model import IfBlock, load_state_machine_from_text
+
+_FIXTURE = Path(__file__).with_name("fixtures") / "macro_runtime_alignment.fcstm"
 
 
-@pytest.fixture()
-def simple_domain():
-    """Build a minimal model domain used by expansion API tests."""
+def _case_by_kind_target(formal, kind, target_path):
+    for case in formal.cases:
+        if case.kind == kind and case.target_state_path == target_path:
+            return case
+    raise AssertionError("missing %s -> %s case" % (kind, target_path))
+
+
+def _conditions(case):
+    return set(case.condition.variables)
+
+
+@pytest.mark.unittest
+def test_stable_leaf_fallback_records_during_action_blocks_not_var_updates():
+    """Fallback keeps executable model blocks and no longer exposes writeback text."""
     model = load_state_machine_from_text(
         """
         def int x = 0;
         state Root {
+            >> during before { x = x + 10; }
             state A { during { x = x + 1; } }
             [*] -> A;
         }
         """
     )
-    return build_bmc_domain(model, bound=1)
-
-
-@pytest.mark.unittest
-def test_public_expand_api_exports_exact_names():
-    """The BMC root and expand module expose only the macro expansion API."""
-    import pyfcstm.bmc as bmc
-    import pyfcstm.bmc.expand as expand
-
-    assert "MacroExpansionOptions" in bmc.__all__
-    assert "expand_macro_step_cases" in bmc.__all__
-    assert set(expand.__all__) == {"MacroExpansionOptions", "expand_macro_step_cases"}
-    assert bmc.MacroExpansionOptions is MacroExpansionOptions
-    assert bmc.expand_macro_step_cases is expand_macro_step_cases
-
-
-@pytest.mark.unittest
-def test_expand_imports_do_not_load_z3_or_verify_registry():
-    """Macro expansion remains solver-independent and verify-registry independent."""
-    code = """
-import sys
-import pyfcstm.bmc.expand
-import pyfcstm.bmc as bmc
-_ = bmc.expand_macro_step_cases
-blocked = [name for name in sys.modules if name == 'z3' or name.startswith('z3.') or name == 'pyfcstm.verify.registry']
-if blocked:
-    raise SystemExit('blocked imports: ' + ','.join(sorted(blocked)))
-"""
-    subprocess.run([sys.executable, "-c", code], check=True)
-
-
-@pytest.mark.unittest
-def test_sentinel_sources_expand_to_absorb_formals(simple_domain):
-    """Terminated and diagnostic source expansion delegates to sentinel absorbs."""
-    terminated = expand_macro_step_cases(terminated_source(simple_domain))
-    diagnostic = expand_macro_step_cases(diagnostic_source(simple_domain))
-
-    assert isinstance(terminated, MacroStepFormal)
-    assert [case.kind for case in terminated.success_cases] == ["absorb"]
-    assert terminated.success_cases[0].source_state_id == STATE_TERMINATE_ID
-    assert terminated.success_cases[0].target_state_id == STATE_TERMINATE_ID
-    assert terminated.delta_cases == ()
-    assert [case.kind for case in diagnostic.success_cases] == ["absorb"]
-    assert diagnostic.success_cases[0].source_state_id == STATE_DIAGNOSTIC_ID
-    assert diagnostic.success_cases[0].target_state_id == STATE_DIAGNOSTIC_ID
-    assert diagnostic.success_cases[0].is_diagnostic is True
-
-
-@pytest.mark.unittest
-def test_expand_requires_domain_backed_source(simple_domain):
-    """Direct sources without a domain fail closed instead of using side channels."""
-    direct = MacroStepSource("stable_leaf", "recurrence", 0, "Root.A")
-
-    with pytest.raises(InvalidBmcEncoding, match="domain-backed"):
-        expand_macro_step_cases(direct)
-
-    source = stable_leaf_source(simple_domain, "Root.A")
-    formal = expand_macro_step_cases(source)
-    assert formal.source is source
-
-
-@pytest.mark.unittest
-def test_macro_expansion_options_validate_runtime_caps():
-    """Expansion options reject non-positive caps and invalid partition budgets."""
-    assert MacroExpansionOptions().max_micro_steps == 1000
-    assert MacroExpansionOptions().max_stack_depth == 64
-    assert MacroExpansionOptions(verify_partition=False).verify_partition is False
-
-    invalid_options = [
-        {"max_micro_steps": 0},
-        {"max_stack_depth": 0},
-        {"partition_max_assignments": 0},
-        {"verify_partition": "yes"},
-    ]
-    for kwargs in invalid_options:
-        with pytest.raises(InvalidBmcEncoding):
-            MacroExpansionOptions(**kwargs)
-
-
-@pytest.mark.unittest
-def test_hot_stable_leaf_initial_and_recurrence_have_same_cases(simple_domain):
-    """Hot leaf initial sources reuse recurrence stable-leaf macro semantics."""
-    initial = source_from_initial_spec(
-        simple_domain,
-        InitialSpec(mode="state", state_path="Root.A"),
-    )
-    recurrence = stable_leaf_source(simple_domain, "Root.A", origin="recurrence")
-
-    initial_formal = expand_macro_step_cases(initial)
-    recurrence_formal = expand_macro_step_cases(recurrence)
-
-    assert initial.origin == "initial"
-    assert recurrence.origin == "recurrence"
-    assert initial.to_semantic_canonical(
-        include_origin=False
-    ) == recurrence.to_semantic_canonical(include_origin=False)
-    assert [case.to_canonical() for case in initial_formal.cases] == [
-        case.to_canonical() for case in recurrence_formal.cases
-    ]
-
-
-@pytest.mark.unittest
-def test_stable_leaf_fallback_executes_during_chain_not_carry_only(simple_domain):
-    """Fallback writeback records lifecycle effects rather than no-op carry."""
-    source = stable_leaf_source(simple_domain, "Root.A")
-    formal = expand_macro_step_cases(source)
-    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
-
-    assert fallback.condition.to_canonical() == BoolTemplate.true().to_canonical()
-    assert fallback.var_update[0].variable_name == "x"
-    assert fallback.var_update[0].is_carry is False
-    assert fallback.var_update[0].expression != "pre:x"
-
-
-@pytest.mark.unittest
-def test_event_used_by_fallback_condition_is_reported_as_negative_fallback_use():
-    """Fallback metadata includes event reads from negated accepted transitions."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            event Go;
-            state A;
-            state B;
-            [*] -> A;
-            A -> B :: Go;
-        }
-        """
-    )
     domain = build_bmc_domain(model, bound=1)
     formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
+    fallback = _case_by_kind_target(formal, "fallback", "Root.A")
 
-    assert [event.path for event in fallback.used_events] == ["Root.A.Go"]
-    assert [event.polarity for event in fallback.used_events] == ["negative"]
-    assert [event.reason for event in fallback.used_events] == ["fallback"]
-
-
-@pytest.mark.unittest
-def test_failed_event_candidate_metadata_is_reported_on_fallback():
-    """Fallback metadata includes event reads from rejected candidates."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A;
-            state B;
-            pseudo state P;
-            [*] -> A;
-            A -> P :: Go;
-            A -> B;
-            P -> P;
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
-
-    assert fallback.failed_conditions
-    assert [event.path for event in fallback.used_events] == ["Root.A.Go"]
-    assert [event.polarity for event in fallback.used_events] == ["negative"]
-    assert [event.reason for event in fallback.used_events] == ["fallback"]
+    assert fallback.condition.variables == ()
+    assert [block.runtime_role for block in fallback.action_blocks] == [
+        "leaf_during",
+        "leaf_during",
+    ]
+    assert "var_update" not in fallback.to_canonical()
 
 
 @pytest.mark.unittest
-def test_rejected_event_candidate_metadata_is_reported_on_later_transitions():
-    """Accepted later cases keep event reads used by priority masks."""
+def test_transition_priority_masks_exclude_accepted_paths_not_raw_guards():
+    """Later transitions are gated by accepted:<label> atoms for earlier paths."""
     model = load_state_machine_from_text(
         """
         def int x = 0;
@@ -213,246 +64,167 @@ def test_rejected_event_candidate_metadata_is_reported_on_later_transitions():
             state A;
             state B;
             state C;
-            pseudo state P;
             [*] -> A;
-            A -> P :: Go;
-            P -> P;
-            A -> B :: Fire;
-            A -> C;
+            A -> B : if [x > 0];
+            A -> C : if [x < 10];
         }
         """
     )
     domain = build_bmc_domain(model, bound=1)
     formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    by_target = {case.target_state_path: case for case in formal.success_cases}
+    first = _case_by_kind_target(formal, "transition", "Root.B")
+    second = _case_by_kind_target(formal, "transition", "Root.C")
+    fallback = _case_by_kind_target(formal, "fallback", "Root.A")
 
-    assert sorted(
-        (event.path, event.polarity, event.reason)
-        for event in by_target["Root.B"].used_events
-    ) == [
-        ("Root.A.Fire", "positive", "trigger"),
-        ("Root.A.Go", "negative", "priority"),
+    assert _conditions(first) == {"guard:g0"}
+    assert "accepted:%s" % first.label in _conditions(second)
+    assert "guard:g1" in second.condition.variables
+    assert {
+        priority.excluded_case_labels for priority in second.priority_exclusions
+    } == {(first.label,)}
+    assert "accepted:%s" % first.label in _conditions(fallback)
+    assert "accepted:%s" % second.label in _conditions(fallback)
+
+
+@pytest.mark.unittest
+def test_action_if_block_is_recorded_without_splitting_cases():
+    """Action-local IfBlock stays inside ActionBlock and never becomes a condition atom."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A {
+                during {
+                    if [x > 0] { x = x + 1; } else { x = x - 1; }
+                }
+            }
+            [*] -> A;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    fallback = _case_by_kind_target(formal, "fallback", "Root.A")
+
+    assert len(formal.cases) == 1
+    assert fallback.condition.variables == ()
+    assert isinstance(fallback.action_blocks[0].operations[0], IfBlock)
+
+
+@pytest.mark.unittest
+def test_runtime_fixture_records_guard_anchors_after_prefix_actions():
+    """Guards are raw expressions with action-block anchors, not pre-substituted text."""
+    model = load_state_machine_from_text(_FIXTURE.read_text())
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.System.A"))
+
+    to_b = _case_by_kind_target(formal, "transition", "Root.System.B")
+    to_done = _case_by_kind_target(formal, "transition", "Root.Done")
+    to_trap = _case_by_kind_target(formal, "transition", "Root.System.Trap.TrapLeaf")
+
+    assert _conditions(to_trap) == {
+        "event:Root.System.A.Tick",
+        "event:Root.System.Trap.Arm",
+    }
+    assert "accepted:%s" % to_trap.label in _conditions(to_b)
+    assert [
+        (str(g.expr.to_ast_node()), g.after_action_block_index)
+        for g in to_b.guard_requirements
+    ] == [("x < 13", 2)]
+    assert [
+        (str(g.expr.to_ast_node()), g.after_action_block_index)
+        for g in to_done.guard_requirements
+    ] == [
+        ("x >= 13", 2),
+        ("y >= 30", 4),
     ]
-    assert sorted(
-        (event.path, event.polarity, event.reason)
-        for event in by_target["Root.C"].used_events
-    ) == [
-        ("Root.A.Fire", "negative", "priority"),
-        ("Root.A.Go", "negative", "priority"),
+    assert [block.runtime_role for block in to_done.action_blocks[:5]] == [
+        "state_exit",
+        "transition_effect",
+        "transition_effect",
+        "plain_during_after",
+        "state_exit",
     ]
 
 
 @pytest.mark.unittest
-def test_verify_partition_option_raises_for_budget_too_small():
-    """Partition self-check failures surface as build errors, not silent deltas."""
+def test_hot_pseudo_entry_uses_guard_anchor_zero_for_first_route_guard():
+    """Hot-started pseudo entry does not invent pre-guard action effects."""
+    model = load_state_machine_from_text(_FIXTURE.read_text())
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain, "Root.System.Route"))
+
+    to_b = _case_by_kind_target(formal, "initial", "Root.System.B")
+    to_done = _case_by_kind_target(formal, "initial", "Root.Done")
+    delta = _case_by_kind_target(formal, "delta", "__diagnostic__")
+
+    assert [
+        (str(g.expr.to_ast_node()), g.after_action_block_index)
+        for g in to_b.guard_requirements
+    ] == [("x < 13", 0)]
+    assert [
+        (str(g.expr.to_ast_node()), g.after_action_block_index)
+        for g in to_done.guard_requirements
+    ] == [
+        ("x >= 13", 0),
+        ("y >= 30", 2),
+    ]
+    assert _conditions(delta) == {
+        "accepted:%s" % to_b.label,
+        "accepted:%s" % to_done.label,
+    }
+
+
+@pytest.mark.unittest
+def test_rejected_pseudo_loop_allows_later_transition_and_fallback():
+    """A structurally repeated pseudo candidate is failed, not accepted priority."""
     model = load_state_machine_from_text(
         """
         def int x = 0;
         state Root {
             event Go;
             state A { during { x = x + 1; } }
-            state B;
+            pseudo state Loop;
+            state Done;
             [*] -> A;
-            A -> B :: Go;
+            A -> Loop :: Go;
+            A -> Done :: Go;
+            Loop -> Loop;
         }
         """
     )
     domain = build_bmc_domain(model, bound=1)
-    source = stable_leaf_source(domain, "Root.A")
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
 
-    with pytest.raises(BmcBuildError, match="assignment budget"):
+    selected = _case_by_kind_target(formal, "transition", "Root.Done")
+    fallback = _case_by_kind_target(formal, "fallback", "Root.A")
+
+    assert selected.condition.variables == ("event:Root.A.Go",)
+    assert fallback.failed_conditions
+    assert fallback.action_blocks[0].runtime_role == "leaf_during"
+
+
+@pytest.mark.unittest
+def test_variable_progressing_pseudo_loop_fails_closed():
+    """PR-9 refuses to summarize pseudo loops whose convergence depends on effects."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            pseudo state P;
+            state B;
+            [*] -> A;
+            A -> P : if [x < 4];
+            P -> P : if [x < 4] effect { x = x + 1; }
+            P -> B : if [x >= 4];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+
+    with pytest.raises(BmcBuildError, match="micro-step safety limit"):
         expand_macro_step_cases(
-            source,
-            MacroExpansionOptions(partition_max_assignments=1),
+            stable_leaf_source(domain, "Root.A"),
+            MacroExpansionOptions(max_micro_steps=20),
         )
-
-
-@pytest.mark.unittest
-def test_source_domain_must_preserve_model_back_reference(simple_domain):
-    """Expansion fails closed if a hand-built domain has no model snapshot."""
-    cloned = type(simple_domain)(
-        bound=simple_domain.bound,
-        states=simple_domain.states,
-        events=simple_domain.events,
-        variables=simple_domain.variables,
-        frames=simple_domain.frames,
-        steps=simple_domain.steps,
-        event_inputs=simple_domain.event_inputs,
-        initial_state_ids=simple_domain.initial_state_ids,
-        stable_state_ids=simple_domain.stable_state_ids,
-    )
-    source = stable_leaf_source(cloned, "Root.A")
-
-    with pytest.raises(InvalidBmcEncoding, match="state machine model"):
-        expand_macro_step_cases(source)
-
-
-@pytest.mark.unittest
-def test_runtime_aligned_safety_caps_fail_closed(simple_domain):
-    """Expansion caps raise build errors instead of leaking partial cases."""
-    source = stable_leaf_source(simple_domain, "Root.A")
-
-    cap_options = [
-        MacroExpansionOptions(max_micro_steps=1),
-        MacroExpansionOptions(max_stack_depth=1),
-    ]
-    for options in cap_options:
-        with pytest.raises(BmcBuildError):
-            expand_macro_step_cases(source, options)
-
-
-@pytest.mark.unittest
-def test_guarded_if_without_else_keeps_fallback_partition():
-    """Runtime no-op branch paths remain explicit fallback cases."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A {
-                during {
-                    if [x > 0] { x = x + 1; }
-                }
-            }
-            [*] -> A;
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    fallback_cases = [case for case in formal.success_cases if case.kind == "fallback"]
-
-    assert len(fallback_cases) == 2
-    by_update = {case.var_update[0].expression: case for case in fallback_cases}
-    assert sorted(by_update) == ["pre:x", "pre:x + 1"]
-    assert _evaluate_x_only(by_update["pre:x + 1"], x=1) is True
-    assert _evaluate_x_only(by_update["pre:x"], x=0) is True
-
-
-@pytest.mark.unittest
-def test_operation_block_temporaries_are_visible_to_later_statements():
-    """Block-local temporaries follow runtime scope inside one operation block."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A {
-                during {
-                    tmp = x + 2;
-                    x = tmp * 3;
-                }
-            }
-            [*] -> A;
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    fallback = next(case for case in formal.success_cases if case.kind == "fallback")
-
-    assert fallback.var_update[0].expression == "3 * pre:x + 6"
-
-
-@pytest.mark.unittest
-def test_boolean_connectives_are_expanded_in_case_partition():
-    """Boolean equality and implication are expanded into guard atom formulas."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A;
-            state B;
-            [*] -> A;
-            A -> B : if [(x < 0) == (x <= -1)];
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    selected = [case for case in formal.cases if _evaluate_x_only(case, x=0)]
-
-    assert len(selected) == 1
-    assert selected[0].kind == "transition"
-    assert selected[0].target_state_path == "Root.B"
-
-
-@pytest.mark.unittest
-def test_plain_during_before_can_branch_before_child_entry():
-    """Composite plain during-before if paths feed child entry semantics."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        def int y = 0;
-        state Root {
-            state Parent {
-                during before {
-                    if [x > 0] { y = y + 10; }
-                }
-                state A { enter { y = y + 1; } }
-                [*] -> A;
-            }
-            [*] -> Parent;
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(source_from_initial_spec(domain, InitialSpec()))
-    cases = [case for case in formal.success_cases if case.kind == "initial"]
-
-    assert len(cases) == 2
-    by_update = {case.var_update[1].expression: case for case in cases}
-    assert sorted(by_update) == ["pre:y + 1", "pre:y + 11"]
-    assert _evaluate_x_only(by_update["pre:y + 11"], x=1) is True
-    assert _evaluate_x_only(by_update["pre:y + 1"], x=0) is True
-
-
-@pytest.mark.unittest
-def test_constant_zero_divisor_does_not_crash_expansion():
-    """Constant zero divisors remain symbolic instead of crashing expansion."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A;
-            state B;
-            [*] -> A;
-            A -> B : if [x / 0 > 1];
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    assert any(case.kind == "fallback" for case in formal.success_cases)
-    assert any(case.kind == "transition" for case in formal.success_cases)
-
-
-def _evaluate_x_only(case: Any, x: int) -> bool:
-    """Evaluate a test case condition with one integer variable.
-
-    :param case: Macro-step case whose condition should be evaluated.
-    :type case: pyfcstm.bmc.macro.CycleCase
-    :param x: Runtime value for the ``x`` variable.
-    :type x: int
-    :return: Whether the case condition holds under the test assignment.
-    :rtype: bool
-
-    Example::
-
-        >>> from pyfcstm.bmc.macro import BoolTemplate, CycleCase
-        >>> case = CycleCase("transition", 0, "Root", 0, "Root", "Root::transition::Root::0", BoolTemplate.true(), ())
-        >>> _evaluate_x_only(case, 0)
-        True
-    """
-    values = {}
-    for variable in case.condition.variables:
-        if variable.startswith("guard:"):
-            expr = variable[len("guard:") :].replace("pre:x", "x")
-            try:
-                values[variable] = bool(eval(expr, {"__builtins__": {}}, {"x": x}))
-            except ZeroDivisionError:
-                # ZeroDivisionError: this helper may emulate guard atoms that
-                # intentionally keep a constant zero divisor symbolic.
-                values[variable] = False
-        elif variable.startswith("event:"):
-            values[variable] = False
-    return case.condition.evaluate(values)

--- a/test/bmc/test_macro_expansion.py
+++ b/test/bmc/test_macro_expansion.py
@@ -129,20 +129,14 @@ def test_hot_stable_leaf_initial_and_recurrence_have_same_cases(simple_domain):
     initial_formal = expand_macro_step_cases(initial)
     recurrence_formal = expand_macro_step_cases(recurrence)
 
-    def normalized(formal):
-        return [
-            (
-                case.kind,
-                case.target_state_path,
-                case.condition.to_canonical(),
-                [item.expression for item in case.var_update],
-            )
-            for case in formal.cases
-        ]
-
     assert initial.origin == "initial"
     assert recurrence.origin == "recurrence"
-    assert normalized(initial_formal) == normalized(recurrence_formal)
+    assert initial.to_semantic_canonical(
+        include_origin=False
+    ) == recurrence.to_semantic_canonical(include_origin=False)
+    assert [case.to_canonical() for case in initial_formal.cases] == [
+        case.to_canonical() for case in recurrence_formal.cases
+    ]
 
 
 @pytest.mark.unittest
@@ -225,6 +219,20 @@ def test_source_domain_must_preserve_model_back_reference(simple_domain):
 
     with pytest.raises(InvalidBmcEncoding, match="state machine model"):
         expand_macro_step_cases(source)
+
+
+@pytest.mark.unittest
+def test_runtime_aligned_safety_caps_fail_closed(simple_domain):
+    """Expansion caps raise build errors instead of leaking partial cases."""
+    source = stable_leaf_source(simple_domain, "Root.A")
+
+    cap_options = [
+        MacroExpansionOptions(max_micro_steps=1),
+        MacroExpansionOptions(max_stack_depth=1),
+    ]
+    for options in cap_options:
+        with pytest.raises(BmcBuildError):
+            expand_macro_step_cases(source, options)
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -539,6 +539,75 @@ def test_variable_progressing_pseudo_loop_after_entry_effect_aligns_with_runtime
 
 
 @pytest.mark.unittest
+@pytest.mark.parametrize(
+    ("loop_guard", "exit_guard"),
+    [
+        ("x <= 3", "x > 3"),
+        ("x <= 3", "!(x <= 3)"),
+        ("4 > x", "4 <= x"),
+        ("x < 4", "!(x < 4)"),
+        ("4 > x", "3 < x"),
+    ],
+)
+@pytest.mark.parametrize("loop_first", [True, False])
+def test_variable_progressing_pseudo_loop_normalizes_equivalent_threshold_guards(
+    loop_guard,
+    exit_guard,
+    loop_first,
+):
+    """Equivalent integer threshold forms align with runtime pseudo-loop cycles."""
+    if loop_first:
+        pseudo_transitions = """
+            P -> P : if [%s] effect { x = x + 2; }
+            P -> B : if [%s];
+        """ % (
+            loop_guard,
+            exit_guard,
+        )
+    else:
+        pseudo_transitions = """
+            P -> B : if [%s];
+            P -> P : if [%s] effect { x = x + 2; }
+        """ % (
+            exit_guard,
+            loop_guard,
+        )
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            pseudo state P;
+            state B;
+            [*] -> A;
+            A -> P : if [x < 4];
+            %s
+        }
+        """
+        % pseudo_transitions
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    assert not formal.build_diagnostic_conditions
+    assert len(formal.cases) == 2
+    for initial_x in (-1, 0, 1, 2, 3, 4):
+        selected = _selected_case(formal, initial_x, 0, ())
+        runtime = SimulationRuntime(
+            model,
+            initial_state="Root.A",
+            initial_vars={"x": initial_x},
+        )
+        runtime.cycle([])
+
+        runtime_state = ".".join(runtime.current_state.path)
+        assert selected.target_state_path == runtime_state
+        assert (
+            _eval_update_expr(_updates(selected)["x"], x=initial_x) == runtime.vars["x"]
+        )
+
+
+@pytest.mark.unittest
 def test_cold_leaf_root_enters_and_stabilizes_instead_of_terminating():
     """Cold root leaf expansion follows initialization, not root synthetic exit."""
     model = load_state_machine_from_text(

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -6,7 +6,13 @@ from pathlib import Path
 
 import pytest
 
-from pyfcstm.bmc import build_bmc_domain, entry_source, stable_leaf_source
+from pyfcstm.bmc import (
+    STATE_TERMINATE_ID,
+    TERMINATE_CASE_PATH,
+    build_bmc_domain,
+    entry_source,
+    stable_leaf_source,
+)
 from pyfcstm.bmc.expand import expand_macro_step_cases
 from pyfcstm.model import IfBlock, Operation, load_state_machine_from_text
 from pyfcstm.simulate import SimulationRuntime
@@ -112,6 +118,25 @@ def _runtime_cycle(model, state, initial_vars, events):
     )
     runtime.cycle(list(events))
     return ".".join(runtime.current_state.path), dict(runtime.vars)
+
+
+@pytest.mark.unittest
+def test_root_leaf_exit_expands_to_runtime_termination():
+    """A root leaf exit transition is a valid terminate path, not corruption."""
+    model = load_state_machine_from_text("state Root;")
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root"))
+
+    case = _selected_case(formal, {}, ())
+    runtime = SimulationRuntime(model, initial_state="Root", initial_vars={})
+    runtime.cycle([])
+
+    assert case.kind == "transition"
+    assert case.target_state_id == STATE_TERMINATE_ID
+    assert case.target_state_path == TERMINATE_CASE_PATH
+    assert case.action_blocks == ()
+    assert runtime.is_ended
+    assert runtime.brief_stack == []
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -547,6 +547,10 @@ def test_variable_progressing_pseudo_loop_after_entry_effect_aligns_with_runtime
         ("4 > x", "4 <= x"),
         ("x < 4", "!(x < 4)"),
         ("4 > x", "3 < x"),
+        ("x <= 4 - 1", "x > 4 - 1"),
+        ("4 > x", "x >= 2 + 2"),
+        ("x < 2 * 2", "!(x < 2 + 2)"),
+        ("x <= 9 % 5 - 1", "4 <= x"),
     ],
 )
 @pytest.mark.parametrize("loop_first", [True, False])

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -1,4 +1,4 @@
-"""Runtime-alignment tests for BMC macro-step expansion."""
+"""Runtime-alignment tests for PR-9 macro-step path expansion."""
 
 from __future__ import annotations
 
@@ -6,650 +6,209 @@ from pathlib import Path
 
 import pytest
 
-from pyfcstm.bmc import (
-    STATE_DIAGNOSTIC_ID,
-    STATE_TERMINATE_ID,
-    BmcBuildError,
-    build_bmc_domain,
-)
+from pyfcstm.bmc import build_bmc_domain, entry_source, stable_leaf_source
 from pyfcstm.bmc.expand import expand_macro_step_cases
-from pyfcstm.bmc.query import InitialSpec
-from pyfcstm.bmc.source import source_from_initial_spec, stable_leaf_source
-from pyfcstm.model import load_state_machine_from_text
+from pyfcstm.model import IfBlock, Operation, load_state_machine_from_text
 from pyfcstm.simulate import SimulationRuntime
 
 _FIXTURE = Path(__file__).with_name("fixtures") / "macro_runtime_alignment.fcstm"
 
 
-@pytest.fixture(scope="module")
-def alignment_model():
-    """Load the checked-in macro expansion alignment fixture."""
-    return load_state_machine_from_text(_FIXTURE.read_text(encoding="utf-8"))
+def _execute_statements(statements, vars_):
+    for statement in statements:
+        if isinstance(statement, Operation):
+            vars_[statement.var_name] = statement.expr(**vars_)
+            continue
+        if isinstance(statement, IfBlock):
+            selected = False
+            for branch in statement.branches:
+                if branch.condition is None or bool(branch.condition(**vars_)):
+                    _execute_statements(branch.statements, vars_)
+                    selected = True
+                    break
+            if selected:
+                continue
+            continue
+        raise AssertionError("unsupported test statement %r" % (statement,))
 
 
-@pytest.fixture(scope="module")
-def alignment_domain(alignment_model):
-    """Build the BMC domain for the macro expansion alignment fixture."""
-    return build_bmc_domain(alignment_model, bound=1)
+def _replay_action_prefix(case, initial_vars, block_count=None):
+    vars_ = dict(initial_vars)
+    blocks = (
+        case.action_blocks if block_count is None else case.action_blocks[:block_count]
+    )
+    for block in blocks:
+        if not block.is_abstract:
+            _execute_statements(block.operations, vars_)
+    return vars_
 
 
-def _case_eval(case, x, y, events=()):
-    values = {"x": x, "y": y}
-    for variable in case.condition.variables:
-        if variable.startswith("event:"):
-            values[variable] = variable[len("event:") :] in events
-        elif variable.startswith("guard:"):
-            values[variable] = _eval_guard_atom(variable[len("guard:") :], x, y)
-    return case.condition.evaluate(values)
+def _eval_condition(template, case, registry, initial_vars, events, active=None):
+    if active is None:
+        active = set()
+    if template.kind == "true":
+        return True
+    if template.kind == "false":
+        return False
+    if template.kind == "not":
+        return not _eval_condition(
+            template.operands[0], case, registry, initial_vars, events, active
+        )
+    if template.kind == "and":
+        return all(
+            _eval_condition(item, case, registry, initial_vars, events, active)
+            for item in template.operands
+        )
+    if template.kind == "or":
+        return any(
+            _eval_condition(item, case, registry, initial_vars, events, active)
+            for item in template.operands
+        )
+    atom = template.name
+    assert atom is not None
+    if atom.startswith("event:"):
+        return atom[len("event:") :] in events
+    if atom.startswith("guard:"):
+        requirement_id = atom[len("guard:") :]
+        guards = {item.requirement_id: item for item in case.guard_requirements}
+        guard = guards[requirement_id]
+        anchored_vars = _replay_action_prefix(
+            case, initial_vars, guard.after_action_block_index
+        )
+        return bool(guard.expr(**anchored_vars))
+    if atom.startswith("accepted:"):
+        label = atom[len("accepted:") :]
+        if label in active:
+            raise AssertionError("recursive accepted atom %s" % label)
+        active.add(label)
+        accepted_case = registry[label]
+        result = _eval_condition(
+            accepted_case.condition,
+            accepted_case,
+            registry,
+            initial_vars,
+            events,
+            active,
+        )
+        active.remove(label)
+        return result
+    raise AssertionError("unexpected atom %s" % atom)
 
 
-def _eval_guard_atom(atom, x, y):
-    expr = atom.replace("pre:x", "x").replace("pre:y", "y")
-    safe_globals = {"__builtins__": {}}
-    try:
-        return bool(eval(expr, safe_globals, {"x": x, "y": y}))
-    except (NameError, SyntaxError, TypeError, ValueError, ZeroDivisionError) as err:
-        # NameError: guard atom references a variable outside this test helper's
-        # fixture scope; SyntaxError: malformed atom text from the expander;
-        # TypeError/ValueError/ZeroDivisionError: Python rejects the numeric
-        # expression while emulating runtime guard evaluation.
-        raise BmcBuildError("cannot evaluate guard atom %r" % atom) from err
+def _selected_case(formal, initial_vars, events):
+    registry = {case.label: case for case in formal.cases}
+    selected = [
+        case
+        for case in formal.cases
+        if _eval_condition(case.condition, case, registry, initial_vars, events)
+    ]
+    assert len(selected) == 1, [case.label for case in selected]
+    return selected[0]
 
 
-def _updates(case):
-    return {item.variable_name: item.expression for item in case.var_update}
-
-
-def _eval_update_expr(expr, x=0, y=0):
-    """Evaluate a generated update expression in the alignment fixture scope."""
-    source = expr.replace("pre:x", "x").replace("pre:y", "y")
-    try:
-        return eval(source, {"__builtins__": {}}, {"x": x, "y": y})
-    except (NameError, SyntaxError, TypeError, ValueError, ZeroDivisionError) as err:
-        # NameError: update references a variable outside this fixture scope;
-        # SyntaxError: malformed generated expression; TypeError/ValueError/
-        # ZeroDivisionError: Python rejects the numeric expression while
-        # emulating runtime writeback.
-        raise BmcBuildError("cannot evaluate update expression %r" % expr) from err
-
-
-def _runtime_after(model, initial_state, x=0, y=0, events=()):
+def _runtime_cycle(model, state, initial_vars, events):
     runtime = SimulationRuntime(
-        model,
-        initial_state=initial_state,
-        initial_vars={"x": x, "y": y},
+        model, initial_state=state, initial_vars=dict(initial_vars)
     )
     runtime.cycle(list(events))
-    state_path = (
-        "(terminated)" if runtime.is_ended else ".".join(runtime.current_state.path)
-    )
-    return state_path, dict(runtime.vars)
-
-
-def _selected_case(formal, x, y, events=()):
-    matching = [case for case in formal.cases if _case_eval(case, x, y, events)]
-    assert len(matching) == 1, [case.label for case in matching]
-    return matching[0]
-
-
-@pytest.mark.unittest
-def test_issue_fixture_stable_leaf_cases_match_golden_table(alignment_domain):
-    """The A-source expansion matches the issue fixture's partition and recipes."""
-    source = stable_leaf_source(alignment_domain, "Root.System.A")
-    formal = expand_macro_step_cases(source)
-
-    by_target_kind = {
-        (case.kind, case.target_state_path): case for case in formal.cases
-    }
-    trap = by_target_kind[("transition", "Root.System.Trap.TrapLeaf")]
-    route_b = next(
-        case
-        for case in formal.success_cases
-        if case.kind == "transition" and case.target_state_path == "Root.System.B"
-    )
-    done = by_target_kind[("transition", "Root.Done")]
-    fallback = by_target_kind[("fallback", "Root.System.A")]
-
-    assert _updates(trap) == {"x": "pre:x + 1420", "y": "pre:y + 1010"}
-    assert _updates(route_b) == {"x": "2 * pre:x + 1007", "y": "pre:y + 1011"}
-    assert _updates(done) == {"x": "pre:x + 11102", "y": "pre:y + 11036"}
-    assert _updates(fallback) == {"x": "pre:x + 1001", "y": "pre:y + 1000"}
-
-    tick = "Root.System.A.Tick"
-    arm = "Root.System.Trap.Arm"
-    expected = [
-        (trap, 0, 0, (tick, arm)),
-        (route_b, 0, 0, (tick,)),
-        (done, 11, 0, (tick,)),
-        (fallback, 0, 0, ()),
-        (fallback, 11, -200, (tick,)),
-    ]
-    for selected, x, y, events in expected:
-        assert _selected_case(formal, x, y, events) is selected
-
-    assert sorted(event.path for event in trap.used_events) == [
-        "Root.System.A.Tick",
-        "Root.System.Trap.Arm",
-    ]
-    assert any(
-        event.path == "Root.System.Trap.Arm" and event.reason == "priority"
-        for event in route_b.used_events
-    )
-
-
-@pytest.mark.unittest
-def test_issue_fixture_stable_leaf_cases_align_with_simulation_runtime(
-    alignment_model,
-    alignment_domain,
-):
-    """Every representative A-source runtime example selects the expected case."""
-    formal = expand_macro_step_cases(
-        stable_leaf_source(alignment_domain, "Root.System.A")
-    )
-    tick = "Root.System.A.Tick"
-    arm = "Root.System.Trap.Arm"
-    examples = [
-        (0, 0, (), "Root.System.A", {"x": 1001, "y": 1000}),
-        (0, 0, (tick, arm), "Root.System.Trap.TrapLeaf", {"x": 1420, "y": 1010}),
-        (0, 0, (tick,), "Root.System.B", {"x": 1007, "y": 1011}),
-        (11, 0, (tick,), "Root.Done", {"x": 11113, "y": 11036}),
-        (11, -200, (tick,), "Root.System.A", {"x": 1012, "y": 800}),
-    ]
-
-    for x, y, events, expected_state, expected_vars in examples:
-        case = _selected_case(formal, x, y, events)
-        runtime_state, runtime_vars = _runtime_after(
-            alignment_model,
-            "Root.System.A",
-            x=x,
-            y=y,
-            events=events,
-        )
-        assert case.target_state_path == expected_state
-        assert runtime_state == expected_state
-        assert runtime_vars == expected_vars
-
-
-@pytest.mark.unittest
-def test_non_stoppable_hot_composite_delta_and_evented_initial_aligns_with_runtime(
-    alignment_model,
-    alignment_domain,
-):
-    """Hot Trap expansion splits Arm success from the semantic diagnostic delta."""
-    source = source_from_initial_spec(
-        alignment_domain,
-        InitialSpec(mode="state", state_path="Root.System.Trap"),
-    )
-    formal = expand_macro_step_cases(source)
-    arm = "Root.System.Trap.Arm"
-
-    success = _selected_case(formal, 0, 0, (arm,))
-    delta = _selected_case(formal, 0, 0, ())
-
-    assert success.kind == "initial"
-    assert success.target_state_path == "Root.System.Trap.TrapLeaf"
-    assert _updates(success) == {"x": "pre:x + 1400", "y": "pre:y + 1000"}
-    assert delta.kind == "delta"
-    assert delta.target_state_id == STATE_DIAGNOSTIC_ID
-    assert _updates(delta) == {"x": "pre:x", "y": "pre:y"}
-
-    runtime_state, runtime_vars = _runtime_after(
-        alignment_model,
-        "Root.System.Trap",
-        events=(arm,),
-    )
-    assert runtime_state == success.target_state_path
-    assert runtime_vars == {"x": 1400, "y": 1000}
-
-    runtime = SimulationRuntime(
-        alignment_model,
-        initial_state="Root.System.Trap",
-        initial_vars={"x": 0, "y": 0},
-    )
-    runtime.cycle([])
-    assert ".".join(runtime.current_state.path) == "Root.System.Trap"
-    assert runtime.vars == {"x": 0, "y": 0}
-
-
-@pytest.mark.unittest
-def test_cold_root_initial_cycle_aligns_with_runtime(alignment_model, alignment_domain):
-    """Cold entry expansion includes root/System initial descent and first during."""
-    formal = expand_macro_step_cases(
-        source_from_initial_spec(alignment_domain, InitialSpec())
-    )
-    case = _selected_case(formal, 0, 0, ())
-
-    assert case.kind == "initial"
-    assert case.target_state_path == "Root.System.A"
-    assert _updates(case) == {"x": "pre:x + 1011", "y": "pre:y + 1001"}
-
-    runtime = SimulationRuntime(alignment_model)
-    runtime.cycle([])
-    assert ".".join(runtime.current_state.path) == "Root.System.A"
-    assert runtime.vars == {"x": 1011, "y": 1001}
-
-
-@pytest.mark.unittest
-def test_pseudo_hot_start_and_parent_continuation_cases(alignment_domain):
-    """Expansion covers pseudo routing and exit-to-parent continuation guards."""
-    source = source_from_initial_spec(
-        alignment_domain,
-        InitialSpec(mode="state", state_path="Root.System.Route"),
-    )
-    formal = expand_macro_step_cases(source)
-
-    to_b = _selected_case(formal, 0, 0, ())
-    to_done = _selected_case(formal, 13, 8, ())
-    delta = _selected_case(formal, 13, 7, ())
-
-    assert to_b.kind == "initial"
-    assert to_b.target_state_path == "Root.System.B"
-    assert _updates(to_b) == {"x": "2 * pre:x + 1003", "y": "pre:y + 1001"}
-    assert to_done.kind == "initial"
-    assert to_done.target_state_path == "Root.Done"
-    assert _updates(to_done) == {"x": "pre:x + 11100", "y": "pre:y + 11026"}
-    assert delta.kind == "delta"
-    assert delta.target_state_id == STATE_DIAGNOSTIC_ID
-
-
-@pytest.mark.unittest
-def test_plain_before_boundary_and_aspect_before_each_run_once():
-    """Plain boundary and aspect-before actions stay runtime-aligned."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 1;
-        state Root {
-            state Parent {
-                during before { x = x + 10; }
-                >> during before { x = x * 2; }
-                state A {
-                    enter { x = x + 1; }
-                    during { x = x + 3; }
-                }
-                [*] -> A;
-            }
-            [*] -> Parent;
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(source_from_initial_spec(domain, InitialSpec()))
-    case = _selected_case(formal, 1, 0, ())
-
-    assert case.kind == "initial"
-    assert case.target_state_path == "Root.Parent.A"
-    assert _updates(case) == {"x": "2 * pre:x + 25"}
-
-    runtime = SimulationRuntime(model)
-    runtime.cycle([])
-    assert ".".join(runtime.current_state.path) == case.target_state_path
-    assert runtime.vars == {"x": 27}
-
-
-@pytest.mark.unittest
-def test_rejected_guarded_pseudo_pair_loop_falls_back_like_runtime():
-    """Repeated pseudo frontiers are failed candidates, not recursion leaks."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A { during { x = x + 1; } }
-            pseudo state P;
-            pseudo state Q;
-            [*] -> A;
-            A -> P : if [x < 10];
-            P -> Q;
-            Q -> P;
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-
-    case = _selected_case(formal, 0, 0, ())
-
-    assert case.kind == "fallback"
-    assert case.target_state_path == "Root.A"
-    assert case.failed_conditions
-    assert _updates(case) == {"x": "pre:x + 1"}
-
-    runtime = SimulationRuntime(
-        model,
-        initial_state="Root.A",
-        initial_vars={"x": 0},
-    )
-    runtime.cycle([])
-    assert ".".join(runtime.current_state.path) == case.target_state_path
-    assert runtime.vars == {"x": 1}
-
-
-@pytest.mark.unittest
-def test_rejected_pseudo_loop_allows_later_transition_and_matches_runtime():
-    """Validation-skipped pseudo loops do not mask later accepted transitions."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A { during { x = x + 1; } }
-            pseudo state Loop;
-            state Done;
-            [*] -> A;
-            A -> Loop :: Go;
-            A -> Done :: Go;
-            Loop -> Loop;
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-    go = "Root.A.Go"
-
-    selected = _selected_case(formal, 0, 0, (go,))
-    fallback = _selected_case(formal, 0, 0, ())
-
-    assert selected.kind == "transition"
-    assert selected.target_state_path == "Root.Done"
-    assert fallback.kind == "fallback"
-    assert fallback.target_state_path == "Root.A"
-    assert fallback.failed_conditions
-
-    runtime = SimulationRuntime(
-        model,
-        initial_state="Root.A",
-        initial_vars={"x": 0},
-    )
-    runtime.cycle([go])
-    assert ".".join(runtime.current_state.path) == selected.target_state_path
-    assert runtime.vars == {"x": 0}
-
-
-@pytest.mark.unittest
-def test_variable_progressing_pseudo_loop_reaches_stable_runtime_target():
-    """Variable-progressing pseudo validation loops match runtime outcomes."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A { during { x = x + 10; } }
-            pseudo state P;
-            state B;
-            [*] -> A;
-            A -> P : if [x < 3];
-            P -> P : if [x < 3] effect { x = x + 1; }
-            P -> B : if [x >= 3];
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-
-    for initial_x in (0, 1, 2):
-        selected = _selected_case(formal, initial_x, 0, ())
-        runtime = SimulationRuntime(
-            model,
-            initial_state="Root.A",
-            initial_vars={"x": initial_x},
-        )
-        runtime.cycle([])
-
-        assert selected.kind == "transition"
-        assert selected.target_state_path == "Root.B"
-        assert _updates(selected) == {"x": "3"}
-        assert ".".join(runtime.current_state.path) == "Root.B"
-        assert runtime.vars == {"x": 3}
-
-    fallback = _selected_case(formal, 3, 0, ())
-    runtime = SimulationRuntime(
-        model,
-        initial_state="Root.A",
-        initial_vars={"x": 3},
-    )
-    runtime.cycle([])
-
-    assert fallback.kind == "fallback"
-    assert fallback.target_state_path == "Root.A"
-    assert _updates(fallback) == {"x": "pre:x + 10"}
-    assert ".".join(runtime.current_state.path) == "Root.A"
-    assert runtime.vars == {"x": 13}
-
-
-@pytest.mark.unittest
-def test_variable_progressing_pseudo_loop_with_exit_priority_aligns_with_runtime():
-    """Threshold pseudo-loop acceleration preserves declaration priority."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A { during { x = x + 10; } }
-            pseudo state P;
-            state B;
-            [*] -> A;
-            A -> P : if [x < 3];
-            P -> B : if [x >= 3];
-            P -> P : if [x < 3] effect { x = x + 1; }
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-
-    for initial_x in (0, 1, 2):
-        selected = _selected_case(formal, initial_x, 0, ())
-        runtime = SimulationRuntime(
-            model,
-            initial_state="Root.A",
-            initial_vars={"x": initial_x},
-        )
-        runtime.cycle([])
-
-        assert selected.kind == "transition"
-        assert selected.target_state_path == "Root.B"
-        assert _updates(selected) == {"x": "3"}
-        assert ".".join(runtime.current_state.path) == "Root.B"
-        assert runtime.vars == {"x": 3}
-
-    fallback = _selected_case(formal, 3, 0, ())
-    assert fallback.kind == "fallback"
-    assert fallback.target_state_path == "Root.A"
-    assert _updates(fallback) == {"x": "pre:x + 10"}
-
-
-@pytest.mark.unittest
-def test_variable_progressing_pseudo_loop_with_step_two_aligns_with_runtime():
-    """Threshold pseudo-loop acceleration supports positive non-unit steps."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A;
-            pseudo state P;
-            state B;
-            [*] -> A;
-            A -> P : if [x < 4];
-            P -> P : if [x < 4] effect { x = x + 2; }
-            P -> B : if [x >= 4];
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-
-    for initial_x in (0, 1, 2, 3):
-        selected = _selected_case(formal, initial_x, 0, ())
-        runtime = SimulationRuntime(
-            model,
-            initial_state="Root.A",
-            initial_vars={"x": initial_x},
-        )
-        runtime.cycle([])
-
-        assert selected.kind == "transition"
-        assert selected.target_state_path == "Root.B"
-        assert (
-            _eval_update_expr(_updates(selected)["x"], x=initial_x) == runtime.vars["x"]
-        )
-        assert ".".join(runtime.current_state.path) == "Root.B"
-
-    fallback = _selected_case(formal, 4, 0, ())
-    assert fallback.kind == "fallback"
-    assert fallback.target_state_path == "Root.A"
-    assert _updates(fallback) == {"x": "pre:x"}
-
-
-@pytest.mark.unittest
-def test_variable_progressing_pseudo_loop_after_entry_effect_aligns_with_runtime():
-    """Threshold acceleration preserves affine values produced before the loop."""
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A;
-            pseudo state P;
-            state B;
-            [*] -> A;
-            A -> P : if [x < 4] effect { x = x + 1; }
-            P -> P : if [x < 4] effect { x = x + 2; }
-            P -> B : if [x >= 4];
-        }
-        """
-    )
-    domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
-
-    for initial_x in (0, 1, 2, 3):
-        selected = _selected_case(formal, initial_x, 0, ())
-        runtime = SimulationRuntime(
-            model,
-            initial_state="Root.A",
-            initial_vars={"x": initial_x},
-        )
-        runtime.cycle([])
-
-        assert selected.kind == "transition"
-        assert selected.target_state_path == "Root.B"
-        assert (
-            _eval_update_expr(_updates(selected)["x"], x=initial_x) == runtime.vars["x"]
-        )
-        assert ".".join(runtime.current_state.path) == "Root.B"
-
-    fallback = _selected_case(formal, 4, 0, ())
-    assert fallback.kind == "fallback"
-    assert fallback.target_state_path == "Root.A"
-    assert _updates(fallback) == {"x": "pre:x"}
+    return ".".join(runtime.current_state.path), dict(runtime.vars)
 
 
 @pytest.mark.unittest
 @pytest.mark.parametrize(
-    ("loop_guard", "exit_guard"),
+    ("initial_vars", "events", "expected_target"),
     [
-        ("x <= 3", "x > 3"),
-        ("x <= 3", "!(x <= 3)"),
-        ("4 > x", "4 <= x"),
-        ("x < 4", "!(x < 4)"),
-        ("4 > x", "3 < x"),
-        ("x <= 4 - 1", "x > 4 - 1"),
-        ("4 > x", "x >= 2 + 2"),
-        ("x < 2 * 2", "!(x < 2 + 2)"),
-        ("x <= 9 % 5 - 1", "4 <= x"),
+        ({"x": 0, "y": 0}, ("Root.System.A.Tick",), "Root.System.B"),
+        ({"x": 11, "y": 0}, ("Root.System.A.Tick",), "Root.Done"),
+        ({"x": 11, "y": -200}, ("Root.System.A.Tick",), "Root.System.A"),
+        (
+            {"x": 0, "y": 0},
+            ("Root.System.A.Tick", "Root.System.Trap.Arm"),
+            "Root.System.Trap.TrapLeaf",
+        ),
+        ({"x": 4, "y": 5}, (), "Root.System.A"),
     ],
 )
-@pytest.mark.parametrize("loop_first", [True, False])
-def test_variable_progressing_pseudo_loop_normalizes_equivalent_threshold_guards(
-    loop_guard,
-    exit_guard,
-    loop_first,
+def test_stable_a_cases_select_same_target_and_actions_as_runtime(
+    initial_vars,
+    events,
+    expected_target,
 ):
-    """Equivalent integer threshold forms align with runtime pseudo-loop cycles."""
-    if loop_first:
-        pseudo_transitions = """
-            P -> P : if [%s] effect { x = x + 2; }
-            P -> B : if [%s];
-        """ % (
-            loop_guard,
-            exit_guard,
-        )
-    else:
-        pseudo_transitions = """
-            P -> B : if [%s];
-            P -> P : if [%s] effect { x = x + 2; }
-        """ % (
-            exit_guard,
-            loop_guard,
-        )
-    model = load_state_machine_from_text(
-        """
-        def int x = 0;
-        state Root {
-            state A;
-            pseudo state P;
-            state B;
-            [*] -> A;
-            A -> P : if [x < 4];
-            %s
-        }
-        """
-        % pseudo_transitions
-    )
+    """Flat path cases align with runtime transition validation and fallback."""
+    model = load_state_machine_from_text(_FIXTURE.read_text())
     domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.System.A"))
 
-    assert not formal.build_diagnostic_conditions
-    assert len(formal.cases) == 2
-    for initial_x in (-1, 0, 1, 2, 3, 4):
-        selected = _selected_case(formal, initial_x, 0, ())
-        runtime = SimulationRuntime(
-            model,
-            initial_state="Root.A",
-            initial_vars={"x": initial_x},
-        )
-        runtime.cycle([])
+    case = _selected_case(formal, initial_vars, events)
+    replayed_vars = _replay_action_prefix(case, initial_vars)
+    runtime_state, runtime_vars = _runtime_cycle(
+        model,
+        "Root.System.A",
+        initial_vars,
+        events,
+    )
 
-        runtime_state = ".".join(runtime.current_state.path)
-        assert selected.target_state_path == runtime_state
-        assert (
-            _eval_update_expr(_updates(selected)["x"], x=initial_x) == runtime.vars["x"]
-        )
+    assert case.target_state_path == expected_target
+    assert runtime_state == expected_target
+    assert replayed_vars == runtime_vars
 
 
 @pytest.mark.unittest
-def test_cold_leaf_root_enters_and_stabilizes_instead_of_terminating():
-    """Cold root leaf expansion follows initialization, not root synthetic exit."""
+@pytest.mark.parametrize(
+    ("initial_vars", "expected_kind", "expected_target"),
+    [
+        ({"x": 0, "y": 0}, "initial", "Root.System.B"),
+        ({"x": 13, "y": 8}, "initial", "Root.Done"),
+        ({"x": 13, "y": 0}, "delta", "__diagnostic__"),
+    ],
+)
+def test_hot_route_entry_cases_use_runtime_guard_anchors(
+    initial_vars,
+    expected_kind,
+    expected_target,
+):
+    """Hot pseudo entry selects B, Done, or semantic delta by anchored guards."""
+    model = load_state_machine_from_text(_FIXTURE.read_text())
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(entry_source(domain, "Root.System.Route"))
+
+    case = _selected_case(formal, initial_vars, ())
+
+    assert case.kind == expected_kind
+    assert case.target_state_path == expected_target
+    if case.kind != "delta":
+        replayed_vars = _replay_action_prefix(case, initial_vars)
+        runtime_state, runtime_vars = _runtime_cycle(
+            model,
+            "Root.System.Route",
+            initial_vars,
+            (),
+        )
+        assert runtime_state == expected_target
+        assert replayed_vars == runtime_vars
+
+
+@pytest.mark.unittest
+def test_runtime_alignment_condition_has_no_action_if_atoms():
+    """Action-local conditions stay inside operations and not case conditions."""
     model = load_state_machine_from_text(
         """
         def int x = 0;
         state Root {
-            enter { x = x + 10; }
-            during { x = x + 1; }
+            state A {
+                during {
+                    if [x > 0] { x = x + 1; } else { x = x - 1; }
+                }
+            }
+            [*] -> A;
         }
         """
     )
     domain = build_bmc_domain(model, bound=1)
-    formal = expand_macro_step_cases(source_from_initial_spec(domain, InitialSpec()))
-    case = _selected_case(formal, 0, 0, ())
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    case = formal.cases[0]
 
-    assert case.kind == "initial"
-    assert case.target_state_path == "Root"
-    assert _updates(case) == {"x": "pre:x + 11"}
-
-    runtime = SimulationRuntime(model)
-    runtime.cycle([])
-    assert ".".join(runtime.current_state.path) == "Root"
-    assert runtime.vars == {"x": 11}
-
-    hot_formal = expand_macro_step_cases(
-        source_from_initial_spec(domain, InitialSpec(mode="state", state_path="Root"))
-    )
-    hot_case = _selected_case(hot_formal, 0, 0, ())
-    assert hot_case.kind == "transition"
-    assert hot_case.target_state_id == STATE_TERMINATE_ID
-    assert hot_case.target_state_path == "__terminate__"
-    assert _updates(hot_case) == {"x": "pre:x"}
-
-    hot_runtime = SimulationRuntime(
-        model,
-        initial_state="Root",
-        initial_vars={"x": 0},
-    )
-    hot_runtime.cycle([])
-    assert hot_runtime.is_ended is True
-    assert hot_runtime.vars == {"x": 0}
+    assert case.condition.variables == ()
+    assert isinstance(case.action_blocks[0].operations[0], IfBlock)
+    assert _replay_action_prefix(case, {"x": 2}) == {"x": 3}
+    assert _replay_action_prefix(case, {"x": 0}) == {"x": -1}

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -240,6 +240,117 @@ def test_pseudo_hot_start_and_parent_continuation_cases(alignment_domain):
 
 
 @pytest.mark.unittest
+def test_plain_before_boundary_and_aspect_before_each_run_once():
+    """Plain boundary and aspect-before actions stay runtime-aligned."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 1;
+        state Root {
+            state Parent {
+                during before { x = x + 10; }
+                >> during before { x = x * 2; }
+                state A {
+                    enter { x = x + 1; }
+                    during { x = x + 3; }
+                }
+                [*] -> A;
+            }
+            [*] -> Parent;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(source_from_initial_spec(domain, InitialSpec()))
+    case = _selected_case(formal, 1, 0, ())
+
+    assert case.kind == "initial"
+    assert case.target_state_path == "Root.Parent.A"
+    assert _updates(case) == {"x": "2 * pre:x + 25"}
+
+    runtime = SimulationRuntime(model)
+    runtime.cycle([])
+    assert ".".join(runtime.current_state.path) == case.target_state_path
+    assert runtime.vars == {"x": 27}
+
+
+@pytest.mark.unittest
+def test_rejected_guarded_pseudo_pair_loop_falls_back_like_runtime():
+    """Repeated pseudo frontiers are failed candidates, not recursion leaks."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A { during { x = x + 1; } }
+            pseudo state P;
+            pseudo state Q;
+            [*] -> A;
+            A -> P : if [x < 10];
+            P -> Q;
+            Q -> P;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    case = _selected_case(formal, 0, 0, ())
+
+    assert case.kind == "fallback"
+    assert case.target_state_path == "Root.A"
+    assert case.failed_conditions
+    assert _updates(case) == {"x": "pre:x + 1"}
+
+    runtime = SimulationRuntime(
+        model,
+        initial_state="Root.A",
+        initial_vars={"x": 0},
+    )
+    runtime.cycle([])
+    assert ".".join(runtime.current_state.path) == case.target_state_path
+    assert runtime.vars == {"x": 1}
+
+
+@pytest.mark.unittest
+def test_rejected_pseudo_loop_allows_later_transition_and_matches_runtime():
+    """Validation-skipped pseudo loops do not mask later accepted transitions."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A { during { x = x + 1; } }
+            pseudo state Loop;
+            state Done;
+            [*] -> A;
+            A -> Loop :: Go;
+            A -> Done :: Go;
+            Loop -> Loop;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+    go = "Root.A.Go"
+
+    selected = _selected_case(formal, 0, 0, (go,))
+    fallback = _selected_case(formal, 0, 0, ())
+
+    assert selected.kind == "transition"
+    assert selected.target_state_path == "Root.Done"
+    assert fallback.kind == "fallback"
+    assert fallback.target_state_path == "Root.A"
+    assert fallback.failed_conditions
+
+    runtime = SimulationRuntime(
+        model,
+        initial_state="Root.A",
+        initial_vars={"x": 0},
+    )
+    runtime.cycle([go])
+    assert ".".join(runtime.current_state.path) == selected.target_state_path
+    assert runtime.vars == {"x": 0}
+
+
+@pytest.mark.unittest
 def test_cold_leaf_root_enters_and_stabilizes_instead_of_terminating():
     """Cold root leaf expansion follows initialization, not root synthetic exit."""
     model = load_state_machine_from_text(

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -60,6 +60,19 @@ def _updates(case):
     return {item.variable_name: item.expression for item in case.var_update}
 
 
+def _eval_update_expr(expr, x=0, y=0):
+    """Evaluate a generated update expression in the alignment fixture scope."""
+    source = expr.replace("pre:x", "x").replace("pre:y", "y")
+    try:
+        return eval(source, {"__builtins__": {}}, {"x": x, "y": y})
+    except (NameError, SyntaxError, TypeError, ValueError, ZeroDivisionError) as err:
+        # NameError: update references a variable outside this fixture scope;
+        # SyntaxError: malformed generated expression; TypeError/ValueError/
+        # ZeroDivisionError: Python rejects the numeric expression while
+        # emulating runtime writeback.
+        raise BmcBuildError("cannot evaluate update expression %r" % expr) from err
+
+
 def _runtime_after(model, initial_state, x=0, y=0, events=()):
     runtime = SimulationRuntime(
         model,
@@ -439,6 +452,90 @@ def test_variable_progressing_pseudo_loop_with_exit_priority_aligns_with_runtime
     assert fallback.kind == "fallback"
     assert fallback.target_state_path == "Root.A"
     assert _updates(fallback) == {"x": "pre:x + 10"}
+
+
+@pytest.mark.unittest
+def test_variable_progressing_pseudo_loop_with_step_two_aligns_with_runtime():
+    """Threshold pseudo-loop acceleration supports positive non-unit steps."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            pseudo state P;
+            state B;
+            [*] -> A;
+            A -> P : if [x < 4];
+            P -> P : if [x < 4] effect { x = x + 2; }
+            P -> B : if [x >= 4];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    for initial_x in (0, 1, 2, 3):
+        selected = _selected_case(formal, initial_x, 0, ())
+        runtime = SimulationRuntime(
+            model,
+            initial_state="Root.A",
+            initial_vars={"x": initial_x},
+        )
+        runtime.cycle([])
+
+        assert selected.kind == "transition"
+        assert selected.target_state_path == "Root.B"
+        assert (
+            _eval_update_expr(_updates(selected)["x"], x=initial_x) == runtime.vars["x"]
+        )
+        assert ".".join(runtime.current_state.path) == "Root.B"
+
+    fallback = _selected_case(formal, 4, 0, ())
+    assert fallback.kind == "fallback"
+    assert fallback.target_state_path == "Root.A"
+    assert _updates(fallback) == {"x": "pre:x"}
+
+
+@pytest.mark.unittest
+def test_variable_progressing_pseudo_loop_after_entry_effect_aligns_with_runtime():
+    """Threshold acceleration preserves affine values produced before the loop."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            pseudo state P;
+            state B;
+            [*] -> A;
+            A -> P : if [x < 4] effect { x = x + 1; }
+            P -> P : if [x < 4] effect { x = x + 2; }
+            P -> B : if [x >= 4];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    for initial_x in (0, 1, 2, 3):
+        selected = _selected_case(formal, initial_x, 0, ())
+        runtime = SimulationRuntime(
+            model,
+            initial_state="Root.A",
+            initial_vars={"x": initial_x},
+        )
+        runtime.cycle([])
+
+        assert selected.kind == "transition"
+        assert selected.target_state_path == "Root.B"
+        assert (
+            _eval_update_expr(_updates(selected)["x"], x=initial_x) == runtime.vars["x"]
+        )
+        assert ".".join(runtime.current_state.path) == "Root.B"
+
+    fallback = _selected_case(formal, 4, 0, ())
+    assert fallback.kind == "fallback"
+    assert fallback.target_state_path == "Root.A"
+    assert _updates(fallback) == {"x": "pre:x"}
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -351,6 +351,97 @@ def test_rejected_pseudo_loop_allows_later_transition_and_matches_runtime():
 
 
 @pytest.mark.unittest
+def test_variable_progressing_pseudo_loop_reaches_stable_runtime_target():
+    """Variable-progressing pseudo validation loops match runtime outcomes."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A { during { x = x + 10; } }
+            pseudo state P;
+            state B;
+            [*] -> A;
+            A -> P : if [x < 3];
+            P -> P : if [x < 3] effect { x = x + 1; }
+            P -> B : if [x >= 3];
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    for initial_x in (0, 1, 2):
+        selected = _selected_case(formal, initial_x, 0, ())
+        runtime = SimulationRuntime(
+            model,
+            initial_state="Root.A",
+            initial_vars={"x": initial_x},
+        )
+        runtime.cycle([])
+
+        assert selected.kind == "transition"
+        assert selected.target_state_path == "Root.B"
+        assert _updates(selected) == {"x": "3"}
+        assert ".".join(runtime.current_state.path) == "Root.B"
+        assert runtime.vars == {"x": 3}
+
+    fallback = _selected_case(formal, 3, 0, ())
+    runtime = SimulationRuntime(
+        model,
+        initial_state="Root.A",
+        initial_vars={"x": 3},
+    )
+    runtime.cycle([])
+
+    assert fallback.kind == "fallback"
+    assert fallback.target_state_path == "Root.A"
+    assert _updates(fallback) == {"x": "pre:x + 10"}
+    assert ".".join(runtime.current_state.path) == "Root.A"
+    assert runtime.vars == {"x": 13}
+
+
+@pytest.mark.unittest
+def test_variable_progressing_pseudo_loop_with_exit_priority_aligns_with_runtime():
+    """Threshold pseudo-loop acceleration preserves declaration priority."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A { during { x = x + 10; } }
+            pseudo state P;
+            state B;
+            [*] -> A;
+            A -> P : if [x < 3];
+            P -> B : if [x >= 3];
+            P -> P : if [x < 3] effect { x = x + 1; }
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    for initial_x in (0, 1, 2):
+        selected = _selected_case(formal, initial_x, 0, ())
+        runtime = SimulationRuntime(
+            model,
+            initial_state="Root.A",
+            initial_vars={"x": initial_x},
+        )
+        runtime.cycle([])
+
+        assert selected.kind == "transition"
+        assert selected.target_state_path == "Root.B"
+        assert _updates(selected) == {"x": "3"}
+        assert ".".join(runtime.current_state.path) == "Root.B"
+        assert runtime.vars == {"x": 3}
+
+    fallback = _selected_case(formal, 3, 0, ())
+    assert fallback.kind == "fallback"
+    assert fallback.target_state_path == "Root.A"
+    assert _updates(fallback) == {"x": "pre:x + 10"}
+
+
+@pytest.mark.unittest
 def test_cold_leaf_root_enters_and_stabilizes_instead_of_terminating():
     """Cold root leaf expansion follows initialization, not root synthetic exit."""
     model = load_state_machine_from_text(

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -1,4 +1,4 @@
-"""Runtime-alignment tests for PR-9 macro-step path expansion."""
+"""Runtime-alignment tests for macro-step path expansion."""
 
 from __future__ import annotations
 

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -212,3 +212,153 @@ def test_runtime_alignment_condition_has_no_action_if_atoms():
     assert isinstance(case.action_blocks[0].operations[0], IfBlock)
     assert _replay_action_prefix(case, {"x": 2}) == {"x": 3}
     assert _replay_action_prefix(case, {"x": 0}) == {"x": -1}
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    ("events", "expected_target", "expected_roles", "expected_x"),
+    [
+        (
+            (),
+            "Root.A",
+            [
+                "aspect_during_before",
+                "aspect_during_before",
+                "leaf_during",
+                "leaf_during",
+                "aspect_during_after",
+                "aspect_during_after",
+            ],
+            111107,
+        ),
+        (
+            ("Root.Go",),
+            "Root.B",
+            [
+                "state_exit",
+                "state_exit",
+                "state_enter",
+                "state_enter",
+                "aspect_during_before",
+                "aspect_during_before",
+                "leaf_during",
+                "leaf_during",
+                "aspect_during_after",
+                "aspect_during_after",
+            ],
+            111145,
+        ),
+    ],
+)
+def test_multiple_lifecycle_actions_preserve_runtime_order(
+    events,
+    expected_target,
+    expected_roles,
+    expected_x,
+):
+    """Repeated actions in the same lifecycle stage remain ordered blocks."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            >> during before { x = x + 100; }
+            >> during before { x = x + 1000; }
+            >> during after { x = x + 10000; }
+            >> during after { x = x + 100000; }
+            state A {
+                enter { x = x + 1; }
+                enter { x = x + 2; }
+                during { x = x + 3; }
+                during { x = x + 4; }
+                exit { x = x + 5; }
+                exit { x = x + 6; }
+            }
+            state B {
+                enter { x = x + 7; }
+                enter { x = x + 8; }
+                during { x = x + 9; }
+                during { x = x + 10; }
+            }
+            [*] -> A;
+            A -> B : Go;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    case = _selected_case(formal, {"x": 0}, events)
+    runtime_state, runtime_vars = _runtime_cycle(model, "Root.A", {"x": 0}, events)
+
+    assert case.target_state_path == expected_target
+    assert [block.runtime_role for block in case.action_blocks] == expected_roles
+    assert _replay_action_prefix(case, {"x": 0}) == {"x": expected_x}
+    assert runtime_state == expected_target
+    assert runtime_vars == {"x": expected_x}
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    ("events", "expected_target", "expected_actions"),
+    [
+        (
+            (),
+            "Root.A",
+            [
+                ("aspect_during_before", "Root.RootBefore"),
+                ("leaf_during", "Root.A.ADuring"),
+                ("aspect_during_after", "Root.RootAfter"),
+            ],
+        ),
+        (
+            ("Root.Go",),
+            "Root.B",
+            [
+                ("state_exit", "Root.A.AExit"),
+                ("aspect_during_before", "Root.RootBefore"),
+                ("aspect_during_after", "Root.RootAfter"),
+            ],
+        ),
+    ],
+)
+def test_abstract_actions_are_recorded_as_noop_occurrence_blocks(
+    events,
+    expected_target,
+    expected_actions,
+):
+    """Abstract actions remain observable blocks while preserving no-op vars."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            >> during before abstract RootBefore;
+            >> during after abstract RootAfter;
+            state A {
+                enter abstract AEnter;
+                during abstract ADuring;
+                exit abstract AExit;
+            }
+            state B;
+            [*] -> A;
+            A -> B : Go;
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(stable_leaf_source(domain, "Root.A"))
+
+    case = _selected_case(formal, {"x": 0}, events)
+    runtime_state, runtime_vars = _runtime_cycle(model, "Root.A", {"x": 0}, events)
+
+    assert case.target_state_path == expected_target
+    assert [
+        (block.runtime_role, block.action_name) for block in case.action_blocks
+    ] == expected_actions
+    assert all(
+        block.is_abstract and block.operations == () for block in case.action_blocks
+    )
+    assert _replay_action_prefix(case, {"x": 0}) == {"x": 0}
+    assert runtime_state == expected_target
+    assert runtime_vars == {"x": 0}

--- a/test/bmc/test_macro_runtime_alignment.py
+++ b/test/bmc/test_macro_runtime_alignment.py
@@ -1,0 +1,283 @@
+"""Runtime-alignment tests for BMC macro-step expansion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pyfcstm.bmc import (
+    STATE_DIAGNOSTIC_ID,
+    STATE_TERMINATE_ID,
+    BmcBuildError,
+    build_bmc_domain,
+)
+from pyfcstm.bmc.expand import expand_macro_step_cases
+from pyfcstm.bmc.query import InitialSpec
+from pyfcstm.bmc.source import source_from_initial_spec, stable_leaf_source
+from pyfcstm.model import load_state_machine_from_text
+from pyfcstm.simulate import SimulationRuntime
+
+_FIXTURE = Path(__file__).with_name("fixtures") / "macro_runtime_alignment.fcstm"
+
+
+@pytest.fixture(scope="module")
+def alignment_model():
+    """Load the checked-in macro expansion alignment fixture."""
+    return load_state_machine_from_text(_FIXTURE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def alignment_domain(alignment_model):
+    """Build the BMC domain for the macro expansion alignment fixture."""
+    return build_bmc_domain(alignment_model, bound=1)
+
+
+def _case_eval(case, x, y, events=()):
+    values = {"x": x, "y": y}
+    for variable in case.condition.variables:
+        if variable.startswith("event:"):
+            values[variable] = variable[len("event:") :] in events
+        elif variable.startswith("guard:"):
+            values[variable] = _eval_guard_atom(variable[len("guard:") :], x, y)
+    return case.condition.evaluate(values)
+
+
+def _eval_guard_atom(atom, x, y):
+    expr = atom.replace("pre:x", "x").replace("pre:y", "y")
+    safe_globals = {"__builtins__": {}}
+    try:
+        return bool(eval(expr, safe_globals, {"x": x, "y": y}))
+    except (NameError, SyntaxError, TypeError, ValueError, ZeroDivisionError) as err:
+        # NameError: guard atom references a variable outside this test helper's
+        # fixture scope; SyntaxError: malformed atom text from the expander;
+        # TypeError/ValueError/ZeroDivisionError: Python rejects the numeric
+        # expression while emulating runtime guard evaluation.
+        raise BmcBuildError("cannot evaluate guard atom %r" % atom) from err
+
+
+def _updates(case):
+    return {item.variable_name: item.expression for item in case.var_update}
+
+
+def _runtime_after(model, initial_state, x=0, y=0, events=()):
+    runtime = SimulationRuntime(
+        model,
+        initial_state=initial_state,
+        initial_vars={"x": x, "y": y},
+    )
+    runtime.cycle(list(events))
+    state_path = (
+        "(terminated)" if runtime.is_ended else ".".join(runtime.current_state.path)
+    )
+    return state_path, dict(runtime.vars)
+
+
+def _selected_case(formal, x, y, events=()):
+    matching = [case for case in formal.cases if _case_eval(case, x, y, events)]
+    assert len(matching) == 1, [case.label for case in matching]
+    return matching[0]
+
+
+@pytest.mark.unittest
+def test_issue_fixture_stable_leaf_cases_match_golden_table(alignment_domain):
+    """The A-source expansion matches the issue fixture's partition and recipes."""
+    source = stable_leaf_source(alignment_domain, "Root.System.A")
+    formal = expand_macro_step_cases(source)
+
+    by_target_kind = {
+        (case.kind, case.target_state_path): case for case in formal.cases
+    }
+    trap = by_target_kind[("transition", "Root.System.Trap.TrapLeaf")]
+    route_b = next(
+        case
+        for case in formal.success_cases
+        if case.kind == "transition" and case.target_state_path == "Root.System.B"
+    )
+    done = by_target_kind[("transition", "Root.Done")]
+    fallback = by_target_kind[("fallback", "Root.System.A")]
+
+    assert _updates(trap) == {"x": "pre:x + 1420", "y": "pre:y + 1010"}
+    assert _updates(route_b) == {"x": "2 * pre:x + 1007", "y": "pre:y + 1011"}
+    assert _updates(done) == {"x": "pre:x + 11102", "y": "pre:y + 11036"}
+    assert _updates(fallback) == {"x": "pre:x + 1001", "y": "pre:y + 1000"}
+
+    tick = "Root.System.A.Tick"
+    arm = "Root.System.Trap.Arm"
+    expected = [
+        (trap, 0, 0, (tick, arm)),
+        (route_b, 0, 0, (tick,)),
+        (done, 11, 0, (tick,)),
+        (fallback, 0, 0, ()),
+        (fallback, 11, -200, (tick,)),
+    ]
+    for selected, x, y, events in expected:
+        assert _selected_case(formal, x, y, events) is selected
+
+    assert sorted(event.path for event in trap.used_events) == [
+        "Root.System.A.Tick",
+        "Root.System.Trap.Arm",
+    ]
+    assert any(
+        event.path == "Root.System.Trap.Arm" and event.reason == "priority"
+        for event in route_b.used_events
+    )
+
+
+@pytest.mark.unittest
+def test_issue_fixture_stable_leaf_cases_align_with_simulation_runtime(
+    alignment_model,
+    alignment_domain,
+):
+    """Every representative A-source runtime example selects the expected case."""
+    formal = expand_macro_step_cases(
+        stable_leaf_source(alignment_domain, "Root.System.A")
+    )
+    tick = "Root.System.A.Tick"
+    arm = "Root.System.Trap.Arm"
+    examples = [
+        (0, 0, (), "Root.System.A", {"x": 1001, "y": 1000}),
+        (0, 0, (tick, arm), "Root.System.Trap.TrapLeaf", {"x": 1420, "y": 1010}),
+        (0, 0, (tick,), "Root.System.B", {"x": 1007, "y": 1011}),
+        (11, 0, (tick,), "Root.Done", {"x": 11113, "y": 11036}),
+        (11, -200, (tick,), "Root.System.A", {"x": 1012, "y": 800}),
+    ]
+
+    for x, y, events, expected_state, expected_vars in examples:
+        case = _selected_case(formal, x, y, events)
+        runtime_state, runtime_vars = _runtime_after(
+            alignment_model,
+            "Root.System.A",
+            x=x,
+            y=y,
+            events=events,
+        )
+        assert case.target_state_path == expected_state
+        assert runtime_state == expected_state
+        assert runtime_vars == expected_vars
+
+
+@pytest.mark.unittest
+def test_non_stoppable_hot_composite_delta_and_evented_initial_aligns_with_runtime(
+    alignment_model,
+    alignment_domain,
+):
+    """Hot Trap expansion splits Arm success from the semantic diagnostic delta."""
+    source = source_from_initial_spec(
+        alignment_domain,
+        InitialSpec(mode="state", state_path="Root.System.Trap"),
+    )
+    formal = expand_macro_step_cases(source)
+    arm = "Root.System.Trap.Arm"
+
+    success = _selected_case(formal, 0, 0, (arm,))
+    delta = _selected_case(formal, 0, 0, ())
+
+    assert success.kind == "initial"
+    assert success.target_state_path == "Root.System.Trap.TrapLeaf"
+    assert _updates(success) == {"x": "pre:x + 1400", "y": "pre:y + 1000"}
+    assert delta.kind == "delta"
+    assert delta.target_state_id == STATE_DIAGNOSTIC_ID
+    assert _updates(delta) == {"x": "pre:x", "y": "pre:y"}
+
+    runtime_state, runtime_vars = _runtime_after(
+        alignment_model,
+        "Root.System.Trap",
+        events=(arm,),
+    )
+    assert runtime_state == success.target_state_path
+    assert runtime_vars == {"x": 1400, "y": 1000}
+
+    runtime = SimulationRuntime(
+        alignment_model,
+        initial_state="Root.System.Trap",
+        initial_vars={"x": 0, "y": 0},
+    )
+    runtime.cycle([])
+    assert ".".join(runtime.current_state.path) == "Root.System.Trap"
+    assert runtime.vars == {"x": 0, "y": 0}
+
+
+@pytest.mark.unittest
+def test_cold_root_initial_cycle_aligns_with_runtime(alignment_model, alignment_domain):
+    """Cold entry expansion includes root/System initial descent and first during."""
+    formal = expand_macro_step_cases(
+        source_from_initial_spec(alignment_domain, InitialSpec())
+    )
+    case = _selected_case(formal, 0, 0, ())
+
+    assert case.kind == "initial"
+    assert case.target_state_path == "Root.System.A"
+    assert _updates(case) == {"x": "pre:x + 1011", "y": "pre:y + 1001"}
+
+    runtime = SimulationRuntime(alignment_model)
+    runtime.cycle([])
+    assert ".".join(runtime.current_state.path) == "Root.System.A"
+    assert runtime.vars == {"x": 1011, "y": 1001}
+
+
+@pytest.mark.unittest
+def test_pseudo_hot_start_and_parent_continuation_cases(alignment_domain):
+    """Expansion covers pseudo routing and exit-to-parent continuation guards."""
+    source = source_from_initial_spec(
+        alignment_domain,
+        InitialSpec(mode="state", state_path="Root.System.Route"),
+    )
+    formal = expand_macro_step_cases(source)
+
+    to_b = _selected_case(formal, 0, 0, ())
+    to_done = _selected_case(formal, 13, 8, ())
+    delta = _selected_case(formal, 13, 7, ())
+
+    assert to_b.kind == "initial"
+    assert to_b.target_state_path == "Root.System.B"
+    assert _updates(to_b) == {"x": "2 * pre:x + 1003", "y": "pre:y + 1001"}
+    assert to_done.kind == "initial"
+    assert to_done.target_state_path == "Root.Done"
+    assert _updates(to_done) == {"x": "pre:x + 11100", "y": "pre:y + 11026"}
+    assert delta.kind == "delta"
+    assert delta.target_state_id == STATE_DIAGNOSTIC_ID
+
+
+@pytest.mark.unittest
+def test_cold_leaf_root_enters_and_stabilizes_instead_of_terminating():
+    """Cold root leaf expansion follows initialization, not root synthetic exit."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            enter { x = x + 10; }
+            during { x = x + 1; }
+        }
+        """
+    )
+    domain = build_bmc_domain(model, bound=1)
+    formal = expand_macro_step_cases(source_from_initial_spec(domain, InitialSpec()))
+    case = _selected_case(formal, 0, 0, ())
+
+    assert case.kind == "initial"
+    assert case.target_state_path == "Root"
+    assert _updates(case) == {"x": "pre:x + 11"}
+
+    runtime = SimulationRuntime(model)
+    runtime.cycle([])
+    assert ".".join(runtime.current_state.path) == "Root"
+    assert runtime.vars == {"x": 11}
+
+    hot_formal = expand_macro_step_cases(
+        source_from_initial_spec(domain, InitialSpec(mode="state", state_path="Root"))
+    )
+    hot_case = _selected_case(hot_formal, 0, 0, ())
+    assert hot_case.kind == "transition"
+    assert hot_case.target_state_id == STATE_TERMINATE_ID
+    assert hot_case.target_state_path == "__terminate__"
+    assert _updates(hot_case) == {"x": "pre:x"}
+
+    hot_runtime = SimulationRuntime(
+        model,
+        initial_state="Root",
+        initial_vars={"x": 0},
+    )
+    hot_runtime.cycle([])
+    assert hot_runtime.is_ended is True
+    assert hot_runtime.vars == {"x": 0}


### PR DESCRIPTION
## 背景

本 PR 是 [PR #305](https://github.com/HansBug/pyfcstm/pull/305) 伞计划中的 **PR-9：宏步语义展开**，基于已合入伞分支的 PR-8 / [PR #328](https://github.com/HansBug/pyfcstm/pull/328) source/case contract 继续推进。PR-9 的定位是实现 issue #251 中 `expand_macro_step_cases(source)` 的 runtime-aligned semantic kernel；本轮复盘后确认：该 kernel 应输出 **flat control-path plan**，而不是提前完成 solver 写回表达式。

上游状态：

- PR-1 / [PR #315](https://github.com/HansBug/pyfcstm/pull/315) 已合入：`pyfcstm.bmc` query / expression 数据模型。
- PR-2 / [PR #323](https://github.com/HansBug/pyfcstm/pull/323) 已合入：独立 `.fbmcq` ANTLR grammar。
- PR-3 / [PR #326](https://github.com/HansBug/pyfcstm/pull/326) 已合入：`.fbmcq` parser 与 AST 构建。
- PR-5 / [PR #331](https://github.com/HansBug/pyfcstm/pull/331) 已合入：`.fbmcq` 编辑器高亮与文档支持。
- PR-6 / [PR #324](https://github.com/HansBug/pyfcstm/pull/324) 已合入：`BmcDomain`、state/event/var/frame/step/event-input 编号与 sentinel。
- PR-8 / [PR #328](https://github.com/HansBug/pyfcstm/pull/328) 已合入：`MacroStepSource` / macro case / fallback / delta / absorb / partition self-check contract。

当前 PR 之前的实现方向曾经把 action operation symbolic execution 放在 PR-9 内，并输出 `VarUpdate` 字符串表达式。经过与 issue #251 公式设计、`SimulationRuntime` rollback/validation 行为、以及后续 PR-10 relation builder 边界对齐后，本 PR 将重写为更干净的 path-plan contract。本 PR 会同步修正 PR-8 留下的 macro contract，删除旧 writeback truth source，不保留两套相互竞争的 public API。

## 核心设计共识

### 1. Priority mask 排除前序 accepted continuation，而不是 raw trigger / guard

同一 decision point 下 transition / initial transition / parent continuation transition 按 declaration order 尝试。对第 `j` 个候选，靠后的 case 必须排除所有更早候选的 **accepted continuation union**：

```text
accepted_i = raw_event_guard_i
             ∧ continuation_to_stable_or_terminated_i
             ∧ nested_descent_or_parent_continuation_conditions_i

condition_j = not(accepted_0 or ... or accepted_{j-1})
              ∧ raw_event_guard_j
              ∧ continuation_to_stable_or_terminated_j
```

不能写成：

```text
not(raw_event_guard_0 or ... or raw_event_guard_{j-1}) ∧ raw_event_guard_j
```

原因是 `SimulationRuntime` 会先 speculative validation：如果前序 raw event/guard 为真但 continuation 无法稳定落到 stable leaf / terminated，runtime 会 rollback 并继续尝试后序候选或 fallback。因此前序 raw trigger/guard 不应遮蔽后序 accepted path。

该规则同时适用于：

- leaf / composite / parent state 的普通 outgoing transitions；
- composite initial transitions；
- pseudo-route / generated pseudo chain 内部的有序选择；
- child-to-parent exit 后的 `post_child_exit` parent continuation；
- stable leaf fallback 的 accepted-case exclusion。

### 2. Case condition 只表达 control path 条件

`CycleCase.condition` 只允许包含决定 control path 的条件：

- event trigger / event absence when required by fallback exclusion；
- transition guard；
- composite initial / pseudo descent / generated combo / parent continuation guard；
- priority exclusion over earlier accepted paths；
- fallback / delta exclusion over accepted ordinary paths；
- source-local build diagnostic exclusion when issue #251 明确要求。

它 **不包含**：

- source state guard；source guard 由 PR-10 lowering 时形成 `A = source_guard ∧ path_condition`；
- lifecycle/effect/during action block 内部 `IfBlock` 条件；
- lifecycle/effect/during assignment 的 RHS 条件合成；
- 后继 state / variable writeback constraints。

注意：transition guard 语法也写作 `if [cond]`，但它属于 control path 条件；只有 action block 内部的 `IfBlock` 不进入 case condition。例如 pseudo route 的 `Route -> B : if [x < 13]` 必须成为 path condition，不能与 `effect { if (...) { ... } }` 混淆。

### 3. Action block 只记录执行序列，不在 PR-9 中拆分 `IfBlock`

PR-9 只负责枚举 runtime control path，并记录该路径上会按顺序执行哪些 model action block。action block 内部的 `IfBlock` 仍作为 `OperationStatement` 保留在对应 block 里，不拆分 case，不进入 path condition。

后续 PR-10 负责按 block 边界调用现有 solver operation lowering（例如 `execute_operations_domain`）来处理 assignment、temporary local、branch merge 与 Z3 `If(...)` 表达式。这样可以复用现有 `pyfcstm.solver.operation` 的 action semantics，而不是在 macro expander 里维护第二套 operation symbolic executor。

### 4. PR-9 返回 flat cases，不要求 public tree

内部实现可以用 DFS/frontier/worklist 树状搜索来对齐 runtime；public API 返回仍是 flat `MacroStepFormal(success_cases=..., delta_cases=..., build_diagnostic_conditions=...)`。每个 `CycleCase` 是一条完整 accepted control path 或 fallback/absorb/delta path 的 summary，足够 PR-10 构造 `A => R`。

## 本 PR 目标

新增或重写 solver-independent macro-step expander。Public entry 仍以 `MacroStepSource` 为唯一语义入口：

```python
from pyfcstm.bmc import expand_macro_step_cases

formal = expand_macro_step_cases(source)
```

`source` 必须是通过 public constructors 构造出的 domain-backed source；`source.domain` 是展开器使用的权威 domain。若直接手工构造的 `MacroStepSource` 缺少 domain，或额外测试 helper domain 与 `source.domain` 不一致，必须 fail closed 为 `InvalidBmcEncoding` / `BmcBuildError`，不得静默以 side-channel domain 覆盖 source profile。

预期输出仍是 source-local formal buckets：

```python
MacroStepFormal(
    source=source,
    success_cases=(...),
    delta_cases=(...),
    build_diagnostic_conditions=(...),
)
```

但 `CycleCase` contract 将从“含 var_update 的 relation 半成品”调整为“control-path plan”：

- `condition`: source-free path condition；它是 `BoolTemplate` over event atoms + guard-requirement atoms + priority/fallback structural masks，其中每个 guard atom 通过 `GuardRequirement.after_action_block_index` 绑定到 action prefix evaluation point；
- `target_state_id` / `target_state_path`: accepted path 的 stable/terminated/diagnostic target；
- `used_events`: path condition 与 priority/fallback exclusion 实际读取的 full event paths；
- `action_blocks`: runtime 顺序的 action block sequence；
- `guard_requirements`: transition / initial / pseudo / parent continuation guard 的结构化 metadata；这是 PR-10 lower guard atom 的唯一结构化来源，必须带 action-prefix evaluation anchor；
- `priority_exclusions`: 当前 path 排除了哪些前序 accepted path，便于 PR-10/debug/witness 解释；它只是 metadata，不替代 `condition` truth source；
- `failed_conditions` / diagnostic metadata：仅用于解释 validation rejected candidate，不能参与普通 fallback 漏洞填补。

本 PR **必须**移除 PR-8 中不再符合新 contract 的 `VarUpdate` / `build_var_updates` / string-expression writeback API，不能把旧字段保留为 PR-10 可消费的兼容 shim。若实现期需要测试内部 carry helper，它必须是 private helper，且不得进入 root export、canonical schema 或 PR-10 handoff。

## 非目标

本 PR 不做：

- 不构建正式 Z3 `Core_N` / `Phi_N` / `T_N` relation。
- 不把 action `IfBlock` 展开成多个 macro cases。
- 不在 PR-9 内执行完整 symbolic variable writeback。
- 不编译 `.fbmcq` property objective。
- 不接 `pyfcstm.verify.registry`。
- 不实现 witness JSON decode / replay API。
- 不用 solver-time `ExactlyOne` / case selector 修补 case partition。
- 不把 source guard 混入 `CycleCase.condition`。
- 不把 `A` 与 `R` 合并为一个 conjunction；后续 relation builder 必须 lower 为 `Implies(A, R)`。
- 不实现依赖 action 写变量推进的 pseudo self-loop 加速；这类路径在 PR-9 只能 fail closed 为 `BmcBuildError` / build diagnostic，或者在未来独立设计专门的 loop summary。

## 拟新增 / 调整 API

### `pyfcstm.bmc.expand`

- `MacroExpansionOptions`
  - `max_micro_steps: int = 1000`，对齐 runtime cycle 内 micro-step cap；测试必须证明 expander 与 runtime 在 cap 命中时同向 fail closed。
  - `max_stack_depth: int = 64`，对齐 runtime structural stack-depth cap；测试必须证明 expander 与 runtime 在 depth cap 命中时同向 fail closed。
  - `verify_partition: bool = True`，默认执行 source-local structural partition self-check。
  - `partition_max_assignments: int = 4096`，只作为小型 `BoolTemplate` truth-table fallback / regression checker 的 assignment budget；默认 checker 不能因为 issue #251 fixture guard atom 数超过 12 就假 fail-closed。
- `expand_macro_step_cases(source, options=None)`
  - public source-only macro-step expander。
  - 不额外接收 side-channel domain。
  - 默认 fail closed；unsupported / unknown / timeout 不生成普通 success case。

### `pyfcstm.bmc.macro` contract 调整方向

最终 public names 必须稳定、单一且 3.7 兼容；新增 dataclass 使用 `typing.Tuple[...]` / `typing.Optional[...]` 与 `dataclass(frozen=True)`，不得使用 `list[str]`、`X | Y`、`match`、`typing.Self` 等 3.7 不兼容写法。

计划保留 / 新增以下 public 概念：

- `BoolTemplate`: solver-independent path condition recipe；本 PR 不改名。
- `EventUse`: full event path + polarity + reason，覆盖 selected trigger 以及 priority/fallback exclusion 中被读取的事件。
- `GuardRequirement`: transition/initial/pseudo/parent continuation guard 的结构化引用；字段固定见下文。
- `ActionBlock`: 一个 runtime action block 边界。
- `PriorityExclusion`: 当前 path 对前序 accepted path union 的排除记录；字段固定见下文，不允许退化为 raw trigger/guard exclusion。
- `CycleCase`: flat control path summary。
- `MacroStepFormal`: source-local success/delta/diagnostic buckets 与 partition self-check result。

`GuardRequirement` / `PriorityExclusion` / `ActionBlock` 的字段必须固定，防止 PR-9 / PR-10 在 guard evaluation point、priority explanation 和 block boundary 上各自假设。

`GuardRequirement` 的字段必须固定，防止 PR-9 / PR-10 在 guard evaluation point 上各自假设：

```python
@dataclass(frozen=True)
class GuardRequirement:
    requirement_id: str
    owner_state_id: int
    owner_state_path: str
    transition_label: str
    expr: Expr
    polarity: str
    reason: str
    after_action_block_index: int
```

语义约束：

- `requirement_id` 是 `condition` 中 guard atom 的 canonical id；对应 `BoolTemplate.atom` name 固定为 `guard:<requirement_id>`。
- `after_action_block_index` 表示该 guard 在执行完 `case.action_blocks[:index]` 之后、执行 `case.action_blocks[index:]` 之前求值；第一个 transition guard 通常是 `0`，而 pseudo route / parent continuation guard 可能位于若干 exit/effect/enter block 之后。
- `polarity` 白名单为 `"positive"` / `"negative"`；negative guard 只能来自 structural mask / priority / fallback，不改变 raw guard AST 本身。
- `reason` 白名单至少包含 `"transition_guard"`、`"initial_guard"`、`"pseudo_guard"`、`"parent_continuation_guard"`、`"priority"`、`"fallback"`、`"delta_exclusion"`。
- PR-9 不把 guard AST 预代换成 cycle-start expression；PR-10 必须按 `after_action_block_index` interleave action lowering 后再 lower guard expression。

`PriorityExclusion` 的字段也必须固定：

```python
@dataclass(frozen=True)
class PriorityExclusion:
    decision_id: str
    reason: str
    excluded_case_labels: Tuple[str, ...]
    excluded_condition: BoolTemplate
    event_paths: Tuple[str, ...]
    guard_requirement_ids: Tuple[str, ...]
```

语义约束：

- `excluded_condition` 是前序 accepted continuation union 的 structural `BoolTemplate`，只用于 explain/canonical/debug；`CycleCase.condition` 仍是 case path 的 truth source。
- `excluded_condition` 和 `case.condition` 中引用前序 accepted case 时使用 `BoolTemplate.atom("accepted:<case_label>")`，由 PR-10 lowering 层通过跨 case `lowered_case_registry` 解析。
- `excluded_case_labels` 指向被当前 path 排除的更早 accepted path labels，不能指向 raw transition labels。
- `event_paths` 与 `guard_requirement_ids` 是该 exclusion 实际读取的 event/guard atom 集合，用于 witness/debug 和 `used_events` completeness tests。

`ActionBlock` 的设计必须明确 block boundary，不能把多个 lifecycle/effect/during block flatten 成一个 operation list：

```python
@dataclass(frozen=True)
class ActionBlock:
    block_kind: str
    runtime_role: str
    owner_state_id: int
    owner_state_path: str
    operations: Tuple[OperationStatement, ...]
    action_name: Optional[str] = None
    transition_label: Optional[str] = None
    is_abstract: bool = False
```

`block_kind` 白名单：

- `"state_action"`：`enter` / `during` / `exit` concrete or abstract action；
- `"aspect_action"`：`>> during before/after` action；
- `"transition_effect"`：ordinary / initial / pseudo / parent continuation transition effect。

`runtime_role` 白名单至少覆盖：

- `"state_enter"`
- `"state_exit"`
- `"leaf_during"`
- `"plain_during_before"`
- `"plain_during_after"`
- `"aspect_during_before"`
- `"aspect_during_after"`
- `"transition_effect"`

若实现期发现 runtime 需要区分更多角色，必须更新白名单、pydoc、canonical tests 与本 PR body。每个 lifecycle/effect/during source block 都必须生成独立 `ActionBlock`；即使两个相邻 block 的 `operations` 都很短，也不能合并。abstract action 首轮对 vars 是 no-op，但可以用 `is_abstract=True` 记录 occurrence，供 future `Called(...)` / witness explain 使用；PR-10 首轮不得把 abstract action 当作可写变量的 block。

`CycleCase` 必须新增：

```python
action_blocks: Tuple[ActionBlock, ...]
```

并移除：

```python
var_update: Tuple[VarUpdate, ...]
```

### 强制移除 / 改名的旧 API

本 PR 必须从 public root export、canonical schema、pydoc/RST 和 tests 中移除：

- `VarUpdate`
- `carry_var_updates`
- `var_update_for`
- `build_var_updates`

`CycleCase.to_canonical()` / `MacroStepFormal.to_canonical()` 不再输出 `var_update` key。旧 `case_antecedent_condition(case)` 若保留，必须改为 `case_path_condition(case)`，并且语义只是 `case.condition` alias；不得拼 source guard、target state 或 writeback。更推荐本 PR 直接删除旧名，避免误导 PR-10 作者。

`pyfcstm.bmc.__init__` 的 module docstring 表格、lazy export sets 与 `__all__` 必须同步到新 contract。`test/bmc/test_bmc_public_api.py` 必须显式断言旧 public 名字不再可从 `pyfcstm.bmc` 导入，最终 canonical `CycleCase` 不得同时暴露 `var_update` 与 `action_blocks` 两套事实源。

## `BoolTemplate` atom namespace

`BoolTemplate` 仍保持 solver-independent string atom，但 PR-9 必须固定 atom namespace，避免 PR-10 猜测：

- `event:<full_event_path>`：event input atom，由 PR-10 用 `event_input_i` substitution。
- `guard:<requirement_id>`：guard-requirement atom，由 PR-10 用 `GuardRequirement.after_action_block_index` interleaving 后得到的 `guard_terms[requirement_id]` substitution。
- `accepted:<case_label>`：前序 accepted continuation / accepted path atom，只能出现在 priority / fallback / delta structural masks 中，由 PR-10 用跨 case `lowered_case_registry[case_label]` substitution。

其它 atom prefix 必须 fail closed 为 `InvalidBmcEncoding` / `BmcBuildError`，不得 silently 当作 opaque true/false。`condition.variables` / canonical dump / partition checker 均使用这些 canonical atom names。

## Partition self-check 设计

PR-9 不依赖 solver-time `ExactlyOne` / disjunction 来修补 partition。默认 self-check 改为 structural-by-construction：

```text
case_0 = accepted_0
case_1 = not(accepted_0) ∧ accepted_1
case_2 = not(accepted_0 ∨ accepted_1) ∧ accepted_2
fallback = not(accepted_0 ∨ accepted_1 ∨ accepted_2)
```

在这种 canonical mask 形态下，pairwise disjointness 与 completeness 对任意 `accepted_i` 语义都成立，不需要枚举所有 guard/event atom。嵌套 decision point 必须在返回 accepted path 时保留同构 mask metadata；outer decision 再用这些 accepted path union 做 priority exclusion。

`partition_max_assignments` 只作为小型 `BoolTemplate` truth-table fallback / regression checker。若 structural checker 无法识别 case 形态且 atom 数超过 budget，才 fail closed 为 `BmcBuildError`；issue #251 fixture 不得因为 path atom 数超过 12 而假 fail-closed。验收必须包含 >12 guard/event atom 的 structural partition regression。

`MacroStepFormal.build_diagnostic_conditions` 仍是 bare `Tuple[BoolTemplate, ...]`，不是 `CycleCase(kind="diagnostic")`；body、pydoc 与 canonical schema 必须避免它和 semantic diagnostic sentinel case 混淆。

## `used_events` 定义

`used_events` 是 control-path event input 的解释集合，不从 action assignment RHS 的普通 `UFunc` 数学调用推导。它必须等于：

```text
selected trigger event atoms
∪ event atoms inside current accepted path continuation
∪ event atoms inside priority exclusion accepted-path union
∪ event atoms inside fallback / delta exclusion accepted-path union
```

所有 event 使用 `Event.path_name` / domain full path 作为 canonical key。same-short-name events 必须保持区分。若未来 DSL 允许 action block 直接读取 event input，PR-10 operation lowering 需要单独定义 action event-read semantics；本 PR 不把 action operations 当作 event selector。

## Pseudo route / loop 处理

Pseudo state 不是 stable boundary。PR-9 必须支持 issue #251 fixture 中的普通 pseudo route / generated combo pseudo chain：pseudo outgoing transition guard 属于 control path condition，transition effect 属于 `ActionBlock(block_kind="transition_effect")`。

本 PR 不复用旧 `_Store` / `_ValueTemplate` 来判断 pseudo loop 或产生 writeback。若要支持窄模式 pseudo loop summary，只能基于 transition guard AST 和 structural path metadata；不得依赖 action symbolic execution。依赖 transition effect 修改变量才能终止的 pseudo self-loop，本 PR 默认 fail closed 为 `BmcBuildError` / build diagnostic，并在测试中覆盖“不会 silently 生成错误 ordinary case”。

## Guard evaluation anchor 设计

本 PR 选择 **raw guard + sequencing anchor** 方案，而不是在 PR-9 中把 guard expression 预代换成 cycle-start expression。

原因：issue #251 fixture 中同一个 raw guard `x < 13` 在不同 source/path 上语义不同：

- stable leaf `Root.System.A -> Route` 先执行 `effect { x = x + 2; }`，随后 Route guard `x < 13` 对 cycle-start 变量等价于 `x_i < 11`；
- hot `Root.System.Route` 没有前缀 effect，同一个 Route guard 对 cycle-start 变量仍是 `x_0 < 13`。

因此 `case.condition` 不把 guard atom 当作可直接用 `vars_i` lower 的 raw expression；它只引用 `GuardRequirement.requirement_id`。PR-10 lowering 必须按 `GuardRequirement.after_action_block_index` 把 guard 放在对应 action prefix 后求值。这样 PR-9 不需要重新实现 `_Store` / `_ValueTemplate` 式 variable writeback，也不会把 action `IfBlock` 拆进 condition；PR-10 仍可复用 `execute_operations_domain` 统一处理 assignments、local temporaries、definedness 与 branch merge。PR-10 可把已 lower 的 prefix guard/event terms 作为 `path_conditions` 传入 operation lowering 做剪枝，但 correctness 不能依赖剪枝。

验收必须包含：

- stable `A -> Route effect { x = x + 2; }` 后 Route guard `x < 13` 的 guard requirement anchor 大于 0；test-only lowering 得到 `x_i < 11`；
- hot `Route` 同一 raw guard 的 anchor 为 0；test-only lowering 得到 `x_0 < 13`；
- parent continuation guard after `Route -> [*] effect { y = y + 20; }` 的 anchor 位于该 transition effect 之后；test-only lowering 能得到 issue #251 表中的 `y_i >= -2` / hot `y_0 >= 8` 边界。

## 后续 PR-10 如何消费本 PR API

PR-10 relation lowering 预期只做以下事情，不重新解释 runtime transition order：

```python
lowered_case_registry = {}

for case in expand_macro_step_cases(source).success_cases:
    source_guard = lower_source_guard(source, frame_i)
    env = persistent_var_env(frame_i)
    guard_terms = {}
    diagnostics = []

    requirements_by_anchor = group_guard_requirements(case.guard_requirements)

    for action_index in range(len(case.action_blocks) + 1):
        for requirement in requirements_by_anchor.get(action_index, ()):
            guard_terms[requirement.requirement_id] = lower_guard_requirement(
                requirement,
                env,
                path_conditions=(source_guard,),
            )

        if action_index == len(case.action_blocks):
            break

        action_block = case.action_blocks[action_index]
        execution = execute_operations_domain(
            list(action_block.operations),
            env,
            path_conditions=tuple(prefix_path_conditions(source_guard, guard_terms, action_index)),
            source=operation_source_for(case, action_block),
            timeout_ms=operation_timeout_ms,
        )
        if execution.failure is not None:
            diagnostics.append(
                operation_failure_diagnostic(case, action_block, execution.failure)
            )
        diagnostics.extend(execution.definedness_constraints)
        env = {
            name: execution.env[name]
            for name in persistent_var_names
            if name in execution.env
        }

    path_condition = evaluate_case_condition(
        case.condition,
        event_input_i,
        guard_terms,
        lowered_case_registry,
    )
    A = source_guard & path_condition

    R = state_next == case.target_state_id
    for var in domain.vars:
        R &= var_next[var] == env.get(var.name, var_pre[var])

    clauses.append(Implies(A, R))
    lowered_case_registry[case.label] = path_condition
```

重要边界：

- `A` 是 source guard 与 case path condition 的 conjunction。
- `R` 是 target state 与 normalized writeback constraints。
- 最终是 `Implies(A, R)`，不是 `And(A, R)`。
- action `IfBlock` 在 `execute_operations_domain` 内变成 Z3 `If(...)` / merged branch value，不增加 macro cases。
- `execute_operations_domain` 当前真实输出是 `OperationExecution.env`、`definedness_constraints`、`expr_constraints`、`branches`、`failure`；PR-10 若需要更高层 `persistent_values` / diagnostics，必须在 PR-10 新增 adapter，不得把虚构 API 写进 PR-9 contract。
- 每个 action block 后只把 persistent vars 传给下一 block，防止 block-local temporary 泄漏。
- Guard lowering 必须通过 `GuardRequirement.after_action_block_index` 交错到 action prefix 之后；PR-10 不得把 raw guard 全部按 cycle-start `vars_i` 一次性 lower。
- `evaluate_case_condition`、`prefix_path_conditions`、`lowered_case_registry` 都属于 PR-10 private lowering helper，不是 PR-9 public API；PR-9 只负责提供 `condition`、`guard_requirements`、`priority_exclusions` 和 `action_blocks`。
- priority/fallback/delta mask 中的 `accepted:<case_label>` 必须通过 `lowered_case_registry` 解析，避免每个 case 只用本地 `guard_terms` 时无法 lower 前序 accepted continuation。

## Runtime alignment 计划

实现上不直接调用 `SimulationRuntime` 私有方法作为 production expander；production expander 必须是 symbolic frontier/worklist builder。但测试必须把 `SimulationRuntime` 作为 oracle。

BMC 专用 fixture 必须自包含地落在 `test/bmc/fixtures/` 或 `test/bmc/` 内的 checked-in literal/file 中，不能从 issue、docs、其它测试树或 jsfcstm 目录读取。issue #251 代表 fixture 的每一行 stable leaf / hot entry table 都必须同时经过：

1. expander selected-case / action-block metadata 检查；
2. `SimulationRuntime.cycle()` replay oracle；
3. test-only concrete action-block evaluator，用于验证 `action_blocks` 顺序足以复现 post persistent vars；
4. expected table golden。

三者必须断言 pre/post state、persistent vars、selected case label、used event full paths、case kind、action block order、fallback/absorb/delta/diagnostic 分类一致。若 issue 表格和当前 runtime 真实行为不一致，先停止并修订 PR body / 伞 PR说明，不允许直接按表格硬写实现。

### 结构对齐

PR-9 symbolic helper 应逐项对应 runtime 路径：

| PR-9 helper | Runtime oracle | 对齐语义 |
|---|---|---|
| source -> initial frontier | hot-start stack / root cold entry behavior | stable leaf hot start 与 recurrence 同构；entry source 处理 cold/composite/pseudo/non-stoppable。 |
| leaf active expansion | `_select_transition` + `_run_leaf_during` | leaf active 先尝试 accepted transition；没有 accepted transition 才 during fallback。 |
| ordered candidate expansion | `_select_transition` | declaration order；validation rejected 后继续后序 candidate；priority mask 使用 accepted continuation。 |
| composite initial expansion | `_attempt_init_transition` | init transitions declaration order；validation rejected 后继续后序 initial transition。 |
| transition execution expansion | `_execute_transition_on_context` | source exit、transition effect、target enter、pseudo/composite/exit-to-parent continuation。 |
| validation search / frontier loop | `_run_cycle_on_context` / `_validation_search_reaches_stable` | 到 stable leaf / terminated 为 ordinary outcome；无法 stable 的 candidate 是 failed metadata；depth/step cap 是 build diagnostic。 |
| parent continuation | `_finalize_exit_to_parent` + `post_child_exit` branch | child -> `[*]` 后 parent during after，再考虑 parent-level transitions。 |
| action block recording | lifecycle/effect/during concrete action execution order | 记录 block 边界和 operation tuple，不执行 action `IfBlock` 分支拆分。 |

### 行为对齐

新增 BMC 专用 runtime alignment fixture，不依赖其它测试树。代表性 fixture 直接来自 issue #251，包括 root aspect、composite during before/after、leaf during、exit、transition effect、composite initial、pseudo route、exit-to-parent、parent continuation、event trigger、validation skip 与 rollback fallback。

测试必须同时断言：

- selected case label；
- source / target state path；
- case kind 与 `is_diagnostic`；
- path condition 只包含 control requirements；
- pseudo/generated transition guard 进入 condition；
- action `IfBlock` 不拆分 case、不进入 condition；
- action block order、role enum 与 block boundary；
- concrete action-block replay post vars 与 `SimulationRuntime` 完全一致；
- used event full paths；
- hot stable leaf initial vs recurrence normalized equality；
- fallback / absorb / delta classification。

## 重点语义要求

### 1. Fallback 不是 no-op stutter

stable leaf source 没有 accepted transition 时，fallback 必须执行 runtime leaf during chain：ancestor `>> during before`、leaf `during`、ancestor `>> during after`。PR-9 不直接输出最终 var update，但必须在 `action_blocks` 中记录这些 block；test-only evaluator 必须证明它们能复现 runtime post vars。

Fallback condition 的 canonical 形式是：

```text
fallback = not(accepted_0 or ... or accepted_{k-1})
```

其中每个 `accepted_i` 都是完整 accepted continuation，不是 raw trigger/guard。

### 2. Non-stoppable entry uncovered 才进入 semantic delta

- `entry` source uncovered ordinary region 可进入 diagnostic sentinel `$\delta$`。
- `stable_leaf` recurrence / hot stable source 不生成 semantic delta；如果展开遇到 unsupported / unknown / timeout，应走 `BmcBuildError` / build diagnostic，而不是 ordinary `$\delta$`。
- `terminated` / `diagnostic` source 使用 ordinary absorb `CycleCase`，且 `action_blocks == ()`。

### 3. Action block boundaries must be preserved

每个 lifecycle/effect/during block 必须作为独立 `ActionBlock` 进入 case。不能把多个 block flatten 成一个 operation list，因为 concrete block-local temporary variable 只能在同一 block 内读取，不能跨 block 泄漏。

### 4. Build diagnostic / semantic delta / failed candidate 不得混淆

- `failed_conditions` 只解释某个 candidate raw trigger/guard 为真但 continuation validation failed；它不能从 fallback uncovered region 中扣掉。
- semantic delta 只代表 issue #251 允许的 non-stoppable entry uncovered ordinary region。
- unsupported operation、无法安全表达的 guard、partition unknown、step/depth cap 超限应 fail closed 为 `BmcBuildError` 或 build diagnostic，不得伪装成普通 fallback/delta case。PR-9 首轮只要求 fail-closed 与 reason text 可观察，不强制细分 diagnostic subclass；PR-10 / health gate 可在后续细化 reason enum。

## 覆盖 hardening 追踪

当前 coverage audit 发现，`pyfcstm.bmc.macro` / `pyfcstm.bmc.expand` 的未覆盖行不能笼统归类为“防御分支”。本 PR 在进入最终 ready 前会按 [coverage hardening comment](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883652329) 执行：

- 补齐真实 macro-step 展开场景：sentinel absorb、root entry、nested composite entry、literal boolean guard、failed initial / parent continuation delta、exit-to-terminate、pseudo exit pending 清理、lifecycle `ref`、空 concrete action。
- 补齐 partition / accepted-mask 核心算法场景：sentinel structural partition、fallback / delta structural positive and negative cases、diagnostic bucket、accepted atom unknown/cycle。
- 补齐 public API contract validation 负例。
- 清理 dead helper 与深层 invariant 分支，避免用 corrupt model 测试伪造覆盖率。

该 comment 是本轮 coverage hardening 的权威任务清单；后续 commit、local coverage 和 multi-agent review 必须对照该清单确认无 C/I 缺口。


### 最新复审 follow-up hardening

Latest review 后剩余的 sentinel purity 直接测试缺口、fallback `PriorityExclusion.guard_requirement_ids` metadata 语义说明、以及 sentinel validator fail-fast 口径，统一记录在 [follow-up hardening comment](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883829127)。本 PR 后续 commit 和 reviewer 复审必须确认该 comment 中 I-1 / I-2 已完成，M-1 无阻塞残留。 codex/claude 复审后追加发现的 sentinel diagnostics `python -O` fail-closed 漏洞已在 [fix update comment](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883885849) 中记录并由 commit `2db50660` 修复。

### Coverage / abstract-action hardening follow-up

当前 `macro.py` / `expand.py` 剩余未覆盖行、内部 invariant 异常口径、以及多 lifecycle action / abstract action 补测计划，已在 [coverage / abstract-action hardening comment](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4885159088) 逐行记录；最新实现与本地验证结果记录在 [internal error issue-link update](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4885269946)。本 PR 后续实现、local coverage、CI 与 multi-agent review 必须对照这些 comment 确认：public validation 与真实语义场景用测试覆盖；纯内部 invariant 改为显式 internal error，报错信息带 `https://github.com/HansBug/pyfcstm/issues`，且只在确认不可达后 `# pragma: no cover`；abstract action 保留为 `ActionBlock(is_abstract=True, operations=())` 的 no-op occurrence。

## TDD / 验收测试计划

计划重写 / 新增：

- `test/bmc/test_macro_expansion.py`
- `test/bmc/test_macro_runtime_alignment.py`
- `test/bmc/test_macro_contract.py`
- `test/bmc/test_bmc_public_api.py`
- `test/bmc/fixtures/` 下 checked-in FCSTM fixture（或等价 test-tree literal）。

测试总则：issue #251 stable leaf table 与 hot entry table 的每个代表行必须由 `SimulationRuntime.cycle()` replay oracle 验证，不能只做静态 golden 对比；所有 fixture 和 expected data 必须位于 Python `test/` tree 内。

最低测试集：

1. source dispatch：entry / stable_leaf / terminated / diagnostic 都返回合法 `MacroStepFormal`。
1. sentinel absorb：terminated / diagnostic self-loop，ordinary `CycleCase`，`action_blocks == ()`。
1. hot stable leaf：`origin="initial"` 与 `origin="recurrence"` 通过 semantic canonical helper 归一化后 cases 一致。
1. priority hostile：同 source 两个 guards 同时为真，只选择 declaration order 靠前且 validation accepted 的 transition。
1. validation hostile：前序 event/guard 为真但 continuation validation failed 时，后序 transition 仍可选；若无后序 accepted，则 fallback 覆盖该区域。
1. accepted-priority hostile：构造“前序 raw trigger true 但 continuation failed、后序 raw trigger true 且 accepted”的模型，断言后序 condition 不被前序 raw trigger 排除。
1. action-if hostile：transition effect / lifecycle action 中含 `IfBlock`，断言 macro case 数量不随 action `IfBlock` 增加，case condition 不含 action-if guard，test-only action replay 与 runtime post vars 一致。
1. guard anchor hostile：覆盖 `A -> Route effect { x = x + 2; }` 后 `Route -> B : if [x < 13]`，断言 stable source 的 Route guard anchor 位于 effect block 之后且 test-only lowering 得到 `x_i < 11`；hot Route 同一 raw guard anchor 为 0 且得到 `x_0 < 13`。
1. parent continuation guard anchor：覆盖 `Route -> [*] effect { y = y + 20; }` 后 `System -> Done : if [y >= 30]`，断言 parent continuation guard anchor 位于 prefix effect 之后，test-only lowering 得到 issue #251 表中的 `y_i >= -2` / hot `y_0 >= 8`。
1. action block shape：构造跨 `enter` / `during` / `effect` / `exit` / aspect 的多 block 模型，断言 `ActionBlock.block_kind`、`runtime_role`、`owner_state_path`、`operations` 与源码/runtime order 一一对应。
1. action ref resolution：`ref` action 必须按 `SimulationRuntime._execute_func` 解析到实际 concrete/abstract block；missing/cyclic ref fail closed，不能记录为空 operations 后静默通过。
1. block-local hostile：两个 consecutive action blocks 使用同名 temporary，断言 block boundary preserved 且 test-only replay 不泄漏 temporary。
1. initial priority：composite initial transitions 也按 accepted continuation priority mask。
1. issue #251 fixture stable leaf table：覆盖 `Root.System.A` 的 `Tick+Arm`、`Tick only x=0`、`Tick only x=11,y=0`、`Tick only x=11,y=-200`、no event fallback。
1. issue #251 fixture hot entry table：hot `Root.System.Trap` with/without `Arm`、hot `Root.System.Route` 三分支、hot `Root.Done` 不重放 `Done.enter`。
1. `post_child_exit` parent continuation：显式覆盖 `Route -> [*] -> System -> Done` 完整 chain。
1. cold root 初始 cycle：对齐 `SimulationRuntime.cycle()` 首次执行，覆盖 root/System initial descent、plain before 与 leaf during。
1. combo trigger / generated pseudo：覆盖 model 展开后的 generated pseudo / transition 语义进入 case expansion 与 replay fixture。
1. route depth limit 64 与 max micro steps 1000：构造 cap/loop 反例，断言 expander 与 runtime 同向 fail closed，且不生成 semantic delta 或普通 fallback。
1. fallback during chain：fallback action blocks 与 concrete replay post vars 完全一致，不是 no-op carry。
1. event paths：used events 为 full path，覆盖 same-short-name event 混淆；另加 hostile test 断言 priority/fallback 中被读取但未最终 selected 的前序 event full path 也进入 `used_events`。
1. transitive used events：嵌套 accepted continuation 中读取的 event 也必须进入后序 priority/fallback exclusion 的 `used_events`。
1. BoolTemplate atom namespace：断言 event / guard / accepted 三类 atom 分别使用 `event:`、`guard:`、`accepted:` prefix，未知 prefix fail closed。
1. lowered-case registry：构造 later transition / fallback condition 含 `accepted:<earlier_label>` 的 fixture，test-only lowering 必须通过 registry 展开前序 accepted condition，不能只看当前 case 的 `guard_terms`。
1. structural partition self-check：构造 overlap/gap/错误 mask 反例，断言 source-local self-check 被调用且 fail closed。
1. partition scale regression：构造 `>max(12, fixture_max_atom_count)` guard/event atom 的 accepted-path union，断言 structural checker 不因 `partition_max_assignments=4096` 假 fail-closed。
1. pseudo loop unsupported：依赖 action effect 推进才能退出的 pseudo self-loop 不得 silently 生成 ordinary case，必须 build diagnostic / `BmcBuildError`。
1. import isolation：`pyfcstm.bmc.expand` / root import 不加载 `z3` 或 `pyfcstm.verify.registry`，除非局部 partition prover 明确、隔离、只在 build-time self-check 使用。
1. public API exact export：root exports、module docstring roadmap、RST 与 new macro contract 一致；`VarUpdate` / `build_var_updates` 等旧 public 名字不可从 `pyfcstm.bmc` 导入，canonical `CycleCase` 不包含 `var_update`。
1. Python 3.7 syntax compatibility：新增 `pyfcstm/bmc` 与 `test/bmc` 代码不得使用 3.8+/3.10+ only 语法；优先通过 CI 3.7 matrix，必要时本地用可用 Python 3.7 运行 `py_compile`。
1. RST export coverage：`make rst_auto RANGE_DIR=bmc` 后新增 public dataclass 出现在对应 API RST 与 `docs/source/api_doc/bmc/index.rst` 中。
## 本地验证计划

设计确认后，开发完成前至少运行：

```bash
make rst_auto RANGE_DIR=bmc
python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py
python -m doctest pyfcstm/bmc/macro.py pyfcstm/bmc/expand.py
ruff check pyfcstm/bmc test/bmc --exclude pyfcstm/bmc/grammar
ruff format --check pyfcstm/bmc test/bmc
SKIP_SLOW_TESTS=1 pytest test/bmc/test_macro_contract.py test/bmc/test_macro_expansion.py test/bmc/test_macro_runtime_alignment.py test/bmc/test_bmc_public_api.py -q
SKIP_SLOW_TESTS=1 pytest test/bmc -q --maxfail=1
make test_boundary_check
SKIP_SLOW_TESTS=1 make unittest
```

Commit message 继续带 `[skip-slow]`，避免无谓拖慢 CI。

## 设计 review 修订记录

本 body 已回应三路 reviewer 的第一轮阻塞意见：

- [claude reviewer](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883050636)：强制删除旧 `VarUpdate` truth source；把 partition checker 改为 structural-by-construction，truth-table 只做小型 fallback；补 `ActionBlock` role、used_events、cap 同向 fail、3.7 兼容与 public export 要求。
- [codex reviewer](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883051147)：修正 PR-10 handoff 伪码，对齐当前 `execute_operations_domain` signature 与 `OperationExecution` 字段；明确 failure / definedness / persistent env 边界。
- [deepseek reviewer](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883053865)：补 `ActionBlock` dataclass 形状；强制移除 `VarUpdate`；明确 pseudo guard 与 action `IfBlock` 分界；补 pseudo loop `_Store` 替代策略、action block shape test、used_events 定义与 RST/API 验收。


第二轮 review 后，本 body 继续回应 [claude reviewer 第二轮意见](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883093197)：选择 raw guard + sequencing anchor 方案；补 `GuardRequirement.after_action_block_index`、`PriorityExclusion` 固定字段、PR-10 interleaving lowering 伪码，以及 issue #251 `x_i < 11` / hot `x_0 < 13` / parent continuation guard anchor 验收项。

第三轮 review 后，本 body 继续回应 [deepseek reviewer 第三轮意见](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4883121033)：固定 `BoolTemplate` atom namespace（`event:` / `guard:` / `accepted:`）；PR-10 伪码增加跨 case `lowered_case_registry`；补 unknown atom fail-closed、registry lowering test、动态 atom-count regression 与 build diagnostic reason 口径。

## Review 重点

请 reviewer 强对抗检查：

- 新 body 是否彻底移除了“PR-9 提前执行 action / 输出 var_update 字符串”的旧 truth source。
- `condition` 是否只包含 transition/control path 条件，是否明确排除 action `IfBlock`。
- priority mask 是否明确使用 accepted continuation，而不是 raw trigger / guard。
- `ActionBlock` / `action_blocks` 是否足够让 PR-10 复用 `solver.operation`，且保留 block-local scope。
- `GuardRequirement.after_action_block_index` 是否足以表达 action-modified guard evaluation，是否能覆盖 issue #251 的 `x_i < 11` / hot `x_0 < 13` 差异。
- `BoolTemplate` atom namespace 与 `lowered_case_registry` 是否足以 lower priority/fallback 中的前序 accepted path。
- structural partition self-check 是否能避免 truth-table atom cap 假失败，同时不把漏洞留给 PR-10 solver-time constraints。
- PR-10 lowering 边界是否足够清楚：`A = source_guard ∧ path_condition`，`R = target state ∧ normalized writeback`，最终 `Implies(A, R)`。
- runtime alignment 测试是否足够严格，是否能防止 witness replay mismatch。
- fallback during chain 是否被列为 blocker。
- build diagnostic / semantic delta / failed candidate 是否有混淆风险。
- import isolation / no verify registry / no root z3 load 是否仍能保持。
- 是否存在把 bug 留给 PR-10、只在后续 solver 里“补洞”的风险。







## 最新 root-leaf termination / issue-link follow-up

codex reviewer 发现合法最小模型 `state Root;` 的 root leaf exit-to-terminate 被误判为 internal error；该问题已在 commit `9447e2c7` 修复并在 [root leaf termination fix update](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4885323175) 记录。本轮同时补齐 Codecov 指出的 `pyfcstm/bmc/domain.py:701` validation 覆盖缺口，并再次确认 BMC internal bug 报错信息包含 `https://github.com/HansBug/pyfcstm/issues`，提示用户携带 FCSTM input、BMC query / expansion source 与 traceback 到 repo issue 页面开票。


## 最新 internal bug report 文案 follow-up

为回应 reviewer 对 expansion source 报错口径的建议，commit `eb1f0e28` 已将 BMC internal bug 报错统一为提示用户携带 FCSTM input、BMC query 或 expansion source、traceback 到 `https://github.com/HansBug/pyfcstm/issues` 开 issue；实现与验证记录见 [internal bug report wording update](https://github.com/HansBug/pyfcstm/pull/335#issuecomment-4885359773)。
