### PR TITLE
公式构建：生成有界轨迹核心公式

### DIFF
--- a/docs/source/api_doc/bmc/index.rst
+++ b/docs/source/api_doc/bmc/index.rst
@@ -20,6 +20,7 @@ pyfcstm.bmc
     macro
     parse
     query
+    relation
     source
 
 \_\_all\_\_

--- a/docs/source/api_doc/bmc/relation.rst
+++ b/docs/source/api_doc/bmc/relation.rst
@@ -1,0 +1,46 @@
+pyfcstm.bmc.relation
+========================================================
+
+.. currentmodule:: pyfcstm.bmc.relation
+
+.. automodule:: pyfcstm.bmc.relation
+
+
+\_\_all\_\_
+-----------------------------------------------------
+
+.. autodata:: __all__
+
+
+BmcTraceSymbols
+-----------------------------------------------------
+
+.. autoclass:: BmcTraceSymbols
+    :members: __post_init__,allocate,frame_state,frame_var,event_input,case_selector,to_canonical,domain,frame_states,frame_vars,event_inputs,case_selectors
+
+
+BmcCaseRelation
+-----------------------------------------------------
+
+.. autoclass:: BmcCaseRelation
+    :members: __post_init__,formula,to_canonical,step_index,case,selector,antecedent,consequent,implication,selector_constraint,post_var_exprs,guard_terms,definedness_constraints
+
+
+BmcStepRelation
+-----------------------------------------------------
+
+.. autoclass:: BmcStepRelation
+    :members: __post_init__,case_registry,to_canonical,step_index,formals,case_relations,formula
+
+
+BmcCoreFormula
+-----------------------------------------------------
+
+.. autoclass:: BmcCoreFormula
+    :members: __post_init__,to_canonical,context,symbols,domain_formula,initial_formula,transition_formula,environment_formula,core,steps,diagnostics
+
+
+build\_bmc\_core\_formula
+-----------------------------------------------------
+
+.. autofunction:: build_bmc_core_formula

--- a/pyfcstm/bmc/__init__.py
+++ b/pyfcstm/bmc/__init__.py
@@ -105,6 +105,13 @@ Public module structure:
        :class:`BmcEngine`, :func:`prepare_bmc_query`
      - Prepare ``StateMachine + .fbmcq`` inputs into bound query and domain
        context without solver, witness, CLI, or verify-registry coupling.
+   * - BMC relation builder
+     - :class:`BmcTraceSymbols`, :class:`BmcCaseRelation`,
+       :class:`BmcStepRelation`, :class:`BmcCoreFormula`,
+       :func:`build_bmc_core_formula`
+     - Lower prepared contexts and macro-step cases into ``Core_N`` while
+       leaving health gates, objectives, solving, and witness replay to later
+       modules.
    * - Query root model
      - :class:`InitialSpec`, :class:`BmcAssumption`,
        :class:`FrameAssumption`, :class:`EventAssumption`,
@@ -237,6 +244,14 @@ _ENGINE_EXPORTS = {
     "prepare_bmc_query",
 }
 
+_RELATION_EXPORTS = {
+    "BmcTraceSymbols",
+    "BmcCaseRelation",
+    "BmcStepRelation",
+    "BmcCoreFormula",
+    "build_bmc_core_formula",
+}
+
 _LAZY_EXPORT_MODULES = {
     "pyfcstm.bmc.binding": _BINDING_EXPORTS,
     "pyfcstm.bmc.domain": _DOMAIN_EXPORTS,
@@ -244,6 +259,7 @@ _LAZY_EXPORT_MODULES = {
     "pyfcstm.bmc.macro": _MACRO_EXPORTS,
     "pyfcstm.bmc.expand": _EXPAND_EXPORTS,
     "pyfcstm.bmc.engine": _ENGINE_EXPORTS,
+    "pyfcstm.bmc.relation": _RELATION_EXPORTS,
 }
 
 
@@ -300,6 +316,7 @@ def __dir__():
         | _MACRO_EXPORTS
         | _EXPAND_EXPORTS
         | _ENGINE_EXPORTS
+        | _RELATION_EXPORTS
     )
 
 
@@ -393,4 +410,9 @@ __all__ = [
     "BmcPreparedContext",
     "BmcEngine",
     "prepare_bmc_query",
+    "BmcTraceSymbols",
+    "BmcCaseRelation",
+    "BmcStepRelation",
+    "BmcCoreFormula",
+    "build_bmc_core_formula",
 ]

--- a/pyfcstm/bmc/expand.py
+++ b/pyfcstm/bmc/expand.py
@@ -621,8 +621,16 @@ class _MacroExpander:
         result = []
         for item in entered:
             if any(frame.state is composite_frame.state for frame in item.stack):
+                plain_before_pending = (
+                    composite_frame.plain_before_pending
+                    if target_state.is_pseudo
+                    else False
+                )
                 item = self._replace_frame(
-                    item, composite_frame.state, "active", plain_before_pending=False
+                    item,
+                    composite_frame.state,
+                    "active",
+                    plain_before_pending=plain_before_pending,
                 )
             result.append(item)
         return tuple(result)

