### PR TITLE
内核入口：建立 BMC 引擎原型

### DIFF
--- a/docs/source/api_doc/bmc/engine.rst
+++ b/docs/source/api_doc/bmc/engine.rst
@@ -1,0 +1,39 @@
+pyfcstm.bmc.engine
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.engine
+
+.. automodule:: pyfcstm.bmc.engine
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+BmcOptions
+-----------------------------------------------------
+
+.. autoclass:: BmcOptions
+    :members: __post_init__,to_canonical,max_bound
+
+
+BmcPreparedContext
+-----------------------------------------------------
+
+.. autoclass:: BmcPreparedContext
+    :members: __post_init__,bound,references,to_canonical,model,query,bound_query,domain,options,source_text
+
+
+BmcEngine
+-----------------------------------------------------
+
+.. autoclass:: BmcEngine
+    :members: __init__,model,options,prepare
+
+
+prepare\_bmc\_query
+-----------------------------------------------------
+
+.. autofunction:: prepare_bmc_query

--- a/docs/source/api_doc/bmc/index.rst
+++ b/docs/source/api_doc/bmc/index.rst
@@ -12,6 +12,7 @@ pyfcstm.bmc
     ast
     binding
     domain
+    engine
     errors
     grammar/index
     listener

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -13,6 +13,8 @@ Package contracts:
   separate from model-aware binding or solver lowering.
 * Domain-numbering and macro-step exports are resolved lazily so parser-only
   imports do not load ``pyfcstm.model``.
+* Engine exports are resolved lazily; importing :mod:`pyfcstm.bmc` does not
+  prepare queries or load model-aware engine modules.
 * Macro-step contracts are solver-independent and do not import ``z3`` from the
   root package.
 * The root package must not depend on ``pyfcstm.verify`` or its registry.
@@ -93,6 +95,11 @@ Public module structure:
        :func:`verify_boolean_partition`, :func:`verify_source_partition`
      - Construct carry, absorb, fallback, and semantic-delta cases while keeping
        partition self-checks outside formal trace formulas.
+   * - BMC engine preparation
+     - :class:`BmcOptions`, :class:`BmcPreparedContext`,
+       :class:`BmcEngine`, :func:`prepare_bmc_query`
+     - Prepare ``StateMachine + .fbmcq`` inputs into bound query and domain
+       context without solver, witness, CLI, or verify-registry coupling.
    * - Query root model
      - :class:`InitialSpec`, :class:`BmcAssumption`,
        :class:`FrameAssumption`, :class:`EventAssumption`,
@@ -214,22 +221,30 @@ _MACRO_EXPORTS = {
     "verify_source_partition",
 }
 
+_ENGINE_EXPORTS = {
+    "BmcOptions",
+    "BmcPreparedContext",
+    "BmcEngine",
+    "prepare_bmc_query",
+}
+
 _LAZY_EXPORT_MODULES = {
     "pyfcstm.bmc.binding": _BINDING_EXPORTS,
     "pyfcstm.bmc.domain": _DOMAIN_EXPORTS,
     "pyfcstm.bmc.source": _SOURCE_EXPORTS,
     "pyfcstm.bmc.macro": _MACRO_EXPORTS,
+    "pyfcstm.bmc.engine": _ENGINE_EXPORTS,
 }
 
 
 def __getattr__(name: str):
-    """Lazily resolve model-aware binding, domain, and macro-step exports.
+    """Lazily resolve model-aware binding, domain, macro-step, and engine exports.
 
-    Binding, domain numbering, and macro-step helpers are kept behind lazy
-    exports so parser-only callers can import :mod:`pyfcstm.bmc` without
-    loading model-aware or later BMC layers. This preserves the convenience API
-    while keeping parse/query data structures independent from solver and
-    verify-registry wiring.
+    Binding, domain numbering, macro-step helpers, and the preparation engine
+    are kept behind lazy exports so parser-only callers can import
+    :mod:`pyfcstm.bmc` without loading model-aware or later BMC layers. This
+    preserves the convenience API while keeping parse/query data structures
+    independent from solver and verify-registry wiring.
 
     :param name: Attribute name requested from :mod:`pyfcstm.bmc`.
     :type name: str
@@ -273,6 +288,7 @@ def __dir__():
         | _DOMAIN_EXPORTS
         | _SOURCE_EXPORTS
         | _MACRO_EXPORTS
+        | _ENGINE_EXPORTS
     )
 
 
@@ -361,4 +377,8 @@ __all__ = [
     "build_semantic_delta_case",
     "verify_boolean_partition",
     "verify_source_partition",
+    "BmcOptions",
+    "BmcPreparedContext",
+    "BmcEngine",
+    "prepare_bmc_query",
 ]