--- a/pyfcstm/bmc/relation.py
+++ b/pyfcstm/bmc/relation.py
@@ -150,7 +150,11 @@ def _domain_constraints_exprs(
 
 
 def _failure_message(kind: str, reason: str, label: str) -> str:
-    return "%s failed while lowering %s: %s" % (kind, label, reason)
+    return "unsupported_bmc_core: %s failed while lowering %s: %s" % (
+        kind,
+        label,
+        reason,
+    )
 
 
 def _raise_expr_failure(result, label: str) -> None:

--- a/pyfcstm/bmc/relation.py
+++ b/pyfcstm/bmc/relation.py
@@ -1,0 +1,1680 @@
+"""Build solver-level BMC core trace relations.
+
+This module lowers the solver-independent BMC preparation and macro-step
+handoff objects into the first SMT formula layer.  The public entry point
+:func:`build_bmc_core_formula` consumes a
+:class:`pyfcstm.bmc.engine.BmcPreparedContext`, allocates bounded frame / step
+symbols, expands macro-step cases, and constructs the core formula
+``Core_N = D_N ∧ I_0 ∧ T_N ∧ ENV_N``.
+
+The relation builder deliberately stops before property compilation.  It does
+not decide whether a query is reachable, forbidden, covered, or healthy; later
+layers add ``InitHealthy_0`` / ``NoDiag_N`` gates and objective constraints on
+top of the returned core formula.
+
+Public concepts:
+
+* :class:`BmcTraceSymbols` - Z3 symbols for frames, event inputs, and case
+  selectors.
+* :class:`BmcCaseRelation` - One lowered macro-step case implication.
+* :class:`BmcStepRelation` - All case implications for one symbolic step.
+* :class:`BmcCoreFormula` - The complete ``D_N`` / ``I_0`` / ``T_N`` /
+  ``ENV_N`` bundle.
+
+Example::
+
+    >>> from pyfcstm.bmc import BmcEngine, build_bmc_core_formula
+    >>> from pyfcstm.model import load_state_machine_from_text
+    >>> model = load_state_machine_from_text('state Root;')
+    >>> context = BmcEngine(model).prepare('check reach <= 1: terminated();')
+    >>> core = build_bmc_core_formula(context)
+    >>> core.to_canonical()['node']
+    'bmc_core_formula'
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
+
+import z3
+
+from pyfcstm.bmc import ast as bmc_ast
+from pyfcstm.bmc.binding import BoundAssumption
+from pyfcstm.bmc.domain import (
+    STATE_DIAGNOSTIC_ID,
+    STATE_TERMINATE_ID,
+    BmcDomain,
+)
+from pyfcstm.bmc.engine import BmcPreparedContext
+from pyfcstm.bmc.errors import BmcBuildError, UnsupportedBmcQuery
+from pyfcstm.bmc.expand import expand_macro_step_cases
+from pyfcstm.bmc.macro import (
+    ActionBlock,
+    BoolTemplate,
+    CycleCase,
+    GuardRequirement,
+    MacroStepFormal,
+)
+from pyfcstm.bmc.query import EventCardinalityAssumption, FrameAssumption
+from pyfcstm.bmc.source import (
+    diagnostic_source,
+    source_from_initial_spec,
+    stable_leaf_source,
+    terminated_source,
+)
+from pyfcstm.model import Expr
+from pyfcstm.solver.domain import DomainConstraint, DomainSource, translate_expr_domain
+from pyfcstm.solver.operation import execute_operations_domain
+
+_CanonicalDict = Dict[str, Any]
+_Z3Expr = Union[z3.ArithRef, z3.BoolRef]
+_EVENT_ATOM_PREFIX = "event:"
+_GUARD_ATOM_PREFIX = "guard:"
+_ACCEPTED_ATOM_PREFIX = "accepted:"
+_ISSUE_URL = "https://github.com/HansBug/pyfcstm/issues"
+
+
+def _internal_bmc_error(detail: str) -> BmcBuildError:
+    return BmcBuildError(
+        "internal BMC bug: %s This indicates that pyfcstm's BMC relation "
+        "builder received an inconsistent internal object or missed a required "
+        "precondition; please report this with the FCSTM input, .fbmcq query, "
+        "and traceback at %s." % (detail, _ISSUE_URL)
+    )
+
+
+def _require_context(context: object) -> BmcPreparedContext:
+    if not isinstance(context, BmcPreparedContext):
+        raise BmcBuildError("context must be BmcPreparedContext.")
+    if context.domain.model is not context.model:
+        raise BmcBuildError(
+            "context.domain must be built from context.model for relation building."
+        )
+    return context
+
+
+def _z3_text(expr: z3.ExprRef) -> str:
+    return str(expr)
+
+
+def _and(items: Iterable[z3.ExprRef]) -> z3.BoolRef:
+    values = tuple(items)
+    if not values:
+        return z3.BoolVal(True)
+    if len(values) == 1:
+        return values[0]
+    return z3.And(*values)
+
+
+def _or(items: Iterable[z3.ExprRef]) -> z3.BoolRef:
+    values = tuple(items)
+    if not values:  # pragma: no cover - relation callers pass non-empty domains.
+        return z3.BoolVal(False)
+    if len(values) == 1:  # pragma: no cover - current state domains include sentinels.
+        return values[0]
+    return z3.Or(*values)
+
+
+def _state_in(symbol: z3.ArithRef, state_ids: Sequence[int]) -> z3.BoolRef:
+    ids = tuple(state_ids)
+    if not ids:  # pragma: no cover - BmcDomain validates allowed state sets.
+        raise _internal_bmc_error("state domain set is empty while building D_N.")
+    return _or(symbol == z3.IntVal(state_id) for state_id in ids)
+
+
+def _safe_symbol_fragment(value: str) -> str:
+    body = re.sub(r"[^0-9A-Za-z_]+", "_", value).strip("_") or "item"
+    digest = hashlib.sha1(value.encode("utf-8")).hexdigest()[:10]
+    return "%s_%s" % (body[:80], digest)
+
+
+def _domain_constraints_exprs(
+    items: Sequence[DomainConstraint],
+) -> Tuple[z3.ExprRef, ...]:
+    return tuple(item.constraint for item in items)
+
+
+def _failure_message(kind: str, reason: str, label: str) -> str:
+    return "%s failed while lowering %s: %s" % (kind, label, reason)
+
+
+def _raise_expr_failure(result, label: str) -> None:
+    failure = getattr(result, "failure", None)
+    if failure is None:
+        return
+    message = _failure_message(failure.kind, failure.reason, label)
+    if failure.kind in {"not_implemented", "z3_error", "type_error", "value_error"}:
+        raise UnsupportedBmcQuery(message)
+    raise BmcBuildError(
+        message
+    )  # pragma: no cover - current translators use known failure kinds.
+
+
+def _expect_bool(expr: _Z3Expr, label: str) -> z3.BoolRef:
+    if not z3.is_bool(expr):  # pragma: no cover - binder/model typing prevents this.
+        raise UnsupportedBmcQuery("%s must lower to a Boolean expression." % label)
+    return expr
+
+
+def _expect_arith(expr: _Z3Expr, label: str) -> z3.ArithRef:
+    if not z3.is_arith(expr):  # pragma: no cover - binder/model typing prevents this.
+        raise UnsupportedBmcQuery("%s must lower to a numeric expression." % label)
+    return expr
+
+
+@dataclass(frozen=True)
+class _LoweredValue:
+    expr: _Z3Expr
+    definedness_constraints: Tuple[DomainConstraint, ...] = ()
+
+
+@dataclass(frozen=True)
+class BmcTraceSymbols:
+    """Z3 symbols for one bounded BMC trace.
+
+    :param domain: Domain snapshot that owns the symbols.
+    :type domain: pyfcstm.bmc.domain.BmcDomain
+    :param frame_states: State-id symbols for ``F_0..F_N``.
+    :type frame_states: Tuple[z3.ArithRef, ...]
+    :param frame_vars: Per-frame persistent-variable symbols.
+    :type frame_vars: Tuple[Mapping[str, z3.ArithRef], ...]
+    :param event_inputs: Per-step event-input symbols.
+    :type event_inputs: Tuple[Mapping[str, z3.BoolRef], ...]
+    :param case_selectors: Per-step case-selector symbols.
+    :type case_selectors: Tuple[Mapping[str, z3.BoolRef], ...]
+
+    Example::
+
+        >>> from pyfcstm.bmc.domain import build_bmc_domain
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+        >>> symbols = BmcTraceSymbols.allocate(domain, {0: ('case0',)})
+        >>> symbols.frame_state(0).sort().name()
+        'Int'
+        >>> 'case0' in symbols.case_selectors[0]
+        True
+    """
+
+    domain: BmcDomain
+    frame_states: Tuple[z3.ArithRef, ...]
+    frame_vars: Tuple[Mapping[str, z3.ArithRef], ...]
+    event_inputs: Tuple[Mapping[str, z3.BoolRef], ...]
+    case_selectors: Tuple[Mapping[str, z3.BoolRef], ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.domain, BmcDomain):
+            raise BmcBuildError("domain must be BmcDomain.")
+        if len(self.frame_states) != self.domain.bound + 1:
+            raise BmcBuildError("frame_states must contain bound + 1 symbols.")
+        if len(self.frame_vars) != self.domain.bound + 1:
+            raise BmcBuildError("frame_vars must contain bound + 1 mappings.")
+        if len(self.event_inputs) != self.domain.bound:
+            raise BmcBuildError("event_inputs must contain bound mappings.")
+        if len(self.case_selectors) != self.domain.bound:
+            raise BmcBuildError("case_selectors must contain bound mappings.")
+        object.__setattr__(
+            self,
+            "frame_vars",
+            tuple(
+                {key: value for key, value in mapping.items()}
+                for mapping in self.frame_vars
+            ),
+        )
+        object.__setattr__(
+            self,
+            "event_inputs",
+            tuple(
+                {key: value for key, value in mapping.items()}
+                for mapping in self.event_inputs
+            ),
+        )
+        object.__setattr__(
+            self,
+            "case_selectors",
+            tuple(
+                {key: value for key, value in mapping.items()}
+                for mapping in self.case_selectors
+            ),
+        )
+
+    @classmethod
+    def allocate(
+        cls,
+        domain: BmcDomain,
+        case_labels_by_step: Optional[Mapping[int, Sequence[str]]] = None,
+    ) -> "BmcTraceSymbols":
+        """Allocate trace symbols for ``domain``.
+
+        :param domain: Domain snapshot to allocate for.
+        :type domain: pyfcstm.bmc.domain.BmcDomain
+        :param case_labels_by_step: Optional mapping from step index to case
+            labels that need selector symbols, defaults to ``None``.
+        :type case_labels_by_step: Optional[Mapping[int, Sequence[str]]], optional
+        :return: Allocated symbol bundle.
+        :rtype: BmcTraceSymbols
+        :raises pyfcstm.bmc.errors.BmcBuildError: If the domain is malformed.
+
+        Example::
+
+            >>> from pyfcstm.bmc.domain import build_bmc_domain
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+            >>> BmcTraceSymbols.allocate(domain).to_canonical()['node']
+            'bmc_trace_symbols'
+        """
+        if not isinstance(domain, BmcDomain):
+            raise BmcBuildError("domain must be BmcDomain.")
+        labels_by_step = case_labels_by_step or {}
+        frame_states = tuple(
+            z3.Int("F_%d_state" % frame.index) for frame in domain.frames
+        )
+        frame_vars = []
+        for frame in domain.frames:
+            mapping = {}
+            for var in domain.variables:
+                symbol_name = "F_%d_%s" % (frame.index, _safe_symbol_fragment(var.name))
+                if var.declared_type == "int":
+                    mapping[var.name] = z3.Int(symbol_name)
+                elif var.declared_type == "float":
+                    mapping[var.name] = z3.Real(symbol_name)
+                else:  # pragma: no cover - BmcDomain only admits int/float vars.
+                    raise BmcBuildError(
+                        "Unsupported persistent variable type for BMC relation: %r."
+                        % var.declared_type
+                    )
+            frame_vars.append(mapping)
+        event_inputs = []
+        for step in domain.steps:
+            mapping = {}
+            for event in domain.events:
+                mapping[event.path] = z3.Bool(
+                    "E_%d_event_%d_%s"
+                    % (step.index, event.id, _safe_symbol_fragment(event.path))
+                )
+            event_inputs.append(mapping)
+        case_selectors = []
+        for step in domain.steps:
+            labels = tuple(labels_by_step.get(step.index, ()))
+            if len(set(labels)) != len(labels):
+                raise _internal_bmc_error(
+                    "duplicate case labels supplied for step %d." % step.index
+                )
+            case_selectors.append(
+                {
+                    label: z3.Bool(
+                        "C_%d_%s" % (step.index, _safe_symbol_fragment(label))
+                    )
+                    for label in labels
+                }
+            )
+        return cls(
+            domain=domain,
+            frame_states=frame_states,
+            frame_vars=tuple(frame_vars),
+            event_inputs=tuple(event_inputs),
+            case_selectors=tuple(case_selectors),
+        )
+
+    def frame_state(self, frame_index: int) -> z3.ArithRef:
+        """Return the state symbol for a frame.
+
+        :param frame_index: Frame index in ``0..N``.
+        :type frame_index: int
+        :return: State-id symbol.
+        :rtype: z3.ArithRef
+        :raises pyfcstm.bmc.errors.BmcBuildError: If ``frame_index`` is invalid.
+
+        Example::
+
+            >>> from pyfcstm.bmc.domain import build_bmc_domain
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+            >>> BmcTraceSymbols.allocate(domain).frame_state(0).decl().name()
+            'F_0_state'
+        """
+        if frame_index < 0 or frame_index >= len(self.frame_states):
+            raise BmcBuildError("frame index out of range: %r." % frame_index)
+        return self.frame_states[frame_index]
+
+    def frame_var(self, frame_index: int, name: str) -> z3.ArithRef:
+        """Return a persistent-variable symbol for a frame.
+
+        :param frame_index: Frame index in ``0..N``.
+        :type frame_index: int
+        :param name: Persistent variable name.
+        :type name: str
+        :return: Variable symbol.
+        :rtype: z3.ArithRef
+        :raises pyfcstm.bmc.errors.BmcBuildError: If the frame or variable is
+            unknown.
+
+        Example::
+
+            >>> from pyfcstm.bmc.domain import build_bmc_domain
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> domain = build_bmc_domain(load_state_machine_from_text('def int x = 0; state Root;'), 1)
+            >>> BmcTraceSymbols.allocate(domain).frame_var(0, 'x').sort().name()
+            'Int'
+        """
+        if frame_index < 0 or frame_index >= len(self.frame_vars):
+            raise BmcBuildError("frame index out of range: %r." % frame_index)
+        try:
+            return self.frame_vars[frame_index][name]
+        except KeyError as err:
+            # KeyError: the requested variable name is absent from this domain's
+            # persistent-variable symbol mapping.
+            raise BmcBuildError("Unknown frame variable: %r." % name) from err
+
+    def event_input(self, step_index: int, event_path: str) -> z3.BoolRef:
+        """Return an event-input symbol for a step.
+
+        :param step_index: Step index in ``0..N-1``.
+        :type step_index: int
+        :param event_path: Fully resolved event path.
+        :type event_path: str
+        :return: Event-input symbol.
+        :rtype: z3.BoolRef
+        :raises pyfcstm.bmc.errors.BmcBuildError: If the step or event is
+            unknown.
+
+        Example::
+
+            >>> from pyfcstm.bmc.domain import build_bmc_domain
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> model = load_state_machine_from_text('state Root { event Go; state A; [*] -> A; }')
+            >>> domain = build_bmc_domain(model, 1)
+            >>> BmcTraceSymbols.allocate(domain).event_input(0, 'Root.Go').sort().name()
+            'Bool'
+        """
+        if step_index < 0 or step_index >= len(self.event_inputs):
+            raise BmcBuildError("step index out of range: %r." % step_index)
+        try:
+            return self.event_inputs[step_index][event_path]
+        except KeyError as err:
+            # KeyError: the requested event path is absent from this domain's
+            # per-step event-input mapping.
+            raise BmcBuildError("Unknown event input: %r." % event_path) from err
+
+    def case_selector(self, step_index: int, label: str) -> z3.BoolRef:
+        """Return a case-selector symbol for a step.
+
+        :param step_index: Step index in ``0..N-1``.
+        :type step_index: int
+        :param label: Macro-step case label.
+        :type label: str
+        :return: Case-selector symbol.
+        :rtype: z3.BoolRef
+        :raises pyfcstm.bmc.errors.BmcBuildError: If the selector is unknown.
+
+        Example::
+
+            >>> from pyfcstm.bmc.domain import build_bmc_domain
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+            >>> symbols = BmcTraceSymbols.allocate(domain, {0: ('Root::fallback::Root::0',)})
+            >>> symbols.case_selector(0, 'Root::fallback::Root::0').sort().name()
+            'Bool'
+        """
+        if step_index < 0 or step_index >= len(self.case_selectors):
+            raise BmcBuildError("step index out of range: %r." % step_index)
+        try:
+            return self.case_selectors[step_index][label]
+        except KeyError as err:
+            # KeyError: the requested case label is absent from this step's
+            # selector mapping.
+            raise BmcBuildError("Unknown case selector: %r." % label) from err
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable symbol summary.
+
+        :return: Canonical symbol dictionary.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc.domain import build_bmc_domain
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> domain = build_bmc_domain(load_state_machine_from_text('state Root;'), 1)
+            >>> BmcTraceSymbols.allocate(domain).to_canonical()['frame_states'][0]
+            'F_0_state'
+        """
+        return {
+            "node": "bmc_trace_symbols",
+            "bound": self.domain.bound,
+            "frame_states": [_z3_text(item) for item in self.frame_states],
+            "frame_vars": [
+                {name: _z3_text(expr) for name, expr in sorted(mapping.items())}
+                for mapping in self.frame_vars
+            ],
+            "event_inputs": [
+                {name: _z3_text(expr) for name, expr in sorted(mapping.items())}
+                for mapping in self.event_inputs
+            ],
+            "case_selectors": [
+                {name: _z3_text(expr) for name, expr in sorted(mapping.items())}
+                for mapping in self.case_selectors
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class BmcCaseRelation:
+    """Lowered relation for one macro-step case.
+
+    :param step_index: Step index owning this case.
+    :type step_index: int
+    :param case: Macro-step case that was lowered.
+    :type case: pyfcstm.bmc.macro.CycleCase
+    :param selector: Case-selector symbol bound to ``antecedent``.
+    :type selector: z3.BoolRef
+    :param antecedent: Source guard and lowered case condition.
+    :type antecedent: z3.BoolRef
+    :param consequent: Target-state, post-var, and definedness constraints.
+    :type consequent: z3.BoolRef
+    :param implication: ``z3.Implies(antecedent, consequent)``.
+    :type implication: z3.BoolRef
+    :param selector_constraint: Equality between selector and antecedent.
+    :type selector_constraint: z3.BoolRef
+    :param post_var_exprs: Final expression for every persistent variable.
+    :type post_var_exprs: Mapping[str, z3.ArithRef]
+    :param guard_terms: Lowered guard terms keyed by requirement id.
+    :type guard_terms: Mapping[str, z3.BoolRef]
+    :param definedness_constraints: Runtime-definedness constraints in source
+        order.
+    :type definedness_constraints: Tuple[pyfcstm.solver.domain.DomainConstraint, ...]
+
+    Example::
+
+        >>> import z3
+        >>> from pyfcstm.bmc.macro import BoolTemplate, CycleCase
+        >>> case = CycleCase('fallback', 0, 'Root', 0, 'Root', 'Root::fallback::Root::0', BoolTemplate.true(), ())
+        >>> rel = BmcCaseRelation(0, case, z3.Bool('c'), z3.BoolVal(True), z3.BoolVal(True), z3.BoolVal(True), z3.BoolVal(True), {}, {}, ())
+        >>> rel.to_canonical()['case_label']
+        'Root::fallback::Root::0'
+    """
+
+    step_index: int
+    case: CycleCase
+    selector: z3.BoolRef
+    antecedent: z3.BoolRef
+    consequent: z3.BoolRef
+    implication: z3.BoolRef
+    selector_constraint: z3.BoolRef
+    post_var_exprs: Mapping[str, z3.ArithRef]
+    guard_terms: Mapping[str, z3.BoolRef]
+    definedness_constraints: Tuple[DomainConstraint, ...] = ()
+
+    def __post_init__(self) -> None:
+        if isinstance(self.step_index, bool) or not isinstance(self.step_index, int):
+            raise BmcBuildError("step_index must be an integer.")
+        if self.step_index < 0:
+            raise BmcBuildError("step_index must be non-negative.")
+        if not isinstance(self.case, CycleCase):
+            raise BmcBuildError("case must be CycleCase.")
+        for name in (
+            "selector",
+            "antecedent",
+            "consequent",
+            "implication",
+            "selector_constraint",
+        ):
+            if not z3.is_bool(getattr(self, name)):
+                raise BmcBuildError("%s must be a Z3 Boolean expression." % name)
+        post_vars = {key: value for key, value in self.post_var_exprs.items()}
+        if not all(z3.is_arith(value) for value in post_vars.values()):
+            raise BmcBuildError(
+                "post_var_exprs must contain Z3 arithmetic expressions."
+            )
+        guard_terms = {key: value for key, value in self.guard_terms.items()}
+        if not all(z3.is_bool(value) for value in guard_terms.values()):
+            raise BmcBuildError("guard_terms must contain Z3 Boolean expressions.")
+        if not all(
+            isinstance(item, DomainConstraint) for item in self.definedness_constraints
+        ):
+            raise BmcBuildError(
+                "definedness_constraints must contain DomainConstraint objects."
+            )
+        object.__setattr__(self, "post_var_exprs", post_vars)
+        object.__setattr__(self, "guard_terms", guard_terms)
+        object.__setattr__(
+            self, "definedness_constraints", tuple(self.definedness_constraints)
+        )
+
+    @property
+    def formula(self) -> z3.BoolRef:
+        """Return selector binding and implication for this case.
+
+        :return: Case formula.
+        :rtype: z3.BoolRef
+
+        Example::
+
+            >>> import z3
+            >>> from pyfcstm.bmc.macro import BoolTemplate, CycleCase
+            >>> case = CycleCase('fallback', 0, 'Root', 0, 'Root', 'Root::fallback::Root::0', BoolTemplate.true(), ())
+            >>> rel = BmcCaseRelation(0, case, z3.Bool('c'), z3.BoolVal(True), z3.BoolVal(True), z3.BoolVal(True), z3.BoolVal(True), {}, {}, ())
+            >>> rel.formula.sort().name()
+            'Bool'
+        """
+        return _and((self.selector_constraint, self.implication))
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable case-relation dictionary.
+
+        :return: Canonical case relation.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> import z3
+            >>> from pyfcstm.bmc.macro import BoolTemplate, CycleCase
+            >>> case = CycleCase('fallback', 0, 'Root', 0, 'Root', 'Root::fallback::Root::0', BoolTemplate.true(), ())
+            >>> rel = BmcCaseRelation(0, case, z3.Bool('c'), z3.BoolVal(True), z3.BoolVal(True), z3.BoolVal(True), z3.BoolVal(True), {}, {}, ())
+            >>> rel.to_canonical()['node']
+            'bmc_case_relation'
+        """
+        return {
+            "node": "bmc_case_relation",
+            "step_index": self.step_index,
+            "case_label": self.case.label,
+            "case_kind": self.case.kind,
+            "source_state_id": self.case.source_state_id,
+            "target_state_id": self.case.target_state_id,
+            "is_diagnostic": self.case.is_diagnostic,
+            "selector": _z3_text(self.selector),
+            "antecedent": _z3_text(self.antecedent),
+            "consequent": _z3_text(self.consequent),
+            "implication": _z3_text(self.implication),
+            "selector_constraint": _z3_text(self.selector_constraint),
+            "post_var_exprs": {
+                name: _z3_text(expr)
+                for name, expr in sorted(self.post_var_exprs.items())
+            },
+            "guard_terms": {
+                name: _z3_text(expr) for name, expr in sorted(self.guard_terms.items())
+            },
+            "definedness_constraints": [
+                _z3_text(item.constraint) for item in self.definedness_constraints
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class BmcStepRelation:
+    """Lowered relation for one symbolic BMC step.
+
+    :param step_index: Step index in ``0..N-1``.
+    :type step_index: int
+    :param formals: Macro-step formals consumed by this step.
+    :type formals: Tuple[pyfcstm.bmc.macro.MacroStepFormal, ...]
+    :param case_relations: Lowered case relations.
+    :type case_relations: Tuple[BmcCaseRelation, ...]
+    :param formula: Conjunction of selector bindings and implications.
+    :type formula: z3.BoolRef
+
+    Example::
+
+        >>> import z3
+        >>> step = BmcStepRelation(0, (), (), z3.BoolVal(True))
+        >>> step.to_canonical()['step_index']
+        0
+    """
+
+    step_index: int
+    formals: Tuple[MacroStepFormal, ...]
+    case_relations: Tuple[BmcCaseRelation, ...]
+    formula: z3.BoolRef
+
+    def __post_init__(self) -> None:
+        if isinstance(self.step_index, bool) or not isinstance(self.step_index, int):
+            raise BmcBuildError("step_index must be an integer.")
+        if self.step_index < 0:
+            raise BmcBuildError("step_index must be non-negative.")
+        if not all(isinstance(item, MacroStepFormal) for item in self.formals):
+            raise BmcBuildError("formals must contain MacroStepFormal objects.")
+        if not all(isinstance(item, BmcCaseRelation) for item in self.case_relations):
+            raise BmcBuildError("case_relations must contain BmcCaseRelation objects.")
+        if not z3.is_bool(self.formula):
+            raise BmcBuildError("formula must be a Z3 Boolean expression.")
+        object.__setattr__(self, "formals", tuple(self.formals))
+        object.__setattr__(self, "case_relations", tuple(self.case_relations))
+
+    @property
+    def case_registry(self) -> Mapping[str, BmcCaseRelation]:
+        """Return lowered cases keyed by label for this step.
+
+        :return: Case-label mapping.
+        :rtype: Mapping[str, BmcCaseRelation]
+
+        Example::
+
+            >>> import z3
+            >>> BmcStepRelation(0, (), (), z3.BoolVal(True)).case_registry
+            {}
+        """
+        return {item.case.label: item for item in self.case_relations}
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable step-relation dictionary.
+
+        :return: Canonical step relation.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> import z3
+            >>> BmcStepRelation(0, (), (), z3.BoolVal(True)).to_canonical()['node']
+            'bmc_step_relation'
+        """
+        return {
+            "node": "bmc_step_relation",
+            "step_index": self.step_index,
+            "source_count": len(self.formals),
+            "case_count": len(self.case_relations),
+            "formula": _z3_text(self.formula),
+            "cases": [item.to_canonical() for item in self.case_relations],
+        }
+
+
+@dataclass(frozen=True)
+class BmcCoreFormula:
+    """Complete solver-level core formula for a bounded trace.
+
+    :param context: Prepared BMC context consumed by the builder.
+    :type context: pyfcstm.bmc.engine.BmcPreparedContext
+    :param symbols: Trace symbols used by the formulas.
+    :type symbols: BmcTraceSymbols
+    :param domain_formula: ``D_N`` domain constraints.
+    :type domain_formula: z3.BoolRef
+    :param initial_formula: ``I_0`` initial-frame constraints.
+    :type initial_formula: z3.BoolRef
+    :param transition_formula: ``T_N`` transition relation.
+    :type transition_formula: z3.BoolRef
+    :param environment_formula: ``ENV_N`` environment assumptions.
+    :type environment_formula: z3.BoolRef
+    :param core: ``D_N ∧ I_0 ∧ T_N ∧ ENV_N``.
+    :type core: z3.BoolRef
+    :param steps: Lowered step relations.
+    :type steps: Tuple[BmcStepRelation, ...]
+    :param diagnostics: Builder diagnostics, defaults to ``()``.
+    :type diagnostics: Tuple[str, ...], optional
+
+    Example::
+
+        >>> from pyfcstm.bmc import BmcEngine, build_bmc_core_formula
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> model = load_state_machine_from_text('state Root;')
+        >>> context = BmcEngine(model).prepare('check reach <= 1: terminated();')
+        >>> build_bmc_core_formula(context).to_canonical()['bound']
+        1
+    """
+
+    context: BmcPreparedContext
+    symbols: BmcTraceSymbols
+    domain_formula: z3.BoolRef
+    initial_formula: z3.BoolRef
+    transition_formula: z3.BoolRef
+    environment_formula: z3.BoolRef
+    core: z3.BoolRef
+    steps: Tuple[BmcStepRelation, ...]
+    diagnostics: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        _require_context(self.context)
+        if not isinstance(self.symbols, BmcTraceSymbols):
+            raise BmcBuildError("symbols must be BmcTraceSymbols.")
+        for name in (
+            "domain_formula",
+            "initial_formula",
+            "transition_formula",
+            "environment_formula",
+            "core",
+        ):
+            if not z3.is_bool(getattr(self, name)):
+                raise BmcBuildError("%s must be a Z3 Boolean expression." % name)
+        if not all(isinstance(item, BmcStepRelation) for item in self.steps):
+            raise BmcBuildError("steps must contain BmcStepRelation objects.")
+        if not all(isinstance(item, str) for item in self.diagnostics):
+            raise BmcBuildError("diagnostics must contain strings.")
+        object.__setattr__(self, "steps", tuple(self.steps))
+        object.__setattr__(self, "diagnostics", tuple(self.diagnostics))
+
+    def to_canonical(self) -> _CanonicalDict:
+        """Return a JSON-stable core-formula summary.
+
+        :return: Canonical core formula.
+        :rtype: Dict[str, object]
+
+        Example::
+
+            >>> from pyfcstm.bmc import BmcEngine, build_bmc_core_formula
+            >>> from pyfcstm.model import load_state_machine_from_text
+            >>> model = load_state_machine_from_text('state Root;')
+            >>> core = build_bmc_core_formula(BmcEngine(model).prepare('check reach <= 1: terminated();'))
+            >>> core.to_canonical()['node']
+            'bmc_core_formula'
+        """
+        return {
+            "node": "bmc_core_formula",
+            "bound": self.context.bound,
+            "formulas": {
+                "D_N": _z3_text(self.domain_formula),
+                "I_0": _z3_text(self.initial_formula),
+                "T_N": _z3_text(self.transition_formula),
+                "ENV_N": _z3_text(self.environment_formula),
+                "Core_N": _z3_text(self.core),
+            },
+            "symbols": self.symbols.to_canonical(),
+            "steps": [item.to_canonical() for item in self.steps],
+            "diagnostics": list(self.diagnostics),
+        }
+
+
+def _z3_arith_binary(
+    op: str, left: z3.ArithRef, right: z3.ArithRef, label: str
+) -> _Z3Expr:
+    try:
+        if op == "+":
+            return left + right
+        if op == "-":
+            return left - right
+        if op == "*":
+            return left * right
+        if op == "/":
+            return left / right
+        if op == "%":
+            return left % right
+        if op == "**":
+            return left**right
+        if op == "&":  # pragma: no cover - reserved for future BitVec profile.
+            return left & right
+        if op == "|":  # pragma: no cover - reserved for future BitVec profile.
+            return left | right
+        if op == "^":  # pragma: no cover - reserved for future BitVec profile.
+            return left ^ right
+        if op == "<<":  # pragma: no cover - reserved for future BitVec profile.
+            return left << right
+        if op == ">>":  # pragma: no cover - reserved for future BitVec profile.
+            return left >> right
+    except TypeError as err:
+        # TypeError: Python or Z3 operator overloads reject unsupported operand
+        # sort combinations, such as bitwise operators on Real expressions.
+        raise UnsupportedBmcQuery(
+            "%s is unsupported for operator %s: %s" % (label, op, err)
+        ) from err
+    except (
+        z3.Z3Exception
+    ) as err:  # pragma: no cover - TypeError covers current sort failures.
+        # Z3Exception: Z3 rejects malformed arithmetic expressions or sort
+        # combinations after overload dispatch.
+        raise UnsupportedBmcQuery(
+            "%s is unsupported for operator %s: %s" % (label, op, err)
+        ) from err
+    raise UnsupportedBmcQuery(  # pragma: no cover - AST validates operator names.
+        "%s uses unsupported numeric operator %r." % (label, op)
+    )
+
+
+def _z3_comparison(
+    op: str, left: z3.ArithRef, right: z3.ArithRef, label: str
+) -> z3.BoolRef:
+    try:
+        if op == "<":
+            return left < right
+        if op == "<=":
+            return left <= right
+        if op == ">":
+            return left > right
+        if op == ">=":
+            return left >= right
+        if op == "==":
+            return left == right
+        if op == "!=":
+            return left != right
+    except (
+        TypeError
+    ) as err:  # pragma: no cover - current AST/binder keeps comparisons well typed.
+        # TypeError: Python/Z3 comparison overloads reject unsupported operand
+        # shapes before Z3 creates an expression.
+        raise UnsupportedBmcQuery(
+            "%s comparison %s is unsupported: %s" % (label, op, err)
+        ) from err
+    except (
+        z3.Z3Exception
+    ) as err:  # pragma: no cover - current AST/binder keeps comparisons well typed.
+        # Z3Exception: Z3 rejects malformed comparison sort combinations.
+        raise UnsupportedBmcQuery(
+            "%s comparison %s is unsupported: %s" % (label, op, err)
+        ) from err
+    raise UnsupportedBmcQuery(  # pragma: no cover - AST validates operator names.
+        "%s uses unsupported comparison operator %r." % (label, op)
+    )
+
+
+def _z3_ufunc(func: str, operand: z3.ArithRef, label: str) -> _LoweredValue:
+    constraints = []
+    try:
+        if func == "abs":
+            return _LoweredValue(z3.If(operand >= 0, operand, -operand))
+        if func == "sign":
+            zero = z3.IntVal(0) if z3.is_int(operand) else z3.RealVal(0)
+            one = z3.IntVal(1) if z3.is_int(operand) else z3.RealVal(1)
+            minus_one = z3.IntVal(-1) if z3.is_int(operand) else z3.RealVal(-1)
+            return _LoweredValue(
+                z3.If(operand == zero, zero, z3.If(operand > zero, one, minus_one))
+            )
+        if func == "floor":
+            return _LoweredValue(operand if z3.is_int(operand) else z3.ToInt(operand))
+        if func == "ceil":
+            return _LoweredValue(operand if z3.is_int(operand) else -z3.ToInt(-operand))
+        if func == "trunc":
+            if z3.is_int(operand):
+                return _LoweredValue(operand)
+            return _LoweredValue(
+                z3.If(operand >= 0, z3.ToInt(operand), -z3.ToInt(-operand))
+            )
+        if func == "round":
+            from pyfcstm.solver.expr import python_round_to_z3
+
+            return _LoweredValue(python_round_to_z3(operand))
+        if func == "sqrt":
+            constraints.append(
+                DomainConstraint(operand >= 0, DomainSource(label=label))
+            )
+            root = z3.Sqrt(operand if z3.is_real(operand) else z3.ToReal(operand))
+            return _LoweredValue(root, tuple(constraints))
+    except TypeError as err:  # pragma: no cover - current ufunc calls are arith-sorted.
+        # TypeError: Python/Z3 overloads reject unsupported function operands.
+        raise UnsupportedBmcQuery(
+            "%s function %s is unsupported: %s" % (label, func, err)
+        ) from err
+    except (
+        z3.Z3Exception
+    ) as err:  # pragma: no cover - current ufunc calls are arith-sorted.
+        # Z3Exception: Z3 rejects unsupported function operand sorts.
+        raise UnsupportedBmcQuery(
+            "%s function %s is unsupported: %s" % (label, func, err)
+        ) from err
+    raise UnsupportedBmcQuery("%s uses unsupported function %r." % (label, func))
+
+
+def _resolve_frame(frame_selector: object, current_frame: int, bound: int) -> int:
+    if frame_selector == "current":
+        return current_frame
+    if isinstance(frame_selector, bool) or not isinstance(
+        frame_selector, int
+    ):  # pragma: no cover - binder validates selectors.
+        raise BmcBuildError("Invalid frame selector: %r." % (frame_selector,))
+    if (
+        frame_selector < 0 or frame_selector > bound
+    ):  # pragma: no cover - binder validates selectors.
+        raise BmcBuildError("Frame selector out of range: %r." % frame_selector)
+    return frame_selector  # pragma: no cover - binder disallows explicit frame selectors here.
+
+
+def _resolve_step(selector: object, current_step: Optional[int], bound: int) -> int:
+    if (
+        selector == "current"
+    ):  # pragma: no cover - relation callers currently use frame predicates.
+        if (
+            current_step is None
+        ):  # pragma: no cover - frame-only callers have no step context.
+            raise UnsupportedBmcQuery(
+                "event(..., current) needs a transition step context."
+            )
+        return current_step
+    if isinstance(selector, bool) or not isinstance(
+        selector, int
+    ):  # pragma: no cover - binder validates selectors.
+        raise BmcBuildError("Invalid step selector: %r." % (selector,))
+    if (
+        selector < 0 or selector >= bound
+    ):  # pragma: no cover - binder validates selectors.
+        raise BmcBuildError("Step selector out of range: %r." % selector)
+    return (
+        selector  # pragma: no cover - relation callers currently use frame predicates.
+    )
+
+
+def _lower_bmc_num_expr(
+    expr: bmc_ast.BmcNumExpr,
+    symbols: BmcTraceSymbols,
+    *,
+    frame_index: int,
+    step_index: Optional[int] = None,
+) -> _LoweredValue:
+    label = "BMC numeric expression %s" % expr
+    if isinstance(expr, bmc_ast.IntLiteral):
+        return _LoweredValue(z3.IntVal(expr.value))
+    if isinstance(expr, bmc_ast.FloatLiteral):
+        return _LoweredValue(z3.RealVal(str(expr.value)))
+    if isinstance(expr, bmc_ast.NameRef):
+        return _LoweredValue(symbols.frame_var(frame_index, expr.name))
+    if isinstance(expr, bmc_ast.FrameVar):
+        return _LoweredValue(symbols.frame_var(frame_index, expr.name))
+    if isinstance(expr, bmc_ast.Cycle):
+        return _LoweredValue(z3.IntVal(frame_index))
+    if isinstance(expr, bmc_ast.MathConst):
+        constants = {"pi": math.pi, "E": math.e, "tau": math.tau}
+        return _LoweredValue(z3.RealVal(str(constants[expr.name])))
+    if isinstance(expr, bmc_ast.NumUnaryOp):
+        operand = _lower_bmc_num_expr(
+            expr.operand,
+            symbols,
+            frame_index=frame_index,
+            step_index=step_index,
+        )
+        value = _expect_arith(operand.expr, label)
+        if expr.op == "+":
+            return _LoweredValue(value, operand.definedness_constraints)
+        if expr.op == "-":
+            return _LoweredValue(-value, operand.definedness_constraints)
+        raise UnsupportedBmcQuery(  # pragma: no cover - AST validates operator names.
+            "%s uses unsupported unary operator %r." % (label, expr.op)
+        )
+    if isinstance(expr, bmc_ast.NumBinaryOp):
+        left = _lower_bmc_num_expr(
+            expr.left, symbols, frame_index=frame_index, step_index=step_index
+        )
+        right = _lower_bmc_num_expr(
+            expr.right, symbols, frame_index=frame_index, step_index=step_index
+        )
+        left_expr = _expect_arith(left.expr, label)
+        right_expr = _expect_arith(right.expr, label)
+        constraints = [*left.definedness_constraints, *right.definedness_constraints]
+        if expr.op in ("/", "%"):
+            constraints.append(
+                DomainConstraint(right_expr != 0, DomainSource(label=label))
+            )
+        return _LoweredValue(
+            _z3_arith_binary(expr.op, left_expr, right_expr, label),
+            tuple(constraints),
+        )
+    if isinstance(expr, bmc_ast.NumConditionalOp):
+        condition = _lower_bmc_cond_expr(
+            expr.condition, symbols, frame_index=frame_index, step_index=step_index
+        )
+        if_true = _lower_bmc_num_expr(
+            expr.if_true, symbols, frame_index=frame_index, step_index=step_index
+        )
+        if_false = _lower_bmc_num_expr(
+            expr.if_false, symbols, frame_index=frame_index, step_index=step_index
+        )
+        return _LoweredValue(
+            z3.If(
+                _expect_bool(condition.expr, label),
+                _expect_arith(if_true.expr, label),
+                _expect_arith(if_false.expr, label),
+            ),
+            (
+                *condition.definedness_constraints,
+                *if_true.definedness_constraints,
+                *if_false.definedness_constraints,
+            ),
+        )
+    if isinstance(expr, bmc_ast.UFuncCall):
+        operand = _lower_bmc_num_expr(
+            expr.operand, symbols, frame_index=frame_index, step_index=step_index
+        )
+        result = _z3_ufunc(expr.func, _expect_arith(operand.expr, label), label)
+        return _LoweredValue(
+            result.expr,
+            (*operand.definedness_constraints, *result.definedness_constraints),
+        )
+    raise UnsupportedBmcQuery(  # pragma: no cover - current AST class set is closed.
+        "Unsupported BMC numeric expression: %s." % type(expr).__name__
+    )
+
+
+def _lower_bmc_cond_expr(
+    expr: bmc_ast.BmcCondExpr,
+    symbols: BmcTraceSymbols,
+    *,
+    frame_index: int,
+    step_index: Optional[int] = None,
+) -> _LoweredValue:
+    label = "BMC condition expression %s" % expr
+    if isinstance(expr, bmc_ast.BoolLiteral):
+        return _LoweredValue(z3.BoolVal(expr.value))
+    if isinstance(expr, bmc_ast.NumericComparison):
+        left = _lower_bmc_num_expr(
+            expr.left, symbols, frame_index=frame_index, step_index=step_index
+        )
+        right = _lower_bmc_num_expr(
+            expr.right, symbols, frame_index=frame_index, step_index=step_index
+        )
+        return _LoweredValue(
+            _z3_comparison(
+                expr.op,
+                _expect_arith(left.expr, label),
+                _expect_arith(right.expr, label),
+                label,
+            ),
+            (*left.definedness_constraints, *right.definedness_constraints),
+        )
+    if isinstance(expr, bmc_ast.CondUnaryOp):
+        operand = _lower_bmc_cond_expr(
+            expr.operand, symbols, frame_index=frame_index, step_index=step_index
+        )
+        if expr.op == "!":
+            return _LoweredValue(
+                z3.Not(_expect_bool(operand.expr, label)),
+                operand.definedness_constraints,
+            )
+        raise UnsupportedBmcQuery(  # pragma: no cover - AST validates operator names.
+            "%s uses unsupported condition unary operator %r." % (label, expr.op)
+        )
+    if isinstance(expr, bmc_ast.CondBinaryOp):
+        left = _lower_bmc_cond_expr(
+            expr.left, symbols, frame_index=frame_index, step_index=step_index
+        )
+        right = _lower_bmc_cond_expr(
+            expr.right, symbols, frame_index=frame_index, step_index=step_index
+        )
+        left_expr = _expect_bool(left.expr, label)
+        right_expr = _expect_bool(right.expr, label)
+        if expr.op == "&&":
+            value = z3.And(left_expr, right_expr)
+        elif expr.op == "||":
+            value = z3.Or(left_expr, right_expr)
+        elif expr.op == "=>":
+            value = z3.Implies(left_expr, right_expr)
+        elif expr.op == "xor":
+            value = z3.Xor(left_expr, right_expr)
+        elif expr.op in {"iff", "=="}:
+            value = left_expr == right_expr
+        elif expr.op == "!=":
+            value = left_expr != right_expr
+        else:
+            raise UnsupportedBmcQuery(  # pragma: no cover - AST validates operator names.
+                "%s uses unsupported condition operator %r." % (label, expr.op)
+            )
+        return _LoweredValue(
+            value, (*left.definedness_constraints, *right.definedness_constraints)
+        )
+    if isinstance(expr, bmc_ast.CondConditionalOp):
+        condition = _lower_bmc_cond_expr(
+            expr.condition, symbols, frame_index=frame_index, step_index=step_index
+        )
+        if_true = _lower_bmc_cond_expr(
+            expr.if_true, symbols, frame_index=frame_index, step_index=step_index
+        )
+        if_false = _lower_bmc_cond_expr(
+            expr.if_false, symbols, frame_index=frame_index, step_index=step_index
+        )
+        return _LoweredValue(
+            z3.If(
+                _expect_bool(condition.expr, label),
+                _expect_bool(if_true.expr, label),
+                _expect_bool(if_false.expr, label),
+            ),
+            (
+                *condition.definedness_constraints,
+                *if_true.definedness_constraints,
+                *if_false.definedness_constraints,
+            ),
+        )
+    if isinstance(expr, bmc_ast.Active):
+        frame = _resolve_frame(expr.frame, frame_index, symbols.domain.bound)
+        state_id = symbols.domain.state_path_to_id(expr.state_path)
+        return _LoweredValue(symbols.frame_state(frame) == z3.IntVal(state_id))
+    if isinstance(expr, bmc_ast.Terminated):
+        frame = _resolve_frame(expr.frame, frame_index, symbols.domain.bound)
+        return _LoweredValue(
+            symbols.frame_state(frame) == z3.IntVal(STATE_TERMINATE_ID)
+        )
+    if isinstance(
+        expr, bmc_ast.Event
+    ):  # pragma: no cover - environment assumptions lower event atoms separately.
+        step = _resolve_step(expr.selector, step_index, symbols.domain.bound)
+        event = symbols.domain.event_by_path(expr.event_path)
+        return _LoweredValue(symbols.event_input(step, event.path))
+    if isinstance(
+        expr, bmc_ast.Case
+    ):  # pragma: no cover - objective compiler owns case atoms.
+        step = _resolve_step(expr.frame, step_index, symbols.domain.bound)
+        return _LoweredValue(symbols.case_selector(step, expr.label))
+    if isinstance(
+        expr, bmc_ast.Called
+    ):  # pragma: no cover - binder rejects called() until call semantics exist.
+        raise UnsupportedBmcQuery(
+            "called() atoms are not lowered by the relation builder."
+        )
+    raise UnsupportedBmcQuery(  # pragma: no cover - current AST class set is closed.
+        "Unsupported BMC condition expression: %s." % type(expr).__name__
+    )
+
+
+def _translate_model_expr(expr: Expr, env: Mapping[str, _Z3Expr], label: str):
+    result = translate_expr_domain(
+        expr,
+        dict(env),
+        source=DomainSource(label=label),
+        prune_unreachable=True,
+    )
+    _raise_expr_failure(result, label)
+    if (
+        result.z3_expr is None
+    ):  # pragma: no cover - failures return through _raise_expr_failure.
+        raise _internal_bmc_error("expression %s translated without a value." % label)
+    return result
+
+
+@dataclass(frozen=True)
+class _CaseLowering:
+    case: CycleCase
+    guard_terms: Mapping[str, z3.BoolRef]
+    final_env: Mapping[str, z3.ArithRef]
+    definedness_constraints: Tuple[DomainConstraint, ...]
+
+
+def _lower_guard_requirement(
+    guard: GuardRequirement,
+    env: Mapping[str, _Z3Expr],
+    constraints: Sequence[DomainConstraint],
+    case_label: str,
+) -> Tuple[z3.BoolRef, Tuple[DomainConstraint, ...]]:
+    label = "guard %s in case %s" % (guard.requirement_id, case_label)
+    result = _translate_model_expr(guard.expr, env, label)
+    guard_expr = _expect_bool(result.z3_expr, label)
+    if (
+        guard.polarity == "negative"
+    ):  # pragma: no cover - current expander emits positive guard requirements.
+        guard_expr = z3.Not(guard_expr)
+    elif (
+        guard.polarity != "positive"
+    ):  # pragma: no cover - GuardRequirement validates polarity.
+        raise _internal_bmc_error("unknown guard polarity %r." % guard.polarity)
+    return guard_expr, (*constraints, *result.definedness_constraints)
+
+
+def _execute_action_block(
+    block: ActionBlock,
+    env: Mapping[str, _Z3Expr],
+    case_label: str,
+) -> Tuple[Mapping[str, z3.ArithRef], Tuple[DomainConstraint, ...]]:
+    if block.is_abstract:
+        return dict(env), ()
+    execution = execute_operations_domain(
+        list(block.operations),
+        dict(env),
+        source=DomainSource(
+            label="action block %s in case %s" % (block.runtime_role, case_label)
+        ),
+        prune_unreachable=True,
+    )
+    if execution.failure is not None:
+        failure = execution.failure
+        message = _failure_message(
+            failure.kind,
+            failure.reason,
+            "action block %s in case %s" % (block.runtime_role, case_label),
+        )
+        raise UnsupportedBmcQuery(message)
+    return dict(execution.env), tuple(execution.definedness_constraints)
+
+
+def _prepare_case_lowering(
+    case: CycleCase, pre_env: Mapping[str, _Z3Expr]
+) -> _CaseLowering:
+    guards_by_anchor: Dict[int, List[GuardRequirement]] = {}
+    for guard in case.guard_requirements:
+        guards_by_anchor.setdefault(guard.after_action_block_index, []).append(guard)
+    env = dict(pre_env)
+    guard_terms: Dict[str, z3.BoolRef] = {}
+    definedness: List[DomainConstraint] = []
+    for anchor in range(len(case.action_blocks) + 1):
+        for guard in sorted(
+            guards_by_anchor.get(anchor, ()), key=lambda item: item.requirement_id
+        ):
+            term, new_definedness = _lower_guard_requirement(
+                guard, env, definedness, case.label
+            )
+            guard_terms[guard.requirement_id] = term
+            definedness = list(new_definedness)
+        if anchor < len(case.action_blocks):
+            env, block_definedness = _execute_action_block(
+                case.action_blocks[anchor], env, case.label
+            )
+            definedness.extend(block_definedness)
+    return _CaseLowering(
+        case=case,
+        guard_terms=guard_terms,
+        final_env=env,
+        definedness_constraints=tuple(definedness),
+    )
+
+
+def _lower_bool_template(
+    template: BoolTemplate,
+    lowering: _CaseLowering,
+    accepted_lookup,
+    active: Set[str],
+    symbols: BmcTraceSymbols,
+    step_index: int,
+) -> z3.BoolRef:
+    if template.kind == "true":
+        return z3.BoolVal(True)
+    if (
+        template.kind == "false"
+    ):  # pragma: no cover - false macro paths are pruned before lowering.
+        return z3.BoolVal(False)
+    if template.kind == "not":
+        return z3.Not(
+            _lower_bool_template(
+                template.operands[0],
+                lowering,
+                accepted_lookup,
+                active,
+                symbols,
+                step_index,
+            )
+        )
+    if template.kind == "and":
+        return _and(
+            _lower_bool_template(
+                item,
+                lowering,
+                accepted_lookup,
+                active,
+                symbols,
+                step_index,
+            )
+            for item in template.operands
+        )
+    if template.kind == "or":
+        return _or(
+            _lower_bool_template(
+                item,
+                lowering,
+                accepted_lookup,
+                active,
+                symbols,
+                step_index,
+            )
+            for item in template.operands
+        )
+    if template.kind == "atom":
+        atom = template.name
+        if atom is None:  # pragma: no cover - BoolTemplate validates atom names.
+            raise _internal_bmc_error("BoolTemplate atom has no name.")
+        if atom.startswith(_EVENT_ATOM_PREFIX):
+            return symbols.event_input(step_index, atom[len(_EVENT_ATOM_PREFIX) :])
+        if atom.startswith(_GUARD_ATOM_PREFIX):
+            guard_id = atom[len(_GUARD_ATOM_PREFIX) :]
+            try:
+                return lowering.guard_terms[guard_id]
+            except KeyError as err:  # pragma: no cover - macro validation pairs guard atoms and requirements.
+                # KeyError: macro validation should have guaranteed that guard
+                # atoms have matching guard requirements.
+                raise _internal_bmc_error("missing guard term %r." % guard_id) from err
+        if atom.startswith(_ACCEPTED_ATOM_PREFIX):
+            label = atom[len(_ACCEPTED_ATOM_PREFIX) :]
+            return accepted_lookup(label, active)
+        raise BmcBuildError(  # pragma: no cover - BoolTemplate atom namespace is validated by macro contract.
+            "Unsupported macro condition atom namespace: %r." % atom
+        )
+    raise _internal_bmc_error(  # pragma: no cover - BoolTemplate validates kinds.
+        "unsupported BoolTemplate kind %r." % template.kind
+    )
+
+
+def _build_case_relation(
+    step_index: int,
+    symbols: BmcTraceSymbols,
+    lowering: _CaseLowering,
+    antecedents: Mapping[str, z3.BoolRef],
+) -> BmcCaseRelation:
+    case = lowering.case
+    selector = symbols.case_selector(step_index, case.label)
+    source_guard = symbols.frame_state(step_index) == z3.IntVal(case.source_state_id)
+    condition = antecedents[case.label]
+    antecedent = _and((source_guard, condition))
+    post_constraints: List[z3.ExprRef] = [
+        symbols.frame_state(step_index + 1) == z3.IntVal(case.target_state_id)
+    ]
+    post_var_exprs = {}
+    for var in symbols.domain.variables:
+        try:
+            value = lowering.final_env[var.name]
+        except (
+            KeyError
+        ) as err:  # pragma: no cover - operation executor preserves visible names.
+            # KeyError: execute_operations_domain must preserve every variable
+            # visible in the incoming persistent environment.
+            raise _internal_bmc_error(
+                "case %s did not produce a post expression for %s."
+                % (case.label, var.name)
+            ) from err
+        arith_value = _expect_arith(
+            value, "post variable %s for case %s" % (var.name, case.label)
+        )
+        post_var_exprs[var.name] = arith_value
+        post_constraints.append(
+            symbols.frame_var(step_index + 1, var.name) == arith_value
+        )
+    post_constraints.extend(_domain_constraints_exprs(lowering.definedness_constraints))
+    consequent = _and(post_constraints)
+    implication = z3.Implies(antecedent, consequent)
+    selector_constraint = selector == antecedent
+    return BmcCaseRelation(
+        step_index=step_index,
+        case=case,
+        selector=selector,
+        antecedent=antecedent,
+        consequent=consequent,
+        implication=implication,
+        selector_constraint=selector_constraint,
+        post_var_exprs=post_var_exprs,
+        guard_terms=lowering.guard_terms,
+        definedness_constraints=lowering.definedness_constraints,
+    )
+
+
+def _build_step_relation(
+    step_index: int,
+    symbols: BmcTraceSymbols,
+    formals: Sequence[MacroStepFormal],
+) -> BmcStepRelation:
+    case_list = [case for formal in formals for case in formal.cases]
+    if len({case.label for case in case_list}) != len(
+        case_list
+    ):  # pragma: no cover - macro labels are unique.
+        raise _internal_bmc_error("duplicate case labels in step %d." % step_index)
+    pre_env = {
+        var.name: symbols.frame_var(step_index, var.name)
+        for var in symbols.domain.variables
+    }
+    lowerings = {
+        case.label: _prepare_case_lowering(case, pre_env) for case in case_list
+    }
+    condition_cache: Dict[str, z3.BoolRef] = {}
+
+    def accepted_lookup(label: str, active: Set[str]) -> z3.BoolRef:
+        if (
+            label not in lowerings
+        ):  # pragma: no cover - macro validation keeps accepted labels local.
+            raise _internal_bmc_error(
+                "accepted atom references unknown case label %r in step %d."
+                % (label, step_index)
+            )
+        accepted_case = lowerings[label].case
+        source_guard = symbols.frame_state(step_index) == z3.IntVal(
+            accepted_case.source_state_id
+        )
+        return _and((source_guard, condition_for(label, active)))
+
+    def condition_for(label: str, active: Set[str]) -> z3.BoolRef:
+        if label in condition_cache:
+            return condition_cache[label]
+        if (
+            label in active
+        ):  # pragma: no cover - macro validation rejects recursive accepted dependencies.
+            raise _internal_bmc_error(
+                "recursive accepted-case dependency while lowering %r." % label
+            )
+        active.add(label)
+        lowering = lowerings[label]
+        value = _lower_bool_template(
+            lowering.case.condition,
+            lowering,
+            accepted_lookup,
+            active,
+            symbols,
+            step_index,
+        )
+        active.remove(label)
+        condition_cache[label] = value
+        return value
+
+    for case in case_list:
+        condition_for(case.label, set())
+
+    relations = tuple(
+        _build_case_relation(
+            step_index, symbols, lowerings[case.label], condition_cache
+        )
+        for case in case_list
+    )
+    return BmcStepRelation(
+        step_index=step_index,
+        formals=tuple(formals),
+        case_relations=relations,
+        formula=_and(item.formula for item in relations),
+    )
+
+
+def _initial_source(context: BmcPreparedContext):
+    source = source_from_initial_spec(
+        context.domain, context.bound_query.initial.source
+    )
+    if context.bound_query.initial.mode == "state":
+        if (
+            context.bound_query.initial.resolved_state_id != source.source_state_id
+        ):  # pragma: no cover - binder/source helpers share one domain.
+            raise _internal_bmc_error(
+                "bound initial state id does not match initial source id."
+            )
+    return source
+
+
+def _recurrence_formals(domain: BmcDomain) -> Tuple[MacroStepFormal, ...]:
+    formals = []
+    for state_id in domain.recurrence_state_ids:
+        if state_id == STATE_TERMINATE_ID:
+            source = terminated_source(domain, origin="recurrence")
+        elif state_id == STATE_DIAGNOSTIC_ID:
+            source = diagnostic_source(domain, origin="recurrence")
+        else:
+            source = stable_leaf_source(domain, state_id, origin="recurrence")
+        formals.append(expand_macro_step_cases(source))
+    return tuple(formals)
+
+
+def _formals_by_step(
+    context: BmcPreparedContext,
+) -> Tuple[Tuple[MacroStepFormal, ...], ...]:
+    initial = (expand_macro_step_cases(_initial_source(context)),)
+    if context.bound == 1:
+        return (initial,)
+    recurrence = _recurrence_formals(context.domain)
+    return (initial,) + tuple(recurrence for _ in range(1, context.bound))
+
+
+def _build_domain_formula(symbols: BmcTraceSymbols) -> z3.BoolRef:
+    constraints = [_state_in(symbols.frame_state(0), symbols.domain.frame0_state_ids)]
+    for frame_index in range(1, symbols.domain.bound + 1):
+        constraints.append(
+            _state_in(
+                symbols.frame_state(frame_index), symbols.domain.recurrence_state_ids
+            )
+        )
+    return _and(constraints)
+
+
+def _build_initial_formula(
+    context: BmcPreparedContext, symbols: BmcTraceSymbols
+) -> z3.BoolRef:
+    source = _initial_source(context)
+    constraints: List[z3.ExprRef] = [
+        symbols.frame_state(0) == z3.IntVal(source.source_state_id)
+    ]
+    env: Dict[str, _Z3Expr] = {}
+    for var in context.domain.variables:
+        define = context.model.defines[var.name]
+        result = _translate_model_expr(
+            define.init, env, "initializer for %s" % var.name
+        )
+        value = _expect_arith(result.z3_expr, "initializer for %s" % var.name)
+        constraints.extend(_domain_constraints_exprs(result.definedness_constraints))
+        constraints.append(symbols.frame_var(0, var.name) == value)
+        env[var.name] = symbols.frame_var(0, var.name)
+    predicate = context.bound_query.initial.predicate
+    if predicate is not None:
+        lowered = _lower_bmc_cond_expr(predicate, symbols, frame_index=0)
+        constraints.extend(_domain_constraints_exprs(lowered.definedness_constraints))
+        constraints.append(_expect_bool(lowered.expr, "initial where predicate"))
+    return _and(constraints)
+
+
+def _build_environment_formula(
+    context: BmcPreparedContext, symbols: BmcTraceSymbols
+) -> z3.BoolRef:
+    constraints: List[z3.ExprRef] = []
+    for assumption in context.bound_query.assumptions:
+        if not isinstance(
+            assumption, BoundAssumption
+        ):  # pragma: no cover - BoundBmcQuery validates assumptions.
+            raise _internal_bmc_error(
+                "bound assumptions contain a non-BoundAssumption object."
+            )
+        if assumption.kind == "frame":
+            source = assumption.source
+            if not isinstance(
+                source, FrameAssumption
+            ):  # pragma: no cover - binder preserves source type.
+                raise _internal_bmc_error(
+                    "frame bound assumption has wrong source type."
+                )
+            frames = (
+                range(context.bound + 1)
+                if source.kind == "always"
+                else (assumption.frame,)
+            )
+            for frame in frames:
+                if (
+                    frame is None
+                ):  # pragma: no cover - binder sets frame for at-assumptions.
+                    raise _internal_bmc_error("frame assumption has no frame index.")
+                lowered = _lower_bmc_cond_expr(
+                    source.predicate, symbols, frame_index=frame
+                )
+                constraints.extend(
+                    _domain_constraints_exprs(lowered.definedness_constraints)
+                )
+                constraints.append(_expect_bool(lowered.expr, "frame assumption"))
+            continue
+        if assumption.kind == "event":
+            if (
+                len(assumption.resolved_event_ids) != 1
+            ):  # pragma: no cover - binder resolves one event per event assumption.
+                raise _internal_bmc_error(
+                    "event assumption must resolve exactly one event id."
+                )
+            event = context.domain.event_by_id(assumption.resolved_event_ids[0])
+            expected = bool(getattr(assumption.source, "expected"))
+            for cycle in assumption.cycles:
+                event_expr = symbols.event_input(cycle, event.path)
+                constraints.append(event_expr if expected else z3.Not(event_expr))
+            continue
+        if assumption.kind == "event_cardinality":
+            source = assumption.source
+            if not isinstance(
+                source, EventCardinalityAssumption
+            ):  # pragma: no cover - binder preserves source type.
+                raise _internal_bmc_error(
+                    "event-cardinality assumption has wrong source type."
+                )
+            if source.kind == "any":
+                continue
+            if (
+                source.kind != "at_most_one"
+            ):  # pragma: no cover - query model validates cardinality kinds.
+                raise UnsupportedBmcQuery(
+                    "Unsupported event cardinality kind: %r." % source.kind
+                )
+            events = [
+                context.domain.event_by_id(event_id)
+                for event_id in assumption.resolved_event_ids
+            ]
+            for step in range(context.bound):
+                constraints.append(
+                    z3.AtMost(
+                        *[symbols.event_input(step, event.path) for event in events], 1
+                    )
+                )
+            continue
+        raise _internal_bmc_error(  # pragma: no cover - BoundAssumption validates known kinds.
+            "unknown bound assumption kind %r." % assumption.kind
+        )
+    return _and(constraints)
+
+
+def build_bmc_core_formula(context: BmcPreparedContext) -> BmcCoreFormula:
+    """Build ``Core_N`` for a prepared BMC context.
+
+    The returned formula is exactly the core relation layer:
+    ``D_N ∧ I_0 ∧ T_N ∧ ENV_N``.  Health gates, objective predicates,
+    solving, and witness replay are intentionally left to later layers.
+
+    :param context: Prepared BMC context from :class:`pyfcstm.bmc.BmcEngine`.
+    :type context: pyfcstm.bmc.engine.BmcPreparedContext
+    :return: Solver-level core formula bundle.
+    :rtype: BmcCoreFormula
+    :raises pyfcstm.bmc.errors.BmcBuildError: If the prepared context or macro
+        handoff data is internally inconsistent.
+    :raises pyfcstm.bmc.errors.UnsupportedBmcQuery: If a well-formed query or
+        action uses a solver feature not supported by this relation builder.
+
+    Example::
+
+        >>> from pyfcstm.bmc import BmcEngine, build_bmc_core_formula
+        >>> from pyfcstm.model import load_state_machine_from_text
+        >>> model = load_state_machine_from_text('state Root;')
+        >>> context = BmcEngine(model).prepare('check reach <= 1: terminated();')
+        >>> build_bmc_core_formula(context).core.sort().name()
+        'Bool'
+    """
+    prepared = _require_context(context)
+    formals_by_step = _formals_by_step(prepared)
+    case_labels_by_step = {
+        step_index: tuple(case.label for formal in formals for case in formal.cases)
+        for step_index, formals in enumerate(formals_by_step)
+    }
+    symbols = BmcTraceSymbols.allocate(prepared.domain, case_labels_by_step)
+    steps = tuple(
+        _build_step_relation(step_index, symbols, formals)
+        for step_index, formals in enumerate(formals_by_step)
+    )
+    domain_formula = _build_domain_formula(symbols)
+    initial_formula = _build_initial_formula(prepared, symbols)
+    transition_formula = _and(step.formula for step in steps)
+    environment_formula = _build_environment_formula(prepared, symbols)
+    core = _and(
+        (domain_formula, initial_formula, transition_formula, environment_formula)
+    )
+    return BmcCoreFormula(
+        context=prepared,
+        symbols=symbols,
+        domain_formula=domain_formula,
+        initial_formula=initial_formula,
+        transition_formula=transition_formula,
+        environment_formula=environment_formula,
+        core=core,
+        steps=steps,
+        diagnostics=(),
+    )
+
+
+__all__ = [
+    "BmcTraceSymbols",
+    "BmcCaseRelation",
+    "BmcStepRelation",
+    "BmcCoreFormula",
+    "build_bmc_core_formula",
+]

--- a/pyfcstm/bmc/relation.py
+++ b/pyfcstm/bmc/relation.py
@@ -1021,6 +1021,26 @@ def _lower_bmc_num_expr(
         condition = _lower_bmc_cond_expr(
             expr.condition, symbols, frame_index=frame_index, step_index=step_index
         )
+        condition_expr = _expect_bool(condition.expr, label)
+        if z3.is_true(condition_expr):
+            if_true = _lower_bmc_num_expr(
+                expr.if_true, symbols, frame_index=frame_index, step_index=step_index
+            )
+            return _LoweredValue(
+                _expect_arith(if_true.expr, label),
+                (*condition.definedness_constraints, *if_true.definedness_constraints),
+            )
+        if z3.is_false(condition_expr):
+            if_false = _lower_bmc_num_expr(
+                expr.if_false, symbols, frame_index=frame_index, step_index=step_index
+            )
+            return _LoweredValue(
+                _expect_arith(if_false.expr, label),
+                (
+                    *condition.definedness_constraints,
+                    *if_false.definedness_constraints,
+                ),
+            )
         if_true = _lower_bmc_num_expr(
             expr.if_true, symbols, frame_index=frame_index, step_index=step_index
         )
@@ -1029,14 +1049,18 @@ def _lower_bmc_num_expr(
         )
         return _LoweredValue(
             z3.If(
-                _expect_bool(condition.expr, label),
+                condition_expr,
                 _expect_arith(if_true.expr, label),
                 _expect_arith(if_false.expr, label),
             ),
             (
                 *condition.definedness_constraints,
-                *if_true.definedness_constraints,
-                *if_false.definedness_constraints,
+                *_guarded_domain_constraints(
+                    condition_expr, if_true.definedness_constraints
+                ),
+                *_guarded_domain_constraints(
+                    z3.Not(condition_expr), if_false.definedness_constraints
+                ),
             ),
         )
     if isinstance(expr, bmc_ast.UFuncCall):
@@ -1095,34 +1119,82 @@ def _lower_bmc_cond_expr(
         left = _lower_bmc_cond_expr(
             expr.left, symbols, frame_index=frame_index, step_index=step_index
         )
+        left_expr = _expect_bool(left.expr, label)
+        if expr.op == "&&" and z3.is_false(left_expr):
+            return _LoweredValue(z3.BoolVal(False), left.definedness_constraints)
+        if expr.op == "||" and z3.is_true(left_expr):
+            return _LoweredValue(z3.BoolVal(True), left.definedness_constraints)
         right = _lower_bmc_cond_expr(
             expr.right, symbols, frame_index=frame_index, step_index=step_index
         )
-        left_expr = _expect_bool(left.expr, label)
         right_expr = _expect_bool(right.expr, label)
         if expr.op == "&&":
             value = z3.And(left_expr, right_expr)
+            definedness_constraints = (
+                *left.definedness_constraints,
+                *_guarded_domain_constraints(left_expr, right.definedness_constraints),
+            )
         elif expr.op == "||":
             value = z3.Or(left_expr, right_expr)
+            definedness_constraints = (
+                *left.definedness_constraints,
+                *_guarded_domain_constraints(
+                    z3.Not(left_expr), right.definedness_constraints
+                ),
+            )
         elif expr.op == "=>":
             value = z3.Implies(left_expr, right_expr)
+            definedness_constraints = (
+                *left.definedness_constraints,
+                *right.definedness_constraints,
+            )
         elif expr.op == "xor":
             value = z3.Xor(left_expr, right_expr)
+            definedness_constraints = (
+                *left.definedness_constraints,
+                *right.definedness_constraints,
+            )
         elif expr.op in {"iff", "=="}:
             value = left_expr == right_expr
+            definedness_constraints = (
+                *left.definedness_constraints,
+                *right.definedness_constraints,
+            )
         elif expr.op == "!=":
             value = left_expr != right_expr
+            definedness_constraints = (
+                *left.definedness_constraints,
+                *right.definedness_constraints,
+            )
         else:
             raise UnsupportedBmcQuery(  # pragma: no cover - AST validates operator names.
                 "%s uses unsupported condition operator %r." % (label, expr.op)
             )
-        return _LoweredValue(
-            value, (*left.definedness_constraints, *right.definedness_constraints)
-        )
+        return _LoweredValue(value, definedness_constraints)
     if isinstance(expr, bmc_ast.CondConditionalOp):
         condition = _lower_bmc_cond_expr(
             expr.condition, symbols, frame_index=frame_index, step_index=step_index
         )
+        condition_expr = _expect_bool(condition.expr, label)
+        if z3.is_true(condition_expr):
+            if_true = _lower_bmc_cond_expr(
+                expr.if_true, symbols, frame_index=frame_index, step_index=step_index
+            )
+            return _LoweredValue(
+                _expect_bool(if_true.expr, label),
+                (*condition.definedness_constraints, *if_true.definedness_constraints),
+            )
+        if z3.is_false(condition_expr):
+            if_false = _lower_bmc_cond_expr(
+                expr.if_false, symbols, frame_index=frame_index, step_index=step_index
+            )
+            return _LoweredValue(
+                _expect_bool(if_false.expr, label),
+                (
+                    *condition.definedness_constraints,
+                    *if_false.definedness_constraints,
+                ),
+            )
         if_true = _lower_bmc_cond_expr(
             expr.if_true, symbols, frame_index=frame_index, step_index=step_index
         )
@@ -1131,14 +1203,18 @@ def _lower_bmc_cond_expr(
         )
         return _LoweredValue(
             z3.If(
-                _expect_bool(condition.expr, label),
+                condition_expr,
                 _expect_bool(if_true.expr, label),
                 _expect_bool(if_false.expr, label),
             ),
             (
                 *condition.definedness_constraints,
-                *if_true.definedness_constraints,
-                *if_false.definedness_constraints,
+                *_guarded_domain_constraints(
+                    condition_expr, if_true.definedness_constraints
+                ),
+                *_guarded_domain_constraints(
+                    z3.Not(condition_expr), if_false.definedness_constraints
+                ),
             ),
         )
     if isinstance(expr, bmc_ast.Active):

--- a/pyfcstm/bmc/relation.py
+++ b/pyfcstm/bmc/relation.py
@@ -184,6 +184,12 @@ class _LoweredValue:
 
 
 @dataclass(frozen=True)
+class _LoweredBoolTemplate:
+    expr: z3.BoolRef
+    definedness_constraints: Tuple[DomainConstraint, ...] = ()
+
+
+@dataclass(frozen=True)
 class BmcTraceSymbols:
     """Z3 symbols for one bounded BMC trace.
 
@@ -480,7 +486,10 @@ class BmcCaseRelation:
     :type step_index: int
     :param case: Macro-step case that was lowered.
     :type case: pyfcstm.bmc.macro.CycleCase
-    :param selector: Case-selector symbol bound to ``antecedent``.
+    :param selector: Case-selector symbol bound to ``antecedent``.  The
+        relation builder treats macro-step partition validity as an upstream
+        contract: selector equality exposes selected cases but does not
+        independently diagnose malformed partitions.
     :type selector: z3.BoolRef
     :param antecedent: Source guard and lowered case condition.
     :type antecedent: z3.BoolRef
@@ -711,7 +720,10 @@ class BmcCoreFormula:
     :type core: z3.BoolRef
     :param steps: Lowered step relations.
     :type steps: Tuple[BmcStepRelation, ...]
-    :param diagnostics: Builder diagnostics, defaults to ``()``.
+    :param diagnostics: Reserved build-time diagnostics, defaults to ``()``.
+        Relation-level semantic-delta information is currently exposed through
+        case metadata, so this tuple is empty in the initial core-relation
+        builder.
     :type diagnostics: Tuple[str, ...], optional
 
     Example::
@@ -1179,8 +1191,29 @@ def _translate_model_expr(expr: Expr, env: Mapping[str, _Z3Expr], label: str):
 class _CaseLowering:
     case: CycleCase
     guard_terms: Mapping[str, z3.BoolRef]
+    guard_definedness: Mapping[str, Tuple[DomainConstraint, ...]]
     final_env: Mapping[str, z3.ArithRef]
     definedness_constraints: Tuple[DomainConstraint, ...]
+
+
+def _guarded_domain_constraints(
+    guard: z3.BoolRef,
+    constraints: Sequence[DomainConstraint],
+) -> Tuple[DomainConstraint, ...]:
+    if z3.is_true(guard):
+        return tuple(constraints)
+    return tuple(
+        DomainConstraint(z3.Implies(guard, item.constraint), item.source)
+        for item in constraints
+    )
+
+
+def _append_guarded_constraints(
+    target: List[DomainConstraint],
+    guard: z3.BoolRef,
+    constraints: Sequence[DomainConstraint],
+) -> None:
+    target.extend(_guarded_domain_constraints(guard, constraints))
 
 
 def _lower_guard_requirement(
@@ -1237,6 +1270,7 @@ def _prepare_case_lowering(
         guards_by_anchor.setdefault(guard.after_action_block_index, []).append(guard)
     env = dict(pre_env)
     guard_terms: Dict[str, z3.BoolRef] = {}
+    guard_definedness: Dict[str, Tuple[DomainConstraint, ...]] = {}
     definedness: List[DomainConstraint] = []
     for anchor in range(len(case.action_blocks) + 1):
         for guard in sorted(
@@ -1246,6 +1280,7 @@ def _prepare_case_lowering(
                 guard, env, definedness, case.label
             )
             guard_terms[guard.requirement_id] = term
+            guard_definedness[guard.requirement_id] = tuple(new_definedness)
             definedness = list(new_definedness)
         if anchor < len(case.action_blocks):
             env, block_definedness = _execute_action_block(
@@ -1255,6 +1290,7 @@ def _prepare_case_lowering(
     return _CaseLowering(
         case=case,
         guard_terms=guard_terms,
+        guard_definedness=guard_definedness,
         final_env=env,
         definedness_constraints=tuple(definedness),
     )
@@ -1267,27 +1303,30 @@ def _lower_bool_template(
     active: Set[str],
     symbols: BmcTraceSymbols,
     step_index: int,
-) -> z3.BoolRef:
+) -> _LoweredBoolTemplate:
     if template.kind == "true":
-        return z3.BoolVal(True)
+        return _LoweredBoolTemplate(z3.BoolVal(True))
     if (
         template.kind == "false"
     ):  # pragma: no cover - false macro paths are pruned before lowering.
-        return z3.BoolVal(False)
+        return _LoweredBoolTemplate(z3.BoolVal(False))
     if template.kind == "not":
-        return z3.Not(
-            _lower_bool_template(
-                template.operands[0],
-                lowering,
-                accepted_lookup,
-                active,
-                symbols,
-                step_index,
-            )
+        operand = _lower_bool_template(
+            template.operands[0],
+            lowering,
+            accepted_lookup,
+            active,
+            symbols,
+            step_index,
+        )
+        return _LoweredBoolTemplate(
+            z3.Not(operand.expr), operand.definedness_constraints
         )
     if template.kind == "and":
-        return _and(
-            _lower_bool_template(
+        expr = z3.BoolVal(True)
+        definedness: List[DomainConstraint] = []
+        for item in template.operands:
+            lowered = _lower_bool_template(
                 item,
                 lowering,
                 accepted_lookup,
@@ -1295,11 +1334,16 @@ def _lower_bool_template(
                 symbols,
                 step_index,
             )
-            for item in template.operands
-        )
+            _append_guarded_constraints(
+                definedness, expr, lowered.definedness_constraints
+            )
+            expr = z3.And(expr, lowered.expr)
+        return _LoweredBoolTemplate(expr, tuple(definedness))
     if template.kind == "or":
-        return _or(
-            _lower_bool_template(
+        expr = z3.BoolVal(False)
+        definedness = []
+        for item in template.operands:
+            lowered = _lower_bool_template(
                 item,
                 lowering,
                 accepted_lookup,
@@ -1307,18 +1351,26 @@ def _lower_bool_template(
                 symbols,
                 step_index,
             )
-            for item in template.operands
-        )
+            _append_guarded_constraints(
+                definedness, z3.Not(expr), lowered.definedness_constraints
+            )
+            expr = z3.Or(expr, lowered.expr)
+        return _LoweredBoolTemplate(expr, tuple(definedness))
     if template.kind == "atom":
         atom = template.name
         if atom is None:  # pragma: no cover - BoolTemplate validates atom names.
             raise _internal_bmc_error("BoolTemplate atom has no name.")
         if atom.startswith(_EVENT_ATOM_PREFIX):
-            return symbols.event_input(step_index, atom[len(_EVENT_ATOM_PREFIX) :])
+            return _LoweredBoolTemplate(
+                symbols.event_input(step_index, atom[len(_EVENT_ATOM_PREFIX) :])
+            )
         if atom.startswith(_GUARD_ATOM_PREFIX):
             guard_id = atom[len(_GUARD_ATOM_PREFIX) :]
             try:
-                return lowering.guard_terms[guard_id]
+                return _LoweredBoolTemplate(
+                    lowering.guard_terms[guard_id],
+                    lowering.guard_definedness[guard_id],
+                )
             except KeyError as err:  # pragma: no cover - macro validation pairs guard atoms and requirements.
                 # KeyError: macro validation should have guaranteed that guard
                 # atoms have matching guard requirements.
@@ -1338,12 +1390,12 @@ def _build_case_relation(
     step_index: int,
     symbols: BmcTraceSymbols,
     lowering: _CaseLowering,
-    antecedents: Mapping[str, z3.BoolRef],
+    antecedents: Mapping[str, _LoweredBoolTemplate],
 ) -> BmcCaseRelation:
     case = lowering.case
     selector = symbols.case_selector(step_index, case.label)
     source_guard = symbols.frame_state(step_index) == z3.IntVal(case.source_state_id)
-    condition = antecedents[case.label]
+    condition = antecedents[case.label].expr
     antecedent = _and((source_guard, condition))
     post_constraints: List[z3.ExprRef] = [
         symbols.frame_state(step_index + 1) == z3.IntVal(case.target_state_id)
@@ -1368,7 +1420,11 @@ def _build_case_relation(
         post_constraints.append(
             symbols.frame_var(step_index + 1, var.name) == arith_value
         )
-    post_constraints.extend(_domain_constraints_exprs(lowering.definedness_constraints))
+    definedness_constraints = (
+        *antecedents[case.label].definedness_constraints,
+        *lowering.definedness_constraints,
+    )
+    post_constraints.extend(_domain_constraints_exprs(definedness_constraints))
     consequent = _and(post_constraints)
     implication = z3.Implies(antecedent, consequent)
     selector_constraint = selector == antecedent
@@ -1382,7 +1438,7 @@ def _build_case_relation(
         selector_constraint=selector_constraint,
         post_var_exprs=post_var_exprs,
         guard_terms=lowering.guard_terms,
-        definedness_constraints=lowering.definedness_constraints,
+        definedness_constraints=definedness_constraints,
     )
 
 
@@ -1403,9 +1459,9 @@ def _build_step_relation(
     lowerings = {
         case.label: _prepare_case_lowering(case, pre_env) for case in case_list
     }
-    condition_cache: Dict[str, z3.BoolRef] = {}
+    condition_cache: Dict[str, _LoweredBoolTemplate] = {}
 
-    def accepted_lookup(label: str, active: Set[str]) -> z3.BoolRef:
+    def accepted_lookup(label: str, active: Set[str]) -> _LoweredBoolTemplate:
         if (
             label not in lowerings
         ):  # pragma: no cover - macro validation keeps accepted labels local.
@@ -1417,9 +1473,15 @@ def _build_step_relation(
         source_guard = symbols.frame_state(step_index) == z3.IntVal(
             accepted_case.source_state_id
         )
-        return _and((source_guard, condition_for(label, active)))
+        condition = condition_for(label, active)
+        return _LoweredBoolTemplate(
+            _and((source_guard, condition.expr)),
+            _guarded_domain_constraints(
+                source_guard, condition.definedness_constraints
+            ),
+        )
 
-    def condition_for(label: str, active: Set[str]) -> z3.BoolRef:
+    def condition_for(label: str, active: Set[str]) -> _LoweredBoolTemplate:
         if label in condition_cache:
             return condition_cache[label]
         if (
@@ -1493,6 +1555,8 @@ def _formals_by_step(
     if context.bound == 1:
         return (initial,)
     recurrence = _recurrence_formals(context.domain)
+    # Recurrence formals are step-invariant immutable macro contracts, so the
+    # same tuple can be shared safely across recurrence steps.
     return (initial,) + tuple(recurrence for _ in range(1, context.bound))
 
 

--- a/pyfcstm/solver/domain.py
+++ b/pyfcstm/solver/domain.py
@@ -231,7 +231,9 @@ def _failure_from_exception(
         return TranslationFailure("type_error", str(err), source=source)
     if isinstance(err, z3.Z3Exception):
         return TranslationFailure("z3_error", str(err), source=source)
-    raise AssertionError(f"Unexpected translation exception: {type(err).__name__}") from err
+    raise AssertionError(
+        f"Unexpected translation exception: {type(err).__name__}"
+    ) from err
 
 
 def _failure_result(
@@ -421,6 +423,81 @@ def _constraint_exprs(items: Sequence[DomainConstraint]) -> Tuple[z3.ExprRef, ..
     return tuple(item.constraint for item in items)
 
 
+def _guarded_domain_constraints(
+    selector: z3.ExprRef,
+    items: Sequence[DomainConstraint],
+) -> Tuple[DomainConstraint, ...]:
+    """Guard runtime-definedness constraints by a lazy evaluation selector.
+
+    :param selector: Predicate under which ``items`` are evaluated.
+    :type selector: z3.ExprRef
+    :param items: Runtime-definedness constraints from a lazy operand.
+    :type items: Sequence[DomainConstraint]
+    :return: Constraints wrapped as ``Implies(selector, constraint)``.
+    :rtype: Tuple[DomainConstraint, ...]
+
+    Example::
+
+        >>> x = z3.Int("x")
+        >>> guarded = _guarded_domain_constraints(x > 0, (DomainConstraint(x != 0),))
+        >>> guarded[0].constraint
+        Implies(x > 0, x != 0)
+    """
+    if not items:
+        return ()
+    if z3.is_true(selector):
+        return tuple(items)
+    return tuple(
+        DomainConstraint(z3.Implies(selector, item.constraint), item.source)
+        for item in items
+    )
+
+
+def _logical_left_type_failure(
+    op: str,
+    left: ExprDomain,
+    *,
+    assumptions: Sequence[z3.ExprRef],
+    source: Optional[DomainSource],
+) -> ExprDomain:
+    """Build the structured failure for a non-Boolean lazy left operand.
+
+    :param op: Logical operator being translated.
+    :type op: str
+    :param left: Already translated left operand.
+    :type left: ExprDomain
+    :param assumptions: Caller-known facts to preserve on the result.
+    :type assumptions: Sequence[z3.ExprRef]
+    :param source: Optional source metadata attached to the failure.
+    :type source: Optional[DomainSource]
+    :return: Failed expression-domain result carrying left-side metadata.
+    :rtype: ExprDomain
+
+    Example::
+
+        >>> result = _logical_left_type_failure(
+        ...     "&&",
+        ...     ExprDomain(z3.IntVal(1)),
+        ...     assumptions=(),
+        ...     source=DomainSource(label="guard"),
+        ... )
+        >>> result.failure.kind
+        'type_error'
+        >>> result.failure.source.label
+        'guard'
+    """
+    return _failure_result(
+        TranslationFailure(
+            "type_error",
+            "Logical operator %r requires a Boolean left operand." % op,
+            source=source,
+        ),
+        assumptions=assumptions,
+        definedness_constraints=left.definedness_constraints,
+        feasibility_checks=left.feasibility_checks,
+    )
+
+
 def _branch_feasibility(
     selector: z3.ExprRef,
     *,
@@ -553,6 +630,105 @@ def _translate_expr_domain(
         )
         if left.failure is not None:
             return left
+        if expr.op in ("&&", "||"):
+            if not z3.is_bool(left.z3_expr):
+                return _logical_left_type_failure(
+                    expr.op, left, assumptions=assumptions, source=source
+                )
+            if expr.op == "&&":
+                right_selector = left.z3_expr
+                if z3.is_false(right_selector):
+                    return _with_parts(
+                        z3.BoolVal(False),
+                        assumptions=assumptions,
+                        definedness_constraints=left.definedness_constraints,
+                        feasibility_checks=left.feasibility_checks,
+                    )
+            else:
+                if z3.is_true(left.z3_expr):
+                    return _with_parts(
+                        z3.BoolVal(True),
+                        assumptions=assumptions,
+                        definedness_constraints=left.definedness_constraints,
+                        feasibility_checks=left.feasibility_checks,
+                    )
+                right_selector = z3.Not(left.z3_expr)
+
+            feasibility_checks: List[BranchFeasibility] = list(left.feasibility_checks)
+            right_reachable = True
+            if prune_unreachable:
+                right_check = _branch_feasibility(
+                    right_selector,
+                    assumptions=assumptions,
+                    path_conditions=path_conditions,
+                    condition_domains=left.definedness_constraints,
+                    source=source,
+                    timeout_ms=timeout_ms,
+                )
+                feasibility_checks.append(right_check)
+                right_reachable = right_check.status != "unsat"
+            if not right_reachable:
+                return _with_parts(
+                    z3.BoolVal(False) if expr.op == "&&" else z3.BoolVal(True),
+                    assumptions=assumptions,
+                    definedness_constraints=left.definedness_constraints,
+                    feasibility_checks=feasibility_checks,
+                )
+
+            right = _translate_expr_domain(
+                expr.y,
+                z3_vars,
+                assumptions=assumptions,
+                path_conditions=(
+                    *path_conditions,
+                    *_constraint_exprs(left.definedness_constraints),
+                    right_selector,
+                ),
+                source=source,
+                prune_unreachable=prune_unreachable,
+                timeout_ms=timeout_ms,
+            )
+            guarded_right_domains = _guarded_domain_constraints(
+                right_selector, right.definedness_constraints
+            )
+            if right.failure is not None:
+                return _failure_result(
+                    right.failure,
+                    assumptions=assumptions,
+                    definedness_constraints=(
+                        *left.definedness_constraints,
+                        *guarded_right_domains,
+                    ),
+                    feasibility_checks=(
+                        *feasibility_checks,
+                        *right.feasibility_checks,
+                    ),
+                )
+
+            z3_expr, failure = _apply_or_failure(
+                lambda: _apply_binary_z3(
+                    expr.op,
+                    left.z3_expr,
+                    right.z3_expr,
+                    expr.x,
+                    expr.y,
+                    warning_stacklevel=6,
+                ),
+                source,
+            )
+            return _with_parts(
+                z3_expr,
+                assumptions=assumptions,
+                definedness_constraints=(
+                    *left.definedness_constraints,
+                    *guarded_right_domains,
+                ),
+                failure=failure,
+                feasibility_checks=(
+                    *feasibility_checks,
+                    *right.feasibility_checks,
+                ),
+            )
         right = _translate_expr_domain(
             expr.y,
             z3_vars,

--- a/test/bmc/semantic_fixture_policy.py
+++ b/test/bmc/semantic_fixture_policy.py
@@ -1,0 +1,212 @@
+"""BMC semantic-fixture ledger for relation-layer alignment tests.
+
+This module records the current BMC-core handling policy for the shared
+``test/fixtures/simulate_semantics`` corpus.  The policy is intentionally a
+test-only ledger: production BMC APIs remain independent from fixture buckets,
+while the tests can verify that every temporary exclusion has an explicit
+follow-up category and every relation-supported case is actually checked.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+
+@dataclass(frozen=True)
+class BmcSemanticFixturePolicy:
+    """Expected BMC-core handling for one semantic fixture case.
+
+    :param mode: One of ``"hard_pass"``, ``"partial"``,
+        ``"expected_unsupported"``, ``"temporary_exclude"``, or
+        ``"long_term_exclude"``.
+    :type mode: str
+    :param bucket: Issue-ledger bucket used by the BMC alignment plan.
+    :type bucket: str
+    :param reason: Human-readable reason for this policy entry.
+    :type reason: str
+    :param ignored_expect_fields: Expectation fields intentionally ignored by a
+        partial runner, defaults to ``()``.
+    :type ignored_expect_fields: Tuple[str, ...], optional
+
+    Example::
+
+        >>> policy = policy_for_case("design_basic_simple_transition")
+        >>> policy.mode
+        'hard_pass'
+        >>> policy.ignored_expect_fields
+        ()
+    """
+
+    mode: str
+    bucket: str
+    reason: str
+    ignored_expect_fields: Tuple[str, ...] = ()
+
+
+PLAIN_BEFORE_ALIGNMENT_CASES = {
+    "combo_initial_guard_not_polluted_by_plain_before",
+    "combo_initial_plain_before_deferred",
+    "manual_initial_pseudo_lifecycle_plain_before_deferred",
+}
+
+NUMERIC_UNSUPPORTED_CASES = {
+    "persistent_default_int_initializer_normalizes_integer_float",
+    "persistent_effect_writeback_normalizes_integer_float",
+    "persistent_int_writeback_normalizes_integer_float",
+}
+
+HANDLER_CALL_PARTIAL_CASES = {
+    "abstract_handler_context_metadata",
+    "abstract_handler_context_vars_are_read_only",
+    "abstract_hook_ref_context_reports_callsite_metadata",
+    "aspect_context_reports_active_leaf",
+    "composite_initial_handler_log_after_transition_uses_selected_child",
+    "composite_initial_handler_log_keeps_stable_branch_before_exit_branch",
+    "composite_initial_handler_log_uses_enter_selected_child",
+    "lifecycle_ref_chain_resolves_long_acyclic_chain",
+    "named_ref_context_reports_callsite",
+    "ref_abstract_handler_reports_calling_state",
+    "ref_context_uses_callsite_stage",
+}
+
+TEMPORARY_BMC_CORE_EXCLUDE_CASES = {
+    # Follow-up: init sentinel, stutter flags, and non-stoppable recurrence.
+    "design_composite_stuck_in_init_wait",
+    "failed_initial_cycle_preserves_root_entry_lifecycle",
+    "failed_initial_cycle_skips_abstract_handler_callbacks",
+    "hot_start_deep_evented_initial_waits_for_event",
+    "design_post_child_exit_without_follow_up",
+    "hot_start_composite_evented_initial_skips_entry_boundary_before",
+    # Follow-up: .fbmcq initial variable override / havoc policy.
+    "hot_start_evented_initial_matches_cold_suffix",
+    "hot_start_initial_vars_override_skips_int_initializer",
+    "persistent_initial_vars_override_skips_initializer",
+    "abstract_hook_context_hot_start_leaf",
+    # Future runtime-error relation work.
+    "design_speculative_dfs_safety_limit",
+    "expression_error_preserves_runtime_snapshot",
+    "expression_failure_if_condition_raises_expression_error",
+    "expression_failure_raises_expression_error",
+    "expression_failure_transition_effect_raises_expression_error",
+    "expression_failure_transition_guard_raises_expression_error",
+    "expression_type_error_wraps_transition_effect",
+    "hot_start_leaf_defers_during_expression_error",
+    "persistent_operation_writeback_rejects_float_and_rolls_back",
+    "pseudo_self_loop_step_limit_raises_dfs_error",
+}
+
+CONSTRUCTOR_DIAGNOSTIC_EXCLUDE_CASES = {
+    "hot_start_initial_vars_reject_bool_values",
+    "hot_start_initial_vars_reject_string_values",
+    "hot_start_rejects_blocked_composite_initial",
+    "hot_start_rejects_overdeep_leaf_stack",
+    "hot_start_rejects_unstable_pseudo_leaf",
+    "persistent_default_int_initializer_rejects_non_integer_float",
+}
+
+BMC_CORE_FIXTURE_LEDGER_CASES = (
+    PLAIN_BEFORE_ALIGNMENT_CASES
+    | NUMERIC_UNSUPPORTED_CASES
+    | HANDLER_CALL_PARTIAL_CASES
+    | TEMPORARY_BMC_CORE_EXCLUDE_CASES
+    | CONSTRUCTOR_DIAGNOSTIC_EXCLUDE_CASES
+)
+
+
+def _temporary_policy(case_id: str) -> BmcSemanticFixturePolicy:
+    if case_id in {
+        "design_composite_stuck_in_init_wait",
+        "failed_initial_cycle_preserves_root_entry_lifecycle",
+        "failed_initial_cycle_skips_abstract_handler_callbacks",
+        "hot_start_deep_evented_initial_waits_for_event",
+        "design_post_child_exit_without_follow_up",
+        "hot_start_composite_evented_initial_skips_entry_boundary_before",
+    }:
+        bucket = "initialization_delta"
+        reason = "STATE_INIT, delta/stutter, or non-stoppable recurrence is scheduled for follow-up initialization work."
+    elif case_id in {
+        "hot_start_evented_initial_matches_cold_suffix",
+        "hot_start_initial_vars_override_skips_int_initializer",
+        "persistent_initial_vars_override_skips_initializer",
+        "abstract_hook_context_hot_start_leaf",
+    }:
+        bucket = "initial_variable_policy"
+        reason = ".fbmcq initial variable override / havoc support is scheduled for follow-up query-policy work."
+    else:
+        bucket = "runtime_step_error"
+        reason = "Runtime step-error semantics are scheduled for later BMC diagnostic research."
+    return BmcSemanticFixturePolicy(
+        mode="temporary_exclude",
+        bucket=bucket,
+        reason=reason,
+    )
+
+
+def policy_for_case(case_id: str) -> BmcSemanticFixturePolicy:
+    """Return the BMC-core fixture policy for ``case_id``.
+
+    :param case_id: Semantic fixture id.
+    :type case_id: str
+    :return: Fixture handling policy.
+    :rtype: BmcSemanticFixturePolicy
+
+    Example::
+
+        >>> policy_for_case("combo_initial_plain_before_deferred").bucket
+        'initial_plain_before'
+        >>> policy_for_case("abstract_handler_context_metadata").mode
+        'partial'
+    """
+    if case_id in PLAIN_BEFORE_ALIGNMENT_CASES:
+        return BmcSemanticFixturePolicy(
+            mode="hard_pass",
+            bucket="initial_plain_before",
+            reason="Initial pseudo/combo plain-before ordering is covered by the current BMC relation.",
+        )
+    if case_id in NUMERIC_UNSUPPORTED_CASES:
+        return BmcSemanticFixturePolicy(
+            mode="expected_unsupported",
+            bucket="numeric_unsupported",
+            reason="Current Int bitwise / integer-normalization lowering is unsupported and must fail loudly.",
+        )
+    if case_id in HANDLER_CALL_PARTIAL_CASES:
+        return BmcSemanticFixturePolicy(
+            mode="partial",
+            bucket="abstract_handler_calls",
+            reason="State, ended, and vars must align now; handler_calls wait for abstract call records.",
+            ignored_expect_fields=("handler_calls",),
+        )
+    if case_id in TEMPORARY_BMC_CORE_EXCLUDE_CASES:
+        return _temporary_policy(case_id)
+    if case_id in CONSTRUCTOR_DIAGNOSTIC_EXCLUDE_CASES:
+        return BmcSemanticFixturePolicy(
+            mode="long_term_exclude",
+            bucket="constructor_diagnostic",
+            reason="Constructor/init diagnostics are outside the current BMC-core relation surface.",
+        )
+    return BmcSemanticFixturePolicy(
+        mode="hard_pass",
+        bucket="baseline",
+        reason="No known BMC-core exclusion; full public state/vars expectations must pass.",
+    )
+
+
+def policy_by_case(case_ids: Iterable[str]) -> Dict[str, BmcSemanticFixturePolicy]:
+    """Return policies keyed by case id for ``case_ids``.
+
+    :param case_ids: Iterable of fixture ids.
+    :type case_ids: Iterable[str]
+    :return: Mapping from id to policy.
+    :rtype: Dict[str, BmcSemanticFixturePolicy]
+
+    Example::
+
+        >>> policies = policy_by_case([
+        ...     "design_basic_simple_transition",
+        ...     "combo_initial_plain_before_deferred",
+        ... ])
+        >>> sorted(policies)
+        ['combo_initial_plain_before_deferred', 'design_basic_simple_transition']
+    """
+    return {case_id: policy_for_case(case_id) for case_id in case_ids}

--- a/test/bmc/test_bmc_public_api.py
+++ b/test/bmc/test_bmc_public_api.py
@@ -102,6 +102,11 @@ def test_bmc_public_api_exports_exact_names():
         "BmcPreparedContext",
         "BmcEngine",
         "prepare_bmc_query",
+        "BmcTraceSymbols",
+        "BmcCaseRelation",
+        "BmcStepRelation",
+        "BmcCoreFormula",
+        "build_bmc_core_formula",
     }
 
     assert set(bmc.__all__) == expected
@@ -145,6 +150,11 @@ def test_bmc_public_api_exports_exact_names():
         "BmcPreparedContext",
         "BmcEngine",
         "prepare_bmc_query",
+        "BmcTraceSymbols",
+        "BmcCaseRelation",
+        "BmcStepRelation",
+        "BmcCoreFormula",
+        "build_bmc_core_formula",
     }
     function_names = {
         "parse_bmc_query",
@@ -167,6 +177,7 @@ def test_bmc_public_api_exports_exact_names():
         "build_bmc_domain",
         "expand_macro_step_cases",
         "prepare_bmc_query",
+        "build_bmc_core_formula",
     }
     for name in expected - lazy_names - function_names:
         assert getattr(bmc, name).__name__ == name
@@ -198,6 +209,7 @@ def test_submodule_all_exports_are_exact():
     macro = importlib.import_module("pyfcstm.bmc.macro")
     expand = importlib.import_module("pyfcstm.bmc.expand")
     engine = importlib.import_module("pyfcstm.bmc.engine")
+    relation = importlib.import_module("pyfcstm.bmc.relation")
 
     assert set(errors.__all__) == {
         "BmcError",
@@ -307,6 +319,13 @@ def test_submodule_all_exports_are_exact():
         "BmcPreparedContext",
         "BmcEngine",
         "prepare_bmc_query",
+    }
+    assert set(relation.__all__) == {
+        "BmcTraceSymbols",
+        "BmcCaseRelation",
+        "BmcStepRelation",
+        "BmcCoreFormula",
+        "build_bmc_core_formula",
     }
 
 

--- a/test/bmc/test_relation_core.py
+++ b/test/bmc/test_relation_core.py
@@ -1,0 +1,217 @@
+"""Core formula tests for BMC relation building."""
+
+from __future__ import annotations
+
+import z3
+import pytest
+
+from pyfcstm.bmc import (
+    BmcEngine,
+    STATE_TERMINATE_ID,
+    UnsupportedBmcQuery,
+    build_bmc_core_formula,
+)
+from pyfcstm.model import load_state_machine_from_text
+
+
+def _solver(*constraints):
+    solver = z3.Solver()
+    solver.add(*constraints)
+    return solver
+
+
+@pytest.mark.unittest
+def test_core_formula_constrains_initial_state_and_variable_initializers() -> None:
+    """I_0 fixes the source state and every persistent initializer."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 2;
+        def float y = 0.5;
+        state Root {
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    context = BmcEngine(model).prepare(
+        'init state("Root.A");\ncheck reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+    root_a = context.domain.state_path_to_id("Root.A")
+
+    assert core.to_canonical()["node"] == "bmc_core_formula"
+    assert _solver(core.core, core.symbols.frame_state(0) != root_a).check() == z3.unsat
+    assert _solver(core.core, core.symbols.frame_var(0, "x") != 2).check() == z3.unsat
+    assert (
+        _solver(core.core, core.symbols.frame_var(0, "y") != z3.RealVal("1/2")).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_terminated_initial_uses_terminate_source_and_absorb_case() -> None:
+    """Initial terminated mode constrains F_0 and produces an absorb relation."""
+    model = load_state_machine_from_text("state Root;")
+    context = BmcEngine(model).prepare(
+        "init terminated;\ncheck reach <= 1: terminated();"
+    )
+    core = build_bmc_core_formula(context)
+
+    assert (
+        _solver(core.core, core.symbols.frame_state(0) != STATE_TERMINATE_ID).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(core.core, core.symbols.frame_state(1) != STATE_TERMINATE_ID).check()
+        == z3.unsat
+    )
+    assert [rel.case.kind for rel in core.steps[0].case_relations] == ["absorb"]
+
+
+@pytest.mark.unittest
+def test_bound_two_uses_recurrence_absorb_after_initial_termination() -> None:
+    """Steps after the initial step use recurrence sources, including sentinels."""
+    model = load_state_machine_from_text("state Root;")
+    context = BmcEngine(model).prepare("check reach <= 2: terminated();")
+    core = build_bmc_core_formula(context)
+
+    assert len(core.steps) == 2
+    assert any(
+        relation.case.kind == "absorb"
+        and relation.case.source_state_id == STATE_TERMINATE_ID
+        for relation in core.steps[1].case_relations
+    )
+    assert (
+        _solver(core.core, core.symbols.frame_state(2) != STATE_TERMINATE_ID).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_initial_where_only_constrains_i0_not_macro_case_partition() -> None:
+    """Initial ``where`` predicates enter ``I_0`` without changing cases."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : if [x == 0];
+        }
+        """
+    )
+    context = BmcEngine(model).prepare(
+        'init state("Root.A") where x > 0;\ncheck reach <= 1: active("Root.B");'
+    )
+    core = build_bmc_core_formula(context)
+
+    assert _solver(core.core).check() == z3.unsat
+    assert "0 < F_0_x" in str(core.initial_formula)
+    assert any(
+        relation.case.target_state_path == "Root.B"
+        for relation in core.steps[0].case_relations
+    )
+    assert all(
+        "where" not in relation.case.label for relation in core.steps[0].case_relations
+    )
+
+
+@pytest.mark.unittest
+def test_action_lowering_failure_is_structured_unsupported() -> None:
+    """Action operation failures are surfaced as BMC unsupported diagnostics."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A { during { x = sin(x); } }
+            [*] -> A;
+        }
+        """
+    )
+    context = BmcEngine(model).prepare(
+        'init state("Root.A");\ncheck reach <= 1: active("Root.A");'
+    )
+
+    with pytest.raises(UnsupportedBmcQuery, match="action block leaf_during"):
+        build_bmc_core_formula(context)
+
+
+@pytest.mark.unittest
+def test_guard_lowering_failure_is_structured_unsupported() -> None:
+    """Guard expression failures are surfaced as BMC unsupported diagnostics."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : if [sin(x) > 0];
+        }
+        """
+    )
+    context = BmcEngine(model).prepare(
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");'
+    )
+
+    with pytest.raises(UnsupportedBmcQuery, match="guard g0"):
+        build_bmc_core_formula(context)
+
+
+@pytest.mark.unittest
+def test_case_relation_uses_implication_not_global_and_and_carries_vars() -> None:
+    """An unselected case must not force its target, and unwritten vars carry."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        def int keep = 5;
+        state Root {
+            event Go;
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : Go effect { x = x + 10; }
+        }
+        """
+    )
+    context = BmcEngine(model).prepare(
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");'
+    )
+    core = build_bmc_core_formula(context)
+    go = core.symbols.event_input(0, "Root.Go")
+    state_b = context.domain.state_path_to_id("Root.B")
+    state_a = context.domain.state_path_to_id("Root.A")
+    relations = {
+        relation.case.kind: relation for relation in core.steps[0].case_relations
+    }
+
+    assert set(relations) == {"fallback", "transition"}
+    assert _solver(core.core, go).check() == z3.sat
+    assert (
+        _solver(core.core, go, core.symbols.frame_state(1) != state_b).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(core.core, go, core.symbols.frame_var(1, "x") != 10).check() == z3.unsat
+    )
+    assert (
+        _solver(
+            core.core,
+            go,
+            core.symbols.frame_var(1, "keep") != core.symbols.frame_var(0, "keep"),
+        ).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(
+            core.core,
+            go,
+            core.symbols.case_selector(0, relations["fallback"].case.label),
+        ).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(core.core, z3.Not(go), core.symbols.frame_state(1) != state_a).check()
+        == z3.unsat
+    )

--- a/test/bmc/test_relation_environment.py
+++ b/test/bmc/test_relation_environment.py
@@ -1,0 +1,281 @@
+"""Environment-assumption tests for BMC relation formulas."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+import z3
+
+from pyfcstm.bmc import BmcEngine, UnsupportedBmcQuery, build_bmc_core_formula
+from pyfcstm.model import load_state_machine_from_text
+
+
+def _solver(*constraints):
+    solver = z3.Solver()
+    solver.add(*constraints)
+    return solver
+
+
+def _event_model():
+    return load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            state A {
+                event Ping;
+            }
+            state B {
+                event Ping;
+            }
+            [*] -> A;
+        }
+        """
+    )
+
+
+@pytest.mark.unittest
+def test_frame_assumptions_lower_always_to_all_frames_and_at_to_one_frame() -> None:
+    """Frame assumptions are lowered over the intended frame set."""
+    model = load_state_machine_from_text("def int x = 0; state Root;")
+    context = BmcEngine(model).prepare(
+        "assume always: x >= 0;\n"
+        'assume at 1: var("x") <= 3;\n'
+        "check reach <= 1: terminated();"
+    )
+    core = build_bmc_core_formula(context)
+
+    assert _solver(core.core, core.symbols.frame_var(0, "x") < 0).check() == z3.unsat
+    assert _solver(core.core, core.symbols.frame_var(1, "x") < 0).check() == z3.unsat
+    assert _solver(core.core, core.symbols.frame_var(1, "x") > 3).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_event_not_equal_is_binder_normalized_to_false() -> None:
+    """Event ``!= true`` assumptions constrain the selected event to false."""
+    context = BmcEngine(_event_model()).prepare(
+        'assume event("Root.A.Ping", 0) != true;\ncheck reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+    event_a = core.symbols.event_input(0, "Root.A.Ping")
+
+    assert _solver(core.core, event_a).check() == z3.unsat
+    assert _solver(core.core, z3.Not(event_a)).check() == z3.sat
+
+
+@pytest.mark.unittest
+def test_default_event_pool_allows_multiple_events_in_same_cycle() -> None:
+    """No implicit at-most-one is added when the query does not request it."""
+    context = BmcEngine(_event_model()).prepare(
+        'assume event("Root.A.Ping", 0) == true;\n'
+        'assume event("Root.B.Ping", 0) == true;\n'
+        'check reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+
+    assert _solver(core.core).check() == z3.sat
+
+
+@pytest.mark.unittest
+def test_user_event_cardinality_at_most_one_is_per_cycle() -> None:
+    """Only user-declared cardinality introduces per-cycle event exclusion."""
+    context = BmcEngine(_event_model()).prepare(
+        'assume event("Root.A.Ping", 0) == true;\n'
+        'assume event("Root.B.Ping", 0) == true;\n'
+        "assume events cardinality at_most_one {\n"
+        '    "Root.A.Ping",\n'
+        '    "Root.B.Ping"\n'
+        "};\n"
+        'check reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+
+    assert _solver(core.core).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_same_short_name_events_remain_distinct_full_paths() -> None:
+    """An assumption on ``A.Ping`` does not constrain the separate ``B.Ping`` input."""
+    context = BmcEngine(_event_model()).prepare(
+        'assume event("Root.A.Ping", 0) == true;\ncheck reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+
+    assert (
+        _solver(core.core, z3.Not(core.symbols.event_input(0, "Root.A.Ping"))).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(core.core, core.symbols.event_input(0, "Root.B.Ping")).check() == z3.sat
+    )
+
+
+@pytest.mark.unittest
+def test_event_selector_star_and_ranges_lower_to_each_selected_cycle() -> None:
+    """Event selectors are expanded by the binder and lowered pointwise."""
+    context = BmcEngine(_event_model()).prepare(
+        'assume event("Root.A.Ping", 0..1) == true;\n'
+        'assume event("Root.B.Ping", *) == false;\n'
+        'check reach <= 3: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+
+    assert (
+        _solver(core.core, z3.Not(core.symbols.event_input(0, "Root.A.Ping"))).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(core.core, z3.Not(core.symbols.event_input(1, "Root.A.Ping"))).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(core.core, z3.Not(core.symbols.event_input(2, "Root.A.Ping"))).check()
+        == z3.sat
+    )
+    for step in range(3):
+        assert (
+            _solver(core.core, core.symbols.event_input(step, "Root.B.Ping")).check()
+            == z3.unsat
+        )
+
+
+@pytest.mark.unittest
+def test_event_cardinality_any_is_noop_even_with_multiple_true_events() -> None:
+    """The explicit ``any`` cardinality policy adds no mutual exclusion."""
+    context = BmcEngine(_event_model()).prepare(
+        "assume events cardinality any;\n"
+        'assume event("Root.A.Ping", 0) == true;\n'
+        'assume event("Root.B.Ping", 0) == true;\n'
+        'check reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+
+    assert _solver(core.core).check() == z3.sat
+
+
+@pytest.mark.unittest
+def test_frame_assumption_expression_matrix_lowers_supported_terms() -> None:
+    """Frame predicates exercise numeric, boolean, ufunc, and domain lowering."""
+    model = load_state_machine_from_text(
+        "def int x = 4; def int y = 2; def float f = 1.5; state Root;"
+    )
+    context = BmcEngine(model).prepare(
+        "assume always: ((x + 2 - y * 3) <= 0) && ((x / y) == 2) "
+        "&& ((x % y) == 0) && ((x ** y) >= 16);\n"
+        "assume always: ((x > y) ? true : false);\n"
+        "assume always: ((x > y) ? x : y) == x;\n"
+        "assume always: abs(-x) == x && sign(-x) == -1;\n"
+        "assume always: floor(f) <= f && ceil(f) >= f && trunc(f) == 1 "
+        "&& round(f) == 2 && sqrt(x) >= 2;\n"
+        "assume always: pi > 3 && E > 2 && tau > 6;\n"
+        "assume always: (+x) == x && cycle >= 0 && 1.5 <= f && x < 5 && x != y;\n"
+        "assume always: trunc(x) == x;\n"
+        "assume always: (true && !false) && (true || false) && (true => true) "
+        "&& (true xor false) && (true iff true) && (true == true) "
+        "&& (true != false);\n"
+        "check reach <= 1: terminated();"
+    )
+    core = build_bmc_core_formula(context)
+
+    assert _solver(core.core).check() == z3.sat
+    assert "Sqrt" in str(core.environment_formula) or "**(1/2)" in str(
+        core.environment_formula
+    )
+    assert "!=" in str(core.environment_formula)
+
+
+@pytest.mark.unittest
+def test_frame_assumptions_lower_active_and_terminated_atoms() -> None:
+    """Frame predicates can constrain active and terminated frame states."""
+    active_model = load_state_machine_from_text("state Root { state A; [*] -> A; }")
+    active_context = BmcEngine(active_model).prepare(
+        'init state("Root.A");\n'
+        'assume at 0: active("Root.A");\n'
+        'assume at 1: active("Root.A");\n'
+        'check reach <= 1: active("Root.A");'
+    )
+    active_core = build_bmc_core_formula(active_context)
+
+    terminated_context = BmcEngine(load_state_machine_from_text("state Root;")).prepare(
+        "init terminated;\n"
+        "assume at 0: terminated();\n"
+        "assume at 1: terminated();\n"
+        "check reach <= 1: terminated();"
+    )
+    terminated_core = build_bmc_core_formula(terminated_context)
+
+    assert _solver(active_core.core).check() == z3.sat
+    assert _solver(terminated_core.core).check() == z3.sat
+    assert (
+        _solver(
+            active_core.core,
+            active_core.symbols.frame_state(0) != active_core.symbols.frame_state(1),
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_frame_assumption_definedness_constraints_can_make_core_unsat() -> None:
+    """Runtime-definedness constraints are part of ``ENV_N``."""
+    model = load_state_machine_from_text("def int x = 4; def int y = 0; state Root;")
+    context = BmcEngine(model).prepare(
+        "assume always: (x / y) >= 0;\ncheck reach <= 1: terminated();"
+    )
+    core = build_bmc_core_formula(context)
+
+    assert _solver(core.core).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_unsupported_frame_expression_reports_structured_bmc_error() -> None:
+    """Unsupported Z3 operations do not leak raw Python or Z3 exceptions."""
+    model = load_state_machine_from_text("def int x = 4; def int y = 2; state Root;")
+    context = BmcEngine(model).prepare(
+        "assume always: (x & y) == 0;\ncheck reach <= 1: terminated();"
+    )
+
+    with pytest.raises(UnsupportedBmcQuery, match="unsupported for operator &"):
+        build_bmc_core_formula(context)
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    ("expression", "operator"),
+    [
+        ("(x | y) == 0", "|"),
+        ("(x ^ y) == 0", "^"),
+        ("(x << y) == 0", "<<"),
+        ("(x >> y) == 0", ">>"),
+        ("(f % 1.0) == 0", "%"),
+    ],
+)
+def test_unsupported_numeric_operator_matrix_reports_structured_bmc_error(
+    expression,
+    operator,
+) -> None:
+    """Unsupported numeric operators fail with structured BMC diagnostics."""
+    model = load_state_machine_from_text(
+        "def int x = 4; def int y = 2; def float f = 1.5; state Root;"
+    )
+    context = BmcEngine(model).prepare(
+        "assume always: %s;\ncheck reach <= 1: terminated();" % expression
+    )
+
+    with pytest.raises(
+        UnsupportedBmcQuery,
+        match="unsupported for operator %s" % re.escape(operator),
+    ):
+        build_bmc_core_formula(context)
+
+
+@pytest.mark.unittest
+def test_unsupported_ufunc_reports_structured_bmc_error() -> None:
+    """Supported parser ufuncs without relation lowering fail explicitly."""
+    model = load_state_machine_from_text("def int x = 4; state Root;")
+    context = BmcEngine(model).prepare(
+        "assume always: sin(x) >= 0;\ncheck reach <= 1: terminated();"
+    )
+
+    with pytest.raises(UnsupportedBmcQuery, match="unsupported function 'sin'"):
+        build_bmc_core_formula(context)

--- a/test/bmc/test_relation_environment.py
+++ b/test/bmc/test_relation_environment.py
@@ -228,6 +228,58 @@ def test_frame_assumption_definedness_constraints_can_make_core_unsat() -> None:
 
 
 @pytest.mark.unittest
+def test_frame_assumption_logical_short_circuit_guards_definedness() -> None:
+    """Skipped logical operands do not add runtime-definedness constraints."""
+    model = load_state_machine_from_text("def int x = 0; state Root;")
+
+    for query in (
+        'assume always: true || (1 / x > 0);\ncheck reach <= 1: active("Root");',
+        'assume always: !(false && (1 / x > 0));\ncheck reach <= 1: active("Root");',
+        'assume always: x == 0 || (1 / x > 0);\ncheck reach <= 1: active("Root");',
+        'assume always: !(x != 0 && (1 / x > 0));\ncheck reach <= 1: active("Root");',
+    ):
+        core = build_bmc_core_formula(BmcEngine(model).prepare(query))
+        assert _solver(core.core).check() == z3.sat
+
+    for query in (
+        'assume always: false || (1 / x > 0);\ncheck reach <= 1: active("Root");',
+        'assume always: true && (1 / x > 0);\ncheck reach <= 1: active("Root");',
+        'assume always: x != 0 || (1 / x > 0);\ncheck reach <= 1: active("Root");',
+        'assume always: !(x == 0 && (1 / x > 0));\ncheck reach <= 1: active("Root");',
+    ):
+        core = build_bmc_core_formula(BmcEngine(model).prepare(query))
+        assert _solver(core.core).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_frame_assumption_conditional_guards_branch_definedness() -> None:
+    """Skipped conditional branches do not constrain runtime-definedness."""
+    model = load_state_machine_from_text("def int x = 0; state Root;")
+
+    for query in (
+        "assume always: ((true) ? 1 : (1 / x)) == 1;\n"
+        'check reach <= 1: active("Root");',
+        "assume always: ((false) ? (1 / x) : 1) == 1;\n"
+        'check reach <= 1: active("Root");',
+        "assume always: (true) ? true : (1 / x > 0);\n"
+        'check reach <= 1: active("Root");',
+        "assume always: (false) ? (1 / x > 0) : true;\n"
+        'check reach <= 1: active("Root");',
+    ):
+        core = build_bmc_core_formula(BmcEngine(model).prepare(query))
+        assert _solver(core.core).check() == z3.sat
+
+    for query in (
+        "assume always: ((false) ? 1 : (1 / x)) == 1;\n"
+        'check reach <= 1: active("Root");',
+        "assume always: (false) ? true : (1 / x > 0);\n"
+        'check reach <= 1: active("Root");',
+    ):
+        core = build_bmc_core_formula(BmcEngine(model).prepare(query))
+        assert _solver(core.core).check() == z3.unsat
+
+
+@pytest.mark.unittest
 def test_unsupported_frame_expression_reports_structured_bmc_error() -> None:
     """Unsupported Z3 operations do not leak raw Python or Z3 exceptions."""
     model = load_state_machine_from_text("def int x = 4; def int y = 2; state Root;")

--- a/test/bmc/test_relation_public_api.py
+++ b/test/bmc/test_relation_public_api.py
@@ -1,0 +1,361 @@
+"""Public API tests for BMC relation building."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+import z3
+
+from pyfcstm.bmc import BmcBuildError, BmcEngine, BmcTraceSymbols, build_bmc_domain
+from pyfcstm.bmc.macro import BoolTemplate, CycleCase
+from pyfcstm.bmc.relation import BmcCaseRelation, BmcCoreFormula, BmcStepRelation
+from pyfcstm.bmc.relation import build_bmc_core_formula
+from pyfcstm.model import load_state_machine_from_text
+
+
+@pytest.mark.unittest
+def test_relation_public_exports_are_lazy_and_complete() -> None:
+    """The relation builder is public without exposing unstable options."""
+    bmc = importlib.import_module("pyfcstm.bmc")
+    relation = importlib.import_module("pyfcstm.bmc.relation")
+
+    expected = {
+        "BmcTraceSymbols",
+        "BmcCaseRelation",
+        "BmcStepRelation",
+        "BmcCoreFormula",
+        "build_bmc_core_formula",
+    }
+
+    assert expected.issubset(set(bmc.__all__))
+    assert expected.issubset(set(dir(bmc)))
+    assert set(relation.__all__) == expected
+    assert "BmcRelationOptions" not in bmc.__all__
+    assert not hasattr(relation, "BmcRelationOptions")
+    assert bmc.BmcTraceSymbols.__name__ == "BmcTraceSymbols"
+    assert callable(bmc.build_bmc_core_formula)
+
+
+@pytest.mark.unittest
+def test_bmc_root_import_still_does_not_load_z3_or_verify() -> None:
+    """Adding relation exports keeps root import lazy and verify-independent."""
+    code = (
+        "import sys; "
+        "import pyfcstm.bmc; "
+        "bad = [name for name in sys.modules "
+        "if name == 'z3' or name.startswith('pyfcstm.verify')]; "
+        "print(bad)"
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )
+
+    assert result.stdout.strip() == "[]"
+
+
+@pytest.mark.unittest
+def test_trace_symbols_allocate_frames_events_and_cases() -> None:
+    """Trace symbols expose frame, event, and case lookup helpers."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    context = BmcEngine(model).prepare('check reach <= 1: active("Root.A");')
+
+    symbols = BmcTraceSymbols.allocate(context.domain, {0: ("case0",)})
+
+    assert symbols.frame_state(0).decl().name() == "F_0_state"
+    assert symbols.frame_var(0, "x").sort().name() == "Int"
+    assert symbols.event_input(0, "Root.Go").sort().name() == "Bool"
+    assert symbols.case_selector(0, "case0").sort().name() == "Bool"
+    assert symbols.to_canonical()["node"] == "bmc_trace_symbols"
+
+
+@pytest.mark.unittest
+def test_trace_symbols_reject_invalid_public_lookups() -> None:
+    """Trace symbol lookup helpers fail closed with BMC errors."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            state A;
+            [*] -> A;
+        }
+        """
+    )
+    symbols = BmcTraceSymbols.allocate(build_bmc_domain(model, 1), {0: ("case0",)})
+
+    with pytest.raises(BmcBuildError, match="frame index out of range"):
+        symbols.frame_state(-1)
+    with pytest.raises(BmcBuildError, match="Unknown frame variable"):
+        symbols.frame_var(0, "missing")
+    with pytest.raises(BmcBuildError, match="frame index out of range"):
+        symbols.frame_var(2, "x")
+    with pytest.raises(BmcBuildError, match="Unknown event input"):
+        symbols.event_input(0, "Root.Missing")
+    with pytest.raises(BmcBuildError, match="step index out of range"):
+        symbols.event_input(1, "Root.Go")
+    with pytest.raises(BmcBuildError, match="Unknown case selector"):
+        symbols.case_selector(0, "missing")
+    with pytest.raises(BmcBuildError, match="step index out of range"):
+        symbols.case_selector(1, "case0")
+
+
+@pytest.mark.unittest
+def test_trace_symbols_allocate_rejects_non_domain() -> None:
+    """The allocator validates its public domain argument."""
+    with pytest.raises(BmcBuildError, match="domain must be BmcDomain"):
+        BmcTraceSymbols.allocate(object())
+
+
+@pytest.mark.unittest
+def test_trace_symbols_dataclass_validates_public_payload_shape() -> None:
+    """Direct public construction validates symbol collection lengths."""
+    domain = build_bmc_domain(load_state_machine_from_text("state Root;"), 1)
+    frame_states = (z3.Int("s0"), z3.Int("s1"))
+    frame_vars = ({}, {})
+    event_inputs = ({},)
+    case_selectors = ({},)
+
+    with pytest.raises(BmcBuildError, match="domain must be BmcDomain"):
+        BmcTraceSymbols(
+            object(), frame_states, frame_vars, event_inputs, case_selectors
+        )
+    with pytest.raises(BmcBuildError, match="frame_states must contain"):
+        BmcTraceSymbols(domain, (), frame_vars, event_inputs, case_selectors)
+    with pytest.raises(BmcBuildError, match="frame_vars must contain"):
+        BmcTraceSymbols(domain, frame_states, (), event_inputs, case_selectors)
+    with pytest.raises(BmcBuildError, match="event_inputs must contain"):
+        BmcTraceSymbols(domain, frame_states, frame_vars, (), case_selectors)
+    with pytest.raises(BmcBuildError, match="case_selectors must contain"):
+        BmcTraceSymbols(domain, frame_states, frame_vars, event_inputs, ())
+
+
+@pytest.mark.unittest
+def test_trace_symbols_duplicate_case_labels_report_internal_bug() -> None:
+    """Duplicate case labels are internal builder bugs with issue guidance."""
+    domain = build_bmc_domain(load_state_machine_from_text("state Root;"), 1)
+
+    with pytest.raises(BmcBuildError, match="internal BMC bug") as error_info:
+        BmcTraceSymbols.allocate(domain, {0: ("case0", "case0")})
+
+    assert "https://github.com/HansBug/pyfcstm/issues" in str(error_info.value)
+
+
+@pytest.mark.unittest
+def test_relation_dataclasses_validate_public_payload_shape() -> None:
+    """Public relation dataclasses reject malformed Z3 payloads."""
+    case = CycleCase(
+        "fallback",
+        0,
+        "Root",
+        0,
+        "Root",
+        "Root::fallback::Root::0",
+        BoolTemplate.true(),
+        (),
+    )
+
+    with pytest.raises(BmcBuildError, match="step_index must be an integer"):
+        BmcCaseRelation(
+            True,
+            case,
+            z3.Bool("selector"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            {},
+            {},
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="selector must be a Z3 Boolean"):
+        BmcCaseRelation(
+            0,
+            case,
+            z3.Int("selector"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            {},
+            {},
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="step_index must be non-negative"):
+        BmcCaseRelation(
+            -1,
+            case,
+            z3.Bool("selector"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            {},
+            {},
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="case must be CycleCase"):
+        BmcCaseRelation(
+            0,
+            object(),
+            z3.Bool("selector"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            {},
+            {},
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="post_var_exprs must contain"):
+        BmcCaseRelation(
+            0,
+            case,
+            z3.Bool("selector"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            {"x": z3.Bool("bad")},
+            {},
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="guard_terms must contain"):
+        BmcCaseRelation(
+            0,
+            case,
+            z3.Bool("selector"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            {},
+            {"g0": z3.Int("bad")},
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="definedness_constraints must contain"):
+        BmcCaseRelation(
+            0,
+            case,
+            z3.Bool("selector"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            {},
+            {},
+            (object(),),
+        )
+    with pytest.raises(BmcBuildError, match="step_index must be an integer"):
+        BmcStepRelation(True, (), (), z3.BoolVal(True))
+    with pytest.raises(BmcBuildError, match="step_index must be non-negative"):
+        BmcStepRelation(-1, (), (), z3.BoolVal(True))
+    with pytest.raises(BmcBuildError, match="case_relations must contain"):
+        BmcStepRelation(0, (), (object(),), z3.BoolVal(True))
+    with pytest.raises(BmcBuildError, match="formals must contain"):
+        BmcStepRelation(0, (object(),), (), z3.BoolVal(True))
+    with pytest.raises(BmcBuildError, match="formula must be a Z3 Boolean"):
+        BmcStepRelation(0, (), (), z3.Int("bad"))
+    assert BmcStepRelation(0, (), (), z3.BoolVal(True)).case_registry == {}
+
+
+@pytest.mark.unittest
+def test_core_formula_dataclass_validates_public_payload_shape() -> None:
+    """Core formula payloads reject malformed symbols, formulas, and steps."""
+    context = BmcEngine(load_state_machine_from_text("state Root;")).prepare(
+        "check reach <= 1: terminated();"
+    )
+    symbols = BmcTraceSymbols.allocate(context.domain)
+
+    with pytest.raises(BmcBuildError, match="symbols must be BmcTraceSymbols"):
+        BmcCoreFormula(
+            context,
+            object(),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            (),
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="domain_formula must be a Z3 Boolean"):
+        BmcCoreFormula(
+            context,
+            symbols,
+            z3.Int("bad"),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            (),
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="steps must contain"):
+        BmcCoreFormula(
+            context,
+            symbols,
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            (object(),),
+            (),
+        )
+    with pytest.raises(BmcBuildError, match="diagnostics must contain"):
+        BmcCoreFormula(
+            context,
+            symbols,
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            z3.BoolVal(True),
+            (),
+            (object(),),
+        )
+
+
+@pytest.mark.unittest
+def test_core_builder_rejects_context_domain_from_different_model() -> None:
+    """The public builder catches inconsistent prepared context internals."""
+    from pyfcstm.bmc.engine import BmcPreparedContext
+
+    model = load_state_machine_from_text("state Root;")
+    other_model = load_state_machine_from_text("state Other;")
+    context = BmcEngine(model).prepare("check reach <= 1: terminated();")
+    mismatched = BmcPreparedContext(
+        model=context.model,
+        query=context.query,
+        bound_query=context.bound_query,
+        domain=build_bmc_domain(other_model, context.bound),
+        options=context.options,
+        source_text=context.source_text,
+    )
+
+    with pytest.raises(BmcBuildError, match="context.domain must be built"):
+        build_bmc_core_formula(mismatched)
+
+
+@pytest.mark.unittest
+def test_build_bmc_core_formula_rejects_non_context() -> None:
+    """The public relation entry validates only its public boundary input."""
+    with pytest.raises(BmcBuildError, match="context must be BmcPreparedContext"):
+        build_bmc_core_formula(object())

--- a/test/bmc/test_relation_runtime_alignment.py
+++ b/test/bmc/test_relation_runtime_alignment.py
@@ -1,0 +1,595 @@
+"""Runtime-alignment tests for BMC relation lowering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import z3
+import pytest
+
+from pyfcstm.bmc import BmcEngine, build_bmc_core_formula
+from pyfcstm.model import load_state_machine_from_text
+from pyfcstm.simulate import SimulationRuntime
+
+_MACRO_ALIGNMENT_FIXTURE = (
+    Path(__file__).with_name("fixtures") / "macro_runtime_alignment.fcstm"
+)
+
+
+def _solver(*constraints):
+    solver = z3.Solver()
+    solver.add(*constraints)
+    return solver
+
+
+def _runtime_state(runtime):
+    if runtime.is_ended:
+        return None
+    return ".".join(runtime.current_state.path)
+
+
+def _event_constraints(core, step_index, events):
+    selected = set(events)
+    return tuple(
+        core.symbols.event_input(step_index, event.path)
+        if event.path in selected
+        else z3.Not(core.symbols.event_input(step_index, event.path))
+        for event in core.context.domain.events
+    )
+
+
+def _assert_relation_matches_runtime(
+    dsl,
+    query_text,
+    *,
+    initial_state=None,
+    initial_vars=None,
+    events=(),
+):
+    model = load_state_machine_from_text(dsl)
+    runtime_kwargs = {}
+    if initial_state is not None:
+        runtime_kwargs["initial_state"] = initial_state
+    if initial_vars is not None:
+        runtime_kwargs["initial_vars"] = dict(initial_vars)
+    runtime = SimulationRuntime(model, **runtime_kwargs)
+    runtime.cycle(list(events))
+
+    context = BmcEngine(model).prepare(query_text)
+    core = build_bmc_core_formula(context)
+    fixed_events = _event_constraints(core, 0, events)
+    expected_state = _runtime_state(runtime)
+    expected_state_id = (
+        core.context.domain.state_path_to_id(expected_state)
+        if expected_state is not None
+        else -1
+    )
+
+    if expected_state is None:
+        from pyfcstm.bmc import STATE_TERMINATE_ID
+
+        expected_state_id = STATE_TERMINATE_ID
+    assert (
+        _solver(
+            core.core,
+            *fixed_events,
+            core.symbols.frame_state(1) != expected_state_id,
+        ).check()
+        == z3.unsat
+    )
+    for name, value in runtime.vars.items():
+        assert (
+            _solver(
+                core.core,
+                *fixed_events,
+                core.symbols.frame_var(1, name) != value,
+            ).check()
+            == z3.unsat
+        )
+
+    selected = [
+        relation
+        for relation in core.steps[0].case_relations
+        if _solver(core.core, *fixed_events, relation.selector).check() == z3.sat
+    ]
+    assert len(selected) == 1
+    assert selected[0].case.target_state_id == expected_state_id
+    return core, selected[0], runtime
+
+
+def _macro_alignment_fixture_with_initializers(x, y):
+    dsl = _MACRO_ALIGNMENT_FIXTURE.read_text()
+    dsl = dsl.replace("def int x = 0;", "def int x = %d;" % x, 1)
+    dsl = dsl.replace("def int y = 0;", "def int y = %d;" % y, 1)
+    return dsl
+
+
+@pytest.mark.unittest
+def test_relation_cold_init_enter_initial_effect_and_during_match_runtime() -> None:
+    """Cold initialization lowers entry effects and first leaf ``during``."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            state A {
+                enter { x = x + 1; }
+                during { x = x + 2; }
+            }
+            [*] -> A effect { x = x + 4; }
+        }
+        """,
+        'check reach <= 1: active("Root.A");',
+    )
+
+    assert selected.case.kind == "initial"
+    assert runtime.vars == {"x": 7}
+    assert (
+        _solver(
+            core.core,
+            core.symbols.frame_var(1, "x") != core.symbols.frame_var(0, "x") + 7,
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_relation_action_ifblock_matches_simulation_runtime() -> None:
+    """Action-local ``if`` is lowered by solver.operation, not macro splitting."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 2;
+        state Root {
+            state A {
+                during {
+                    if [x > 0] { x = x + 1; } else { x = x - 1; }
+                }
+            }
+            [*] -> A;
+        }
+        """
+    )
+    runtime = SimulationRuntime(model, initial_state="Root.A", initial_vars={"x": 2})
+    runtime.cycle([])
+    context = BmcEngine(model).prepare(
+        'init state("Root.A");\ncheck reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+
+    assert runtime.vars == {"x": 3}
+    assert len(core.steps[0].case_relations) == 1
+    assert core.steps[0].case_relations[0].case.condition.variables == ()
+    assert (
+        _solver(core.core, core.symbols.frame_var(1, "x") != runtime.vars["x"]).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_relation_event_transition_effect_matches_simulation_runtime() -> None:
+    """Event transition effects and target states align with one runtime cycle."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            state A;
+            state B { enter { x = x + 2; } }
+            [*] -> A;
+            A -> B : Go effect { x = x + 10; }
+        }
+        """
+    )
+    runtime = SimulationRuntime(model, initial_state="Root.A", initial_vars={"x": 0})
+    runtime.cycle(["Root.Go"])
+    context = BmcEngine(model).prepare(
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");'
+    )
+    core = build_bmc_core_formula(context)
+    state_b = context.domain.state_path_to_id("Root.B")
+
+    assert ".".join(runtime.current_state.path) == "Root.B"
+    assert runtime.vars == {"x": 12}
+    assert (
+        _solver(
+            core.core,
+            core.symbols.event_input(0, "Root.Go"),
+            core.symbols.frame_state(1) != state_b,
+        ).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(
+            core.core,
+            core.symbols.event_input(0, "Root.Go"),
+            core.symbols.frame_var(1, "x") != runtime.vars["x"],
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_relation_exit_effect_enter_order_matches_simulation_runtime() -> None:
+    """Exit, transition effect, and target enter blocks keep runtime order."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            state A { exit { x = x + 5; } }
+            state B { enter { x = x + 2; } }
+            [*] -> A;
+            A -> B : Go effect { x = x + 10; }
+        }
+        """,
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");',
+        initial_state="Root.A",
+        initial_vars={"x": 0},
+        events=("Root.Go",),
+    )
+
+    assert selected.case.kind == "transition"
+    assert runtime.vars == {"x": 17}
+    assert selected.post_var_exprs["x"].decl().name() == "+"
+    assert (
+        _solver(
+            core.core,
+            core.symbols.event_input(0, "Root.Go"),
+            core.symbols.frame_var(1, "x") != 17,
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_relation_transition_priority_accepted_masks_match_runtime() -> None:
+    """Later transitions are masked by accepted earlier transitions."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 5;
+        state Root {
+            state A;
+            state B;
+            state C;
+            [*] -> A;
+            A -> B : if [x > 0];
+            A -> C : if [x < 10];
+        }
+        """
+    )
+    runtime = SimulationRuntime(model, initial_state="Root.A", initial_vars={"x": 5})
+    runtime.cycle([])
+    context = BmcEngine(model).prepare(
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");'
+    )
+    core = build_bmc_core_formula(context)
+    state_b = context.domain.state_path_to_id("Root.B")
+    state_c = context.domain.state_path_to_id("Root.C")
+    selected_b = [
+        relation
+        for relation in core.steps[0].case_relations
+        if relation.case.target_state_id == state_b
+    ][0]
+    masked_c = [
+        relation
+        for relation in core.steps[0].case_relations
+        if relation.case.target_state_id == state_c
+    ][0]
+
+    assert ".".join(runtime.current_state.path) == "Root.B"
+    assert "accepted:%s" % selected_b.case.label in masked_c.case.condition.variables
+    assert _solver(core.core, selected_b.selector).check() == z3.sat
+    assert _solver(core.core, masked_c.selector).check() == z3.unsat
+    assert (
+        _solver(core.core, core.symbols.frame_state(1) != state_b).check() == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_relation_fallback_negates_failed_guard_and_runs_during() -> None:
+    """Fallback cases lower negative guard requirements before actions."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = -1;
+        state Root {
+            state A { during { x = x + 1; } }
+            state B;
+            [*] -> A;
+            A -> B : if [x > 0];
+        }
+        """,
+        'init state("Root.A");\ncheck reach <= 1: active("Root.A");',
+        initial_state="Root.A",
+        initial_vars={"x": -1},
+    )
+
+    assert selected.case.kind == "fallback"
+    assert runtime.vars == {"x": 0}
+    assert any(
+        atom.startswith("accepted:") for atom in selected.case.condition.variables
+    )
+    assert "Not" in str(selected.antecedent)
+    assert _solver(core.core, core.symbols.frame_var(1, "x") != 0).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_relation_pseudo_guard_anchor_uses_prefix_actions() -> None:
+    """Pseudo guards are lowered after prior transition effects execute."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            pseudo state Route;
+            state B;
+            state C;
+            [*] -> A;
+            A -> Route effect { x = x + 2; }
+            Route -> B : if [x >= 2];
+            Route -> C;
+        }
+        """,
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");',
+        initial_state="Root.A",
+        initial_vars={"x": 0},
+    )
+
+    assert selected.case.target_state_path == "Root.B"
+    assert runtime.vars == {"x": 2}
+    assert any(
+        "F_0_x" in str(term) and "+ 2" in str(term)
+        for term in selected.guard_terms.values()
+    )
+    assert _solver(core.core, core.symbols.frame_var(1, "x") != 2).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_relation_hot_pseudo_guard_has_no_stable_prefix_action() -> None:
+    """Hot-starting at a pseudo source does not inherit other source prefixes."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            pseudo state Route;
+            state B;
+            state C;
+            [*] -> A;
+            A -> Route effect { x = x + 2; }
+            Route -> B : if [x >= 2];
+            Route -> C;
+        }
+        """,
+        'init state("Root.Route");\ncheck reach <= 1: active("Root.C");',
+        initial_state="Root.Route",
+        initial_vars={"x": 0},
+    )
+
+    assert selected.case.target_state_path == "Root.C"
+    assert runtime.vars == {"x": 0}
+    assert all("+ 2" not in str(term) for term in selected.guard_terms.values())
+    assert _solver(core.core, core.symbols.frame_var(1, "x") != 0).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_relation_parent_continuation_guard_uses_prefixed_exit_effects() -> None:
+    """Parent continuation guards see prefix actions before selecting Done."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        _macro_alignment_fixture_with_initializers(11, 0),
+        'init state("Root.System.A");\ncheck reach <= 1: active("Root.Done");',
+        initial_state="Root.System.A",
+        initial_vars={"x": 11, "y": 0},
+        events=("Root.System.A.Tick",),
+    )
+
+    assert selected.case.target_state_path == "Root.Done"
+    assert runtime.vars == {"x": 11113, "y": 11036}
+    assert [guard.reason for guard in selected.case.guard_requirements] == [
+        "pseudo_guard",
+        "parent_continuation_guard",
+    ]
+    assert any(
+        "F_0_y" in str(term) and "+ 10" in str(term) and "+ 20" in str(term)
+        for term in selected.guard_terms.values()
+    )
+    assert (
+        _solver(
+            core.core,
+            *_event_constraints(core, 0, ("Root.System.A.Tick",)),
+            core.symbols.frame_var(1, "y") != runtime.vars["y"],
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_relation_rejected_parent_continuation_rolls_back_to_fallback() -> None:
+    """Rejected pseudo and parent candidates do not leak rolled-back effects."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        _macro_alignment_fixture_with_initializers(11, -200),
+        'init state("Root.System.A");\ncheck reach <= 1: active("Root.System.A");',
+        initial_state="Root.System.A",
+        initial_vars={"x": 11, "y": -200},
+        events=("Root.System.A.Tick",),
+    )
+
+    assert selected.case.kind == "fallback"
+    assert selected.case.target_state_path == "Root.System.A"
+    assert runtime.vars == {"x": 1012, "y": 800}
+    assert (
+        _solver(
+            core.core,
+            *_event_constraints(core, 0, ("Root.System.A.Tick",)),
+            core.symbols.frame_var(1, "x") != runtime.vars["x"],
+        ).check()
+        == z3.unsat
+    )
+    assert (
+        _solver(
+            core.core,
+            *_event_constraints(core, 0, ("Root.System.A.Tick",)),
+            core.symbols.frame_var(1, "y") != runtime.vars["y"],
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+def test_relation_hot_composite_initial_descent_matches_runtime() -> None:
+    """Hot-starting a composite lowers its initial descent without parent enter."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            state Parent {
+                enter { x = x + 100; }
+                state Child { enter { x = x + 2; } }
+                [*] -> Child effect { x = x + 4; }
+            }
+            [*] -> Parent;
+        }
+        """,
+        'init state("Root.Parent");\ncheck reach <= 1: active("Root.Parent.Child");',
+        initial_state="Root.Parent",
+        initial_vars={"x": 0},
+    )
+
+    assert selected.case.kind == "initial"
+    assert [block.runtime_role for block in selected.case.action_blocks] == [
+        "transition_effect",
+        "state_enter",
+    ]
+    assert runtime.vars == {"x": 6}
+    assert _solver(core.core, core.symbols.frame_var(1, "x") != 6).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_relation_temporary_variables_do_not_enter_post_var_pool() -> None:
+    """Block-local temporaries can drive assignments but not post-var metadata."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 1;
+        state Root {
+            state A {
+                during {
+                    tmp = x + 1;
+                    x = tmp + 1;
+                }
+            }
+            [*] -> A;
+        }
+        """,
+        'init state("Root.A");\ncheck reach <= 1: active("Root.A");',
+        initial_state="Root.A",
+        initial_vars={"x": 1},
+    )
+
+    assert runtime.vars == {"x": 3}
+    assert set(selected.post_var_exprs) == {"x"}
+    assert "tmp" not in selected.post_var_exprs
+    assert _solver(core.core, core.symbols.frame_var(1, "x") != 3).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_relation_root_leaf_exit_matches_runtime_termination() -> None:
+    """A root leaf exit transition lowers to the terminate sentinel."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        "state Root;",
+        'init state("Root");\ncheck reach <= 1: terminated();',
+        initial_state="Root",
+        initial_vars={},
+    )
+
+    from pyfcstm.bmc import STATE_TERMINATE_ID
+
+    assert runtime.is_ended
+    assert selected.case.kind == "transition"
+    assert selected.case.target_state_id == STATE_TERMINATE_ID
+    assert (
+        _solver(
+            core.core,
+            core.symbols.frame_state(1) != STATE_TERMINATE_ID,
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize(
+    ("events", "expected_x"),
+    [
+        ((), 111107),
+        (("Root.Go",), 111145),
+    ],
+)
+def test_relation_multiple_lifecycle_and_aspect_blocks_match_runtime(
+    events,
+    expected_x,
+) -> None:
+    """Repeated lifecycle/aspect blocks are executed in recorded order."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            >> during before { x = x + 100; }
+            >> during before { x = x + 1000; }
+            >> during after { x = x + 10000; }
+            >> during after { x = x + 100000; }
+            state A {
+                enter { x = x + 1; }
+                enter { x = x + 2; }
+                during { x = x + 3; }
+                during { x = x + 4; }
+                exit { x = x + 5; }
+                exit { x = x + 6; }
+            }
+            state B {
+                enter { x = x + 7; }
+                enter { x = x + 8; }
+                during { x = x + 9; }
+                during { x = x + 10; }
+            }
+            [*] -> A;
+            A -> B : Go;
+        }
+        """,
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");',
+        initial_state="Root.A",
+        initial_vars={"x": 0},
+        events=events,
+    )
+
+    assert runtime.vars == {"x": expected_x}
+    assert selected.post_var_exprs["x"] is not core.symbols.frame_var(0, "x")
+    assert _solver(core.core, *_event_constraints(core, 0, events)).check() == z3.sat
+
+
+@pytest.mark.unittest
+def test_relation_abstract_actions_are_noop_writebacks() -> None:
+    """Abstract action blocks are occurrence metadata and no-op for variables."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            event Go;
+            >> during before abstract RootBefore;
+            >> during after abstract RootAfter;
+            state A {
+                enter abstract AEnter;
+                during abstract ADuring;
+                exit abstract AExit;
+            }
+            state B;
+            [*] -> A;
+            A -> B : Go;
+        }
+        """,
+        'init state("Root.A");\ncheck reach <= 1: active("Root.B");',
+        initial_state="Root.A",
+        initial_vars={"x": 0},
+        events=("Root.Go",),
+    )
+
+    assert runtime.vars == {"x": 0}
+    assert all(block.is_abstract for block in selected.case.action_blocks)
+    assert selected.post_var_exprs["x"].eq(core.symbols.frame_var(0, "x"))

--- a/test/bmc/test_relation_runtime_alignment.py
+++ b/test/bmc/test_relation_runtime_alignment.py
@@ -10,6 +10,7 @@ import pytest
 from pyfcstm.bmc import BmcEngine, build_bmc_core_formula
 from pyfcstm.model import load_state_machine_from_text
 from pyfcstm.simulate import SimulationRuntime
+from pyfcstm.simulate.runtime import SimulationRuntimeExpressionError
 
 _MACRO_ALIGNMENT_FIXTURE = (
     Path(__file__).with_name("fixtures") / "macro_runtime_alignment.fcstm"
@@ -309,6 +310,44 @@ def test_relation_fallback_negates_failed_guard_and_runs_during() -> None:
     )
     assert "Not" in str(selected.antecedent)
     assert _solver(core.core, core.symbols.frame_var(1, "x") != 0).check() == z3.unsat
+
+
+@pytest.mark.unittest
+def test_relation_guard_definedness_blocks_fallback_false_witness() -> None:
+    """Undefined transition guards cannot be converted into fallback traces."""
+    model = load_state_machine_from_text(
+        """
+        def int x = 1;
+        def int y = 0;
+        state Root {
+            state A { during { x = x + 1; } }
+            state B;
+            [*] -> A;
+            A -> B : if [x / y > 0];
+        }
+        """
+    )
+    runtime = SimulationRuntime(
+        model, initial_state="Root.A", initial_vars={"x": 1, "y": 0}
+    )
+    with pytest.raises(SimulationRuntimeExpressionError, match="division by zero"):
+        runtime.cycle([])
+    context = BmcEngine(model).prepare(
+        'init state("Root.A") where x == 1 && y == 0;\n'
+        'check reach <= 1: active("Root.A");'
+    )
+    core = build_bmc_core_formula(context)
+    fallback = next(
+        relation
+        for relation in core.steps[0].case_relations
+        if relation.case.kind == "fallback"
+    )
+
+    assert _solver(core.core).check() == z3.unsat
+    assert _solver(core.core, fallback.selector).check() == z3.unsat
+    assert any(
+        "F_0_y" in str(item.constraint) for item in fallback.definedness_constraints
+    )
 
 
 @pytest.mark.unittest

--- a/test/bmc/test_relation_runtime_alignment.py
+++ b/test/bmc/test_relation_runtime_alignment.py
@@ -351,6 +351,36 @@ def test_relation_guard_definedness_blocks_fallback_false_witness() -> None:
 
 
 @pytest.mark.unittest
+def test_relation_guard_logical_short_circuit_matches_runtime() -> None:
+    """Transition guards use FCSTM short-circuit definedness semantics."""
+    core, selected, runtime = _assert_relation_matches_runtime(
+        """
+        def int x = 0;
+        state Root {
+            state A;
+            state B;
+            [*] -> A;
+            A -> B : if [x == 0 || (1 / x > 0)];
+        }
+        """,
+        'init state("Root.A") where x == 0;\ncheck reach <= 1: active("Root.B");',
+        initial_state="Root.A",
+        initial_vars={"x": 0},
+    )
+
+    assert selected.case.kind == "transition"
+    assert _runtime_state(runtime) == "Root.B"
+    assert (
+        _solver(
+            core.core,
+            core.symbols.frame_state(1)
+            != core.context.domain.state_path_to_id("Root.B"),
+        ).check()
+        == z3.unsat
+    )
+
+
+@pytest.mark.unittest
 def test_relation_pseudo_guard_anchor_uses_prefix_actions() -> None:
     """Pseudo guards are lowered after prior transition effects execute."""
     core, selected, runtime = _assert_relation_matches_runtime(

--- a/test/bmc/test_relation_semantic_fixtures.py
+++ b/test/bmc/test_relation_semantic_fixtures.py
@@ -1,0 +1,296 @@
+"""BMC-core alignment tests over the shared semantic fixture corpus."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable, List, Mapping, Sequence, Tuple
+
+import pytest
+import z3
+
+from pyfcstm.bmc import (
+    BmcBuildError,
+    BmcEngine,
+    STATE_TERMINATE_ID,
+    UnsupportedBmcQuery,
+    build_bmc_core_formula,
+)
+from pyfcstm.simulate import SimulationRuntime
+from test.bmc.semantic_fixture_policy import (
+    NUMERIC_UNSUPPORTED_CASES,
+    BMC_CORE_FIXTURE_LEDGER_CASES,
+    CONSTRUCTOR_DIAGNOSTIC_EXCLUDE_CASES,
+    TEMPORARY_BMC_CORE_EXCLUDE_CASES,
+    policy_by_case,
+    policy_for_case,
+)
+from test.testings.simulate_semantics import (
+    BMC_CORE_RUNNER,
+    SemanticCaseError,
+    _cycle_input_for_step,
+    _effective_cycle_count,
+    _register_fixture_handlers,
+    _simulation_kwargs,
+    build_state_machine_from_case,
+    is_runner_excluded,
+    iter_semantic_cases,
+)
+
+
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:Bitwise AND.*limited support:UserWarning"
+)
+
+
+_SUPPORTED_POLICY_MODES = {
+    "hard_pass",
+    "partial",
+    "expected_unsupported",
+    "temporary_exclude",
+    "long_term_exclude",
+}
+
+
+class _StaticFalseExpectation(Exception):
+    """Internal marker for fixture expectations that are statically false."""
+
+
+def _solver(*constraints: z3.ExprRef) -> z3.Solver:
+    solver = z3.Solver()
+    solver.add(*constraints)
+    return solver
+
+
+def _value_literal(value: Any) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise BmcBuildError(
+            "semantic fixture initial value is not numeric for BMC-core query: %r"
+            % (value,)
+        )
+    return repr(value)
+
+
+def _initial_predicate(initial_vars: Mapping[str, Any]) -> str:
+    return " && ".join(
+        "%s == %s" % (name, _value_literal(value))
+        for name, value in sorted(initial_vars.items())
+    )
+
+
+def _query_text_for_case(case, bound: int) -> str:
+    initial = case.data.get("initial") or {}
+    lines = []
+    initial_vars = initial.get("vars") or {}
+    where = _initial_predicate(initial_vars) if initial_vars else ""
+    if initial.get("state") is not None:
+        target = json.dumps(initial["state"], ensure_ascii=False)
+        line = "init state(%s)" % target
+        if where:
+            line += " where " + where
+        lines.append(line + ";")
+    elif where:
+        lines.append("init cold where %s;" % where)
+    lines.append("check reach <= %d: terminated();" % max(1, bound))
+    return "\n".join(lines)
+
+
+def _event_constraints(core, step_index: int, selected_events: Iterable[str]):
+    selected = set(selected_events)
+    return tuple(
+        core.symbols.event_input(step_index, event.path)
+        if event.path in selected
+        else z3.Not(core.symbols.event_input(step_index, event.path))
+        for event in core.context.domain.events
+    )
+
+
+def _collect_runtime_trace(case) -> Tuple[int, Tuple[Tuple[str, ...], ...]]:
+    model = build_state_machine_from_case(case)
+    runtime = SimulationRuntime(model, **_simulation_kwargs(case))
+    _register_fixture_handlers(runtime, case)
+    event_inputs: List[Tuple[str, ...]] = []
+    frame_index = 0
+    for index, step in enumerate(case.data.get("steps") or []):
+        field_path = "steps[%d]" % index
+        expect = step.get("expect") or {}
+        if "raises" in expect:
+            raise BmcBuildError(
+                "%s has step exception expectations; it must be excluded or handled "
+                "by a future BMC step-error runner." % case.id
+            )
+        cycle_count = _effective_cycle_count(step, case.id, case.yaml_path, field_path)
+        cycle_input = _cycle_input_for_step(step, case.id, case.yaml_path, field_path)
+        for _ in range(cycle_count):
+            result = runtime.cycle(cycle_input)
+            event_inputs.append(tuple(result.input_events))
+            frame_index += 1
+    return frame_index, tuple(event_inputs)
+
+
+def _expect_state(core, frame_index: int, state_path: Any) -> z3.BoolRef:
+    if state_path is None:
+        return z3.BoolVal(True)
+    state_id = core.context.domain.state_path_to_id(state_path)
+    return core.symbols.frame_state(frame_index) == z3.IntVal(state_id)
+
+
+def _expect_ended(core, frame_index: int, ended: bool) -> z3.BoolRef:
+    expr = core.symbols.frame_state(frame_index) == z3.IntVal(STATE_TERMINATE_ID)
+    return expr if ended else z3.Not(expr)
+
+
+def _expect_vars(core, frame_index: int, values: Mapping[str, Any]) -> z3.BoolRef:
+    return z3.And(
+        *[
+            core.symbols.frame_var(frame_index, name) == value
+            for name, value in sorted(values.items())
+        ]
+    )
+
+
+def _expect_vars_exact(core, frame_index: int, values: Mapping[str, Any]) -> z3.BoolRef:
+    variable_names = {var.name for var in core.context.domain.variables}
+    if set(values) != variable_names:
+        raise _StaticFalseExpectation
+    return _expect_vars(core, frame_index, values)
+
+
+def _expect_vars_keys(core, names: Sequence[str]) -> z3.BoolRef:
+    variable_names = {var.name for var in core.context.domain.variables}
+    if set(names) != variable_names:
+        raise _StaticFalseExpectation
+    return z3.BoolVal(True)
+
+
+def _expect_vars_absent(core, names: Sequence[str]) -> z3.BoolRef:
+    variable_names = {var.name for var in core.context.domain.variables}
+    if variable_names.intersection(names):
+        raise _StaticFalseExpectation
+    return z3.BoolVal(True)
+
+
+def _expectation_expr(core, case, ignored_fields: Sequence[str]) -> z3.BoolRef:
+    ignored = set(ignored_fields)
+    constraints = []
+    frame_index = 0
+    public_fields = {
+        "state",
+        "vars",
+        "vars_exact",
+        "vars_keys",
+        "vars_absent",
+        "ended",
+    }
+    observed_public_fields = 0
+    for index, step in enumerate(case.data.get("steps") or []):
+        field_path = "steps[%d]" % index
+        expect = step.get("expect") or {}
+        if "handler_calls" in expect and "handler_calls" not in ignored:
+            raise BmcBuildError(
+                "%s %s handler_calls need an explicit partial BMC policy."
+                % (case.id, field_path)
+            )
+        frame_index += _effective_cycle_count(step, case.id, case.yaml_path, field_path)
+        try:
+            if "state" in expect:
+                observed_public_fields += 1
+                constraints.append(_expect_state(core, frame_index, expect["state"]))
+            if "ended" in expect:
+                observed_public_fields += 1
+                constraints.append(_expect_ended(core, frame_index, expect["ended"]))
+            if "vars" in expect:
+                observed_public_fields += 1
+                constraints.append(_expect_vars(core, frame_index, expect["vars"]))
+            if "vars_exact" in expect:
+                observed_public_fields += 1
+                constraints.append(
+                    _expect_vars_exact(core, frame_index, expect["vars_exact"])
+                )
+            if "vars_keys" in expect:
+                observed_public_fields += 1
+                constraints.append(_expect_vars_keys(core, expect["vars_keys"]))
+            if "vars_absent" in expect:
+                observed_public_fields += 1
+                constraints.append(_expect_vars_absent(core, expect["vars_absent"]))
+        except _StaticFalseExpectation:
+            constraints.append(z3.BoolVal(False))
+        unknown_unignored = (set(expect) - public_fields - ignored) - {"raises"}
+        if unknown_unignored:
+            raise BmcBuildError(
+                "%s %s has unsupported BMC expectation fields: %r"
+                % (case.id, field_path, sorted(unknown_unignored))
+            )
+    if observed_public_fields == 0:
+        raise BmcBuildError(
+            "%s has no public state/ended/vars expectation for BMC-core alignment."
+            % case.id
+        )
+    return z3.And(*constraints) if constraints else z3.BoolVal(True)
+
+
+def _assert_semantic_fixture_matches_bmc_core(case, ignored_fields: Sequence[str]):
+    bound, selected_events_by_step = _collect_runtime_trace(case)
+    model = build_state_machine_from_case(case)
+    query_text = _query_text_for_case(case, bound)
+    core = build_bmc_core_formula(BmcEngine(model).prepare(query_text))
+    event_constraints = []
+    for step_index, selected_events in enumerate(selected_events_by_step):
+        event_constraints.extend(_event_constraints(core, step_index, selected_events))
+    expectation = _expectation_expr(core, case, ignored_fields)
+
+    assert _solver(core.core, *event_constraints).check() == z3.sat
+    assert _solver(core.core, *event_constraints, expectation).check() == z3.sat
+    assert (
+        _solver(core.core, *event_constraints, z3.Not(expectation)).check() == z3.unsat
+    )
+
+
+def _assert_expected_unsupported(case) -> None:
+    bound = sum(
+        _effective_cycle_count(step, case.id, case.yaml_path, "steps[%d]" % index)
+        for index, step in enumerate(case.data.get("steps") or [])
+    )
+    model = build_state_machine_from_case(case)
+    query_text = _query_text_for_case(case, bound)
+    with pytest.raises(UnsupportedBmcQuery, match="unsupported_bmc_core"):
+        build_bmc_core_formula(BmcEngine(model).prepare(query_text))
+
+
+@pytest.mark.unittest
+def test_bmc_semantic_fixture_policy_covers_known_gap_inventory() -> None:
+    cases = {case.id: case for case in iter_semantic_cases()}
+    assert len(cases) >= 165
+    assert BMC_CORE_FIXTURE_LEDGER_CASES <= set(cases)
+    assert len(BMC_CORE_FIXTURE_LEDGER_CASES) == 43
+
+    excluded_in_yaml = {
+        case.id for case in cases.values() if is_runner_excluded(case, BMC_CORE_RUNNER)
+    }
+    assert (
+        excluded_in_yaml
+        == TEMPORARY_BMC_CORE_EXCLUDE_CASES | CONSTRUCTOR_DIAGNOSTIC_EXCLUDE_CASES
+    )
+    assert not (NUMERIC_UNSUPPORTED_CASES & excluded_in_yaml)
+
+    policy_map = policy_by_case(BMC_CORE_FIXTURE_LEDGER_CASES)
+    assert set(policy_map) == BMC_CORE_FIXTURE_LEDGER_CASES
+
+    for case_id in BMC_CORE_FIXTURE_LEDGER_CASES:
+        policy = policy_for_case(case_id)
+        assert policy.mode in _SUPPORTED_POLICY_MODES
+        assert policy.reason
+
+    with pytest.raises(SemanticCaseError, match="unknown runner for exclusion check"):
+        is_runner_excluded(next(iter(cases.values())), "unknown_runner")
+
+
+@pytest.mark.unittest
+@pytest.mark.parametrize("case", iter_semantic_cases(), ids=lambda case: case.id)
+def test_bmc_core_matches_semantic_fixture_public_observations(case) -> None:
+    policy = policy_for_case(case.id)
+    if is_runner_excluded(case, BMC_CORE_RUNNER):
+        pytest.skip("%s: %s" % (policy.bucket, policy.reason))
+    if policy.mode == "expected_unsupported":
+        _assert_expected_unsupported(case)
+        return
+    _assert_semantic_fixture_matches_bmc_core(case, policy.ignored_expect_fields)

--- a/test/fixtures/simulate_semantics/cases/abstract_hook_context_hot_start_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/abstract_hook_context_hot_start_leaf.yaml
@@ -11,6 +11,8 @@ categories:
 - abstract
 - lifecycle
 - hot_start
+exclude_runners:
+- bmc_core
 initial:
   state: Root.A
   vars:

--- a/test/fixtures/simulate_semantics/cases/design_composite_stuck_in_init_wait.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_composite_stuck_in_init_wait.yaml
@@ -8,6 +8,8 @@ categories:
 - runtime
 - template_alignment
 - validation
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/design_post_child_exit_without_follow_up.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_post_child_exit_without_follow_up.yaml
@@ -7,6 +7,8 @@ categories:
 - design_example
 - runtime
 - template_alignment
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/design_speculative_dfs_safety_limit.yaml
+++ b/test/fixtures/simulate_semantics/cases/design_speculative_dfs_safety_limit.yaml
@@ -8,6 +8,8 @@ categories:
 - runtime
 - template_alignment
 - validation
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_error_preserves_runtime_snapshot.yaml
@@ -7,6 +7,8 @@ origin:
     assertions.
 categories:
 - runtime
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_if_condition_raises_expression_error.yaml
@@ -6,6 +6,8 @@ categories:
 - runtime
 - template_alignment
 - if_blocks
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/expression_failure_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_raises_expression_error.yaml
@@ -6,6 +6,8 @@ categories:
 - runtime
 - scenario_example
 - template_alignment
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_effect_raises_expression_error.yaml
@@ -5,6 +5,8 @@ origin:
 categories:
 - runtime
 - template_alignment
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_failure_transition_guard_raises_expression_error.yaml
@@ -5,6 +5,8 @@ origin:
 categories:
 - runtime
 - template_alignment
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/expression_type_error_wraps_transition_effect.yaml
+++ b/test/fixtures/simulate_semantics/cases/expression_type_error_wraps_transition_effect.yaml
@@ -6,6 +6,8 @@ origin:
   - https://github.com/HansBug/pyfcstm/issues/156#issuecomment-4631787793
 categories:
 - runtime
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_preserves_root_entry_lifecycle.yaml
@@ -9,6 +9,8 @@ categories:
 - template_alignment
 - validation
 - lifecycle
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.yaml
+++ b/test/fixtures/simulate_semantics/cases/failed_initial_cycle_skips_abstract_handler_callbacks.yaml
@@ -9,6 +9,8 @@ categories:
 - template_alignment
 - validation
 - abstract