--- a/pyfcstm/bmc/engine.py
+++ b/pyfcstm/bmc/engine.py
@@ -1,0 +1,418 @@
+"""Preparation engine for FCSTM bounded model checking queries.
+
+The engine layer is the first BMC handoff point that combines a
+:class:`pyfcstm.model.StateMachine` with a parser-independent
+:class:`pyfcstm.bmc.query.BmcQuery`.  It parses query text when necessary,
+performs structure-only binding before any domain construction, builds the
+bounded domain, resolves query references against that domain, and returns a
+JSON-stable preparation context.
+
+This module is intentionally a preparation layer only.  It does not expand
+macro-step cases, lower formulas to Z3, compile property objectives, decode
+witnesses, expose CLI commands, or register anything under
+:mod:`pyfcstm.verify`.
+
+The module contains:
+
+* :class:`BmcOptions` - Prepare-time policy options.
+* :class:`BmcPreparedContext` - Prepared query/domain handoff data.
+* :class:`BmcEngine` - Reusable model-bound preparation entry point.
+* :func:`prepare_bmc_query` - Function-style convenience API.
+
+Example::
+
+    >>> from pyfcstm.bmc.engine import BmcEngine
+    >>> from pyfcstm.model import load_state_machine_from_text
+    >>> model = load_state_machine_from_text('state Root;')
+    >>> context = BmcEngine(model).prepare('check reach <= 1: active("Root");')
+    >>> context.bound
+    1
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple, Union
+
+from pyfcstm.bmc.binding import (
+    BoundBmcQuery,
+    BoundReference,
+    bind_bmc_query,
+    bind_bmc_query_structure,
+)
+from pyfcstm.bmc.domain import BmcDomain, build_bmc_domain
+from pyfcstm.bmc.errors import BmcBuildError
+from pyfcstm.bmc.parse import parse_bmc_query
+from pyfcstm.bmc.query import BmcQuery
+from pyfcstm.model import StateMachine
+
+_CanonicalDict = Dict[str, Any]
+_QueryInput = Union[str, BmcQuery]
+
+
+@dataclass(frozen=True)
+class BmcOptions:
+    """Prepare-time policy options for BMC query preparation.
+
+    The first engine prototype keeps options deliberately small.  ``max_bound``
+    is a policy guard for expensive accidental queries; solver tactics,
+    timeouts, witness formatting, and CLI concerns belong to later layers.
+
+    :param max_bound: Maximum allowed query bound, or ``None`` for no limit,
+        defaults to ``None``.
+    :type max_bound: Optional[int], optional
+    :raises pyfcstm.bmc.errors.BmcBuildError: If ``max_bound`` is not ``None``
+        and not a positive integer.
+
+    Example::
+
+        >>> BmcOptions(max_bound=3).to_canonical()["max_bound"]
+        3
+    """
+
+    max_bound: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.max_bound is None:
+            return
+        if isinstance(self.max_bound, bool) or not isinstance(self.max_bound, int):
+            raise BmcBuildError("max_bound must be None or a positive integer.")
+        if self.max_bound <= 0:
+            raise BmcBuildError("max_bound must be None or a positive integer.")
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable options dictionary.
+
+        :return: Canonical options dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> BmcOptions().to_canonical()
+            {'node': 'bmc_options', 'max_bound': None}
+        """
+        return {"node": "bmc_options", "max_bound": self.max_bound}
+
+
+def _require_field(value: object, field_name: str, field_type: type) -> None:
+    if not isinstance(value, field_type):
+        raise BmcBuildError("%s must be %s." % (field_name, field_type.__name__))
+
+
+@dataclass(frozen=True)
+class BmcPreparedContext:
+    """Prepared model, query, domain, and binding snapshot.
+
+    Prepared contexts are solver-independent handoff objects.  The raw model is
+    retained for future engine stages, while :meth:`to_canonical` deliberately
+    emits only JSON-stable query, bound-query, domain, option, and source-text
+    data.
+
+    :param model: State machine used for domain numbering.
+    :type model: pyfcstm.model.StateMachine
+    :param query: Parser-independent BMC query object.
+    :type query: pyfcstm.bmc.query.BmcQuery
+    :param bound_query: Model/domain-aware bound query snapshot.
+    :type bound_query: pyfcstm.bmc.binding.BoundBmcQuery
+    :param domain: Bounded model domain.
+    :type domain: pyfcstm.bmc.domain.BmcDomain
+    :param options: Effective preparation options.
+    :type options: BmcOptions
+    :param source_text: Original ``.fbmcq`` text for string inputs, defaults to
+        ``None`` for AST inputs.
+    :type source_text: Optional[str], optional
+    :raises pyfcstm.bmc.errors.BmcBuildError: If fields are malformed or
+        inconsistent.
+
+    Example::
+
+        >>> from pyfcstm.bmc.engine import BmcEngine
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> model = load_state_machine_from_text('state Root;')
+        >>> BmcEngine(model).prepare('check reach <= 1: active("Root");').bound
+        1
+    """
+
+    model: StateMachine
+    query: BmcQuery
+    bound_query: BoundBmcQuery
+    domain: BmcDomain
+    options: BmcOptions
+    source_text: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        _require_field(self.model, "model", StateMachine)
+        _require_field(self.query, "query", BmcQuery)
+        _require_field(self.bound_query, "bound_query", BoundBmcQuery)
+        _require_field(self.domain, "domain", BmcDomain)
+        _require_field(self.options, "options", BmcOptions)
+        if self.source_text is not None and not isinstance(self.source_text, str):
+            raise BmcBuildError("source_text must be None or str.")
+        if self.domain.bound != self.query.property.bound:
+            raise BmcBuildError(
+                "domain bound %d does not match query bound %d."
+                % (self.domain.bound, self.query.property.bound)
+            )
+        if self.bound_query.property.bound != self.domain.bound:
+            raise BmcBuildError(
+                "bound query bound %d does not match domain bound %d."
+                % (self.bound_query.property.bound, self.domain.bound)
+            )
+        if self.bound_query.query.to_canonical() != self.query.to_canonical():
+            raise BmcBuildError("bound query source does not match query.")
+
+    @property
+    def bound(self) -> int:
+        """Return the prepared query/domain bound.
+
+        :return: Positive BMC bound.
+        :rtype: int
+
+        Example::
+
+            >>> from pyfcstm.bmc.engine import BmcEngine
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> model = load_state_machine_from_text('state Root;')
+            >>> BmcEngine(model).prepare('check reach <= 1: active("Root");').bound
+            1
+        """
+        return self.domain.bound
+
+    @property
+    def references(self) -> Tuple[BoundReference, ...]:
+        """Return references discovered during domain-aware query binding.
+
+        :return: Bound query references.
+        :rtype: Tuple[pyfcstm.bmc.binding.BoundReference, ...]
+
+        Example::
+
+            >>> from pyfcstm.bmc.engine import BmcEngine
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> model = load_state_machine_from_text('state Root;')
+            >>> BmcEngine(model).prepare('check reach <= 1: active("Root");').references[0].kind
+            'state'
+        """
+        return self.bound_query.references
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable prepared-context dictionary.
+
+        The state-machine object is intentionally omitted because it is not a
+        JSON primitive and the domain snapshot contains the stable numbering
+        data needed by later BMC stages.
+
+        :return: Canonical prepared context.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.engine import BmcEngine
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> model = load_state_machine_from_text('state Root;')
+            >>> BmcEngine(model).prepare('check reach <= 1: active("Root");').to_canonical()["node"]
+            'prepared_context'
+        """
+        return {
+            "node": "prepared_context",
+            "options": self.options.to_canonical(),
+            "source_text": self.source_text,
+            "query": self.query.to_canonical(),
+            "bound_query": self.bound_query.to_canonical(),
+            "domain": self.domain.to_canonical(),
+        }
+
+
+def _require_options(options: Optional[BmcOptions]) -> BmcOptions:
+    if options is None:
+        return BmcOptions()
+    if not isinstance(options, BmcOptions):
+        raise BmcBuildError("options must be BmcOptions.")
+    return options
+
+
+def _coerce_query(query: object) -> Tuple[BmcQuery, Optional[str]]:
+    if isinstance(query, str):
+        return parse_bmc_query(query), query
+    if isinstance(query, BmcQuery):
+        return query, None
+    raise BmcBuildError("query must be a str or BmcQuery.")
+
+
+def _enforce_max_bound(options: BmcOptions, query_bound: int) -> None:
+    if options.max_bound is not None and query_bound > options.max_bound:
+        raise BmcBuildError(
+            "max_bound policy rejected query_bound=%d with max_bound=%d."
+            % (query_bound, options.max_bound)
+        )
+
+
+class BmcEngine:
+    """Model-bound entry point for BMC query preparation.
+
+    :param model: State machine to prepare queries against.
+    :type model: pyfcstm.model.StateMachine
+    :param options: Default preparation options, defaults to ``BmcOptions()``.
+    :type options: BmcOptions, optional
+    :raises pyfcstm.bmc.errors.BmcBuildError: If ``model`` or ``options`` is
+        invalid.
+
+    Example::
+
+        >>> from pyfcstm.bmc.engine import BmcEngine
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> model = load_state_machine_from_text('state Root;')
+        >>> engine = BmcEngine(model)
+        >>> engine.prepare('check reach <= 1: active("Root");').bound
+        1
+    """
+
+    def __init__(
+        self, model: StateMachine, options: Optional[BmcOptions] = None
+    ) -> None:
+        """Initialize a BMC preparation engine.
+
+        :param model: State machine to prepare queries against.
+        :type model: pyfcstm.model.StateMachine
+        :param options: Default preparation options, defaults to
+            ``BmcOptions()``.
+        :type options: BmcOptions, optional
+        :return: ``None``.
+        :rtype: None
+        :raises pyfcstm.bmc.errors.BmcBuildError: If ``model`` or ``options``
+            is invalid.
+
+        Example::
+
+            >>> from pyfcstm.bmc.engine import BmcEngine
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> isinstance(BmcEngine(load_state_machine_from_text('state Root;')), BmcEngine)
+            True
+        """
+        if not isinstance(model, StateMachine):
+            raise BmcBuildError("model must be StateMachine.")
+        self._model = model
+        self._options = _require_options(options)
+
+    @property
+    def model(self) -> StateMachine:
+        """Return the state machine held by this engine.
+
+        :return: State machine used for preparation.
+        :rtype: pyfcstm.model.StateMachine
+
+        Example::
+
+            >>> from pyfcstm.bmc.engine import BmcEngine
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> model = load_state_machine_from_text('state Root;')
+            >>> BmcEngine(model).model is model
+            True
+        """
+        return self._model
+
+    @property
+    def options(self) -> BmcOptions:
+        """Return the engine default preparation options.
+
+        :return: Default options.
+        :rtype: BmcOptions
+
+        Example::
+
+            >>> from pyfcstm.bmc.engine import BmcEngine, BmcOptions
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> BmcEngine(load_state_machine_from_text('state Root;'), BmcOptions(max_bound=1)).options.max_bound
+            1
+        """
+        return self._options
+
+    def prepare(
+        self, query: _QueryInput, options: Optional[BmcOptions] = None
+    ) -> BmcPreparedContext:
+        """Prepare a BMC query text or AST against this engine's model.
+
+        Per-call ``options`` completely replace the engine default options.
+        When ``options`` is omitted, the engine default options are used.
+
+        :param query: Query text or parser-independent query object.
+        :type query: Union[str, pyfcstm.bmc.query.BmcQuery]
+        :param options: Per-call options, defaults to ``None``.
+        :type options: BmcOptions, optional
+        :return: Prepared BMC context.
+        :rtype: BmcPreparedContext
+        :raises pyfcstm.bmc.errors.BmcQueryParseError: If query text cannot be
+            parsed.
+        :raises pyfcstm.bmc.errors.InvalidBmcQuery: If query binding fails.
+        :raises pyfcstm.bmc.errors.InvalidBmcDomain: If domain construction
+            fails.
+        :raises pyfcstm.bmc.errors.BmcBuildError: If inputs or option policy
+            are invalid.
+
+        Example::
+
+            >>> from pyfcstm.bmc.engine import BmcEngine
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> model = load_state_machine_from_text('state Root;')
+            >>> BmcEngine(model).prepare('check reach <= 1: active("Root");').domain.bound
+            1
+        """
+        effective_options = (
+            self.options if options is None else _require_options(options)
+        )
+        parsed_query, source_text = _coerce_query(query)
+        structural_bound_query = bind_bmc_query_structure(parsed_query)
+        query_bound = structural_bound_query.property.bound
+        _enforce_max_bound(effective_options, query_bound)
+        domain = build_bmc_domain(self.model, query_bound)
+        bound_query = bind_bmc_query(parsed_query, domain=domain)
+        return BmcPreparedContext(
+            model=self.model,
+            query=parsed_query,
+            bound_query=bound_query,
+            domain=domain,
+            options=effective_options,
+            source_text=source_text,
+        )
+
+
+def prepare_bmc_query(
+    model: StateMachine,
+    query: _QueryInput,
+    options: Optional[BmcOptions] = None,
+) -> BmcPreparedContext:
+    """Prepare a BMC query with a one-shot engine.
+
+    This function is an engine-level convenience wrapper.  It performs the
+    full prepare pipeline and returns a :class:`BmcPreparedContext`, unlike
+    :func:`pyfcstm.bmc.binding.bind_bmc_query`, which only returns a bound
+    query snapshot.
+
+    :param model: State machine to prepare against.
+    :type model: pyfcstm.model.StateMachine
+    :param query: Query text or parser-independent query object.
+    :type query: Union[str, pyfcstm.bmc.query.BmcQuery]
+    :param options: Preparation options, defaults to ``None``.
+    :type options: BmcOptions, optional
+    :return: Prepared BMC context.
+    :rtype: BmcPreparedContext
+    :raises pyfcstm.bmc.errors.BmcError: If parsing, binding, domain
+        construction, or option policy fails.
+
+    Example::
+
+        >>> from pyfcstm.bmc.engine import prepare_bmc_query
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> model = load_state_machine_from_text('state Root;')
+        >>> prepare_bmc_query(model, 'check reach <= 1: active("Root");').bound
+        1
+    """
+    return BmcEngine(model, options).prepare(query)
+
+
+__all__ = [
+    "BmcOptions",
+    "BmcPreparedContext",
+    "BmcEngine",
+    "prepare_bmc_query",
+]

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -97,6 +97,10 @@ def test_bmc_public_api_exports_exact_names():
         "build_semantic_delta_case",
         "verify_boolean_partition",
         "verify_source_partition",
+        "BmcOptions",
+        "BmcPreparedContext",
+        "BmcEngine",
+        "prepare_bmc_query",
     }
 
     assert set(bmc.__all__) == expected
@@ -135,6 +139,10 @@ def test_bmc_public_api_exports_exact_names():
         "build_semantic_delta_case",
         "verify_boolean_partition",
         "verify_source_partition",
+        "BmcOptions",
+        "BmcPreparedContext",
+        "BmcEngine",
+        "prepare_bmc_query",
     }
     function_names = {
         "parse_bmc_query",
@@ -158,6 +166,7 @@ def test_bmc_public_api_exports_exact_names():
         "verify_boolean_partition",
         "verify_source_partition",
         "build_bmc_domain",
+        "prepare_bmc_query",
     }
     for name in expected - lazy_names - function_names:
         assert getattr(bmc, name).__name__ == name
@@ -167,7 +176,10 @@ def test_bmc_public_api_exports_exact_names():
     assert bmc.STATE_DIAGNOSTIC_ID == -2
     assert bmc.TERMINATE_CASE_PATH == "__terminate__"
     assert bmc.DIAGNOSTIC_CASE_PATH == "__diagnostic__"
+    assert bmc.BmcEngine.__name__ == "BmcEngine"
+    assert bmc.BmcOptions().__class__.__name__ == "BmcOptions"
     assert "BmcDomain" in dir(bmc)
+    assert "BmcEngine" in dir(bmc)
 
     with pytest.raises(AttributeError, match="NoSuchBmcExport"):
         getattr(bmc, "NoSuchBmcExport")
@@ -184,6 +196,7 @@ def test_submodule_all_exports_are_exact():
     binding = importlib.import_module("pyfcstm.bmc.binding")
     source = importlib.import_module("pyfcstm.bmc.source")
     macro = importlib.import_module("pyfcstm.bmc.macro")
+    engine = importlib.import_module("pyfcstm.bmc.engine")
 
     assert set(errors.__all__) == {
         "BmcError",
@@ -284,6 +297,12 @@ def test_submodule_all_exports_are_exact():
         "build_semantic_delta_case",
         "verify_boolean_partition",
         "verify_source_partition",
+    }
+    assert set(engine.__all__) == {
+        "BmcOptions",
+        "BmcPreparedContext",
+        "BmcEngine",
+        "prepare_bmc_query",
     }
 
 

--- a/test/bmc/test_engine.py
+++ b/test/bmc/test_engine.py
@@ -1,0 +1,406 @@
+"""BMC engine preparation tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from dataclasses import replace
+
+import pytest
+
+import pyfcstm.bmc.engine as engine_module
+from pyfcstm.bmc import (
+    BmcBuildError,
+    BmcEngine,
+    BmcOptions,
+    BmcPreparedContext,
+    BmcQueryParseError,
+    InvalidBmcQuery,
+    bind_bmc_query,
+    parse_bmc_query,
+    prepare_bmc_query,
+)
+from pyfcstm.bmc.binding import BoundBmcQuery
+from pyfcstm.bmc.domain import BmcDomain
+from pyfcstm.model import StateMachine, load_state_machine_from_text
+
+
+@pytest.fixture()
+def engine_model() -> StateMachine:
+    """Return a compact model with variables, events, and states for prepare."""
+    return load_state_machine_from_text(
+        """
+        def int x = 0;
+        def float pressure = 0.0;
+        state Root {
+            event Tick;
+            event Reset;
+            state Idle;
+            state Done;
+            [*] -> Idle;
+            Idle -> Done :: Tick;
+        }
+        """
+    )
+
+
+@pytest.fixture()
+def engine_query_text() -> str:
+    """Return a representative query text with resolvable references."""
+    return (
+        "init cold;\n\n"
+        "assume always: x >= 0;\n"
+        'assume event("Root.Tick", 0) == true;\n\n'
+        'check reach <= 1: active("Root.Done") or var("pressure") >= 0.0;'
+    )
+
+
+def _round_trip_bound_query(context: BmcPreparedContext) -> BoundBmcQuery:
+    text = str(context.bound_query.to_ast_node())
+    reparsed = parse_bmc_query(text)
+    return bind_bmc_query(reparsed, domain=context.domain)
+
+
+@pytest.mark.unittest
+def test_engine_prepares_query_text_with_domain_references(
+    engine_model: StateMachine, engine_query_text: str
+) -> None:
+    """Preparing text preserves source and resolves model/domain references."""
+    context = BmcEngine(engine_model).prepare(engine_query_text)
+
+    assert isinstance(context, BmcPreparedContext)
+    assert context.model is engine_model
+    assert context.source_text == engine_query_text
+    assert context.bound == 1
+    assert context.domain.bound == 1
+    assert context.query.property.bound == 1
+    assert context.bound_query.property.bound == 1
+    assert context.options == BmcOptions()
+    assert isinstance(context.domain, BmcDomain)
+    assert isinstance(context.bound_query, BoundBmcQuery)
+
+    references = {(ref.kind, ref.name): ref for ref in context.references}
+    assert references[("state", "Root.Done")].resolved_id is not None
+    assert references[("event", "Root.Tick")].resolved_id is not None
+    assert references[("variable", "x")].declared_type == "int"
+    assert references[("variable", "pressure")].declared_type == "float"
+
+    canonical = context.to_canonical()
+    assert list(canonical) == [
+        "node",
+        "options",
+        "source_text",
+        "query",
+        "bound_query",
+        "domain",
+    ]
+    assert canonical["node"] == "prepared_context"
+    assert canonical["source_text"] == engine_query_text
+    assert canonical["options"] == {"node": "bmc_options", "max_bound": None}
+    assert canonical["domain"]["bound"] == 1
+    json.dumps(canonical, sort_keys=True)
+
+    rebound = _round_trip_bound_query(context)
+    rebound_canonical = rebound.to_canonical()
+    prepared_canonical = context.bound_query.to_canonical()
+    for key in ("query", "initial", "assumptions", "property", "references"):
+        assert rebound_canonical[key] == prepared_canonical[key]
+
+
+@pytest.mark.unittest
+def test_engine_prepares_ast_and_function_api_equivalently(
+    engine_model: StateMachine,
+) -> None:
+    """AST and function-style preparation expose equivalent canonical output."""
+    query = parse_bmc_query('check reach <= 2: active("Root.Done");')
+    options = BmcOptions(max_bound=2)
+
+    engine = BmcEngine(engine_model, options)
+    method_context = engine.prepare(query)
+    function_context = prepare_bmc_query(engine_model, query, options=options)
+
+    assert engine.model is engine_model
+    assert engine.options == options
+    assert method_context.source_text is None
+    assert function_context.source_text is None
+    assert method_context.to_canonical() == function_context.to_canonical()
+    assert method_context.query.to_canonical() == query.to_canonical()
+    assert (
+        method_context.bound_query.to_ast_node().to_canonical() == query.to_canonical()
+    )
+
+
+@pytest.mark.unittest
+def test_prepare_call_options_override_engine_default(
+    engine_model: StateMachine,
+) -> None:
+    """Per-call options replace default engine options instead of merging them."""
+    query = parse_bmc_query('check reach <= 2: active("Root.Done");')
+    engine = BmcEngine(engine_model, BmcOptions(max_bound=1))
+
+    with pytest.raises(BmcBuildError, match="query_bound=2.*max_bound=1"):
+        engine.prepare(query)
+
+    context = engine.prepare(query, options=BmcOptions(max_bound=2))
+
+    assert context.options == BmcOptions(max_bound=2)
+    assert context.bound == 2
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("max_bound", [0, -1, True, False, 1.5, "3"])
+def test_bmc_options_reject_invalid_max_bound(max_bound) -> None:
+    """Options reject non-positive, boolean, and non-integer max bounds."""
+    with pytest.raises(BmcBuildError, match="max_bound"):
+        BmcOptions(max_bound=max_bound)
+
+
+@pytest.mark.unittest
+def test_bmc_options_accept_none_and_positive_bounds() -> None:
+    """Options keep a JSON-stable canonical shape for valid bounds."""
+    assert BmcOptions().to_canonical() == {"node": "bmc_options", "max_bound": None}
+    assert BmcOptions(max_bound=3).to_canonical() == {
+        "node": "bmc_options",
+        "max_bound": 3,
+    }
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("model", [None, object()])
+def test_engine_rejects_invalid_model(model) -> None:
+    """Engine construction rejects non-state-machine model objects."""
+    with pytest.raises(BmcBuildError, match="model must be StateMachine"):
+        BmcEngine(model)
+
+
+@pytest.mark.unittest
+def test_engine_rejects_invalid_options(engine_model: StateMachine) -> None:
+    """Engine and prepare calls reject non-BmcOptions option objects."""
+    with pytest.raises(BmcBuildError, match="options must be BmcOptions"):
+        BmcEngine(engine_model, options=object())
+
+    with pytest.raises(BmcBuildError, match="options must be BmcOptions"):
+        BmcEngine(engine_model).prepare(
+            'check reach <= 1: active("Root.Done");',
+            options=object(),
+        )
+
+
+@pytest.mark.unittest
+def test_engine_rejects_invalid_query_input(engine_model: StateMachine) -> None:
+    """Prepare accepts only query text or parser-independent BmcQuery objects."""
+    with pytest.raises(BmcBuildError, match="query must be a str or BmcQuery"):
+        BmcEngine(engine_model).prepare(object())
+
+
+@pytest.mark.unittest
+def test_engine_propagates_parse_errors_before_prepare(
+    engine_model: StateMachine,
+) -> None:
+    """Invalid query text fails as a parse error before binding or domain work."""
+    with pytest.raises(BmcQueryParseError):
+        BmcEngine(engine_model).prepare("check reach <= ;")
+
+
+@pytest.mark.unittest
+def test_engine_rejects_malformed_query_before_domain_build(
+    monkeypatch: pytest.MonkeyPatch, engine_model: StateMachine
+) -> None:
+    """Structure binding runs before domain construction for forged queries."""
+    query = parse_bmc_query('check reach <= 1: active("Root.Done");')
+    object.__setattr__(query, "assumptions", "not-a-sequence")
+
+    def fail_build_domain(model, bound):
+        pytest.fail("build_bmc_domain must not run before structure binding")
+
+    monkeypatch.setattr(engine_module, "build_bmc_domain", fail_build_domain)
+
+    with pytest.raises(InvalidBmcQuery, match="assumptions"):
+        BmcEngine(engine_model).prepare(query)
+
+
+@pytest.mark.unittest
+def test_engine_reports_model_reference_errors_as_query_diagnostics(
+    engine_model: StateMachine,
+) -> None:
+    """Unknown model references fail as InvalidBmcQuery diagnostics."""
+    with pytest.raises(InvalidBmcQuery) as excinfo:
+        BmcEngine(engine_model).prepare('check reach <= 1: active("Root.Missing");')
+
+    diagnostic = getattr(excinfo.value, "diagnostic", None)
+    assert diagnostic is not None
+    assert diagnostic.code == "unknown_state"
+    assert diagnostic.path == "property.predicate"
+
+
+@pytest.mark.unittest
+def test_prepared_context_rejects_invalid_field_types(
+    engine_model: StateMachine,
+) -> None:
+    """Prepared context construction guards every public handoff field."""
+    valid = BmcEngine(engine_model).prepare('check reach <= 1: active("Root.Done");')
+    invalid_fields = {
+        "model": object(),
+        "query": object(),
+        "bound_query": object(),
+        "domain": object(),
+        "options": object(),
+        "source_text": object(),
+    }
+
+    for field_name, invalid_value in invalid_fields.items():
+        kwargs = {
+            "model": valid.model,
+            "query": valid.query,
+            "bound_query": valid.bound_query,
+            "domain": valid.domain,
+            "options": valid.options,
+            "source_text": valid.source_text,
+        }
+        kwargs[field_name] = invalid_value
+        with pytest.raises(BmcBuildError, match=field_name):
+            BmcPreparedContext(**kwargs)
+
+    with pytest.raises(BmcBuildError, match="source_text"):
+        replace(valid, source_text=123)
+
+
+@pytest.mark.unittest
+def test_prepared_context_rejects_mismatched_handoff_objects(
+    engine_model: StateMachine,
+) -> None:
+    """Prepared context rejects inconsistent query, bound query, and domain data."""
+    query_one = parse_bmc_query('check reach <= 1: active("Root.Done");')
+    query_two = parse_bmc_query('check reach <= 2: active("Root.Done");')
+    context_one = BmcEngine(engine_model).prepare(query_one)
+    context_two = BmcEngine(engine_model).prepare(query_two)
+    same_bound_other_query = BmcEngine(engine_model).prepare(
+        'check forbid <= 1: active("Root.Idle");'
+    )
+
+    with pytest.raises(BmcBuildError, match="domain bound"):
+        BmcPreparedContext(
+            context_one.model,
+            context_one.query,
+            context_one.bound_query,
+            context_two.domain,
+            context_one.options,
+            context_one.source_text,
+        )
+
+    with pytest.raises(BmcBuildError, match="bound query bound"):
+        BmcPreparedContext(
+            context_one.model,
+            context_one.query,
+            context_two.bound_query,
+            context_one.domain,
+            context_one.options,
+            context_one.source_text,
+        )
+
+    with pytest.raises(BmcBuildError, match="bound query source"):
+        BmcPreparedContext(
+            context_one.model,
+            context_one.query,
+            same_bound_other_query.bound_query,
+            context_one.domain,
+            context_one.options,
+            context_one.source_text,
+        )
+
+
+@pytest.mark.unittest
+def test_engine_import_boundaries_are_lazy_and_solver_independent() -> None:
+    """Root BMC imports stay parser-only while engine access stays solver-free."""
+    root_code = (
+        "import sys; "
+        "import pyfcstm.bmc; "
+        "bad = [name for name in sys.modules "
+        "if name == 'z3' "
+        "or name == 'pyfcstm.bmc.engine' "
+        "or name.startswith('pyfcstm.model') "
+        "or name.startswith('pyfcstm.verify') "
+        "or name.startswith('pyfcstm.solver')]; "
+        "print(bad)"
+    )
+    engine_code = (
+        "import sys; "
+        "import pyfcstm.bmc as bmc; "
+        "assert bmc.BmcEngine.__name__ == 'BmcEngine'; "
+        "bad = [name for name in sys.modules "
+        "if name == 'z3' "
+        "or name.startswith('pyfcstm.verify') "
+        "or name.startswith('pyfcstm.solver') "
+        "or name in {"
+        "'pyfcstm.bmc.macro', 'pyfcstm.bmc.source', "
+        "'pyfcstm.bmc.relation', 'pyfcstm.bmc.properties', "
+        "'pyfcstm.bmc.witness'"
+        "}]; "
+        "print('engine_loaded', 'pyfcstm.bmc.engine' in sys.modules); "
+        "print('model_loaded', any(name.startswith('pyfcstm.model') for name in sys.modules)); "
+        "print('bad', bad)"
+    )
+
+    root_result = subprocess.run(
+        [sys.executable, "-c", root_code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+    engine_result = subprocess.run(
+        [sys.executable, "-c", engine_code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert root_result.stdout.strip() == "[]"
+    assert engine_result.stdout.splitlines() == [
+        "engine_loaded True",
+        "model_loaded True",
+        "bad []",
+    ]
+
+
+@pytest.mark.unittest
+def test_prepare_does_not_load_later_bmc_or_solver_layers() -> None:
+    """Preparation stays independent from macro, relation, solver, and verify."""
+    code = r'''
+import sys
+from pyfcstm.bmc import BmcEngine
+from pyfcstm.model import load_state_machine_from_text
+
+model = load_state_machine_from_text("""
+state Root {
+    state A;
+    [*] -> A;
+}
+""")
+BmcEngine(model).prepare('check reach <= 1: active("Root.A");')
+bad = [
+    name for name in sys.modules
+    if name == "z3"
+    or name.startswith("pyfcstm.verify")
+    or name.startswith("pyfcstm.solver")
+    or name in {
+        "pyfcstm.bmc.macro",
+        "pyfcstm.bmc.source",
+        "pyfcstm.bmc.relation",
+        "pyfcstm.bmc.properties",
+        "pyfcstm.bmc.witness",
+    }
+]
+print(bad)
+'''
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert result.stdout.strip() == "[]"


### PR DESCRIPTION
## 背景

本 PR 是 BMC 伞 PR [#305](https://github.com/HansBug/pyfcstm/pull/305) 的 **PR-7：内核入口：建立 BMC 引擎原型**。

当前前置状态：

| 前置 | 状态 | 说明 |
|---|---|---|
| PR-1 / [#315](https://github.com/HansBug/pyfcstm/pull/315) | 🟢 已合入 | `.fbmcq` parser-independent AST / query dataclass / canonical spelling |
| PR-2 / [#323](https://github.com/HansBug/pyfcstm/pull/323) | 🟢 已合入 | `.fbmcq` 独立 ANTLR grammar 与 FCSTM expression parity |
| PR-3 / [#326](https://github.com/HansBug/pyfcstm/pull/326) | 🟢 已合入 | listener-based parser、public parse API、AST / text round-trip |
| PR-4 / [#332](https://github.com/HansBug/pyfcstm/pull/332) | 🟢 已合入 | semantic binder、structured diagnostics、model/domain-aware reference resolution |
| PR-5 / [#331](https://github.com/HansBug/pyfcstm/pull/331) | 🟢 已合入 | `.fbmcq` 编辑器高亮与文档入口；非 PR-7 直接依赖，但已完成 |
| PR-6 / [#324](https://github.com/HansBug/pyfcstm/pull/324) | 🟢 已合入 | `BmcDomain`、state/event/variable/frame/step/event-input 编号与 lookup helpers |
| PR-8 / [#328](https://github.com/HansBug/pyfcstm/pull/328) | 🟢 已合入 | `MacroStepSource` / `CycleCase` solver-independent contract；本 PR 不消费 macro expansion |
| PR-9 / [#335](https://github.com/HansBug/pyfcstm/pull/335) | 🔵 Draft 进行中 | runtime-aligned macro expansion；本 PR 不等待 PR-9 完成 |

PR-7 是 **query frontend + domain numbering 的第一个 engine 合流点**：它把 `StateMachine + .fbmcq query` 规范化为后续 compiler / relation / property / witness 层可消费的 prepared context，但本 PR **不求解、不展开宏步、不构建 Z3、不编译 property objective、不接 verify registry**。

## 技术目标

| 目标 | 说明 | 验收信号 |
|---|---|---|
| 建立 Python API 原型入口 | 新增 `pyfcstm.bmc.engine`，提供 `BmcEngine`、`BmcOptions`、`BmcPreparedContext`。 | `from pyfcstm.bmc.engine import BmcEngine` 可用；顶层 `pyfcstm.bmc.BmcEngine` lazy export 可用。 |
| 固化 prepare 流程 | `StateMachine + (BmcQuery 或 .fbmcq text)` → parse（如需要）→ structure binding → option policy → domain construction → model/domain-aware semantic binding → prepared context。 | `prepare()` 对 text 与 AST 输入均返回稳定 `BmcPreparedContext`，后续层只消费 `bound_query + domain`。 |
| 保持层次边界 | PR-7 只做 prepare/context，不做 macro expansion / relation lowering / property objective / witness / CLI / verify registry。 | import isolation 测试证明 `prepare()` 不加载 `pyfcstm.verify` / `pyfcstm.solver` / `z3`；不调用 `pyfcstm.bmc.macro` expansion API。 |
| 结构化错误边界 | parse error、query semantic invalid、model/domain invalid、engine option/policy invalid 不混成不透明异常。 | invalid query 仍抛 `BmcQueryParseError` 或 `InvalidBmcQuery`；invalid model/domain 使用 `InvalidBmcDomain` 或 `BmcBuildError`；option validation / max-bound policy 使用 `BmcBuildError`。 |
| JSON-stable summary | `BmcPreparedContext.to_canonical()` 为后续 golden tests / debug 提供稳定结构。 | canonical dump 顶层 key 固定，不包含 raw model repr、object id 或非 JSON primitive 对象，重复 prepare 稳定。 |

## 设计方案

### 新增模块与 public API

计划新增 `pyfcstm/bmc/engine.py`：

| API / 类型 | 作用 |
|---|---|
| `BmcOptions` | prepare 阶段轻量配置。第一版只包含 `max_bound: Optional[int]`；`None` 表示不限制，非 `None` 时必须是正整数 `>= 1`。不包含 solver timeout / tactic / witness / CLI 选项。 |
| `BmcPreparedContext` | prepare 结果：保存原 model、parser-independent query、`BoundBmcQuery`、`BmcDomain`、effective options、可选 `source_text`，并提供 `to_canonical()` / helper properties。 |
| `BmcEngine` | 面向 Python API 的 engine 原型入口，持有 `StateMachine` 与默认 options；`model` 和 `options` 通过只读 property 暴露。 |
| `BmcEngine.prepare(query, *, options=None)` | 接受 `.fbmcq` text 或 `BmcQuery`，返回 `BmcPreparedContext`。类型标注使用 Python 3.7 兼容的 `Union[str, BmcQuery]`，方法体内用 `isinstance(query, str)` 分发。 |
| `prepare_bmc_query(model, query, *, options=None)` | 函数式 convenience API，便于后续 CLI / tests 复用；它是 engine-level 完整 prepare pipeline（parse → structure binding → option policy → domain → semantic binding，输出 `BmcPreparedContext`），区别于 binder-level `bind_bmc_query(query, model=None, domain=None)`（只做 query semantic binding，输出 `BoundBmcQuery`）。 |

顶层 `pyfcstm.bmc` 需要 lazy export 这些 engine API，保持 parser-only import 不加载 model-aware 层。

### model / option / input 边界

- `BmcEngine(model, options=None)` 要求 `model` 是 `pyfcstm.model.StateMachine`；非 `StateMachine`（包括 `None`）立即抛 `BmcBuildError`，不推迟到 `prepare()`。
- `BmcEngine` 不做额外 model semantic validation；domain 层已有的 snapshot validation / `InvalidBmcDomain` 继续负责 domain construction 失败。
- `BmcOptions(max_bound=None)` 不限制 bound；`BmcOptions(max_bound=N)` 中 `N` 必须是正整数 `>= 1`，拒绝 `0`、负数、bool、非 int。
- `max_bound` exceeded 表示 engine policy 拒绝，不表示 query 本身非法；因此固定抛 `BmcBuildError`，错误消息必须包含 option name、`query_bound` 与 `max_bound`。
- `prepare(..., options=...)` 的 per-call options **完全覆盖** engine default options；未传时使用 engine default options。第一版不做 field-by-field merge。
- `str` 输入保留原始 `source_text`；`BmcQuery` AST 输入的 `source_text` 为 `None`。
- 非 `str` / 非 `BmcQuery` 的 query 输入固定抛 `BmcBuildError`。
- `BmcPreparedContext.__post_init__` 必须显式校验 `model`（`StateMachine`）、`query`（`BmcQuery`）、`bound_query`（`BoundBmcQuery`）、`domain`（`BmcDomain`）、`options`（`BmcOptions`）与 `source_text`（`Optional[str]`）；非法 field 组合固定抛 `BmcBuildError`，避免后续 lowering 层收到 forged context。

### prepare 流程

`BmcEngine.prepare()` 的第一版流程固定为：

1. 输入若为 `str`，调用 `parse_bmc_query()` 得到 `BmcQuery` 并保存原始 `source_text`；输入若为 `BmcQuery`，直接作为 query 且 `source_text=None`；其他类型拒绝为 `BmcBuildError`。
2. 先调用 `bind_bmc_query_structure(query)`，完成 query shape / context validation，并以 `structural_bound.property.bound` 作为唯一 `query_bound` 来源；forged / malformed `BmcQuery` 必须在 domain construction 前失败为 `InvalidBmcQuery`。
3. 校验 effective `BmcOptions.max_bound`；若 `query_bound > max_bound`，抛 `BmcBuildError`，且错误内容包含 `max_bound`、`query_bound`。
4. 使用 `build_bmc_domain(model, query_bound)` 构建 `BmcDomain`；domain/model construction failure 不覆盖前一步 query semantic error。
5. 调用 `bind_bmc_query(query, domain=domain)` 完成 model/domain-aware binding，得到 `BoundBmcQuery`。
6. 返回 `BmcPreparedContext(model=model, query=query, bound_query=bound_query, domain=domain, options=effective_options, source_text=source_text)`。

后续 compiler / relation / property 层只消费 `bound_query + domain`；`query` 仅作为原始 AST / canonical text 来源保留。第一版不开放外部传入 domain。理由：`BmcEngine` 持有 model，外部 domain 是否来自同一个 model 暂无稳定 identity/hash 合同；如后续需要 cache/prebuilt domain，可以单独加 explicit API。

### canonical 与 round-trip 边界

`BmcPreparedContext.to_canonical()` 顶层 key 固定为：

```text
node、options、source_text、query、bound_query、domain
```

- `options` 来自 `BmcOptions.to_canonical()`，至少包含 `max_bound`。
- `source_text` 对 text 输入保留原文，对 AST 输入为 `None`。
- `query` 是 parser-independent query 的 `to_canonical()`。
- `bound_query` 是 model/domain-aware bound query 的 `to_canonical()`，也是 PR-10 handoff 的 query 侧主数据。
- `domain` 是 `BmcDomain.to_canonical()`，也是 PR-10 handoff 的 domain 侧主数据。
- `model` 作为 `BmcPreparedContext` 的 field 保存，但不进入 `to_canonical()`；`StateMachine` 不是 JSON primitive，后续 lowering 层通过 `bound_query + domain` 消费必要 model 信息。
- `node` 键的值固定为 `"prepared_context"`。
- canonical 输出不得包含 model repr、object id、Python dataclass repr 或非 JSON primitive 对象。

Round-trip 验收不强依赖对象 identity：

- AST 输入时 `prepared.query` 与输入 query 语义等价；实现可以保留同一对象，但测试不把 `is` 作为公共契约。
- text 输入时 `prepared.query` 是 `parse_bmc_query(source_text)` 的 parser AST。
- `prepared.bound_query.to_ast_node()` 必须可再次 `str()` 成 `.fbmcq` DSL、再次 `parse_bmc_query()`、再以 `bind_bmc_query(..., domain=prepared.domain)` 绑定，并得到与 `prepared.bound_query.to_canonical()` 等价的 canonical bound query。
- 本 PR 的“等价 canonical bound query”定义为：rebinding 后的 `BoundBmcQuery.to_canonical()` 与 `prepared.bound_query.to_canonical()` 在 `query`、`initial`、`assumptions`、`property`、`references` 这些稳定键上逐键相等；若未来 binder 引入新的 normalization-only metadata，应显式加入测试白名单，不能让 PR-7 默默比较 object identity 或 dataclass repr。
- 对显式 `init` 且 binder 没有 normalization diff 的输入，`prepared.bound_query.to_ast_node().to_canonical()` 与 `prepared.query.to_canonical()` 相等。
- 对省略 `init` 或后续 binder normalization 场景，`bound_query` 的 normalized AST / canonical output 以 binder 契约为准；engine 不要求 raw query canonical 与 normalized bound query canonical 强行相等。

### import boundary

- `import pyfcstm.bmc` 必须保持 parser/query-only，不加载 `pyfcstm.model`、`pyfcstm.verify`、`pyfcstm.solver` 或 `z3`。
- `engine.py` 允许在模块顶层直接 import `pyfcstm.model`、`pyfcstm.bmc.binding`、`pyfcstm.bmc.domain`、`pyfcstm.bmc.parse`、`pyfcstm.bmc.query` 与 `pyfcstm.bmc.errors`，以保持 engine prepare 逻辑可读；但不得 import `pyfcstm.verify`、`pyfcstm.solver`、`z3`、`pyfcstm.bmc.macro`、`pyfcstm.bmc.relation`、`pyfcstm.bmc.properties`、`pyfcstm.bmc.witness`。
- 访问 `pyfcstm.bmc.BmcEngine` 或 `import pyfcstm.bmc.engine` 时允许加载 model-aware BMC 层（`pyfcstm.model`、`pyfcstm.bmc.binding`、`pyfcstm.bmc.domain`），但仍不得加载 `pyfcstm.verify`、`pyfcstm.solver`、`z3`、`pyfcstm.bmc.relation`、`pyfcstm.bmc.properties`、`pyfcstm.bmc.witness`。
- `import pyfcstm.bmc` 不得触发 `pyfcstm.bmc.engine` 加载；只有访问 `pyfcstm.bmc.BmcEngine`、`pyfcstm.bmc.BmcOptions`、`pyfcstm.bmc.BmcPreparedContext` 或 `pyfcstm.bmc.prepare_bmc_query` 时才 lazy-load engine 模块。
- PR-7 不产生 `UnsupportedBmcQuery`；unsupported lowering / objective capability 留给 PR-10 / PR-11。

### 明确不做的内容

| 不进入 PR-7 | 后续归属 | 原因 |
|---|---|---|
| `.fbmcq` token span / line-column diagnostic | 单独 query diagnostics PR 或后续 CLI 需要时补 | 需要 parser/listener/AST span propagation，不属于 engine prepare。 |
| `expand_macro_step_cases()` / transition priority / validation-skip / rollback fallback | PR-9 | 这是 runtime-aligned macro expansion。 |
| Z3 symbol / `$Core_N` / relation lowering / expression lowering | PR-10 | 需要 macro cases 与 relation builder。 |
| reach / forbid / invariant / response / cover objective 编译 | PR-11 | property polarity 与 objective semantics 后置。 |
| SAT model witness decode / replay | PR-12 | 需要 solver model 与 property result。 |
| `pyfcstm.verify` registry / adapters | PR-13 | BMC core 不进入 verify registry。 |
| CLI / docs tutorial / examples | PR-14 | 用户入口后置，PR-7 只做 Python API 原型。 |

## 执行方案

1. **空 PR + PR body review**
   - 从最新 `origin/dev/bmc-query-kernel-umbrella` 创建 `dev/bmc-engine-pr7`。
   - 创建 empty commit 和 PR。
   - 使用 codex / claude / codex-deepseek 三路 reviewer 检查：与伞 PR #305 的 PR-7 计划一致性、PR body 是否可执行、验收标准是否可严格执行。
   - C/I 级问题必须先修 PR body，再进入代码实现。
2. **TDD：public API 与 import boundary**
   - 先写 `test_bmc_public_api.py` 对 engine lazy exports、submodule exports、import isolation 的 failing tests。
3. **TDD：options/context dataclass**
   - 写 `BmcOptions` constructor validation、`to_canonical()`、`BmcPreparedContext` field validation / canonical golden tests。
4. **TDD：prepare text / AST 成功路径**
   - 使用小型 FCSTM model + `.fbmcq` text 与 `BmcQuery` AST 分别 prepare。
   - 断言 bound、domain、bound query references、canonical dump 稳定。
5. **TDD：错误路径**
   - invalid query text、binder-invalid query、unknown state/event/var、invalid model/domain construction、`max_bound` exceeded / invalid option type、非 `str` / 非 `BmcQuery` 输入。
   - 用 monkeypatch 证明 malformed query 在 domain construction 前失败，不把 query invalid 错报为 domain/model invalid。
6. **实现最小 engine**
   - 只实现 prepare/context，不接 solver/macro/property/witness。
7. **文档与 RST**
   - 新增/更新 module docstring、class/function reST docstring、`docs/source/api_doc/bmc/engine.rst`，并更新 `docs/source/api_doc/bmc/index.rst`。
   - 运行 `make rst_auto RANGE_DIR=bmc`。
8. **本地验证 + push + CI**
   - 本地使用 `SKIP_SLOW_TESTS=1` 快速迭代。
   - push 后 watch CI 至全绿。
9. **三路强对抗代码 review**
   - reviewer 必须构造真实反例：forged options/context、invalid model、query/domain bound mismatch、import leakage、unexpected raw exceptions、domain-first 错误边界回归。
   - C/I 必修，M 尽量修但不阻塞。

## 验收标准

### 功能验收

- `BmcEngine(model).prepare(text)` 可解析 `.fbmcq` text 并返回 `BmcPreparedContext`，且 `source_text` 保留原始 text。
- `BmcEngine(model).prepare(query)` 可接受 `BmcQuery` AST 并返回等价 context，且 `source_text is None`。
- `prepare_bmc_query(model, query_or_text, options=...)` 与 `BmcEngine(model, options).prepare(...)` 语义一致。
- per-call `options` 完全覆盖 engine default options；未传 per-call options 时使用 engine default options。
- `prepared.bound_query` 是 `BoundBmcQuery`，且 `prepared.bound_query.property.bound == prepared.domain.bound == prepared.query.property.bound`。
- known state/event/variable 在 `bound_query.references` 中有 resolved id；unknown references 以 `InvalidBmcQuery` + diagnostic 失败。
- forged / malformed `BmcQuery` 在 domain construction 前失败为 `InvalidBmcQuery`，并可用 monkeypatch 证明 `build_bmc_domain` 未被调用。
- `BmcOptions(max_bound=N)` 允许 `bound <= N`，拒绝 `bound > N`；`max_bound=None` 不限制；`0`、负数、bool、非 int 类型配置被 `BmcBuildError` 拒绝。
- 合法 query 但 `bound > max_bound` 固定抛 `BmcBuildError`，错误内容包含 `max_bound`、`query_bound`。
- `BmcEngine(None)` 或传入非 `StateMachine` 实例立即抛 `BmcBuildError`；不实现额外 model semantic validation。
- `BmcPreparedContext.to_canonical()` JSON-stable，顶层 key 精确为 `node`、`options`、`source_text`、`query`、`bound_query`、`domain`，其中 `node == "prepared_context"`；`model` 不进入 canonical dump；重复 prepare 结果中 query/domain/bound references canonical 一致。
- `prepared.bound_query.to_ast_node()` 的 `.fbmcq` round-trip 可 parse / bind 回等价 canonical bound query；等价粒度按“canonical 与 round-trip 边界”章节的稳定键逐键相等执行。
- forged `BmcPreparedContext` field 类型错误（model/query/bound_query/domain/options/source_text）固定抛 `BmcBuildError`。

### 边界验收

- `import pyfcstm.bmc` 不加载 `pyfcstm.bmc.engine`、`pyfcstm.model`、`pyfcstm.verify`、`pyfcstm.solver`、`z3`。
- 访问 `pyfcstm.bmc.BmcEngine` 可以 lazy-load `pyfcstm.bmc.engine` 与 model-aware BMC 层，但不得加载 `pyfcstm.verify`、`pyfcstm.solver`、`z3`、`pyfcstm.bmc.macro`、`pyfcstm.bmc.relation`、`pyfcstm.bmc.properties`、`pyfcstm.bmc.witness`。
- `BmcEngine.prepare()` 不调用 macro expansion，不 import `pyfcstm.bmc.relation` / `pyfcstm.bmc.properties` / `pyfcstm.bmc.witness`。
- 不新增 `pyfcstm.verify.bmc`，不修改 `pyfcstm.verify.registry`。
- 不新增 CLI 命令。
- PR-7 不产生 `UnsupportedBmcQuery`；该错误保留给 lowering / objective compiler 阶段。

### 测试验收

- 新增 `test/bmc/test_engine.py`，覆盖 success、invalid、option、canonical、round-trip、import boundary、forged dataclass invariants。
- 更新 `test/bmc/test_bmc_public_api.py`，精确覆盖 engine lazy exports 与 submodule exports。
- `pyfcstm/bmc/engine.py` 行覆盖率与分支覆盖率严格 100%，并使用明确命令检查：

  ```bash
  SKIP_SLOW_TESTS=1 pytest test/bmc/test_engine.py test/bmc/test_bmc_public_api.py \
    -m unittest \
    --cov=pyfcstm.bmc.engine \
    --cov-branch \
    --cov-report=term-missing \
    --cov-fail-under=100
  ```

- `SKIP_SLOW_TESTS=1 make unittest RANGE_DIR=bmc` 通过。
- `ruff check` / `ruff format --check` 修改文件通过。
- `make rst_auto RANGE_DIR=bmc` 后无非预期 diff。
- GitHub CI 全绿；若 Codecov comment/check 存在，覆盖率不得下降到 PR-7 目标以下。

## Review 要求

本 PR 需要两阶段三路 review：

1. PR body 阶段：codex reviewer / claude reviewer / deepseek reviewer 各自独立评论一致性、可执行性、可验收性。
2. 代码阶段：三路 reviewer 必须做强对抗白盒测试，并将真实 C/I/M 问题和可复现代码直接评论到 PR。

当前 PR 处于 **empty PR / PR body review 阶段**；代码实现将在 body review C/I 清零后开始。