+exclude_runners:
+- bmc_core
 handlers:
 - action: Root.RootInit
   behavior: record_call

--- a/test/fixtures/simulate_semantics/cases/hot_start_composite_evented_initial_skips_entry_boundary_before.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_composite_evented_initial_skips_entry_boundary_before.yaml
@@ -18,6 +18,8 @@ categories:
 - hot_start
 - lifecycle
 - abstract
+exclude_runners:
+- bmc_core
 initial:
   state: Root.Gate
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_deep_evented_initial_waits_for_event.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_deep_evented_initial_waits_for_event.yaml
@@ -18,6 +18,8 @@ categories:
 - hot_start
 - validation
 - lifecycle
+exclude_runners:
+- bmc_core
 initial:
   state: Root.Gate
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_evented_initial_matches_cold_suffix.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_evented_initial_matches_cold_suffix.yaml
@@ -17,6 +17,8 @@ categories:
 - hot_start
 - validation
 - lifecycle
+exclude_runners:
+- bmc_core
 initial:
   state: Root.Gate
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_override_skips_int_initializer.yaml
@@ -8,6 +8,8 @@ categories:
 - runtime
 - template_alignment
 - hot_start
+exclude_runners:
+- bmc_core
 initial:
   state: Root.Safe
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_bool_values.yaml
@@ -9,6 +9,8 @@ categories:
 - runtime
 - hot_start
 - template_alignment
+exclude_runners:
+- bmc_core
 initial:
   state: Root.A
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_initial_vars_reject_string_values.yaml
@@ -9,6 +9,8 @@ categories:
 - runtime
 - hot_start
 - template_alignment
+exclude_runners:
+- bmc_core
 initial:
   state: Root.A
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_leaf_defers_during_expression_error.yaml
@@ -10,6 +10,8 @@ categories:
 - hot_start
 - validation
 - template_alignment
+exclude_runners:
+- bmc_core
 initial:
   state: Root.A
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_blocked_composite_initial.yaml
@@ -11,6 +11,8 @@ categories:
 - hot_start
 - validation
 - template_alignment
+exclude_runners:
+- bmc_core
 initial:
   state: Root.C
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_overdeep_leaf_stack.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_overdeep_leaf_stack.yaml
@@ -13,6 +13,8 @@ categories:
 - template_alignment
 - hot_start
 - validation
+exclude_runners:
+- bmc_core
 initial:
   state: Root.S1.S2.S3.S4.S5.S6.S7.S8.S9.S10.S11.S12.S13.S14.S15.S16.S17.S18.S19.S20.S21.S22.S23.S24.S25.S26.S27.S28.S29.S30.S31.S32.S33.S34.S35.S36.S37.S38.S39.S40.S41.S42.S43.S44.S45.S46.S47.S48.S49.S50.S51.S52.S53.S54.S55.S56.S57.S58.S59.S60.S61.S62.S63.Leaf
   vars:

--- a/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.yaml
+++ b/test/fixtures/simulate_semantics/cases/hot_start_rejects_unstable_pseudo_leaf.yaml
@@ -11,6 +11,8 @@ categories:
 - validation
 - pseudo_chain
 - template_alignment
+exclude_runners:
+- bmc_core
 initial:
   state: Root.P
   vars:

--- a/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_default_int_initializer_rejects_non_integer_float.yaml
@@ -7,6 +7,8 @@ origin:
 categories:
 - runtime
 - template_alignment
+exclude_runners:
+- bmc_core
 initial:
   state: null
   vars: null

--- a/test/fixtures/simulate_semantics/cases/persistent_initial_vars_override_skips_initializer.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_initial_vars_override_skips_initializer.yaml
@@ -8,6 +8,8 @@ categories:
 - runtime
 - hot_start
 - template_alignment
+exclude_runners:
+- bmc_core
 initial:
   state: Root.A
   vars:

--- a/test/fixtures/simulate_semantics/cases/persistent_operation_writeback_rejects_float_and_rolls_back.yaml
+++ b/test/fixtures/simulate_semantics/cases/persistent_operation_writeback_rejects_float_and_rolls_back.yaml
@@ -9,6 +9,8 @@ categories:
 - temporary_vars
 - lifecycle
 - template_alignment
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
+++ b/test/fixtures/simulate_semantics/cases/pseudo_self_loop_step_limit_raises_dfs_error.yaml
@@ -8,6 +8,8 @@ categories:
 - runtime
 - pseudo_chain
 - validation
+exclude_runners:
+- bmc_core
 steps:
 - cycle: []
   expect:

--- a/test/simulate/test_semantic_fixtures.py
+++ b/test/simulate/test_semantic_fixtures.py
@@ -4,6 +4,7 @@ import pytest
 import yaml
 
 from test.testings.simulate_semantics import (
+    BMC_CORE_RUNNER,
     SemanticCaseError,
     iter_semantic_cases,
     load_semantic_case,
@@ -970,7 +971,10 @@ def test_shared_fixture_corpus_satisfies_current_contract():
     assert all(
         case.runners == ("simulation", "generated_python_alignment") for case in cases
     )
-    assert all("exclude_runners" not in case.data for case in cases)
+    assert all(
+        set(case.data.get("exclude_runners") or ()) <= {BMC_CORE_RUNNER}
+        for case in cases
+    )
 
 
 @pytest.mark.unittest

--- a/test/solver/test_domain.py
+++ b/test/solver/test_domain.py
@@ -7,7 +7,15 @@ from typing import List, cast
 import pytest
 import z3
 
-from pyfcstm.model.expr import BinaryOp, Boolean, Expr, Integer, UFunc, UnaryOp, Variable
+from pyfcstm.model.expr import (
+    BinaryOp,
+    Boolean,
+    Expr,
+    Integer,
+    UFunc,
+    UnaryOp,
+    Variable,
+)
 from pyfcstm.solver.expr import expr_to_z3
 
 
@@ -119,7 +127,9 @@ class TestTranslateExprDomain:
         """A failed left operand is returned before translating the right operand."""
         from pyfcstm.solver.domain import translate_expr_domain
 
-        result = translate_expr_domain(BinaryOp(Variable("missing"), "+", Integer(1)), {})
+        result = translate_expr_domain(
+            BinaryOp(Variable("missing"), "+", Integer(1)), {}
+        )
 
         assert result.z3_expr is None
         assert result.failure is not None
@@ -139,6 +149,90 @@ class TestTranslateExprDomain:
         assert result.failure is not None
         assert result.failure.kind == "value_error"
         assert "missing" in result.failure.reason
+
+    def test_logical_binary_definedness_follows_runtime_short_circuit(self):
+        """Logical ``&&`` / ``||`` evaluate right operands only when needed."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        x = z3.Int("x")
+        risky = BinaryOp(BinaryOp(Integer(1), "/", Variable("x")), ">", Integer(0))
+        skipped_cases = (
+            BinaryOp(Boolean(True), "||", risky),
+            BinaryOp(Boolean(False), "&&", risky),
+        )
+        required_cases = (
+            BinaryOp(Boolean(False), "||", risky),
+            BinaryOp(Boolean(True), "&&", risky),
+        )
+
+        for expr in skipped_cases:
+            result = translate_expr_domain(expr, {"x": x})
+            assert result.failure is None
+            solver = z3.Solver()
+            solver.add(*(item.constraint for item in result.definedness_constraints))
+            solver.add(x == 0)
+            assert solver.check() == z3.sat
+
+        for expr in required_cases:
+            result = translate_expr_domain(expr, {"x": x})
+            assert result.failure is None
+            solver = z3.Solver()
+            solver.add(*(item.constraint for item in result.definedness_constraints))
+            solver.add(x == 0)
+            assert solver.check() == z3.unsat
+
+        dynamic_cases = (
+            (BinaryOp(BinaryOp(Variable("x"), "==", Integer(0)), "||", risky), True),
+            (BinaryOp(BinaryOp(Variable("x"), "!=", Integer(0)), "||", risky), False),
+            (BinaryOp(BinaryOp(Variable("x"), "!=", Integer(0)), "&&", risky), True),
+            (BinaryOp(BinaryOp(Variable("x"), "==", Integer(0)), "&&", risky), False),
+        )
+        for expr, zero_is_defined in dynamic_cases:
+            result = translate_expr_domain(expr, {"x": x})
+            assert result.failure is None
+            solver = z3.Solver()
+            solver.add(*(item.constraint for item in result.definedness_constraints))
+            solver.add(x == 0)
+            assert (solver.check() == z3.sat) is zero_is_defined
+
+        plain_result = translate_expr_domain(
+            BinaryOp(Boolean(True), "&&", Boolean(True)), {}
+        )
+        assert plain_result.failure is None
+        assert plain_result.definedness_constraints == ()
+        skipped_failure = translate_expr_domain(
+            BinaryOp(Boolean(True), "||", Variable("missing")), {}
+        )
+        assert skipped_failure.failure is None
+        assert str(skipped_failure.z3_expr) == "True"
+        pruned_result = translate_expr_domain(
+            BinaryOp(BinaryOp(Variable("x"), "==", Integer(0)), "&&", risky),
+            {"x": x},
+            assumptions=(x != 0,),
+        )
+        assert pruned_result.failure is None
+        assert str(pruned_result.z3_expr) == "False"
+        assert pruned_result.feasibility_checks[-1].status == "unsat"
+
+    def test_logical_binary_type_and_reachable_right_failures_are_structured(self):
+        """Lazy logical translation preserves structured type/failure results."""
+        from pyfcstm.solver.domain import translate_expr_domain
+
+        type_result = translate_expr_domain(
+            BinaryOp(Integer(1), "&&", Boolean(True)), {}
+        )
+        assert type_result.z3_expr is None
+        assert type_result.failure is not None
+        assert type_result.failure.kind == "type_error"
+        assert "Boolean left operand" in type_result.failure.reason
+
+        right_failure = translate_expr_domain(
+            BinaryOp(Boolean(True), "&&", Variable("missing")), {}
+        )
+        assert right_failure.z3_expr is None
+        assert right_failure.failure is not None
+        assert right_failure.failure.kind == "value_error"
+        assert "missing" in right_failure.failure.reason
 
     def test_unknown_binary_operator_is_structured_failure(self):
         """Unknown operators are normalized instead of leaking raw exceptions."""
@@ -650,7 +744,9 @@ class TestTranslateExprDomain:
                 )
             return original_translate(expr, z3_vars, **kwargs)
 
-        monkeypatch.setattr(domain, "_translate_expr_domain", translate_with_bad_divisor)
+        monkeypatch.setattr(
+            domain, "_translate_expr_domain", translate_with_bad_divisor
+        )
 
         result = translate_expr_domain(BinaryOp(Integer(1), "/", BadDivisor()), {})
 
@@ -737,7 +833,10 @@ class TestMergeDefinednessConstraints:
 
     def test_merge_preserves_contradictory_constraints(self):
         """Merging does not hide contradictions or run solver policy."""
-        from pyfcstm.solver.domain import DomainConstraint, merge_definedness_constraints
+        from pyfcstm.solver.domain import (
+            DomainConstraint,
+            merge_definedness_constraints,
+        )
 
         x = z3.Int("x")
         merged = merge_definedness_constraints(

--- a/test/testings/simulate_semantics.py
+++ b/test/testings/simulate_semantics.py
@@ -13,6 +13,8 @@ The module contains:
 * :class:`SemanticCaseError` - Schema and fixture-shape diagnostics.
 * :func:`load_semantic_case` - Load one fixture by id or YAML path.
 * :func:`iter_semantic_cases` - Enumerate fixture cases with optional filters.
+* :func:`is_runner_excluded` - Check non-default runner exclusions without
+  adding them to the default fixture runner set.
 * :func:`validate_shared_fixture_contract` - Check the shared public
   observation contract.
 * :func:`run_simulation_case` - Execute one case against
@@ -76,7 +78,8 @@ _ALLOWED_CATEGORIES = {
     "lifecycle",
 }
 _DEFAULT_SHARED_RUNNERS = ("simulation", "generated_python_alignment")
-_ALLOWED_EXCLUDE_RUNNERS = set(_DEFAULT_SHARED_RUNNERS)
+BMC_CORE_RUNNER = "bmc_core"
+_ALLOWED_EXCLUDE_RUNNERS = set(_DEFAULT_SHARED_RUNNERS) | {BMC_CORE_RUNNER}
 _ALLOWED_EXPECT_FIELDS = {
     "state",
     "vars",
@@ -194,6 +197,38 @@ class SemanticCase:
     @property
     def runners(self) -> Sequence[str]:
         return _effective_runners_from_data(self.data, self.id, self.yaml_path)
+
+
+def is_runner_excluded(case: SemanticCase, runner: str) -> bool:
+    """
+    Return whether a fixture excludes a non-default runner.
+
+    The shared fixture schema remains exclude-only.  Default simulation and
+    generated-runtime runners use :attr:`SemanticCase.runners`; additional
+    maintenance runners such as ``"bmc_core"`` are checked directly from
+    ``exclude_runners`` so they do not become default simulation coverage.
+
+    :param case: Loaded semantic fixture.
+    :type case: SemanticCase
+    :param runner: Runner name to check.
+    :type runner: str
+    :return: Whether ``runner`` appears in ``case.data['exclude_runners']``.
+    :rtype: bool
+    :raises SemanticCaseError: If ``runner`` is not a known exclude runner.
+
+    Example::
+
+        >>> case = load_semantic_case("design_basic_simple_transition")
+        >>> is_runner_excluded(case, BMC_CORE_RUNNER)
+        False
+    """
+    if runner not in _ALLOWED_EXCLUDE_RUNNERS:
+        raise _case_error(
+            case.id,
+            case.yaml_path,
+            "unknown runner for exclusion check: %r" % runner,
+        )
+    return runner in set(case.data.get("exclude_runners") or ())
 
 
 def _case_error(case_id: str, yaml_path: str, message: str) -> SemanticCaseError:


### PR DESCRIPTION
## 背景

本 PR 是 [PR #305](https://github.com/HansBug/pyfcstm/pull/305) 伞计划中的 **PR-10：公式构建 / bounded trace core relation**，基于已合入伞分支的 PR-7 / [PR #336](https://github.com/HansBug/pyfcstm/pull/336) prepare-only engine、PR-8 / [PR #328](https://github.com/HansBug/pyfcstm/pull/328) source/case contract、PR-9 / [PR #335](https://github.com/HansBug/pyfcstm/pull/335) runtime-aligned macro control-path plan 继续推进。

PR-9 已冻结给后续 subPR 的 handoff：[`expand_macro_step_cases(source) -> MacroStepFormal`](https://github.com/HansBug/pyfcstm/pull/305#issuecomment-4885536546)。PR-10 的职责不是重新枚举 runtime path，而是把 PR-9 的 flat control-path plan lower 成 Z3 bounded trace relation，并建立 `$D_N / I_0 / T_N / ENV_N / Core_N$` 的 solver-level 数据结构。

上游状态：

- PR-1 / [PR #315](https://github.com/HansBug/pyfcstm/pull/315) 已合入：`.fbmcq` query / expression 数据模型。
- PR-2 / [PR #323](https://github.com/HansBug/pyfcstm/pull/323) 已合入：独立 `.fbmcq` ANTLR grammar。
- PR-3 / [PR #326](https://github.com/HansBug/pyfcstm/pull/326) 已合入：`.fbmcq` parser 与 AST 构建。
- PR-4 / [PR #332](https://github.com/HansBug/pyfcstm/pull/332) 已合入：query semantic binding / diagnostics。
- PR-5 / [PR #331](https://github.com/HansBug/pyfcstm/pull/331) 已合入：`.fbmcq` 编辑器高亮与文档支持。
- PR-6 / [PR #324](https://github.com/HansBug/pyfcstm/pull/324) 已合入：`BmcDomain`、state/event/var/frame/step/event-input 编号与 sentinel。
- PR-7 / [PR #336](https://github.com/HansBug/pyfcstm/pull/336) 已合入：`BmcEngine.prepare()` / `BmcPreparedContext`。
- PR-8 / [PR #328](https://github.com/HansBug/pyfcstm/pull/328) 已合入：source/case/fallback/delta/absorb contract 底座。
- PR-9 / [PR #335](https://github.com/HansBug/pyfcstm/pull/335) 已合入：`expand_macro_step_cases(source)` 输出 runtime-aligned `CycleCase.condition` / `action_blocks` / `guard_requirements` / `priority_exclusions` / `used_events`。

## 核心设计约束

### 1. Case relation 必须是 `Implies(A, R)`

PR-10 必须把每个 selected macro case lower 成 implication：

```text
A_{i,c} = source_guard(case, i)
          ∧ lowered(case.condition)

source_guard(case, i) = (F_i.state == case.source_state_id)

R_{i,c} = (F_{i+1}.state == case.target_state_id)
          ∧ AND_{v in domain.persistent_vars}(F_{i+1}.v == final_env_c[v])
          ∧ runtime-definedness constraints

T_{i,c} = Implies(A_{i,c}, R_{i,c})
```

禁止把前件和后件错误写成：

```text
And(A_{i,c}, R_{i,c})
```

原因：`And(A, R)` 会让未选 case 的 post-state / post-var 约束也被强制成立，直接破坏 transition disjunction 与 witness 语义。PR-10 必须包含能杀死该错误实现的反证测试。

`final_env_c` 必须覆盖 domain 中每一个 persistent variable。未被 `ActionBlock` 写入的变量必须显式 carry：`final_env_c[v] = F_i.v`，不得让 `F_{i+1}.v` 成为 unconstrained fresh symbol。若 relation builder 发现某个 case 不能为所有 persistent vars 产出 post expression，应 fail closed 为内部 BMC 构建错误，而不是继续输出半约束公式。

### 2. `CycleCase.condition` 只 lower control-path atoms

PR-9 已保证 `CycleCase.condition` 只包含这些 atom namespace：

- `event:<full_event_path>`：当前 step event input；
- `guard:<requirement_id>`：由 `GuardRequirement` 提供 raw guard + evaluation anchor；
- `accepted:<case_label>`：前序 accepted path 的 lowered antecedent registry。

PR-10 不得把 source state guard、target state constraint、post var writeback、action-internal `IfBlock` condition 塞回 `CycleCase.condition`。`source_guard(case, i)` belongs to `A`，target/writeback belongs to `R`，action-local branch belongs to operation lowering；`init where` 只属于 `I_0`。

### 3. Guard 必须按 action prefix anchor lower

`GuardRequirement.after_action_block_index` 是 guard evaluation point 的唯一结构化来源。PR-10 lower 一个 `CycleCase` 时必须 interleave：

```text
env_0 = F_i persistent vars
for k in 0..len(case.action_blocks):
    lower guards with after_action_block_index == k using env_k
    if k < len(action_blocks):
        env_{k+1} = execute_operations_domain(case.action_blocks[k].operations, env_k).env
```

同一个 raw guard 在不同路径上可以对应不同 cycle-start expression。例如 `effect { x = x + 2; }` 后的 pseudo guard `x < 13` 应 lower 为 `x_i + 2 < 13`；hot start at pseudo route 没有 prefix effect 时则仍是 `x_i < 13`。

### 4. Action lowering 复用 solver operation 语义

PR-10 不在 relation builder 里维护第二套 operation symbolic executor。每个 `ActionBlock` 应按 runtime 顺序调用现有 `pyfcstm.solver.operation.execute_operations_domain` / related definedness helpers：

- concrete action/effect block lower assignment、temporary local、nested `IfBlock` 与 branch merge；
- action-local `IfBlock` 形成 Z3 `If(...)` expression，不拆 macro case；
- block-local temporary 不得进入 persistent post-var pool；
- PR-10 不再使用 PR-8 早期的 `VarUpdate` 作为 truth source；所有 post-var writeback 都由 `ActionBlock` 顺序执行后的 `execute_operations_domain(...).env` 生成；
- abstract action 首轮是 no-op occurrence：`ActionBlock(is_abstract=True, operations=())` 不写变量，但保留 future `called(...)` / witness explain 入口；
- unsupported operation / expression / Z3 sort issue 必须转成 structured BMC diagnostic / `UnsupportedBmcQuery` / `BmcBuildError`，不能让 raw `TypeError`、`z3.Z3Exception`、`NotImplementedError` 泄漏。

### 5. Environment assumptions 必须来自 binder-normalized query

`ENV_N` 只能消费 `BmcPreparedContext.bound_query`，不得在 tests 或 implementation 中绕过 parser/binder 手造未绑定 assumptions。必须实现：

- `assume always: P` frame predicate lower 为 `∀i ∈ [0, N]. lower(P, F_i)`；
- `assume at k: P` frame predicate lower 为 `lower(P, F_k)`；
- `assume event("E", selector) == true/false` 与 `!=` polarity；listener/binder 已把 `!= true/false` normalize 为 expected bool，因此 `ENV_N` 只消费 `BoundAssumption.source.expected`；
- selector `*` / `a..b` 逐点全称 lower 到每个 selected cycle；
- 默认同一 cycle 多个 event 可以同时为 true，不添加隐式 at-most-one / per-owner natural exclusivity；
- `assume events cardinality any` no-op；
- `assume events cardinality at_most_one { ... }` 是唯一互斥来源，按每个 selected cycle 添加 user-declared `AtMost`。

## 本 PR 目标

新增 solver-level relation builder public API：

```python
from pyfcstm.bmc import BmcEngine, build_bmc_core_formula

context = BmcEngine(model).prepare(query_text)
core = build_bmc_core_formula(context)
```

预期新增 public concepts：

- `BmcTraceSymbols`：bounded frame / step Z3 symbols。
- `BmcCaseRelation`：单个 step + case 的 `antecedent`、`consequent`、`implication`、post-var expression、guard terms、definedness evidence。
- `BmcStepRelation`：单个 `E_i: F_i -> F_{i+1}` 的 case relation 集合、case registry 与 step formula。
- `BmcCoreFormula`：`D_N`、`I_0`、`T_N`、`ENV_N`、diagnostics、`core` / `to_canonical()`。
- `build_bmc_core_formula(context)`：从 `BmcPreparedContext` 构建 solver-level core relation；本 PR 不公开 `BmcRelationOptions`，solver construction policy 统一读取已存在的 `BmcOptions` / `context.options`，避免新增不稳定 public policy surface。

Public API 必须 Python 3.7 兼容：使用 `typing.Tuple[...]` / `typing.Optional[...]`，不使用 `list[str]`、`X | Y`、`match`、`typing.Self`。

## 非目标

本 PR 不做：

- 不实现 reach / forbid / invariant / must_reach / exists_always / response / cover 的完整 objective compiler；PR-11 处理。
- 不解读 solver `sat` / `unsat` 为用户语义结果；PR-11 / PR-12 处理。
- 不生成 witness JSON，不 replay decoded trace；PR-12 处理。
- 不接 `pyfcstm.verify.registry`；PR-13 处理。
- 不重新展开 macro path；必须消费 PR-9 `MacroStepFormal`。
- 不组装最终 `Phi_N = Core_N ∧ InitHealthy_0 ∧ NoDiag_N`；PR-10 只交付 `Core_N = D_N ∧ I_0 ∧ T_N ∧ ENV_N` 与 diagnostic/delta case metadata，健康门禁和 property polarity 由 PR-11 处理。
- 不把 action-local `IfBlock` 拆成 macro cases。
- 不支持 `called(...)` 完整语义；遇到 `called(...)` compiler path 仍必须 structured unsupported / diagnostic。
- 不引入 fixed-width BitVec profile；仍按本轮 `int` / `float` solver/runtime 语义。

## 实施计划

### 阶段 A：TDD contract skeleton

1. 新建 `test/bmc/test_relation_public_api.py`，先断言 public root lazy exports、`__all__`、import isolation、old private leakage、pydoc/RST expectations。
2. 新建 `test/bmc/test_relation_core.py`，写最小 leaf fallback / terminated absorb / cold init relation golden。
3. 新建 `pyfcstm/bmc/relation.py`，只实现 dataclass skeleton、symbol allocation、canonical dump 和 clear diagnostics。
4. 更新 `pyfcstm/bmc/__init__.py` list-table / lazy export sets / `__all__`，运行 `make rst_auto RANGE_DIR=bmc`。

### 阶段 B：trace domain / initial / ENV

1. Allocate symbols：`F_i.state`、`F_i.<var>`、`E_i.<event>`、`case_i.<label>`。
2. `D_N`：
   - `F_0.state in domain.frame0_state_ids`；
   - `F_1..F_N.state in domain.recurrence_state_ids`；
   - declared `int` variables use `z3.Int`，declared `float` variables use `z3.Real` or current solver-compatible Real expression。
3. `I_0`：
   - default `init cold` source semantics；
   - `init state("...")` / `init terminated`；
   - persistent var initializers；
   - `init where` lower only into `I_0`，不得 leak into macro source/case partition。
4. `ENV_N`：frame assumptions、event assumptions、cardinality assumptions，全部基于 `BoundBmcQuery`：
   - `assume always: P` -> all frames `F_0..F_N`；
   - `assume at k: P` -> frame `F_k`；
   - event `==` / `!=` 使用 binder-normalized expected bool；
   - `assume events cardinality any` no-op；
   - `at_most_one` 只编码用户显式 event 列表；默认 event pool 允许同 cycle 多事件同时为 true。

### 阶段 C：case relation lowering

1. 对 initial step 使用 `source_from_initial_spec(context.domain, context.bound_query.initial.source)` + `expand_macro_step_cases(source)`；同时 `I_0` 仍必须消费 `context.bound_query.initial` 中的 binder metadata（例如 `resolved_state_id` 与 `predicate`），不得绕回未绑定 query。
2. 对 recurrence step 为每个 stable/sentinel source 建 relation，terminated / diagnostic source 使用 absorb。
3. Lower `BoolTemplate`：
   - `event:<path>` -> `symbols.event_inputs[i][path]`；
   - `guard:<id>` -> `guard_terms[id]`；
   - `accepted:<label>` -> `lowered_case_registry[label]`；
   - `accepted:<label>` registry 是 per-step lowered antecedent map，只在当前 `T_i = E_i: F_i -> F_{i+1}` 内跨 case 使用，不传播到其它 step；
   - unknown prefix fail closed。
4. Lower `GuardRequirement` by anchor：执行前缀 action block 后，用当前 env lower raw guard。
5. Lower `ActionBlock` sequence via `execute_operations_domain`，得到 final env 与 definedness constraints。
6. Build `antecedent` / `consequent` / `implication`，并绑定 `case_i[label] == antecedent`；`consequent` 必须为 domain 中每个 persistent var 生成 `post_v == final_env[v]`，未写变量以 `pre_v` explicit carry。
7. Build step relation as conjunction of all case implications only；diagnostic / delta classification 作为 case metadata 暴露，不在 PR-10 拼装 `InitHealthy_0` / `NoDiag_N` gate。

### 阶段 D：runtime-alignment harness

实现 test-only helper：

```python
assert_relation_matches_runtime(
    dsl,
    query_text,
    initial_state=None,
    initial_vars=None,
    events=(),
    expected_case_label=None,
)
```

helper 同时跑：

1. `SimulationRuntime` one-cycle oracle；
2. `BmcEngine.prepare()` + `build_bmc_core_formula()`；
3. solver 固定 pre state / pre vars / event inputs；
4. 断言 selected relation 的 post state / post vars 与 runtime oracle 一致。

### 阶段 E：hardening / coverage / docs

1. typed expression support matrix 使用 test-time probe 覆盖 FCSTM numeric/logical operator × int/float profile，至少实测 float/Real `%`、bitwise/shift、变量指数 `**`、全部 `UFUNC_NAME` 的 lower/unsupported 决策。
2. unsupported path structured diagnostics，不泄漏 raw exception。
3. Codecov modified lines 尽量全覆盖；确属 internal impossible branch 时错误信息必须明确“internal BMC bug，请带 FCSTM/query/traceback 到 https://github.com/HansBug/pyfcstm/issues 开 issue”，再 `pragma no cover`。
4. pydoc / API RST / doctest 完成后再进入 final review；每个 public dataclass 的 `__init__` 与 `to_canonical()` 至少各有一个 doctest / example path。

## 测试计划

### Unit / contract tests

- `test_relation_public_api.py`
  - root lazy export；
  - `pyfcstm.bmc` import 不加载 `pyfcstm.verify`；
  - `relation.py` pydoc / `to_canonical()` shape；
  - public API 不暴露 PR-specific identifiers；
  - 不导出 `BmcRelationOptions`。
- `test_relation_core.py`
  - symbol names stable；
  - `D_N` allowed state sets；
  - `I_0` cold / hot leaf / hot composite / terminated；
  - persistent var initializer for cold / hot / terminated modes；
  - `init where` 只进 `I_0`。
- `test_relation_environment.py`
  - `assume always` / `assume at`；
  - `event == true/false`、`!= true/false`；
  - `*` / `a..b` range 逐点 lower；
  - `at_most_one` user event list per selected cycle；
  - `any` no-op and default multi-event SAT（不加隐式互斥）；
  - 同短名 event full path 不混淆：`A.E` assumption 不污染 `B.E` case selection。
- `test_relation_macro_cases.py`
  - `Implies(A,R)` 形状；
  - not `And(A,R)` adversarial fixture：同一 source 两个 event/guard 互斥 case，固定 case0 selected、case1 unselected；正确 `Implies` 下 post target0 SAT，错误 `And(A,R)` 会同时强制 target0/target1 而 UNSAT；
  - explicit carry fixture：selected fallback/during 不写某 persistent var 时，`Core_N ∧ selected_case ∧ post_v != pre_v` UNSAT；
  - `accepted:<label>` registry；
  - priority mask / validation skip；
  - unknown atom namespace fail closed。

### Runtime alignment tests

`test_relation_runtime_alignment.py` 至少覆盖：

1. cold init enter + initial transition + during；
2. hot stable leaf recurrence fallback during；
3. ordinary event transition effect + target enter/during；
4. exit action + transition effect + target enter order；
5. parent continuation after child exit；
6. pseudo route guard anchor after prefix effect；
7. same raw pseudo guard under hot pseudo source without prefix effect；
8. action-local `IfBlock` branch merge，不拆 macro case；
9. temporary variable within action block does not leak；
10. multiple enter/exit/during/aspect blocks preserve order；
11. abstract action occurrence no-op for vars；
12. rollback fallback preserves pre state/vars；
13. terminated absorb and root leaf exit; 
14. semantic diagnostic/delta gating where applicable。

每个 alignment case 至少断言：

- post state equals `SimulationRuntime`；
- every persistent post var equals runtime value (`post_var != expected` UNSAT)，包括 action 未写变量的 explicit carry；
- selected `case_i[label]` SAT；
- conflicting selected case labels UNSAT when applicable；
- `used_events` / event inputs use full path。

### Local validation commands

Implementation 前后按风险逐步运行：

```bash
python -m py_compile pyfcstm/bmc/*.py test/bmc/*.py
python -m doctest pyfcstm/bmc/relation.py
ruff check pyfcstm/bmc test/bmc --exclude pyfcstm/bmc/grammar
ruff format --check pyfcstm/bmc test/bmc
SKIP_SLOW_TESTS=1 pytest test/bmc/test_relation_public_api.py test/bmc/test_relation_core.py -q --maxfail=3
SKIP_SLOW_TESTS=1 pytest test/bmc -q --maxfail=3
make rst_auto RANGE_DIR=bmc
make test_boundary_check
SKIP_SLOW_TESTS=1 make unittest
```


## Plan review 处理记录

三路 plan/body review 已完成并全部直接评论到 PR：

- codex reviewer：[#issuecomment-4885600808](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4885600808)；
- deepseek reviewer：[#issuecomment-4885603056](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4885603056)；
- claude reviewer：[#issuecomment-4885604906](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4885604906)。

本版 body 已吸收 C/I 级反馈：initial source 使用 `context.bound_query.initial.source`；`R_{i,c}` 显式约束全部 persistent vars；`Core_N` / `Phi_N` 边界划给 PR-10 / PR-11；不公开 `BmcRelationOptions`；默认 event pool 不加隐式互斥；`accepted:<label>` registry 限定为 per-step；补齐 `assume always` / `assume at` lowering 公式、`And(A,R)` kill fixture、same-short-name event fixture、explicit carry fixture与 doctest 要求。

## Implementation review 处理记录

三路实现后 review 已完成并全部直接评论到 PR：

- codex reviewer：[#issuecomment-4885990041](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4885990041)，发现 C-1 guard definedness / fallback false witness；
- claude reviewer：[#issuecomment-4885993196](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4885993196)，C/I=0，M=2；
- deepseek reviewer：[#issuecomment-4886010142](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4886010142)，C/I=0，M=2；截断占位 comment：[#issuecomment-4886006678](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4886006678)。

主 session 已处理首轮 C 级与轻量 M 级反馈：[#issuecomment-4886023070](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4886023070)。对应修复让 `BoolTemplate` lowering 携带 control-path definedness，并把 `guard:<id>` / `accepted:<label>` 选择所需 definedness 放入 selected case consequent；新增 `test_relation_guard_definedness_blocks_fallback_false_witness` 覆盖 runtime guard 除零时 fallback false witness 必须 UNSAT。selector/partition 契约、reserved diagnostics 字段、recurrence formals 共享不可变契约也已补充说明。

round 2 codex reviewer 追加发现 query / guard lazy definedness C 级问题：[#issuecomment-4886103776](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4886103776)。主 session 已在 [`0477ffc0`](https://github.com/HansBug/pyfcstm/pull/337/commits/0477ffc067aa45a7780fed5ab3c464b09d3ed735) 处理并发布复核记录：[#issuecomment-4886174327](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4886174327)。当前 lazy definedness 契约为：`.fbmcq` condition 的 `&&` / `||` 与 numeric/boolean ternary 只要求 runtime 实际求值分支的 definedness；FCSTM model guard 通过 `translate_expr_domain()` 使用同一短路语义；action-local `IfBlock` 仍由 solver operation / expression domain 处理，不拆 macro case。

## 当前 PR 状态

- 当前 head：[`c490e29f`](https://github.com/HansBug/pyfcstm/pull/337/commits/c490e29f)（`test(bmc): align semantic fixtures with core relation [skip-slow]`）。本轮已完成 PR-10 fixture scope iteration，进展记录见 [#issuecomment-4895516154](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4895516154)。
- 上游同步：`origin/dev/bmc-query-kernel-umbrella` 当前 head [`605f282a`](https://github.com/HansBug/pyfcstm/commit/605f282ac8b4260ecae5de368ed32080014a1208) 仍是本 PR head 的 ancestor；`git merge-base --is-ancestor origin/dev/bmc-query-kernel-umbrella HEAD` 已通过。
- 本轮已落地 scope：B1 initial pseudo/combo plain-before ordering hard-pass；D2 numeric unsupported structured/loud failure；全量 165 个 shared semantic fixture 进入 `bmc_core` policy ledger / harness；temporary / long-term exclude 均显式写入 fixture 与 policy reason，供 PR-10A / PR-10B / PR-10C / F/G 后续接手。
- 当前 fixture harness 分类：125 hard-pass（含 B1 三个）、11 partial（state/vars/ended 对齐，`handler_calls` 等 PR-10C）、3 expected unsupported（D2）、20 temporary exclude（PR-10A / PR-10B / F 后续）、6 long-term constructor diagnostic exclude（G）。
- 本地验证已通过：`py_compile`、`doctest pyfcstm/bmc/relation.py`、`doctest test/bmc/semantic_fixture_policy.py`、`ruff check`、`ruff format --check`、`pytest test/bmc/test_relation_semantic_fixtures.py -q`（140 passed / 26 skipped）、`pytest test/bmc -q`（3970 passed / 26 skipped）、`make rst_auto RANGE_DIR=bmc`、`make test_boundary_check`、`SKIP_SLOW_TESTS=1 make unittest`（45556 passed / 756 skipped / 67 deselected）。
- CI / Codecov：head `c490e29f` 已 push，等待 GitHub checks 与 Codecov 更新；完成后进入三路 implementation review 复核。

<!-- PR10-FIXTURE-SCOPE-START -->
## 全量 fixture 接入后的 PR-10 范围同步

范围锚点：[#issuecomment-4894808717](https://github.com/HansBug/pyfcstm/pull/337#issuecomment-4894808717)。相关总规划见 [issue #339](https://github.com/HansBug/pyfcstm/issues/339)、执行切分记录 [#issuecomment-4894813884](https://github.com/HansBug/pyfcstm/issues/339#issuecomment-4894813884)，以及伞 PR 同步记录 [#issuecomment-4894818378](https://github.com/HansBug/pyfcstm/pull/305#issuecomment-4894818378)。

当前 PR-10 需要继续完成：

- B1：纯执行逻辑对齐，直接修到 hard alignment，相关 fixture 不得 `bmc_core` exclude。
- D2：当前不支持的验证特性，必须在 BMC core 构建阶段 structured / loud error，不得 silent wrong formula。
- 全量 simulation semantic fixture 接入：新增 BMC 专属 runner/exclude（建议 `bmc_core`）与 policy manifest，确保全部 165 个 fixture 都被枚举到账。
- E 过渡处理：state / vars / ended 可验证部分继续纳入；`handler_calls` 暂时 warning/TODO，不能误报 overlay full-pass。

当前 PR-10 明确不完成但必须显式入账：

- B2 / D1：`state init`、`Delta_i` migration、撤销 `STATE_DIAGNOSTIC` absorb、non-stoppable no-progress 语义迁移；PR-10 先 temporary `bmc_core` exclude，后续 PR-10A 处理，且 PR-10A 必须在 PR-11 前完成。
- C：新 init / havoc / partial initializer override 语法；PR-10 先 temporary `bmc_core` exclude，后续 PR-10B 处理，且 PR-10B 必须在 PR-11 前完成。
- 完整 E：abstract call trace / call snapshot / `handler_calls` 形式化语义；后续 PR-10C 单独处理，不强制阻塞 PR-11。
- F：runtime error / DFS exceed / expression failure / writeback failure；PR-10 先 temporary `bmc_core` exclude 并在 issue #339 继续研究。
- G：入口非法、model/constructor 输入非法；长期 `bmc_core` exclude，不作为 BMC core 现实验证需求。

新增验收口径：PR-10 的 BMC fixture harness 需要对 hard-pass case 检查 `Core_N ∧ I_0 ∧ Env_N ∧ E_all` SAT 且 `Core_N ∧ I_0 ∧ Env_N ∧ ¬E_all` UNSAT；对 partial / unsupported / excluded case 必须有互斥分类、原因和后续处理链接，不允许 silent drop。
<!-- PR10-FIXTURE-SCOPE-END -->

